### PR TITLE
[#1030] Give the orchestrated suite one commit helper that returns the written value

### DIFF
--- a/tests/IntegrationTests/Mailbox/OrchestratedMailbox.cs
+++ b/tests/IntegrationTests/Mailbox/OrchestratedMailbox.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics.CodeAnalysis;
 using MailFathom.AppHost;
 using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
 using MailFathom.IntegrationTests.Orchestration;
 using MailFathom.SyntheticMail.Generation;
 using MailKit;
@@ -12,6 +13,7 @@ using MailKit.Net.Imap;
 using MailKit.Net.Smtp;
 using MailKit.Security;
 using MimeKit;
+using Xunit;
 
 namespace MailFathom.IntegrationTests.Mailbox;
 
@@ -60,6 +62,33 @@ internal sealed class OrchestratedMailbox(OrchestratedMailServerEndpoints endpoi
         await client.ConnectAsync(endpoints.SmtpHost, endpoints.SmtpPort, SecureSocketOptions.None, cancellationToken);
         await client.SendAsync(message, SyntheticSender, [MailboxRecipient], cancellationToken);
         await client.DisconnectAsync(quit: true, cancellationToken);
+    }
+
+    /// <summary>Delivers one synthetic message and reads back the occurrence identity the server gave it.</summary>
+    /// <param name="folderResolutionId">The binding the occurrence is named under.</param>
+    /// <param name="subject">The subject, which is how the delivered message is recognized among the mailbox's.</param>
+    /// <param name="cancellationToken">Cancels the delivery and the reads that follow it.</param>
+    /// <returns>The occurrence identity, carrying the UIDVALIDITY and UID the server itself assigned.</returns>
+    /// <remarks>
+    /// The binding is the caller's rather than this class's, because a test class binds the one inbox under an alias it
+    /// owns so that its rows cannot be confused with another class's. Only the delivery and the two observations are
+    /// shared; which folder resolution the occurrence is named under is not.
+    /// </remarks>
+    internal async Task<EmailOccurrenceId> DeliverAndLocateAsync(
+        MailFolderResolutionId folderResolutionId,
+        string subject,
+        CancellationToken cancellationToken)
+    {
+        await this.DeliverAsync(subject, cancellationToken);
+
+        var inbox = await this.ReadAsync(InboxPath, cancellationToken);
+        var delivered = Assert.Single(inbox, email => email.Subject == subject);
+
+        return EmailOccurrenceId.Create(
+            SyntheticMailAccount.AccountId,
+            folderResolutionId,
+            await this.ReadUidValidityAsync(InboxPath, cancellationToken),
+            delivered.Uid);
     }
 
     /// <summary>Appends one synthetic message directly to a folder, for folders SMTP delivery does not reach.</summary>

--- a/tests/IntegrationTests/Orchestration/OrchestratedMailFathomServices.cs
+++ b/tests/IntegrationTests/Orchestration/OrchestratedMailFathomServices.cs
@@ -50,6 +50,7 @@ using MailFathom.Infrastructure.Spam;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Xunit;
 
 namespace MailFathom.IntegrationTests.Orchestration;
 
@@ -530,6 +531,34 @@ internal sealed class OrchestratedMailFathomServices : IAsyncDisposable
                 await write(scope, session, token);
 
                 return await session.CommitAsync(token);
+            },
+            cancellationToken);
+
+    /// <summary>Runs one write in its own scope and session, and hands back the value the write produced.</summary>
+    /// <typeparam name="TResult">What the write produces, such as the identifier the repository assigned.</typeparam>
+    /// <param name="write">The repository calls that join the session, answering with the value the caller needs.</param>
+    /// <param name="cancellationToken">Cancels the write and the commit.</param>
+    /// <returns>What the write produced, once its session committed.</returns>
+    /// <remarks>
+    /// The scope, the session, and the ordering are <see cref="CommitAsync" />'s. What differs is which of the two
+    /// values reaches the caller: that method answers with the commit result, which is what a test asserting a conflict
+    /// needs and what leaves a test needing the written identifier with nowhere to read it from. Here the commit is
+    /// asserted instead, so an arrangement that silently conflicted fails where it happened rather than at whatever the
+    /// caller asserts about the value next.
+    /// </remarks>
+    internal Task<TResult> CommitProducingAsync<TResult>(
+        Func<IServiceProvider, IPersistenceSession, CancellationToken, Task<TResult>> write,
+        CancellationToken cancellationToken) => this.InScopeAsync(
+            async (scope, token) =>
+            {
+                await using var session = await scope.GetRequiredService<IPersistenceSessionFactory>()
+                    .BeginSessionAsync(token);
+
+                var produced = await write(scope, session, token);
+
+                Assert.Equal(PersistenceCommitResult.Committed, await session.CommitAsync(token));
+
+                return produced;
             },
             cancellationToken);
 

--- a/tests/IntegrationTests/Persistence/StoredSyntheticEmail.cs
+++ b/tests/IntegrationTests/Persistence/StoredSyntheticEmail.cs
@@ -1,0 +1,43 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Synchronization;
+using MailFathom.Domain.Emails;
+using MailFathom.IntegrationTests.Orchestration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MailFathom.IntegrationTests.Persistence;
+
+/// <summary>Writes the stored rows a test needs before it can arrange anything about a message.</summary>
+/// <remarks>
+/// <see cref="SyntheticEmail" /> builds the values; this writes them. The two are separate because the builders are
+/// pure and reusable wherever a value is wanted, while a write needs the composed services and a session of its own.
+/// </remarks>
+internal static class StoredSyntheticEmail
+{
+    /// <summary>Stores one occurrence's metadata and nothing else, and hands back the identifier it was given.</summary>
+    /// <param name="services">The composed services the write runs through.</param>
+    /// <param name="occurrence">The remote occurrence the row is written for.</param>
+    /// <param name="subject">The subject, which is how a test recognizes its own row.</param>
+    /// <param name="cancellationToken">Cancels the write and the commit.</param>
+    /// <returns>The identifier the metadata write assigned, which is what a mutation is then requested against.</returns>
+    /// <remarks>
+    /// The content is declared as having exceeded the size limit, which is the one availability that states there is no
+    /// raw MIME to find rather than that it has yet to arrive. That is what a test about mutations wants: the message
+    /// exists, is complete as far as anything reading it is concerned, and no content store had to be seeded to say so.
+    /// A test that asserts about content itself arranges its own row, since this one deliberately has none.
+    /// </remarks>
+    internal static Task<StoredEmailId> MetadataOnlyAsync(
+        OrchestratedMailFathomServices services,
+        EmailOccurrenceId occurrence,
+        string subject,
+        CancellationToken cancellationToken) => services.CommitProducingAsync(
+            (scope, session, token) => scope.GetRequiredService<IEmailMetadataRepository>().UpsertMetadataAsync(
+                session,
+                SyntheticEmail.RemoteMetadataOf(occurrence, subject),
+                extractedMetadata: null,
+                StoredEmailContentAvailability.ExceededSizeLimit,
+                token),
+            cancellationToken);
+}

--- a/tests/IntegrationTests/Synchronization/OrchestratedMailboxConvergenceTests.cs
+++ b/tests/IntegrationTests/Synchronization/OrchestratedMailboxConvergenceTests.cs
@@ -9,7 +9,6 @@ using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Resilience;
-using MailFathom.Application.Synchronization;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Failures;
 using MailFathom.Domain.Folders;
@@ -88,8 +87,12 @@ public sealed class OrchestratedMailboxConvergenceTests(MailFathomOrchestrationF
         await CommitInboxBindingAsync(services, cancellationToken);
 
         var subject = $"converge-relocate-{Guid.NewGuid():N}";
-        var occurrence = await DeliverAndLocateAsync(mailbox, subject, cancellationToken);
-        var storedEmailId = await StoreMetadataAsync(services, occurrence, subject, cancellationToken);
+        var occurrence = await mailbox.DeliverAndLocateAsync(Inbox.Id, subject, cancellationToken);
+        var storedEmailId = await StoredSyntheticEmail.MetadataOnlyAsync(
+            services,
+            occurrence,
+            subject,
+            cancellationToken);
         var request = MailboxMutationRequest.Relocate(storedEmailId, occurrence, Requester, ArchivePath);
 
         await StopAfterTheCopyAsync(services, request, occurrence, cancellationToken);
@@ -140,8 +143,12 @@ public sealed class OrchestratedMailboxConvergenceTests(MailFathomOrchestrationF
         await CommitInboxBindingAsync(services, cancellationToken);
 
         var subject = $"converge-missing-target-{Guid.NewGuid():N}";
-        var occurrence = await DeliverAndLocateAsync(mailbox, subject, cancellationToken);
-        var storedEmailId = await StoreMetadataAsync(services, occurrence, subject, cancellationToken);
+        var occurrence = await mailbox.DeliverAndLocateAsync(Inbox.Id, subject, cancellationToken);
+        var storedEmailId = await StoredSyntheticEmail.MetadataOnlyAsync(
+            services,
+            occurrence,
+            subject,
+            cancellationToken);
         var request = MailboxMutationRequest.Relocate(storedEmailId, occurrence, Requester, RemovedPath);
         await RecordIntentAsync(services, request, cancellationToken);
 
@@ -191,8 +198,12 @@ public sealed class OrchestratedMailboxConvergenceTests(MailFathomOrchestrationF
         await CommitInboxBindingAsync(services, cancellationToken);
 
         var subject = $"converge-copy-{Guid.NewGuid():N}";
-        var occurrence = await DeliverAndLocateAsync(mailbox, subject, cancellationToken);
-        var storedEmailId = await StoreMetadataAsync(services, occurrence, subject, cancellationToken);
+        var occurrence = await mailbox.DeliverAndLocateAsync(Inbox.Id, subject, cancellationToken);
+        var storedEmailId = await StoredSyntheticEmail.MetadataOnlyAsync(
+            services,
+            occurrence,
+            subject,
+            cancellationToken);
         var request = MailboxMutationRequest.Copy(storedEmailId, occurrence, Requester, CopyPath);
 
         await StopAfterTheCopyCommandAsync(services, request, occurrence, cancellationToken);
@@ -376,8 +387,7 @@ public sealed class OrchestratedMailboxConvergenceTests(MailFathomOrchestrationF
     private static Task<MailboxMutationRecordId> RecordIntentAsync(
         OrchestratedMailFathomServices services,
         MailboxMutationRequest request,
-        CancellationToken cancellationToken) => CommitForAsync(
-            services,
+        CancellationToken cancellationToken) => services.CommitProducingAsync(
             async (scope, session, token) => (await scope.GetRequiredService<IMailboxMutationRecordStore>()
                 .OpenAsync(session, request, token)).Id,
             cancellationToken);
@@ -436,54 +446,6 @@ public sealed class OrchestratedMailboxConvergenceTests(MailFathomOrchestrationF
                     Inbox,
                     token),
                 cancellationToken));
-
-    private static Task<StoredEmailId> StoreMetadataAsync(
-        OrchestratedMailFathomServices services,
-        EmailOccurrenceId occurrence,
-        string subject,
-        CancellationToken cancellationToken) => CommitForAsync(
-            services,
-            (scope, session, token) => scope.GetRequiredService<IEmailMetadataRepository>().UpsertMetadataAsync(
-                session,
-                SyntheticEmail.RemoteMetadataOf(occurrence, subject),
-                extractedMetadata: null,
-                StoredEmailContentAvailability.ExceededSizeLimit,
-                token),
-            cancellationToken);
-
-    private static Task<TResult> CommitForAsync<TResult>(
-        OrchestratedMailFathomServices services,
-        Func<IServiceProvider, IPersistenceSession, CancellationToken, Task<TResult>> write,
-        CancellationToken cancellationToken) => services.InScopeAsync(
-            async (scope, token) =>
-            {
-                await using var session = await scope.GetRequiredService<IPersistenceSessionFactory>()
-                    .BeginSessionAsync(token);
-
-                var produced = await write(scope, session, token);
-
-                Assert.Equal(PersistenceCommitResult.Committed, await session.CommitAsync(token));
-
-                return produced;
-            },
-            cancellationToken);
-
-    private static async Task<EmailOccurrenceId> DeliverAndLocateAsync(
-        OrchestratedMailbox mailbox,
-        string subject,
-        CancellationToken cancellationToken)
-    {
-        await mailbox.DeliverAsync(subject, cancellationToken);
-
-        var inbox = await mailbox.ReadAsync(OrchestratedMailbox.InboxPath, cancellationToken);
-        var delivered = Assert.Single(inbox, email => email.Subject == subject);
-
-        return EmailOccurrenceId.Create(
-            SyntheticMailAccount.AccountId,
-            Inbox.Id,
-            await mailbox.ReadUidValidityAsync(OrchestratedMailbox.InboxPath, cancellationToken),
-            delivered.Uid);
-    }
 
     /// <summary>The columns of one mutation record a test reads back.</summary>
     private sealed record MailboxMutationRow(MailboxMutationStage Stage, int AttemptCount, int? LastFailureCode);

--- a/tests/IntegrationTests/Synchronization/OrchestratedMailboxMutationAuditTrailTests.cs
+++ b/tests/IntegrationTests/Synchronization/OrchestratedMailboxMutationAuditTrailTests.cs
@@ -7,7 +7,6 @@ using MailFathom.Application.Mail;
 using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Persistence;
-using MailFathom.Application.Synchronization;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
 using MailFathom.Domain.Mutations;
@@ -126,8 +125,12 @@ public sealed class OrchestratedMailboxMutationAuditTrailTests(MailFathomOrchest
         await CommitInboxBindingAsync(services, cancellationToken);
 
         var subject = $"audit-trail-off-{Guid.NewGuid():N}";
-        var occurrence = await DeliverAndLocateAsync(mailbox, subject, cancellationToken);
-        var storedEmailId = await StoreMetadataAsync(services, occurrence, subject, cancellationToken);
+        var occurrence = await mailbox.DeliverAndLocateAsync(Inbox.Id, subject, cancellationToken);
+        var storedEmailId = await StoredSyntheticEmail.MetadataOnlyAsync(
+            services,
+            occurrence,
+            subject,
+            cancellationToken);
         var unauditedRequester = MailboxMutationRequester.Command($"trail-off-{Guid.NewGuid():N}");
         var request = MailboxMutationRequest.SetSeen(storedEmailId, occurrence, unauditedRequester, isSeen: true);
 
@@ -156,8 +159,12 @@ public sealed class OrchestratedMailboxMutationAuditTrailTests(MailFathomOrchest
         foreach (var mutation in MailboxMutation.All)
         {
             var subject = $"audit-trail-{mutation.Name}-{Guid.NewGuid():N}";
-            var occurrence = await DeliverAndLocateAsync(mailbox, subject, cancellationToken);
-            var storedEmailId = await StoreMetadataAsync(services, occurrence, subject, cancellationToken);
+            var occurrence = await mailbox.DeliverAndLocateAsync(Inbox.Id, subject, cancellationToken);
+            var storedEmailId = await StoredSyntheticEmail.MetadataOnlyAsync(
+                services,
+                occurrence,
+                subject,
+                cancellationToken);
 
             requests.Add(RequestFor(mutation, storedEmailId, occurrence));
         }
@@ -290,44 +297,4 @@ public sealed class OrchestratedMailboxMutationAuditTrailTests(MailFathomOrchest
                     Inbox,
                     token),
                 cancellationToken));
-
-    private static Task<StoredEmailId> StoreMetadataAsync(
-        OrchestratedMailFathomServices services,
-        EmailOccurrenceId occurrence,
-        string subject,
-        CancellationToken cancellationToken) => services.InScopeAsync(
-            async (scope, token) =>
-            {
-                await using var session = await scope.GetRequiredService<IPersistenceSessionFactory>()
-                    .BeginSessionAsync(token);
-
-                var storedEmailId = await scope.GetRequiredService<IEmailMetadataRepository>().UpsertMetadataAsync(
-                    session,
-                    SyntheticEmail.RemoteMetadataOf(occurrence, subject),
-                    extractedMetadata: null,
-                    StoredEmailContentAvailability.ExceededSizeLimit,
-                    token);
-
-                Assert.Equal(PersistenceCommitResult.Committed, await session.CommitAsync(token));
-
-                return storedEmailId;
-            },
-            cancellationToken);
-
-    private static async Task<EmailOccurrenceId> DeliverAndLocateAsync(
-        OrchestratedMailbox mailbox,
-        string subject,
-        CancellationToken cancellationToken)
-    {
-        await mailbox.DeliverAsync(subject, cancellationToken);
-
-        var inbox = await mailbox.ReadAsync(OrchestratedMailbox.InboxPath, cancellationToken);
-        var delivered = Assert.Single(inbox, email => email.Subject == subject);
-
-        return EmailOccurrenceId.Create(
-            SyntheticMailAccount.AccountId,
-            Inbox.Id,
-            await mailbox.ReadUidValidityAsync(OrchestratedMailbox.InboxPath, cancellationToken),
-            delivered.Uid);
-    }
 }

--- a/tests/IntegrationTests/Synchronization/OrchestratedMailboxMutationRecordTests.cs
+++ b/tests/IntegrationTests/Synchronization/OrchestratedMailboxMutationRecordTests.cs
@@ -8,7 +8,6 @@ using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Resilience;
-using MailFathom.Application.Synchronization;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
 using MailFathom.Domain.Mutations;
@@ -76,8 +75,12 @@ public sealed class OrchestratedMailboxMutationRecordTests(MailFathomOrchestrati
             await CommitInboxBindingAsync(services, cancellationToken));
 
         var subject = $"resume-relocate-{Guid.NewGuid():N}";
-        var occurrence = await DeliverAndLocateAsync(mailbox, subject, cancellationToken);
-        var storedEmailId = await StoreMetadataAsync(services, occurrence, subject, cancellationToken);
+        var occurrence = await mailbox.DeliverAndLocateAsync(Inbox.Id, subject, cancellationToken);
+        var storedEmailId = await StoredSyntheticEmail.MetadataOnlyAsync(
+            services,
+            occurrence,
+            subject,
+            cancellationToken);
         var request = MailboxMutationRequest.Relocate(storedEmailId, occurrence, Requester, ArchivePath);
 
         await StopAfterTheCopyAsync(services, request, occurrence, cancellationToken);
@@ -132,7 +135,11 @@ public sealed class OrchestratedMailboxMutationRecordTests(MailFathomOrchestrati
         await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
         var binding = await OrchestratedFolderBinding.CommitAsync(services, "mutation-identity", cancellationToken);
         var occurrence = SyntheticEmail.OccurrenceIn(binding, uid: 4242U);
-        var storedEmailId = await StoreMetadataAsync(services, occurrence, "mutation-identity", cancellationToken);
+        var storedEmailId = await StoredSyntheticEmail.MetadataOnlyAsync(
+            services,
+            occurrence,
+            "mutation-identity",
+            cancellationToken);
         var request = MailboxMutationRequest.SetSeen(storedEmailId, occurrence, Requester, isSeen: true);
 
         // Act
@@ -176,8 +183,7 @@ public sealed class OrchestratedMailboxMutationRecordTests(MailFathomOrchestrati
         EmailOccurrenceId occurrence,
         CancellationToken cancellationToken)
     {
-        var recordId = await CommitForAsync(
-            services,
+        var recordId = await services.CommitProducingAsync(
             async (scope, session, token) => (await scope.GetRequiredService<IMailboxMutationRecordStore>()
                 .OpenAsync(session, request, token)).Id,
             cancellationToken);
@@ -307,56 +313,6 @@ public sealed class OrchestratedMailboxMutationRecordTests(MailFathomOrchestrati
                 Inbox,
                 token),
             cancellationToken);
-
-    private static Task<StoredEmailId> StoreMetadataAsync(
-        OrchestratedMailFathomServices services,
-        EmailOccurrenceId occurrence,
-        string subject,
-        CancellationToken cancellationToken) => CommitForAsync(
-            services,
-            (scope, session, token) => scope.GetRequiredService<IEmailMetadataRepository>().UpsertMetadataAsync(
-                session,
-                SyntheticEmail.RemoteMetadataOf(occurrence, subject),
-                extractedMetadata: null,
-                StoredEmailContentAvailability.ExceededSizeLimit,
-                token),
-            cancellationToken);
-
-    /// <summary>Commits one write and hands back what it produced, which the shared helper cannot because it reports the commit.</summary>
-    /// <remarks>The commit result is asserted here instead, so arrangement that silently conflicted fails where it happened.</remarks>
-    private static Task<TResult> CommitForAsync<TResult>(
-        OrchestratedMailFathomServices services,
-        Func<IServiceProvider, IPersistenceSession, CancellationToken, Task<TResult>> write,
-        CancellationToken cancellationToken) => services.InScopeAsync(
-            async (scope, token) =>
-            {
-                await using var session = await scope.GetRequiredService<IPersistenceSessionFactory>()
-                    .BeginSessionAsync(token);
-
-                var produced = await write(scope, session, token);
-
-                Assert.Equal(PersistenceCommitResult.Committed, await session.CommitAsync(token));
-
-                return produced;
-            },
-            cancellationToken);
-
-    private static async Task<EmailOccurrenceId> DeliverAndLocateAsync(
-        OrchestratedMailbox mailbox,
-        string subject,
-        CancellationToken cancellationToken)
-    {
-        await mailbox.DeliverAsync(subject, cancellationToken);
-
-        var inbox = await mailbox.ReadAsync(OrchestratedMailbox.InboxPath, cancellationToken);
-        var delivered = Assert.Single(inbox, email => email.Subject == subject);
-
-        return EmailOccurrenceId.Create(
-            SyntheticMailAccount.AccountId,
-            Inbox.Id,
-            await mailbox.ReadUidValidityAsync(OrchestratedMailbox.InboxPath, cancellationToken),
-            delivered.Uid);
-    }
 
     /// <summary>The columns of one mutation record a test reads back.</summary>
     private sealed record MailboxMutationRow(

--- a/tests/IntegrationTests/Synchronization/OrchestratedMailboxMutationTests.cs
+++ b/tests/IntegrationTests/Synchronization/OrchestratedMailboxMutationTests.cs
@@ -67,7 +67,7 @@ public sealed class OrchestratedMailboxMutationTests(MailFathomOrchestrationFixt
         await mailbox.RecreateFolderAsync(ArchiveFolderName, cancellationToken);
 
         var subject = $"relocate-native-{Guid.NewGuid():N}";
-        var occurrence = await DeliverAndLocateAsync(mailbox, subject, cancellationToken);
+        var occurrence = await mailbox.DeliverAndLocateAsync(Inbox.Id, subject, cancellationToken);
 
         await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
 
@@ -119,7 +119,7 @@ public sealed class OrchestratedMailboxMutationTests(MailFathomOrchestrationFixt
         var cancellationToken = TestContext.Current.CancellationToken;
         var mailbox = new OrchestratedMailbox(orchestration.MailServer);
         var subject = $"relocate-fallback-{Guid.NewGuid():N}";
-        var occurrence = await DeliverAndLocateAsync(mailbox, subject, cancellationToken);
+        var occurrence = await mailbox.DeliverAndLocateAsync(Inbox.Id, subject, cancellationToken);
 
         await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
 
@@ -161,8 +161,8 @@ public sealed class OrchestratedMailboxMutationTests(MailFathomOrchestrationFixt
         var neighbourSubject = $"expunge-neighbour-{Guid.NewGuid():N}";
         var targetSubject = $"expunge-target-{Guid.NewGuid():N}";
 
-        var neighbour = await DeliverAndLocateAsync(mailbox, neighbourSubject, cancellationToken);
-        var target = await DeliverAndLocateAsync(mailbox, targetSubject, cancellationToken);
+        var neighbour = await mailbox.DeliverAndLocateAsync(Inbox.Id, neighbourSubject, cancellationToken);
+        var target = await mailbox.DeliverAndLocateAsync(Inbox.Id, targetSubject, cancellationToken);
         await mailbox.MarkDeletedAsync(OrchestratedMailbox.InboxPath, neighbour.Uid, cancellationToken);
 
         await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
@@ -210,7 +210,7 @@ public sealed class OrchestratedMailboxMutationTests(MailFathomOrchestrationFixt
         var cancellationToken = TestContext.Current.CancellationToken;
         var mailbox = new OrchestratedMailbox(orchestration.MailServer);
         var subject = $"label-target-{Guid.NewGuid():N}";
-        var occurrence = await DeliverAndLocateAsync(mailbox, subject, cancellationToken);
+        var occurrence = await mailbox.DeliverAndLocateAsync(Inbox.Id, subject, cancellationToken);
         await mailbox.MarkSeenAsync(OrchestratedMailbox.InboxPath, occurrence.Uid, cancellationToken);
 
         await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
@@ -292,23 +292,5 @@ public sealed class OrchestratedMailboxMutationTests(MailFathomOrchestrationFixt
             cancellationToken);
 
         return await session.RelocateAsync(occurrence, ArchivePath, journal, cancellationToken);
-    }
-
-    /// <summary>Delivers one synthetic message and reads back the occurrence identity the server gave it.</summary>
-    private static async Task<EmailOccurrenceId> DeliverAndLocateAsync(
-        OrchestratedMailbox mailbox,
-        string subject,
-        CancellationToken cancellationToken)
-    {
-        await mailbox.DeliverAsync(subject, cancellationToken);
-
-        var inbox = await mailbox.ReadAsync(OrchestratedMailbox.InboxPath, cancellationToken);
-        var delivered = Assert.Single(inbox, email => email.Subject == subject);
-
-        return EmailOccurrenceId.Create(
-            SyntheticMailAccount.AccountId,
-            Inbox.Id,
-            await mailbox.ReadUidValidityAsync(OrchestratedMailbox.InboxPath, cancellationToken),
-            delivered.Uid);
     }
 }

--- a/tests/IntegrationTests/Synchronization/OrchestratedMutationReconciliationReadTests.cs
+++ b/tests/IntegrationTests/Synchronization/OrchestratedMutationReconciliationReadTests.cs
@@ -4,7 +4,6 @@
 
 using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Persistence;
-using MailFathom.Application.Synchronization;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
 using MailFathom.Domain.Mutations;
@@ -75,7 +74,11 @@ public sealed class OrchestratedMutationReconciliationReadTests(MailFathomOrches
         await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
         var binding = await OrchestratedFolderBinding.CommitAsync(services, FolderAlias, cancellationToken);
         var occurrence = SyntheticEmail.OccurrenceIn(binding, uid: 5001);
-        var storedEmailId = await StoreMetadataAsync(services, occurrence, "relocated", cancellationToken);
+        var storedEmailId = await StoredSyntheticEmail.MetadataOnlyAsync(
+            services,
+            occurrence,
+            "relocated",
+            cancellationToken);
 
         var recordId = await CompletedRelocationAsync(
             services,
@@ -133,9 +136,21 @@ public sealed class OrchestratedMutationReconciliationReadTests(MailFathomOrches
         var seenOccurrence = SyntheticEmail.OccurrenceIn(binding, uid: 5002);
         var relocatedOccurrence = SyntheticEmail.OccurrenceIn(binding, uid: 5003);
         var writtenDownOccurrence = SyntheticEmail.OccurrenceIn(binding, uid: 5004);
-        var seenEmailId = await StoreMetadataAsync(services, seenOccurrence, "flagged", cancellationToken);
-        var relocatedEmailId = await StoreMetadataAsync(services, relocatedOccurrence, "moved", cancellationToken);
-        var writtenDownEmailId = await StoreMetadataAsync(services, writtenDownOccurrence, "pending", cancellationToken);
+        var seenEmailId = await StoredSyntheticEmail.MetadataOnlyAsync(
+            services,
+            seenOccurrence,
+            "flagged",
+            cancellationToken);
+        var relocatedEmailId = await StoredSyntheticEmail.MetadataOnlyAsync(
+            services,
+            relocatedOccurrence,
+            "moved",
+            cancellationToken);
+        var writtenDownEmailId = await StoredSyntheticEmail.MetadataOnlyAsync(
+            services,
+            writtenDownOccurrence,
+            "pending",
+            cancellationToken);
 
         var seenRecordId = await CompletedSeenStoreAsync(
             services,
@@ -193,8 +208,16 @@ public sealed class OrchestratedMutationReconciliationReadTests(MailFathomOrches
 
         var crowdedOccurrence = SyntheticEmail.OccurrenceIn(binding, uid: 5011);
         var quietOccurrence = SyntheticEmail.OccurrenceIn(binding, uid: 5012);
-        var crowdedEmailId = await StoreMetadataAsync(services, crowdedOccurrence, "triaged", cancellationToken);
-        var quietEmailId = await StoreMetadataAsync(services, quietOccurrence, "read once", cancellationToken);
+        var crowdedEmailId = await StoredSyntheticEmail.MetadataOnlyAsync(
+            services,
+            crowdedOccurrence,
+            "triaged",
+            cancellationToken);
+        var quietEmailId = await StoredSyntheticEmail.MetadataOnlyAsync(
+            services,
+            quietOccurrence,
+            "read once",
+            cancellationToken);
 
         // Written down and completed first, so it is the oldest stage change of the lot and therefore the row a
         // newest-first truncation across the whole answer drops.
@@ -327,41 +350,8 @@ public sealed class OrchestratedMutationReconciliationReadTests(MailFathomOrches
     private static Task<MailboxMutationRecordId> OpenAsync(
         OrchestratedMailFathomServices services,
         MailboxMutationRequest request,
-        CancellationToken cancellationToken) => CommitForAsync(
-            services,
+        CancellationToken cancellationToken) => services.CommitProducingAsync(
             async (scope, session, token) => (await scope.GetRequiredService<IMailboxMutationRecordStore>()
                 .OpenAsync(session, request, token)).Id,
-            cancellationToken);
-
-    private static Task<StoredEmailId> StoreMetadataAsync(
-        OrchestratedMailFathomServices services,
-        EmailOccurrenceId occurrence,
-        string subject,
-        CancellationToken cancellationToken) => CommitForAsync(
-            services,
-            (scope, session, token) => scope.GetRequiredService<IEmailMetadataRepository>().UpsertMetadataAsync(
-                session,
-                SyntheticEmail.RemoteMetadataOf(occurrence, subject),
-                extractedMetadata: null,
-                StoredEmailContentAvailability.ExceededSizeLimit,
-                token),
-            cancellationToken);
-
-    /// <summary>Commits one write and hands back what it produced, asserting the commit where it happened.</summary>
-    private static Task<TResult> CommitForAsync<TResult>(
-        OrchestratedMailFathomServices services,
-        Func<IServiceProvider, IPersistenceSession, CancellationToken, Task<TResult>> write,
-        CancellationToken cancellationToken) => services.InScopeAsync(
-            async (scope, token) =>
-            {
-                await using var session = await scope.GetRequiredService<IPersistenceSessionFactory>()
-                    .BeginSessionAsync(token);
-
-                var produced = await write(scope, session, token);
-
-                Assert.Equal(PersistenceCommitResult.Committed, await session.CommitAsync(token));
-
-                return produced;
-            },
             cancellationToken);
 }


### PR DESCRIPTION
Three helpers in the orchestrated mutation tests had been rewritten by three to five sibling classes, by five pull requests that could not see each other. Each clone is folded into the one place that already owns the concept. Nothing about what the suite asserts changes.

## What moved

**`OrchestratedMailFathomServices.CommitProducingAsync<TResult>`** sits beside `CommitAsync` and answers with the value the write produced rather than with the commit result. That gap is why the three `CommitForAsync` copies existed at all — `OrchestratedMailboxMutationRecordTests` even carried a comment about it — so the three are deleted. The commit is asserted inside the helper, exactly as each copy did, so an arrangement that silently conflicted still fails where it happened.

**`OrchestratedMailbox.DeliverAndLocateAsync`** replaces four copies and takes the folder resolution as a parameter, because each class binds the one inbox under an alias it owns and only the delivery and the two observations were ever shared.

**`StoredSyntheticEmail.MetadataOnlyAsync`** sits beside `SyntheticEmail` and replaces four copies. The two are separate files because the builders are pure and reusable wherever a value is wanted, while a write needs the composed services and a session of its own.

## Deliberately untouched

- The three `StoreMetadataAsync` copies under `tests/IntegrationTests/Persistence`, which pass a different availability.
- `ReadRecordRowAsync`, whose projections genuinely differ per class.

## Verification

- `scripts/verify-full.sh` — passed.
- `scripts/verify-fast.sh` — 10282 unit tests, 0 failed.
- `dotnet build tests/IntegrationTests -c Release` — 0 warnings, 0 errors.
- The integration suite itself is dispatched against this branch through the `Integration tests` workflow; neither verification gate covers it, which is what makes it part of this change's acceptance.

Breaking changes: none. No public surface moves — every type here is `internal` to the integration test project.

Closes #1030

Issue: https://github.com/Krzysztof318/MailFathom/issues/1030

Pull request: https://github.com/Krzysztof318/MailFathom/pull/1055
Integration suite run: https://github.com/Krzysztof318/MailFathom/actions/runs/32429539581
