### PR TITLE
[#1033] Read each application port from its own snapshot-scoped reader

### DIFF
--- a/docs/features/mailbox-queries.md
+++ b/docs/features/mailbox-queries.md
@@ -374,8 +374,8 @@ configuration bounds.
   it.
 - `MailFathom.Application.Accounts` — `IMailAccountCatalog`, the port that describes which accounts this deployment serves, and `MailAccountDirectoryReader`, the one use case that publishes that set rather than bounding a read with it. One
   member answers both questions asked of it: whether the account a request named is accepted, and which accounts an
-  unscoped request is narrowed to. `MailSynchronizationOptions` implements it, so the answer comes from the configuration
-  that defines the accounts.
+  unscoped request is narrowed to. `ConfiguredMailAccountCatalog` implements it over the bound mail section, so the
+  answer comes from the configuration that defines the accounts.
 - `MailFathom.Application.Synchronization.Checkpoints` — the freshness port and its read model, kept separate from the
   readers that return mail because every read model attaches freshness.
 - `MailFathom.Infrastructure.Persistence.Emails` — `StoredEmailTimelineReader`, which evaluates every filter, the keyset

--- a/src/Application/Contacts/Collection/IContactCollectionSettingsReader.cs
+++ b/src/Application/Contacts/Collection/IContactCollectionSettingsReader.cs
@@ -17,5 +17,5 @@ public interface IContactCollectionSettingsReader
     /// <summary>Reads what one account collects.</summary>
     /// <param name="accountId">The account whose mail is being synchronized.</param>
     /// <returns>The settings, or <see cref="ContactCollectionSettings.CollectingNothing" /> for an account this deployment does not configure.</returns>
-    ContactCollectionSettings SettingsFor(MailAccountId accountId);
+    ContactCollectionSettings GetContactCollectionSettings(MailAccountId accountId);
 }

--- a/src/Application/Contacts/Collection/MailContactCollector.cs
+++ b/src/Application/Contacts/Collection/MailContactCollector.cs
@@ -93,7 +93,7 @@ public sealed class MailContactCollector
     /// are read again per message and stop the work before the bound is ever asked.
     /// </remarks>
     public ContactCollectionRun OpenRun(MailAccountId accountId, MailFolderSpecialUse? folderRole) =>
-        new(folderRole, new ContactCollectionBudget(this.settingsReader.SettingsFor(accountId).MaxContactsPerRun));
+        new(folderRole, new ContactCollectionBudget(this.settingsReader.GetContactCollectionSettings(accountId).MaxContactsPerRun));
 
     /// <summary>Records whoever one committed message says the account corresponds with.</summary>
     /// <param name="metadata">What was read out of the message that was just stored.</param>
@@ -114,7 +114,7 @@ public sealed class MailContactCollector
         ArgumentNullException.ThrowIfNull(run);
 
         var accountId = metadata.OccurrenceId.AccountId;
-        var settings = this.settingsReader.SettingsFor(accountId);
+        var settings = this.settingsReader.GetContactCollectionSettings(accountId);
 
         if (!settings.IsEnabled || CollectedRoleIn(run.FolderRole) is not { } role)
         {

--- a/src/Host/Configuration/Mail/ConfiguredOutgoingSendPermissionReader.cs
+++ b/src/Host/Configuration/Mail/ConfiguredOutgoingSendPermissionReader.cs
@@ -40,8 +40,15 @@ internal sealed class ConfiguredOutgoingSendPermissionReader(
             return OutgoingSendRefusalReason.DeploymentIsReadOnly;
         }
 
-        return synchronizationSettings.SendingEnabled(accountId)
-            ? null
-            : OutgoingSendRefusalReason.AccountNotEnabled;
+        return this.SendingEnabled(accountId) ? null : OutgoingSendRefusalReason.AccountNotEnabled;
     }
+
+    /// <summary>Reports whether an operator has turned sending on for one account.</summary>
+    /// <remarks>
+    /// An account this snapshot does not name reads as one nobody turned sending on for, which is what it is: the
+    /// switch that would admit it exists on no account of this installation. That is also what a reload removing an
+    /// account means for a send arriving a moment later.
+    /// </remarks>
+    private bool SendingEnabled(MailAccountId accountId) =>
+        synchronizationSettings.FindConfiguredAccount(accountId)?.Delivery.Enabled ?? false;
 }

--- a/src/Host/Configuration/Mail/MailSynchronizationOptions.cs
+++ b/src/Host/Configuration/Mail/MailSynchronizationOptions.cs
@@ -6,28 +6,19 @@ using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography.X509Certificates;
 using MailFathom.Application.Accounts;
-using MailFathom.Application.Contacts.Collection;
 using MailFathom.Application.Emails.Extraction;
-using MailFathom.Application.Folders;
-using MailFathom.Application.Mail;
-using MailFathom.Application.Mail.Delivery.Composition;
-using MailFathom.Application.Mail.Delivery.Filing;
-using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Retrieval.AskMail.Audit;
-using MailFathom.Application.Rules.Actions;
 using MailFathom.Application.Synchronization;
-using MailFathom.Application.Synchronization.Checkpoints;
-using MailFathom.Application.Synchronization.Reconciliation;
 using MailFathom.Domain.Accounts;
-using MailFathom.Domain.Contacts.Collection;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Emails.Authentication;
 using MailFathom.Domain.Emails.Authorship;
 using MailFathom.Domain.Folders;
 using MailFathom.Domain.Synchronization;
 using MailFathom.Domain.Transport;
+using MailFathom.Host.Configuration.Mail.Readers;
 using MailFathom.Infrastructure.Certificates;
 using MailFathom.Infrastructure.Mail;
 using MailFathom.Infrastructure.Mail.OAuth;
@@ -37,24 +28,7 @@ namespace MailFathom.Host.Configuration.Mail;
 
 /// <summary>Configures periodic IMAP synchronization.</summary>
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The options framework materializes this type during configuration binding.")]
-internal sealed class MailSynchronizationOptions
-    : IValidatableObject,
-        IMailTransportSecurityPolicyReader,
-        IMailSynchronizationWindowReader,
-        IRemotelyDeletedEmailDispositionReader,
-        IAuthoredDeleteEmailDispositionReader,
-        IMailRuleActionPermissionReader,
-        IMailboxMutationAuditSettingsReader,
-        IMailAnsweringAuditSettingsReader,
-        IMailAccountCatalog,
-        ITrustedAuthenticationAuthorityReader,
-        ISenderTrustPolicyReader,
-        IOutgoingSenderIdentityReader,
-        IOutgoingMailFilingPolicyReader,
-        IMailFolderParticipationReader,
-        IJunkMailFolderCatalog,
-        IMailFolderMappingReader,
-        IContactCollectionSettingsReader
+internal sealed class MailSynchronizationOptions : IValidatableObject
 {
     /// <summary>The shutdown budget the .NET Generic Host applies when nothing configures one.</summary>
     private static readonly TimeSpan DefaultHostShutdownTimeout = TimeSpan.FromSeconds(30);
@@ -62,30 +36,26 @@ internal sealed class MailSynchronizationOptions
     /// <summary>What the shutdown budget keeps for the hosted services that stop beside a synchronization drain.</summary>
     private static readonly TimeSpan HostShutdownMargin = TimeSpan.FromSeconds(5);
 
-    private readonly Lazy<IReadOnlyDictionary<string, IReadOnlyList<MailFolderMapping>>> mappingsByAccount;
-
-    private readonly Lazy<IReadOnlyDictionary<string, SenderTrustPolicy>> senderTrustPolicies;
-
-    private readonly Lazy<IReadOnlyDictionary<string, ContactCollectionSettings>> contactCollectionSettings;
+    private readonly Lazy<MailSynchronizationSettingsReaders> readers;
 
     /// <summary>Initializes the options the binder is about to write into.</summary>
     /// <remarks>
-    /// Both caches are deferred rather than built here, because nothing is bound yet when this runs. What forces them
-    /// is the first lookup, which happens long after binding and after validation, and a reload binds a new instance
-    /// rather than rewriting this one — so a built value can never describe superseded configuration. The verification
-    /// policies are cached for a second reason as well: each one derives a revision over the whole effective list, and
-    /// every arriving message asks for one.
+    /// The readers are deferred rather than built here, because nothing is bound yet when this runs. What forces them
+    /// is the first port resolved against this snapshot, which happens long after binding and after validation, and a
+    /// reload binds a new instance rather than rewriting this one — so a value they memoize can never describe
+    /// superseded configuration.
     /// </remarks>
-    public MailSynchronizationOptions()
-    {
-        this.mappingsByAccount = new(this.ReadMappingsByAccount, LazyThreadSafetyMode.ExecutionAndPublication);
-        this.senderTrustPolicies = new(
-            this.ReadSenderTrustPolicies,
+    public MailSynchronizationOptions() =>
+        this.readers = new(
+            () => new MailSynchronizationSettingsReaders(this),
             LazyThreadSafetyMode.ExecutionAndPublication);
-        this.contactCollectionSettings = new(
-            this.ReadContactCollectionSettings,
-            LazyThreadSafetyMode.ExecutionAndPublication);
-    }
+
+    /// <summary>Gets the port readers this snapshot is read through.</summary>
+    /// <remarks>
+    /// One set belongs to this instance and is shared by every scope that runs against it, which is what keeps the
+    /// per-account maps three of the readers memoize built once per snapshot rather than once per work unit.
+    /// </remarks>
+    internal MailSynchronizationSettingsReaders Readers => this.readers.Value;
 
     /// <summary>Gets or sets whether periodic synchronization is enabled.</summary>
     public bool Enabled { get; set; }
@@ -509,13 +479,13 @@ internal sealed class MailSynchronizationOptions
         TrustAnchorLoader trustAnchorLoader,
         CancellationToken cancellationToken)
     {
-        var normalizedAccountId = MailAccountId.Create(accountId).Value;
-        var account = this.FindAccount(normalizedAccountId);
+        var accountIdentity = MailAccountId.Create(accountId);
+        var account = this.RequireAccount(accountIdentity);
 
         var material = await account.ResolveConnectionMaterialAsync(resolver, trustAnchorLoader, cancellationToken);
 
         return new ImapAccountSettings(
-            normalizedAccountId,
+            accountIdentity.Value,
             account.Host.Trim(),
             account.Port,
             account.UserName,
@@ -536,415 +506,23 @@ internal sealed class MailSynchronizationOptions
         TrustAnchorLoader trustAnchorLoader,
         CancellationToken cancellationToken)
     {
-        var normalizedAccountId = MailAccountId.Create(accountId).Value;
-        var account = this.FindAccount(normalizedAccountId);
+        var accountIdentity = MailAccountId.Create(accountId);
+        var account = this.RequireAccount(accountIdentity);
 
         if (!account.Delivery.IsConfigured)
         {
-            throw new InvalidOperationException($"Account '{normalizedAccountId}' configures no submission endpoint.");
+            throw new InvalidOperationException($"Account '{accountIdentity.Value}' configures no submission endpoint.");
         }
 
         var material = await account.ResolveDeliveryConnectionMaterialAsync(resolver, trustAnchorLoader, cancellationToken);
 
         return new SmtpAccountSettings(
-            normalizedAccountId,
+            accountIdentity.Value,
             account.Delivery.Host.Trim(),
             account.Delivery.Port,
             account.Delivery.ResolveUserName(account.UserName),
             material);
     }
-
-    /// <inheritdoc />
-    public MailTransportSecurityPolicy GetPolicy(MailAccountId accountId)
-    {
-        var account = this.FindAccount(accountId.Value);
-
-        return account.CreateTransportSecurityPolicy();
-    }
-
-    /// <inheritdoc />
-    public MailTransportSecurityPolicy? GetDeliveryPolicy(MailAccountId accountId)
-    {
-        var account = this.FindAccount(accountId.Value);
-
-        return account.Delivery.IsConfigured ? account.CreateDeliveryTransportSecurityPolicy() : null;
-    }
-
-    /// <inheritdoc />
-    public OutgoingSenderIdentity? FindSenderIdentity(MailAccountId accountId)
-    {
-        var account = this.FindConfiguredAccount(accountId);
-
-        if (account?.Delivery is not { IsConfigured: true } delivery)
-        {
-            return null;
-        }
-
-        return EmailAddress.TryCreate(delivery.FromDisplayName, delivery.ResolveFromAddress(account.UserName), out var address)
-            ? OutgoingSenderIdentity.Create(accountId, address)
-            : null;
-    }
-
-    /// <inheritdoc />
-    /// <remarks>
-    /// An account this deployment does not configure is answered as though it files the copy, which is the same
-    /// direction the port's own default takes: nothing can send as an account nobody configured, so the answer is
-    /// reached only by a caller asking about a message that cannot exist.
-    /// </remarks>
-    public bool FilesSentCopy(MailAccountId accountId) =>
-        this.FindConfiguredAccount(accountId)?.Delivery.FileSentCopy ?? true;
-
-    /// <summary>Reports whether an operator has turned sending on for one account.</summary>
-    /// <param name="accountId">The account a message would be sent as.</param>
-    /// <returns><see langword="true" /> when this deployment may send as that account.</returns>
-    /// <remarks>
-    /// An account this snapshot does not name reads as one nobody turned sending on for, which is what it is: the
-    /// switch that would admit it exists on no account of this installation. That is also what a reload removing an
-    /// account means for a send arriving a moment later.
-    /// </remarks>
-    public bool SendingEnabled(MailAccountId accountId) =>
-        this.FindConfiguredAccount(accountId)?.Delivery.Enabled ?? false;
-
-    /// <inheritdoc />
-    public MailSynchronizationWindow GetWindow(MailAccountId accountId)
-    {
-        var account = this.FindAccount(accountId.Value);
-
-        return account.CreateSynchronizationWindow();
-    }
-
-    /// <inheritdoc />
-    public RemotelyDeletedEmailDisposition GetDisposition(MailAccountId accountId)
-    {
-        var account = this.FindAccount(accountId.Value);
-
-        return account.RemotelyDeletedEmailDisposition;
-    }
-
-    /// <inheritdoc />
-    public AuthoredDeleteEmailDisposition GetAuthoredDeleteDisposition(MailAccountId accountId)
-    {
-        var account = this.FindAccount(accountId.Value);
-
-        return account.AuthoredDeleteEmailDisposition;
-    }
-
-    /// <inheritdoc />
-    public MailRuleActionPermissions GetRuleActionPermissions(MailAccountId accountId)
-    {
-        var account = this.FindAccount(accountId.Value);
-
-        return (account.RuleActions ?? new MailRuleActionPermissionOptions()).ToPermissions();
-    }
-
-    /// <inheritdoc />
-    /// <remarks>
-    /// An account this snapshot no longer names reports <see cref="MailboxMutationAuditSettings.Disabled" /> rather
-    /// than failing, unlike every other per-account reader here. The two callers are why: a mutation is only recorded
-    /// for a configured account, and the retention pass runs over accounts a reload may have removed between one run and
-    /// the next — where the honest answer is that no operator decision applies, not that the deployment is broken.
-    /// </remarks>
-    public MailboxMutationAuditSettings GetAuditSettings(MailAccountId accountId) =>
-        this.FindConfiguredAccount(accountId)?.CreateAuditSettings() ?? MailboxMutationAuditSettings.Disabled;
-
-    /// <inheritdoc />
-    public MailAnsweringAuditSettings GetAnsweringAuditSettings(MailAccountId accountId) =>
-        this.FindConfiguredAccount(accountId)?.CreateAnsweringAuditSettings() ?? MailAnsweringAuditSettings.Disabled;
-
-    /// <inheritdoc />
-    /// <remarks>
-    /// An account this snapshot no longer names answers with none rather than failing, for the reason the audit
-    /// settings above do: the extraction backfill runs over accounts a reload may have removed between one run and the
-    /// next, and believing no header there is the honest answer as well as the safe one.
-    /// </remarks>
-    public TrustedAuthenticationAuthority GetTrustedAuthority(MailAccountId accountId) =>
-        this.FindConfiguredAccount(accountId)?.CreateTrustedAuthority() ?? TrustedAuthenticationAuthority.None;
-
-    /// <inheritdoc />
-    /// <remarks>
-    /// Answered from the cache below rather than rebuilt, because every arriving message asks for one and building a
-    /// policy derives a revision over the whole effective list. An account this snapshot no longer names recognizes
-    /// nobody, for the reason the trusted authority above answers with none.
-    /// </remarks>
-    public SenderTrustPolicy GetTrustPolicy(MailAccountId accountId) =>
-        this.senderTrustPolicies.Value.TryGetValue(accountId.Value, out var policy)
-            ? policy
-            : SenderTrustPolicy.RecognizingNobody;
-
-    /// <summary>Builds every account's verification policy once, keyed by the account identifier the lookups arrive with.</summary>
-    /// <remarks>
-    /// The stored half of each list is empty here and is what <see href="https://github.com/Krzysztof318/MailFathom/issues/760">#760</see>
-    /// fills in: the matcher already takes both halves, so the store arrives as a second list rather than as a second
-    /// rule. An entry whose text is unusable is skipped rather than raised over, and two accounts configured under one
-    /// identifier keep the first, both for the reason the folder mappings do — startup validation refuses each of
-    /// those, and a reload being rejected must not make a lookup throw.
-    /// </remarks>
-    private Dictionary<string, SenderTrustPolicy> ReadSenderTrustPolicies()
-    {
-        IReadOnlyList<SenderDomain> ownAccountDomains = this.TrustOwnAccountDomains ? this.ReadOwnAccountDomains() : [];
-
-        return (this.Accounts ?? [])
-            .Select(static account => (Id: TryReadAccountId(account.AccountId), account.ConfiguredTrustedSenders))
-            .Where(static account => account.Id is not null)
-            .GroupBy(static account => account.Id!, StringComparer.Ordinal)
-            .ToDictionary(
-                static account => account.Key,
-                account => SenderTrustPolicy.Create(
-                    ownAccountDomains,
-                    account.First().ConfiguredTrustedSenders,
-                    storedTrustedSenders: []),
-                StringComparer.Ordinal);
-    }
-
-    /// <inheritdoc />
-    /// <remarks>
-    /// Answered from the cache below, because every message of a switched-on account asks for it and building the
-    /// policy reads every account's own mailbox address. An account this snapshot no longer names collects nothing,
-    /// which is the honest answer as well as the safe one: an account nobody configures has no owner to have asked for
-    /// a book.
-    /// </remarks>
-    public ContactCollectionSettings SettingsFor(MailAccountId accountId) =>
-        this.contactCollectionSettings.Value.TryGetValue(accountId.Value, out var settings)
-            ? settings
-            : ContactCollectionSettings.CollectingNothing;
-
-    /// <summary>Builds every account's collection settings once, keyed by the account identifier the lookups arrive with.</summary>
-    /// <remarks>
-    /// The own addresses are read once for the whole deployment and handed to every account's policy, because an owner
-    /// writing from one of their mailboxes to another is not a correspondent of themselves. An entry whose text is
-    /// unusable is skipped and two accounts configured under one identifier keep the first, both for the reason the
-    /// trust policies above do: startup validation refuses each of those, and a reload being rejected must not make an
-    /// arriving message throw.
-    /// </remarks>
-    private Dictionary<string, ContactCollectionSettings> ReadContactCollectionSettings()
-    {
-        var ownAddresses = this.ReadOwnAccountAddresses();
-
-        return (this.Accounts ?? [])
-            .Select(static account => (Id: TryReadAccountId(account.AccountId), account.ContactCollection))
-            .Where(static account => account.Id is not null && account.ContactCollection is not null)
-            .GroupBy(static account => account.Id!, StringComparer.Ordinal)
-            .ToDictionary(
-                static account => account.Key,
-                account => ReadContactCollection(account.First().ContactCollection!, ownAddresses),
-                StringComparer.Ordinal);
-    }
-
-    /// <summary>Reads one account's configured block as the settings collection runs under.</summary>
-    private static ContactCollectionSettings ReadContactCollection(
-        ContactCollectionOptions configured,
-        IReadOnlyCollection<EmailAddress> ownAddresses) => new()
-        {
-            IsEnabled = configured.Enabled,
-            MinimumMessagesFromSender = configured.MinimumMessagesFromSender,
-            MaxContactsPerRun = configured.MaxContactsPerRun,
-            Policy = ContactCollectionPolicy.Create(configured.ConfiguredExclusions, ownAddresses),
-        };
-
-    /// <summary>Reads the mailboxes this deployment reads on its owner's behalf.</summary>
-    /// <remarks>
-    /// Derived from each account's user name for the reason the own domains below are: it is the only mailbox identity
-    /// an IMAP account states. An account whose user name is a bare login contributes nothing, which costs one address
-    /// that would have been excluded — and the two headers collection reads leave the owner out of both directions
-    /// anyway, since an ordinary folder's author is a correspondent and a sent folder's recipients are.
-    /// </remarks>
-    private IReadOnlyList<EmailAddress> ReadOwnAccountAddresses() =>
-    [
-        .. (this.Accounts ?? [])
-            .Select(static account => EmailAddress.TryCreate(displayName: null, account.UserName, out var address)
-                ? address
-                : (EmailAddress?)null)
-            .OfType<EmailAddress>()
-            .Distinct(),
-    ];
-
-    /// <summary>Reads the domains the configured accounts themselves send and receive under.</summary>
-    /// <remarks>
-    /// Derived from each account's user name, which is the only mailbox identity an IMAP account states: a server is
-    /// reached at a host that is rarely the mail domain, and the account identifier is a key an operator invented. An
-    /// account whose user name is a bare login rather than an address therefore contributes nothing, which is the
-    /// honest answer — inventing a domain out of the host would recognize senders nobody named.
-    /// </remarks>
-    private IReadOnlyList<SenderDomain> ReadOwnAccountDomains() =>
-    [
-        .. (this.Accounts ?? [])
-            .Select(static account => TryReadOwnDomain(account.UserName))
-            .OfType<SenderDomain>()
-            .Distinct(),
-    ];
-
-    /// <summary>Reads the mail domain one account's user name states, or nothing when it states none.</summary>
-    /// <remarks>
-    /// The at-sign is what separates the two shapes an IMAP user name takes. Without one the value is a login and
-    /// naming a domain from it would be a guess; with one it is the mailbox address the account belongs to, and the
-    /// domain is what follows the last at-sign for the reason every address in this system is split there.
-    /// </remarks>
-    private static SenderDomain? TryReadOwnDomain(string? userName) =>
-        userName is not null
-        && userName.Contains('@', StringComparison.Ordinal)
-        && SenderDomain.TryCreateFromMailbox(userName, out var domain)
-            ? domain
-            : null;
-
-    /// <inheritdoc />
-    public bool SynchronizationEnabled => this.Enabled;
-
-    /// <inheritdoc />
-    /// <remarks>
-    /// <para>
-    /// Configuration is what defines the set of accounts, so this answers from the same bound options every other
-    /// per-account reader does. It deliberately ignores <see cref="Enabled" />: that switch stops runs from fetching
-    /// mail, and an operator who turned it off has not asked for the copy already stored to become unreadable. An
-    /// account they removed is a different matter, and its absence here is what makes its stored mail unreadable.
-    /// </para>
-    /// <para>
-    /// An account whose display name is missing or unusable is omitted rather than published under an invented one.
-    /// Startup validation refuses that configuration, so the omission is only reachable while a reload is being
-    /// rejected, and publishing an account under a name no operator chose is the one outcome worse than not publishing
-    /// it at all.
-    /// </para>
-    /// </remarks>
-    public IReadOnlyList<ServedMailAccount> ServedAccounts =>
-    [
-        .. (this.Accounts ?? [])
-            .Where(static candidate => !string.IsNullOrWhiteSpace(candidate.AccountId))
-            .Select(static candidate => candidate.CreateServedAccount())
-            .OfType<ServedMailAccount>()
-            .DistinctBy(static account => account.Id.Value, StringComparer.Ordinal)
-            .OrderBy(static account => account.Id.Value, StringComparer.Ordinal),
-    ];
-
-    /// <inheritdoc />
-    public IReadOnlyList<MailFolderIdentity> FoldersMapped =>
-        [.. this.ConfiguredFolders().Select(static folder => folder.Identity)];
-
-    /// <inheritdoc />
-    public IReadOnlyList<MailFolderIdentity> FoldersSynchronized =>
-        [.. this.ConfiguredFolders().Where(static folder => folder.Participation.IsSynchronized).Select(static folder => folder.Identity)];
-
-    /// <inheritdoc />
-    public IReadOnlyList<MailFolderIdentity> FoldersVisibleToTools =>
-        [.. this.ConfiguredFolders().Where(static folder => folder.Participation.IsVisibleToTools).Select(static folder => folder.Identity)];
-
-    /// <inheritdoc />
-    public IReadOnlyList<MailFolderIdentity> FoldersGeneratingEmbeddings =>
-        [.. this.ConfiguredFolders().Where(static folder => folder.Participation.GeneratesEmbeddings).Select(static folder => folder.Identity)];
-
-    /// <inheritdoc />
-    /// <remarks>
-    /// Read from the configured role rather than from what a server advertised, for the reason
-    /// <see cref="MailFolderMappingOptions.ConfiguredSpecialUse" /> gives. A deployment that maps no junk folder answers
-    /// with nothing here, and every mailbox read then behaves as it did before this existed.
-    /// </remarks>
-    public IReadOnlyList<MailFolderIdentity> JunkFolders =>
-        [.. this.ConfiguredFolders().Where(static folder => folder.SpecialUse is MailFolderSpecialUse.Junk).Select(static folder => folder.Identity)];
-
-    /// <inheritdoc />
-    public bool IsJunkFolder(MailAccountId accountId, MailFolderAlias folderAlias) =>
-        this.ConfiguredFolders().Any(folder =>
-            folder.SpecialUse is MailFolderSpecialUse.Junk
-            && folder.Identity.AccountId == accountId
-            && folder.Identity.Alias == folderAlias);
-
-    /// <summary>Gets the aliases every account maps to its inbox, which is the scope classification defaults to.</summary>
-    /// <remarks>
-    /// Read here rather than in the classification section because this is where the folder mappings are, and because
-    /// the default has to follow the mappings: an operator whose server presents the inbox under another name configures
-    /// the role, and the default scope has to be the alias that role resolved to rather than the literal text INBOX.
-    /// </remarks>
-    internal IEnumerable<MailFolderAlias> InboxFolderAliases =>
-        this.ConfiguredFolders()
-            .Where(static folder => folder.SpecialUse is MailFolderSpecialUse.Inbox)
-            .Select(static folder => folder.Identity.Alias);
-
-    /// <inheritdoc />
-    public MailFolderParticipation GetParticipation(MailAccountId accountId, MailFolderAlias folderAlias) =>
-        this.ConfiguredFolders()
-            .FirstOrDefault(folder => folder.Identity.AccountId == accountId && folder.Identity.Alias == folderAlias)
-            ?.Participation
-        ?? MailFolderParticipation.Unmapped;
-
-    /// <inheritdoc />
-    public MailFolderMapping? FindFolderPlayingRole(MailAccountId accountId, MailFolderSpecialUse role) =>
-        this.MappingsOf(accountId).FirstOrDefault(mapping => mapping.Plays(role));
-
-    /// <inheritdoc />
-    public MailFolderMapping? FindFolderNamed(MailAccountId accountId, MailFolderAlias folderAlias) =>
-        this.MappingsOf(accountId).FirstOrDefault(mapping => mapping.Alias == folderAlias);
-
-    /// <summary>Reads one account's folders as the mappings the folder port answers with.</summary>
-    /// <remarks>
-    /// Answered from the cache below rather than rebuilt, because the two lookups above are asked once per rule
-    /// evaluated against every email of a run, and each rebuild walks the account's folders and constructs a domain
-    /// value per entry.
-    /// </remarks>
-    private IReadOnlyList<MailFolderMapping> MappingsOf(MailAccountId accountId) =>
-        this.mappingsByAccount.Value.TryGetValue(accountId.Value, out var mappings) ? mappings : [];
-
-    /// <summary>Builds every account's mappings once, keyed by the account identifier the lookups arrive with.</summary>
-    /// <remarks>
-    /// It walks <see cref="MailSynchronizationAccountOptions.EffectiveFolders" /> for the reason
-    /// <see cref="ConfiguredFolders" /> does, so an account that configures no folder answers for the inbox mapping it
-    /// is actually run with. An entry whose names are unusable is skipped rather than raised over: startup validation
-    /// refuses that configuration, and a reload being rejected must not make a lookup throw. Two accounts configured
-    /// under one identifier is the same refusal, so the first is kept here rather than the build failing over what
-    /// validation already reports.
-    /// </remarks>
-    private Dictionary<string, IReadOnlyList<MailFolderMapping>> ReadMappingsByAccount() => (this.Accounts ?? [])
-        .Select(static account => (Id: TryReadAccountId(account.AccountId), account.EffectiveFolders))
-        .Where(static account => account.Id is not null)
-        .GroupBy(static account => account.Id!, StringComparer.Ordinal)
-        .ToDictionary(
-            static account => account.Key,
-            static account => MappingsIn(account.First().EffectiveFolders),
-            StringComparer.Ordinal);
-
-    /// <summary>Reads one account's configured folders as the mappings the port answers with, dropping the unusable ones.</summary>
-    private static IReadOnlyList<MailFolderMapping> MappingsIn(IReadOnlyList<MailFolderMappingOptions> folders) =>
-    [
-        .. folders.Select(static folder => TryCreateMapping(folder)).OfType<MailFolderMapping>(),
-    ];
-
-    /// <summary>Normalizes a configured account identifier the way every lookup arrives already normalized, or reports it unusable.</summary>
-    private static string? TryReadAccountId(string? configuredAccountId)
-    {
-        try
-        {
-            return string.IsNullOrWhiteSpace(configuredAccountId)
-                ? null
-                : MailAccountId.Create(configuredAccountId).Value;
-        }
-        catch (ArgumentException)
-        {
-            return null;
-        }
-    }
-
-    /// <summary>Builds one configured folder's mapping, or nothing when its configured names are not values this system issues.</summary>
-    private static MailFolderMapping? TryCreateMapping(MailFolderMappingOptions folder)
-    {
-        try
-        {
-            return folder.CreateMapping();
-        }
-        catch (Exception exception) when (exception is ArgumentException or InvalidOperationException)
-        {
-            return null;
-        }
-    }
-
-    /// <summary>Reads every account's folders as the pair of identity and participation the port answers with.</summary>
-    /// <remarks>
-    /// It walks <see cref="MailSynchronizationAccountOptions.EffectiveFolders" /> rather than the configured list, so an
-    /// account that configures no folder answers for the inbox mapping it is actually run with. An entry whose alias or
-    /// account identifier is unusable is skipped: startup validation refuses that configuration, and inventing an
-    /// identity for it here would attach one folder's decision to a name no operator wrote.
-    /// </remarks>
-    private IEnumerable<ConfiguredFolder> ConfiguredFolders() =>
-        (this.Accounts ?? [])
-            .SelectMany(account => account.EffectiveFolders.Select(folder => new { account.AccountId, Folder = folder }))
-            .Select(static configured => ConfiguredFolder.TryRead(configured.AccountId, configured.Folder))
-            .OfType<ConfiguredFolder>();
 
     /// <summary>Finds every configured earliest received date that could not mean anything on the supplied date.</summary>
     /// <param name="today">The current date the configured bounds are read against.</param>
@@ -1077,32 +655,28 @@ internal sealed class MailSynchronizationOptions
                     MailAccountId.Create(candidate.AccountId).Value,
                     accountId.Value));
 
-    private MailSynchronizationAccountOptions FindAccount(string normalizedAccountId) =>
-        this.FindConfiguredAccount(MailAccountId.Create(normalizedAccountId))
-        ?? throw new InvalidOperationException($"Account '{normalizedAccountId}' is not configured.");
+    /// <summary>Finds the account a reader was handed, failing when this snapshot does not name it.</summary>
+    /// <param name="accountId">The local account identifier.</param>
+    /// <returns>The configured account.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when this snapshot does not name the account.</exception>
+    internal MailSynchronizationAccountOptions RequireAccount(MailAccountId accountId) =>
+        this.FindConfiguredAccount(accountId)
+        ?? throw new InvalidOperationException($"Account '{accountId.Value}' is not configured.");
 
-    /// <summary>One configured folder read as the identity, the participation, and the role the folder ports answer with.</summary>
-    private sealed record ConfiguredFolder(
-        MailFolderIdentity Identity,
-        MailFolderParticipation Participation,
-        MailFolderSpecialUse? SpecialUse)
+    /// <summary>Normalizes a configured account identifier the way every lookup arrives already normalized, or reports it unusable.</summary>
+    /// <param name="configuredAccountId">The identifier as the operator wrote it.</param>
+    /// <returns>The normalized identifier, or <see langword="null" /> when it is not a value this system issues.</returns>
+    internal static string? TryReadAccountId(string? configuredAccountId)
     {
-        /// <summary>Reads one account's folder entry, or nothing when its names are not values this system issues.</summary>
-        internal static ConfiguredFolder? TryRead(
-            string configuredAccountId,
-            MailFolderMappingOptions folder)
+        try
         {
-            if (string.IsNullOrWhiteSpace(configuredAccountId) || string.IsNullOrWhiteSpace(folder.Alias))
-            {
-                return null;
-            }
-
-            return new ConfiguredFolder(
-                new MailFolderIdentity(
-                    MailAccountId.Create(configuredAccountId),
-                    MailFolderAlias.Create(folder.Alias)),
-                folder.Participation,
-                folder.ConfiguredSpecialUse);
+            return string.IsNullOrWhiteSpace(configuredAccountId)
+                ? null
+                : MailAccountId.Create(configuredAccountId).Value;
+        }
+        catch (ArgumentException)
+        {
+            return null;
         }
     }
 }

--- a/src/Host/Configuration/Mail/Readers/ConfiguredAuthoredDeleteEmailDispositionReader.cs
+++ b/src/Host/Configuration/Mail/Readers/ConfiguredAuthoredDeleteEmailDispositionReader.cs
@@ -1,0 +1,18 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail.Mutations;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+
+namespace MailFathom.Host.Configuration.Mail.Readers;
+
+/// <summary>Reads what a delete this deployment itself authors does to the message from the bound section.</summary>
+internal sealed class ConfiguredAuthoredDeleteEmailDispositionReader(MailSynchronizationOptions settings)
+    : IAuthoredDeleteEmailDispositionReader
+{
+    /// <inheritdoc />
+    public AuthoredDeleteEmailDisposition GetAuthoredDeleteDisposition(MailAccountId accountId) =>
+        settings.RequireAccount(accountId).AuthoredDeleteEmailDisposition;
+}

--- a/src/Host/Configuration/Mail/Readers/ConfiguredContactCollectionSettingsReader.cs
+++ b/src/Host/Configuration/Mail/Readers/ConfiguredContactCollectionSettingsReader.cs
@@ -1,0 +1,94 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Contacts.Collection;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Contacts.Collection;
+using MailFathom.Domain.Emails;
+
+namespace MailFathom.Host.Configuration.Mail.Readers;
+
+/// <summary>Reads what an account collects contacts from, and which correspondents it leaves out, from the bound section.</summary>
+/// <remarks>
+/// The settings are built once for the snapshot this reader was constructed over rather than per lookup, because every
+/// message of a switched-on account asks for them and building one reads every account's own mailbox address. The
+/// build is deferred rather than done in the constructor, so a deployment that collects nothing never walks the
+/// accounts.
+/// </remarks>
+internal sealed class ConfiguredContactCollectionSettingsReader : IContactCollectionSettingsReader
+{
+    private readonly MailSynchronizationOptions settings;
+
+    private readonly Lazy<IReadOnlyDictionary<string, ContactCollectionSettings>> settingsByAccount;
+
+    /// <summary>Initializes the reader over one snapshot of the mail section.</summary>
+    /// <param name="settings">The snapshot the collection settings are read from.</param>
+    internal ConfiguredContactCollectionSettingsReader(MailSynchronizationOptions settings)
+    {
+        this.settings = settings;
+        this.settingsByAccount = new(this.ReadSettings, LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// An account this snapshot no longer names collects nothing, which is the honest answer as well as the safe one:
+    /// an account nobody configures has no owner to have asked for a book.
+    /// </remarks>
+    public ContactCollectionSettings GetContactCollectionSettings(MailAccountId accountId) =>
+        this.settingsByAccount.Value.TryGetValue(accountId.Value, out var accountSettings)
+            ? accountSettings
+            : ContactCollectionSettings.CollectingNothing;
+
+    /// <summary>Builds every account's collection settings once, keyed by the account identifier the lookups arrive with.</summary>
+    /// <remarks>
+    /// The own addresses are read once for the whole deployment and handed to every account's policy, because an owner
+    /// writing from one of their mailboxes to another is not a correspondent of themselves. An entry whose text is
+    /// unusable is skipped and two accounts configured under one identifier keep the first, both for the reason the
+    /// trust policies do: startup validation refuses each of those, and a reload being rejected must not make an
+    /// arriving message throw.
+    /// </remarks>
+    private Dictionary<string, ContactCollectionSettings> ReadSettings()
+    {
+        var ownAddresses = this.ReadOwnAccountAddresses();
+
+        return (this.settings.Accounts ?? [])
+            .Select(static account => (
+                Id: MailSynchronizationOptions.TryReadAccountId(account.AccountId),
+                account.ContactCollection))
+            .Where(static account => account.Id is not null && account.ContactCollection is not null)
+            .GroupBy(static account => account.Id!, StringComparer.Ordinal)
+            .ToDictionary(
+                static account => account.Key,
+                account => ReadContactCollection(account.First().ContactCollection!, ownAddresses),
+                StringComparer.Ordinal);
+    }
+
+    /// <summary>Reads one account's configured block as the settings collection runs under.</summary>
+    private static ContactCollectionSettings ReadContactCollection(
+        ContactCollectionOptions configured,
+        IReadOnlyCollection<EmailAddress> ownAddresses) => new()
+        {
+            IsEnabled = configured.Enabled,
+            MinimumMessagesFromSender = configured.MinimumMessagesFromSender,
+            MaxContactsPerRun = configured.MaxContactsPerRun,
+            Policy = ContactCollectionPolicy.Create(configured.ConfiguredExclusions, ownAddresses),
+        };
+
+    /// <summary>Reads the mailboxes this deployment reads on its owner's behalf.</summary>
+    /// <remarks>
+    /// Derived from each account's user name for the reason the trusted own domains are: it is the only mailbox
+    /// identity an IMAP account states. An account whose user name is a bare login contributes nothing, which costs one
+    /// address that would have been excluded — and the two headers collection reads leave the owner out of both
+    /// directions anyway, since an ordinary folder's author is a correspondent and a sent folder's recipients are.
+    /// </remarks>
+    private IReadOnlyList<EmailAddress> ReadOwnAccountAddresses() =>
+    [
+        .. (this.settings.Accounts ?? [])
+            .Select(static account => EmailAddress.TryCreate(displayName: null, account.UserName, out var address)
+                ? address
+                : (EmailAddress?)null)
+            .OfType<EmailAddress>()
+            .Distinct(),
+    ];
+}

--- a/src/Host/Configuration/Mail/Readers/ConfiguredJunkMailFolderCatalog.cs
+++ b/src/Host/Configuration/Mail/Readers/ConfiguredJunkMailFolderCatalog.cs
@@ -1,0 +1,33 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Folders;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Folders;
+
+namespace MailFathom.Host.Configuration.Mail.Readers;
+
+/// <summary>Reads which folders an operator mapped to the junk role from the bound section.</summary>
+internal sealed class ConfiguredJunkMailFolderCatalog(MailSynchronizationOptions settings) : IJunkMailFolderCatalog
+{
+    /// <inheritdoc />
+    /// <remarks>
+    /// Read from the configured role rather than from what a server advertised, for the reason
+    /// <see cref="MailFolderMappingOptions.ConfiguredSpecialUse" /> gives. A deployment that maps no junk folder answers
+    /// with nothing here, and every mailbox read then behaves as it did before this existed.
+    /// </remarks>
+    public IReadOnlyList<MailFolderIdentity> JunkFolders =>
+    [
+        .. ConfiguredMailFolders.Of(settings)
+            .Where(static folder => folder.SpecialUse is MailFolderSpecialUse.Junk)
+            .Select(static folder => folder.Identity),
+    ];
+
+    /// <inheritdoc />
+    public bool IsJunkFolder(MailAccountId accountId, MailFolderAlias folderAlias) =>
+        ConfiguredMailFolders.Of(settings).Any(folder =>
+            folder.SpecialUse is MailFolderSpecialUse.Junk
+            && folder.Identity.AccountId == accountId
+            && folder.Identity.Alias == folderAlias);
+}

--- a/src/Host/Configuration/Mail/Readers/ConfiguredMailAccountCatalog.cs
+++ b/src/Host/Configuration/Mail/Readers/ConfiguredMailAccountCatalog.cs
@@ -1,0 +1,40 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Accounts;
+
+namespace MailFathom.Host.Configuration.Mail.Readers;
+
+/// <summary>Publishes the accounts this deployment serves, read from the bound section that defines them.</summary>
+internal sealed class ConfiguredMailAccountCatalog(MailSynchronizationOptions settings) : IMailAccountCatalog
+{
+    /// <inheritdoc />
+    public bool SynchronizationEnabled => settings.Enabled;
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// <para>
+    /// Configuration is what defines the set of accounts, so this answers from the same bound options every other
+    /// per-account reader does. It deliberately ignores <see cref="MailSynchronizationOptions.Enabled" />: that switch
+    /// stops runs from fetching mail, and an operator who turned it off has not asked for the copy already stored to
+    /// become unreadable. An account they removed is a different matter, and its absence here is what makes its stored
+    /// mail unreadable.
+    /// </para>
+    /// <para>
+    /// An account whose display name is missing or unusable is omitted rather than published under an invented one.
+    /// Startup validation refuses that configuration, so the omission is only reachable while a reload is being
+    /// rejected, and publishing an account under a name no operator chose is the one outcome worse than not publishing
+    /// it at all.
+    /// </para>
+    /// </remarks>
+    public IReadOnlyList<ServedMailAccount> ServedAccounts =>
+    [
+        .. (settings.Accounts ?? [])
+            .Where(static candidate => !string.IsNullOrWhiteSpace(candidate.AccountId))
+            .Select(static candidate => candidate.CreateServedAccount())
+            .OfType<ServedMailAccount>()
+            .DistinctBy(static account => account.Id.Value, StringComparer.Ordinal)
+            .OrderBy(static account => account.Id.Value, StringComparer.Ordinal),
+    ];
+}

--- a/src/Host/Configuration/Mail/Readers/ConfiguredMailAnsweringAuditSettingsReader.cs
+++ b/src/Host/Configuration/Mail/Readers/ConfiguredMailAnsweringAuditSettingsReader.cs
@@ -1,0 +1,17 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Retrieval.AskMail.Audit;
+using MailFathom.Domain.Accounts;
+
+namespace MailFathom.Host.Configuration.Mail.Readers;
+
+/// <summary>Reads whether an answered question is recorded, and for how long, from the bound section.</summary>
+internal sealed class ConfiguredMailAnsweringAuditSettingsReader(MailSynchronizationOptions settings)
+    : IMailAnsweringAuditSettingsReader
+{
+    /// <inheritdoc />
+    public MailAnsweringAuditSettings GetAnsweringAuditSettings(MailAccountId accountId) =>
+        settings.FindConfiguredAccount(accountId)?.CreateAnsweringAuditSettings() ?? MailAnsweringAuditSettings.Disabled;
+}

--- a/src/Host/Configuration/Mail/Readers/ConfiguredMailFolderMappingReader.cs
+++ b/src/Host/Configuration/Mail/Readers/ConfiguredMailFolderMappingReader.cs
@@ -1,0 +1,82 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Folders;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Folders;
+
+namespace MailFathom.Host.Configuration.Mail.Readers;
+
+/// <summary>Reads one account's folder mappings from the bound section.</summary>
+/// <remarks>
+/// The mappings are built once for the snapshot this reader was constructed over rather than per lookup, because the
+/// two lookups below are asked once per rule evaluated against every email of a run, and each rebuild walks the
+/// account's folders and constructs a domain value per entry.
+/// </remarks>
+internal sealed class ConfiguredMailFolderMappingReader : IMailFolderMappingReader
+{
+    private readonly MailSynchronizationOptions settings;
+
+    private readonly Lazy<IReadOnlyDictionary<string, IReadOnlyList<MailFolderMapping>>> mappingsByAccount;
+
+    /// <summary>Initializes the reader over one snapshot of the mail section.</summary>
+    /// <param name="settings">The snapshot the mappings are read from.</param>
+    internal ConfiguredMailFolderMappingReader(MailSynchronizationOptions settings)
+    {
+        this.settings = settings;
+        this.mappingsByAccount = new(this.ReadMappings, LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    /// <inheritdoc />
+    public MailFolderMapping? FindFolderPlayingRole(MailAccountId accountId, MailFolderSpecialUse role) =>
+        this.MappingsOf(accountId).FirstOrDefault(mapping => mapping.Plays(role));
+
+    /// <inheritdoc />
+    public MailFolderMapping? FindFolderNamed(MailAccountId accountId, MailFolderAlias folderAlias) =>
+        this.MappingsOf(accountId).FirstOrDefault(mapping => mapping.Alias == folderAlias);
+
+    /// <summary>Reads one account's folders as the mappings this port answers with.</summary>
+    private IReadOnlyList<MailFolderMapping> MappingsOf(MailAccountId accountId) =>
+        this.mappingsByAccount.Value.TryGetValue(accountId.Value, out var mappings) ? mappings : [];
+
+    /// <summary>Builds every account's mappings once, keyed by the account identifier the lookups arrive with.</summary>
+    /// <remarks>
+    /// It walks <see cref="MailSynchronizationAccountOptions.EffectiveFolders" /> for the reason
+    /// <see cref="ConfiguredMailFolders.Of" /> does, so an account that configures no folder answers for the inbox
+    /// mapping it is actually run with. An entry whose names are unusable is skipped rather than raised over: startup
+    /// validation refuses that configuration, and a reload being rejected must not make a lookup throw. Two accounts
+    /// configured under one identifier is the same refusal, so the first is kept here rather than the build failing
+    /// over what validation already reports.
+    /// </remarks>
+    private Dictionary<string, IReadOnlyList<MailFolderMapping>> ReadMappings() =>
+        (this.settings.Accounts ?? [])
+            .Select(static account => (
+                Id: MailSynchronizationOptions.TryReadAccountId(account.AccountId),
+                account.EffectiveFolders))
+            .Where(static account => account.Id is not null)
+            .GroupBy(static account => account.Id!, StringComparer.Ordinal)
+            .ToDictionary(
+                static account => account.Key,
+                static account => MappingsIn(account.First().EffectiveFolders),
+                StringComparer.Ordinal);
+
+    /// <summary>Reads one account's configured folders as the mappings the port answers with, dropping the unusable ones.</summary>
+    private static IReadOnlyList<MailFolderMapping> MappingsIn(IReadOnlyList<MailFolderMappingOptions> folders) =>
+    [
+        .. folders.Select(static folder => TryCreateMapping(folder)).OfType<MailFolderMapping>(),
+    ];
+
+    /// <summary>Builds one configured folder's mapping, or nothing when its configured names are not values this system issues.</summary>
+    private static MailFolderMapping? TryCreateMapping(MailFolderMappingOptions folder)
+    {
+        try
+        {
+            return folder.CreateMapping();
+        }
+        catch (Exception exception) when (exception is ArgumentException or InvalidOperationException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Host/Configuration/Mail/Readers/ConfiguredMailFolderParticipationReader.cs
+++ b/src/Host/Configuration/Mail/Readers/ConfiguredMailFolderParticipationReader.cs
@@ -1,0 +1,37 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Folders;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Folders;
+
+namespace MailFathom.Host.Configuration.Mail.Readers;
+
+/// <summary>Reads what each mapped folder takes part in from the bound section.</summary>
+internal sealed class ConfiguredMailFolderParticipationReader(MailSynchronizationOptions settings)
+    : IMailFolderParticipationReader
+{
+    /// <inheritdoc />
+    public IReadOnlyList<MailFolderIdentity> FoldersMapped =>
+        [.. ConfiguredMailFolders.Of(settings).Select(static folder => folder.Identity)];
+
+    /// <inheritdoc />
+    public IReadOnlyList<MailFolderIdentity> FoldersSynchronized =>
+        [.. ConfiguredMailFolders.Of(settings).Where(static folder => folder.Participation.IsSynchronized).Select(static folder => folder.Identity)];
+
+    /// <inheritdoc />
+    public IReadOnlyList<MailFolderIdentity> FoldersVisibleToTools =>
+        [.. ConfiguredMailFolders.Of(settings).Where(static folder => folder.Participation.IsVisibleToTools).Select(static folder => folder.Identity)];
+
+    /// <inheritdoc />
+    public IReadOnlyList<MailFolderIdentity> FoldersGeneratingEmbeddings =>
+        [.. ConfiguredMailFolders.Of(settings).Where(static folder => folder.Participation.GeneratesEmbeddings).Select(static folder => folder.Identity)];
+
+    /// <inheritdoc />
+    public MailFolderParticipation GetParticipation(MailAccountId accountId, MailFolderAlias folderAlias) =>
+        ConfiguredMailFolders.Of(settings)
+            .FirstOrDefault(folder => folder.Identity.AccountId == accountId && folder.Identity.Alias == folderAlias)
+            ?.Participation
+        ?? MailFolderParticipation.Unmapped;
+}

--- a/src/Host/Configuration/Mail/Readers/ConfiguredMailFolders.cs
+++ b/src/Host/Configuration/Mail/Readers/ConfiguredMailFolders.cs
@@ -1,0 +1,76 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Folders;
+
+namespace MailFathom.Host.Configuration.Mail.Readers;
+
+/// <summary>Reads the configured folder entries the folder ports answer from.</summary>
+/// <remarks>
+/// Shared by the participation reader, the junk catalog, and the classification scope default rather than written once
+/// per reader, because all three ask the same question of the same section: which folders an operator mapped, under
+/// which account, and what each one takes part in.
+/// </remarks>
+internal static class ConfiguredMailFolders
+{
+    /// <summary>Reads every account's folders as the pair of identity and participation the ports answer with.</summary>
+    /// <param name="settings">The snapshot the folders are read from.</param>
+    /// <returns>One entry per usable configured folder.</returns>
+    /// <remarks>
+    /// It walks <see cref="MailSynchronizationAccountOptions.EffectiveFolders" /> rather than the configured list, so an
+    /// account that configures no folder answers for the inbox mapping it is actually run with. An entry whose alias or
+    /// account identifier is unusable is skipped: startup validation refuses that configuration, and inventing an
+    /// identity for it here would attach one folder's decision to a name no operator wrote.
+    /// </remarks>
+    internal static IEnumerable<ConfiguredFolder> Of(MailSynchronizationOptions settings) =>
+        (settings.Accounts ?? [])
+            .SelectMany(account => account.EffectiveFolders.Select(folder => new { account.AccountId, Folder = folder }))
+            .Select(static configured => ConfiguredFolder.TryRead(configured.AccountId, configured.Folder))
+            .OfType<ConfiguredFolder>();
+
+    /// <summary>Reads the aliases every account maps to its inbox, which is the scope classification defaults to.</summary>
+    /// <param name="settings">The snapshot the folders are read from.</param>
+    /// <returns>One alias per account that maps a folder to the inbox role.</returns>
+    /// <remarks>
+    /// Read beside the folder mappings because the default has to follow them: an operator whose server presents the
+    /// inbox under another name configures the role, and the default scope has to be the alias that role resolved to
+    /// rather than the literal text INBOX.
+    /// </remarks>
+    internal static IEnumerable<MailFolderAlias> InboxAliasesOf(MailSynchronizationOptions settings) =>
+        Of(settings)
+            .Where(static folder => folder.SpecialUse is MailFolderSpecialUse.Inbox)
+            .Select(static folder => folder.Identity.Alias);
+}
+
+/// <summary>One configured folder read as the identity, the participation, and the role the folder ports answer with.</summary>
+/// <param name="Identity">The account and alias the folder is known by.</param>
+/// <param name="Participation">What the folder takes part in.</param>
+/// <param name="SpecialUse">The role the operator configured for it, or <see langword="null" /> when they configured none.</param>
+internal sealed record ConfiguredFolder(
+    MailFolderIdentity Identity,
+    MailFolderParticipation Participation,
+    MailFolderSpecialUse? SpecialUse)
+{
+    /// <summary>Reads one account's folder entry, or nothing when its names are not values this system issues.</summary>
+    /// <param name="configuredAccountId">The account identifier the entry was configured under.</param>
+    /// <param name="folder">The configured folder entry.</param>
+    /// <returns>The folder read, or <see langword="null" /> when its names are unusable.</returns>
+    internal static ConfiguredFolder? TryRead(
+        string configuredAccountId,
+        MailFolderMappingOptions folder)
+    {
+        if (string.IsNullOrWhiteSpace(configuredAccountId) || string.IsNullOrWhiteSpace(folder.Alias))
+        {
+            return null;
+        }
+
+        return new ConfiguredFolder(
+            new MailFolderIdentity(
+                MailAccountId.Create(configuredAccountId),
+                MailFolderAlias.Create(folder.Alias)),
+            folder.Participation,
+            folder.ConfiguredSpecialUse);
+    }
+}

--- a/src/Host/Configuration/Mail/Readers/ConfiguredMailRuleActionPermissionReader.cs
+++ b/src/Host/Configuration/Mail/Readers/ConfiguredMailRuleActionPermissionReader.cs
@@ -1,0 +1,17 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Rules.Actions;
+using MailFathom.Domain.Accounts;
+
+namespace MailFathom.Host.Configuration.Mail.Readers;
+
+/// <summary>Reads which rule actions an operator admitted on an account from the bound section.</summary>
+internal sealed class ConfiguredMailRuleActionPermissionReader(MailSynchronizationOptions settings)
+    : IMailRuleActionPermissionReader
+{
+    /// <inheritdoc />
+    public MailRuleActionPermissions GetRuleActionPermissions(MailAccountId accountId) =>
+        (settings.RequireAccount(accountId).RuleActions ?? new MailRuleActionPermissionOptions()).ToPermissions();
+}

--- a/src/Host/Configuration/Mail/Readers/ConfiguredMailSynchronizationWindowReader.cs
+++ b/src/Host/Configuration/Mail/Readers/ConfiguredMailSynchronizationWindowReader.cs
@@ -1,0 +1,18 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Synchronization.Checkpoints;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Synchronization;
+
+namespace MailFathom.Host.Configuration.Mail.Readers;
+
+/// <summary>Reads the stretch of time an account is synchronized over from the bound section.</summary>
+internal sealed class ConfiguredMailSynchronizationWindowReader(MailSynchronizationOptions settings)
+    : IMailSynchronizationWindowReader
+{
+    /// <inheritdoc />
+    public MailSynchronizationWindow GetWindow(MailAccountId accountId) =>
+        settings.RequireAccount(accountId).CreateSynchronizationWindow();
+}

--- a/src/Host/Configuration/Mail/Readers/ConfiguredMailTransportSecurityPolicyReader.cs
+++ b/src/Host/Configuration/Mail/Readers/ConfiguredMailTransportSecurityPolicyReader.cs
@@ -1,0 +1,26 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Transport;
+
+namespace MailFathom.Host.Configuration.Mail.Readers;
+
+/// <summary>Reads the transport security an account connects and submits under from the bound section.</summary>
+internal sealed class ConfiguredMailTransportSecurityPolicyReader(MailSynchronizationOptions settings)
+    : IMailTransportSecurityPolicyReader
+{
+    /// <inheritdoc />
+    public MailTransportSecurityPolicy GetPolicy(MailAccountId accountId) =>
+        settings.RequireAccount(accountId).CreateTransportSecurityPolicy();
+
+    /// <inheritdoc />
+    public MailTransportSecurityPolicy? GetDeliveryPolicy(MailAccountId accountId)
+    {
+        var account = settings.RequireAccount(accountId);
+
+        return account.Delivery.IsConfigured ? account.CreateDeliveryTransportSecurityPolicy() : null;
+    }
+}

--- a/src/Host/Configuration/Mail/Readers/ConfiguredMailboxMutationAuditSettingsReader.cs
+++ b/src/Host/Configuration/Mail/Readers/ConfiguredMailboxMutationAuditSettingsReader.cs
@@ -1,0 +1,23 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail.Mutations.Audit;
+using MailFathom.Domain.Accounts;
+
+namespace MailFathom.Host.Configuration.Mail.Readers;
+
+/// <summary>Reads whether a mailbox mutation is recorded, and for how long, from the bound section.</summary>
+internal sealed class ConfiguredMailboxMutationAuditSettingsReader(MailSynchronizationOptions settings)
+    : IMailboxMutationAuditSettingsReader
+{
+    /// <inheritdoc />
+    /// <remarks>
+    /// An account this snapshot no longer names reports <see cref="MailboxMutationAuditSettings.Disabled" /> rather
+    /// than failing, unlike every other per-account reader here. The two callers are why: a mutation is only recorded
+    /// for a configured account, and the retention pass runs over accounts a reload may have removed between one run and
+    /// the next — where the honest answer is that no operator decision applies, not that the deployment is broken.
+    /// </remarks>
+    public MailboxMutationAuditSettings GetAuditSettings(MailAccountId accountId) =>
+        settings.FindConfiguredAccount(accountId)?.CreateAuditSettings() ?? MailboxMutationAuditSettings.Disabled;
+}

--- a/src/Host/Configuration/Mail/Readers/ConfiguredOutgoingMailFilingPolicyReader.cs
+++ b/src/Host/Configuration/Mail/Readers/ConfiguredOutgoingMailFilingPolicyReader.cs
@@ -1,0 +1,22 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail.Delivery.Filing;
+using MailFathom.Domain.Accounts;
+
+namespace MailFathom.Host.Configuration.Mail.Readers;
+
+/// <summary>Reads whether a sent message is filed back into the account's own mailbox from the bound section.</summary>
+internal sealed class ConfiguredOutgoingMailFilingPolicyReader(MailSynchronizationOptions settings)
+    : IOutgoingMailFilingPolicyReader
+{
+    /// <inheritdoc />
+    /// <remarks>
+    /// An account this deployment does not configure is answered as though it files the copy, which is the same
+    /// direction the port's own default takes: nothing can send as an account nobody configured, so the answer is
+    /// reached only by a caller asking about a message that cannot exist.
+    /// </remarks>
+    public bool FilesSentCopy(MailAccountId accountId) =>
+        settings.FindConfiguredAccount(accountId)?.Delivery.FileSentCopy ?? true;
+}

--- a/src/Host/Configuration/Mail/Readers/ConfiguredOutgoingSenderIdentityReader.cs
+++ b/src/Host/Configuration/Mail/Readers/ConfiguredOutgoingSenderIdentityReader.cs
@@ -1,0 +1,29 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail.Delivery.Composition;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+
+namespace MailFathom.Host.Configuration.Mail.Readers;
+
+/// <summary>Reads the mailbox an account sends as from the bound section.</summary>
+internal sealed class ConfiguredOutgoingSenderIdentityReader(MailSynchronizationOptions settings)
+    : IOutgoingSenderIdentityReader
+{
+    /// <inheritdoc />
+    public OutgoingSenderIdentity? FindSenderIdentity(MailAccountId accountId)
+    {
+        var account = settings.FindConfiguredAccount(accountId);
+
+        if (account?.Delivery is not { IsConfigured: true } delivery)
+        {
+            return null;
+        }
+
+        return EmailAddress.TryCreate(delivery.FromDisplayName, delivery.ResolveFromAddress(account.UserName), out var address)
+            ? OutgoingSenderIdentity.Create(accountId, address)
+            : null;
+    }
+}

--- a/src/Host/Configuration/Mail/Readers/ConfiguredRemotelyDeletedEmailDispositionReader.cs
+++ b/src/Host/Configuration/Mail/Readers/ConfiguredRemotelyDeletedEmailDispositionReader.cs
@@ -1,0 +1,18 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Synchronization.Reconciliation;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+
+namespace MailFathom.Host.Configuration.Mail.Readers;
+
+/// <summary>Reads what becomes of a stored email the server no longer holds from the bound section.</summary>
+internal sealed class ConfiguredRemotelyDeletedEmailDispositionReader(MailSynchronizationOptions settings)
+    : IRemotelyDeletedEmailDispositionReader
+{
+    /// <inheritdoc />
+    public RemotelyDeletedEmailDisposition GetDisposition(MailAccountId accountId) =>
+        settings.RequireAccount(accountId).RemotelyDeletedEmailDisposition;
+}

--- a/src/Host/Configuration/Mail/Readers/ConfiguredSenderTrustPolicyReader.cs
+++ b/src/Host/Configuration/Mail/Readers/ConfiguredSenderTrustPolicyReader.cs
@@ -1,0 +1,96 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails.Authentication;
+
+namespace MailFathom.Host.Configuration.Mail.Readers;
+
+/// <summary>Reads which senders an account recognizes from the bound section.</summary>
+/// <remarks>
+/// The policies are built once for the snapshot this reader was constructed over rather than per lookup, because every
+/// arriving message asks for one and building a policy derives a revision over the whole effective list. The build is
+/// deferred rather than done in the constructor, so a deployment that never reads a message never walks the accounts.
+/// </remarks>
+internal sealed class ConfiguredSenderTrustPolicyReader : ISenderTrustPolicyReader
+{
+    private readonly MailSynchronizationOptions settings;
+
+    private readonly Lazy<IReadOnlyDictionary<string, SenderTrustPolicy>> policiesByAccount;
+
+    /// <summary>Initializes the reader over one snapshot of the mail section.</summary>
+    /// <param name="settings">The snapshot the policies are read from.</param>
+    internal ConfiguredSenderTrustPolicyReader(MailSynchronizationOptions settings)
+    {
+        this.settings = settings;
+        this.policiesByAccount = new(this.ReadPolicies, LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// An account this snapshot no longer names recognizes nobody, for the reason the trusted authority answers with
+    /// none: a reload can remove an account while a message of it is still being read.
+    /// </remarks>
+    public SenderTrustPolicy GetTrustPolicy(MailAccountId accountId) =>
+        this.policiesByAccount.Value.TryGetValue(accountId.Value, out var policy)
+            ? policy
+            : SenderTrustPolicy.RecognizingNobody;
+
+    /// <summary>Builds every account's verification policy once, keyed by the account identifier the lookups arrive with.</summary>
+    /// <remarks>
+    /// The stored half of each list is empty here and is what <see href="https://github.com/Krzysztof318/MailFathom/issues/760">#760</see>
+    /// fills in: the matcher already takes both halves, so the store arrives as a second list rather than as a second
+    /// rule. An entry whose text is unusable is skipped rather than raised over, and two accounts configured under one
+    /// identifier keep the first, both for the reason the folder mappings do — startup validation refuses each of
+    /// those, and a reload being rejected must not make a lookup throw.
+    /// </remarks>
+    private Dictionary<string, SenderTrustPolicy> ReadPolicies()
+    {
+        IReadOnlyList<SenderDomain> ownAccountDomains =
+            this.settings.TrustOwnAccountDomains ? this.ReadOwnAccountDomains() : [];
+
+        return (this.settings.Accounts ?? [])
+            .Select(static account => (
+                Id: MailSynchronizationOptions.TryReadAccountId(account.AccountId),
+                account.ConfiguredTrustedSenders))
+            .Where(static account => account.Id is not null)
+            .GroupBy(static account => account.Id!, StringComparer.Ordinal)
+            .ToDictionary(
+                static account => account.Key,
+                account => SenderTrustPolicy.Create(
+                    ownAccountDomains,
+                    account.First().ConfiguredTrustedSenders,
+                    storedTrustedSenders: []),
+                StringComparer.Ordinal);
+    }
+
+    /// <summary>Reads the domains the configured accounts themselves send and receive under.</summary>
+    /// <remarks>
+    /// Derived from each account's user name, which is the only mailbox identity an IMAP account states: a server is
+    /// reached at a host that is rarely the mail domain, and the account identifier is a key an operator invented. An
+    /// account whose user name is a bare login rather than an address therefore contributes nothing, which is the
+    /// honest answer — inventing a domain out of the host would recognize senders nobody named.
+    /// </remarks>
+    private IReadOnlyList<SenderDomain> ReadOwnAccountDomains() =>
+    [
+        .. (this.settings.Accounts ?? [])
+            .Select(static account => TryReadOwnDomain(account.UserName))
+            .OfType<SenderDomain>()
+            .Distinct(),
+    ];
+
+    /// <summary>Reads the mail domain one account's user name states, or nothing when it states none.</summary>
+    /// <remarks>
+    /// The at-sign is what separates the two shapes an IMAP user name takes. Without one the value is a login and
+    /// naming a domain from it would be a guess; with one it is the mailbox address the account belongs to, and the
+    /// domain is what follows the last at-sign for the reason every address in this system is split there.
+    /// </remarks>
+    private static SenderDomain? TryReadOwnDomain(string? userName) =>
+        userName is not null
+        && userName.Contains('@', StringComparison.Ordinal)
+        && SenderDomain.TryCreateFromMailbox(userName, out var domain)
+            ? domain
+            : null;
+}

--- a/src/Host/Configuration/Mail/Readers/ConfiguredTrustedAuthenticationAuthorityReader.cs
+++ b/src/Host/Configuration/Mail/Readers/ConfiguredTrustedAuthenticationAuthorityReader.cs
@@ -1,0 +1,23 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails.Authentication;
+
+namespace MailFathom.Host.Configuration.Mail.Readers;
+
+/// <summary>Reads which authentication results an account believes from the bound section.</summary>
+internal sealed class ConfiguredTrustedAuthenticationAuthorityReader(MailSynchronizationOptions settings)
+    : ITrustedAuthenticationAuthorityReader
+{
+    /// <inheritdoc />
+    /// <remarks>
+    /// An account this snapshot no longer names answers with none rather than failing, for the reason the audit
+    /// settings do: the extraction backfill runs over accounts a reload may have removed between one run and the
+    /// next, and believing no header there is the honest answer as well as the safe one.
+    /// </remarks>
+    public TrustedAuthenticationAuthority GetTrustedAuthority(MailAccountId accountId) =>
+        settings.FindConfiguredAccount(accountId)?.CreateTrustedAuthority() ?? TrustedAuthenticationAuthority.None;
+}

--- a/src/Host/Configuration/Mail/Readers/MailSynchronizationSettingsReaders.cs
+++ b/src/Host/Configuration/Mail/Readers/MailSynchronizationSettingsReaders.cs
@@ -1,0 +1,70 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Host.Configuration.Mail.Readers;
+
+/// <summary>The one set of port readers a snapshot of the mail section is read through.</summary>
+/// <remarks>
+/// <para>
+/// One instance belongs to one <see cref="MailSynchronizationOptions" />, which is what a reload replaces, so a reader
+/// here is built once per snapshot and shared by every scope that runs against it. That lifetime is the point: three
+/// of the readers memoize a per-account map, and each of those maps walks every account and every account's own
+/// addresses — work a per-scope reader would repeat on every work unit and every message.
+/// </para>
+/// <para>
+/// The readers are constructed together and their maps are not, so resolving any one port stays as cheap as it was
+/// while each map is still built by the first lookup that needs it.
+/// </para>
+/// </remarks>
+/// <param name="settings">The snapshot every reader here reads.</param>
+internal sealed class MailSynchronizationSettingsReaders(MailSynchronizationOptions settings)
+{
+    /// <summary>Gets the transport security an account connects and submits under.</summary>
+    internal ConfiguredMailTransportSecurityPolicyReader TransportSecurityPolicies { get; } = new(settings);
+
+    /// <summary>Gets the stretch of time an account is synchronized over.</summary>
+    internal ConfiguredMailSynchronizationWindowReader SynchronizationWindows { get; } = new(settings);
+
+    /// <summary>Gets what becomes of a stored email the server no longer holds.</summary>
+    internal ConfiguredRemotelyDeletedEmailDispositionReader RemotelyDeletedEmailDispositions { get; } = new(settings);
+
+    /// <summary>Gets what a delete this deployment itself authors does to the message.</summary>
+    internal ConfiguredAuthoredDeleteEmailDispositionReader AuthoredDeleteEmailDispositions { get; } = new(settings);
+
+    /// <summary>Gets which rule actions an operator admitted on an account.</summary>
+    internal ConfiguredMailRuleActionPermissionReader RuleActionPermissions { get; } = new(settings);
+
+    /// <summary>Gets whether a mailbox mutation is recorded, and for how long.</summary>
+    internal ConfiguredMailboxMutationAuditSettingsReader MutationAuditSettings { get; } = new(settings);
+
+    /// <summary>Gets whether an answered question is recorded, and for how long.</summary>
+    internal ConfiguredMailAnsweringAuditSettingsReader AnsweringAuditSettings { get; } = new(settings);
+
+    /// <summary>Gets the accounts this deployment serves.</summary>
+    internal ConfiguredMailAccountCatalog AccountCatalog { get; } = new(settings);
+
+    /// <summary>Gets which authentication results an account believes.</summary>
+    internal ConfiguredTrustedAuthenticationAuthorityReader TrustedAuthenticationAuthorities { get; } = new(settings);
+
+    /// <summary>Gets which senders an account recognizes.</summary>
+    internal ConfiguredSenderTrustPolicyReader SenderTrustPolicies { get; } = new(settings);
+
+    /// <summary>Gets the mailbox an account sends as.</summary>
+    internal ConfiguredOutgoingSenderIdentityReader OutgoingSenderIdentities { get; } = new(settings);
+
+    /// <summary>Gets whether a sent message is filed back into the account's own mailbox.</summary>
+    internal ConfiguredOutgoingMailFilingPolicyReader OutgoingMailFilingPolicies { get; } = new(settings);
+
+    /// <summary>Gets what each mapped folder takes part in.</summary>
+    internal ConfiguredMailFolderParticipationReader FolderParticipation { get; } = new(settings);
+
+    /// <summary>Gets which folders an operator mapped to the junk role.</summary>
+    internal ConfiguredJunkMailFolderCatalog JunkFolderCatalog { get; } = new(settings);
+
+    /// <summary>Gets one account's folder mappings.</summary>
+    internal ConfiguredMailFolderMappingReader FolderMappings { get; } = new(settings);
+
+    /// <summary>Gets what an account collects contacts from, and which correspondents it leaves out.</summary>
+    internal ConfiguredContactCollectionSettingsReader ContactCollection { get; } = new(settings);
+}

--- a/src/Host/Configuration/Spam/ConfiguredSpamClassificationSettingsReader.cs
+++ b/src/Host/Configuration/Spam/ConfiguredSpamClassificationSettingsReader.cs
@@ -5,6 +5,7 @@
 using MailFathom.Application.Spam;
 using MailFathom.Domain.Folders;
 using MailFathom.Host.Configuration.Mail;
+using MailFathom.Host.Configuration.Mail.Readers;
 using Microsoft.Extensions.Options;
 
 namespace MailFathom.Host.Configuration.Spam;
@@ -52,5 +53,5 @@ internal sealed class ConfiguredSpamClassificationSettingsReader(
             ? configured
                 .Where(static alias => !string.IsNullOrWhiteSpace(alias))
                 .Select(MailFolderAlias.Create)
-            : synchronizationOptions.InboxFolderAliases;
+            : ConfiguredMailFolders.InboxAliasesOf(synchronizationOptions);
 }

--- a/src/Host/HostComposition.cs
+++ b/src/Host/HostComposition.cs
@@ -510,28 +510,31 @@ internal static class HostComposition
         // the material it connects with, and the account list it was scheduled from all from the same reload.
         builder.Services.AddScoped<ScopedMailSynchronizationSettings>();
         builder.Services.AddScoped(provider => provider.GetRequiredService<ScopedMailSynchronizationSettings>().Current);
-        builder.Services.AddScoped<IMailTransportSecurityPolicyReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
-        builder.Services.AddScoped<IMailSynchronizationWindowReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
-        builder.Services.AddScoped<IRemotelyDeletedEmailDispositionReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
-        builder.Services.AddScoped<IAuthoredDeleteEmailDispositionReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
-        builder.Services.AddScoped<IMailRuleActionPermissionReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
-        builder.Services.AddScoped<IMailboxMutationAuditSettingsReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
-        builder.Services.AddScoped<IMailAnsweringAuditSettingsReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
-        builder.Services.AddScoped<IMailAccountCatalog>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
-        builder.Services.AddScoped<ITrustedAuthenticationAuthorityReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
-        builder.Services.AddScoped<ISenderTrustPolicyReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
+        // Each port is a scoped forwarder to the reader the scope's own snapshot owns, rather than a reader constructed
+        // per scope: three of them memoize a per-account map, and each of those maps walks every account and every
+        // account's own addresses — work a per-scope reader would repeat on every work unit and every message.
+        builder.Services.AddScoped<IMailTransportSecurityPolicyReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>().Readers.TransportSecurityPolicies);
+        builder.Services.AddScoped<IMailSynchronizationWindowReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>().Readers.SynchronizationWindows);
+        builder.Services.AddScoped<IRemotelyDeletedEmailDispositionReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>().Readers.RemotelyDeletedEmailDispositions);
+        builder.Services.AddScoped<IAuthoredDeleteEmailDispositionReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>().Readers.AuthoredDeleteEmailDispositions);
+        builder.Services.AddScoped<IMailRuleActionPermissionReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>().Readers.RuleActionPermissions);
+        builder.Services.AddScoped<IMailboxMutationAuditSettingsReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>().Readers.MutationAuditSettings);
+        builder.Services.AddScoped<IMailAnsweringAuditSettingsReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>().Readers.AnsweringAuditSettings);
+        builder.Services.AddScoped<IMailAccountCatalog>(provider => provider.GetRequiredService<MailSynchronizationOptions>().Readers.AccountCatalog);
+        builder.Services.AddScoped<ITrustedAuthenticationAuthorityReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>().Readers.TrustedAuthenticationAuthorities);
+        builder.Services.AddScoped<ISenderTrustPolicyReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>().Readers.SenderTrustPolicies);
         // Resolved from the same snapshot as the verdicts above, so one work unit reads mail under one reload. Which of
         // the two profiles it is follows the setting, and the disabled one records the same not-assessed state a
         // message with no readable body reaches — so a stored row never says which of the two reasons produced it.
         builder.Services.AddScoped(provider =>
             provider.GetRequiredService<MailSynchronizationOptions>().MachineAuthorshipProfile);
-        builder.Services.AddScoped<IOutgoingSenderIdentityReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
-        builder.Services.AddScoped<IOutgoingMailFilingPolicyReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
+        builder.Services.AddScoped<IOutgoingSenderIdentityReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>().Readers.OutgoingSenderIdentities);
+        builder.Services.AddScoped<IOutgoingMailFilingPolicyReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>().Readers.OutgoingMailFilingPolicies);
         builder.Services.AddScoped<IOutgoingSendPermissionReader, ConfiguredOutgoingSendPermissionReader>();
-        builder.Services.AddScoped<IMailFolderParticipationReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
-        builder.Services.AddScoped<IJunkMailFolderCatalog>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
-        builder.Services.AddScoped<IMailFolderMappingReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
-        builder.Services.AddScoped<IContactCollectionSettingsReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
+        builder.Services.AddScoped<IMailFolderParticipationReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>().Readers.FolderParticipation);
+        builder.Services.AddScoped<IJunkMailFolderCatalog>(provider => provider.GetRequiredService<MailSynchronizationOptions>().Readers.JunkFolderCatalog);
+        builder.Services.AddScoped<IMailFolderMappingReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>().Readers.FolderMappings);
+        builder.Services.AddScoped<IContactCollectionSettingsReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>().Readers.ContactCollection);
         builder.Services.AddScoped<ISpamClassificationSettingsReader, ConfiguredSpamClassificationSettingsReader>();
         builder.Services.AddScoped<ISpamActionSettingsReader, ConfiguredSpamActionSettingsReader>();
         builder.Services.AddScoped<IImapAccountSettingsProvider, ConfiguredImapAccountSettingsProvider>();

--- a/src/Host/Hosting/Workers/MailSynchronizationCoordinator.cs
+++ b/src/Host/Hosting/Workers/MailSynchronizationCoordinator.cs
@@ -116,7 +116,7 @@ internal sealed partial class MailSynchronizationCoordinator : BackgroundService
         CancellationToken schedulingToken,
         CancellationToken workUnitToken)
     {
-        foreach (var accountId in this.settings.Current.ServedAccounts.Select(static account => account.Id))
+        foreach (var accountId in this.settings.Current.Readers.AccountCatalog.ServedAccounts.Select(static account => account.Id))
         {
             if (this.supervisedAccounts.TryGetValue(accountId.Value, out var supervision) && !supervision.IsCompleted)
             {

--- a/tests/Application.UnitTests/TestDoubles/StubContactCollectionSettingsReader.cs
+++ b/tests/Application.UnitTests/TestDoubles/StubContactCollectionSettingsReader.cs
@@ -20,5 +20,5 @@ internal sealed class StubContactCollectionSettingsReader(ContactCollectionSetti
         new(ContactCollectionSettings.CollectingNothing);
 
     /// <inheritdoc />
-    public ContactCollectionSettings SettingsFor(MailAccountId accountId) => settings;
+    public ContactCollectionSettings GetContactCollectionSettings(MailAccountId accountId) => settings;
 }

--- a/tests/Host.UnitTests/Configuration/Mail/ContactCollectionConfigurationTests.cs
+++ b/tests/Host.UnitTests/Configuration/Mail/ContactCollectionConfigurationTests.cs
@@ -19,7 +19,7 @@ public sealed class ContactCollectionConfigurationTests
     public void SettingsFor_AnAccountThatConfiguredNothing_CollectsNobody()
     {
         // Act
-        var settings = OptionsFor(AccountAt("work", "owner@work.example")).SettingsFor(MailAccountId.Create("work"));
+        var settings = OptionsFor(AccountAt("work", "owner@work.example")).Readers.ContactCollection.GetContactCollectionSettings(MailAccountId.Create("work"));
 
         // Assert
         Assert.False(settings.IsEnabled);
@@ -39,7 +39,7 @@ public sealed class ContactCollectionConfigurationTests
         };
 
         // Act
-        var settings = OptionsFor(account).SettingsFor(MailAccountId.Create("work"));
+        var settings = OptionsFor(account).Readers.ContactCollection.GetContactCollectionSettings(MailAccountId.Create("work"));
 
         // Assert
         Assert.True(settings.IsEnabled);
@@ -57,8 +57,8 @@ public sealed class ContactCollectionConfigurationTests
         var options = OptionsFor(work, AccountAt("personal", "owner@personal.example"));
 
         // Act
-        var onWork = options.SettingsFor(MailAccountId.Create("work"));
-        var onPersonal = options.SettingsFor(MailAccountId.Create("personal"));
+        var onWork = options.Readers.ContactCollection.GetContactCollectionSettings(MailAccountId.Create("work"));
+        var onPersonal = options.Readers.ContactCollection.GetContactCollectionSettings(MailAccountId.Create("personal"));
 
         // Assert
         Assert.True(onWork.IsEnabled);
@@ -74,7 +74,7 @@ public sealed class ContactCollectionConfigurationTests
         work.ContactCollection = new ContactCollectionOptions { Enabled = true };
 
         // Act
-        var settings = OptionsFor(work).SettingsFor(MailAccountId.Create("removed"));
+        var settings = OptionsFor(work).Readers.ContactCollection.GetContactCollectionSettings(MailAccountId.Create("removed"));
 
         // Assert
         Assert.False(settings.IsEnabled);
@@ -91,7 +91,7 @@ public sealed class ContactCollectionConfigurationTests
         var options = OptionsFor(work, AccountAt("personal", "owner@personal.example"));
 
         // Act
-        var policy = options.SettingsFor(MailAccountId.Create("work")).Policy;
+        var policy = options.Readers.ContactCollection.GetContactCollectionSettings(MailAccountId.Create("work")).Policy;
 
         // Assert
         Assert.False(policy.Admits(AddressOf("owner@personal.example")));
@@ -123,7 +123,7 @@ public sealed class ContactCollectionConfigurationTests
         };
 
         // Act
-        var policy = OptionsFor(account).SettingsFor(MailAccountId.Create("work")).Policy;
+        var policy = OptionsFor(account).Readers.ContactCollection.GetContactCollectionSettings(MailAccountId.Create("work")).Policy;
 
         // Assert
         Assert.Equal(expectedAdmitted, policy.Admits(AddressOf("anna@mail.partner.example")));
@@ -143,7 +143,7 @@ public sealed class ContactCollectionConfigurationTests
         };
 
         // Act
-        var policy = OptionsFor(account).SettingsFor(MailAccountId.Create("work")).Policy;
+        var policy = OptionsFor(account).Readers.ContactCollection.GetContactCollectionSettings(MailAccountId.Create("work")).Policy;
 
         // Assert
         Assert.False(policy.Admits(AddressOf("billing-eu@partner.example")));
@@ -167,7 +167,7 @@ public sealed class ContactCollectionConfigurationTests
         };
 
         // Act
-        var policy = OptionsFor(account).SettingsFor(MailAccountId.Create("work")).Policy;
+        var policy = OptionsFor(account).Readers.ContactCollection.GetContactCollectionSettings(MailAccountId.Create("work")).Policy;
 
         // Assert
         Assert.True(policy.Admits(AddressOf("anna@partner.example")));

--- a/tests/Host.UnitTests/Configuration/Mail/MailAccountDeliveryValidationTests.cs
+++ b/tests/Host.UnitTests/Configuration/Mail/MailAccountDeliveryValidationTests.cs
@@ -29,7 +29,7 @@ public sealed class MailAccountDeliveryValidationTests
 
         // Assert
         Assert.Empty(results);
-        Assert.Null(options.GetDeliveryPolicy(MailAccountId.Create("primary")));
+        Assert.Null(options.Readers.TransportSecurityPolicies.GetDeliveryPolicy(MailAccountId.Create("primary")));
     }
 
     /// <summary>A complete submission endpoint under the account's own policy is accepted and reachable.</summary>
@@ -46,10 +46,10 @@ public sealed class MailAccountDeliveryValidationTests
 
         // Assert
         Assert.Empty(results);
-        var policy = options.GetDeliveryPolicy(MailAccountId.Create("primary"));
+        var policy = options.Readers.TransportSecurityPolicies.GetDeliveryPolicy(MailAccountId.Create("primary"));
         Assert.Equal(MailConnectionSecurity.StartTlsRequired, policy?.ConnectionSecurity);
         Assert.Equal(
-            options.GetPolicy(MailAccountId.Create("primary")).Authentication.PermittedMechanisms,
+            options.Readers.TransportSecurityPolicies.GetPolicy(MailAccountId.Create("primary")).Authentication.PermittedMechanisms,
             policy?.Authentication.PermittedMechanisms);
     }
 
@@ -64,8 +64,8 @@ public sealed class MailAccountDeliveryValidationTests
         var options = ConfiguredMailAccounts.Holding(account);
 
         // Act
-        var readingPolicy = options.GetPolicy(MailAccountId.Create("primary"));
-        var deliveryPolicy = options.GetDeliveryPolicy(MailAccountId.Create("primary"));
+        var readingPolicy = options.Readers.TransportSecurityPolicies.GetPolicy(MailAccountId.Create("primary"));
+        var deliveryPolicy = options.Readers.TransportSecurityPolicies.GetDeliveryPolicy(MailAccountId.Create("primary"));
 
         // Assert
         Assert.Equal(MailConnectionSecurity.TlsOnConnect, readingPolicy.ConnectionSecurity);
@@ -269,6 +269,6 @@ public sealed class MailAccountDeliveryValidationTests
 
         // Assert
         Assert.Empty(results);
-        Assert.NotNull(options.FindSenderIdentity(MailAccountId.Create("primary")));
+        Assert.NotNull(options.Readers.OutgoingSenderIdentities.FindSenderIdentity(MailAccountId.Create("primary")));
     }
 }

--- a/tests/Host.UnitTests/Configuration/Mail/MailAccountDisplayNameValidationTests.cs
+++ b/tests/Host.UnitTests/Configuration/Mail/MailAccountDisplayNameValidationTests.cs
@@ -141,7 +141,7 @@ public sealed class MailAccountDisplayNameValidationTests
         var options = OptionsFor(CreateAccount("acct-1", "  Work mail  "), pushed);
 
         // Act
-        var servedAccounts = options.ServedAccounts;
+        var servedAccounts = options.Readers.AccountCatalog.ServedAccounts;
 
         // Assert
         Assert.Equal(
@@ -160,7 +160,7 @@ public sealed class MailAccountDisplayNameValidationTests
         var options = OptionsFor(CreateAccount("acct-1", "Work mail"), CreateAccount("acct-2", displayName: string.Empty));
 
         // Act
-        var servedAccounts = options.ServedAccounts;
+        var servedAccounts = options.Readers.AccountCatalog.ServedAccounts;
 
         // Assert
         Assert.Equal("acct-1", Assert.Single(servedAccounts).Id.Value);
@@ -177,7 +177,7 @@ public sealed class MailAccountDisplayNameValidationTests
         options.Enabled = enabled;
 
         // Act, Assert
-        Assert.Equal(enabled, options.SynchronizationEnabled);
+        Assert.Equal(enabled, options.Readers.AccountCatalog.SynchronizationEnabled);
     }
 
     private static MailSynchronizationOptions OptionsFor(params MailSynchronizationAccountOptions[] accounts) => new()

--- a/tests/Host.UnitTests/Configuration/Mail/MailDeliverySenderIdentityTests.cs
+++ b/tests/Host.UnitTests/Configuration/Mail/MailDeliverySenderIdentityTests.cs
@@ -28,7 +28,7 @@ public sealed class MailDeliverySenderIdentityTests
         var options = ConfiguredMailAccounts.Holding(account);
 
         // Act
-        var identity = options.FindSenderIdentity(Primary);
+        var identity = options.Readers.OutgoingSenderIdentities.FindSenderIdentity(Primary);
 
         // Assert
         Assert.Equal("mailfathom@example.test", identity?.Address.Address);
@@ -49,7 +49,7 @@ public sealed class MailDeliverySenderIdentityTests
         var options = ConfiguredMailAccounts.Holding(account);
 
         // Act
-        var identity = options.FindSenderIdentity(Primary);
+        var identity = options.Readers.OutgoingSenderIdentities.FindSenderIdentity(Primary);
 
         // Assert
         Assert.Equal("office@example.test", identity?.Address.Address);
@@ -64,7 +64,7 @@ public sealed class MailDeliverySenderIdentityTests
         var options = ConfiguredMailAccounts.Holding(ConfiguredMailAccounts.Primary());
 
         // Act and assert
-        Assert.Null(options.FindSenderIdentity(Primary));
+        Assert.Null(options.Readers.OutgoingSenderIdentities.FindSenderIdentity(Primary));
     }
 
     /// <summary>An account a reload removed answers with nothing, as every per-account reader here does.</summary>
@@ -77,7 +77,7 @@ public sealed class MailDeliverySenderIdentityTests
         var options = ConfiguredMailAccounts.Holding(account);
 
         // Act and assert
-        Assert.Null(options.FindSenderIdentity(MailAccountId.Create("secondary")));
+        Assert.Null(options.Readers.OutgoingSenderIdentities.FindSenderIdentity(MailAccountId.Create("secondary")));
     }
 
     /// <summary>
@@ -137,6 +137,6 @@ public sealed class MailDeliverySenderIdentityTests
 
         // Assert
         Assert.Single(results);
-        Assert.Null(options.FindSenderIdentity(Primary));
+        Assert.Null(options.Readers.OutgoingSenderIdentities.FindSenderIdentity(Primary));
     }
 }

--- a/tests/Host.UnitTests/Configuration/Mail/MailFolderMappingLookupTests.cs
+++ b/tests/Host.UnitTests/Configuration/Mail/MailFolderMappingLookupTests.cs
@@ -29,7 +29,7 @@ public sealed class MailFolderMappingLookupTests
             new MailFolderMappingOptions { Alias = "spam", RemotePath = "INBOX.Spam", SpecialUse = "Junk" }));
 
         // Act
-        var folder = options.FindFolderPlayingRole(Primary, MailFolderSpecialUse.Junk);
+        var folder = options.Readers.FolderMappings.FindFolderPlayingRole(Primary, MailFolderSpecialUse.Junk);
 
         // Assert
         Assert.NotNull(folder);
@@ -44,7 +44,7 @@ public sealed class MailFolderMappingLookupTests
         var options = OptionsFor(CreateAccount(new MailFolderMappingOptions { Alias = "archive", SpecialUse = "Archive" }));
 
         // Act
-        var folder = options.FindFolderPlayingRole(Primary, MailFolderSpecialUse.Archive);
+        var folder = options.Readers.FolderMappings.FindFolderPlayingRole(Primary, MailFolderSpecialUse.Archive);
 
         // Assert
         Assert.NotNull(folder);
@@ -61,7 +61,7 @@ public sealed class MailFolderMappingLookupTests
             new MailFolderMappingOptions { Alias = "junk", RemotePath = "INBOX.Junk" }));
 
         // Act
-        var folder = options.FindFolderPlayingRole(Primary, MailFolderSpecialUse.Junk);
+        var folder = options.Readers.FolderMappings.FindFolderPlayingRole(Primary, MailFolderSpecialUse.Junk);
 
         // Assert
         Assert.Null(folder);
@@ -81,7 +81,7 @@ public sealed class MailFolderMappingLookupTests
         }));
 
         // Act
-        var folder = options.FindFolderPlayingRole(Primary, MailFolderSpecialUse.Junk);
+        var folder = options.Readers.FolderMappings.FindFolderPlayingRole(Primary, MailFolderSpecialUse.Junk);
 
         // Assert
         Assert.NotNull(folder);
@@ -97,7 +97,7 @@ public sealed class MailFolderMappingLookupTests
         var options = OptionsFor(CreateAccount());
 
         // Act
-        var folder = options.FindFolderPlayingRole(Primary, MailFolderSpecialUse.Inbox);
+        var folder = options.Readers.FolderMappings.FindFolderPlayingRole(Primary, MailFolderSpecialUse.Inbox);
 
         // Assert
         Assert.NotNull(folder);
@@ -111,7 +111,7 @@ public sealed class MailFolderMappingLookupTests
         var options = OptionsFor(CreateAccount(new MailFolderMappingOptions { Alias = "junk", SpecialUse = "Junk" }));
 
         // Act
-        var folder = options.FindFolderPlayingRole(MailAccountId.Create("withdrawn"), MailFolderSpecialUse.Junk);
+        var folder = options.Readers.FolderMappings.FindFolderPlayingRole(MailAccountId.Create("withdrawn"), MailFolderSpecialUse.Junk);
 
         // Assert
         Assert.Null(folder);
@@ -125,7 +125,7 @@ public sealed class MailFolderMappingLookupTests
             new MailFolderMappingOptions { Alias = "spam", RemotePath = "INBOX.Spam", SpecialUse = "Junk" }));
 
         // Act
-        var folder = options.FindFolderNamed(Primary, MailFolderAlias.Create("SpAm"));
+        var folder = options.Readers.FolderMappings.FindFolderNamed(Primary, MailFolderAlias.Create("SpAm"));
 
         // Assert
         Assert.NotNull(folder);
@@ -139,7 +139,7 @@ public sealed class MailFolderMappingLookupTests
         var options = OptionsFor(CreateAccount(new MailFolderMappingOptions { Alias = "inbox", SpecialUse = "Inbox" }));
 
         // Act
-        var folder = options.FindFolderNamed(Primary, MailFolderAlias.Create("archive"));
+        var folder = options.Readers.FolderMappings.FindFolderNamed(Primary, MailFolderAlias.Create("archive"));
 
         // Assert
         Assert.Null(folder);
@@ -155,8 +155,8 @@ public sealed class MailFolderMappingLookupTests
             new MailFolderMappingOptions { Alias = "inbox", SpecialUse = "Inbox" }));
 
         // Act
-        var broken = options.FindFolderNamed(Primary, MailFolderAlias.Create("broken"));
-        var inbox = options.FindFolderPlayingRole(Primary, MailFolderSpecialUse.Inbox);
+        var broken = options.Readers.FolderMappings.FindFolderNamed(Primary, MailFolderAlias.Create("broken"));
+        var inbox = options.Readers.FolderMappings.FindFolderPlayingRole(Primary, MailFolderSpecialUse.Inbox);
 
         // Assert
         Assert.Null(broken);

--- a/tests/Host.UnitTests/Configuration/Mail/MailFolderParticipationOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Mail/MailFolderParticipationOptionsTests.cs
@@ -5,6 +5,7 @@
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Folders;
 using MailFathom.Host.Configuration.Mail;
+using MailFathom.Host.Configuration.Mail.Readers;
 using MailFathom.Infrastructure.Mail;
 using MailFathom.Infrastructure.Secrets.Discovery;
 using Xunit;
@@ -24,13 +25,13 @@ public sealed class MailFolderParticipationOptionsTests
         var options = OptionsFor(CreateAccount());
 
         // Act
-        var participation = options.GetParticipation(Primary, MailFolderAlias.Create("INBOX"));
+        var participation = options.Readers.FolderParticipation.GetParticipation(Primary, MailFolderAlias.Create("INBOX"));
 
         // Assert
         var inbox = new MailFolderIdentity(Primary, MailFolderAlias.Create("INBOX"));
         Assert.Equal(MailFolderParticipation.Full, participation);
-        Assert.Equal([inbox], options.FoldersVisibleToTools);
-        Assert.Equal([inbox], options.FoldersGeneratingEmbeddings);
+        Assert.Equal([inbox], options.Readers.FolderParticipation.FoldersVisibleToTools);
+        Assert.Equal([inbox], options.Readers.FolderParticipation.FoldersGeneratingEmbeddings);
     }
 
     /// <summary>A folder that names its target and no switch behaves exactly as it did before the switches existed.</summary>
@@ -45,7 +46,7 @@ public sealed class MailFolderParticipationOptionsTests
         }));
 
         // Act
-        var participation = options.GetParticipation(Primary, MailFolderAlias.Create("ARCHIVE"));
+        var participation = options.Readers.FolderParticipation.GetParticipation(Primary, MailFolderAlias.Create("ARCHIVE"));
 
         // Assert
         Assert.Equal(MailFolderParticipation.Full, participation);
@@ -65,16 +66,16 @@ public sealed class MailFolderParticipationOptionsTests
         var privateFolder = new MailFolderIdentity(Primary, MailFolderAlias.Create("PRIVATE"));
 
         // Act
-        var visible = options.FoldersVisibleToTools;
-        var participation = options.GetParticipation(Primary, MailFolderAlias.Create("PRIVATE"));
+        var visible = options.Readers.FolderParticipation.FoldersVisibleToTools;
+        var participation = options.Readers.FolderParticipation.GetParticipation(Primary, MailFolderAlias.Create("PRIVATE"));
 
         // Assert
         Assert.DoesNotContain(privateFolder, visible);
         Assert.True(participation.IsSynchronized);
         Assert.True(participation.GeneratesEmbeddings);
         Assert.False(participation.IsVisibleToTools);
-        Assert.Equal([privateFolder], options.FoldersGeneratingEmbeddings);
-        Assert.Equal([privateFolder], options.FoldersSynchronized);
+        Assert.Equal([privateFolder], options.Readers.FolderParticipation.FoldersGeneratingEmbeddings);
+        Assert.Equal([privateFolder], options.Readers.FolderParticipation.FoldersSynchronized);
     }
 
     /// <summary>A noisy folder can stay listed and filterable while costing no provider tokens.</summary>
@@ -91,14 +92,14 @@ public sealed class MailFolderParticipationOptionsTests
         var newsletters = new MailFolderIdentity(Primary, MailFolderAlias.Create("NEWSLETTERS"));
 
         // Act
-        var participation = options.GetParticipation(Primary, MailFolderAlias.Create("NEWSLETTERS"));
+        var participation = options.Readers.FolderParticipation.GetParticipation(Primary, MailFolderAlias.Create("NEWSLETTERS"));
 
         // Assert
-        Assert.DoesNotContain(newsletters, options.FoldersGeneratingEmbeddings);
+        Assert.DoesNotContain(newsletters, options.Readers.FolderParticipation.FoldersGeneratingEmbeddings);
         Assert.False(participation.GeneratesEmbeddings);
         Assert.True(participation.IsVisibleToTools);
-        Assert.Equal([newsletters], options.FoldersVisibleToTools);
-        Assert.Equal([newsletters], options.FoldersSynchronized);
+        Assert.Equal([newsletters], options.Readers.FolderParticipation.FoldersVisibleToTools);
+        Assert.Equal([newsletters], options.Readers.FolderParticipation.FoldersSynchronized);
     }
 
     /// <summary>A folder nothing mirrors takes part in nothing, so it is admitted to neither without either switch being configured.</summary>
@@ -114,13 +115,13 @@ public sealed class MailFolderParticipationOptionsTests
         }));
 
         // Act
-        var participation = options.GetParticipation(Primary, MailFolderAlias.Create("JUNK"));
+        var participation = options.Readers.FolderParticipation.GetParticipation(Primary, MailFolderAlias.Create("JUNK"));
 
         // Assert
         Assert.Equal(MailFolderParticipation.MappedOnly, participation);
         Assert.True(participation.IsMapped);
-        Assert.Empty(options.FoldersVisibleToTools);
-        Assert.Empty(options.FoldersGeneratingEmbeddings);
+        Assert.Empty(options.Readers.FolderParticipation.FoldersVisibleToTools);
+        Assert.Empty(options.Readers.FolderParticipation.FoldersGeneratingEmbeddings);
     }
 
     /// <summary>A pass over stored mail runs against the folders a mapping mirrors, which is neither an unmirrored one nor an unmapped one.</summary>
@@ -135,7 +136,7 @@ public sealed class MailFolderParticipationOptionsTests
         // Act, Assert
         Assert.Equal(
             [new MailFolderIdentity(Primary, MailFolderAlias.Create("ARCHIVE"))],
-            options.FoldersSynchronized);
+            options.Readers.FolderParticipation.FoldersSynchronized);
     }
 
     /// <summary>A folder no mapping names is a folder MailFathom does not have, so what it stored earlier takes part in nothing.</summary>
@@ -151,7 +152,7 @@ public sealed class MailFolderParticipationOptionsTests
         }));
 
         // Act
-        var participation = options.GetParticipation(Primary, MailFolderAlias.Create("ARCHIVE"));
+        var participation = options.Readers.FolderParticipation.GetParticipation(Primary, MailFolderAlias.Create("ARCHIVE"));
 
         // Assert
         Assert.Equal(MailFolderParticipation.Unmapped, participation);
@@ -174,8 +175,8 @@ public sealed class MailFolderParticipationOptionsTests
         }));
 
         // Act
-        var unmirrored = options.GetParticipation(Primary, MailFolderAlias.Create("JUNK"));
-        var unmapped = options.GetParticipation(Primary, MailFolderAlias.Create("ARCHIVE"));
+        var unmirrored = options.Readers.FolderParticipation.GetParticipation(Primary, MailFolderAlias.Create("JUNK"));
+        var unmapped = options.Readers.FolderParticipation.GetParticipation(Primary, MailFolderAlias.Create("ARCHIVE"));
 
         // Assert
         Assert.NotEqual(unmirrored, unmapped);
@@ -205,14 +206,14 @@ public sealed class MailFolderParticipationOptionsTests
         };
 
         // Act
-        var visible = options.FoldersVisibleToTools;
+        var visible = options.Readers.FolderParticipation.FoldersVisibleToTools;
 
         // Assert
         Assert.Equal(
             [new MailFolderIdentity(MailAccountId.Create("secondary"), MailFolderAlias.Create("PRIVATE"))],
             visible);
         Assert.True(options
-            .GetParticipation(MailAccountId.Create("secondary"), MailFolderAlias.Create("PRIVATE"))
+            .Readers.FolderParticipation.GetParticipation(MailAccountId.Create("secondary"), MailFolderAlias.Create("PRIVATE"))
             .IsVisibleToTools);
     }
 
@@ -360,9 +361,9 @@ public sealed class MailFolderParticipationOptionsTests
         }));
 
         // Act, Assert
-        Assert.Equal([new MailFolderIdentity(Primary, MailFolderAlias.Create("JUNK"))], options.JunkFolders);
-        Assert.True(options.IsJunkFolder(Primary, MailFolderAlias.Create("JUNK")));
-        Assert.False(options.IsJunkFolder(Primary, MailFolderAlias.Create("INBOX")));
+        Assert.Equal([new MailFolderIdentity(Primary, MailFolderAlias.Create("JUNK"))], options.Readers.JunkFolderCatalog.JunkFolders);
+        Assert.True(options.Readers.JunkFolderCatalog.IsJunkFolder(Primary, MailFolderAlias.Create("JUNK")));
+        Assert.False(options.Readers.JunkFolderCatalog.IsJunkFolder(Primary, MailFolderAlias.Create("INBOX")));
     }
 
     /// <summary>A deployment that maps no junk folder answers with nothing, and every mailbox read behaves as it did before.</summary>
@@ -377,8 +378,8 @@ public sealed class MailFolderParticipationOptionsTests
         }));
 
         // Act, Assert
-        Assert.Empty(options.JunkFolders);
-        Assert.False(options.IsJunkFolder(Primary, MailFolderAlias.Create("ARCHIVE")));
+        Assert.Empty(options.Readers.JunkFolderCatalog.JunkFolders);
+        Assert.False(options.Readers.JunkFolderCatalog.IsJunkFolder(Primary, MailFolderAlias.Create("ARCHIVE")));
     }
 
     /// <summary>An account that configures no folder still runs with an inbox mapping, which is what classification defaults to.</summary>
@@ -389,7 +390,7 @@ public sealed class MailFolderParticipationOptionsTests
         var options = OptionsFor(CreateAccount());
 
         // Act, Assert
-        Assert.Equal([MailFolderAlias.Create("INBOX")], options.InboxFolderAliases);
+        Assert.Equal([MailFolderAlias.Create("INBOX")], ConfiguredMailFolders.InboxAliasesOf(options));
     }
 
     /// <summary>A server presenting the inbox under another name is configured by role, and the default scope follows the role.</summary>
@@ -405,7 +406,7 @@ public sealed class MailFolderParticipationOptionsTests
         }));
 
         // Act, Assert
-        Assert.Equal([MailFolderAlias.Create("PRIMARY-MAIL")], options.InboxFolderAliases);
+        Assert.Equal([MailFolderAlias.Create("PRIMARY-MAIL")], ConfiguredMailFolders.InboxAliasesOf(options));
     }
 
     private static MailSynchronizationOptions OptionsFor(MailSynchronizationAccountOptions account) =>

--- a/tests/Host.UnitTests/Configuration/Mail/MailSynchronizationOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Mail/MailSynchronizationOptionsTests.cs
@@ -225,7 +225,7 @@ public sealed class MailSynchronizationOptionsTests
         };
 
         // Act
-        var servedAccountIds = options.ServedAccounts.Select(account => account.Id);
+        var servedAccountIds = options.Readers.AccountCatalog.ServedAccounts.Select(account => account.Id);
 
         // Assert
         Assert.Equal([MailAccountId.Create("primary"), MailAccountId.Create("secondary")], servedAccountIds);
@@ -239,7 +239,7 @@ public sealed class MailSynchronizationOptionsTests
         var options = new MailSynchronizationOptions { Accounts = [CreateAccount("primary")] };
 
         // Act
-        var servedAccountIds = options.ServedAccounts.Select(account => account.Id);
+        var servedAccountIds = options.Readers.AccountCatalog.ServedAccounts.Select(account => account.Id);
 
         // Assert
         Assert.DoesNotContain(MailAccountId.Create("PRIMARY"), servedAccountIds);
@@ -253,7 +253,7 @@ public sealed class MailSynchronizationOptionsTests
         var options = new MailSynchronizationOptions { Enabled = false, Accounts = [CreateAccount("primary")] };
 
         // Act, Assert
-        Assert.Equal(MailAccountId.Create("primary"), Assert.Single(options.ServedAccounts).Id);
+        Assert.Equal(MailAccountId.Create("primary"), Assert.Single(options.Readers.AccountCatalog.ServedAccounts).Id);
     }
 
     [Fact]
@@ -263,7 +263,7 @@ public sealed class MailSynchronizationOptionsTests
         var options = new MailSynchronizationOptions();
 
         // Act, Assert
-        Assert.Empty(options.ServedAccounts);
+        Assert.Empty(options.Readers.AccountCatalog.ServedAccounts);
     }
 
     /// <summary>An account whose identifier never bound is not a served account, and reading the set does not fail on it.</summary>
@@ -274,7 +274,7 @@ public sealed class MailSynchronizationOptionsTests
         var options = new MailSynchronizationOptions { Accounts = [CreateAccount("primary"), CreateAccount("   ")] };
 
         // Act, Assert
-        Assert.Equal(MailAccountId.Create("primary"), Assert.Single(options.ServedAccounts).Id);
+        Assert.Equal(MailAccountId.Create("primary"), Assert.Single(options.Readers.AccountCatalog.ServedAccounts).Id);
     }
 
     [Fact]
@@ -460,7 +460,7 @@ public sealed class MailSynchronizationOptionsTests
         var options = new MailSynchronizationOptions { Enabled = true, Accounts = [account] };
 
         // Act
-        var settings = options.GetAnsweringAuditSettings(MailAccountId.Create("primary"));
+        var settings = options.Readers.AnsweringAuditSettings.GetAnsweringAuditSettings(MailAccountId.Create("primary"));
 
         // Assert
         Assert.False(settings.IsEnabled);
@@ -475,7 +475,7 @@ public sealed class MailSynchronizationOptionsTests
         var options = new MailSynchronizationOptions { Enabled = true, Accounts = [CreateAccount("primary")] };
 
         // Act
-        var settings = options.GetAnsweringAuditSettings(MailAccountId.Create("somebody-elses"));
+        var settings = options.Readers.AnsweringAuditSettings.GetAnsweringAuditSettings(MailAccountId.Create("somebody-elses"));
 
         // Assert
         Assert.Equal(MailAnsweringAuditSettings.Disabled, settings);
@@ -700,7 +700,7 @@ public sealed class MailSynchronizationOptionsTests
         var options = new MailSynchronizationOptions { Accounts = [CreateAccount("  primary  ")] };
 
         // Act
-        var policy = options.GetPolicy(MailAccountId.Create("primary"));
+        var policy = options.Readers.TransportSecurityPolicies.GetPolicy(MailAccountId.Create("primary"));
 
         // Assert
         Assert.Equal(MailConnectionSecurity.TlsOnConnect, policy.ConnectionSecurity);
@@ -715,7 +715,7 @@ public sealed class MailSynchronizationOptionsTests
         var options = new MailSynchronizationOptions { Accounts = [account] };
 
         // Act
-        var window = options.GetWindow(MailAccountId.Create("primary"));
+        var window = options.Readers.SynchronizationWindows.GetWindow(MailAccountId.Create("primary"));
 
         // Assert
         Assert.Equal(new DateOnly(2024, 1, 1), window.EarliestEmailReceivedDate);
@@ -729,7 +729,7 @@ public sealed class MailSynchronizationOptionsTests
         var options = new MailSynchronizationOptions { Accounts = [CreateAccount("primary")] };
 
         // Act
-        var window = options.GetWindow(MailAccountId.Create("primary"));
+        var window = options.Readers.SynchronizationWindows.GetWindow(MailAccountId.Create("primary"));
 
         // Assert
         Assert.Equal(MailSynchronizationWindow.Unbounded, window);
@@ -745,8 +745,8 @@ public sealed class MailSynchronizationOptionsTests
         var options = new MailSynchronizationOptions { Accounts = [followingServer, CreateAccount("archive")] };
 
         // Act
-        var dispositions = options.ServedAccounts
-            .Select(account => options.GetDisposition(account.Id))
+        var dispositions = options.Readers.AccountCatalog.ServedAccounts
+            .Select(account => options.Readers.RemotelyDeletedEmailDispositions.GetDisposition(account.Id))
             .ToArray();
 
         // Assert
@@ -763,7 +763,7 @@ public sealed class MailSynchronizationOptionsTests
         var options = new MailSynchronizationOptions { Accounts = [CreateAccount("primary")] };
 
         // Act
-        var disposition = options.GetDisposition(MailAccountId.Create("primary"));
+        var disposition = options.Readers.RemotelyDeletedEmailDispositions.GetDisposition(MailAccountId.Create("primary"));
 
         // Assert
         Assert.Equal(RemotelyDeletedEmailDisposition.RetainTombstone, disposition);
@@ -860,8 +860,8 @@ public sealed class MailSynchronizationOptionsTests
         var accountId = MailAccountId.Create("primary");
 
         // Act
-        var remoteDisposition = options.GetDisposition(accountId);
-        var authoredDisposition = options.GetAuthoredDeleteDisposition(accountId);
+        var remoteDisposition = options.Readers.RemotelyDeletedEmailDispositions.GetDisposition(accountId);
+        var authoredDisposition = options.Readers.AuthoredDeleteEmailDispositions.GetAuthoredDeleteDisposition(accountId);
 
         // Assert
         Assert.Equal(RemotelyDeletedEmailDisposition.EraseLocalCopy, remoteDisposition);
@@ -878,8 +878,8 @@ public sealed class MailSynchronizationOptionsTests
         var options = new MailSynchronizationOptions { Accounts = [forgetful, CreateAccount("archive")] };
 
         // Act
-        var dispositions = options.ServedAccounts
-            .Select(account => options.GetAuthoredDeleteDisposition(account.Id))
+        var dispositions = options.Readers.AccountCatalog.ServedAccounts
+            .Select(account => options.Readers.AuthoredDeleteEmailDispositions.GetAuthoredDeleteDisposition(account.Id))
             .ToArray();
 
         // Assert

--- a/tests/Host.UnitTests/Configuration/Mail/OutgoingMailFilingConfigurationTests.cs
+++ b/tests/Host.UnitTests/Configuration/Mail/OutgoingMailFilingConfigurationTests.cs
@@ -73,7 +73,7 @@ public sealed class OutgoingMailFilingConfigurationTests
         }));
 
         // Act
-        var folder = options.FindFolderPlayingRole(Primary, MailFolderSpecialUse.Outbox);
+        var folder = options.Readers.FolderMappings.FindFolderPlayingRole(Primary, MailFolderSpecialUse.Outbox);
 
         // Assert
         Assert.NotNull(folder);
@@ -95,7 +95,7 @@ public sealed class OutgoingMailFilingConfigurationTests
         }));
 
         // Act
-        var folder = options.FindFolderPlayingRole(Primary, MailFolderSpecialUse.Outbox);
+        var folder = options.Readers.FolderMappings.FindFolderPlayingRole(Primary, MailFolderSpecialUse.Outbox);
 
         // Assert
         Assert.Null(folder);
@@ -112,7 +112,7 @@ public sealed class OutgoingMailFilingConfigurationTests
         var options = OptionsFor(CreateAccount());
 
         // Act
-        var filesSentCopy = options.FilesSentCopy(Primary);
+        var filesSentCopy = options.Readers.OutgoingMailFilingPolicies.FilesSentCopy(Primary);
 
         // Assert
         Assert.True(filesSentCopy);
@@ -131,7 +131,7 @@ public sealed class OutgoingMailFilingConfigurationTests
         };
 
         // Act
-        var filesSentCopy = OptionsFor(account).FilesSentCopy(Primary);
+        var filesSentCopy = OptionsFor(account).Readers.OutgoingMailFilingPolicies.FilesSentCopy(Primary);
 
         // Assert
         Assert.False(filesSentCopy);
@@ -145,7 +145,7 @@ public sealed class OutgoingMailFilingConfigurationTests
         var options = OptionsFor(CreateAccount());
 
         // Act
-        var filesSentCopy = options.FilesSentCopy(MailAccountId.Create("withdrawn"));
+        var filesSentCopy = options.Readers.OutgoingMailFilingPolicies.FilesSentCopy(MailAccountId.Create("withdrawn"));
 
         // Assert
         Assert.True(filesSentCopy);

--- a/tests/Host.UnitTests/Configuration/Mail/Readers/MailSynchronizationSettingsReadersTests.cs
+++ b/tests/Host.UnitTests/Configuration/Mail/Readers/MailSynchronizationSettingsReadersTests.cs
@@ -1,0 +1,130 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Accounts;
+using MailFathom.Host.Configuration.Mail;
+using MailFathom.Host.UnitTests.TestDoubles;
+using MailFathom.Infrastructure.Mail;
+using MailFathom.Infrastructure.Secrets.Discovery;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Configuration.Mail.Readers;
+
+/// <summary>Covers the lifetime the port readers are built with, which is what their memoized maps cost or save.</summary>
+/// <remarks>
+/// Every reader is registered as a scoped forwarder to the snapshot's own set, so a run unit and every message it
+/// reads share one build. These tests hold that: an answer built once is observed as the same instance from two
+/// scopes, and a snapshot handed down by an enclosing run answers from its own set rather than from the published one.
+/// </remarks>
+public sealed class MailSynchronizationSettingsReadersTests
+{
+    /// <summary>The readers belong to the snapshot, so every scope over one snapshot reads through one set.</summary>
+    [Fact]
+    public void Readers_TwoScopesOverOnePublishedSnapshot_ShareOneSet()
+    {
+        // Arrange
+        var published = new StubSettingsSnapshot<MailSynchronizationOptions>(
+            OptionsFor(AccountAt("work", "owner@work.example")));
+
+        // Act
+        var first = new ScopedMailSynchronizationSettings(published).Current.Readers;
+        var second = new ScopedMailSynchronizationSettings(published).Current.Readers;
+
+        // Assert
+        Assert.Same(first, second);
+    }
+
+    /// <summary>Every arriving message asks for a policy, so the map behind it is built once rather than once per scope.</summary>
+    [Fact]
+    public void GetTrustPolicy_AskedFromTwoScopesOfOneSnapshot_AnswersFromOneBuild()
+    {
+        // Arrange
+        var published = new StubSettingsSnapshot<MailSynchronizationOptions>(
+            OptionsFor(AccountAt("work", "owner@work.example")));
+        var work = MailAccountId.Create("work");
+
+        // Act
+        var first = new ScopedMailSynchronizationSettings(published).Current
+            .Readers.SenderTrustPolicies.GetTrustPolicy(work);
+        var second = new ScopedMailSynchronizationSettings(published).Current
+            .Readers.SenderTrustPolicies.GetTrustPolicy(work);
+
+        // Assert
+        Assert.Same(first, second);
+    }
+
+    /// <summary>Collection settings are read per message as well, and are memoized for the same reason.</summary>
+    [Fact]
+    public void GetContactCollectionSettings_AskedFromTwoScopesOfOneSnapshot_AnswersFromOneBuild()
+    {
+        // Arrange
+        var account = AccountAt("work", "owner@work.example");
+        account.ContactCollection = new ContactCollectionOptions { Enabled = true };
+        var published = new StubSettingsSnapshot<MailSynchronizationOptions>(OptionsFor(account));
+        var work = MailAccountId.Create("work");
+
+        // Act
+        var first = new ScopedMailSynchronizationSettings(published).Current
+            .Readers.ContactCollection.GetContactCollectionSettings(work);
+        var second = new ScopedMailSynchronizationSettings(published).Current
+            .Readers.ContactCollection.GetContactCollectionSettings(work);
+
+        // Assert
+        Assert.Same(first, second);
+    }
+
+    /// <summary>A reload binds a new snapshot, which brings a set of its own rather than the superseded one's answers.</summary>
+    [Fact]
+    public void Readers_AReloadPublishingANewSnapshot_BuildItsOwnSet()
+    {
+        // Arrange
+        var published = new StubSettingsSnapshot<MailSynchronizationOptions>(
+            OptionsFor(AccountAt("work", "owner@work.example")));
+        var beforeReload = new ScopedMailSynchronizationSettings(published).Current.Readers;
+
+        // Act
+        published.Current = OptionsFor(AccountAt("work", "owner@work.example"));
+        var afterReload = new ScopedMailSynchronizationSettings(published).Current.Readers;
+
+        // Assert
+        Assert.NotSame(beforeReload, afterReload);
+    }
+
+    /// <summary>A run hands its snapshot down, so the scope reads that snapshot's accounts rather than the published list.</summary>
+    [Fact]
+    public void Readers_AScopeHandedTheRunsSnapshot_ReadTheAccountsOfThatSnapshot()
+    {
+        // Arrange
+        var published = new StubSettingsSnapshot<MailSynchronizationOptions>(
+            OptionsFor(AccountAt("added-by-a-reload", "owner@work.example")));
+        var runSnapshot = OptionsFor(AccountAt("scheduled-by-the-run", "owner@work.example"));
+        var scope = new ScopedMailSynchronizationSettings(published);
+
+        // Act
+        scope.UseRunSnapshot(runSnapshot);
+
+        // Assert
+        Assert.Same(runSnapshot.Readers, scope.Current.Readers);
+        Assert.Equal(
+            [MailAccountId.Create("scheduled-by-the-run")],
+            scope.Current.Readers.AccountCatalog.ServedAccounts.Select(static account => account.Id));
+    }
+
+    private static MailSynchronizationOptions OptionsFor(params MailSynchronizationAccountOptions[] accounts) => new()
+    {
+        Accounts = [.. accounts],
+    };
+
+    private static MailSynchronizationAccountOptions AccountAt(string accountId, string userName) => new()
+    {
+        AccountId = accountId,
+        DisplayName = $"Account {accountId}",
+        Host = "imap.example.test",
+        UserName = userName,
+        Secrets = new MailAccountSecretOptions
+        {
+            Password = new ConfiguredSecret { SecretReference = $"systemd-credential:imap-{accountId}-password" },
+        },
+    };
+}

--- a/tests/Host.UnitTests/Configuration/Mail/SenderTrustPolicyConfigurationTests.cs
+++ b/tests/Host.UnitTests/Configuration/Mail/SenderTrustPolicyConfigurationTests.cs
@@ -26,7 +26,7 @@ public sealed class SenderTrustPolicyConfigurationTests
 
         // Act
         var trust = options
-            .GetTrustPolicy(MailAccountId.Create("personal"))
+            .Readers.SenderTrustPolicies.GetTrustPolicy(MailAccountId.Create("personal"))
             .Evaluate(WrittenBy("work.example"), AddressOf("owner@work.example"));
 
         // Assert
@@ -46,7 +46,7 @@ public sealed class SenderTrustPolicyConfigurationTests
 
         // Act
         var trust = options
-            .GetTrustPolicy(MailAccountId.Create("personal"))
+            .Readers.SenderTrustPolicies.GetTrustPolicy(MailAccountId.Create("personal"))
             .Evaluate(WrittenBy("work.example"), AddressOf("owner@work.example"));
 
         // Assert
@@ -62,7 +62,7 @@ public sealed class SenderTrustPolicyConfigurationTests
 
         // Act
         var trust = options
-            .GetTrustPolicy(MailAccountId.Create("work"))
+            .Readers.SenderTrustPolicies.GetTrustPolicy(MailAccountId.Create("work"))
             .Evaluate(WrittenBy("work.example"), AddressOf("owner@work.example"));
 
         // Assert
@@ -80,10 +80,10 @@ public sealed class SenderTrustPolicyConfigurationTests
 
         // Act
         var onWork = options
-            .GetTrustPolicy(MailAccountId.Create("work"))
+            .Readers.SenderTrustPolicies.GetTrustPolicy(MailAccountId.Create("work"))
             .Evaluate(WrittenBy("partner.example"), displayedSender: null);
         var onPersonal = options
-            .GetTrustPolicy(MailAccountId.Create("personal"))
+            .Readers.SenderTrustPolicies.GetTrustPolicy(MailAccountId.Create("personal"))
             .Evaluate(WrittenBy("partner.example"), displayedSender: null);
 
         // Assert
@@ -107,7 +107,7 @@ public sealed class SenderTrustPolicyConfigurationTests
 
         // Act
         var trust = OptionsFor(account)
-            .GetTrustPolicy(MailAccountId.Create("work"))
+            .Readers.SenderTrustPolicies.GetTrustPolicy(MailAccountId.Create("work"))
             .Evaluate(WrittenBy("mail.partner.example"), displayedSender: null);
 
         // Assert
@@ -120,7 +120,7 @@ public sealed class SenderTrustPolicyConfigurationTests
     {
         // Act
         var policy = OptionsFor(AccountAt("work", "owner@work.example"))
-            .GetTrustPolicy(MailAccountId.Create("removed"));
+            .Readers.SenderTrustPolicies.GetTrustPolicy(MailAccountId.Create("removed"));
 
         // Assert
         Assert.Same(SenderTrustPolicy.RecognizingNobody, policy);

--- a/tests/Host.UnitTests/Configuration/Mail/TrustedAuthenticationAuthorityConfigurationTests.cs
+++ b/tests/Host.UnitTests/Configuration/Mail/TrustedAuthenticationAuthorityConfigurationTests.cs
@@ -24,7 +24,7 @@ public sealed class TrustedAuthenticationAuthorityConfigurationTests
         var options = OptionsFor(account);
 
         // Act
-        var authority = options.GetTrustedAuthority(MailAccountId.Create("primary"));
+        var authority = options.Readers.TrustedAuthenticationAuthorities.GetTrustedAuthority(MailAccountId.Create("primary"));
 
         // Assert
         Assert.True(authority.NamesAServer);
@@ -37,7 +37,7 @@ public sealed class TrustedAuthenticationAuthorityConfigurationTests
     public void GetTrustedAuthority_AccountNamingNoServer_BelievesNothing()
     {
         // Act
-        var authority = OptionsFor(CreateAccount("primary")).GetTrustedAuthority(MailAccountId.Create("primary"));
+        var authority = OptionsFor(CreateAccount("primary")).Readers.TrustedAuthenticationAuthorities.GetTrustedAuthority(MailAccountId.Create("primary"));
 
         // Assert
         Assert.Equal(TrustedAuthenticationAuthority.None, authority);
@@ -48,7 +48,7 @@ public sealed class TrustedAuthenticationAuthorityConfigurationTests
     public void GetTrustedAuthority_AccountThisSnapshotNoLongerNames_BelievesNothing()
     {
         // Act
-        var authority = OptionsFor(CreateAccount("primary")).GetTrustedAuthority(MailAccountId.Create("removed"));
+        var authority = OptionsFor(CreateAccount("primary")).Readers.TrustedAuthenticationAuthorities.GetTrustedAuthority(MailAccountId.Create("removed"));
 
         // Assert
         Assert.Equal(TrustedAuthenticationAuthority.None, authority);

--- a/tests/Host.UnitTests/Configuration/ValidatedSettingsSnapshotTests.cs
+++ b/tests/Host.UnitTests/Configuration/ValidatedSettingsSnapshotTests.cs
@@ -318,7 +318,7 @@ public sealed class ValidatedSettingsSnapshotTests
         // Assert
         Assert.Equal(
             MailConnectionSecurity.StartTlsRequired,
-            harness.Settings.Current.GetPolicy(MailAccountId.Create("primary")).ConnectionSecurity);
+            harness.Settings.Current.Readers.TransportSecurityPolicies.GetPolicy(MailAccountId.Create("primary")).ConnectionSecurity);
     }
 
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The harness owns the settings and every test disposes the harness.")]

--- a/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
+++ b/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
@@ -186,7 +186,7 @@ internal static class SynchronizationTestHost
         // configure, so both answer that there is nothing to keep and nothing to erase.
         services.AddSingleton(CreateTrailThatKeepsNothing());
         services.AddSingleton(CreateAuditStoreWithNothingToErase());
-        services.AddScoped<IMailboxMutationAuditSettingsReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
+        services.AddScoped<IMailboxMutationAuditSettingsReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>().Readers.MutationAuditSettings);
         services.AddScoped<MailboxMutationAuditTrailRetention>();
 
         // No run erases what a folder the account has stopped mirroring stored, and both of these are registered so
@@ -205,15 +205,15 @@ internal static class SynchronizationTestHost
         services.AddSingleton(new MailRuleSetEvaluator(timeProvider));
         services.AddScoped(_ => new MailRuleEvaluationOptions());
         services.AddScoped<IAuthoredDeleteEmailDispositionReader>(
-            provider => provider.GetRequiredService<MailSynchronizationOptions>());
+            provider => provider.GetRequiredService<MailSynchronizationOptions>().Readers.AuthoredDeleteEmailDispositions);
         services.AddScoped<IMailRuleActionPermissionReader>(
-            provider => provider.GetRequiredService<MailSynchronizationOptions>());
+            provider => provider.GetRequiredService<MailSynchronizationOptions>().Readers.RuleActionPermissions);
 
         // A rule may name its destination by the role a folder plays, and a condition may ask what role the folder an
         // email is in plays, so both the recorder and the pass read the account's mappings through this port. The host
         // answers it from the same snapshot every other per-account reader answers from.
         services.AddScoped<IMailFolderMappingReader>(
-            provider => provider.GetRequiredService<MailSynchronizationOptions>());
+            provider => provider.GetRequiredService<MailSynchronizationOptions>().Readers.FolderMappings);
         services.AddScoped<MailFolderReferenceResolver>();
         services.AddScoped<MailRuleActionRecorder>();
         // A rule may file into a folder the account maps and does not mirror, which nothing binds until a change needs
@@ -258,7 +258,7 @@ internal static class SynchronizationTestHost
         services.AddSingleton(Substitute.For<IAuthoredMailTally>());
         services.AddSingleton(Substitute.For<IContactCollectionTelemetry>());
         services.AddScoped<IContactCollectionSettingsReader>(provider =>
-            provider.GetRequiredService<MailSynchronizationOptions>());
+            provider.GetRequiredService<MailSynchronizationOptions>().Readers.ContactCollection);
         services.AddScoped(_ => AccessAuthorizations.ForPrincipal(AuthorizedPrincipal.Process));
         services.AddScoped<ContactBook>();
         services.AddScoped<MailContactCollector>();
@@ -280,9 +280,9 @@ internal static class SynchronizationTestHost
         services.AddSingleton(publishedSettings);
         services.AddScoped<ScopedMailSynchronizationSettings>();
         services.AddScoped(provider => provider.GetRequiredService<ScopedMailSynchronizationSettings>().Current);
-        services.AddScoped<IMailTransportSecurityPolicyReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
-        services.AddScoped<IMailSynchronizationWindowReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
-        services.AddScoped<IRemotelyDeletedEmailDispositionReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
+        services.AddScoped<IMailTransportSecurityPolicyReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>().Readers.TransportSecurityPolicies);
+        services.AddScoped<IMailSynchronizationWindowReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>().Readers.SynchronizationWindows);
+        services.AddScoped<IRemotelyDeletedEmailDispositionReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>().Readers.RemotelyDeletedEmailDispositions);
 
         return services.BuildServiceProvider();
     }

--- a/tests/IntegrationTests/Orchestration/FixedContactCollectionSettingsReader.cs
+++ b/tests/IntegrationTests/Orchestration/FixedContactCollectionSettingsReader.cs
@@ -18,5 +18,5 @@ internal sealed class FixedContactCollectionSettingsReader(ContactCollectionSett
     : IContactCollectionSettingsReader
 {
     /// <inheritdoc />
-    public ContactCollectionSettings SettingsFor(MailAccountId accountId) => settings;
+    public ContactCollectionSettings GetContactCollectionSettings(MailAccountId accountId) => settings;
 }


### PR DESCRIPTION
`MailSynchronizationOptions` implemented sixteen application ports beside `IValidatableObject`, and every feature that needed a per-account lookup appended one more to it. Each port now has a reader of its own under `src/Host/Configuration/Mail/Readers/`, and the options type keeps only the bound section, its validation, and the two account lookups the readers share.

## The lifetime the readers are built with

The readers are built **once per snapshot** rather than once per scope. Three of them memoize a per-account map — sender trust policies, contact collection settings, folder mappings — and each of those maps walks every account and every account's own addresses, so a per-scope reader would repeat that work on every work unit and every message.

One set belongs to one `MailSynchronizationOptions` instance, which is what a reload replaces and what an enclosing run hands its scopes through `ScopedMailSynchronizationSettings.UseRunSnapshot`. Building the set where `ValidatedSettingsSnapshot` publishes instead would have been wrong in the one case that matters: a run holding an older snapshot would then read the newly published snapshot's readers, and the work unit would stop running under one reload. `MailSynchronizationSettingsReadersTests` holds both halves — two scopes over one snapshot get the same answer instance, and a scope handed a run snapshot reads that snapshot's accounts.

Each map keeps its own `Lazy`, so a deployment that never reads a message still never walks the accounts. The ports stay registered scoped, now as forwarders to the snapshot's set.

## The rename

`IContactCollectionSettingsReader.SettingsFor` is now `GetContactCollectionSettings`, so the port reads like every sibling. Two production call sites and the test doubles follow it. This is a C# API rename inside the solution — it touches none of the four public surfaces, so no operator action follows from it.

## Where the ports moved to

| Port | Reader |
|---|---|
| `IMailTransportSecurityPolicyReader` | `ConfiguredMailTransportSecurityPolicyReader` |
| `IMailSynchronizationWindowReader` | `ConfiguredMailSynchronizationWindowReader` |
| `IRemotelyDeletedEmailDispositionReader` | `ConfiguredRemotelyDeletedEmailDispositionReader` |
| `IAuthoredDeleteEmailDispositionReader` | `ConfiguredAuthoredDeleteEmailDispositionReader` |
| `IMailRuleActionPermissionReader` | `ConfiguredMailRuleActionPermissionReader` |
| `IMailboxMutationAuditSettingsReader` | `ConfiguredMailboxMutationAuditSettingsReader` |
| `IMailAnsweringAuditSettingsReader` | `ConfiguredMailAnsweringAuditSettingsReader` |
| `IMailAccountCatalog` | `ConfiguredMailAccountCatalog` |
| `ITrustedAuthenticationAuthorityReader` | `ConfiguredTrustedAuthenticationAuthorityReader` |
| `ISenderTrustPolicyReader` | `ConfiguredSenderTrustPolicyReader` |
| `IOutgoingSenderIdentityReader` | `ConfiguredOutgoingSenderIdentityReader` |
| `IOutgoingMailFilingPolicyReader` | `ConfiguredOutgoingMailFilingPolicyReader` |
| `IMailFolderParticipationReader` | `ConfiguredMailFolderParticipationReader` |
| `IJunkMailFolderCatalog` | `ConfiguredJunkMailFolderCatalog` |
| `IMailFolderMappingReader` | `ConfiguredMailFolderMappingReader` |
| `IContactCollectionSettingsReader` | `ConfiguredContactCollectionSettingsReader` |

`ConfiguredMailFolders` holds the configured-folder walk the three folder readers and the classification scope default all ask for, and `SendingEnabled` moves into `ConfiguredOutgoingSendPermissionReader`, which was its only caller.

## What this does not change

No configuration key, no MCP tool argument, no database column, and no deployment contract. The options type keeps `IValidatableObject` and the same refusals, and every reader answers exactly what the method it replaced answered, including each one's behaviour for an account a reload removed.

## Verification

- `scripts/verify-full.sh` — passed. 10364 tests, 0 failed; aggregate line coverage 95.55% (required 85%); workflow contract suite 237 passed, 0 failed.
- `$check-docs-licenses` — Docs pass, Changelog n/a, Licenses n/a. `docs/features/mailbox-queries.md` claimed `MailSynchronizationOptions` implements `IMailAccountCatalog`; it now names the reader that does.

Closes #1033
