### PR TITLE
[#1027] Give the two IMAP copy filers one append

### DIFF
--- a/src/Application/Mail/Delivery/Drafts/MailDraftFiler.cs
+++ b/src/Application/Mail/Delivery/Drafts/MailDraftFiler.cs
@@ -3,7 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Diagnostics.CodeAnalysis;
-using MailFathom.Application.EmailContent.Storage;
+using MailFathom.Application.Mail.Delivery.Filing;
 using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Mail.Mutations.Destinations;
 using MailFathom.Application.Persistence;
@@ -45,43 +45,43 @@ namespace MailFathom.Application.Mail.Delivery.Drafts;
 /// </remarks>
 public sealed class MailDraftFiler
 {
+    private readonly MailboxCopyAppender appends;
     private readonly IMailboxWriteSessionFactory writeSessions;
     private readonly MailboxDestinationResolver destinations;
-    private readonly IEmailContentStore contentStore;
     private readonly IMailDraftStore drafts;
     private readonly IMailTransportSecurityPolicyReader transportSecurityPolicies;
     private readonly OptimisticConcurrencyRetryPolicy commitPolicy;
     private readonly TimeProvider timeProvider;
 
-    /// <summary>Initializes the filer from the session it appends through and the record it writes each copy onto.</summary>
-    /// <param name="writeSessions">Opens the one session able to change a mailbox.</param>
+    /// <summary>Initializes the filer from the append it files through and the record it writes each copy onto.</summary>
+    /// <param name="appends">Puts each revision into the drafts folder, in the order that keeps it one copy.</param>
+    /// <param name="writeSessions">Opens the one session able to change a mailbox, which a removal needs of its own.</param>
     /// <param name="destinations">Turns the drafts role into the folder of this account it means.</param>
-    /// <param name="contentStore">Holds the stored MIME each revision is appended from.</param>
     /// <param name="drafts">Keeps the durable account of every draft and every copy of one.</param>
     /// <param name="transportSecurityPolicies">Supplies the connection and authentication policy the commands obey.</param>
     /// <param name="commitPolicy">Commits each movement of the draft.</param>
-    /// <param name="timeProvider">Stamps the copy's internal date and everything the record notes.</param>
+    /// <param name="timeProvider">Stamps everything the record notes.</param>
     /// <exception cref="ArgumentNullException">Thrown when a collaborator is <see langword="null" />.</exception>
     public MailDraftFiler(
+        MailboxCopyAppender appends,
         IMailboxWriteSessionFactory writeSessions,
         MailboxDestinationResolver destinations,
-        IEmailContentStore contentStore,
         IMailDraftStore drafts,
         IMailTransportSecurityPolicyReader transportSecurityPolicies,
         OptimisticConcurrencyRetryPolicy commitPolicy,
         TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(appends);
         ArgumentNullException.ThrowIfNull(writeSessions);
         ArgumentNullException.ThrowIfNull(destinations);
-        ArgumentNullException.ThrowIfNull(contentStore);
         ArgumentNullException.ThrowIfNull(drafts);
         ArgumentNullException.ThrowIfNull(transportSecurityPolicies);
         ArgumentNullException.ThrowIfNull(commitPolicy);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
+        this.appends = appends;
         this.writeSessions = writeSessions;
         this.destinations = destinations;
-        this.contentStore = contentStore;
         this.drafts = drafts;
         this.transportSecurityPolicies = transportSecurityPolicies;
         this.commitPolicy = commitPolicy;
@@ -118,7 +118,10 @@ public sealed class MailDraftFiler
         }
         catch (Exception failure)
         {
-            return await this.RecordFailureAsync(draft, FailureCodeOf(failure), MailDraftFilingOutcome.Failed);
+            return await this.RecordFailureAsync(
+                draft,
+                MailboxCopyAppender.FailureCodeOf(failure),
+                MailDraftFilingOutcome.Failed);
         }
     }
 
@@ -162,82 +165,38 @@ public sealed class MailDraftFiler
             : appended;
     }
 
-    /// <summary>Appends the stored message as a new copy in the drafts folder, and confirms what the server said.</summary>
-    /// <remarks>
-    /// Everything that can fail without reaching a mail server happens before the issued write, which is what keeps an
-    /// ordinary connection failure repeatable. Past that write the append may already be in the folder, so every ending
-    /// is recorded as an outcome nobody can settle rather than raised into a retry that would append a second copy.
-    /// </remarks>
-    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Past the issued write the append may already have reached the folder, so every way it can end has to be recorded as an outcome nobody can settle rather than raised into a retry that would leave a second draft in the owner's folder.")]
+    /// <summary>Appends the stored message as a new copy in the drafts folder, moving the draft as the append passes.</summary>
     private async Task<MailDraftFilingResult> AppendCurrentRevisionAsync(
         MailDraftRecord draft,
         CancellationToken cancellationToken)
     {
-        if (await this.ResolveDraftsFolderAsync(draft, cancellationToken) is not { } destination)
-        {
-            return await this.RecordFailureAsync(
-                draft,
-                MailFathomErrorCode.OutgoingEmailFilingDestinationUnavailable,
-                MailDraftFilingOutcome.DestinationUnavailable);
-        }
-
-        var content = await this.contentStore.FindMailDraftContentAsync(draft.Id, cancellationToken);
-
-        if (content is null || content.RawMime.IsEmpty)
-        {
-            // The record and its message are written in one transaction, so a draft without one describes a revision
-            // that can never be appended rather than a message still being stored.
-            return await this.RecordFailureAsync(
-                draft,
-                MailFathomErrorCode.OutgoingEmailFilingFailedUnexpectedly,
-                MailDraftFilingOutcome.Failed);
-        }
-
-        var transportSecurityPolicy = this.transportSecurityPolicies.GetPolicy(draft.AccountId);
-
-        await using var session = await this.writeSessions.OpenForWritingAsync(
+        var appended = await this.appends.AppendAsync(
             draft.AccountId,
-            destination.Binding,
-            transportSecurityPolicy,
-            cancellationToken);
-
-        await this.commitPolicy.CommitAsync(
-            (persistenceSession, token) => this.drafts.RecordAppendIssuedAsync(
-                persistenceSession,
-                draft.Id,
-                destination.Binding,
-                this.timeProvider.GetUtcNow(),
+            OutgoingMailFiling.Draft,
+            MailboxCopySource.MailDraft(draft.Id),
+            (binding, token) => this.commitPolicy.CommitAsync(
+                (persistenceSession, commitToken) => this.drafts.RecordAppendIssuedAsync(
+                    persistenceSession,
+                    draft.Id,
+                    binding,
+                    this.timeProvider.GetUtcNow(),
+                    commitToken),
                 token),
-            cancellationToken);
-
-        try
-        {
-            var copy = await session.AppendAsync(
-                content.RawMime,
-                OutgoingMailFiling.Draft.Flags,
-                this.timeProvider.GetUtcNow(),
-                cancellationToken);
-
-            // Committed outside the caller's cancellation, because the append has already happened on somebody else's
-            // server and a shutdown that abandoned this write would leave the draft saying the outcome is unknown for
-            // a copy the server named exactly.
-            await this.commitPolicy.CommitAsync(
-                (persistenceSession, token) => this.drafts.RecordAppendConfirmedAsync(
+            copy => this.commitPolicy.CommitAsync(
+                (persistenceSession, commitToken) => this.drafts.RecordAppendConfirmedAsync(
                     persistenceSession,
                     draft.Id,
                     copy,
-                    token),
-                CancellationToken.None);
+                    commitToken),
+                CancellationToken.None),
+            cancellationToken);
 
+        if (appended.Failure is not { } failure)
+        {
             return Result(draft, MailDraftFilingOutcome.Filed);
         }
-        catch (Exception failure)
-        {
-            return await this.RecordFailureAsync(
-                draft,
-                FailureCodeOf(failure),
-                MailDraftFilingOutcome.OutcomeUnknown);
-        }
+
+        return await this.RecordFailureAsync(draft, failure, FilingOutcomeOf(appended.Outcome));
     }
 
     /// <summary>Takes every copy a revision replaced back out of the folder, leaving the current one standing.</summary>
@@ -443,15 +402,16 @@ public sealed class MailDraftFiler
         return Result(draft, outcome, failure);
     }
 
-    /// <summary>Names the code that stands for whatever ended an attempt.</summary>
+    /// <summary>Reads what the append reported as what it means for the draft the copy belongs to.</summary>
     /// <remarks>
-    /// A first-party failure already carries the code an operator looks up, so it is kept. What is left is genuinely
-    /// unaccounted for and says so rather than borrowing a code that would mislead.
+    /// <see cref="MailboxCopyAppendOutcome.Appended" /> never reaches here, because a result carrying no failure is the
+    /// copy that was filed. What is left is a revision that could not be appended, which the draft outlives.
     /// </remarks>
-    private static MailFathomErrorCode FailureCodeOf(Exception failure) => failure switch
+    private static MailDraftFilingOutcome FilingOutcomeOf(MailboxCopyAppendOutcome outcome) => outcome switch
     {
-        MailFathomException named => named.ErrorCode,
-        _ => MailFathomErrorCode.OutgoingEmailFilingFailedUnexpectedly,
+        MailboxCopyAppendOutcome.DestinationUnavailable => MailDraftFilingOutcome.DestinationUnavailable,
+        MailboxCopyAppendOutcome.OutcomeUnknown => MailDraftFilingOutcome.OutcomeUnknown,
+        _ => MailDraftFilingOutcome.Failed,
     };
 
     private static MailDraftFilingResult Result(

--- a/src/Application/Mail/Delivery/Filing/MailboxCopyAppendResult.cs
+++ b/src/Application/Mail/Delivery/Filing/MailboxCopyAppendResult.cs
@@ -1,0 +1,89 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Delivery.Filing;
+using MailFathom.Domain.Failures;
+
+namespace MailFathom.Application.Mail.Delivery.Filing;
+
+/// <summary>States what happened when a copy of a message MailFathom composed was appended to a folder.</summary>
+/// <remarks>
+/// The three refusals are separate because what a caller may do next differs: two of them happened before the command
+/// went out and leave the folder exactly as it was, while the third happened after it and leaves nobody able to say
+/// whether the copy is there. Reporting them as one reason would let a caller retry the one append that must never be
+/// repeated.
+/// </remarks>
+public enum MailboxCopyAppendOutcome
+{
+    /// <summary>The server accepted the copy and answered for it.</summary>
+    Appended = 0,
+
+    /// <summary>No folder of the account plays the role the filing names, so there is nowhere to append to.</summary>
+    DestinationUnavailable = 1,
+
+    /// <summary>Nothing is stored under the source, so there are no bytes to append.</summary>
+    MessageUnavailable = 2,
+
+    /// <summary>The append was issued and how it ended is not knowable, so the copy may or may not be in the folder.</summary>
+    OutcomeUnknown = 3,
+}
+
+/// <summary>Carries what the server said about an appended copy, or the reason nothing was appended.</summary>
+/// <remarks>
+/// A failure is a result rather than an exception for the reason the whole filing mechanism is one: a copy that could
+/// not be filed says nothing about the send or the draft it belongs to, and raising would end the pass that was
+/// settling the messages beside it.
+/// </remarks>
+public sealed record MailboxCopyAppendResult
+{
+    private MailboxCopyAppendResult(
+        MailboxCopyAppendOutcome outcome,
+        AppendedMailCopy? copy,
+        MailFathomErrorCode? failure)
+    {
+        this.Outcome = outcome;
+        this.Copy = copy;
+        this.Failure = failure;
+    }
+
+    /// <summary>Gets what happened.</summary>
+    public MailboxCopyAppendOutcome Outcome { get; }
+
+    /// <summary>Gets what the server said about the copy, which is present exactly when the append was answered.</summary>
+    public AppendedMailCopy? Copy { get; }
+
+    /// <summary>Gets the code standing for why nothing was filed, which is absent exactly when the copy was.</summary>
+    public MailFathomErrorCode? Failure { get; }
+
+    /// <summary>Reports a copy the server accepted.</summary>
+    /// <param name="copy">What the server said about it.</param>
+    /// <returns>An appended result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="copy" /> is <see langword="null" />.</exception>
+    public static MailboxCopyAppendResult Appended(AppendedMailCopy copy)
+    {
+        ArgumentNullException.ThrowIfNull(copy);
+
+        return new MailboxCopyAppendResult(MailboxCopyAppendOutcome.Appended, copy, failure: null);
+    }
+
+    /// <summary>Reports a role no folder of the account plays.</summary>
+    /// <returns>A result naming a destination that is not available.</returns>
+    public static MailboxCopyAppendResult DestinationUnavailable() => new(
+        MailboxCopyAppendOutcome.DestinationUnavailable,
+        copy: null,
+        MailFathomErrorCode.OutgoingEmailFilingDestinationUnavailable);
+
+    /// <summary>Reports a source nothing is stored under.</summary>
+    /// <returns>A result naming a message that cannot be appended.</returns>
+    public static MailboxCopyAppendResult MessageUnavailable() => new(
+        MailboxCopyAppendOutcome.MessageUnavailable,
+        copy: null,
+        MailFathomErrorCode.OutgoingEmailFilingFailedUnexpectedly);
+
+    /// <summary>Reports an append that was issued and never settled.</summary>
+    /// <param name="failure">The code standing for whatever ended it.</param>
+    /// <returns>A result nobody can settle.</returns>
+    public static MailboxCopyAppendResult OutcomeUnknown(MailFathomErrorCode failure) =>
+        new(MailboxCopyAppendOutcome.OutcomeUnknown, copy: null, failure);
+}

--- a/src/Application/Mail/Delivery/Filing/MailboxCopyAppender.cs
+++ b/src/Application/Mail/Delivery/Filing/MailboxCopyAppender.cs
@@ -25,7 +25,9 @@ namespace MailFathom.Application.Mail.Delivery.Filing;
 /// <b>The order of the two writes is the whole of the safety here.</b> An <c>APPEND</c> issued twice is a second
 /// message in somebody's folder rather than a repeat of the first, and nothing that folder shows afterwards tells the
 /// two apart. So the caller's record of the copy is made durable before the command goes out, and everything that can
-/// fail without reaching a mail server happens before that write. The two writes are the caller's because the row they
+/// fail without leaving a copy in the folder happens before that write. Opening the session does reach the server —
+/// it connects, authenticates, and selects the folder — but none of that puts a message anywhere, which is what makes
+/// an attempt that ended before the issued write repeatable. The two writes are the caller's because the row they
 /// move belongs to the caller, but when each of them runs is not: they are taken as callbacks so the ordering cannot
 /// hold on one filing path and lapse on another.
 /// </para>
@@ -100,9 +102,11 @@ public sealed class MailboxCopyAppender
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="source" />, <paramref name="recordIssuedAsync" />, or <paramref name="recordConfirmedAsync" /> is <see langword="null" />.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="filing" /> is the unspecified struct default.</exception>
     /// <remarks>
-    /// A caller that stops before the issued write gets an <see cref="OperationCanceledException" /> and a mail server
-    /// that was never reached, so the next pass files the copy as though this attempt had never started. Past that
-    /// write nothing is raised, because a shutdown there says nothing about a command that may already be in flight.
+    /// A caller that stops before the issued write gets an <see cref="OperationCanceledException" /> and no
+    /// <c>APPEND</c> issued, so the next pass files the copy as though this attempt had never started. That says
+    /// nothing about whether the server was reached: a stop while the session is opening can arrive after the
+    /// connection, the authentication, or the folder selection, none of which leaves anything in the folder. Past the
+    /// issued write nothing is raised, because a shutdown there says nothing about a command that may be in flight.
     /// </remarks>
     [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Past the issued write the append may already have reached the folder, so every way it can end has to be recorded as an outcome nobody can settle rather than raised into a retry that would file a second copy.")]
     public async Task<MailboxCopyAppendResult> AppendAsync(
@@ -144,7 +148,7 @@ public sealed class MailboxCopyAppender
             transportSecurityPolicy,
             cancellationToken);
 
-        // Written only once everything that could fail without reaching a mail server already has. From here on a
+        // Written only once everything that can fail without leaving a copy in the folder already has. From here on a
         // failure leaves the caller's row saying the append may have happened, which is what stops a second copy — so
         // anything that can be established first is established first.
         await recordIssuedAsync(destination.Binding, cancellationToken);

--- a/src/Application/Mail/Delivery/Filing/MailboxCopyAppender.cs
+++ b/src/Application/Mail/Delivery/Filing/MailboxCopyAppender.cs
@@ -1,0 +1,185 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using MailFathom.Application.EmailContent.Storage;
+using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Destinations;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Delivery.Filing;
+using MailFathom.Domain.Failures;
+using MailFathom.Domain.Folders;
+
+namespace MailFathom.Application.Mail.Delivery.Filing;
+
+/// <summary>Puts one copy of a message MailFathom composed into a folder of the account it belongs to.</summary>
+/// <remarks>
+/// <para>
+/// Every copy this system files goes through here, whatever kind of message it is a copy of. A sent copy, a mirror of
+/// a message still waiting to go out, and a revision of a draft differ in the role their folder plays, the flags the
+/// copy carries, and the durable record each is written onto — and in nothing else, so the append itself is one call
+/// and a fourth kind of copy inherits it rather than restating it.
+/// </para>
+/// <para>
+/// <b>The order of the two writes is the whole of the safety here.</b> An <c>APPEND</c> issued twice is a second
+/// message in somebody's folder rather than a repeat of the first, and nothing that folder shows afterwards tells the
+/// two apart. So the caller's record of the copy is made durable before the command goes out, and everything that can
+/// fail without reaching a mail server happens before that write. The two writes are the caller's because the row they
+/// move belongs to the caller, but when each of them runs is not: they are taken as callbacks so the ordering cannot
+/// hold on one filing path and lapse on another.
+/// </para>
+/// <para>
+/// Nothing here raises for a copy that could not be filed. Past the issued write the append may already be in the
+/// folder, so every way it can end is classified into a code and returned, rather than raised into a retry that would
+/// leave the owner with two copies of their own message.
+/// </para>
+/// </remarks>
+public sealed class MailboxCopyAppender
+{
+    private readonly IMailboxWriteSessionFactory writeSessions;
+    private readonly MailboxDestinationResolver destinations;
+    private readonly IEmailContentStore contentStore;
+    private readonly IMailTransportSecurityPolicyReader transportSecurityPolicies;
+    private readonly TimeProvider timeProvider;
+
+    /// <summary>Initializes the appender from the session it appends through and the store it reads the message from.</summary>
+    /// <param name="writeSessions">Opens the one session able to change a mailbox.</param>
+    /// <param name="destinations">Turns the role a filing names into the folder of the account it means.</param>
+    /// <param name="contentStore">Holds the stored MIME the copy is appended from.</param>
+    /// <param name="transportSecurityPolicies">Supplies the connection and authentication policy the append obeys.</param>
+    /// <param name="timeProvider">Stamps the copy's internal date.</param>
+    /// <exception cref="ArgumentNullException">Thrown when a collaborator is <see langword="null" />.</exception>
+    public MailboxCopyAppender(
+        IMailboxWriteSessionFactory writeSessions,
+        MailboxDestinationResolver destinations,
+        IEmailContentStore contentStore,
+        IMailTransportSecurityPolicyReader transportSecurityPolicies,
+        TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(writeSessions);
+        ArgumentNullException.ThrowIfNull(destinations);
+        ArgumentNullException.ThrowIfNull(contentStore);
+        ArgumentNullException.ThrowIfNull(transportSecurityPolicies);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        this.writeSessions = writeSessions;
+        this.destinations = destinations;
+        this.contentStore = contentStore;
+        this.transportSecurityPolicies = transportSecurityPolicies;
+        this.timeProvider = timeProvider;
+    }
+
+    /// <summary>Names the code that stands for whatever ended an attempt.</summary>
+    /// <param name="failure">What ended it.</param>
+    /// <returns>The code an operator looks the failure up by.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="failure" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// A first-party failure already carries the code an operator looks up, so it is kept. What is left is genuinely
+    /// unaccounted for and says so rather than borrowing a code that would mislead.
+    /// </remarks>
+    public static MailFathomErrorCode FailureCodeOf(Exception failure)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+
+        return failure switch
+        {
+            MailFathomException named => named.ErrorCode,
+            _ => MailFathomErrorCode.OutgoingEmailFilingFailedUnexpectedly,
+        };
+    }
+
+    /// <summary>Appends one copy, having made the caller's record of it durable first.</summary>
+    /// <param name="accountId">The account whose folder the copy goes into.</param>
+    /// <param name="filing">Which place the copy goes into, which decides the role and the flags.</param>
+    /// <param name="source">The stored message the copy is appended from.</param>
+    /// <param name="recordIssuedAsync">Commits the caller's record that an append is about to be issued into the resolved folder.</param>
+    /// <param name="recordConfirmedAsync">Commits the caller's record of what the server said, which runs outside the caller's cancellation.</param>
+    /// <param name="cancellationToken">Cancels everything up to and including the append.</param>
+    /// <returns>What the server said about the copy, or the reason nothing was appended.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="source" />, <paramref name="recordIssuedAsync" />, or <paramref name="recordConfirmedAsync" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="filing" /> is the unspecified struct default.</exception>
+    /// <remarks>
+    /// A caller that stops before the issued write gets an <see cref="OperationCanceledException" /> and a mail server
+    /// that was never reached, so the next pass files the copy as though this attempt had never started. Past that
+    /// write nothing is raised, because a shutdown there says nothing about a command that may already be in flight.
+    /// </remarks>
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Past the issued write the append may already have reached the folder, so every way it can end has to be recorded as an outcome nobody can settle rather than raised into a retry that would file a second copy.")]
+    public async Task<MailboxCopyAppendResult> AppendAsync(
+        MailAccountId accountId,
+        OutgoingMailFiling filing,
+        MailboxCopySource source,
+        Func<MailFolderResolution, CancellationToken, Task> recordIssuedAsync,
+        Func<AppendedMailCopy, Task> recordConfirmedAsync,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(recordIssuedAsync);
+        ArgumentNullException.ThrowIfNull(recordConfirmedAsync);
+
+        if (!filing.IsSpecified)
+        {
+            throw new ArgumentException("The unspecified default of the struct names no filing.", nameof(filing));
+        }
+
+        if (await this.ResolveDestinationAsync(accountId, filing.Role, cancellationToken) is not { } destination)
+        {
+            return MailboxCopyAppendResult.DestinationUnavailable();
+        }
+
+        var content = await source.FindContentAsync(this.contentStore, cancellationToken);
+
+        if (content is null || content.RawMime.IsEmpty)
+        {
+            // A record and its message are written in one transaction, so a record without one describes a copy that
+            // can never be appended rather than a message still being stored. No later attempt can invent it.
+            return MailboxCopyAppendResult.MessageUnavailable();
+        }
+
+        var transportSecurityPolicy = this.transportSecurityPolicies.GetPolicy(accountId);
+
+        await using var session = await this.writeSessions.OpenForWritingAsync(
+            accountId,
+            destination.Binding,
+            transportSecurityPolicy,
+            cancellationToken);
+
+        // Written only once everything that could fail without reaching a mail server already has. From here on a
+        // failure leaves the caller's row saying the append may have happened, which is what stops a second copy — so
+        // anything that can be established first is established first.
+        await recordIssuedAsync(destination.Binding, cancellationToken);
+
+        try
+        {
+            var copy = await session.AppendAsync(
+                content.RawMime,
+                filing.Flags,
+                this.timeProvider.GetUtcNow(),
+                cancellationToken);
+
+            // Handed over without the caller's cancellation, for the reason a delivery outcome is: the append has
+            // already happened on somebody else's server, and a shutdown that abandoned this write would leave the row
+            // saying the outcome is unknown for a copy the server named exactly.
+            await recordConfirmedAsync(copy);
+
+            return MailboxCopyAppendResult.Appended(copy);
+        }
+        catch (Exception failure)
+        {
+            return MailboxCopyAppendResult.OutcomeUnknown(FailureCodeOf(failure));
+        }
+    }
+
+    /// <summary>Finds the folder of the account that plays a role, as it currently resolves.</summary>
+    private async Task<MailboxDestination?> ResolveDestinationAsync(
+        MailAccountId accountId,
+        MailFolderSpecialUse role,
+        CancellationToken cancellationToken)
+    {
+        var reference = MailFolderReference.ToRole(role);
+
+        var resolved = await this.destinations.ResolveAsync(accountId, [reference], cancellationToken);
+
+        return resolved.Find(reference).Destination;
+    }
+}

--- a/src/Application/Mail/Delivery/Filing/MailboxCopySource.cs
+++ b/src/Application/Mail/Delivery/Filing/MailboxCopySource.cs
@@ -1,0 +1,62 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.EmailContent.Storage;
+using MailFathom.Domain.Delivery;
+using MailFathom.Domain.Delivery.Drafts;
+
+namespace MailFathom.Application.Mail.Delivery.Filing;
+
+/// <summary>Names the stored message a filed copy is appended from.</summary>
+/// <remarks>
+/// <para>
+/// Both messages this system appends are raw MIME held behind <see cref="IEmailContentStore" />, and they are keyed
+/// differently because they belong to different things: a send's payload belongs to the record of the send, a draft's
+/// to the draft its author is still editing. What reads them is one append, so which of the two it is travels as a
+/// value rather than as a second appender.
+/// </para>
+/// <para>
+/// It is not a general handle on stored content. Nothing here reaches a synchronized message or a recurring send's
+/// draft, because neither is a copy MailFathom files into a folder of its own.
+/// </para>
+/// </remarks>
+public sealed record MailboxCopySource
+{
+    private readonly OutgoingEmailId? outgoingEmailId;
+    private readonly MailDraftId? mailDraftId;
+
+    private MailboxCopySource(OutgoingEmailId? outgoingEmailId, MailDraftId? mailDraftId)
+    {
+        this.outgoingEmailId = outgoingEmailId;
+        this.mailDraftId = mailDraftId;
+    }
+
+    /// <summary>Names the message one outgoing record will be, or already was, transmitted as.</summary>
+    /// <param name="outgoingEmailId">The record of the send.</param>
+    /// <returns>A source that reads the send's stored payload.</returns>
+    public static MailboxCopySource OutgoingEmail(OutgoingEmailId outgoingEmailId) =>
+        new(outgoingEmailId, mailDraftId: null);
+
+    /// <summary>Names the message the current revision of one draft is held as.</summary>
+    /// <param name="mailDraftId">The draft to append.</param>
+    /// <returns>A source that reads the draft's stored payload.</returns>
+    public static MailboxCopySource MailDraft(MailDraftId mailDraftId) =>
+        new(outgoingEmailId: null, mailDraftId);
+
+    /// <summary>Reads the bytes this source names.</summary>
+    /// <param name="contentStore">The port every piece of raw MIME is held behind.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The stored message, or <see langword="null" /> when none is stored under this source.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contentStore" /> is <see langword="null" />.</exception>
+    public Task<StoredEmailContent?> FindContentAsync(
+        IEmailContentStore contentStore,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(contentStore);
+
+        return this.outgoingEmailId is { } outgoingEmail
+            ? contentStore.FindOutgoingContentAsync(outgoingEmail, cancellationToken)
+            : contentStore.FindMailDraftContentAsync(this.mailDraftId!.Value, cancellationToken);
+    }
+}

--- a/src/Application/Mail/Delivery/Filing/OutgoingMailFiler.cs
+++ b/src/Application/Mail/Delivery/Filing/OutgoingMailFiler.cs
@@ -3,7 +3,6 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Diagnostics.CodeAnalysis;
-using MailFathom.Application.EmailContent.Storage;
 using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Mail.Mutations.Destinations;
 using MailFathom.Application.Persistence;
@@ -30,11 +29,10 @@ namespace MailFathom.Application.Mail.Delivery.Filing;
 /// changes it, and the message is untouched either way.
 /// </para>
 /// <para>
-/// The order of the two writes is the whole of the safety here. An <c>APPEND</c> issued twice is a second message in
-/// somebody's folder rather than a repeat of the first, and nothing that folder shows afterwards tells the two apart —
-/// so the row is durable at <see cref="OutgoingMailFilingStage.Issued" /> before the command goes out, and a row found
-/// there is reported rather than appended again. Everything that can fail without reaching the server happens before
-/// that write, which is what keeps an ordinary connection failure retryable.
+/// The append itself is <see cref="MailboxCopyAppender" />'s, and with it the order of the two writes that is the whole
+/// of the safety here: the row is durable at <see cref="OutgoingMailFilingStage.Issued" /> before the command goes out,
+/// and a row found there is reported rather than appended again. What stays here is which row moves and what a copy
+/// that could not be filed means for the send it belongs to.
 /// </para>
 /// <para>
 /// Nothing here can fail a delivery. A send whose copy could not be filed is a send that happened, so the failure is
@@ -43,43 +41,43 @@ namespace MailFathom.Application.Mail.Delivery.Filing;
 /// </remarks>
 public sealed class OutgoingMailFiler
 {
+    private readonly MailboxCopyAppender appends;
     private readonly IMailboxWriteSessionFactory writeSessions;
     private readonly MailboxDestinationResolver destinations;
-    private readonly IEmailContentStore contentStore;
     private readonly IOutgoingMailFilingStore filings;
     private readonly IMailTransportSecurityPolicyReader transportSecurityPolicies;
     private readonly OptimisticConcurrencyRetryPolicy commitPolicy;
     private readonly TimeProvider timeProvider;
 
-    /// <summary>Initializes the filer from the session it appends through and the record it writes the copy onto.</summary>
-    /// <param name="writeSessions">Opens the one session able to change a mailbox.</param>
+    /// <summary>Initializes the filer from the append it files through and the record it writes the copy onto.</summary>
+    /// <param name="appends">Puts the copy into the folder the filing names, in the order that keeps it one copy.</param>
+    /// <param name="writeSessions">Opens the one session able to change a mailbox, which a withdrawal needs of its own.</param>
     /// <param name="destinations">Turns the role a filing names into the folder of this account it means.</param>
-    /// <param name="contentStore">Holds the stored MIME the copy is appended from.</param>
     /// <param name="filings">Keeps the durable account of every copy that has been filed.</param>
-    /// <param name="transportSecurityPolicies">Supplies the connection and authentication policy the append obeys.</param>
+    /// <param name="transportSecurityPolicies">Supplies the connection and authentication policy the commands obey.</param>
     /// <param name="commitPolicy">Commits each movement of the filing row.</param>
-    /// <param name="timeProvider">Stamps the copy's internal date and everything the row records.</param>
+    /// <param name="timeProvider">Stamps everything the row records.</param>
     /// <exception cref="ArgumentNullException">Thrown when a collaborator is <see langword="null" />.</exception>
     public OutgoingMailFiler(
+        MailboxCopyAppender appends,
         IMailboxWriteSessionFactory writeSessions,
         MailboxDestinationResolver destinations,
-        IEmailContentStore contentStore,
         IOutgoingMailFilingStore filings,
         IMailTransportSecurityPolicyReader transportSecurityPolicies,
         OptimisticConcurrencyRetryPolicy commitPolicy,
         TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(appends);
         ArgumentNullException.ThrowIfNull(writeSessions);
         ArgumentNullException.ThrowIfNull(destinations);
-        ArgumentNullException.ThrowIfNull(contentStore);
         ArgumentNullException.ThrowIfNull(filings);
         ArgumentNullException.ThrowIfNull(transportSecurityPolicies);
         ArgumentNullException.ThrowIfNull(commitPolicy);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
+        this.appends = appends;
         this.writeSessions = writeSessions;
         this.destinations = destinations;
-        this.contentStore = contentStore;
         this.filings = filings;
         this.transportSecurityPolicies = transportSecurityPolicies;
         this.commitPolicy = commitPolicy;
@@ -131,7 +129,7 @@ public sealed class OutgoingMailFiler
             return await this.RecordFailureAsync(
                 record,
                 filing,
-                FailureCodeOf(failure),
+                MailboxCopyAppender.FailureCodeOf(failure),
                 OutgoingMailFilingOutcome.Failed);
         }
     }
@@ -214,7 +212,7 @@ public sealed class OutgoingMailFiler
             return await this.RecordFailureAsync(
                 record,
                 filing,
-                FailureCodeOf(failure),
+                MailboxCopyAppender.FailureCodeOf(failure),
                 OutgoingMailFilingOutcome.Failed);
         }
     }
@@ -236,15 +234,16 @@ public sealed class OutgoingMailFiler
             _ => OutgoingMailFilingOutcome.AlreadyFiled,
         };
 
-    /// <summary>Names the code that stands for whatever ended an attempt.</summary>
+    /// <summary>Reads what the append reported as what it means for the send the copy belongs to.</summary>
     /// <remarks>
-    /// A first-party failure already carries the code an operator looks up, so it is kept. What is left is genuinely
-    /// unaccounted for and says so rather than borrowing a code that would mislead.
+    /// <see cref="MailboxCopyAppendOutcome.Appended" /> never reaches here, because a result carrying no failure is the
+    /// copy that was filed. What is left is a message that could not be appended, which fails the filing and no more.
     /// </remarks>
-    private static MailFathomErrorCode FailureCodeOf(Exception failure) => failure switch
+    private static OutgoingMailFilingOutcome FilingOutcomeOf(MailboxCopyAppendOutcome outcome) => outcome switch
     {
-        MailFathomException named => named.ErrorCode,
-        _ => MailFathomErrorCode.OutgoingEmailFilingFailedUnexpectedly,
+        MailboxCopyAppendOutcome.DestinationUnavailable => OutgoingMailFilingOutcome.DestinationUnavailable,
+        MailboxCopyAppendOutcome.OutcomeUnknown => OutgoingMailFilingOutcome.OutcomeUnknown,
+        _ => OutgoingMailFilingOutcome.Failed,
     };
 
     private static OutgoingMailFilingResult Result(
@@ -253,89 +252,41 @@ public sealed class OutgoingMailFiler
         OutgoingMailFilingOutcome outcome,
         MailFathomErrorCode? failure) => new(record.Id, filing, outcome, failure);
 
-    /// <summary>Runs the attempt itself, from the answers that need no server to the append the server settles.</summary>
-    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Past the issued write the append may already have reached the folder, so every way it can end has to be recorded as an outcome nobody can settle rather than raised into a retry that would file a second copy.")]
+    /// <summary>Files the copy, moving the filing row through the stages the append passes.</summary>
     private async Task<OutgoingMailFilingResult> AppendAsync(
         OutgoingEmailRecord record,
         OutgoingMailFiling filing,
         CancellationToken cancellationToken)
     {
-        var resolution = await this.ResolveDestinationAsync(record, filing, cancellationToken);
-
-        if (resolution.Destination is not { } destination)
-        {
-            return await this.RecordFailureAsync(
-                record,
-                filing,
-                MailFathomErrorCode.OutgoingEmailFilingDestinationUnavailable,
-                OutgoingMailFilingOutcome.DestinationUnavailable);
-        }
-
-        var content = await this.contentStore.FindOutgoingContentAsync(record.Id, cancellationToken);
-
-        if (content is null || content.RawMime.IsEmpty)
-        {
-            // The record and its message are written in one transaction, so a record without one describes a send that
-            // can never happen rather than a message still being stored. There is nothing to append, and no later
-            // attempt can invent it.
-            return await this.RecordFailureAsync(
-                record,
-                filing,
-                MailFathomErrorCode.OutgoingEmailFilingFailedUnexpectedly,
-                OutgoingMailFilingOutcome.Failed);
-        }
-
-        var transportSecurityPolicy = this.transportSecurityPolicies.GetPolicy(record.AccountId);
-
-        await using var session = await this.writeSessions.OpenForWritingAsync(
+        var appended = await this.appends.AppendAsync(
             record.AccountId,
-            destination.Binding,
-            transportSecurityPolicy,
-            cancellationToken);
-
-        // Written only once everything that could fail without reaching a mail server already has. From here on a
-        // failure leaves the row saying the append may have happened, which is what stops a second copy — so anything
-        // that can be established first is established first.
-        await this.commitPolicy.CommitAsync(
-            (persistenceSession, token) => this.filings.RecordAppendIssuedAsync(
-                persistenceSession,
-                record.Id,
-                filing,
-                destination.Binding,
-                this.timeProvider.GetUtcNow(),
+            filing,
+            MailboxCopySource.OutgoingEmail(record.Id),
+            (binding, token) => this.commitPolicy.CommitAsync(
+                (persistenceSession, commitToken) => this.filings.RecordAppendIssuedAsync(
+                    persistenceSession,
+                    record.Id,
+                    filing,
+                    binding,
+                    this.timeProvider.GetUtcNow(),
+                    commitToken),
                 token),
-            cancellationToken);
-
-        try
-        {
-            var copy = await session.AppendAsync(
-                content.RawMime,
-                filing.Flags,
-                this.timeProvider.GetUtcNow(),
-                cancellationToken);
-
-            // Committed outside the caller's cancellation, for the reason a delivery outcome is: the append has already
-            // happened on somebody else's server, and a shutdown that abandoned this write would leave the row saying
-            // the outcome is unknown for a copy the server named exactly.
-            await this.commitPolicy.CommitAsync(
-                (persistenceSession, token) => this.filings.RecordAppendConfirmedAsync(
+            copy => this.commitPolicy.CommitAsync(
+                (persistenceSession, commitToken) => this.filings.RecordAppendConfirmedAsync(
                     persistenceSession,
                     record.Id,
                     filing,
                     copy,
-                    token),
-                CancellationToken.None);
+                    commitToken),
+                CancellationToken.None),
+            cancellationToken);
 
+        if (appended.Failure is not { } failure)
+        {
             return Result(record, filing, OutgoingMailFilingOutcome.Filed, failure: null);
         }
-        catch (Exception failure)
-        {
-            return await this.RecordFailureAsync(
-                record,
-                filing,
-                FailureCodeOf(failure),
-                OutgoingMailFilingOutcome.OutcomeUnknown);
-        }
+
+        return await this.RecordFailureAsync(record, filing, failure, FilingOutcomeOf(appended.Outcome));
     }
 
     private async Task<MailboxDestinationResolution> ResolveDestinationAsync(

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -883,6 +883,10 @@ public static class ServiceCollectionExtensions
         // pass that drives them rather than with the mail adapters, because each one is a write session opened per
         // append through the same pool every other mutation goes through.
         services.AddScoped<IOutgoingMailFilingStore, OutgoingMailFilingStore>();
+        // The one append every filed copy goes through, whatever kind of message it is a copy of. It is registered once
+        // and shared by the filers rather than owned by either, because the order of its two writes is what keeps a
+        // copy one copy, and an ordering that held on one filing path and lapsed on another would be no ordering.
+        services.AddScoped<MailboxCopyAppender>();
         services.AddScoped<OutgoingMailFiler>();
         services.AddScoped<OutgoingMailFilingPass>();
         // The drafts a mailbox holds, registered beside the filing they reuse rather than with it: a draft is appended

--- a/tests/Application.UnitTests/Mail/Delivery/Filing/MailboxCopyAppenderTests.cs
+++ b/tests/Application.UnitTests/Mail/Delivery/Filing/MailboxCopyAppenderTests.cs
@@ -1,0 +1,454 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Security.Cryptography;
+using System.Text;
+using MailFathom.Application.EmailContent.Storage;
+using MailFathom.Application.Folders;
+using MailFathom.Application.Mail;
+using MailFathom.Application.Mail.Delivery.Filing;
+using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Destinations;
+using MailFathom.Application.Persistence;
+using MailFathom.Application.Synchronization.Sessions;
+using MailFathom.Application.UnitTests.TestDoubles;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Delivery;
+using MailFathom.Domain.Delivery.Drafts;
+using MailFathom.Domain.Delivery.Filing;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Failures;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+using MailFathom.Domain.Transport;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Mail.Delivery.Filing;
+
+/// <summary>Covers the one append every copy of a message MailFathom composed is filed through.</summary>
+/// <remarks>
+/// What is written about here is the order of the two writes around the command and what each way of ending is
+/// reported as, because those are what a second filing path would otherwise restate and get subtly wrong. Which row
+/// each write moves belongs to the filer that supplied it and is covered where that filer is.
+/// </remarks>
+public sealed class MailboxCopyAppenderTests
+{
+    private static readonly MailAccountId Account = MailAccountId.Create("work");
+
+    private static readonly DateTimeOffset Moment = new(2026, 8, 21, 9, 0, 0, TimeSpan.Zero);
+
+    private static readonly MailTransportSecurityPolicy RequiredTlsPolicy = MailTransportSecurityPolicy.Create(
+        MailConnectionSecurity.TlsOnConnect,
+        MailAuthenticationPolicy.Create(
+            [MailAuthenticationMechanism.Plain],
+            allowInsecureConnection: false,
+            allowClearTextAuthenticationOverUnencryptedConnection: false),
+        MailServerCertificateTrust.SystemTrustStore,
+        trustedCertificateAuthorityReference: null);
+
+    private static readonly OutgoingEmailId Send = OutgoingEmailId.Create(Guid.NewGuid());
+
+    private static readonly MailDraftId Draft = MailDraftId.Create(Guid.NewGuid());
+
+    private readonly FakeTimeProvider clock = new(Moment);
+    private readonly StubMailFolderMappings mappings = StubMailFolderMappings.Nothing;
+    private readonly InMemoryMailFolderResolutionStore folderResolutions = new();
+    private readonly IEmailContentStore contentStore = Substitute.For<IEmailContentStore>();
+    private readonly IMailboxWriteSession writeSession = Substitute.For<IMailboxWriteSession>();
+    private readonly IMailboxWriteSessionFactory writeSessions = Substitute.For<IMailboxWriteSessionFactory>();
+
+    private readonly IMailTransportSecurityPolicyReader transportSecurityPolicies =
+        Substitute.For<IMailTransportSecurityPolicyReader>();
+
+    private readonly List<string> steps = [];
+
+    /// <summary>Gets the binding the caller was told to write its issued record against.</summary>
+    private MailFolderResolution? IssuedInto { get; set; }
+
+    /// <summary>A role no folder of the account plays leaves nothing asked of the mail server and nothing written.</summary>
+    [Fact]
+    public async Task AppendAsync_ARoleNoFolderPlays_ReachesNoServerAndIssuesNoRecord()
+    {
+        // Arrange
+        var appender = this.Appender();
+
+        // Act
+        var appended = await this.AppendAsync(appender, MailboxCopySource.OutgoingEmail(Send));
+
+        // Assert
+        Assert.Equal(MailboxCopyAppendOutcome.DestinationUnavailable, appended.Outcome);
+        Assert.Equal(MailFathomErrorCode.OutgoingEmailFilingDestinationUnavailable, appended.Failure);
+        Assert.Null(appended.Copy);
+        Assert.Empty(this.steps);
+        await this.writeSessions.DidNotReceiveWithAnyArgs().OpenForWritingAsync(
+            Arg.Any<MailAccountId>(),
+            Arg.Any<MailFolderResolution>(),
+            Arg.Any<MailTransportSecurityPolicy>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// A record and its message are written in one transaction, so a source with no appendable message describes a copy
+    /// that can never exist rather than a message still being stored. Nothing is issued, and no later attempt can
+    /// invent the bytes.
+    /// </summary>
+    /// <param name="storesAnEmptyMessage">Whether the store holds a message of no bytes rather than none at all.</param>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task AppendAsync_ASourceWithNoAppendableMessage_ReachesNoServerAndIssuesNoRecord(
+        bool storesAnEmptyMessage)
+    {
+        // Arrange
+        this.MapSentFolder();
+        this.contentStore
+            .FindOutgoingContentAsync(Send, Arg.Any<CancellationToken>())
+            .Returns(storesAnEmptyMessage ? Stored(ReadOnlyMemory<byte>.Empty) : null);
+        var appender = this.Appender();
+
+        // Act
+        var appended = await this.AppendAsync(appender, MailboxCopySource.OutgoingEmail(Send));
+
+        // Assert
+        Assert.Equal(MailboxCopyAppendOutcome.MessageUnavailable, appended.Outcome);
+        Assert.Equal(MailFathomErrorCode.OutgoingEmailFilingFailedUnexpectedly, appended.Failure);
+        Assert.Empty(this.steps);
+        await this.writeSessions.DidNotReceiveWithAnyArgs().OpenForWritingAsync(
+            Arg.Any<MailAccountId>(),
+            Arg.Any<MailFolderResolution>(),
+            Arg.Any<MailTransportSecurityPolicy>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// The issued record is durable before the command goes out and the confirmation is written after the server
+    /// answered. That order is the whole of the safety here: an <c>APPEND</c> issued twice is a second message in
+    /// somebody's folder, and a row found at the issued stage is what stops the second one.
+    /// </summary>
+    [Fact]
+    public async Task AppendAsync_AServerThatAcceptsTheCopy_RecordsTheAppendIssuedBeforeItAndConfirmedAfterIt()
+    {
+        // Arrange
+        var binding = this.MapSentFolder();
+        this.StoreOutgoingMessage();
+        var placed = new AppendedMailCopy(
+            RemoteEmailPlacement.Reported(ImapUidValidity.Create(7), ImapUid.Create(31)),
+            InternetMessageId: null);
+        this.AnswerAppendWith(placed);
+        var appender = this.Appender();
+
+        // Act
+        var appended = await this.AppendAsync(appender, MailboxCopySource.OutgoingEmail(Send));
+
+        // Assert
+        Assert.Equal(MailboxCopyAppendOutcome.Appended, appended.Outcome);
+        Assert.Same(placed, appended.Copy);
+        Assert.Null(appended.Failure);
+        Assert.Equal(["issued", "append", "confirmed"], this.steps);
+        Assert.Equal(binding, this.IssuedInto);
+        await this.writeSession.Received(1).AppendAsync(
+            Arg.Any<ReadOnlyMemory<byte>>(),
+            OutgoingMailFiling.Sent.Flags,
+            Moment,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>A draft's copy is read from the draft's own stored revision rather than from any outgoing record.</summary>
+    [Fact]
+    public async Task AppendAsync_ADraftSource_AppendsTheRevisionTheDraftIsHeldAs()
+    {
+        // Arrange
+        this.MapDraftsFolder();
+        this.contentStore
+            .FindMailDraftContentAsync(Draft, Arg.Any<CancellationToken>())
+            .Returns(Stored(Encoding.ASCII.GetBytes("Subject: a revision\r\n\r\nbody")));
+        this.AnswerAppendWith(new AppendedMailCopy(
+            RemoteEmailPlacement.Reported(ImapUidValidity.Create(1), ImapUid.Create(4)),
+            InternetMessageId: null));
+        var appender = this.Appender();
+
+        // Act
+        var appended = await this.AppendAsync(
+            appender,
+            MailboxCopySource.MailDraft(Draft),
+            OutgoingMailFiling.Draft);
+
+        // Assert
+        Assert.Equal(MailboxCopyAppendOutcome.Appended, appended.Outcome);
+        await this.contentStore.DidNotReceiveWithAnyArgs().FindOutgoingContentAsync(
+            Arg.Any<OutgoingEmailId>(),
+            Arg.Any<CancellationToken>());
+        await this.writeSession.Received(1).AppendAsync(
+            Arg.Any<ReadOnlyMemory<byte>>(),
+            OutgoingMailFiling.Draft.Flags,
+            Moment,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// An append the server never answered leaves nobody able to say whether the copy is in the folder, so it is
+    /// reported as an outcome nothing can settle rather than raised into a retry that would file a second copy. A
+    /// first-party failure keeps the code an operator looks it up by.
+    /// </summary>
+    [Fact]
+    public async Task AppendAsync_AnAppendTheServerNeverAnswered_ReportsAnOutcomeNobodyCanSettle()
+    {
+        // Arrange
+        this.MapSentFolder();
+        this.StoreOutgoingMessage();
+        this.writeSession
+            .AppendAsync(
+                Arg.Any<ReadOnlyMemory<byte>>(),
+                Arg.Any<AppendedMailFlags>(),
+                Arg.Any<DateTimeOffset>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new MailboxUnavailableException(
+                Account,
+                MailFolderAlias.Create("sent"),
+                new TimeoutException("The append was issued and the server never answered.")));
+        var appender = this.Appender();
+
+        // Act
+        var appended = await this.AppendAsync(appender, MailboxCopySource.OutgoingEmail(Send));
+
+        // Assert
+        Assert.Equal(MailboxCopyAppendOutcome.OutcomeUnknown, appended.Outcome);
+        Assert.Equal(MailFathomErrorCode.MailboxUnavailable, appended.Failure);
+        Assert.Null(appended.Copy);
+
+        // The issued record is already durable, which is what a later pass reads to know a copy may be in the folder.
+        Assert.Equal(["issued"], this.steps);
+    }
+
+    /// <summary>
+    /// A confirmation that could not be written is the same ambiguity as an append that was never answered: the copy is
+    /// already in somebody's folder and the record does not say so. Reporting it as an ordinary failure would let the
+    /// copy be filed a second time.
+    /// </summary>
+    [Fact]
+    public async Task AppendAsync_AConfirmationThatCouldNotBeWritten_ReportsAnOutcomeNobodyCanSettle()
+    {
+        // Arrange
+        this.MapSentFolder();
+        this.StoreOutgoingMessage();
+        this.AnswerAppendWith(new AppendedMailCopy(RemoteEmailPlacement.NotReported(), InternetMessageId: null));
+        var appender = this.Appender();
+
+        // Act
+        var appended = await appender.AppendAsync(
+            Account,
+            OutgoingMailFiling.Sent,
+            MailboxCopySource.OutgoingEmail(Send),
+            this.RecordIssuedAsync,
+            _ => throw new PersistenceConcurrencyConflictException("every attempt conflicted"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(MailboxCopyAppendOutcome.OutcomeUnknown, appended.Outcome);
+        Assert.Equal(MailFathomErrorCode.PersistenceConcurrencyConflict, appended.Failure);
+        Assert.Equal(["issued", "append"], this.steps);
+    }
+
+    /// <summary>A failure carrying no code of its own says it is unaccounted for rather than borrowing one that would mislead.</summary>
+    [Fact]
+    public async Task AppendAsync_AFailureCarryingNoErrorCode_NamesItUnaccountedFor()
+    {
+        // Arrange
+        this.MapSentFolder();
+        this.StoreOutgoingMessage();
+        this.writeSession
+            .AppendAsync(
+                Arg.Any<ReadOnlyMemory<byte>>(),
+                Arg.Any<AppendedMailFlags>(),
+                Arg.Any<DateTimeOffset>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("something nobody classified"));
+        var appender = this.Appender();
+
+        // Act
+        var appended = await this.AppendAsync(appender, MailboxCopySource.OutgoingEmail(Send));
+
+        // Assert
+        Assert.Equal(MailboxCopyAppendOutcome.OutcomeUnknown, appended.Outcome);
+        Assert.Equal(MailFathomErrorCode.OutgoingEmailFilingFailedUnexpectedly, appended.Failure);
+    }
+
+    /// <summary>The unusable struct default names no place for the copy to go, so it is refused rather than resolved.</summary>
+    [Fact]
+    public async Task AppendAsync_TheUnspecifiedFiling_IsRefused()
+    {
+        // Arrange
+        var appender = this.Appender();
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<ArgumentException>(() => appender.AppendAsync(
+            Account,
+            default,
+            MailboxCopySource.OutgoingEmail(Send),
+            this.RecordIssuedAsync,
+            this.RecordConfirmedAsync,
+            TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal("filing", refusal.ParamName);
+    }
+
+    /// <summary>Every collaborator the append needs from its caller is required.</summary>
+    [Fact]
+    public async Task AppendAsync_ACallerSuppliedCollaboratorThatIsNull_IsRefused()
+    {
+        // Arrange
+        var appender = this.Appender();
+
+        // Act
+        var missingSource = await Assert.ThrowsAsync<ArgumentNullException>(() => appender.AppendAsync(
+            Account,
+            OutgoingMailFiling.Sent,
+            null!,
+            this.RecordIssuedAsync,
+            this.RecordConfirmedAsync,
+            TestContext.Current.CancellationToken));
+        var missingIssuedWrite = await Assert.ThrowsAsync<ArgumentNullException>(() => appender.AppendAsync(
+            Account,
+            OutgoingMailFiling.Sent,
+            MailboxCopySource.OutgoingEmail(Send),
+            null!,
+            this.RecordConfirmedAsync,
+            TestContext.Current.CancellationToken));
+        var missingConfirmation = await Assert.ThrowsAsync<ArgumentNullException>(() => appender.AppendAsync(
+            Account,
+            OutgoingMailFiling.Sent,
+            MailboxCopySource.OutgoingEmail(Send),
+            this.RecordIssuedAsync,
+            null!,
+            TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(
+            ["source", "recordIssuedAsync", "recordConfirmedAsync"],
+            new[] { missingSource, missingIssuedWrite, missingConfirmation }.Select(refusal => refusal.ParamName));
+    }
+
+    /// <summary>Reading a source's bytes needs the port they are held behind.</summary>
+    [Fact]
+    public async Task FindContentAsync_NoContentStore_IsRefused() =>
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            MailboxCopySource.OutgoingEmail(Send).FindContentAsync(null!, CancellationToken.None));
+
+    /// <summary>A copy is reported with what the server said about it, which a result cannot be built without.</summary>
+    [Fact]
+    public void Appended_NoCopy_IsRefused() =>
+        Assert.Throws<ArgumentNullException>(() => MailboxCopyAppendResult.Appended(null!));
+
+    /// <summary>Nothing about what ended an attempt can be read from an absent exception.</summary>
+    [Fact]
+    public void FailureCodeOf_NoFailure_IsRefused() =>
+        Assert.Throws<ArgumentNullException>(() => MailboxCopyAppender.FailureCodeOf(null!));
+
+    private static StoredEmailContent Stored(ReadOnlyMemory<byte> rawMime) =>
+        new(rawMime, rawMime.Length, SHA256.HashData(rawMime.Span));
+
+    private MailboxCopyAppender Appender()
+    {
+        this.transportSecurityPolicies.GetPolicy(Arg.Any<MailAccountId>()).Returns(RequiredTlsPolicy);
+        this.writeSessions
+            .OpenForWritingAsync(
+                Arg.Any<MailAccountId>(),
+                Arg.Any<MailFolderResolution>(),
+                Arg.Any<MailTransportSecurityPolicy>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => this.writeSession);
+
+        var persistenceSessions = Substitute.For<IPersistenceSessionFactory>();
+
+        var destinations = new MailboxDestinationResolver(
+            this.mappings.Resolver,
+            this.folderResolutions,
+            new MailFolderResolver(
+                Substitute.For<IRemoteFolderCatalog>(),
+                Substitute.For<IRemoteFolderCreator>(),
+                this.folderResolutions,
+                Substitute.For<IMailFolderMappingChangeAuditor>(),
+                persistenceSessions,
+                this.clock),
+            this.transportSecurityPolicies);
+
+        return new MailboxCopyAppender(
+            this.writeSessions,
+            destinations,
+            this.contentStore,
+            this.transportSecurityPolicies,
+            this.clock);
+    }
+
+    private Task<MailboxCopyAppendResult> AppendAsync(
+        MailboxCopyAppender appender,
+        MailboxCopySource source,
+        OutgoingMailFiling? filing = null) =>
+        appender.AppendAsync(
+            Account,
+            filing ?? OutgoingMailFiling.Sent,
+            source,
+            this.RecordIssuedAsync,
+            this.RecordConfirmedAsync,
+            TestContext.Current.CancellationToken);
+
+    private Task RecordIssuedAsync(MailFolderResolution binding, CancellationToken cancellationToken)
+    {
+        this.IssuedInto = binding;
+        this.steps.Add("issued");
+
+        return Task.CompletedTask;
+    }
+
+    private Task RecordConfirmedAsync(AppendedMailCopy copy)
+    {
+        this.steps.Add("confirmed");
+
+        return Task.CompletedTask;
+    }
+
+    private MailFolderResolution MapSentFolder() => this.Map(MailFolderSpecialUse.Sent, "sent", "INBOX.Sent");
+
+    private MailFolderResolution MapDraftsFolder() => this.Map(MailFolderSpecialUse.Drafts, "drafts", "INBOX.Drafts");
+
+    private MailFolderResolution Map(MailFolderSpecialUse role, string alias, string remotePath)
+    {
+        var folderAlias = MailFolderAlias.Create(alias);
+
+        this.mappings.With(
+            Account,
+            MailFolderMapping.ToRemotePath(
+                folderAlias,
+                RemoteFolderPath.Create(remotePath),
+                MailFolderParticipation.Full,
+                mayCreateMissingFolder: false,
+                role));
+
+        return this.folderResolutions.Bind(Account, folderAlias, remotePath);
+    }
+
+    private void StoreOutgoingMessage() =>
+        this.contentStore
+            .FindOutgoingContentAsync(Send, Arg.Any<CancellationToken>())
+            .Returns(Stored(Encoding.ASCII.GetBytes("Subject: a send\r\n\r\nbody")));
+
+    private void AnswerAppendWith(AppendedMailCopy copy) =>
+        this.writeSession
+            .AppendAsync(
+                Arg.Any<ReadOnlyMemory<byte>>(),
+                Arg.Any<AppendedMailFlags>(),
+                Arg.Any<DateTimeOffset>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                this.steps.Add("append");
+
+                return Task.FromResult(copy);
+            });
+}

--- a/tests/Application.UnitTests/Mail/Delivery/Filing/MailboxCopyAppenderTests.cs
+++ b/tests/Application.UnitTests/Mail/Delivery/Filing/MailboxCopyAppenderTests.cs
@@ -254,6 +254,68 @@ public sealed class MailboxCopyAppenderTests
         Assert.Equal(["issued", "append"], this.steps);
     }
 
+    /// <summary>
+    /// A caller that stops after the issued write is reported rather than raised, which is the one place a shutdown is
+    /// not passed on. The command is already out, so an <see cref="OperationCanceledException" /> escaping here would
+    /// end the pass with the row saying nothing, and whatever resumed it would file a second copy of somebody's own
+    /// message. Before that write the opposite holds, and the filing pass covers it.
+    /// </summary>
+    /// <param name="stopArrivesDuringTheConfirmation">Whether the caller stops while the record is being confirmed rather than while the command is out.</param>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task AppendAsync_ACallerThatStopsAfterTheIssuedWrite_ReportsAnOutcomeNobodyCanSettle(
+        bool stopArrivesDuringTheConfirmation)
+    {
+        // Arrange
+        this.MapSentFolder();
+        this.StoreOutgoingMessage();
+        using var shutdown = new CancellationTokenSource();
+
+        if (stopArrivesDuringTheConfirmation)
+        {
+            this.AnswerAppendWith(new AppendedMailCopy(RemoteEmailPlacement.NotReported(), InternetMessageId: null));
+        }
+        else
+        {
+            this.writeSession
+                .AppendAsync(
+                    Arg.Any<ReadOnlyMemory<byte>>(),
+                    Arg.Any<AppendedMailFlags>(),
+                    Arg.Any<DateTimeOffset>(),
+                    Arg.Any<CancellationToken>())
+                .Returns<AppendedMailCopy>(_ =>
+                {
+                    this.steps.Add("append");
+                    shutdown.Cancel();
+
+                    throw new OperationCanceledException(shutdown.Token);
+                });
+        }
+
+        var appender = this.Appender();
+
+        // Act
+        var appended = await appender.AppendAsync(
+            Account,
+            OutgoingMailFiling.Sent,
+            MailboxCopySource.OutgoingEmail(Send),
+            this.RecordIssuedAsync,
+            _ =>
+            {
+                shutdown.Cancel();
+
+                throw new OperationCanceledException(shutdown.Token);
+            },
+            shutdown.Token);
+
+        // Assert
+        Assert.True(shutdown.IsCancellationRequested);
+        Assert.Equal(MailboxCopyAppendOutcome.OutcomeUnknown, appended.Outcome);
+        Assert.Equal(MailFathomErrorCode.OutgoingEmailFilingFailedUnexpectedly, appended.Failure);
+        Assert.Equal(["issued", "append"], this.steps);
+    }
+
     /// <summary>A failure carrying no code of its own says it is unaccounted for rather than borrowing one that would mislead.</summary>
     [Fact]
     public async Task AppendAsync_AFailureCarryingNoErrorCode_NamesItUnaccountedFor()

--- a/tests/Application.UnitTests/Mail/Mutations/MailboxWriteCapabilityBoundaryTests.cs
+++ b/tests/Application.UnitTests/Mail/Mutations/MailboxWriteCapabilityBoundaryTests.cs
@@ -29,14 +29,15 @@ namespace MailFathom.Application.UnitTests.Mail.Mutations;
 /// The expected set is the list of tiers the decision record names and nothing else, so growing it by a *tier* is an
 /// amendment to that record rather than an edit here. It has grown once that way: filing a copy of a message MailFathom
 /// composed is a write no mutation of the owner's own mail can express, because the message it appends does not exist
-/// on the server yet. It has grown once more without a tier being added — a draft's copies are filed by a type of their
-/// own, under the same tier, which that record decided in advance when it said the drafts role is decided by the filing
-/// tier and filed by nothing yet.
+/// on the server yet. It has grown twice more without a tier being added, both times inside the filing tier — a draft's
+/// copies are filed by a type of their own, which that record decided in advance when it said the drafts role is
+/// decided by the filing tier and filed by nothing yet, and the append itself is one type both filers call rather than
+/// a protocol each restates.
 /// </para>
 /// </remarks>
 public sealed class MailboxWriteCapabilityBoundaryTests
 {
-    /// <summary>Three application types can obtain a session that writes, and each acts within a tier the decision record names.</summary>
+    /// <summary>Four application types can obtain a session that writes, and each acts within a tier the decision record names.</summary>
     /// <remarks>
     /// Failing here is not a reason to extend the expected set. A read path that needs to write is a read path that has
     /// acquired something
@@ -44,8 +45,9 @@ public sealed class MailboxWriteCapabilityBoundaryTests
     /// refuses it, and a change to the owner's own mail belongs behind <see cref="IMailboxMutationPerformer" /> instead.
     /// A further name is admissible only where the act it performs is one that record already decided — which is what
     /// the draft filer is, since the copies it appends and withdraws are messages MailFathom composed and stored itself,
-    /// in the folder the drafts role names, carrying the flag that tier assigns. A name performing anything else is a
-    /// tier that record reopens for or refuses.
+    /// in the folder the drafts role names, carrying the flag that tier assigns, and which the appender is by being the
+    /// filing tier's own append rather than a fourth act. A name performing anything else is a tier that record reopens
+    /// for or refuses.
     /// </remarks>
     [Fact]
     public void ApplicationAssembly_HoldsTheWriteCapabilityInTheTiersTheDecisionRecordNames()
@@ -67,7 +69,12 @@ public sealed class MailboxWriteCapabilityBoundaryTests
 
         // Assert
         Assert.Equal(
-            [nameof(MailDraftFiler), nameof(MailboxMutationPerformer), nameof(OutgoingMailFiler)],
+            [
+                nameof(MailDraftFiler),
+                nameof(MailboxCopyAppender),
+                nameof(MailboxMutationPerformer),
+                nameof(OutgoingMailFiler),
+            ],
             holders);
     }
 

--- a/tests/Application.UnitTests/TestDoubles/MailDraftHarness.cs
+++ b/tests/Application.UnitTests/TestDoubles/MailDraftHarness.cs
@@ -7,6 +7,7 @@ using MailFathom.Application.Folders;
 using MailFathom.Application.Mail;
 using MailFathom.Application.Mail.Delivery;
 using MailFathom.Application.Mail.Delivery.Drafts;
+using MailFathom.Application.Mail.Delivery.Filing;
 using MailFathom.Application.Mail.Delivery.Outbox;
 using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Mail.Mutations.Destinations;
@@ -193,9 +194,14 @@ internal sealed class MailDraftHarness
             this.transportSecurityPolicies);
 
         this.Filer = new MailDraftFiler(
+            new MailboxCopyAppender(
+                this.writeSessions,
+                destinations,
+                this.Contents,
+                this.transportSecurityPolicies,
+                this.clock),
             this.writeSessions,
             destinations,
-            this.Contents,
             this.Drafts,
             this.transportSecurityPolicies,
             this.commitPolicy,

--- a/tests/Application.UnitTests/TestDoubles/OutgoingMailFilingHarness.cs
+++ b/tests/Application.UnitTests/TestDoubles/OutgoingMailFilingHarness.cs
@@ -101,9 +101,14 @@ internal sealed class OutgoingMailFilingHarness
             clock);
 
         this.Filer = new OutgoingMailFiler(
+            new MailboxCopyAppender(
+                writeSessions,
+                destinations,
+                contentStore,
+                transportSecurityPolicies,
+                clock),
             writeSessions,
             destinations,
-            contentStore,
             this.Filings,
             transportSecurityPolicies,
             commitPolicy,

--- a/tests/Host.UnitTests/Hosting/Workers/OutboxDeliveryWorkerTests.cs
+++ b/tests/Host.UnitTests/Hosting/Workers/OutboxDeliveryWorkerTests.cs
@@ -224,6 +224,7 @@ public sealed class OutboxDeliveryWorkerTests
             collection.AddScoped<MailFolderReferenceResolver>();
             collection.AddScoped<MailFolderResolver>();
             collection.AddScoped<MailboxDestinationResolver>();
+            collection.AddScoped<MailboxCopyAppender>();
             collection.AddScoped<OutgoingMailFiler>();
             collection.AddScoped<OutgoingMailFilingPass>();
 

--- a/tests/Mcp.UnitTests/TestDoubles/DraftedMailDeployment.cs
+++ b/tests/Mcp.UnitTests/TestDoubles/DraftedMailDeployment.cs
@@ -18,6 +18,7 @@ using MailFathom.Application.Mail.Delivery.Addressing;
 using MailFathom.Application.Mail.Delivery.Authoring;
 using MailFathom.Application.Mail.Delivery.Composition;
 using MailFathom.Application.Mail.Delivery.Drafts;
+using MailFathom.Application.Mail.Delivery.Filing;
 using MailFathom.Application.Mail.Delivery.Operations;
 using MailFathom.Application.Mail.Delivery.Outbox;
 using MailFathom.Application.Mail.Mutations;
@@ -178,21 +179,24 @@ internal sealed class DraftedMailDeployment
     {
         var transportSecurityPolicies = Substitute.For<IMailTransportSecurityPolicyReader>();
         var folderResolutions = Substitute.For<IMailFolderResolutionStore>();
+        var writeSessions = Substitute.For<IMailboxWriteSessionFactory>();
+
+        var destinations = new MailboxDestinationResolver(
+            StubMailFolderMappings.Nothing.Resolver,
+            folderResolutions,
+            new MailFolderResolver(
+                Substitute.For<IRemoteFolderCatalog>(),
+                Substitute.For<IRemoteFolderCreator>(),
+                folderResolutions,
+                Substitute.For<IMailFolderMappingChangeAuditor>(),
+                persistenceSessions,
+                clock),
+            transportSecurityPolicies);
 
         return new MailDraftFiler(
-            Substitute.For<IMailboxWriteSessionFactory>(),
-            new MailboxDestinationResolver(
-                StubMailFolderMappings.Nothing.Resolver,
-                folderResolutions,
-                new MailFolderResolver(
-                    Substitute.For<IRemoteFolderCatalog>(),
-                    Substitute.For<IRemoteFolderCreator>(),
-                    folderResolutions,
-                    Substitute.For<IMailFolderMappingChangeAuditor>(),
-                    persistenceSessions,
-                    clock),
-                transportSecurityPolicies),
-            contents,
+            new MailboxCopyAppender(writeSessions, destinations, contents, transportSecurityPolicies, clock),
+            writeSessions,
+            destinations,
             drafts,
             transportSecurityPolicies,
             commitPolicy,


### PR DESCRIPTION
## What this changes

`OutgoingMailFiler` and `MailDraftFiler` were written by two concurrent branches and each carried its own copy of the same eight-step IMAP append. `MailboxCopyAppender` now owns that append, and both filers call it.

The eight steps were: resolve the destination by role, read the stored MIME, guard an absent or empty message, read the transport security policy, open the write session, commit the issued record **before** the command goes out, `APPEND`, then commit the confirmation under `CancellationToken.None`. The ordering is the point — an `APPEND` issued twice is a second message in somebody's folder, and the row found at the issued stage is what stops the second one — and it was holding in two places at once, one of which could have drifted without the other noticing.

## The shape

`MailboxCopyAppender` holds `IMailboxWriteSessionFactory`, `MailboxDestinationResolver`, `IEmailContentStore`, `IMailTransportSecurityPolicyReader`, and `TimeProvider`. No interface, one method, registered scoped beside the filers.

Both durable writes stay the caller's, because the row each moves belongs to the caller: the filing row for a send, the draft's copy row for a draft. What is no longer the caller's is *when* each runs. They are taken as callbacks, so the confirmation is committed inside the same `try` that classifies a post-issue failure — which is what keeps a confirmation that could not be written reported as `OutcomeUnknown` rather than as an ordinary failure a later pass would retry into a second copy.

`MailboxCopySource` names which stored message a copy is appended from, a send or a draft, so one appender reads both through the one content port rather than needing a second one.

`FailureCodeOf` moved onto the appender as a single public static; both private copies are deleted.

## What is deliberately left alone

The two withdrawals, exactly as the issue requires. `OutgoingMailFiler.WithdrawFromServerAsync` withdraws once and lets any exception become a single `Failed` outcome; `MailDraftFiler.WithdrawOneAsync` loops per superseded copy, catches `MailboxFolderRecreatedException` by name, has three distinct abandonment reasons, and settles each copy's stage without ever recording a filing failure. Different failure classification, different record movement, different granularity — merging them would flatten all three.

Both filers therefore keep the write-session factory, the destination resolver, and the transport policy reader for their own withdrawal path.

## Behaviour

Unchanged, and that is the claim the existing tests carry: every filer test passes untouched, including the ordering assertions and the shutdown-before-the-issued-write test. Two things worth naming because they are the ones a refactor of this shape gets wrong:

- Cancellation before the issued write still propagates as `OperationCanceledException`, so a stopped host leaves a mail server that was never reached and the next pass files the copy as though this attempt had never started.
- Cancellation *after* it does not propagate. It is classified alongside every other post-issue ending, because a shutdown there says nothing about a command that may already be in flight.

## Tests

`MailboxCopyAppenderTests` covers the appender directly: the role no folder plays, the source with no appendable message (absent and empty), the issued-before-and-confirmed-after ordering, a draft source reading the draft's own revision, an append the server never answered, a confirmation that could not be written, a failure carrying no error code of its own, and the argument guards. New files are at 100% line coverage; the aggregate is 95.58%.

`MailboxWriteCapabilityBoundaryTests` now admits `MailboxCopyAppender` as a fourth name. It is not a new tier: ADR 0007's filing tier already decided that appending a message MailFathom composed is a write, and the appender *is* that tier's append rather than a fourth act. The test's remarks say so.

## Contract surfaces

None. No MCP tool argument, configuration key, database column, or deployment contract moves.

Closes #1027
