### PR TITLE
[#1035] Give the knowledge query the two filters the search request added, and keep one chat failure mapping

### DIFF
--- a/docs/features/mail-answering.md
+++ b/docs/features/mail-answering.md
@@ -38,6 +38,8 @@ The tool publishes the query and the narrowing `search_emails` publishes to its 
 | `subjectFragment` | Only mail whose subject contains this text, which narrows before anything is ranked |
 | `receivedOnOrAfter`, `receivedBefore` | Only mail received in the range, the start inclusive and the end exclusive |
 | `isRemotelySeen` | Only mail the server last reported as read, or as unread |
+| `isRemotelyFlagged` | Only mail the server last reported as flagged, or as unflagged, which is the star a mail client shows |
+| `keyword` | Only mail carrying this keyword, matched whole and without regard to case |
 | `hasAttachments` | Only mail that carries attachments, or that carries none |
 
 The filters are the greater part of what makes a question reach the mail a search would. A question that is naturally a
@@ -45,10 +47,13 @@ narrowing — one person's mail, one week, mail carrying an attachment — is th
 are both weakest at, so expressing it as words in a query means competing with every other word in that query. Expressed
 as a filter it selects the mail exactly, and the ranking is then left to do the part it is good at.
 
-Two arguments a caller of `search_emails` holds are deliberately withheld, and each for its own reason:
+The arguments a caller of `search_emails` holds and a model does not are deliberately withheld, each for its own reason:
 
 - **The accounts and folders**, because they are the caller's authorization rather than a search preference. A model
   writes queries and never its own boundary.
+- **Whether junk mail is read**, because that is settled when the run resolves the scope above, and a run resolves it
+  excluded. Answering is the path the exclusion exists for: mail written to manipulate whoever reads it now has a model
+  reading it, and a caller hunting a wrongly filed message reaches for the listing or the search that can ask for it.
 - **The result count**, because it is the deployment's bound on how much mail one lookup draws out. The one party with
   an incentive to ask for more mail must not be able to ask for more mail.
 

--- a/src/AI/ProviderAdapters/ChatCallFailureMapping.cs
+++ b/src/AI/ProviderAdapters/ChatCallFailureMapping.cs
@@ -1,0 +1,68 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Chat;
+using MailFathom.Domain.Failures;
+
+namespace MailFathom.AI.ProviderAdapters;
+
+/// <summary>Turns what a call to a chat endpoint failed with into the failure its caller is told about.</summary>
+/// <remarks>
+/// <para>
+/// One mapping for both paths to a chat provider — the single bounded request and the decorator every turn of an agent
+/// run passes through — because the two differ in what they wrap a call in and in nothing about what its failure means.
+/// Written once each, they drift by an edit to one of them, and a classification meaning one thing in a single answer
+/// and another inside a run is a difference nobody would think to look for.
+/// </para>
+/// <para>
+/// It maps and never classifies. <see cref="ProviderCallFailureClassification" /> reads what the remote party did, and
+/// its remarks refuse this role deliberately: each calling boundary publishes a failure enumeration of its own, so the
+/// chat one is named here and the embedding one where it is used.
+/// </para>
+/// </remarks>
+internal static class ChatCallFailureMapping
+{
+    /// <summary>Names the chat failure a classified provider call amounts to.</summary>
+    /// <param name="failure">What the call established about the provider.</param>
+    /// <returns>The failure a chat caller is told about.</returns>
+    public static ChatGenerationFailure ToChatFailure(ProviderCallFailure failure) => failure switch
+    {
+        ProviderCallFailure.CredentialRejected => ChatGenerationFailure.CredentialRejected,
+        ProviderCallFailure.RateLimited => ChatGenerationFailure.RateLimited,
+        ProviderCallFailure.RequestTimedOut => ChatGenerationFailure.RequestTimedOut,
+        ProviderCallFailure.RequestRefused => ChatGenerationFailure.RequestRefused,
+        _ => ChatGenerationFailure.TransportFaulted,
+    };
+
+    /// <summary>Reports whether the resilience pipeline declined to call the endpoint at all.</summary>
+    /// <param name="rejection">What the pipeline raised instead of calling.</param>
+    /// <returns><see langword="true" /> when the endpoint was never reached.</returns>
+    /// <remarks>
+    /// <para>
+    /// Its circuit is open, or its concurrency budget is spent. Recognized by code rather than by type, which is what a
+    /// stable error code is for: the resilience library and the exception it raises belong to another adapter boundary
+    /// that this one may not reference.
+    /// </para>
+    /// <para>
+    /// Guarded by nothing, deliberately. Its callers are exception filters, where the runtime turns anything raised into
+    /// a filter that did not match, so a guard here would refuse an argument by silently letting the failure travel on
+    /// unclassified instead of reporting it. The one thing a filter is handed is the exception it caught.
+    /// </para>
+    /// </remarks>
+    public static bool IsEndpointNotCalled(MailFathomException rejection) =>
+        rejection.ErrorCode == MailFathomErrorCode.OutboundDependencyUnavailable;
+
+    /// <summary>Names the failure a call the pipeline never made is reported as.</summary>
+    /// <param name="rejection">What the pipeline raised instead of calling, carried on as the cause.</param>
+    /// <param name="endpointAlias">The deployment's own name for the endpoint that was not reached.</param>
+    /// <returns>The failure to raise in its place.</returns>
+    /// <remarks>
+    /// A transport fault rather than a refusal of its own kind, because that is what the caller has to act on: nothing
+    /// about the request was wrong and the endpoint is worth calling again once the budget or the circuit allows it.
+    /// </remarks>
+    public static ChatGenerationFailedException ToEndpointNotCalledFailure(
+        MailFathomException rejection,
+        string endpointAlias) =>
+        new(endpointAlias, ChatGenerationFailure.TransportFaulted, rejection);
+}

--- a/src/AI/ProviderAdapters/ProviderChatModelClient.cs
+++ b/src/AI/ProviderAdapters/ProviderChatModelClient.cs
@@ -186,16 +186,9 @@ internal sealed class ProviderChatModelClient : IChatModelClient
                 attemptToken => this.SendAsync(credential, conversation, attemptToken),
                 cancellationToken);
         }
-        catch (MailFathomException rejection)
-            when (rejection.ErrorCode == MailFathomErrorCode.OutboundDependencyUnavailable)
+        catch (MailFathomException rejection) when (ChatCallFailureMapping.IsEndpointNotCalled(rejection))
         {
-            // The pipeline declined to call the endpoint at all — its circuit is open, or its concurrency budget is
-            // spent. Recognized by code rather than by type, which is what a stable error code is for: the resilience
-            // library and the exception it raises belong to another adapter boundary that this one may not reference.
-            throw new ChatGenerationFailedException(
-                endpoint.Alias,
-                ChatGenerationFailure.TransportFaulted,
-                rejection);
+            throw ChatCallFailureMapping.ToEndpointNotCalledFailure(rejection, endpoint.Alias);
         }
 
         return this.MapAnswer(response);
@@ -240,7 +233,10 @@ internal sealed class ProviderChatModelClient : IChatModelClient
         }
         catch (Exception failure) when (ProviderCallFailureClassification.Classify(failure) is { } classified)
         {
-            throw new ChatGenerationFailedException(endpoint.Alias, ToChatFailure(classified), failure);
+            throw new ChatGenerationFailedException(
+                endpoint.Alias,
+                ChatCallFailureMapping.ToChatFailure(classified),
+                failure);
         }
     }
 
@@ -343,13 +339,4 @@ internal sealed class ProviderChatModelClient : IChatModelClient
                 ChatGenerationStop.ContentFiltered,
             _ => ChatGenerationStop.Unreported,
         };
-
-    private static ChatGenerationFailure ToChatFailure(ProviderCallFailure failure) => failure switch
-    {
-        ProviderCallFailure.CredentialRejected => ChatGenerationFailure.CredentialRejected,
-        ProviderCallFailure.RateLimited => ChatGenerationFailure.RateLimited,
-        ProviderCallFailure.RequestTimedOut => ChatGenerationFailure.RequestTimedOut,
-        ProviderCallFailure.RequestRefused => ChatGenerationFailure.RequestRefused,
-        _ => ChatGenerationFailure.TransportFaulted,
-    };
 }

--- a/src/AI/ProviderAdapters/ResilientChatClient.cs
+++ b/src/AI/ProviderAdapters/ResilientChatClient.cs
@@ -125,16 +125,9 @@ internal sealed class ResilientChatClient : Microsoft.Extensions.AI.DelegatingCh
                 attemptToken => this.SendAsync(conversation, options, attemptToken),
                 cancellationToken);
         }
-        catch (MailFathomException rejection)
-            when (rejection.ErrorCode == MailFathomErrorCode.OutboundDependencyUnavailable)
+        catch (MailFathomException rejection) when (ChatCallFailureMapping.IsEndpointNotCalled(rejection))
         {
-            // The pipeline declined to call the endpoint at all — its circuit is open, or its concurrency budget is
-            // spent. Recognized by code rather than by type, which is what a stable error code is for: the resilience
-            // library and the exception it raises belong to another adapter boundary that this one may not reference.
-            throw new ChatGenerationFailedException(
-                this.endpoint.Alias,
-                ChatGenerationFailure.TransportFaulted,
-                rejection);
+            throw ChatCallFailureMapping.ToEndpointNotCalledFailure(rejection, this.endpoint.Alias);
         }
     }
 
@@ -161,7 +154,10 @@ internal sealed class ResilientChatClient : Microsoft.Extensions.AI.DelegatingCh
         }
         catch (Exception failure) when (ProviderCallFailureClassification.Classify(failure) is { } classified)
         {
-            throw new ChatGenerationFailedException(this.endpoint.Alias, ToChatFailure(classified), failure);
+            throw new ChatGenerationFailedException(
+                this.endpoint.Alias,
+                ChatCallFailureMapping.ToChatFailure(classified),
+                failure);
         }
     }
 
@@ -181,13 +177,4 @@ internal sealed class ResilientChatClient : Microsoft.Extensions.AI.DelegatingCh
 
         this.healthRecorder.RecordMisconfigured(AiProviderRole.Chat);
     }
-
-    private static ChatGenerationFailure ToChatFailure(ProviderCallFailure failure) => failure switch
-    {
-        ProviderCallFailure.CredentialRejected => ChatGenerationFailure.CredentialRejected,
-        ProviderCallFailure.RateLimited => ChatGenerationFailure.RateLimited,
-        ProviderCallFailure.RequestTimedOut => ChatGenerationFailure.RequestTimedOut,
-        ProviderCallFailure.RequestRefused => ChatGenerationFailure.RequestRefused,
-        _ => ChatGenerationFailure.TransportFaulted,
-    };
 }

--- a/src/AI/Retrieval/ScopedMailKnowledgeRetrieval.cs
+++ b/src/AI/Retrieval/ScopedMailKnowledgeRetrieval.cs
@@ -27,9 +27,9 @@ namespace MailFathom.AI.Retrieval;
 /// own rather than the framework's text-search provider. That provider offers a query and nothing else, which leaves a
 /// question that is naturally a filter — mail from one person, mail of one week, mail carrying an attachment — to be
 /// answered by ranking free text across the whole scope, and that is the one shape lexical and vector similarity are
-/// both weakest at. What is exposed is exactly what <c>search_emails</c> publishes minus the two arguments a model may
-/// not hold: the scope, which is the caller's authorization, and the result count, which is the deployment's bound on
-/// how much mail one lookup draws out.
+/// both weakest at. What is exposed is exactly what <c>search_emails</c> publishes minus the arguments a model may not
+/// hold: the scope, which is the caller's authorization; whether junk mail is read, which the run settles when it
+/// resolves that scope; and the result count, which is the deployment's bound on how much mail one lookup draws out.
 /// </para>
 /// <para>
 /// One instance serves one run. It records the passages it handed over so the answer can carry them, and that record is
@@ -190,6 +190,10 @@ internal sealed class ScopedMailKnowledgeRetrieval
         DateTimeOffset? receivedBefore = null,
         [Description("Return only mail the mail server last reported as read (true) or unread (false). Omit to match either. Searching never changes this state.")]
         bool? isRemotelySeen = null,
+        [Description("Return only mail the mail server last reported as flagged (true) or unflagged (false), which is the star most mail clients show. Omit to match either. This is the \\Flagged flag on a message and is unrelated to the Flagged folder role.")]
+        bool? isRemotelyFlagged = null,
+        [Description("Return only mail carrying this keyword, which is a flag a mail client or server set rather than one of the five standard ones, such as $Junk or a label. Matched as a whole keyword without regard to case, up to 64 characters. Omit to match any keyword.")]
+        string? keyword = null,
         [Description("Return only mail that carries attachments (true) or that carries none (false). Omit to match either. Inline images and cryptographic signature parts do not count as attachments.")]
         bool? hasAttachments = null,
         CancellationToken cancellationToken = default)
@@ -203,6 +207,8 @@ internal sealed class ScopedMailKnowledgeRetrieval
             ReceivedOnOrAfter = receivedOnOrAfter,
             ReceivedBefore = receivedBefore,
             IsRemotelySeen = isRemotelySeen,
+            IsRemotelyFlagged = isRemotelyFlagged,
+            Keyword = keyword,
             HasAttachments = hasAttachments,
         };
 

--- a/src/Application/Retrieval/EmailKnowledgeQuery.cs
+++ b/src/Application/Retrieval/EmailKnowledgeQuery.cs
@@ -15,8 +15,8 @@ namespace MailFathom.Application.Retrieval;
 /// one shape lexical and vector similarity are both weakest at.
 /// </para>
 /// <para>
-/// The fields are deliberately the structured filters of <see cref="SearchEmailsRequest" /> and no others. Two of that
-/// request's members are withheld rather than omitted by accident, and each for its own reason:
+/// The fields are deliberately the structured filters of <see cref="SearchEmailsRequest" /> and no others. That
+/// request's remaining members are withheld rather than omitted by accident, and each for its own reason:
 /// </para>
 /// <list type="bullet">
 /// <item>
@@ -28,12 +28,25 @@ namespace MailFathom.Application.Retrieval;
 /// </item>
 /// <item>
 /// <description>
+/// Whether the junk folder is read at all is settled when that scope is resolved rather than by a lookup, and an
+/// answering run resolves it excluded. Answering is the path the exclusion exists for — mail written to manipulate
+/// whoever reads it now has a model reading it — and a caller hunting a wrongly filed message reaches for the listing
+/// or the search that can ask for it.
+/// </description>
+/// </item>
+/// <item>
+/// <description>
 /// The result count is the deployment's bound on how much mail one lookup may draw out. Exposing it would let the one
 /// party with an incentive to ask for more mail ask for more mail, so the bound is applied where the passages are built
 /// and nothing about a query can widen it.
 /// </description>
 /// </item>
 /// </list>
+/// <para>
+/// That list is asserted rather than trusted. A test names the withheld members and compares the two types' properties
+/// against them, because the filters this type mirrors are added to a published request by work that has no reason to
+/// read this file — which is how the two drifted apart before, with these remarks stating a parity that no longer held.
+/// </para>
 /// <para>
 /// Nothing here is validated. The values reach the same use case that validates the published tool's, so a filter this
 /// system would refuse from a caller is refused from a model in the same words and by the same code.
@@ -62,6 +75,12 @@ public sealed record EmailKnowledgeQuery
 
     /// <summary>Gets the remote <c>\Seen</c> state to require, or <see langword="null" /> for either.</summary>
     public bool? IsRemotelySeen { get; init; }
+
+    /// <summary>Gets the remote <c>\Flagged</c> state to require, or <see langword="null" /> for either.</summary>
+    public bool? IsRemotelyFlagged { get; init; }
+
+    /// <summary>Gets the keyword an email must carry, in any case, or <see langword="null" /> for any keyword.</summary>
+    public string? Keyword { get; init; }
 
     /// <summary>Gets whether attachments are required, or <see langword="null" /> for either.</summary>
     public bool? HasAttachments { get; init; }

--- a/src/Application/Retrieval/MailboxKnowledgeSearch.cs
+++ b/src/Application/Retrieval/MailboxKnowledgeSearch.cs
@@ -79,6 +79,8 @@ public sealed class MailboxKnowledgeSearch : IEmailKnowledgeSearch
             ReceivedOnOrAfter = query.ReceivedOnOrAfter,
             ReceivedBefore = query.ReceivedBefore,
             IsRemotelySeen = query.IsRemotelySeen,
+            IsRemotelyFlagged = query.IsRemotelyFlagged,
+            Keyword = query.Keyword,
             HasAttachments = query.HasAttachments,
             ResultLimit = this.bounds.MaximumPassages,
         };

--- a/tests/AI.UnitTests/Orchestration/MailAnsweringAgentCompositionTests.cs
+++ b/tests/AI.UnitTests/Orchestration/MailAnsweringAgentCompositionTests.cs
@@ -134,6 +134,8 @@ public sealed class MailAnsweringAgentCompositionTests
                 "receivedOnOrAfter",
                 "receivedBefore",
                 "isRemotelySeen",
+                "isRemotelyFlagged",
+                "keyword",
                 "hasAttachments",
             ],
             tool.JsonSchema.GetProperty("properties").EnumerateObject().Select(property => property.Name));

--- a/tests/AI.UnitTests/Retrieval/ScopedMailKnowledgeRetrievalTests.cs
+++ b/tests/AI.UnitTests/Retrieval/ScopedMailKnowledgeRetrievalTests.cs
@@ -55,6 +55,8 @@ public sealed class ScopedMailKnowledgeRetrievalTests
             ["receivedOnOrAfter"] = "2026-07-01T00:00:00+00:00",
             ["receivedBefore"] = "2026-07-08T00:00:00+00:00",
             ["isRemotelySeen"] = true,
+            ["isRemotelyFlagged"] = true,
+            ["keyword"] = "$Label",
             ["hasAttachments"] = false,
         });
 
@@ -71,6 +73,8 @@ public sealed class ScopedMailKnowledgeRetrievalTests
                 ReceivedOnOrAfter = new DateTimeOffset(2026, 7, 1, 0, 0, 0, TimeSpan.Zero),
                 ReceivedBefore = new DateTimeOffset(2026, 7, 8, 0, 0, 0, TimeSpan.Zero),
                 IsRemotelySeen = true,
+                IsRemotelyFlagged = true,
+                Keyword = "$Label",
                 HasAttachments = false,
             },
             query);

--- a/tests/Application.UnitTests/Retrieval/EmailKnowledgeQueryTests.cs
+++ b/tests/Application.UnitTests/Retrieval/EmailKnowledgeQueryTests.cs
@@ -1,0 +1,50 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Reflection;
+using MailFathom.Application.Emails.SearchEmails;
+using MailFathom.Application.Retrieval;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Retrieval;
+
+/// <summary>Covers the parity the knowledge query claims with the search request a caller reaches the same mail through.</summary>
+public sealed class EmailKnowledgeQueryTests
+{
+    /// <summary>
+    /// The members of <see cref="SearchEmailsRequest" /> a knowledge query withholds, each for the reason
+    /// <see cref="EmailKnowledgeQuery" />'s own remarks give beside it.
+    /// </summary>
+    /// <remarks>
+    /// Named rather than derived, because a filter that goes missing and a filter that is withheld on purpose look
+    /// identical from the outside: only a written decision tells them apart, and this is where that decision is read
+    /// back. A member added to the request reaches the query or reaches this list, and nothing else passes.
+    /// </remarks>
+    private static readonly string[] WithheldFromAKnowledgeQuery =
+    [
+        nameof(SearchEmailsRequest.Accounts),
+        nameof(SearchEmailsRequest.Folders),
+        nameof(SearchEmailsRequest.IncludeJunkMail),
+        nameof(SearchEmailsRequest.ResultLimit),
+    ];
+
+    /// <summary>A filter one surface can express and the other cannot is a disagreement neither of them announces.</summary>
+    [Fact]
+    public void EmailKnowledgeQuery_AgainstTheSearchRequest_DeclaresEveryFilterItDoesNotWithhold()
+    {
+        // Arrange
+        var expected = PublishedPropertyNames(typeof(SearchEmailsRequest))
+            .Except(WithheldFromAKnowledgeQuery)
+            .Order(StringComparer.Ordinal);
+
+        // Act
+        var declared = PublishedPropertyNames(typeof(EmailKnowledgeQuery)).Order(StringComparer.Ordinal);
+
+        // Assert
+        Assert.Equal(expected, declared);
+    }
+
+    private static IEnumerable<string> PublishedPropertyNames(Type type) =>
+        type.GetProperties(BindingFlags.Public | BindingFlags.Instance).Select(property => property.Name);
+}

--- a/tests/Application.UnitTests/Retrieval/MailboxKnowledgeSearchTests.cs
+++ b/tests/Application.UnitTests/Retrieval/MailboxKnowledgeSearchTests.cs
@@ -317,6 +317,8 @@ public sealed class MailboxKnowledgeSearchTests
             ReceivedOnOrAfter = FirstJuly,
             ReceivedBefore = FirstJuly.AddDays(7),
             IsRemotelySeen = false,
+            IsRemotelyFlagged = true,
+            Keyword = "$Label",
             HasAttachments = true,
         };
 
@@ -337,6 +339,8 @@ public sealed class MailboxKnowledgeSearchTests
                 Written(FirstJuly.AddDays(7)),
                 "False",
                 "True",
+                "$LABEL",
+                "True",
             ],
             new[]
             {
@@ -346,6 +350,8 @@ public sealed class MailboxKnowledgeSearchTests
                 Written(selection.ReceivedOnOrAfter),
                 Written(selection.ReceivedBefore),
                 selection.IsRemotelySeen?.ToString() ?? Absent,
+                selection.IsRemotelyFlagged?.ToString() ?? Absent,
+                selection.Keyword ?? Absent,
                 selection.HasAttachments?.ToString() ?? Absent,
             });
     }


### PR DESCRIPTION
## What changed

`EmailKnowledgeQuery` stated that its fields were the structured filters of `SearchEmailsRequest` and no others, with two members withheld on purpose. Two filters added to the request afterwards reached none of the answering path, so the remark had been false since: `IsRemotelyFlagged` and `Keyword` were declared nowhere, mapped nowhere, and unreachable from the tool a model calls.

- `EmailKnowledgeQuery` declares both, with the search request's own wording.
- `MailboxKnowledgeSearch.FindPassagesAsync` maps both onto the request it hands the published search.
- `ScopedMailKnowledgeRetrieval.SearchAsync` publishes `isRemotelyFlagged` and `keyword` to the model, each with a `[Description]` written in that tool's own voice.
- The remarks are corrected either way. `IncludeJunkMail` is now named as a third withheld member rather than left unlisted, with the reason it is withheld: an answering run resolves its scope with junk excluded, and that decision belongs to the scope rather than to a lookup.
- `EmailKnowledgeQueryTests` compares the two types' published properties against a named withheld set, so the next filter added to the request either reaches the query or is written down as withheld. Verified to fail when a filter is moved into the withheld set, not only to pass as written.

`ToChatFailure` stood byte-identical in `ProviderChatModelClient` and `ResilientChatClient`, as did the catch turning a pipeline refusal into a transport fault. Both live once in `ChatCallFailureMapping`, beside the classification they read. `ProviderCallFailureClassification` keeps refusing the role its own remarks refuse, and `ToEmbeddingFailure` stays where it is.

## Behavior

An `ask_mail` run can now narrow on the remote `\Flagged` state and on a keyword, which `search_emails` has accepted for two releases. Both filters only narrow: the scope, the junk exclusion, and the run's retrieval ceiling are unchanged and remain unreachable from anything a model writes. The chat-failure change is structural and alters no classification.

No configuration key, database column, MCP tool contract, or deployment contract changes. The `search_mail` tool a model is offered gains two optional arguments; it is composed per run inside the process and is published to no external caller.

## Verification

- `scripts/verify-fast.sh` — passed
- `scripts/verify-full.sh` — passed, 10339 unit tests and 237 contract assertions
- `scripts/review-obligations.sh` — every retrieval path's tests and pages are in this change; the chat-client rows are answered by the change there being structural

Closes #1035
