### PR TITLE
[#1036] Take the duplication ledger's three sanctioned folds

### DIFF
--- a/src/Application/Mail/Delivery/Governance/AuthoredSendGovernor.cs
+++ b/src/Application/Mail/Delivery/Governance/AuthoredSendGovernor.cs
@@ -80,12 +80,9 @@ public sealed class AuthoredSendGovernor(
             ?? throw new InvalidOperationException(
                 "A send is governed against the caller that asked for it, so it is reached under a principal.");
 
-        foreach (var recipient in request.Recipients)
+        if (recipientPolicy.FindFirstRefusal(request.Recipients) is { } refusal)
         {
-            if (recipientPolicy.Judge(recipient.Address) is { } refusal)
-            {
-                throw OutgoingMailRefusedException.RecipientRefused(refusal);
-            }
+            throw OutgoingMailRefusedException.RecipientRefused(refusal);
         }
 
         var unvouchedCount = await vouching.CountUnvouchedAsync(authored, cancellationToken);

--- a/src/Application/Mail/Delivery/Governance/OutgoingMailGovernor.cs
+++ b/src/Application/Mail/Delivery/Governance/OutgoingMailGovernor.cs
@@ -66,12 +66,9 @@ public sealed class OutgoingMailGovernor(
             throw OutgoingMailRefusedException.SendingNotEnabled(refusal);
         }
 
-        foreach (var recipient in request.Recipients)
+        if (recipientPolicy.FindFirstRefusal(request.Recipients) is { } recipientRefusal)
         {
-            if (recipientPolicy.Judge(recipient.Address) is { } recipientRefusal)
-            {
-                throw OutgoingMailRefusedException.RecipientRefused(recipientRefusal);
-            }
+            throw OutgoingMailRefusedException.RecipientRefused(recipientRefusal);
         }
 
         if (ceilings.IsUnbounded)

--- a/src/Domain/Delivery/Governance/OutgoingRecipientPolicy.cs
+++ b/src/Domain/Delivery/Governance/OutgoingRecipientPolicy.cs
@@ -81,4 +81,28 @@ public sealed class OutgoingRecipientPolicy
             ? OutgoingRecipientRefusalReason.OutsideAllowedRecipients
             : null;
     }
+
+    /// <summary>Judges everybody one message is addressed to, and reports the first refusal.</summary>
+    /// <param name="recipients">The addresses the message would be offered to.</param>
+    /// <returns>The reason the first refused recipient is refused, or <see langword="null" /> when the policy admits them all.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="recipients" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// It stops at the first refusal because the message is refused whole either way, which is the reason
+    /// <see cref="Judge" /> states. Reading on would only name a second address the author learns about on the next
+    /// attempt, and the reason reported carries no address at all.
+    /// </remarks>
+    public OutgoingRecipientRefusalReason? FindFirstRefusal(IReadOnlyList<OutgoingRecipient> recipients)
+    {
+        ArgumentNullException.ThrowIfNull(recipients);
+
+        foreach (var recipient in recipients)
+        {
+            if (this.Judge(recipient.Address) is { } refusal)
+            {
+                return refusal;
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/Mcp/Tools/AuthoredMailArguments.cs
+++ b/src/Mcp/Tools/AuthoredMailArguments.cs
@@ -12,6 +12,7 @@ using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Delivery;
 using MailFathom.Domain.Delivery.Drafts;
 using MailFathom.Domain.Emails;
+using MailFathom.Domain.Failures;
 
 namespace MailFathom.Mcp.Tools;
 
@@ -143,55 +144,40 @@ internal static class AuthoredMailArguments
     /// <param name="to">The addresses named in the <c>To</c> header, or <see langword="null" /> where the act names none.</param>
     /// <param name="cc">The addresses named in the <c>Cc</c> header, or <see langword="null" />.</param>
     /// <param name="bcc">The addresses named in the <c>Bcc</c> header, or <see langword="null" />.</param>
+    /// <param name="tooManyRecipients">Raises the caller's own refusal for a list longer than a record holds.</param>
+    /// <param name="fieldUnusable">Raises the caller's own refusal for a header carrying an entry that names nobody.</param>
     /// <returns>The recipients the author named, in the order the headers are read in.</returns>
     /// <remarks>
+    /// <para>
     /// The order is the order the headers are read in, which is the order the composition writes them in. Nothing is
     /// deduplicated or parsed here: whether text names a mailbox is the composition's question, and how many people a
     /// message may actually reach is the deployment's number, both asked once for every way a message is authored.
     /// What is answered here is only how long the caller's own lists are, because that is what decides whether they are
     /// expanded at all, and the check therefore belongs in front of the expansion rather than after it.
+    /// </para>
+    /// <para>
+    /// A send and a draft read the same headers and refuse the same values, and differ only in the failure they raise:
+    /// a caller told its <em>submission</em> was refused while saving a draft would read that as a message having been
+    /// offered to a server and turned down, which is the one thing that certainly did not happen. So the act supplies
+    /// the two refusals rather than the reading being written twice, and the code and the sentence stay the same either
+    /// way because both are published from one place.
+    /// </para>
     /// </remarks>
-    /// <exception cref="MailSubmissionRefusedException">Thrown when the three headers name more people than a record holds, or an entry carries no address.</exception>
+    /// <exception cref="MailFathomException">Thrown as whichever refusal the act supplied, when the three headers name more people than a record holds or an entry carries no address.</exception>
     public static IReadOnlyList<NamedRecipient> NamedRecipients(
         IReadOnlyList<string>? to,
         IReadOnlyList<string>? cc,
-        IReadOnlyList<string>? bcc)
+        IReadOnlyList<string>? bcc,
+        Func<MailFathomException> tooManyRecipients,
+        Func<AuthoredEmailRefusal, MailFathomException> fieldUnusable)
     {
         if (Counted(to, cc, bcc) > OutgoingEmailRequest.MaximumRecipientCount)
         {
-            throw MailSubmissionRefusedException.TooManyRecipients();
+            throw tooManyRecipients();
         }
 
         return Collect(to, cc, bcc, out var unusableField)
-            ?? throw MailSubmissionRefusedException.From(
-                new AuthoredEmailRefusal(AuthoredEmailRefusalReason.FieldUnusable, unusableField));
-    }
-
-    /// <summary>Collects the three headers into the one recipient list a draft is written from.</summary>
-    /// <param name="to">The addresses named in the <c>To</c> header, or <see langword="null" /> where the caller named none.</param>
-    /// <param name="cc">The addresses named in the <c>Cc</c> header, or <see langword="null" />.</param>
-    /// <param name="bcc">The addresses named in the <c>Bcc</c> header, or <see langword="null" />.</param>
-    /// <returns>The recipients the author named, in the order the headers are read in.</returns>
-    /// <remarks>
-    /// It reads exactly what <see cref="NamedRecipients" /> reads and refuses exactly what it refuses, and differs in
-    /// the failure it raises: a caller told its <em>submission</em> was refused while saving a draft would read that as
-    /// a message having been offered to a server and turned down, which is the one thing that certainly did not
-    /// happen. The code and the sentence are the same either way, because both are published from one place.
-    /// </remarks>
-    /// <exception cref="MailDraftRefusedException">Thrown when the three headers name more people than a record holds, or an entry carries no address.</exception>
-    public static IReadOnlyList<NamedRecipient> DraftedRecipients(
-        IReadOnlyList<string>? to,
-        IReadOnlyList<string>? cc,
-        IReadOnlyList<string>? bcc)
-    {
-        if (Counted(to, cc, bcc) > OutgoingEmailRequest.MaximumRecipientCount)
-        {
-            throw MailDraftRefusedException.TooManyRecipients();
-        }
-
-        return Collect(to, cc, bcc, out var unusableField)
-            ?? throw MailDraftRefusedException.From(
-                new AuthoredEmailRefusal(AuthoredEmailRefusalReason.FieldUnusable, unusableField));
+            ?? throw fieldUnusable(new AuthoredEmailRefusal(AuthoredEmailRefusalReason.FieldUnusable, unusableField));
     }
 
     /// <summary>Reports whether text could name an account at all, before anything looks for one it names.</summary>

--- a/src/Mcp/Tools/Drafts/DraftedMailWriting.cs
+++ b/src/Mcp/Tools/Drafts/DraftedMailWriting.cs
@@ -74,7 +74,12 @@ internal sealed class DraftedMailWriting(AuthoredMailDrafting drafting, Authored
         var request = new MailDraftRequest
         {
             Account = NamedAccount(fields.Account),
-            Recipients = AuthoredMailArguments.DraftedRecipients(fields.To, fields.Cc, fields.Bcc),
+            Recipients = AuthoredMailArguments.NamedRecipients(
+                fields.To,
+                fields.Cc,
+                fields.Bcc,
+                MailDraftRefusedException.TooManyRecipients,
+                MailDraftRefusedException.From),
             Subject = fields.Subject,
             PlainTextBody = fields.PlainTextBody,
             HtmlBody = fields.HtmlBody,
@@ -103,7 +108,12 @@ internal sealed class DraftedMailWriting(AuthoredMailDrafting drafting, Authored
             Act = AuthoredAct(answer),
             PlainTextBody = fields.PlainTextBody,
             HtmlBody = fields.HtmlBody,
-            Recipients = AuthoredMailArguments.DraftedRecipients(fields.To, fields.Cc, fields.Bcc),
+            Recipients = AuthoredMailArguments.NamedRecipients(
+                fields.To,
+                fields.Cc,
+                fields.Bcc,
+                MailDraftRefusedException.TooManyRecipients,
+                MailDraftRefusedException.From),
             Author = Author(),
             Revises = revises,
         };

--- a/src/Mcp/Tools/ForwardEmailTool.cs
+++ b/src/Mcp/Tools/ForwardEmailTool.cs
@@ -136,7 +136,8 @@ internal sealed class ForwardEmailTool(AuthoredResponseSubmission submission)
             Act = AuthoredResponseAct.Forward,
             PlainTextBody = plainTextBody,
             HtmlBody = htmlBody,
-            Recipients = AuthoredMailArguments.NamedRecipients(to, cc, bcc),
+            Recipients = AuthoredMailArguments.NamedRecipients(
+                to, cc, bcc, MailSubmissionRefusedException.TooManyRecipients, MailSubmissionRefusedException.From),
             Requester = AuthoredMailArguments.Requester(idempotencyKey),
         };
 

--- a/src/Mcp/Tools/McpToolAuthorization.cs
+++ b/src/Mcp/Tools/McpToolAuthorization.cs
@@ -54,10 +54,9 @@ internal static class McpToolAuthorization
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="next" /> or <paramref name="request" /> is <see langword="null" />.</exception>
     /// <exception cref="InvalidOperationException">Thrown when the listing arrives without a service provider, which leaves nothing able to say whose grant to apply.</exception>
     /// <remarks>
-    /// The inner pipeline runs first and descriptors are removed from what it produced, for the reason the availability
-    /// filter gives: the tools a listing carries are the SDK's to compose — a page of them, with a cursor — and a filter
-    /// that decided not to call it would be reimplementing that. A descriptor naming a tool this surface does not publish
-    /// is removed as well, because nothing declared what reaching it would require.
+    /// The inner pipeline runs first and descriptors are removed from what it produced, for the reason
+    /// <see cref="AskMailAdvertisement.WithoutUnavailableAnsweringAsync" /> states. A descriptor naming a tool this
+    /// surface does not publish is removed as well, because nothing declared what reaching it would require.
     /// </remarks>
     public static async Task<ListToolsResult> WithoutUnauthorizedToolsAsync(
         McpRequestHandler<ListToolsRequestParams, ListToolsResult> next,
@@ -77,8 +76,7 @@ internal static class McpToolAuthorization
             return listing;
         }
 
-        // The result is rewritten rather than mutated, because the listing the SDK produced is not this filter's to
-        // change in place and a later page's cursor travels with it unaltered.
+        // Rewritten rather than mutated, for the reason AskMailAdvertisement.WithoutUnavailableAnsweringAsync gives.
         return new ListToolsResult
         {
             Tools = permitted,

--- a/src/Mcp/Tools/ReplyToEmailTool.cs
+++ b/src/Mcp/Tools/ReplyToEmailTool.cs
@@ -135,7 +135,12 @@ internal sealed class ReplyToEmailTool(AuthoredResponseSubmission submission)
             Act = AuthoredAct(audience),
             PlainTextBody = plainTextBody,
             HtmlBody = htmlBody,
-            Recipients = AuthoredMailArguments.NamedRecipients(to: null, cc, bcc: null),
+            Recipients = AuthoredMailArguments.NamedRecipients(
+                to: null,
+                cc,
+                bcc: null,
+                MailSubmissionRefusedException.TooManyRecipients,
+                MailSubmissionRefusedException.From),
             Requester = AuthoredMailArguments.Requester(idempotencyKey),
         };
 

--- a/src/Mcp/Tools/SendEmailTool.cs
+++ b/src/Mcp/Tools/SendEmailTool.cs
@@ -129,7 +129,8 @@ internal sealed class SendEmailTool(AuthoredMailSubmission submission)
         var request = new MailSubmissionRequest
         {
             Account = NamedAccount(account),
-            Recipients = AuthoredMailArguments.NamedRecipients(to, cc, bcc),
+            Recipients = AuthoredMailArguments.NamedRecipients(
+                to, cc, bcc, MailSubmissionRefusedException.TooManyRecipients, MailSubmissionRefusedException.From),
             Subject = subject,
             PlainTextBody = plainTextBody,
             HtmlBody = htmlBody,

--- a/tests/Domain.UnitTests/Delivery/Governance/OutgoingRecipientPolicyTests.cs
+++ b/tests/Domain.UnitTests/Delivery/Governance/OutgoingRecipientPolicyTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Domain.Delivery;
 using MailFathom.Domain.Delivery.Governance;
 using MailFathom.Domain.Emails;
 using Xunit;
@@ -125,6 +126,74 @@ public sealed class OutgoingRecipientPolicyTests
         Assert.Null(refusal);
     }
 
+    /// <summary>A message everybody on it is admitted for is admitted whole, whichever header each recipient is named in.</summary>
+    [Fact]
+    public void FindFirstRefusal_EveryRecipientAdmitted_ReportsNoRefusal()
+    {
+        // Arrange
+        var policy = OutgoingRecipientPolicy.Create([DomainRule("example.test")], []);
+
+        // Act
+        var refusal = policy.FindFirstRefusal(
+        [
+            Recipient("anna@example.test", OutgoingRecipientRole.To),
+            Recipient("bruno@team.example.test", OutgoingRecipientRole.Cc),
+        ]);
+
+        // Assert
+        Assert.Null(refusal);
+    }
+
+    /// <summary>The message is judged whole, so a recipient in any header refuses it and the reason is that recipient's own.</summary>
+    [Fact]
+    public void FindFirstRefusal_RecipientRefusedInALaterHeader_ReportsThatRecipientsReason()
+    {
+        // Arrange
+        var policy = OutgoingRecipientPolicy.Create([], [DomainRule("rival.test")]);
+
+        // Act
+        var refusal = policy.FindFirstRefusal(
+        [
+            Recipient("anna@example.test", OutgoingRecipientRole.To),
+            Recipient("bruno@rival.test", OutgoingRecipientRole.Bcc),
+        ]);
+
+        // Assert
+        Assert.Equal(OutgoingRecipientRefusalReason.DeniedByPolicy, refusal);
+    }
+
+    /// <summary>The reading stops at the first refusal, so a denial ahead of an outsider is the reason reported.</summary>
+    [Fact]
+    public void FindFirstRefusal_SeveralRecipientsRefused_ReportsTheFirstOfThem()
+    {
+        // Arrange
+        var policy = OutgoingRecipientPolicy.Create([DomainRule("example.test")], [DomainRule("rival.test")]);
+
+        // Act
+        var refusal = policy.FindFirstRefusal(
+        [
+            Recipient("anna@rival.test", OutgoingRecipientRole.To),
+            Recipient("bruno@elsewhere.test", OutgoingRecipientRole.To),
+        ]);
+
+        // Assert
+        Assert.Equal(OutgoingRecipientRefusalReason.DeniedByPolicy, refusal);
+    }
+
+    /// <summary>A message addressed to nobody names nobody the policy could refuse.</summary>
+    [Fact]
+    public void FindFirstRefusal_NoRecipients_ReportsNoRefusal()
+    {
+        // Arrange
+        var policy = OutgoingRecipientPolicy.Create([DomainRule("example.test")], []);
+
+        // Act
+        var refusal = policy.FindFirstRefusal([]);
+
+        // Assert
+        Assert.Null(refusal);
+    }
+
     /// <summary>Text that names no organization or mailbox is no entry at all, which is what a configuration refuses at startup.</summary>
     [Theory]
     [InlineData(null)]
@@ -184,6 +253,9 @@ public sealed class OutgoingRecipientPolicyTests
 
         return rule;
     }
+
+    private static OutgoingRecipient Recipient(string address, OutgoingRecipientRole role) =>
+        OutgoingRecipient.Create(Address(address), role);
 
     private static EmailAddress Address(string address)
     {

--- a/tests/Mcp.UnitTests/Tools/Drafts/SaveDraftToolTests.cs
+++ b/tests/Mcp.UnitTests/Tools/Drafts/SaveDraftToolTests.cs
@@ -287,6 +287,35 @@ public sealed class SaveDraftToolTests
         Assert.Empty(deployment.Drafts.Drafts);
     }
 
+    /// <summary>A list longer than a record holds is refused on its length, as the draft's own refusal rather than a submission's.</summary>
+    /// <remarks>
+    /// The reading is the one every authored act shares, so what this proves is the half that is the draft's: a caller
+    /// saving a draft is never told a <em>submission</em> was refused, because nothing was offered to a server.
+    /// </remarks>
+    [Fact]
+    public async Task SaveDraftAsync_MorePeopleThanARecordHolds_IsRefusedAsADraft()
+    {
+        // Arrange
+        var deployment = new DraftedMailDeployment();
+        var addresses = Enumerable
+            .Range(0, OutgoingEmailRequest.MaximumRecipientCount + 1)
+            .Select(index => $"person{index}@example.test")
+            .ToArray();
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<MailDraftRefusedException>(
+            () => deployment.SaveTool.SaveDraftAsync(
+                "Shall we?",
+                DraftedMailDeployment.ServedAccount,
+                "Lunch on Thursday",
+                addresses,
+                cancellationToken: TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomErrorCode.AuthoredMailBoundExceeded, refusal.ErrorCode);
+        Assert.Empty(deployment.Drafts.Drafts);
+    }
+
     /// <summary>A recipient that carries no address names nobody, and the refusal says which header rather than what was in it.</summary>
     [Fact]
     public async Task SaveDraftAsync_ARecipientCarryingNoAddress_IsRefusedWithoutRepeatingWhatWasSent()


### PR DESCRIPTION
## What this does

Issue #1036 recorded seven verified duplications that were each too small to schedule and cheapest when their file was already open, and it closes when every item is either applied alongside other work or closed with a line saying it was judged not worth doing. This settles the ledger: it takes the three folds the ledger itself named as worth taking, and records the verdict for the four it did not.

**Assumption stated up front**, because the ledger's acceptance says an item is applied *alongside other work in its file* and no other work was in flight here: an explicit request to run this issue is the maintainer opening those files, so the three sanctioned folds are taken together in one change rather than one change per item. Nothing here introduces a generic, a base class, or an interface, and no refusal code, message, or ordering changes on any surface.

## The three applied

**The recipient-policy loop, written twice.** `OutgoingMailGovernor` and `AuthoredSendGovernor` each walked `request.Recipients` calling `OutgoingRecipientPolicy.Judge`. The walk becomes `OutgoingRecipientPolicy.FindFirstRefusal(IReadOnlyList<OutgoingRecipient>)` — the collection overload the ledger named, on the type that already owns the rule. Both evaluations stay where they are: `AuthoredSendGovernor` documents its double evaluation as intended, and what moved is the loop rather than the decision.

**The list-tools filters, rebuilding a narrowed listing identically.** Both carried the same two-line comment about rewriting a `ListToolsResult` rather than mutating it. `McpToolAuthorization` already cited "the availability filter" for the surrounding argument, so the prose stays in `AskMailAdvertisement` and `McpToolAuthorization` now points at it by name — a cross-reference in place of the copy, including in the doc remark that restated it.

**`AuthoredMailArguments.DraftedRecipients`.** It read exactly what `NamedRecipients` read and differed only in the exception type it raised. The justification recorded in the file — that a caller would misread a submission refusal — does not hold: `McpToolFailure` publishes `ErrorCode` and `Message` and nothing else, so the type name never reaches a client, and both refusals are already published from `AuthoredMailRefusalPublication`. So `NamedRecipients` now takes the two refusal factories its caller should raise and `DraftedRecipients` is gone. Merging the two exception types is explicitly **not** part of this — the ledger records that as a separate, larger decision.

## The four judged not worth doing

- **Six paged query result records repeat their refusal guard.** Not extracted, as the ledger reasoned: a generic to remove six argument guards costs a reader one indirection at the exact point a refusal is asserted, and the useful output — the page-size number — was already taken by the keyset-paging work. Verified still standing across all six files.
- **Three transport startup reports repeat a hosted-service preamble.** Not taken. `McpEndpointOptions` and `AdminEndpointOptions` share no interface and the grant report composes its section path differently, so any shared iteration needs a generic payload or a per-report selector — both refused by the issue's own acceptance. Verified still standing.
- **`private sealed class CommittingSession`, declared 26 times.** Not taken here. Taking it means retiring both idioms at once — the 26 nested declarations *and* the ~36 further files spelling the same concept as `Substitute.For<IPersistenceSession>()` — or it has added a third spelling. That is a change of its own across three test projects, which is precisely what this issue forbids, and it owes a covering test on top.
- **The requester-identity predicate written twice.** Left alone, which the ledger records as also correct. `SetMailFlagsTool.Requester` mints an identity for a null argument, bounds against a different constant, and produces a different domain type; a shared `CouldBeARequesterIdentity(string?, int)` would remove three lines and add a parameter that exists only to carry the difference.

## Verification

- `scripts/verify-full.sh` — passed over this content.
- `scripts/verify-fast.sh` — 10364/10364 tests pass.
- `scripts/review-obligations.sh` — every row read; none survives as a finding. No behavior a page describes moved, and the tests naming the two governors already run through the new call.
- `$check-docs-licenses` — Docs `n/a`, Changelog `n/a`, Licenses `n/a`. No documentation names any moved symbol, no dependency, image, service, or model changed.

## Tests

- `OutgoingRecipientPolicyTests` gains four cases for `FindFirstRefusal`: every recipient admitted, a recipient refused in a later header, several refused with the first reported, and an empty list.
- `SaveDraftToolTests` gains the too-many-recipients case for a draft, which is the one path where a wrong refusal factory would silently raise a submission refusal for a draft. The field-unusable half was already covered.

## Breaking changes

None. No MCP tool contract, configuration key, database column, or deployment contract is touched.

Closes #1036
