### PR TITLE
[#1029] Read telemetry measurements through the shared recorder

### DIFF
--- a/tests/Infrastructure.UnitTests/Observability/DerivedWorkGateTelemetryTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/DerivedWorkGateTelemetryTests.cs
@@ -2,12 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Collections.Concurrent;
-using System.Diagnostics.Metrics;
-using System.Globalization;
 using MailFathom.Application.Spam.Gating;
-using MailFathom.Common.Observability;
 using MailFathom.Infrastructure.Observability;
+using MailFathom.TestSupport;
 using Xunit;
 
 namespace MailFathom.Infrastructure.UnitTests.Observability;
@@ -38,26 +35,27 @@ public sealed class DerivedWorkGateTelemetryTests
     public void RecordAdmission_OneDecision_CountsItUnderItsOwnAdmission(DerivedWorkAdmission admission, string tag)
     {
         // Arrange
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(AdmissionsInstrumentName);
 
         // Act
         this.telemetry.RecordAdmission(admission);
 
         // Assert
-        Assert.Equal(1, Assert.Single(collector.Read(AdmissionsInstrumentName, tag)).Value);
+        Assert.Equal([tag], measurements.DimensionOf(AdmissionsInstrumentName, AdmissionTagName));
+        Assert.Equal([1d], measurements.ValuesOf(AdmissionsInstrumentName));
     }
 
     [Fact]
     public void RecordDiscardedPassages_AJunkVerdictOverDerivedData_CountsThePassagesItRemoved()
     {
         // Arrange
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(DiscardedInstrumentName);
 
         // Act
         this.telemetry.RecordDiscardedPassages(6);
 
         // Assert
-        Assert.Equal(6, collector.Read(DiscardedInstrumentName).Sum(measurement => measurement.Value));
+        Assert.Equal(6, measurements.ValuesOf(DiscardedInstrumentName).Sum());
     }
 
     /// <summary>A deployment whose classification has caught up removes nothing, and a zero is not a measurement.</summary>
@@ -65,68 +63,12 @@ public sealed class DerivedWorkGateTelemetryTests
     public void RecordDiscardedPassages_AJunkVerdictOverNothingDerived_PublishesNoMeasurement()
     {
         // Arrange
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(DiscardedInstrumentName);
 
         // Act
         this.telemetry.RecordDiscardedPassages(0);
 
         // Assert
-        Assert.Empty(collector.Read(DiscardedInstrumentName));
+        Assert.Empty(measurements.Read(DiscardedInstrumentName));
     }
-
-    /// <summary>Reads what the counters on MailFathom's own meter published.</summary>
-    private sealed class MeasurementCollector : IDisposable
-    {
-        private readonly MeterListener listener = new();
-
-        // Concurrent because the listener is enabled for every instrument on MailFathom's one meter, so any other test
-        // class publishing to it writes here while this one reads — which a plain list reports as a modified collection.
-        private readonly ConcurrentQueue<PublishedMeasurement> measurements = [];
-
-        internal MeasurementCollector()
-        {
-            this.listener.InstrumentPublished = (instrument, activeListener) =>
-            {
-                if (StringComparer.Ordinal.Equals(instrument.Meter.Name, Telemetry.Name))
-                {
-                    activeListener.EnableMeasurementEvents(instrument);
-                }
-            };
-            this.listener.SetMeasurementEventCallback<long>(this.Record);
-            this.listener.Start();
-        }
-
-        public void Dispose() => this.listener.Dispose();
-
-        /// <summary>Returns what one instrument published, in order.</summary>
-        internal IReadOnlyList<PublishedMeasurement> Read(string instrumentName) =>
-            [
-                .. this.measurements.ToArray().Where(measurement =>
-                    StringComparer.Ordinal.Equals(measurement.InstrumentName, instrumentName)),
-            ];
-
-        /// <summary>Returns what one instrument published for one admission, in order.</summary>
-        internal IReadOnlyList<PublishedMeasurement> Read(string instrumentName, string admission) =>
-            [
-                .. this.Read(instrumentName).Where(measurement =>
-                    measurement.Tags.TryGetValue(AdmissionTagName, out var tag) && Equals(tag, admission)),
-            ];
-
-        private void Record<TMeasurement>(
-            Instrument instrument,
-            TMeasurement measurement,
-            ReadOnlySpan<KeyValuePair<string, object?>> tags,
-            object? state)
-            where TMeasurement : struct =>
-            this.measurements.Enqueue(new PublishedMeasurement(
-                instrument.Name,
-                Convert.ToDouble(measurement, CultureInfo.InvariantCulture),
-                tags.ToArray().ToDictionary(tag => tag.Key, tag => tag.Value, StringComparer.Ordinal)));
-    }
-
-    /// <summary>One measurement an instrument published, with the dimensions it carried.</summary>
-    private sealed record PublishedMeasurement(
-        string InstrumentName,
-        double Value,
-        IReadOnlyDictionary<string, object?> Tags);
 }

--- a/tests/Infrastructure.UnitTests/Observability/JobQueueTelemetryTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/JobQueueTelemetryTests.cs
@@ -2,14 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Collections.Concurrent;
-using System.Diagnostics.Metrics;
-using System.Globalization;
 using MailFathom.Application.Jobs;
 using MailFathom.Application.Jobs.Execution;
 using MailFathom.Application.Jobs.Scheduling;
-using MailFathom.Common.Observability;
 using MailFathom.Infrastructure.Observability;
+using MailFathom.TestSupport;
 using Xunit;
 
 namespace MailFathom.Infrastructure.UnitTests.Observability;
@@ -39,16 +36,18 @@ public sealed class JobQueueTelemetryTests
     public void RecordAttempt_AnAttemptThatSucceeded_CountsItAndRecordsItsDuration()
     {
         // Arrange
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(AttemptsInstrumentName, DurationInstrumentName);
 
         // Act
         QueueTelemetry.RecordAttempt(Result(JobExecutionOutcome.Succeeded, TimeSpan.FromSeconds(3)));
 
         // Assert
-        var attempt = Assert.Single(collector.Read(AttemptsInstrumentName));
+        var attempt = Assert.Single(PublishedFor(measurements, JobType.ClassifyEmailSpam, AttemptsInstrumentName));
         Assert.Equal(1, attempt.Value);
         Assert.Equal("succeeded", attempt.Tags["mailfathom.job.outcome"]);
-        Assert.Equal(3, Assert.Single(collector.Read(DurationInstrumentName)).Value);
+        Assert.Equal(
+            3,
+            Assert.Single(PublishedFor(measurements, JobType.ClassifyEmailSpam, DurationInstrumentName)).Value);
     }
 
     /// <summary>
@@ -59,7 +58,9 @@ public sealed class JobQueueTelemetryTests
     public void RecordAttempt_AFailureTheQueueWillTryAgain_CountsARetryAndNoDeadLetter()
     {
         // Arrange
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(
+            RetriesInstrumentName,
+            DeadLettersInstrumentName);
 
         // Act
         QueueTelemetry.RecordAttempt(Result(
@@ -70,8 +71,10 @@ public sealed class JobQueueTelemetryTests
                 JobFailureDisposition.RetryScheduled)));
 
         // Assert
-        Assert.Equal(1, Assert.Single(collector.Read(RetriesInstrumentName)).Value);
-        Assert.Empty(collector.Read(DeadLettersInstrumentName));
+        Assert.Equal(
+            1,
+            Assert.Single(PublishedFor(measurements, JobType.ClassifyEmailSpam, RetriesInstrumentName)).Value);
+        Assert.Empty(PublishedFor(measurements, JobType.ClassifyEmailSpam, DeadLettersInstrumentName));
     }
 
     /// <summary>
@@ -83,7 +86,9 @@ public sealed class JobQueueTelemetryTests
     public void RecordAttempt_AJobNothingWillAttemptAgain_CountsItWithTheClassificationThatEndedIt()
     {
         // Arrange
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(
+            DeadLettersInstrumentName,
+            RetriesInstrumentName);
 
         // Act
         QueueTelemetry.RecordAttempt(Result(
@@ -94,10 +99,10 @@ public sealed class JobQueueTelemetryTests
                 JobFailureDisposition.DeadLettered)));
 
         // Assert
-        var deadLetter = Assert.Single(collector.Read(DeadLettersInstrumentName));
+        var deadLetter = Assert.Single(PublishedFor(measurements, JobType.ClassifyEmailSpam, DeadLettersInstrumentName));
         Assert.Equal(1, deadLetter.Value);
         Assert.Equal("permanent", deadLetter.Tags["mailfathom.job.failure"]);
-        Assert.Empty(collector.Read(RetriesInstrumentName));
+        Assert.Empty(PublishedFor(measurements, JobType.ClassifyEmailSpam, RetriesInstrumentName));
     }
 
     /// <summary>
@@ -108,7 +113,7 @@ public sealed class JobQueueTelemetryTests
     public void RecordAttempt_AnAttemptTheHostGaveBack_CountsItAsReleasedRatherThanAsAFailure()
     {
         // Arrange
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(AttemptsInstrumentName);
 
         // Act
         QueueTelemetry.RecordAttempt(Result(JobExecutionOutcome.ReleasedForShutdown, TimeSpan.FromSeconds(1)));
@@ -116,7 +121,8 @@ public sealed class JobQueueTelemetryTests
         // Assert
         Assert.Equal(
             "released_for_shutdown",
-            Assert.Single(collector.Read(AttemptsInstrumentName)).Tags["mailfathom.job.outcome"]);
+            Assert.Single(PublishedFor(measurements, JobType.ClassifyEmailSpam, AttemptsInstrumentName))
+                .Tags["mailfathom.job.outcome"]);
     }
 
     /// <summary>
@@ -137,13 +143,21 @@ public sealed class JobQueueTelemetryTests
             new JobAttemptFailure(
                 JobFailureRecord.Create(JobFailureClassification.Permanent, Reason),
                 JobFailureDisposition.DeadLettered));
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(
+            AttemptsInstrumentName,
+            DurationInstrumentName,
+            DeadLettersInstrumentName);
 
         // Act
         QueueTelemetry.RecordAttempt(result);
 
         // Assert
-        var published = collector.Read(AttemptsInstrumentName, DurationInstrumentName, DeadLettersInstrumentName);
+        var published = PublishedFor(
+            measurements,
+            JobType.ClassifyEmailSpam,
+            AttemptsInstrumentName,
+            DurationInstrumentName,
+            DeadLettersInstrumentName);
         Assert.NotEmpty(published);
         Assert.All(published, measurement => Assert.All(
             measurement.Tags,
@@ -160,13 +174,15 @@ public sealed class JobQueueTelemetryTests
     public void RecordQueueDepth_AMeasuredQueue_PublishesTheDepthOfEachTypeMeasured()
     {
         // Arrange
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(DepthInstrumentName);
 
         // Act
         QueueTelemetry.RecordQueueDepth([new JobQueueDepthReading(JobType.ClassifyEmailSpam, 41)]);
 
         // Assert
-        var depth = Assert.Single(collector.ReadObservable(DepthInstrumentName));
+        measurements.ObserveGaugesAfresh();
+
+        var depth = Assert.Single(PublishedFor(measurements, JobType.ClassifyEmailSpam, DepthInstrumentName));
         Assert.Equal(41, depth.Value);
         Assert.Equal(JobType.ClassifyEmailSpam.Name, depth.Tags[JobTypeTagName]);
     }
@@ -179,14 +195,18 @@ public sealed class JobQueueTelemetryTests
     public void RecordQueueDepth_AQueueThatDrained_ReplacesTheDepthRatherThanKeepingTheEarlierOne()
     {
         // Arrange
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(DepthInstrumentName);
         QueueTelemetry.RecordQueueDepth([new JobQueueDepthReading(JobType.ClassifyEmailSpam, 41)]);
 
         // Act
         QueueTelemetry.RecordQueueDepth([new JobQueueDepthReading(JobType.ClassifyEmailSpam, 0)]);
 
         // Assert
-        Assert.Equal(0, Assert.Single(collector.ReadObservable(DepthInstrumentName)).Value);
+        measurements.ObserveGaugesAfresh();
+
+        Assert.Equal(
+            0,
+            Assert.Single(PublishedFor(measurements, JobType.ClassifyEmailSpam, DepthInstrumentName)).Value);
     }
 
     /// <summary>An occasion that reached the queue is one decision, and it stepped over nothing.</summary>
@@ -194,16 +214,19 @@ public sealed class JobQueueTelemetryTests
     public void RecordScheduleDispatch_AnOccasionThatWasDispatched_CountsTheDecisionAndNoSkippedOccasion()
     {
         // Arrange
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(
+            ScheduleDispatchesInstrumentName,
+            ScheduleSkipsInstrumentName);
 
         // Act
         QueueTelemetry.RecordScheduleDispatch(Dispatch(JobScheduleDispatchOutcome.Dispatched));
 
         // Assert
-        var dispatch = Assert.Single(collector.ReadOf(JobType.RunScheduledMailRules, ScheduleDispatchesInstrumentName));
+        var dispatch = Assert.Single(
+            PublishedFor(measurements, JobType.RunScheduledMailRules, ScheduleDispatchesInstrumentName));
         Assert.Equal(1, dispatch.Value);
         Assert.Equal("dispatched", dispatch.Tags["mailfathom.job.outcome"]);
-        Assert.Empty(collector.ReadOf(JobType.RunScheduledMailRules, ScheduleSkipsInstrumentName));
+        Assert.Empty(PublishedFor(measurements, JobType.RunScheduledMailRules, ScheduleSkipsInstrumentName));
     }
 
     /// <summary>An occasion that passed while nothing was running is skipped rather than replayed, and the skip is counted.</summary>
@@ -216,13 +239,14 @@ public sealed class JobQueueTelemetryTests
         string expectedTag)
     {
         // Arrange
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(ScheduleSkipsInstrumentName);
 
         // Act
         QueueTelemetry.RecordScheduleDispatch(Dispatch(outcome, skippedOccurrenceCount: 4));
 
         // Assert
-        var skipped = Assert.Single(collector.ReadOf(JobType.RunScheduledMailRules, ScheduleSkipsInstrumentName));
+        var skipped = Assert.Single(
+            PublishedFor(measurements, JobType.RunScheduledMailRules, ScheduleSkipsInstrumentName));
         Assert.Equal(4, skipped.Value);
         Assert.Equal(expectedTag, skipped.Tags["mailfathom.job.outcome"]);
     }
@@ -232,14 +256,17 @@ public sealed class JobQueueTelemetryTests
     public void RecordScheduleDispatch_AnyOccasion_PublishesNeitherTheScheduleNorTheInstantItNamed()
     {
         // Arrange
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(
+            ScheduleDispatchesInstrumentName,
+            ScheduleSkipsInstrumentName);
         var dispatch = Dispatch(JobScheduleDispatchOutcome.Dispatched, skippedOccurrenceCount: 1);
 
         // Act
         QueueTelemetry.RecordScheduleDispatch(dispatch);
 
         // Assert
-        var published = collector.ReadOf(
+        var published = PublishedFor(
+            measurements,
             JobType.RunScheduledMailRules,
             ScheduleDispatchesInstrumentName,
             ScheduleSkipsInstrumentName);
@@ -272,70 +299,14 @@ public sealed class JobQueueTelemetryTests
             AttemptFailure = attemptFailure,
         };
 
-    /// <summary>Reads MailFathom's own meter, which is the only way an instrument published on it can be asserted on.</summary>
-    private sealed class MeasurementCollector : IDisposable
-    {
-        private readonly MeterListener listener = new();
-
-        // Concurrent because the listener is enabled for every instrument on MailFathom's one meter, so any other test
-        // class publishing to it writes here while this one reads — which a plain list reports as a modified collection.
-        private readonly ConcurrentQueue<PublishedMeasurement> measurements = [];
-
-        internal MeasurementCollector()
-        {
-            this.listener.InstrumentPublished = (instrument, activeListener) =>
-            {
-                if (StringComparer.Ordinal.Equals(instrument.Meter.Name, Telemetry.Name))
-                {
-                    activeListener.EnableMeasurementEvents(instrument);
-                }
-            };
-            this.listener.SetMeasurementEventCallback<long>(this.Record);
-            this.listener.SetMeasurementEventCallback<double>(this.Record);
-            this.listener.Start();
-        }
-
-        public void Dispose() => this.listener.Dispose();
-
-        /// <summary>Returns what the named instruments published for this class's job type.</summary>
-        internal IReadOnlyList<PublishedMeasurement> Read(params string[] instrumentNames) =>
-            this.ReadOf(JobType.ClassifyEmailSpam, instrumentNames);
-
-        /// <summary>Returns what the named instruments published for one job type.</summary>
-        internal IReadOnlyList<PublishedMeasurement> ReadOf(JobType jobType, params string[] instrumentNames) =>
+    /// <summary>Selects what the named instruments published for one job type out of what the shared meter recorded.</summary>
+    private static IReadOnlyList<RecordedMeasurement> PublishedFor(
+        RecordedMailFathomMeasurements measurements,
+        JobType jobType,
+        params string[] instrumentNames) =>
         [
-            .. this.measurements.ToArray().Where(measurement =>
-                instrumentNames.Contains(measurement.InstrumentName, StringComparer.Ordinal)
-                && Names(measurement, jobType)),
+            .. instrumentNames
+                .SelectMany(measurements.Read)
+                .Where(measurement => Equals(measurement.Tags.GetValueOrDefault(JobTypeTagName), jobType.Name)),
         ];
-
-        /// <summary>Collects every gauge once and returns what one instrument published for this class's job type.</summary>
-        internal IReadOnlyList<PublishedMeasurement> ReadObservable(string instrumentName)
-        {
-            this.measurements.Clear();
-            this.listener.RecordObservableInstruments();
-
-            return this.Read(instrumentName);
-        }
-
-        private static bool Names(PublishedMeasurement measurement, JobType jobType) =>
-            measurement.Tags.TryGetValue(JobTypeTagName, out var published) && Equals(published, jobType.Name);
-
-        private void Record<TMeasurement>(
-            Instrument instrument,
-            TMeasurement measurement,
-            ReadOnlySpan<KeyValuePair<string, object?>> tags,
-            object? state)
-            where TMeasurement : struct =>
-            this.measurements.Enqueue(new PublishedMeasurement(
-                instrument.Name,
-                Convert.ToDouble(measurement, CultureInfo.InvariantCulture),
-                tags.ToArray().ToDictionary(tag => tag.Key, tag => tag.Value, StringComparer.Ordinal)));
-    }
-
-    /// <summary>One measurement an instrument published, with the dimensions it carried.</summary>
-    private sealed record PublishedMeasurement(
-        string InstrumentName,
-        double Value,
-        IReadOnlyDictionary<string, object?> Tags);
 }

--- a/tests/Infrastructure.UnitTests/Observability/MailSynchronizationTelemetryTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/MailSynchronizationTelemetryTests.cs
@@ -4,11 +4,10 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Diagnostics.Metrics;
-using System.Globalization;
 using MailFathom.Common.Observability;
 using MailFathom.Domain.Accounts;
 using MailFathom.Infrastructure.Observability;
+using MailFathom.TestSupport;
 using Microsoft.Extensions.Time.Testing;
 using Xunit;
 
@@ -104,7 +103,7 @@ public sealed class MailSynchronizationTelemetryTests : IDisposable
     {
         // Arrange
         var account = MailAccountId.Create("records-a-failed-cycle");
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(RunDurationInstrumentName);
 
         // Act
         using (var run = this.telemetry.BeginAccountRun(account))
@@ -114,7 +113,7 @@ public sealed class MailSynchronizationTelemetryTests : IDisposable
         }
 
         // Assert
-        var duration = Assert.Single(collector.Read(RunDurationInstrumentName, account));
+        var duration = Assert.Single(PublishedFor(measurements, RunDurationInstrumentName, account));
 
         Assert.Equal(30, duration.Value);
         Assert.Equal("failed", duration.Tags[OutcomeTagName]);
@@ -126,7 +125,7 @@ public sealed class MailSynchronizationTelemetryTests : IDisposable
     {
         // Arrange
         var account = MailAccountId.Create("records-failed-convergence");
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(RunDurationInstrumentName);
 
         // Act
         using (var run = this.telemetry.BeginAccountRun(account))
@@ -135,7 +134,9 @@ public sealed class MailSynchronizationTelemetryTests : IDisposable
         }
 
         // Assert
-        Assert.Equal("failed", Assert.Single(collector.Read(RunDurationInstrumentName, account)).Tags[OutcomeTagName]);
+        Assert.Equal(
+            "failed",
+            Assert.Single(PublishedFor(measurements, RunDurationInstrumentName, account)).Tags[OutcomeTagName]);
     }
 
     /// <summary>Shutdown ends a cycle without an outcome, and an account stopped is not an account that failed.</summary>
@@ -144,7 +145,7 @@ public sealed class MailSynchronizationTelemetryTests : IDisposable
     {
         // Arrange
         var account = MailAccountId.Create("records-an-interruption");
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(RunDurationInstrumentName);
 
         // Act
         using (this.telemetry.BeginAccountRun(account))
@@ -154,7 +155,7 @@ public sealed class MailSynchronizationTelemetryTests : IDisposable
         // Assert
         Assert.Equal(
             "interrupted",
-            Assert.Single(collector.Read(RunDurationInstrumentName, account)).Tags[OutcomeTagName]);
+            Assert.Single(PublishedFor(measurements, RunDurationInstrumentName, account)).Tags[OutcomeTagName]);
     }
 
     /// <summary>Counting messages is what says a mailbox is being brought in, and the two counts narrow for different reasons.</summary>
@@ -163,7 +164,9 @@ public sealed class MailSynchronizationTelemetryTests : IDisposable
     {
         // Arrange
         var account = MailAccountId.Create("counts-its-messages");
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(
+            StoredEmailsInstrumentName,
+            SkippedEmailsInstrumentName);
 
         // Act
         using (var folder = this.telemetry.BeginFolderRun(account))
@@ -172,8 +175,8 @@ public sealed class MailSynchronizationTelemetryTests : IDisposable
         }
 
         // Assert
-        var stored = Assert.Single(collector.Read(StoredEmailsInstrumentName, account));
-        var skipped = Assert.Single(collector.Read(SkippedEmailsInstrumentName, account));
+        var stored = Assert.Single(PublishedFor(measurements, StoredEmailsInstrumentName, account));
+        var skipped = Assert.Single(PublishedFor(measurements, SkippedEmailsInstrumentName, account));
 
         Assert.Equal(12, stored.Value);
         Assert.Equal("ARCHIVE", stored.Tags[FolderTagName]);
@@ -196,7 +199,7 @@ public sealed class MailSynchronizationTelemetryTests : IDisposable
             "mail_server_unavailable" => folder => folder.MailServerUnavailable("INBOX"),
             _ => folder => folder.UnexpectedFailure("INBOX"),
         };
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(FailuresInstrumentName);
 
         // Act
         using (var folder = this.telemetry.BeginFolderRun(account))
@@ -205,7 +208,7 @@ public sealed class MailSynchronizationTelemetryTests : IDisposable
         }
 
         // Assert
-        var failure = Assert.Single(collector.Read(FailuresInstrumentName, account));
+        var failure = Assert.Single(PublishedFor(measurements, FailuresInstrumentName, account));
 
         Assert.Equal(1, failure.Value);
         Assert.Equal(expected, failure.Tags[FailureTagName]);
@@ -222,7 +225,7 @@ public sealed class MailSynchronizationTelemetryTests : IDisposable
     {
         // Arrange
         var account = MailAccountId.Create(accountId);
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(FailuresInstrumentName);
 
         // Act
         using (var folder = this.telemetry.BeginFolderRun(account))
@@ -238,7 +241,7 @@ public sealed class MailSynchronizationTelemetryTests : IDisposable
         }
 
         // Assert
-        Assert.Empty(collector.Read(FailuresInstrumentName, account));
+        Assert.Empty(PublishedFor(measurements, FailuresInstrumentName, account));
         Assert.Equal(expected, this.PublishedSpan(account, "synchronize_folder").GetTagItem(OutcomeTagName));
     }
 
@@ -248,7 +251,7 @@ public sealed class MailSynchronizationTelemetryTests : IDisposable
     {
         // Arrange
         var account = MailAccountId.Create("interrupted-folder");
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(FailuresInstrumentName);
 
         // Act
         using (var folder = this.telemetry.BeginFolderRun(account))
@@ -257,7 +260,7 @@ public sealed class MailSynchronizationTelemetryTests : IDisposable
         }
 
         // Assert
-        Assert.Empty(collector.Read(FailuresInstrumentName, account));
+        Assert.Empty(PublishedFor(measurements, FailuresInstrumentName, account));
         Assert.Equal("interrupted", this.PublishedSpan(account, "synchronize_folder").GetTagItem(OutcomeTagName));
     }
 
@@ -267,14 +270,18 @@ public sealed class MailSynchronizationTelemetryTests : IDisposable
     {
         // Arrange
         var account = MailAccountId.Create("is-backing-off");
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(
+            BackoffInstrumentName,
+            ConsecutiveFailuresInstrumentName);
 
         // Act
         this.telemetry.RecordScheduledDelay(account, TimeSpan.FromMinutes(8), consecutiveFailureCount: 3);
 
         // Assert
-        Assert.Equal(480, Assert.Single(collector.ReadGauge(BackoffInstrumentName, account)).Value);
-        Assert.Equal(3, Assert.Single(collector.ReadGauge(ConsecutiveFailuresInstrumentName, account)).Value);
+        measurements.ObserveGaugesAfresh();
+
+        Assert.Equal(480, Assert.Single(PublishedFor(measurements, BackoffInstrumentName, account)).Value);
+        Assert.Equal(3, Assert.Single(PublishedFor(measurements, ConsecutiveFailuresInstrumentName, account)).Value);
     }
 
     /// <summary>An account nobody supervises any more must stop reporting, or its last wait reads as an account still waiting.</summary>
@@ -283,7 +290,9 @@ public sealed class MailSynchronizationTelemetryTests : IDisposable
     {
         // Arrange
         var account = MailAccountId.Create("left-configuration");
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(
+            BackoffInstrumentName,
+            ConsecutiveFailuresInstrumentName);
 
         this.telemetry.RecordScheduledDelay(account, TimeSpan.FromMinutes(5), consecutiveFailureCount: 0);
 
@@ -291,8 +300,10 @@ public sealed class MailSynchronizationTelemetryTests : IDisposable
         this.telemetry.RecordSupervisionEnded(account);
 
         // Assert
-        Assert.Empty(collector.ReadGauge(BackoffInstrumentName, account));
-        Assert.Empty(collector.ReadGauge(ConsecutiveFailuresInstrumentName, account));
+        measurements.ObserveGaugesAfresh();
+
+        Assert.Empty(PublishedFor(measurements, BackoffInstrumentName, account));
+        Assert.Empty(PublishedFor(measurements, ConsecutiveFailuresInstrumentName, account));
     }
 
     /// <summary>The depth is what separates a pipeline that is idle from one whose accounts are all queued behind the bound.</summary>
@@ -307,19 +318,25 @@ public sealed class MailSynchronizationTelemetryTests : IDisposable
     {
         // Arrange
         var account = MailAccountId.Create("waits-for-a-slot");
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(
+            QueuedRunsInstrumentName,
+            ActiveRunsInstrumentName);
 
         // Act and assert
         using (this.telemetry.EnterRunQueue())
         using (this.telemetry.EnterRunQueue())
         using (this.telemetry.BeginAccountRun(account))
         {
-            Assert.Contains(collector.ReadUntaggedGauge(QueuedRunsInstrumentName), gauge => gauge.Value == 2);
-            Assert.Contains(collector.ReadUntaggedGauge(ActiveRunsInstrumentName), gauge => gauge.Value == 1);
+            measurements.ObserveGaugesAfresh();
+
+            Assert.Contains(measurements.Read(QueuedRunsInstrumentName), gauge => gauge.Value == 2);
+            Assert.Contains(measurements.Read(ActiveRunsInstrumentName), gauge => gauge.Value == 1);
         }
 
-        Assert.All(collector.ReadUntaggedGauge(QueuedRunsInstrumentName), gauge => Assert.Equal(0, gauge.Value));
-        Assert.All(collector.ReadUntaggedGauge(ActiveRunsInstrumentName), gauge => Assert.Equal(0, gauge.Value));
+        measurements.ObserveGaugesAfresh();
+
+        Assert.All(measurements.Read(QueuedRunsInstrumentName), gauge => Assert.Equal(0, gauge.Value));
+        Assert.All(measurements.Read(ActiveRunsInstrumentName), gauge => Assert.Equal(0, gauge.Value));
     }
 
     /// <summary>
@@ -331,7 +348,7 @@ public sealed class MailSynchronizationTelemetryTests : IDisposable
     {
         // Arrange
         var account = MailAccountId.Create("carries-no-mail");
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements();
 
         // Act
         using (var run = this.telemetry.BeginAccountRun(account))
@@ -350,7 +367,8 @@ public sealed class MailSynchronizationTelemetryTests : IDisposable
             .SelectMany(activity => activity.TagObjects)
             .Select(tag => tag.Key)
             .Distinct(StringComparer.Ordinal);
-        var measurementTagNames = collector.ReadEverythingFor(account)
+        var measurementTagNames = measurements.Recorded
+            .Where(measurement => Equals(measurement.Tags.GetValueOrDefault(AccountTagName), account.Value))
             .SelectMany(measurement => measurement.Tags.Keys)
             .Distinct(StringComparer.Ordinal);
 
@@ -371,98 +389,19 @@ public sealed class MailSynchronizationTelemetryTests : IDisposable
         "mailfathom.mail.sync.skipped",
     ];
 
+    /// <summary>Selects what one instrument published for one account, which is what tells one test's cycle from another's.</summary>
+    private static IReadOnlyList<RecordedMeasurement> PublishedFor(
+        RecordedMailFathomMeasurements measurements,
+        string instrumentName,
+        MailAccountId accountId) =>
+        [
+            .. measurements.Read(instrumentName).Where(measurement =>
+                Equals(measurement.Tags.GetValueOrDefault(AccountTagName), accountId.Value)),
+        ];
+
     /// <summary>Selects one span this test produced out of whatever the shared source published while it ran.</summary>
     private Activity PublishedSpan(MailAccountId accountId, string operationName) => Assert.Single(
         this.published,
         activity => activity.OperationName == operationName
             && Equals(activity.GetTagItem(AccountTagName), accountId.Value));
-
-    /// <summary>Collects what the application's meter publishes while one test runs.</summary>
-    /// <remarks>
-    /// The collection is concurrent because the writer and the reader are not the same thread: this listener enables
-    /// every instrument of the process-wide meter, and xUnit runs test classes in parallel, so a class publishing its
-    /// own telemetry records here from whichever thread it runs on. Every read filters by instrument and by account for
-    /// the same reason.
-    /// </remarks>
-    private sealed class MeasurementCollector : IDisposable
-    {
-        private readonly MeterListener listener = new();
-        private readonly ConcurrentQueue<PublishedMeasurement> measurements = new();
-
-        internal MeasurementCollector()
-        {
-            this.listener.InstrumentPublished = (instrument, activeListener) =>
-            {
-                if (StringComparer.Ordinal.Equals(instrument.Meter.Name, Telemetry.Name))
-                {
-                    activeListener.EnableMeasurementEvents(instrument);
-                }
-            };
-            this.listener.SetMeasurementEventCallback<long>(this.Record);
-            this.listener.SetMeasurementEventCallback<double>(this.Record);
-            this.listener.Start();
-        }
-
-        public void Dispose() => this.listener.Dispose();
-
-        /// <summary>Returns what one instrument published for one account since this collector started.</summary>
-        internal IReadOnlyList<PublishedMeasurement> Read(string instrumentName, MailAccountId accountId) =>
-        [
-            .. this.measurements.Where(measurement =>
-                StringComparer.Ordinal.Equals(measurement.InstrumentName, instrumentName)
-                && measurement.Tags.TryGetValue(AccountTagName, out var account)
-                && Equals(account, accountId.Value)),
-        ];
-
-        /// <summary>Returns everything published for one account, whichever instrument published it.</summary>
-        internal IReadOnlyList<PublishedMeasurement> ReadEverythingFor(MailAccountId accountId) =>
-        [
-            .. this.measurements.Where(measurement =>
-                measurement.Tags.TryGetValue(AccountTagName, out var account)
-                && Equals(account, accountId.Value)),
-        ];
-
-        /// <summary>Collects the gauges once and returns what one of them published for one account.</summary>
-        internal IReadOnlyList<PublishedMeasurement> ReadGauge(string instrumentName, MailAccountId accountId)
-        {
-            this.CollectGauges();
-
-            return this.Read(instrumentName, accountId);
-        }
-
-        /// <summary>Collects the gauges once and returns what one instrument published for the process.</summary>
-        internal IReadOnlyList<PublishedMeasurement> ReadUntaggedGauge(string instrumentName)
-        {
-            this.CollectGauges();
-
-            return
-            [
-                .. this.measurements.Where(measurement =>
-                    StringComparer.Ordinal.Equals(measurement.InstrumentName, instrumentName)),
-            ];
-        }
-
-        private void CollectGauges()
-        {
-            this.measurements.Clear();
-            this.listener.RecordObservableInstruments();
-        }
-
-        private void Record<TMeasurement>(
-            Instrument instrument,
-            TMeasurement measurement,
-            ReadOnlySpan<KeyValuePair<string, object?>> tags,
-            object? state)
-            where TMeasurement : struct =>
-            this.measurements.Enqueue(new PublishedMeasurement(
-                instrument.Name,
-                Convert.ToDouble(measurement, CultureInfo.InvariantCulture),
-                tags.ToArray().ToDictionary(tag => tag.Key, tag => tag.Value, StringComparer.Ordinal)));
-    }
-
-    /// <summary>One measurement an instrument published, with the dimensions it carried.</summary>
-    private sealed record PublishedMeasurement(
-        string InstrumentName,
-        double Value,
-        IReadOnlyDictionary<string, object?> Tags);
 }

--- a/tests/Infrastructure.UnitTests/Observability/MailboxContentVolumeTelemetryTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/MailboxContentVolumeTelemetryTests.cs
@@ -2,11 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Collections.Concurrent;
-using System.Diagnostics.Metrics;
-using System.Globalization;
 using MailFathom.Application.Synchronization;
-using MailFathom.Common.Observability;
 using MailFathom.Domain.Accounts;
 using MailFathom.Infrastructure.Observability;
 using MailFathom.TestSupport;
@@ -60,17 +56,17 @@ public sealed class MailboxContentVolumeTelemetryTests : IDisposable
     {
         // Arrange
         var account = MailAccountId.Create("counts-bytes");
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(FetchedInstrumentName, StoredInstrumentName);
 
         // Act
         this.telemetry.Report(account, "INBOX", VolumeWith(fetchedBytes: 5000, storedBytes: 4800));
 
         // Assert
-        var fetched = Assert.Single(collector.Read(FetchedInstrumentName, account));
+        var fetched = Assert.Single(ReportedFor(measurements, FetchedInstrumentName, account));
         Assert.Equal(5000, fetched.Value);
         Assert.Equal("INBOX", fetched.Tags[FolderTagName]);
 
-        var stored = Assert.Single(collector.Read(StoredInstrumentName, account));
+        var stored = Assert.Single(ReportedFor(measurements, StoredInstrumentName, account));
         Assert.Equal(4800, stored.Value);
     }
 
@@ -84,7 +80,7 @@ public sealed class MailboxContentVolumeTelemetryTests : IDisposable
     {
         // Arrange
         var account = MailAccountId.Create("spent-its-budget");
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(LimitsReachedInstrumentName);
 
         // Act
         this.telemetry.Report(
@@ -93,7 +89,7 @@ public sealed class MailboxContentVolumeTelemetryTests : IDisposable
             VolumeWith(fetchedBytes: 1000, storedBytes: 1000) with { StoppedForContentBudget = true });
 
         // Assert
-        var limit = Assert.Single(collector.Read(LimitsReachedInstrumentName, account));
+        var limit = Assert.Single(ReportedFor(measurements, LimitsReachedInstrumentName, account));
         Assert.Equal(1, limit.Value);
         Assert.Equal("run_budget", limit.Tags[LimitTagName]);
         Assert.Contains(
@@ -107,7 +103,7 @@ public sealed class MailboxContentVolumeTelemetryTests : IDisposable
     {
         // Arrange
         var account = MailAccountId.Create("reached-its-ceiling");
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(LimitsReachedInstrumentName);
 
         // Act
         this.telemetry.Report(
@@ -116,7 +112,7 @@ public sealed class MailboxContentVolumeTelemetryTests : IDisposable
             VolumeWith(fetchedBytes: 0, storedBytes: 0) with { DeferredForStorageEmailCount = 3 });
 
         // Assert
-        var limit = Assert.Single(collector.Read(LimitsReachedInstrumentName, account));
+        var limit = Assert.Single(ReportedFor(measurements, LimitsReachedInstrumentName, account));
         Assert.Equal(1, limit.Value);
         Assert.Equal("storage_ceiling", limit.Tags[LimitTagName]);
         Assert.Contains(
@@ -131,27 +127,27 @@ public sealed class MailboxContentVolumeTelemetryTests : IDisposable
     {
         // Arrange
         var account = MailAccountId.Create("reached-no-limit");
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(LimitsReachedInstrumentName);
 
         // Act
         this.telemetry.Report(account, "INBOX", VolumeWith(fetchedBytes: 10, storedBytes: 10));
 
         // Assert
-        Assert.Empty(collector.Read(LimitsReachedInstrumentName, account));
+        Assert.Empty(ReportedFor(measurements, LimitsReachedInstrumentName, account));
     }
 
     /// <summary>The level is the deployment's, so it carries no account dimension for a dashboard to sum.</summary>
     /// <remarks>
     /// The gauge is read by value rather than as the only one published, because the meter is process-wide and each
     /// test of this class constructs a telemetry of its own: every instance registers a gauge that outlives its test,
-    /// so the collector sees one measurement per instance built so far. Only the one this test produced says anything
+    /// so the recorder sees one measurement per instance built so far. Only the one this test produced says anything
     /// about it. Production builds a single instance, which is why the duplication is a property of the suite alone.
     /// </remarks>
     [Fact]
     public void Report_AnyRun_PublishesTheMeasuredLevelWithoutAnAccountDimension()
     {
         // Arrange
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(StoredTotalInstrumentName);
 
         // Act
         this.telemetry.Report(
@@ -160,8 +156,10 @@ public sealed class MailboxContentVolumeTelemetryTests : IDisposable
             VolumeWith(fetchedBytes: 0, storedBytes: 0) with { StoredContentBytes = 987_654 });
 
         // Assert
+        measurements.ObserveGaugesAfresh();
+
         var level = Assert.Single(
-            collector.ReadUntagged(StoredTotalInstrumentName),
+            measurements.Read(StoredTotalInstrumentName),
             measurement => measurement.Value == 987_654);
 
         Assert.DoesNotContain(AccountTagName, level.Tags.Keys);
@@ -194,75 +192,13 @@ public sealed class MailboxContentVolumeTelemetryTests : IDisposable
         RefilledEmailCount: 0,
         StoppedForContentBudget: false);
 
-    /// <summary>Collects what the application's meter publishes while one test runs.</summary>
-    /// <remarks>
-    /// The collection is concurrent because the writer and the reader are not the same thread. This listener enables
-    /// every instrument of the process-wide meter, so a test in another class reporting its own telemetry calls
-    /// <see cref="Record" /> from whatever thread it runs on, and xUnit runs classes in parallel. A plain
-    /// <see cref="List{T}" /> here failed with <c>Collection was modified</c> out of the reading query rather than out
-    /// of anything the failing test did — the kind of defect that reports itself against whichever test happened to be
-    /// reading. Enumerating a <see cref="ConcurrentQueue{T}" /> takes a moment-in-time snapshot instead, which is also
-    /// why a read may see a measurement another test produced: the reads below filter by instrument, and the assertions
-    /// select by value, for the reason the class remark already gives.
-    /// </remarks>
-    private sealed class MeasurementCollector : IDisposable
-    {
-        private readonly MeterListener listener = new();
-        private readonly ConcurrentQueue<PublishedMeasurement> measurements = new();
-
-        internal MeasurementCollector()
-        {
-            this.listener.InstrumentPublished = (instrument, activeListener) =>
-            {
-                if (StringComparer.Ordinal.Equals(instrument.Meter.Name, Telemetry.Name))
-                {
-                    activeListener.EnableMeasurementEvents(instrument);
-                }
-            };
-            this.listener.SetMeasurementEventCallback<long>(this.Record);
-            this.listener.SetMeasurementEventCallback<double>(this.Record);
-            this.listener.Start();
-        }
-
-        public void Dispose() => this.listener.Dispose();
-
-        /// <summary>Returns what one instrument published for one account since this collector started.</summary>
-        internal IReadOnlyList<PublishedMeasurement> Read(string instrumentName, MailAccountId accountId) =>
+    /// <summary>Selects what one instrument published for one account, which is what tells one run's report from another's.</summary>
+    private static IReadOnlyList<RecordedMeasurement> ReportedFor(
+        RecordedMailFathomMeasurements measurements,
+        string instrumentName,
+        MailAccountId accountId) =>
         [
-            .. this.measurements.Where(measurement =>
-                StringComparer.Ordinal.Equals(measurement.InstrumentName, instrumentName)
-                && measurement.Tags.TryGetValue(AccountTagName, out var account)
-                && Equals(account, accountId.Value)),
+            .. measurements.Read(instrumentName).Where(measurement =>
+                Equals(measurement.Tags.GetValueOrDefault(AccountTagName), accountId.Value)),
         ];
-
-        /// <summary>Collects the gauges once and returns what one instrument published for the process.</summary>
-        internal IReadOnlyList<PublishedMeasurement> ReadUntagged(string instrumentName)
-        {
-            this.measurements.Clear();
-            this.listener.RecordObservableInstruments();
-
-            return
-            [
-                .. this.measurements.Where(measurement =>
-                    StringComparer.Ordinal.Equals(measurement.InstrumentName, instrumentName)),
-            ];
-        }
-
-        private void Record<TMeasurement>(
-            Instrument instrument,
-            TMeasurement measurement,
-            ReadOnlySpan<KeyValuePair<string, object?>> tags,
-            object? state)
-            where TMeasurement : struct =>
-            this.measurements.Enqueue(new PublishedMeasurement(
-                instrument.Name,
-                Convert.ToDouble(measurement, CultureInfo.InvariantCulture),
-                tags.ToArray().ToDictionary(tag => tag.Key, tag => tag.Value, StringComparer.Ordinal)));
-    }
-
-    /// <summary>One measurement an instrument published, with the dimensions it carried.</summary>
-    private sealed record PublishedMeasurement(
-        string InstrumentName,
-        double Value,
-        IReadOnlyDictionary<string, object?> Tags);
 }

--- a/tests/Infrastructure.UnitTests/Observability/MailboxConvergenceTelemetryTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/MailboxConvergenceTelemetryTests.cs
@@ -2,11 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Collections.Concurrent;
-using System.Diagnostics.Metrics;
-using System.Globalization;
 using MailFathom.Application.Mail.Mutations.Convergence;
-using MailFathom.Common.Observability;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Mutations;
 using MailFathom.Infrastructure.Observability;
@@ -59,7 +55,7 @@ public sealed class MailboxConvergenceTelemetryTests : IDisposable
     {
         // Arrange
         var account = MailAccountId.Create("counts-by-kind");
-        using var collector = new GaugeCollector();
+        using var measurements = new RecordedMailFathomMeasurements(OutstandingInstrumentName);
 
         // Act
         this.telemetry.Report(account, ReportWith(
@@ -70,7 +66,9 @@ public sealed class MailboxConvergenceTelemetryTests : IDisposable
                 RecordedAt)));
 
         // Assert
-        var published = Assert.Single(collector.Read(OutstandingInstrumentName, account));
+        measurements.ObserveGaugesAfresh();
+
+        var published = Assert.Single(ReportedFor(measurements, OutstandingInstrumentName, account));
         Assert.Equal(2, published.Value);
         Assert.Equal("relocate", published.Tags["mailfathom.mailbox.mutation"]);
         Assert.Equal("dead-lettered", published.Tags["mailfathom.mailbox.mutation.lifecycle"]);
@@ -85,7 +83,7 @@ public sealed class MailboxConvergenceTelemetryTests : IDisposable
     {
         // Arrange
         var account = MailAccountId.Create("age-at-read-time");
-        using var collector = new GaugeCollector();
+        using var measurements = new RecordedMailFathomMeasurements(OldestAgeInstrumentName);
         this.telemetry.Report(account, ReportWith(
             new MailboxMutationLifecycleCount(
                 MailboxMutation.Copy,
@@ -95,9 +93,11 @@ public sealed class MailboxConvergenceTelemetryTests : IDisposable
 
         // Act
         this.clock.Advance(TimeSpan.FromMinutes(30));
-        var ages = collector.Read(OldestAgeInstrumentName, account);
+        measurements.ObserveGaugesAfresh();
 
         // Assert
+        var ages = ReportedFor(measurements, OldestAgeInstrumentName, account);
+
         Assert.Equal(TimeSpan.FromMinutes(30).TotalSeconds, Assert.Single(ages).Value);
     }
 
@@ -110,7 +110,7 @@ public sealed class MailboxConvergenceTelemetryTests : IDisposable
     {
         // Arrange
         var account = MailAccountId.Create("emptied");
-        using var collector = new GaugeCollector();
+        using var measurements = new RecordedMailFathomMeasurements(OutstandingInstrumentName);
         this.telemetry.Report(account, ReportWith(
             new MailboxMutationLifecycleCount(
                 MailboxMutation.Delete,
@@ -122,7 +122,9 @@ public sealed class MailboxConvergenceTelemetryTests : IDisposable
         this.telemetry.Report(account, new MailboxConvergenceReport(1, 0, 0, 0, []));
 
         // Assert
-        Assert.Empty(collector.Read(OutstandingInstrumentName, account));
+        measurements.ObserveGaugesAfresh();
+
+        Assert.Empty(ReportedFor(measurements, OutstandingInstrumentName, account));
     }
 
     /// <summary>Most passes have nothing to do, and a line per account per interval is noise an operator learns to ignore.</summary>
@@ -158,68 +160,20 @@ public sealed class MailboxConvergenceTelemetryTests : IDisposable
     private static MailboxConvergenceReport ReportWith(params MailboxMutationLifecycleCount[] outstanding) =>
         new(0, 0, 0, 0, outstanding);
 
+    /// <summary>Selects what one gauge reported for one account, which is what tells this test's from its neighbours'.</summary>
+    private static IReadOnlyList<RecordedMeasurement> ReportedFor(
+        RecordedMailFathomMeasurements measurements,
+        string instrumentName,
+        MailAccountId accountId) =>
+        [
+            .. measurements.Read(instrumentName).Where(measurement =>
+                Equals(measurement.Tags.GetValueOrDefault(AccountTagName), accountId.Value)),
+        ];
+
     private IReadOnlyList<RecordingLoggerProvider.LogRecord> RecordsFor(MailAccountId accountId) =>
         [
             .. this.logs.Records.Where(record =>
                 record.Properties.TryGetValue("AccountId", out var loggedAccount)
                 && Equals(loggedAccount, accountId.Value)),
         ];
-
-    /// <summary>Reads MailFathom's own meter on demand, which is the only way an observable gauge can be asserted on.</summary>
-    private sealed class GaugeCollector : IDisposable
-    {
-        private readonly MeterListener listener = new();
-
-        // Concurrent because the listener is enabled for every instrument on MailFathom's one meter, so any other test
-        // class publishing to it writes here while this one reads — which a plain list reports as a modified collection.
-        private readonly ConcurrentQueue<PublishedMeasurement> measurements = [];
-
-        internal GaugeCollector()
-        {
-            this.listener.InstrumentPublished = (instrument, activeListener) =>
-            {
-                if (StringComparer.Ordinal.Equals(instrument.Meter.Name, Telemetry.Name))
-                {
-                    activeListener.EnableMeasurementEvents(instrument);
-                }
-            };
-            this.listener.SetMeasurementEventCallback<long>(this.Record);
-            this.listener.SetMeasurementEventCallback<double>(this.Record);
-            this.listener.Start();
-        }
-
-        public void Dispose() => this.listener.Dispose();
-
-        /// <summary>Collects every gauge once and returns what one instrument published for one account.</summary>
-        internal IReadOnlyList<PublishedMeasurement> Read(string instrumentName, MailAccountId accountId)
-        {
-            this.measurements.Clear();
-            this.listener.RecordObservableInstruments();
-
-            return
-            [
-                .. this.measurements.ToArray().Where(measurement =>
-                    StringComparer.Ordinal.Equals(measurement.InstrumentName, instrumentName)
-                    && measurement.Tags.TryGetValue(AccountTagName, out var account)
-                    && Equals(account, accountId.Value)),
-            ];
-        }
-
-        private void Record<TMeasurement>(
-            Instrument instrument,
-            TMeasurement measurement,
-            ReadOnlySpan<KeyValuePair<string, object?>> tags,
-            object? state)
-            where TMeasurement : struct =>
-            this.measurements.Enqueue(new PublishedMeasurement(
-                instrument.Name,
-                Convert.ToDouble(measurement, CultureInfo.InvariantCulture),
-                tags.ToArray().ToDictionary(tag => tag.Key, tag => tag.Value, StringComparer.Ordinal)));
-    }
-
-    /// <summary>One measurement a gauge published, with the dimensions it carried.</summary>
-    private sealed record PublishedMeasurement(
-        string InstrumentName,
-        double Value,
-        IReadOnlyDictionary<string, object?> Tags);
 }

--- a/tests/Infrastructure.UnitTests/Observability/MailboxMutationTelemetryTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/MailboxMutationTelemetryTests.cs
@@ -4,8 +4,6 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Diagnostics.Metrics;
-using System.Globalization;
 using MailFathom.Common.Observability;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Folders;
@@ -20,7 +18,7 @@ namespace MailFathom.Infrastructure.UnitTests.Observability;
 
 /// <summary>Covers the three endings a mutation is published under, and the dimensions it is published by.</summary>
 /// <remarks>
-/// The listener and the collector both observe the application's own source and meter, which everything MailFathom
+/// The listener and the recorder both observe the application's own source and meter, which everything MailFathom
 /// publishes shares, so each test names an account of its own and reads only what carries it. That is what keeps a
 /// mutation published by another test class at the same moment out of these assertions.
 /// </remarks>
@@ -75,7 +73,7 @@ public sealed class MailboxMutationTelemetryTests : IDisposable
     {
         // Arrange
         var account = MailAccountId.Create("publishes-succeeded");
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(CountInstrumentName);
 
         // Act
         using (var scope = this.telemetry.Begin(
@@ -88,7 +86,7 @@ public sealed class MailboxMutationTelemetryTests : IDisposable
         }
 
         // Assert
-        var counted = Assert.Single(collector.Read(CountInstrumentName, account));
+        var counted = Assert.Single(PublishedFor(measurements, CountInstrumentName, account));
 
         Assert.Equal(1, counted.Value);
         Assert.Equal(MailboxMutation.Relocate.Name, counted.Tags[MutationTagName]);
@@ -112,7 +110,9 @@ public sealed class MailboxMutationTelemetryTests : IDisposable
     {
         // Arrange
         var account = MailAccountId.Create("publishes-cancelled");
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(
+            CountInstrumentName,
+            DurationInstrumentName);
         using var caller = new CancellationTokenSource();
 
         // Act
@@ -122,8 +122,12 @@ public sealed class MailboxMutationTelemetryTests : IDisposable
         }
 
         // Assert
-        Assert.Equal("cancelled", Assert.Single(collector.Read(CountInstrumentName, account)).Tags[OutcomeTagName]);
-        Assert.Equal("cancelled", Assert.Single(collector.Read(DurationInstrumentName, account)).Tags[OutcomeTagName]);
+        Assert.Equal(
+            "cancelled",
+            Assert.Single(PublishedFor(measurements, CountInstrumentName, account)).Tags[OutcomeTagName]);
+        Assert.Equal(
+            "cancelled",
+            Assert.Single(PublishedFor(measurements, DurationInstrumentName, account)).Tags[OutcomeTagName]);
 
         Assert.Equal(ActivityStatusCode.Unset, this.SpanOf(account).Status);
     }
@@ -134,7 +138,7 @@ public sealed class MailboxMutationTelemetryTests : IDisposable
     {
         // Arrange
         var account = MailAccountId.Create("publishes-failed");
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(CountInstrumentName);
 
         // Act
         using (this.telemetry.Begin(MailboxMutation.SetSeen, account, Folder, TestContext.Current.CancellationToken))
@@ -142,7 +146,9 @@ public sealed class MailboxMutationTelemetryTests : IDisposable
         }
 
         // Assert
-        Assert.Equal("failed", Assert.Single(collector.Read(CountInstrumentName, account)).Tags[OutcomeTagName]);
+        Assert.Equal(
+            "failed",
+            Assert.Single(PublishedFor(measurements, CountInstrumentName, account)).Tags[OutcomeTagName]);
         Assert.Equal(ActivityStatusCode.Error, this.SpanOf(account).Status);
     }
 
@@ -177,7 +183,7 @@ public sealed class MailboxMutationTelemetryTests : IDisposable
     {
         // Arrange
         var account = MailAccountId.Create("publishes-filing");
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(CountInstrumentName);
 
         // Act
         using (var scope = this.telemetry.BeginFiling(
@@ -190,63 +196,24 @@ public sealed class MailboxMutationTelemetryTests : IDisposable
         }
 
         // Assert
-        var counted = Assert.Single(collector.Read(CountInstrumentName, account));
+        var counted = Assert.Single(PublishedFor(measurements, CountInstrumentName, account));
 
         Assert.Equal("file-outgoing-copy", counted.Tags[MutationTagName]);
         Assert.Equal("succeeded", counted.Tags[OutcomeTagName]);
     }
 
+    /// <summary>Selects what one instrument published for one account, which is what tells one test's write from another's.</summary>
+    private static IReadOnlyList<RecordedMeasurement> PublishedFor(
+        RecordedMailFathomMeasurements measurements,
+        string instrumentName,
+        MailAccountId accountId) =>
+        [
+            .. measurements.Read(instrumentName).Where(measurement =>
+                Equals(measurement.Tags.GetValueOrDefault(AccountTagName), accountId.Value)),
+        ];
+
     private Activity SpanOf(MailAccountId accountId) =>
         Assert.Single(
             this.published,
             activity => Equals(activity.GetTagItem(AccountTagName), accountId.Value));
-
-    /// <summary>Collects what the application's meter published while one test ran.</summary>
-    private sealed class MeasurementCollector : IDisposable
-    {
-        private readonly MeterListener listener = new();
-        private readonly ConcurrentQueue<PublishedMeasurement> measurements = new();
-
-        internal MeasurementCollector()
-        {
-            this.listener.InstrumentPublished = (instrument, activeListener) =>
-            {
-                if (StringComparer.Ordinal.Equals(instrument.Meter.Name, Telemetry.Name))
-                {
-                    activeListener.EnableMeasurementEvents(instrument);
-                }
-            };
-            this.listener.SetMeasurementEventCallback<long>(this.Record);
-            this.listener.SetMeasurementEventCallback<double>(this.Record);
-            this.listener.Start();
-        }
-
-        public void Dispose() => this.listener.Dispose();
-
-        /// <summary>Returns what one instrument published for one account since this collector started.</summary>
-        internal IReadOnlyList<PublishedMeasurement> Read(string instrumentName, MailAccountId accountId) =>
-        [
-            .. this.measurements.Where(measurement =>
-                StringComparer.Ordinal.Equals(measurement.InstrumentName, instrumentName)
-                && measurement.Tags.TryGetValue(AccountTagName, out var account)
-                && Equals(account, accountId.Value)),
-        ];
-
-        private void Record<TMeasurement>(
-            Instrument instrument,
-            TMeasurement measurement,
-            ReadOnlySpan<KeyValuePair<string, object?>> tags,
-            object? state)
-            where TMeasurement : struct =>
-            this.measurements.Enqueue(new PublishedMeasurement(
-                instrument.Name,
-                Convert.ToDouble(measurement, CultureInfo.InvariantCulture),
-                tags.ToArray().ToDictionary(tag => tag.Key, tag => tag.Value, StringComparer.Ordinal)));
-    }
-
-    /// <summary>One measurement an instrument published, with the dimensions it carried.</summary>
-    private sealed record PublishedMeasurement(
-        string InstrumentName,
-        double Value,
-        IReadOnlyDictionary<string, object?> Tags);
 }

--- a/tests/Infrastructure.UnitTests/Observability/SensitiveContentDerivationTelemetryTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/SensitiveContentDerivationTelemetryTests.cs
@@ -2,14 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Collections.Concurrent;
-using System.Diagnostics.Metrics;
-using System.Globalization;
 using MailFathom.Application.SensitiveContent;
 using MailFathom.Application.SensitiveContent.Detection;
 using MailFathom.Application.SensitiveContent.Redaction;
-using MailFathom.Common.Observability;
 using MailFathom.Infrastructure.Observability;
+using MailFathom.TestSupport;
 using Xunit;
 
 namespace MailFathom.Infrastructure.UnitTests.Observability;
@@ -39,7 +36,7 @@ public sealed class SensitiveContentDerivationTelemetryTests
     public void RecordDerived_ARedactedText_CountsItAndTimesTheScanItCost()
     {
         // Arrange
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(RedactedInstrumentName, DurationInstrumentName);
 
         // Act
         this.telemetry.RecordDerived(
@@ -47,11 +44,8 @@ public sealed class SensitiveContentDerivationTelemetryTests
             TimeSpan.FromMilliseconds(250));
 
         // Assert
-        var redacted = Assert.Single(collector.Read(RedactedInstrumentName));
-        var duration = Assert.Single(collector.Read(DurationInstrumentName));
-
-        Assert.Equal(1, redacted.Value);
-        Assert.Equal(0.25, duration.Value);
+        Assert.Equal([1d], measurements.ValuesOf(RedactedInstrumentName));
+        Assert.Equal([0.25d], measurements.ValuesOf(DurationInstrumentName));
     }
 
     /// <summary>Which kind of material a mailbox produces is what decides whether a category list is right.</summary>
@@ -59,7 +53,7 @@ public sealed class SensitiveContentDerivationTelemetryTests
     public void RecordDerived_FindingsOfSeveralCategories_CountsEachCategoryOnItsOwnSeries()
     {
         // Arrange
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(FindingsInstrumentName);
 
         // Act
         this.telemetry.RecordDerived(
@@ -74,7 +68,7 @@ public sealed class SensitiveContentDerivationTelemetryTests
             TimeSpan.FromMilliseconds(10));
 
         // Assert
-        var findings = collector.Read(FindingsInstrumentName);
+        var findings = measurements.Read(FindingsInstrumentName);
 
         Assert.Equal(
             [("CloudKey", 2d), ("EmailAddress", 1d)],
@@ -86,7 +80,7 @@ public sealed class SensitiveContentDerivationTelemetryTests
     public void RecordDerived_ATextTheCeilingDidNotCut_ReportsNoOmission()
     {
         // Arrange
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(OmittedInstrumentName);
 
         // Act
         this.telemetry.RecordDerived(
@@ -94,7 +88,7 @@ public sealed class SensitiveContentDerivationTelemetryTests
             TimeSpan.FromMilliseconds(10));
 
         // Assert
-        Assert.Empty(collector.Read(OmittedInstrumentName));
+        Assert.Empty(measurements.Read(OmittedInstrumentName));
     }
 
     /// <summary>What the ceiling cuts here is cut out of the index for as long as the message stays derived.</summary>
@@ -102,7 +96,7 @@ public sealed class SensitiveContentDerivationTelemetryTests
     public void RecordDerived_ATextTheCeilingCut_ReportsHowMuchWasDropped()
     {
         // Arrange
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(OmittedInstrumentName);
 
         // Act
         this.telemetry.RecordDerived(
@@ -110,9 +104,7 @@ public sealed class SensitiveContentDerivationTelemetryTests
             TimeSpan.FromMilliseconds(10));
 
         // Assert
-        var omitted = Assert.Single(collector.Read(OmittedInstrumentName));
-
-        Assert.Equal(4096, omitted.Value);
+        Assert.Equal([4096d], measurements.ValuesOf(OmittedInstrumentName));
     }
 
     /// <summary>A refused derived write is a message that gains no passages at all, which an operator has to see.</summary>
@@ -124,7 +116,7 @@ public sealed class SensitiveContentDerivationTelemetryTests
         string expectedTag)
     {
         // Arrange
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(RefusalsInstrumentName);
         var scanner = Enum.Parse<SensitiveContentScannerKind>(scannerName);
 
         // Act
@@ -132,7 +124,7 @@ public sealed class SensitiveContentDerivationTelemetryTests
 
         // Assert
         var refusal = Assert.Single(
-            collector.Read(RefusalsInstrumentName),
+            measurements.Read(RefusalsInstrumentName),
             measurement => Equals(measurement.Tags[ScannerTagName], expectedTag));
 
         Assert.Equal(1, refusal.Value);
@@ -145,54 +137,4 @@ public sealed class SensitiveContentDerivationTelemetryTests
             confidence: 1,
             SensitiveContentDetector.Create("test", "1"),
             DetectedAt);
-
-    /// <summary>Reads what the counters and the histogram on MailFathom's own meter published.</summary>
-    private sealed class MeasurementCollector : IDisposable
-    {
-        private readonly MeterListener listener = new();
-
-        // Concurrent because the listener is enabled for every instrument on MailFathom's one meter, so any other test
-        // class publishing to it writes here while this one reads — which a plain list reports as a modified collection.
-        private readonly ConcurrentQueue<PublishedMeasurement> measurements = [];
-
-        internal MeasurementCollector()
-        {
-            this.listener.InstrumentPublished = (instrument, activeListener) =>
-            {
-                if (StringComparer.Ordinal.Equals(instrument.Meter.Name, Telemetry.Name))
-                {
-                    activeListener.EnableMeasurementEvents(instrument);
-                }
-            };
-            this.listener.SetMeasurementEventCallback<long>(this.Record);
-            this.listener.SetMeasurementEventCallback<double>(this.Record);
-            this.listener.Start();
-        }
-
-        public void Dispose() => this.listener.Dispose();
-
-        /// <summary>Returns what one instrument published, in order.</summary>
-        internal IReadOnlyList<PublishedMeasurement> Read(string instrumentName) =>
-            [
-                .. this.measurements.ToArray().Where(measurement =>
-                    StringComparer.Ordinal.Equals(measurement.InstrumentName, instrumentName)),
-            ];
-
-        private void Record<TMeasurement>(
-            Instrument instrument,
-            TMeasurement measurement,
-            ReadOnlySpan<KeyValuePair<string, object?>> tags,
-            object? state)
-            where TMeasurement : struct =>
-            this.measurements.Enqueue(new PublishedMeasurement(
-                instrument.Name,
-                Convert.ToDouble(measurement, CultureInfo.InvariantCulture),
-                tags.ToArray().ToDictionary(tag => tag.Key, tag => tag.Value, StringComparer.Ordinal)));
-    }
-
-    /// <summary>One measurement an instrument published, with the dimensions it carried.</summary>
-    private sealed record PublishedMeasurement(
-        string InstrumentName,
-        double Value,
-        IReadOnlyDictionary<string, object?> Tags);
 }

--- a/tests/Infrastructure.UnitTests/Observability/SensitiveContentEgressTelemetryTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/SensitiveContentEgressTelemetryTests.cs
@@ -2,15 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Collections.Concurrent;
-using System.Diagnostics.Metrics;
-using System.Globalization;
 using MailFathom.Application.SensitiveContent;
 using MailFathom.Application.SensitiveContent.Detection;
 using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Application.SensitiveContent.Redaction;
-using MailFathom.Common.Observability;
 using MailFathom.Infrastructure.Observability;
+using MailFathom.TestSupport;
 using Xunit;
 
 namespace MailFathom.Infrastructure.UnitTests.Observability;
@@ -41,7 +38,7 @@ public sealed class SensitiveContentEgressTelemetryTests
     public void RecordGuarded_AScannedText_CountsItAndTimesItAgainstItsEgressPoint()
     {
         // Arrange
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(GuardedInstrumentName, DurationInstrumentName);
 
         // Act
         this.telemetry.RecordGuarded(
@@ -50,11 +47,10 @@ public sealed class SensitiveContentEgressTelemetryTests
             TimeSpan.FromMilliseconds(250));
 
         // Assert
-        var guarded = Assert.Single(collector.Read(GuardedInstrumentName, "mcp_snippet"));
-        var duration = Assert.Single(collector.Read(DurationInstrumentName, "mcp_snippet"));
-
-        Assert.Equal(1, guarded.Value);
-        Assert.Equal(0.25, duration.Value);
+        Assert.Equal([1d], measurements.ValuesOf(GuardedInstrumentName));
+        Assert.Equal(["mcp_snippet"], measurements.DimensionOf(GuardedInstrumentName, EgressPointTagName));
+        Assert.Equal([0.25d], measurements.ValuesOf(DurationInstrumentName));
+        Assert.Equal(["mcp_snippet"], measurements.DimensionOf(DurationInstrumentName, EgressPointTagName));
     }
 
     /// <summary>Which kind of material a mailbox produces is what decides whether a category list is right.</summary>
@@ -62,7 +58,7 @@ public sealed class SensitiveContentEgressTelemetryTests
     public void RecordGuarded_FindingsOfSeveralCategories_CountsEachCategoryOnItsOwnSeries()
     {
         // Arrange
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(FindingsInstrumentName);
 
         // Act
         this.telemetry.RecordGuarded(
@@ -78,8 +74,11 @@ public sealed class SensitiveContentEgressTelemetryTests
             TimeSpan.FromMilliseconds(10));
 
         // Assert
-        var findings = collector.Read(FindingsInstrumentName, "chat_prompt");
+        var findings = measurements.Read(FindingsInstrumentName);
 
+        Assert.All(
+            measurements.DimensionOf(FindingsInstrumentName, EgressPointTagName),
+            egressPoint => Assert.Equal("chat_prompt", egressPoint));
         Assert.Equal(
             [("CloudKey", 2d), ("EmailAddress", 1d)],
             findings.Select(finding => (finding.Tags[CategoryTagName] as string, finding.Value)).Order());
@@ -90,7 +89,7 @@ public sealed class SensitiveContentEgressTelemetryTests
     public void RecordGuarded_ATextTheCeilingDidNotCut_ReportsNoOmission()
     {
         // Arrange
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(OmittedInstrumentName);
 
         // Act
         this.telemetry.RecordGuarded(
@@ -99,7 +98,7 @@ public sealed class SensitiveContentEgressTelemetryTests
             TimeSpan.FromMilliseconds(10));
 
         // Assert
-        Assert.Empty(collector.Read(OmittedInstrumentName, "hosted_embedding_input"));
+        Assert.Empty(measurements.Read(OmittedInstrumentName));
     }
 
     /// <summary>Text nothing analyzed is exactly the text that must not leave, so an operator is told how much of it there was.</summary>
@@ -107,7 +106,7 @@ public sealed class SensitiveContentEgressTelemetryTests
     public void RecordGuarded_ATextTheCeilingCut_ReportsHowMuchWasDropped()
     {
         // Arrange
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(OmittedInstrumentName);
 
         // Act
         this.telemetry.RecordGuarded(
@@ -116,9 +115,8 @@ public sealed class SensitiveContentEgressTelemetryTests
             TimeSpan.FromMilliseconds(10));
 
         // Assert
-        var omitted = Assert.Single(collector.Read(OmittedInstrumentName, "mcp_snippet"));
-
-        Assert.Equal(4096, omitted.Value);
+        Assert.Equal([4096d], measurements.ValuesOf(OmittedInstrumentName));
+        Assert.Equal(["mcp_snippet"], measurements.DimensionOf(OmittedInstrumentName, EgressPointTagName));
     }
 
     /// <summary>A refusal an operator cannot see is a protection nobody can tell is in force.</summary>
@@ -130,7 +128,7 @@ public sealed class SensitiveContentEgressTelemetryTests
         string expectedTag)
     {
         // Arrange
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(RefusalsInstrumentName);
         var scanner = Enum.Parse<SensitiveContentScannerKind>(scannerName);
 
         // Act
@@ -138,10 +136,11 @@ public sealed class SensitiveContentEgressTelemetryTests
 
         // Assert
         var refusal = Assert.Single(
-            collector.Read(RefusalsInstrumentName, "chat_prompt"),
+            measurements.Read(RefusalsInstrumentName),
             measurement => Equals(measurement.Tags[ScannerTagName], expectedTag));
 
         Assert.Equal(1, refusal.Value);
+        Assert.Equal("chat_prompt", refusal.Tags[EgressPointTagName]);
     }
 
     /// <summary>A dashboard and an alert are written against the tag value, so every point has to publish its own.</summary>
@@ -153,7 +152,7 @@ public sealed class SensitiveContentEgressTelemetryTests
     public void RecordGuarded_EachEgressPoint_PublishesItsOwnTagValue(string egressPointName, string expectedTag)
     {
         // Arrange
-        using var collector = new MeasurementCollector();
+        using var measurements = new RecordedMailFathomMeasurements(GuardedInstrumentName);
         var egressPoint = Enum.Parse<SensitiveContentEgressPoint>(egressPointName);
 
         // Act
@@ -163,7 +162,8 @@ public sealed class SensitiveContentEgressTelemetryTests
             TimeSpan.FromMilliseconds(10));
 
         // Assert
-        Assert.Equal(1, Assert.Single(collector.Read(GuardedInstrumentName, expectedTag)).Value);
+        Assert.Equal([1d], measurements.ValuesOf(GuardedInstrumentName));
+        Assert.Equal([expectedTag], measurements.DimensionOf(GuardedInstrumentName, EgressPointTagName));
     }
 
     private static SensitiveContentFinding FindingOf(string category, int start) =>
@@ -173,56 +173,4 @@ public sealed class SensitiveContentEgressTelemetryTests
             confidence: 1,
             SensitiveContentDetector.Create("test", "1"),
             DetectedAt);
-
-    /// <summary>Reads what the counters and the histogram on MailFathom's own meter published.</summary>
-    private sealed class MeasurementCollector : IDisposable
-    {
-        private readonly MeterListener listener = new();
-
-        // Concurrent because the listener is enabled for every instrument on MailFathom's one meter, so any other test
-        // class publishing to it writes here while this one reads — which a plain list reports as a modified collection.
-        private readonly ConcurrentQueue<PublishedMeasurement> measurements = [];
-
-        internal MeasurementCollector()
-        {
-            this.listener.InstrumentPublished = (instrument, activeListener) =>
-            {
-                if (StringComparer.Ordinal.Equals(instrument.Meter.Name, Telemetry.Name))
-                {
-                    activeListener.EnableMeasurementEvents(instrument);
-                }
-            };
-            this.listener.SetMeasurementEventCallback<long>(this.Record);
-            this.listener.SetMeasurementEventCallback<double>(this.Record);
-            this.listener.Start();
-        }
-
-        public void Dispose() => this.listener.Dispose();
-
-        /// <summary>Returns what one instrument published for one egress point, in order.</summary>
-        internal IReadOnlyList<PublishedMeasurement> Read(string instrumentName, string egressPoint) =>
-            [
-                .. this.measurements.ToArray().Where(measurement =>
-                    StringComparer.Ordinal.Equals(measurement.InstrumentName, instrumentName)
-                    && measurement.Tags.TryGetValue(EgressPointTagName, out var point)
-                    && Equals(point, egressPoint)),
-            ];
-
-        private void Record<TMeasurement>(
-            Instrument instrument,
-            TMeasurement measurement,
-            ReadOnlySpan<KeyValuePair<string, object?>> tags,
-            object? state)
-            where TMeasurement : struct =>
-            this.measurements.Enqueue(new PublishedMeasurement(
-                instrument.Name,
-                Convert.ToDouble(measurement, CultureInfo.InvariantCulture),
-                tags.ToArray().ToDictionary(tag => tag.Key, tag => tag.Value, StringComparer.Ordinal)));
-    }
-
-    /// <summary>One measurement an instrument published, with the dimensions it carried.</summary>
-    private sealed record PublishedMeasurement(
-        string InstrumentName,
-        double Value,
-        IReadOnlyDictionary<string, object?> Tags);
 }

--- a/tests/Infrastructure.UnitTests/Observability/StoredMailRederivationTelemetryTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/StoredMailRederivationTelemetryTests.cs
@@ -4,13 +4,13 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Diagnostics.Metrics;
 using System.Globalization;
 using MailFathom.Application.Mail.Maintenance;
 using MailFathom.Common.Observability;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Folders;
 using MailFathom.Infrastructure.Observability;
+using MailFathom.TestSupport;
 using Microsoft.Extensions.Time.Testing;
 using Xunit;
 
@@ -25,6 +25,14 @@ namespace MailFathom.Infrastructure.UnitTests.Observability;
 /// </remarks>
 public sealed class StoredMailRederivationTelemetryTests : IDisposable
 {
+    private const string RederivedInstrumentName = "mailfathom.mail.rederivation.rederived";
+
+    private const string UnreadableInstrumentName = "mailfathom.mail.rederivation.unreadable";
+
+    private const string MissingContentInstrumentName = "mailfathom.mail.rederivation.missing_content";
+
+    private const string PassDurationInstrumentName = "mailfathom.mail.rederivation.pass.duration";
+
     private readonly FakeTimeProvider timeProvider = new(new DateTimeOffset(2026, 8, 18, 12, 0, 0, TimeSpan.Zero));
     private readonly ConcurrentBag<Activity> published = [];
     private readonly ActivityListener listener;
@@ -188,7 +196,11 @@ public sealed class StoredMailRederivationTelemetryTests : IDisposable
         var telemetry = new StoredMailRederivationTelemetry(this.timeProvider);
         var account = MailAccountId.Create("rederive-counts");
 
-        using var collector = new MeasurementCollector(account);
+        using var measurements = new RecordedMailFathomMeasurements(
+            RederivedInstrumentName,
+            UnreadableInstrumentName,
+            MissingContentInstrumentName,
+            PassDurationInstrumentName);
 
         // Act
         using (var run = telemetry.BeginRun(account, folderAlias: null))
@@ -203,10 +215,10 @@ public sealed class StoredMailRederivationTelemetryTests : IDisposable
         Assert.Equal(
             [500d, 2d, 3d, 9d],
             [
-                collector.Sum("mailfathom.mail.rederivation.rederived"),
-                collector.Sum("mailfathom.mail.rederivation.unreadable"),
-                collector.Sum("mailfathom.mail.rederivation.missing_content"),
-                collector.Sum("mailfathom.mail.rederivation.pass.duration"),
+                Walked(measurements, RederivedInstrumentName, account).Sum(),
+                Walked(measurements, UnreadableInstrumentName, account).Sum(),
+                Walked(measurements, MissingContentInstrumentName, account).Sum(),
+                Walked(measurements, PassDurationInstrumentName, account).Sum(),
             ]);
     }
 
@@ -221,7 +233,9 @@ public sealed class StoredMailRederivationTelemetryTests : IDisposable
         var telemetry = new StoredMailRederivationTelemetry(this.timeProvider);
         var account = MailAccountId.Create("rederive-clean");
 
-        using var collector = new MeasurementCollector(account);
+        using var measurements = new RecordedMailFathomMeasurements(
+            UnreadableInstrumentName,
+            MissingContentInstrumentName);
 
         // Act
         using (var run = telemetry.BeginRun(account, folderAlias: null))
@@ -232,8 +246,8 @@ public sealed class StoredMailRederivationTelemetryTests : IDisposable
         }
 
         // Assert
-        Assert.Empty(collector.Read("mailfathom.mail.rederivation.unreadable"));
-        Assert.Empty(collector.Read("mailfathom.mail.rederivation.missing_content"));
+        Assert.Empty(Walked(measurements, UnreadableInstrumentName, account));
+        Assert.Empty(Walked(measurements, MissingContentInstrumentName, account));
     }
 
     /// <summary>
@@ -247,7 +261,9 @@ public sealed class StoredMailRederivationTelemetryTests : IDisposable
         var telemetry = new StoredMailRederivationTelemetry(this.timeProvider);
         var account = MailAccountId.Create("rederive-cancelled");
 
-        using var collector = new MeasurementCollector(account);
+        using var measurements = new RecordedMailFathomMeasurements(
+            PassDurationInstrumentName,
+            RederivedInstrumentName);
 
         // Act
         using (var run = telemetry.BeginRun(account, folderAlias: null))
@@ -258,9 +274,22 @@ public sealed class StoredMailRederivationTelemetryTests : IDisposable
         }
 
         // Assert
-        Assert.Empty(collector.Read("mailfathom.mail.rederivation.pass.duration"));
-        Assert.Empty(collector.Read("mailfathom.mail.rederivation.rederived"));
+        Assert.Empty(Walked(measurements, PassDurationInstrumentName, account));
+        Assert.Empty(Walked(measurements, RederivedInstrumentName, account));
     }
+
+    /// <summary>Selects the values one instrument published for the scope one test walked, out of what the meter recorded.</summary>
+    private static IReadOnlyList<double> Walked(
+        RecordedMailFathomMeasurements measurements,
+        string instrumentName,
+        MailAccountId account) =>
+        [
+            .. measurements.Read(instrumentName)
+                .Where(measurement => Equals(
+                    measurement.Tags.GetValueOrDefault(StoredMailRederivationTelemetry.AccountTagName),
+                    account.Value))
+                .Select(measurement => measurement.Value),
+        ];
 
     private Activity OnlyPass() => Assert.Single(
         this.published,
@@ -270,63 +299,4 @@ public sealed class StoredMailRederivationTelemetryTests : IDisposable
         this.published,
         activity => activity.OperationName == spanName
             && Equals(activity.GetTagItem(StoredMailRederivationTelemetry.AccountTagName), account.Value));
-
-    /// <summary>Reads what the re-derivation instruments published for one account.</summary>
-    private sealed class MeasurementCollector : IDisposable
-    {
-        private readonly MeterListener listener = new();
-
-        // Concurrent because the listener is enabled for every instrument on MailFathom's one meter, so any other test
-        // class publishing to it writes here while this one reads — which a plain list reports as a modified collection.
-        private readonly ConcurrentQueue<(string InstrumentName, double Value)> measurements = [];
-
-        private readonly MailAccountId account;
-
-        internal MeasurementCollector(MailAccountId account)
-        {
-            this.account = account;
-            this.listener.InstrumentPublished = (instrument, activeListener) =>
-            {
-                if (StringComparer.Ordinal.Equals(instrument.Meter.Name, Telemetry.Name))
-                {
-                    activeListener.EnableMeasurementEvents(instrument);
-                }
-            };
-            this.listener.SetMeasurementEventCallback<long>(this.Record);
-            this.listener.SetMeasurementEventCallback<double>(this.Record);
-            this.listener.Start();
-        }
-
-        public void Dispose() => this.listener.Dispose();
-
-        /// <summary>Returns what one instrument published for this collector's account, in order.</summary>
-        internal IReadOnlyList<double> Read(string instrumentName) =>
-            [
-                .. this.measurements.ToArray()
-                    .Where(measurement => StringComparer.Ordinal.Equals(measurement.InstrumentName, instrumentName))
-                    .Select(measurement => measurement.Value),
-            ];
-
-        /// <summary>Returns the total one instrument published for this collector's account.</summary>
-        internal double Sum(string instrumentName) => this.Read(instrumentName).Sum();
-
-        private void Record<TMeasurement>(
-            Instrument instrument,
-            TMeasurement measurement,
-            ReadOnlySpan<KeyValuePair<string, object?>> tags,
-            object? state)
-            where TMeasurement : struct
-        {
-            var walked = tags.ToArray().Any(tag =>
-                StringComparer.Ordinal.Equals(tag.Key, StoredMailRederivationTelemetry.AccountTagName)
-                && Equals(tag.Value, this.account.Value));
-
-            if (walked)
-            {
-                this.measurements.Enqueue((
-                    instrument.Name,
-                    Convert.ToDouble(measurement, CultureInfo.InvariantCulture)));
-            }
-        }
-    }
 }

--- a/tests/SharedSources.UnitTests/RecordedMailFathomMeasurementsTests.cs
+++ b/tests/SharedSources.UnitTests/RecordedMailFathomMeasurementsTests.cs
@@ -87,6 +87,25 @@ public sealed class RecordedMailFathomMeasurementsTests
         Assert.Equal([7d], measurements.ValuesOf(InstrumentName));
     }
 
+    /// <summary>A gauge reading is the state the instrument is in now, so an earlier one must not still be there.</summary>
+    [Fact]
+    public void ObserveGaugesAfresh_ASecondReading_KeepsOnlyWhatTheGaugeReportsNow()
+    {
+        // Arrange
+        const string InstrumentName = "mailfathom.test.reobserved.gauge";
+        var reported = 4L;
+        Telemetry.Meter.CreateObservableGauge(InstrumentName, () => reported);
+        using var measurements = new RecordedMailFathomMeasurements(InstrumentName);
+        measurements.ObserveGauges();
+
+        // Act
+        reported = 9L;
+        measurements.ObserveGaugesAfresh();
+
+        // Assert
+        Assert.Equal([9d], measurements.ValuesOf(InstrumentName));
+    }
+
     /// <summary>A dimension an instrument never published reads as absent rather than as an empty value.</summary>
     [Fact]
     public void DimensionOf_ATagTheMeasurementDidNotCarry_ReadsAsAbsent()

--- a/tests/shared/RecordedMailFathomMeasurements.cs
+++ b/tests/shared/RecordedMailFathomMeasurements.cs
@@ -69,6 +69,18 @@ internal sealed class RecordedMailFathomMeasurements : IDisposable
     /// <remarks>A gauge is only measured when something asks, so a test that never asks records nothing from one.</remarks>
     internal void ObserveGauges() => this.listener.RecordObservableInstruments();
 
+    /// <summary>Discards what has been recorded and asks every observable instrument being watched again.</summary>
+    /// <remarks>
+    /// A gauge reports the state it is in whenever it is asked, so a second reading appended to the first reads as a
+    /// series rather than as the one state the instrument holds now. A test that asks once while a condition holds and
+    /// once after it has passed is asserting on the second answer alone, which is what discarding the first leaves it.
+    /// </remarks>
+    internal void ObserveGaugesAfresh()
+    {
+        this.recorded.Clear();
+        this.listener.RecordObservableInstruments();
+    }
+
     /// <summary>Gets what one instrument published, in the order it measured.</summary>
     /// <param name="instrumentName">The instrument to read.</param>
     /// <returns>Its measurements, or an empty sequence when it took none.</returns>


### PR DESCRIPTION
Nine telemetry suites each declared a private `MeterListener` collector that `tests/shared/RecordedMailFathomMeasurements.cs` already provides and that nine other suites already use. Every body was the same field, the same `InstrumentPublished` filter on `Telemetry.Name`, the same `long` and `double` callbacks, the same `ConcurrentQueue`, and a byte-identical `Record<TMeasurement>` widening through `Convert.ToDouble(..., CultureInfo.InvariantCulture)`; eight also declared a private `PublishedMeasurement` record that is `RecordedMeasurement` under another name.

All nine now read through the shared recorder, which is what makes a change to how a measurement is recorded reach every telemetry suite rather than half of them. This is a readability and maintenance change: no assertion was weakened, no production file moved, and nothing about what `src/` publishes changed.

## What the filters became

A filter that lived on the private collector — an admission, an egress point, an account, a job type — is now expressed at the assertion through the recorder's existing `Read`, `ValuesOf`, and `DimensionOf`, which is where the dimension being asserted belongs. No filtering overload was added to the shared double. Where a suite genuinely reads one instrument for one account or one job type in several tests, that selection is a private static helper on the test class rather than a second collector.

## The gauge readers

Four of the nine read observable gauges and cleared the collection before `RecordObservableInstruments()`, which the shared recorder could not do. `ObserveGaugesAfresh()` discards what has been recorded and observes again, so a second reading is the state the instrument holds now rather than a series appended to the first. `MailSynchronizationTelemetryTests` is the one that needs it rather than merely benefits: it reads the queued and active levels once while two runs are waiting and again after the wait ended, and without the discard the second read still carries the first's non-zero values.

The issue's census named three gauge readers; `MailSynchronizationTelemetryTests` is the fourth, and it clears the same way.

## Beyond the issue's census

The issue lists eight suites. `tests/Infrastructure.UnitTests/Observability/MailboxMutationTelemetryTests.cs` is a ninth carrying the identical collector and `PublishedMeasurement` record in the same directory. Leaving it would have meant a follow-up issue for one file and a private collector still standing next to the recorder that replaced the other eight, so it is folded here and named explicitly rather than passed over.

## Contract surfaces

None. The change is confined to `tests/`: no MCP tool contract, configuration key, database column, or deployment contract moves, and no dependency is added or upgraded.

## Verification

- `scripts/verify-full.sh`: passed. 10324 tests, 0 failed; aggregate line coverage 95.54% against the 85% floor; `dotnet format` rewrote nothing.
- `scripts/review-obligations.sh`: no production file under `src/` changed, no `describes:` marker covers a changed path, no register trigger moved.
- `$check-docs-licenses`: Docs `n/a`, Changelog `n/a`, Licenses `n/a` — the inventory is empty and nothing under `docs/` refers to the recorder or the collectors removed.

Closes #1029

- Issue: https://github.com/Krzysztof318/MailFathom/issues/1029

- Pull request: https://github.com/Krzysztof318/MailFathom/pull/1056
