### PR TITLE
[#1031] Split the two composition roots every branch appends to into named stages

### DIFF
--- a/src/Host/Configuration/Embeddings/EmbeddingBackfillOptions.cs
+++ b/src/Host/Configuration/Embeddings/EmbeddingBackfillOptions.cs
@@ -4,6 +4,7 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
+using MailFathom.Application.Emails.Embeddings.Backfill;
 
 namespace MailFathom.Host.Configuration.Embeddings;
 
@@ -54,4 +55,12 @@ internal sealed class EmbeddingBackfillOptions
     /// <summary>Gets or sets how many batches one run processes before it yields until the next interval.</summary>
     [Range(1, 1000)]
     public int MaxBatchesPerRun { get; set; } = 5;
+
+    /// <summary>Reads the two keys one sweep is bounded by.</summary>
+    /// <returns>The bounds the sweep stops at.</returns>
+    internal StoredEmailEmbeddingBackfillOptions ToBackfillOptions() => new()
+    {
+        BatchSize = this.BatchSize,
+        MaxBatchesPerRun = this.MaxBatchesPerRun,
+    };
 }

--- a/src/Host/Configuration/Jobs/JobQueueOptions.cs
+++ b/src/Host/Configuration/Jobs/JobQueueOptions.cs
@@ -5,6 +5,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using MailFathom.Application.Jobs.Execution;
 
 namespace MailFathom.Host.Configuration.Jobs;
 
@@ -121,6 +122,24 @@ internal sealed class JobQueueOptions : IValidatableObject
     /// </remarks>
     [Range(typeof(TimeSpan), "00:00:01", "00:10:00")]
     public TimeSpan PollInterval { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>Reads the six keys one attempt at a job is bounded by.</summary>
+    /// <returns>The settings the worker claims, retries, and gives up under.</returns>
+    /// <remarks>Create refuses an inverted pair, which the options validator has already rejected at startup.</remarks>
+    internal JobExecutionSettings ToExecutionSettings() => JobExecutionSettings.Create(
+        this.BatchSize,
+        this.LeaseDuration,
+        this.ExecutionTimeout,
+        this.MaxAttempts,
+        this.RetryBaseDelay,
+        this.RetryMaxDelay);
+
+    /// <summary>Reads the three keys that say how much of this instance background work may take.</summary>
+    /// <returns>The capacity the gate hands out.</returns>
+    internal JobCapacitySettings ToCapacitySettings() => JobCapacitySettings.Create(
+        this.MaxConcurrentJobs,
+        this.MaxConcurrentJobsPerType,
+        this.MaxQueueDepthPerType);
 
     /// <inheritdoc />
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)

--- a/src/Host/Configuration/Mail/MailDeliveryOptions.cs
+++ b/src/Host/Configuration/Mail/MailDeliveryOptions.cs
@@ -4,6 +4,8 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
+using MailFathom.Application.Mail.Delivery.Composition;
+using MailFathom.Application.Mail.Delivery.Outbox;
 using MailFathom.Domain.Delivery;
 using MailFathom.Domain.Delivery.Governance;
 
@@ -159,6 +161,29 @@ internal sealed class MailDeliveryOptions : IValidatableObject
     /// </remarks>
     [Range(1, 1000)]
     public int SignalQueueCapacity { get; set; } = 64;
+
+    /// <summary>Reads the seven keys one pass over the outbox is bounded by.</summary>
+    /// <returns>The settings the pass claims, retries, and gives up under.</returns>
+    /// <remarks>Create refuses a pair the options validator has already rejected at startup, so nothing here has to decide what an unusable one would have meant.</remarks>
+    internal MailOutboxSettings ToOutboxSettings() => MailOutboxSettings.Create(
+        this.MaxDeliveriesPerPass,
+        this.LeaseDuration,
+        this.AttemptTimeout,
+        this.MaxAttempts,
+        this.RetryBaseDelay,
+        this.RetryMaxDelay,
+        this.AllowedSendLateness);
+
+    /// <summary>Reads the five keys a message this deployment composes is bounded by.</summary>
+    /// <returns>The bounds every authored message is checked against.</returns>
+    internal OutgoingEmailBounds ToOutgoingEmailBounds() => new()
+    {
+        MaxRecipientCount = this.MaxRecipientCount,
+        MaxBodyCharacters = this.MaxBodyCharacters,
+        MaxAttachmentCount = this.MaxAttachmentCount,
+        MaxAttachmentBytes = this.MaxAttachmentBytes,
+        MaxMessageBytes = this.MaxMessageBytes,
+    };
 
     /// <inheritdoc />
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)

--- a/src/Host/Configuration/Mail/MailExtractionBackfillOptions.cs
+++ b/src/Host/Configuration/Mail/MailExtractionBackfillOptions.cs
@@ -4,6 +4,7 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
+using MailFathom.Application.Emails.Extraction;
 
 namespace MailFathom.Host.Configuration.Mail;
 
@@ -35,4 +36,18 @@ internal sealed class MailExtractionBackfillOptions
     /// <summary>Gets or sets how many batches one run processes before it yields until the next interval.</summary>
     [Range(1, 1000)]
     public int MaxBatchesPerRun { get; set; } = 10;
+
+    /// <summary>Reads the two keys one walk is bounded by, beside what the sensitive-content section asks of it.</summary>
+    /// <param name="rebuildsStaleDerivedData">
+    /// Whether a message whose derived copy predates the current scanners is re-read. It comes from the sensitive-content
+    /// section rather than from this one, because it answers a question about that section: an operator switching a
+    /// scanner on is deciding what happens to the mail already stored. The walk that carries it out is this one.
+    /// </param>
+    /// <returns>The bounds the walk stops at.</returns>
+    internal StoredEmailExtractionBackfillOptions ToBackfillOptions(bool rebuildsStaleDerivedData) => new()
+    {
+        BatchSize = this.BatchSize,
+        MaxBatchesPerRun = this.MaxBatchesPerRun,
+        RebuildsStaleDerivedData = rebuildsStaleDerivedData,
+    };
 }

--- a/src/Host/Configuration/Mail/MailSynchronizationOptions.cs
+++ b/src/Host/Configuration/Mail/MailSynchronizationOptions.cs
@@ -7,12 +7,14 @@ using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography.X509Certificates;
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Contacts.Collection;
+using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Folders;
 using MailFathom.Application.Mail;
 using MailFathom.Application.Mail.Delivery.Composition;
 using MailFathom.Application.Mail.Delivery.Filing;
 using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Mail.Mutations.Audit;
+using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Retrieval.AskMail.Audit;
 using MailFathom.Application.Rules.Actions;
 using MailFathom.Application.Synchronization;
@@ -443,6 +445,35 @@ internal sealed class MailSynchronizationOptions
 
     /// <summary>Gets or sets configured accounts and folders to synchronize.</summary>
     public List<MailSynchronizationAccountOptions> Accounts { get; set; } = [];
+
+    /// <summary>Reads the two keys a convergence pass is bounded by.</summary>
+    /// <returns>The bounds the pass runs under.</returns>
+    internal MailboxConvergenceOptions ToConvergenceOptions() => new()
+    {
+        MaxMutationsPerPass = this.MaxMutationsPerConvergencePass,
+        UnknownOutcomeGrace = this.UnknownMutationOutcomeGrace,
+    };
+
+    /// <summary>Reads the five keys one synchronization run is bounded by.</summary>
+    /// <returns>The bounds the run stops at.</returns>
+    internal MailboxSynchronizationOptions ToSynchronizationOptions() => new()
+    {
+        MaxMetadataBatchSize = this.MaxMetadataBatchSize,
+        MaxRawMimeBytes = this.MaxRawMimeBytes,
+        MaxMetadataBatchesPerRun = this.MaxMetadataBatchesPerRun,
+        MaxReconciledEmailsPerRun = this.MaxReconciledEmailsPerRun,
+        MaxContentBytesPerRun = this.MaxContentBytesPerRun,
+    };
+
+    /// <summary>Reads the four keys a MIME walk is bounded by, and whether it verifies a signature for itself.</summary>
+    /// <returns>The limits the parse is performed under.</returns>
+    internal EmailMimeExtractionOptions ToMimeExtractionOptions() => new()
+    {
+        MaxPartCount = this.MaxMimePartCount,
+        MaxNestingDepth = this.MaxMimeNestingDepth,
+        MaxExtractedTextCharacters = this.MaxExtractedTextCharacters,
+        VerifyDkimLocally = this.VerifyDkimLocally,
+    };
 
     /// <summary>Computes the host shutdown budget a configured drain needs to be honored.</summary>
     /// <param name="shutdownDrainTimeout">The configured drain the synchronization coordinator applies.</param>

--- a/src/Host/Configuration/Mail/MailboxSearchOptions.cs
+++ b/src/Host/Configuration/Mail/MailboxSearchOptions.cs
@@ -26,4 +26,9 @@ internal sealed class MailboxSearchOptions
     /// <remarks>The floor exists because a shorter extract shows a matched word with nothing around it, which tells a reader nothing the relevance rank does not already.</remarks>
     [Range(EmailSearchSnippetBounds.MinimumWordsPerSnippet, EmailSearchSnippetBounds.MaximumWordsPerSnippet)]
     public int WordsPerSnippet { get; set; } = EmailSearchSnippetBounds.Default.WordsPerSnippet;
+
+    /// <summary>Reads the two keys one search result's extracts are bounded by.</summary>
+    /// <returns>The bounds every search in the process applies.</returns>
+    internal EmailSearchSnippetBounds ToSnippetBounds() =>
+        EmailSearchSnippetBounds.Create(this.SnippetsPerEmail, this.WordsPerSnippet);
 }

--- a/src/Host/Configuration/Persistence/EmailContentOptions.cs
+++ b/src/Host/Configuration/Persistence/EmailContentOptions.cs
@@ -5,6 +5,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using MailFathom.Application.EmailContent;
 
 namespace MailFathom.Host.Configuration.Persistence;
 
@@ -62,6 +63,14 @@ internal sealed class EmailContentOptions : IValidatableObject
     /// <summary>Gets or sets how long an attachment download link stays redeemable.</summary>
     /// <remarks>An absent block takes the working default. Whether any link is issued at all is decided elsewhere, by whether the deployment declared a public address.</remarks>
     public AttachmentDownloadOptions AttachmentDownloads { get; set; } = new();
+
+    /// <summary>Reads the two keys one read of message content is bounded by.</summary>
+    /// <returns>The bounds the read truncates at.</returns>
+    internal EmailContentReadOptions ToReadOptions() => new()
+    {
+        MaxBodyCharacters = this.MaxBodyCharacters,
+        MaxCharactersPerRead = this.MaxCharactersPerRead,
+    };
 
     /// <summary>Checks what no range attribute can state on its own.</summary>
     /// <param name="validationContext">The context the options framework validates against.</param>

--- a/src/Host/HostComposition.cs
+++ b/src/Host/HostComposition.cs
@@ -9,14 +9,10 @@ using MailFathom.Application.Access;
 using MailFathom.Application.Accounts;
 using MailFathom.Application.AiProviders;
 using MailFathom.Application.Contacts.Collection;
-using MailFathom.Application.EmailContent;
 using MailFathom.Application.EmailContent.Attachments;
 using MailFathom.Application.EmailContent.Storage;
-using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Generation;
 using MailFathom.Application.Emails.Embeddings.Limits;
-using MailFathom.Application.Emails.Extraction;
-using MailFathom.Application.Emails.Search;
 using MailFathom.Application.Folders;
 using MailFathom.Application.Jobs.Execution;
 using MailFathom.Application.Jobs.Scheduling;
@@ -29,7 +25,6 @@ using MailFathom.Application.Mail.Delivery.Scheduling;
 using MailFathom.Application.Mail.Maintenance;
 using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Mail.Mutations.Audit;
-using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Retrieval.AskMail.Audit;
 using MailFathom.Application.Rules;
@@ -42,7 +37,6 @@ using MailFathom.Application.SensitiveContent.Redaction;
 using MailFathom.Application.Spam;
 using MailFathom.Application.Spam.Actions;
 using MailFathom.Application.Spam.Runs;
-using MailFathom.Application.Synchronization;
 using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Application.Synchronization.Reconciliation;
 using MailFathom.Host.Api;
@@ -564,27 +558,19 @@ internal static class HostComposition
     /// <summary>Maps the bound sections onto the ceilings, budgets, and settings the application layer takes.</summary>
     private static void AddApplicationBounds(WebApplicationBuilder builder)
     {
+        AddMailSynchronizationBounds(builder);
+        AddMailDeliveryBounds(builder);
+        AddStoredMailBounds(builder);
+        AddJobQueue(builder);
+    }
+
+    /// <summary>Maps the synchronization section onto the bounds a run, a convergence pass, and a MIME walk take.</summary>
+    private static void AddMailSynchronizationBounds(WebApplicationBuilder builder)
+    {
         builder.Services.AddScoped(provider =>
-        {
-            var synchronizationSettings = provider.GetRequiredService<MailSynchronizationOptions>();
-            return new MailboxConvergenceOptions
-            {
-                MaxMutationsPerPass = synchronizationSettings.MaxMutationsPerConvergencePass,
-                UnknownOutcomeGrace = synchronizationSettings.UnknownMutationOutcomeGrace,
-            };
-        });
+            provider.GetRequiredService<MailSynchronizationOptions>().ToConvergenceOptions());
         builder.Services.AddScoped(provider =>
-        {
-            var synchronizationSettings = provider.GetRequiredService<MailSynchronizationOptions>();
-            return new MailboxSynchronizationOptions
-            {
-                MaxMetadataBatchSize = synchronizationSettings.MaxMetadataBatchSize,
-                MaxRawMimeBytes = synchronizationSettings.MaxRawMimeBytes,
-                MaxMetadataBatchesPerRun = synchronizationSettings.MaxMetadataBatchesPerRun,
-                MaxReconciledEmailsPerRun = synchronizationSettings.MaxReconciledEmailsPerRun,
-                MaxContentBytesPerRun = synchronizationSettings.MaxContentBytesPerRun,
-            };
-        });
+            provider.GetRequiredService<MailSynchronizationOptions>().ToSynchronizationOptions());
         // A singleton, because the ceiling is one answer for the one content store every account writes into. Reading it
         // per scope would give each concurrent folder run a ceiling of its own, which is the sum it exists to bound.
         builder.Services.AddSingleton(provider => new StoredContentCeiling(
@@ -595,32 +581,18 @@ internal static class HostComposition
         builder.Services.AddSingleton(provider => new RawMimeMemoryBudget(
             provider.GetRequiredService<ISettingsSnapshot<MailSynchronizationOptions>>().Current.MaxInFlightRawMimeBytes));
         builder.Services.AddScoped(provider =>
-        {
-            var synchronizationSettings = provider.GetRequiredService<MailSynchronizationOptions>();
-            return new EmailMimeExtractionOptions
-            {
-                MaxPartCount = synchronizationSettings.MaxMimePartCount,
-                MaxNestingDepth = synchronizationSettings.MaxMimeNestingDepth,
-                MaxExtractedTextCharacters = synchronizationSettings.MaxExtractedTextCharacters,
-                VerifyDkimLocally = synchronizationSettings.VerifyDkimLocally,
-            };
-        });
+            provider.GetRequiredService<MailSynchronizationOptions>().ToMimeExtractionOptions());
+    }
+
+    /// <summary>Maps the delivery section onto the outbox's settings, the ceilings a send is judged against, and what one message may carry.</summary>
+    private static void AddMailDeliveryBounds(WebApplicationBuilder builder)
+    {
         // A singleton, because the outbox's bounds describe the process rather than a work unit: an attempt count is
         // carried across runs on the record, and a lease read per scope would let two passes of the same instance
         // disagree about how long they hold what they claimed. That also means it is read once at startup, which the
         // configuration reference marks as needing a restart.
         builder.Services.AddSingleton(provider =>
-        {
-            var deliverySettings = provider.GetRequiredService<IOptions<MailDeliveryOptions>>().Value;
-            return MailOutboxSettings.Create(
-                deliverySettings.MaxDeliveriesPerPass,
-                deliverySettings.LeaseDuration,
-                deliverySettings.AttemptTimeout,
-                deliverySettings.MaxAttempts,
-                deliverySettings.RetryBaseDelay,
-                deliverySettings.RetryMaxDelay,
-                deliverySettings.AllowedSendLateness);
-        });
+            provider.GetRequiredService<IOptions<MailDeliveryOptions>>().Value.ToOutboxSettings());
         // A singleton for a different reason: it carries accounts from the scope that wrote a record to the loop that
         // delivers it, so a queue per scope would be a queue nobody reads.
         builder.Services.AddSingleton(provider => new MailOutboxSignal(
@@ -641,26 +613,14 @@ internal static class HostComposition
         builder.Services.AddSingleton(provider => new AuthoredSendSettings(
             provider.GetRequiredService<IOptions<MailDeliveryOptions>>().Value.UnvouchedRecipients));
         builder.Services.AddScoped(provider =>
-        {
-            var deliverySettings = provider.GetRequiredService<IOptions<MailDeliveryOptions>>().Value;
-            return new OutgoingEmailBounds
-            {
-                MaxRecipientCount = deliverySettings.MaxRecipientCount,
-                MaxBodyCharacters = deliverySettings.MaxBodyCharacters,
-                MaxAttachmentCount = deliverySettings.MaxAttachmentCount,
-                MaxAttachmentBytes = deliverySettings.MaxAttachmentBytes,
-                MaxMessageBytes = deliverySettings.MaxMessageBytes,
-            };
-        });
+            provider.GetRequiredService<IOptions<MailDeliveryOptions>>().Value.ToOutgoingEmailBounds());
+    }
+
+    /// <summary>Maps the content, backfill, persistence, and search sections onto what a read of stored mail returns and what the walks over it take.</summary>
+    private static void AddStoredMailBounds(WebApplicationBuilder builder)
+    {
         builder.Services.AddScoped(provider =>
-        {
-            var contentSettings = provider.GetRequiredService<IOptions<EmailContentOptions>>().Value;
-            return new EmailContentReadOptions
-            {
-                MaxBodyCharacters = contentSettings.MaxBodyCharacters,
-                MaxCharactersPerRead = contentSettings.MaxCharactersPerRead,
-            };
-        });
+            provider.GetRequiredService<IOptions<EmailContentOptions>>().Value.ToReadOptions());
         // A singleton beside the scoped read bounds above, because what it carries is where this deployment publishes itself
         // and how long a capability it hands out lives — two facts about the process rather than about a request. The two
         // come from different sections deliberately: the address is a property of the installation that anything handing
@@ -672,57 +632,31 @@ internal static class HostComposition
                 .ComposeAddressFor(EmailAttachmentDownloadEndpoint.RoutePrefix),
             provider.GetRequiredService<IOptions<EmailContentOptions>>().Value.AttachmentDownloads.LinkLifetime));
         builder.Services.AddScoped(provider =>
-        {
-            var backfillSettings = provider.GetRequiredService<IOptions<MailExtractionBackfillOptions>>().Value;
-            return new StoredEmailExtractionBackfillOptions
-            {
-                BatchSize = backfillSettings.BatchSize,
-                MaxBatchesPerRun = backfillSettings.MaxBatchesPerRun,
-
-                // Read from the sensitive-content section rather than from the backfill's own, because it answers a question
-                // about that section: an operator switching a scanner on is deciding what happens to the mail already
-                // stored. The walk that carries it out is this one, which is why the value arrives here.
-                RebuildsStaleDerivedData = provider.GetRequiredService<IOptions<SensitiveContentOptions>>()
-                    .Value.RebuildStaleDerivedData,
-            };
-        });
+            provider.GetRequiredService<IOptions<MailExtractionBackfillOptions>>().Value.ToBackfillOptions(
+                provider.GetRequiredService<IOptions<SensitiveContentOptions>>().Value.RebuildStaleDerivedData));
         builder.Services.AddScoped(provider =>
-        {
-            var embeddingBackfillSettings = provider.GetRequiredService<IOptions<EmbeddingBackfillOptions>>().Value;
-            return new StoredEmailEmbeddingBackfillOptions
-            {
-                BatchSize = embeddingBackfillSettings.BatchSize,
-                MaxBatchesPerRun = embeddingBackfillSettings.MaxBatchesPerRun,
-            };
-        });
+            provider.GetRequiredService<IOptions<EmbeddingBackfillOptions>>().Value.ToBackfillOptions());
         builder.Services.AddSingleton(provider => new PersistenceConcurrencyOptions
         {
             MaximumCommitAttempts = provider.GetRequiredService<IOptions<PersistenceOptions>>().Value.MaximumConcurrencyCommitAttempts,
         });
-        // A singleton, because the ordering between the timeout and the lease is one deployment-wide guarantee rather than a
-        // per-scope value, and mapping it here is where the bound options stop being the host's shape and become the
-        // application's. Create refuses an inverted pair, which the options validator has already rejected at startup.
+        // A singleton rather than a scoped value: the bound is a deployment-wide privacy control, so every search in the
+        // process applies the one an operator configured rather than whichever snapshot a scope happened to open under.
         builder.Services.AddSingleton(provider =>
-        {
-            var jobSettings = provider.GetRequiredService<IOptions<JobQueueOptions>>().Value;
-            return JobExecutionSettings.Create(
-                jobSettings.BatchSize,
-                jobSettings.LeaseDuration,
-                jobSettings.ExecutionTimeout,
-                jobSettings.MaxAttempts,
-                jobSettings.RetryBaseDelay,
-                jobSettings.RetryMaxDelay);
-        });
+            provider.GetRequiredService<IOptions<MailboxSearchOptions>>().Value.ToSnippetBounds());
+    }
+
+    /// <summary>Registers the worker that runs durable background work, the bounds it runs under, and the handlers it dispatches to.</summary>
+    private static void AddJobQueue(WebApplicationBuilder builder)
+    {
+        // A singleton, because the ordering between the timeout and the lease is one deployment-wide guarantee rather than a
+        // per-scope value, and mapping it onto the application's settings is where the bound options stop being the host's shape.
+        builder.Services.AddSingleton(provider =>
+            provider.GetRequiredService<IOptions<JobQueueOptions>>().Value.ToExecutionSettings());
         // How much of this instance background work may take is one statement about the instance, so the capacity and the
         // gate that hands it out are singletons: a per-scope ceiling would be a ceiling per pass, which bounds nothing.
         builder.Services.AddSingleton(provider =>
-        {
-            var jobSettings = provider.GetRequiredService<IOptions<JobQueueOptions>>().Value;
-            return JobCapacitySettings.Create(
-                jobSettings.MaxConcurrentJobs,
-                jobSettings.MaxConcurrentJobsPerType,
-                jobSettings.MaxQueueDepthPerType);
-        });
+            provider.GetRequiredService<IOptions<JobQueueOptions>>().Value.ToCapacitySettings());
         builder.Services.AddSingleton<JobConcurrencyGate>();
         // A singleton holding nothing but the scope factory: what it creates per attempt is the scope, and the executor it
         // resolves there is scoped like every other consumer of the persistence session.
@@ -753,13 +687,6 @@ internal static class HostComposition
         // The second source of recurring dispatches, beside the rules': the repetitions an owner declared, read from
         // the database rather than from configuration because that is where somebody makes and stops one.
         builder.Services.AddScoped<IScheduledJobSource, RecurringSendScheduleSource>();
-        // A singleton rather than a scoped value: the bound is a deployment-wide privacy control, so every search in the
-        // process applies the one an operator configured rather than whichever snapshot a scope happened to open under.
-        builder.Services.AddSingleton(provider =>
-        {
-            var searchSettings = provider.GetRequiredService<IOptions<MailboxSearchOptions>>().Value;
-            return EmailSearchSnippetBounds.Create(searchSettings.SnippetsPerEmail, searchSettings.WordsPerSnippet);
-        });
     }
 
     /// <summary>Declares the gates the startup probe waits on, and the validators that report before the workers run.</summary>

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -257,6 +257,36 @@ public static class ServiceCollectionExtensions
         // request.
         services.AddSingleton<IAuthorizationRefusalTelemetry, AuthorizationRefusalTelemetry>();
 
+        AddPersistenceAdapters(services, currentConnectionSettings, textSearchConfiguration);
+        AddEmbeddingAdapters(services);
+        AddStoredMailAdapters(services);
+        AddMailRuleAdapters(services);
+        AddJobQueueAdapters(services);
+        AddSpamClassificationStores(services);
+        AddReadSideStores(services);
+        AddMailContentAdapters(services);
+        AddSynchronization(services);
+        AddMailboxReaders(services);
+        AddSpamClassification(services);
+        AddMailAnswering(services, answeringBudget);
+        AddMailProtocolAdapters(services);
+        AddMailboxMutationRecords(services);
+        AddMailDelivery(services);
+        AddMailboxMutations(services);
+        AddContacts(services);
+
+        return services;
+    }
+
+    /// <summary>Registers the PostgreSQL connection this process owns, the context over it, and the session every store commits through.</summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="currentConnectionSettings">Supplies where the PostgreSQL connection string and its password currently come from.</param>
+    /// <param name="textSearchConfiguration">The validated PostgreSQL text search configuration the lexical index is built with.</param>
+    private static void AddPersistenceAdapters(
+        IServiceCollection services,
+        Func<IServiceProvider, PostgresConnectionSettings> currentConnectionSettings,
+        PostgresTextSearchConfiguration textSearchConfiguration)
+    {
         // A value rather than an accessor, unlike the connection settings beside it: this one is compiled into the
         // search vector's column definition, so it is fixed for a deployment's schema and a reload cannot adopt a new
         // one without reindexing. Changing it is a migration, not a configuration reload.
@@ -316,6 +346,12 @@ public static class ServiceCollectionExtensions
         // the metadata write does on its way past, because both of those stages may still change what a message is.
         services.AddScoped<IStoredEmailChunkingStore, StoredEmailChunkingStore>();
         services.AddScoped<MailChunkingPass>();
+    }
+
+    /// <summary>Registers the tables a message's vectors live in, the ceilings a generation is spent against, and the operator acts on a profile.</summary>
+    /// <param name="services">The service collection.</param>
+    private static void AddEmbeddingAdapters(IServiceCollection services)
+    {
         // The backlog is a singleton because the bound it enforces is one process-wide limit on how much embedding work
         // is held in memory; a scoped one would hold that bound per scope, and a synchronization run would be offering
         // into a backlog no worker is reading. Registered whether or not this deployment embeds, because the
@@ -366,6 +402,12 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IEmbeddingWorkloadReader, EmbeddingWorkloadReader>();
         services.AddScoped<CountedEmbeddingActivation>();
         services.AddScoped<EmbeddingStatusReader>();
+    }
+
+    /// <summary>Registers the tables stored mail itself lives in, and the two maintenance walks an operator drives over them.</summary>
+    /// <param name="services">The service collection.</param>
+    private static void AddStoredMailAdapters(IServiceCollection services)
+    {
         services.AddScoped<IEmailMetadataRepository, StoredEmailMetadataRepository>();
         // Placing a message in its conversation is part of both write paths — the arrival that commits it and the
         // re-derivation that re-reads it — so it is registered once rather than composed into either. It holds no
@@ -392,6 +434,12 @@ public static class ServiceCollectionExtensions
         // instance, and a gauge answering per scope would report whichever scope last ran a pass.
         services.AddSingleton<MailExtractionBackfillTelemetry>();
         services.AddScoped<IStoredEmailReconciliationStore, StoredEmailReconciliationStore>();
+    }
+
+    /// <summary>Registers what a rule evaluation writes down and what the administrative surface reads back out of it.</summary>
+    /// <param name="services">The service collection.</param>
+    private static void AddMailRuleAdapters(IServiceCollection services)
+    {
         services.AddScoped<IMailRuleEvaluationStore, MailRuleEvaluationStore>();
         services.AddScoped<IMailRuleEvaluationRunStore, MailRuleEvaluationRunStore>();
         // What the administrative surface asks of the two rule stores. Each is a use case rather than a second port,
@@ -400,6 +448,12 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<MailRuleHistoryTelemetry>();
         services.AddScoped<IMailRuleExecutionStore, MailRuleExecutionStore>();
         services.AddScoped<MailRuleHistory>();
+    }
+
+    /// <summary>Registers the queue every background pass claims work from, its dead letters, and its recurring schedule.</summary>
+    /// <param name="services">The service collection.</param>
+    private static void AddJobQueueAdapters(IServiceCollection services)
+    {
         // Scoped like every other store, and deliberately not registered beside a worker: nothing here runs a job. It
         // takes no persistence session either, so a caller cannot enlist an enqueue in the transaction that stored the
         // message the work is about.
@@ -415,7 +469,12 @@ public static class ServiceCollectionExtensions
         // A singleton with the instruments on it, for the reason every other telemetry type here is one: an instrument
         // created per scope would publish a second time series for the same measurement.
         services.AddSingleton<JobQueueTelemetry>();
+    }
 
+    /// <summary>Registers what a classification verdict is written to and read back from, whatever this deployment decides to classify.</summary>
+    /// <param name="services">The service collection.</param>
+    private static void AddSpamClassificationStores(IServiceCollection services)
+    {
         // Registered whether or not classification is switched on, for the reason every other store here is: what a
         // deployment decides is whether anything calls it, and a port resolvable only under one configuration is a
         // composition that fails at the moment somebody changes their mind rather than at startup.
@@ -426,7 +485,12 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ISpamClassificationHistoryReader, SpamClassificationHistoryReader>();
         services.AddScoped<SpamClassificationRunReader>();
         services.AddScoped<SpamClassificationHistory>();
+    }
 
+    /// <summary>Registers the read side over stored mail, which takes no persistence session and joins no transaction.</summary>
+    /// <param name="services">The service collection.</param>
+    private static void AddReadSideStores(IServiceCollection services)
+    {
         // The read side takes no persistence session and joins no transaction, so its ports are registered beside the
         // write repositories rather than through one of them.
         services.AddScoped<IStoredEmailTimelineReader, StoredEmailTimelineReader>();
@@ -463,6 +527,12 @@ public static class ServiceCollectionExtensions
         // source asks for a credential and this is what knows the credential lives in PostgreSQL, sealed.
         services.AddScoped<IMailboxRefreshTokenStore, MailboxRefreshTokenStore>();
         services.AddScoped<MailboxRefreshTokenRecorder>();
+    }
+
+    /// <summary>Registers the MimeKit adapters a stored message is parsed, rendered, and served out of, and the signed links an attachment is fetched through.</summary>
+    /// <param name="services">The service collection.</param>
+    private static void AddMailContentAdapters(IServiceCollection services)
+    {
         // MimeKit arrives with MailKit, so message parsing needs no dependency of its own; the adapter keeps its types
         // out of Application the same way the IMAP adapter keeps MailKit's out.
         // Wrapped where a scanner is switched on, because this port is where every derived copy of a body begins: the
@@ -536,6 +606,12 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IAttachmentDownloadTicketReader>(provider => new SignedAttachmentDownloadTicketReader(
             provider.GetRequiredService<DataEncryptionKeyRing>(),
             provider.GetRequiredService<TimeProvider>()));
+    }
+
+    /// <summary>Registers folder resolution and the passes that bring a mailbox and its local copy back into agreement.</summary>
+    /// <param name="services">The service collection.</param>
+    private static void AddSynchronization(IServiceCollection services)
+    {
         services.AddScoped<IMailFolderResolutionStore, MailFolderResolutionStore>();
         services.AddScoped<IStoredMailFolderMirrorStore, StoredMailFolderMirrorStore>();
         services.AddScoped<IMailFolderMappingChangeAuditor, LoggedMailFolderMappingChangeAuditor>();
@@ -554,6 +630,12 @@ public static class ServiceCollectionExtensions
         services.AddScoped<MailboxReconciler>();
         services.AddScoped<StoredEmailExtractionBackfill>();
         services.AddScoped<MailboxScopeResolver>();
+    }
+
+    /// <summary>Registers what a caller-facing read publishes, the two guards every derivation and every egress passes through, and the readers a protocol surface reaches.</summary>
+    /// <param name="services">The service collection.</param>
+    private static void AddMailboxReaders(IServiceCollection services)
+    {
         // Singletons for the reason every other publisher here is one: a span source is a fact about the process, and a
         // scoped instance would build one per request for no gain.
         services.AddSingleton<IMailboxReadTelemetry, MailboxReadTelemetry>();
@@ -589,6 +671,12 @@ public static class ServiceCollectionExtensions
         services.AddScoped<EmailContentReader>();
         services.AddScoped<EmailAttachmentDownloadReader>();
         services.AddScoped<MailboxSearchReader>();
+    }
+
+    /// <summary>Registers the classifier itself, the ordering that puts it in front of every other derivation, and what a verdict causes.</summary>
+    /// <param name="services">The service collection.</param>
+    private static void AddSpamClassification(IServiceCollection services)
+    {
         // Both halves of classification, registered for every deployment rather than only where it is switched on: what
         // the switch decides is whether the classifier does anything, and the classifier asks the settings reader that.
         // The scanner is the one dependency a supported deployment may not have — this change ships no implementation of
@@ -619,6 +707,15 @@ public static class ServiceCollectionExtensions
         // classifier resolves nothing from here, which is what keeps a deployment that records verdicts and touches
         // nothing genuinely unable to reach a mailbox through classification.
         services.AddScoped<SpamActionRecorder>();
+    }
+
+    /// <summary>Registers the retrieval one question about the mailbox is served from, the bounds it runs under, and the trail it leaves behind.</summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="answeringBudget">The validated ceilings one question about the mailbox is subject to.</param>
+    private static void AddMailAnswering(
+        IServiceCollection services,
+        MailAnsweringBudget answeringBudget)
+    {
         // Registered for every deployment rather than only where a chat endpoint was declared, because what it is is a
         // reading of the search above: an instance that answers no questions simply resolves it and never calls it, and
         // the bounds it hands passages over under are the same wherever the retrieval is reached from.
@@ -659,6 +756,12 @@ public static class ServiceCollectionExtensions
         // reason the bounds above are — an instance that answers nothing admits nothing and spends nothing.
         services.AddSingleton<MailAnsweringSpendTracker>();
         services.AddSingleton<IMailAnsweringSpendLedger>(provider => provider.GetRequiredService<MailAnsweringSpendTracker>());
+    }
+
+    /// <summary>Registers the MailKit sessions this process reaches a mail server over, and the token source that authenticates them.</summary>
+    /// <param name="services">The service collection.</param>
+    private static void AddMailProtocolAdapters(IServiceCollection services)
+    {
         // The cache outlives every scope because a token is valid for whichever work unit next needs the account,
         // while the source that fills it is scoped to the configuration snapshot it resolves settings from.
         services.AddSingleton<MailAccessTokenCache>();
@@ -723,6 +826,12 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IRemoteFolderCreator>(provider => new MailKitRemoteFolderCreator(
             provider.GetRequiredService<MailboxWriteConnectionPool>(),
             provider.GetRequiredService<ILogger<MailKitRemoteFolderCreator>>()));
+    }
+
+    /// <summary>Registers what a mutation is written down as before the session that acts on it is opened.</summary>
+    /// <param name="services">The service collection.</param>
+    private static void AddMailboxMutationRecords(IServiceCollection services)
+    {
         // The record is written before the session that acts on it is opened, so the store is registered beside the
         // other repositories that take a persistence session rather than with the mail adapters above.
         services.AddScoped<IMailboxMutationRecordStore, MailboxMutationRecordStore>();
@@ -731,6 +840,12 @@ public static class ServiceCollectionExtensions
         // so a protocol request resolves nothing over the network before it has been decided whether it may write.
         services.AddScoped<IAuthoredMailboxTargetReader, AuthoredMailboxTargetReader>();
         services.AddScoped<MailFlagChangeRecorder>();
+    }
+
+    /// <summary>Registers the outbox, the drafts beside it, the bounds a send is judged against, and every use case that authors one.</summary>
+    /// <param name="services">The service collection.</param>
+    private static void AddMailDelivery(IServiceCollection services)
+    {
         // The outgoing record is written before the delivery session above is opened, and for a stronger reason than the
         // mutation record is: a send is the one act here that cannot be undone once it leaves. The outbox in front of it
         // is what makes the record and the message it points at one write.
@@ -816,6 +931,12 @@ public static class ServiceCollectionExtensions
         // every bound this deployment sets is asked again at the moment the message would leave rather than only when
         // it was written.
         services.AddScoped<MailDraftPromotion>();
+    }
+
+    /// <summary>Registers what a finished mutation leaves behind, the pass that converges an unfinished one, and the gauges both publish.</summary>
+    /// <param name="services">The service collection.</param>
+    private static void AddMailboxMutations(IServiceCollection services)
+    {
         // Read by synchronization rather than by the performer, so that a relocation coming back through an ordinary
         // run is recognized as MailFathom's own instead of being stored as a second email.
         services.AddScoped<IMailboxMutationReconciliationStore, MailboxMutationReconciliationStore>();
@@ -850,7 +971,12 @@ public static class ServiceCollectionExtensions
             provider.GetRequiredService<IMailAccessTokenSource>(),
             provider.GetRequiredService<OutboundOperationExecutor>(),
             provider.GetRequiredService<ITransientFailureClassifier>()));
+    }
 
+    /// <summary>Registers the contact book, the two caller-facing use cases over it, and the collection that fills it from arriving mail.</summary>
+    /// <param name="services">The service collection.</param>
+    private static void AddContacts(IServiceCollection services)
+    {
         // The contact book. Registered unconditionally, because it is a store rather than a capability a deployment
         // switches on: every surface over it is optional, and none of them can be reached without the book existing.
         services.AddScoped<IContactStore, ContactStore>();
@@ -870,8 +996,6 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IAuthoredMailTally, AuthoredMailTally>();
         services.AddSingleton<IContactCollectionTelemetry, ContactCollectionTelemetry>();
         services.AddScoped<MailContactCollector>();
-
-        return services;
     }
 
     /// <summary>Registers the units of work that turn a message's passages into vectors.</summary>

--- a/tests/Host.UnitTests/Configuration/Embeddings/EmbeddingBackfillOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Embeddings/EmbeddingBackfillOptionsTests.cs
@@ -82,6 +82,21 @@ public sealed class EmbeddingBackfillOptionsTests
         Assert.Contains(errors, error => error.MemberNames.Contains(expectedMember, StringComparer.Ordinal));
     }
 
+    /// <summary>Both keys one sweep stops at reach the bounds the walk takes.</summary>
+    [Fact]
+    public void ToBackfillOptions_ConfiguredSection_CarriesBothKeysTheSweepStopsAt()
+    {
+        // Arrange
+        var settings = new EmbeddingBackfillOptions { BatchSize = 9, MaxBatchesPerRun = 4 };
+
+        // Act
+        var bounds = settings.ToBackfillOptions();
+
+        // Assert
+        Assert.Equal(9, bounds.BatchSize);
+        Assert.Equal(4, bounds.MaxBatchesPerRun);
+    }
+
     /// <summary>Runs the attribute rules, which is what the options framework does with this type on start.</summary>
     private static List<ValidationResult> ValidateEveryProperty(EmbeddingBackfillOptions settings)
     {

--- a/tests/Host.UnitTests/Configuration/Jobs/JobQueueOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Jobs/JobQueueOptionsTests.cs
@@ -194,6 +194,54 @@ public sealed class JobQueueOptionsTests
                 StringComparer.Ordinal));
     }
 
+    /// <summary>Every key one attempt at a job is bounded by reaches the settings the worker runs under.</summary>
+    [Fact]
+    public void ToExecutionSettings_ConfiguredSection_CarriesEveryKeyTheWorkerRunsUnder()
+    {
+        // Arrange
+        var settings = new JobQueueOptions
+        {
+            BatchSize = 6,
+            LeaseDuration = TimeSpan.FromMinutes(9),
+            ExecutionTimeout = TimeSpan.FromMinutes(4),
+            MaxAttempts = 7,
+            RetryBaseDelay = TimeSpan.FromSeconds(15),
+            RetryMaxDelay = TimeSpan.FromMinutes(25),
+        };
+
+        // Act
+        var execution = settings.ToExecutionSettings();
+
+        // Assert
+        Assert.Equal(6, execution.BatchSize);
+        Assert.Equal(TimeSpan.FromMinutes(9), execution.LeaseDuration);
+        Assert.Equal(TimeSpan.FromMinutes(4), execution.ExecutionTimeout);
+        Assert.Equal(7, execution.MaxAttempts);
+        Assert.Equal(TimeSpan.FromSeconds(15), execution.RetryBaseDelay);
+        Assert.Equal(TimeSpan.FromMinutes(25), execution.RetryMaxDelay);
+    }
+
+    /// <summary>All three capacity keys reach the gate, and none is read off a neighbour.</summary>
+    [Fact]
+    public void ToCapacitySettings_ConfiguredSection_CarriesEveryKeyTheGateHandsOut()
+    {
+        // Arrange
+        var settings = new JobQueueOptions
+        {
+            MaxConcurrentJobs = 8,
+            MaxConcurrentJobsPerType = 3,
+            MaxQueueDepthPerType = 900,
+        };
+
+        // Act
+        var capacity = settings.ToCapacitySettings();
+
+        // Assert
+        Assert.Equal(8, capacity.MaxConcurrentJobs);
+        Assert.Equal(3, capacity.MaxConcurrentJobsPerType);
+        Assert.Equal(900, capacity.MaxQueueDepthPerType);
+    }
+
     private static List<ValidationResult> Validate(JobQueueOptions settings)
     {
         var results = new List<ValidationResult>();

--- a/tests/Host.UnitTests/Configuration/Mail/MailDeliveryOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Mail/MailDeliveryOptionsTests.cs
@@ -469,6 +469,60 @@ public sealed class MailDeliveryOptionsTests
         return mailbox;
     }
 
+    /// <summary>Every key one pass over the outbox is bounded by reaches the settings the pass runs under.</summary>
+    [Fact]
+    public void ToOutboxSettings_ConfiguredSection_CarriesEveryKeyThePassRunsUnder()
+    {
+        // Arrange
+        var options = new MailDeliveryOptions
+        {
+            MaxDeliveriesPerPass = 7,
+            LeaseDuration = TimeSpan.FromMinutes(11),
+            AttemptTimeout = TimeSpan.FromMinutes(3),
+            MaxAttempts = 4,
+            RetryBaseDelay = TimeSpan.FromSeconds(45),
+            RetryMaxDelay = TimeSpan.FromMinutes(20),
+            AllowedSendLateness = TimeSpan.FromHours(2),
+        };
+
+        // Act
+        var settings = options.ToOutboxSettings();
+
+        // Assert
+        Assert.Equal(7, settings.MaxDeliveriesPerPass);
+        Assert.Equal(TimeSpan.FromMinutes(11), settings.LeaseDuration);
+        Assert.Equal(TimeSpan.FromMinutes(3), settings.AttemptTimeout);
+        Assert.Equal(4, settings.MaxAttempts);
+        Assert.Equal(TimeSpan.FromSeconds(45), settings.RetryBaseDelay);
+        Assert.Equal(TimeSpan.FromMinutes(20), settings.RetryMaxDelay);
+        Assert.Equal(TimeSpan.FromHours(2), settings.AllowedLateness);
+    }
+
+    /// <summary>Every key a composed message is checked against reaches the bounds, and none is read off a neighbour.</summary>
+    [Fact]
+    public void ToOutgoingEmailBounds_ConfiguredSection_CarriesEveryKeyAMessageIsCheckedAgainst()
+    {
+        // Arrange
+        var options = new MailDeliveryOptions
+        {
+            MaxRecipientCount = 31,
+            MaxBodyCharacters = 32,
+            MaxAttachmentCount = 33,
+            MaxAttachmentBytes = 34L,
+            MaxMessageBytes = 35L,
+        };
+
+        // Act
+        var bounds = options.ToOutgoingEmailBounds();
+
+        // Assert
+        Assert.Equal(31, bounds.MaxRecipientCount);
+        Assert.Equal(32, bounds.MaxBodyCharacters);
+        Assert.Equal(33, bounds.MaxAttachmentCount);
+        Assert.Equal(34L, bounds.MaxAttachmentBytes);
+        Assert.Equal(35L, bounds.MaxMessageBytes);
+    }
+
     private static IReadOnlyList<ValidationResult> Validate(MailDeliveryOptions options) =>
         [.. options.Validate(new ValidationContext(options))];
 

--- a/tests/Host.UnitTests/Configuration/Mail/MailExtractionBackfillOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Mail/MailExtractionBackfillOptionsTests.cs
@@ -1,0 +1,43 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Host.Configuration.Mail;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Configuration.Mail;
+
+/// <summary>Covers the bounds the extraction backfill walks stored mail under, and what the sensitive-content section asks of it.</summary>
+public sealed class MailExtractionBackfillOptionsTests
+{
+    /// <summary>Both keys one walk is bounded by reach the bounds the walk stops at.</summary>
+    [Fact]
+    public void ToBackfillOptions_ConfiguredSection_CarriesBothKeysTheWalkStopsAt()
+    {
+        // Arrange
+        var settings = new MailExtractionBackfillOptions { BatchSize = 12, MaxBatchesPerRun = 5 };
+
+        // Act
+        var bounds = settings.ToBackfillOptions(rebuildsStaleDerivedData: false);
+
+        // Assert
+        Assert.Equal(12, bounds.BatchSize);
+        Assert.Equal(5, bounds.MaxBatchesPerRun);
+    }
+
+    /// <summary>Whether a stale derived copy is rebuilt is the other section's answer, so it arrives as an argument rather than as a key here.</summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ToBackfillOptions_RebuildDecidedElsewhere_CarriesWhatThatSectionAnswered(bool rebuildsStaleDerivedData)
+    {
+        // Arrange
+        var settings = new MailExtractionBackfillOptions();
+
+        // Act
+        var bounds = settings.ToBackfillOptions(rebuildsStaleDerivedData);
+
+        // Assert
+        Assert.Equal(rebuildsStaleDerivedData, bounds.RebuildsStaleDerivedData);
+    }
+}

--- a/tests/Host.UnitTests/Configuration/Mail/MailSynchronizationOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Mail/MailSynchronizationOptionsTests.cs
@@ -1224,6 +1224,75 @@ public sealed class MailSynchronizationOptionsTests
             .Bind(options, binderOptions => binderOptions.ErrorOnUnknownConfiguration = true));
     }
 
+    /// <summary>Every key a convergence pass is bounded by reaches the bound the application takes.</summary>
+    [Fact]
+    public void ToConvergenceOptions_ConfiguredSection_CarriesEveryKeyThePassIsBoundedBy()
+    {
+        // Arrange
+        var options = new MailSynchronizationOptions
+        {
+            MaxMutationsPerConvergencePass = 17,
+            UnknownMutationOutcomeGrace = TimeSpan.FromHours(3),
+        };
+
+        // Act
+        var bounds = options.ToConvergenceOptions();
+
+        // Assert
+        Assert.Equal(17, bounds.MaxMutationsPerPass);
+        Assert.Equal(TimeSpan.FromHours(3), bounds.UnknownOutcomeGrace);
+    }
+
+    /// <summary>Every key one run stops at reaches the bound the application takes, and none is read off a neighbour.</summary>
+    [Fact]
+    public void ToSynchronizationOptions_ConfiguredSection_CarriesEveryKeyTheRunStopsAt()
+    {
+        // Arrange
+        var options = new MailSynchronizationOptions
+        {
+            MaxMetadataBatchSize = 11,
+            MaxRawMimeBytes = 12L,
+            MaxMetadataBatchesPerRun = 13,
+            MaxReconciledEmailsPerRun = 14,
+            MaxContentBytesPerRun = 15L,
+        };
+
+        // Act
+        var bounds = options.ToSynchronizationOptions();
+
+        // Assert
+        Assert.Equal(11, bounds.MaxMetadataBatchSize);
+        Assert.Equal(12L, bounds.MaxRawMimeBytes);
+        Assert.Equal(13, bounds.MaxMetadataBatchesPerRun);
+        Assert.Equal(14, bounds.MaxReconciledEmailsPerRun);
+        Assert.Equal(15L, bounds.MaxContentBytesPerRun);
+    }
+
+    /// <summary>Every limit a MIME walk is performed under reaches the parse, including whether it verifies for itself.</summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ToMimeExtractionOptions_ConfiguredSection_CarriesEveryLimitTheParseIsPerformedUnder(bool verifyDkimLocally)
+    {
+        // Arrange
+        var options = new MailSynchronizationOptions
+        {
+            MaxMimePartCount = 21,
+            MaxMimeNestingDepth = 22,
+            MaxExtractedTextCharacters = 23,
+            VerifyDkimLocally = verifyDkimLocally,
+        };
+
+        // Act
+        var limits = options.ToMimeExtractionOptions();
+
+        // Assert
+        Assert.Equal(21, limits.MaxPartCount);
+        Assert.Equal(22, limits.MaxNestingDepth);
+        Assert.Equal(23, limits.MaxExtractedTextCharacters);
+        Assert.Equal(verifyDkimLocally, limits.VerifyDkimLocally);
+    }
+
     private static TrustAnchorLoader CreateTrustAnchorLoader() =>
         new(new PlaintextOnlySecretReferenceResolver());
 

--- a/tests/Host.UnitTests/Configuration/Mail/MailboxSearchOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Mail/MailboxSearchOptionsTests.cs
@@ -28,6 +28,21 @@ public sealed class MailboxSearchOptionsTests
         Assert.Equal(EmailSearchSnippetBounds.Default.WordsPerSnippet, options.WordsPerSnippet);
     }
 
+    /// <summary>Both keys reach the bounds every search in the process applies.</summary>
+    [Fact]
+    public void ToSnippetBounds_ConfiguredSection_CarriesBothKeysTheSearchApplies()
+    {
+        // Arrange
+        var options = new MailboxSearchOptions { SnippetsPerEmail = 2, WordsPerSnippet = 19 };
+
+        // Act
+        var bounds = options.ToSnippetBounds();
+
+        // Assert
+        Assert.Equal(2, bounds.SnippetsPerEmail);
+        Assert.Equal(19, bounds.WordsPerSnippet);
+    }
+
     /// <summary>The bound is the privacy control, so a value outside the range fails startup rather than being clamped.</summary>
     [Theory]
     [InlineData(0, EmailSearchSnippetBounds.MinimumWordsPerSnippet, nameof(MailboxSearchOptions.SnippetsPerEmail))]

--- a/tests/Host.UnitTests/Configuration/Persistence/EmailContentOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Persistence/EmailContentOptionsTests.cs
@@ -172,6 +172,21 @@ public sealed class EmailContentOptionsTests
         Assert.Contains("LinkLifetime", result.ErrorMessage, StringComparison.Ordinal);
     }
 
+    /// <summary>Both keys one read is bounded by reach the bounds the read truncates at.</summary>
+    [Fact]
+    public void ToReadOptions_ConfiguredSection_CarriesBothKeysTheReadTruncatesAt()
+    {
+        // Arrange
+        var options = new EmailContentOptions { MaxBodyCharacters = 40_000, MaxCharactersPerRead = 90_000 };
+
+        // Act
+        var bounds = options.ToReadOptions();
+
+        // Assert
+        Assert.Equal(40_000, bounds.MaxBodyCharacters);
+        Assert.Equal(90_000, bounds.MaxCharactersPerRead);
+    }
+
     private static ValidationResult[] Validate(EmailContentOptions options)
     {
         var results = new List<ValidationResult>();


### PR DESCRIPTION
## What changed

`AddInfrastructure` held 200 registrations in one 637-line method and `AddApplicationBounds` twenty in one 199-line method. Both were the maximal-conflict files in the repository, because both were the one place anything new could be appended. Each now calls named private stages, so two branches touching different subjects touch different methods.

**`src/Infrastructure/ServiceCollectionExtensions.cs`** — `AddInfrastructure` now calls seventeen private stages, cut where the flat sequence already changes subject: `AddPersistenceAdapters`, `AddEmbeddingAdapters`, `AddStoredMailAdapters`, `AddMailRuleAdapters`, `AddJobQueueAdapters`, `AddSpamClassificationStores`, `AddReadSideStores`, `AddMailContentAdapters`, `AddSynchronization`, `AddMailboxReaders`, `AddSpamClassification`, `AddMailAnswering`, `AddMailProtocolAdapters`, `AddMailboxMutationRecords`, `AddMailDelivery`, `AddMailboxMutations`, `AddContacts`. The two access-authorization registrations stay in the parent, because every stage below registers something that asks them.

**`src/Host/HostComposition.cs`** — `AddApplicationBounds` now calls `AddMailSynchronizationBounds`, `AddMailDeliveryBounds`, `AddStoredMailBounds`, and `AddJobQueue`.

**The projections move onto the options types**, beside their properties and following `MailDeliveryOptions.ToPolicy()`: `MailSynchronizationOptions.To{Convergence,Synchronization,MimeExtraction}Options()`, `MailDeliveryOptions.To{OutboxSettings,OutgoingEmailBounds}()`, `EmailContentOptions.ToReadOptions()`, `MailExtractionBackfillOptions.ToBackfillOptions(bool)`, `EmbeddingBackfillOptions.ToBackfillOptions()`, `JobQueueOptions.To{Execution,Capacity}Settings()`, and `MailboxSearchOptions.ToSnippetBounds()`. Each registration becomes one call and reads the same source — `IOptions<T>.Value` or `ISettingsSnapshot<T>.Current` — it read before. The five one-argument constructions (`StoredContentCeiling`, `RawMimeMemoryBudget`, `MailOutboxSignal`, `AuthoredSendSettings`, `PersistenceConcurrencyOptions`) stay inline, as does `AttachmentDownloadSettings`, which composes two sections rather than projecting one.

## Why the split is safe

The `AddInfrastructure` cut is mechanical and was verified as such rather than argued:

- the 223 `services.*` statements read top to bottom across the seventeen stages are **byte-identical in order** to what the single method held;
- a diff of every `//` line in the file before and after shows **only additions** — the new XML docs — so every lifetime comment still sits on the registration it explains.

In `AddApplicationBounds`, one registration changed relative position: `EmailSearchSnippetBounds` moves from after the job handlers into `AddStoredMailBounds`. It is a unique service type with no `TryAdd` and no `IEnumerable<T>` consumer. The two multi-registered types, `IJobHandler` (five) and `IScheduledJobSource` (two), keep their exact relative order inside `AddJobQueue`.

`HostCompositionTests` — the one place the real service graph is composed, with `ValidateOnBuild` and `ValidateScopes` on — passes unchanged, which is the acceptance criterion for "no registration or lifetime moved".

## Where this departs from the issue

The issue named ten stages for `AddInfrastructure`: `AddPersistenceAdapters`, `AddMailProtocolAdapters`, `AddSynchronization`, `AddMailboxMutations`, `AddEmbeddingsAndRetrieval`, `AddMailDelivery`, `AddContacts`, `AddRulesAndSpam`, `AddAuditTrails`, `AddInfrastructureTelemetry`. Six of them are used verbatim. The other four name a *thematic* grouping the file's order does not offer contiguously — the rule stores, the job stores, and the spam stores are three separate runs with other subjects between them, and the telemetry singletons are scattered across the whole sequence.

Gathering them thematically would have meant moving registrations relative to each other, which the same acceptance line forbids ("with no registration moved between them"), and it would have invalidated the 62 comment lines that place a registration relative to its neighbours — "beside the record store", "registered here rather than beside the OAuth client", "beside the readers rather than with the repositories that take one". The issue's own context calls the method "one flat sequence, which is what makes a split mechanical and behaviour-preserving", so the cut follows the sequence and each stage is named for what it actually holds. Seventeen stages rather than ten follows from the same constraint.

For `AddApplicationBounds` the issue named three stages; a fourth, `AddStoredMailBounds`, holds the content, backfill, persistence, and search bounds that belong to none of the three and would otherwise have been left loose in the parent.

The issue counted eight multi-property projections; this change converts eleven, which is every registration projecting a bound section onto an application type. Leaving three identically shaped projections inline would have been the inconsistency the convention exists to remove.

## Tests

New unit tests cover every projection, asserting each key reaches the property it maps to so a mis-mapping fails rather than compiling — `MailSynchronizationOptionsTests`, `MailDeliveryOptionsTests`, `MailboxSearchOptionsTests`, `JobQueueOptionsTests`, `EmbeddingBackfillOptionsTests`, `EmailContentOptionsTests`, and a new `MailExtractionBackfillOptionsTests`. ADR 0002 asks for exactly this ("unit tests cover ... mapping from options DTOs to business settings"); until now the mappings were only reachable through a container.

## Contracts

No break. No configuration key, default, range, or reload class changes; no MCP tool argument, database column, or deployment contract is touched. `scripts/verify-full.sh` passed.

Closes #1031

- Issue: https://github.com/Krzysztof318/MailFathom/issues/1031
