### PR TITLE
[#1063] Hand jq each patch as a file so a large one still reports

### DIFF
--- a/scripts/review-obligations.sh
+++ b/scripts/review-obligations.sh
@@ -67,20 +67,28 @@ while IFS=$'\t' read -r status path renamed_path; do
 
   # The patch carries one thing the index needs and the name list cannot: whether a test this change
   # adds names the type of a source file it also changed. A removed file has no patch worth reading.
-  patch=''
+  #
+  # It reaches `jq` as a file rather than as an argument, because Linux caps a *single* argv string
+  # at 32 pages — 128 KiB — however much room the whole argument list has. A patch past that fails
+  # `execve` with `E2BIG`, which under `set -e` ends the run rather than dropping one record: the
+  # whole reading is lost on exactly the large change most likely to owe something.
+  : > "$work_directory/patch"
   if [[ "$local_status" != 'removed' ]]; then
-    patch="$(git diff "$base_ref" -- "$path" | sed -n '/^@@/,$p')"
+    git diff "$base_ref" -- "$path" | sed -n '/^@@/,$p' > "$work_directory/patch"
   fi
 
+  # `--rawfile` reads the file verbatim, trailing newline and all, where the command substitution it
+  # replaces dropped one. The trailing newlines are stripped back off so the record keeps the shape
+  # the pipeline's own `files.json` has, which is what lets both callers share one index.
   jq -nc \
     --arg filename "$path" \
     --arg previous "$previous_path" \
     --arg status "$local_status" \
-    --arg patch "$patch" \
+    --rawfile patch "$work_directory/patch" \
     '{filename: $filename,
       previous_filename: (if $previous == "" then null else $previous end),
       status: $status,
-      patch: (if $patch == "" then null else $patch end)}' \
+      patch: ($patch | sub("\n+$"; "") | if . == "" then null else . end)}' \
     >> "$work_directory/records"
 done < <(git diff --name-status --find-renames "$base_ref")
 

--- a/scripts/test-agent-workflow.sh
+++ b/scripts/test-agent-workflow.sh
@@ -4888,6 +4888,11 @@ review_obligations_reports_on_a_patch_past_the_argument_limit() {
 
   create_review_obligations_fixture "$fixture_root"
 
+  # Nothing is staged here, and the omission is the point rather than an oversight: the fixture's
+  # base commit already carries `MailboxWidget.cs`, so overwriting it is a tracked modification that
+  # `git diff --name-status` reports on its own. The tests above stage what they write because they
+  # write `MailboxSprocket.cs`, which the fixture does not carry — an unstaged file there would be
+  # reported as untracked instead of diffed, which is the case one of them exists to cover.
   local filler line
   filler="$(printf 'x%.0s' {1..64})"
   {

--- a/scripts/test-agent-workflow.sh
+++ b/scripts/test-agent-workflow.sh
@@ -4878,6 +4878,32 @@ review_obligations_reports_without_gating() {
   run_review_obligations "$fixture_root" "$output_file"
 }
 
+# Linux caps a *single* argv string at 128 KiB however much room the whole argument list has, so a
+# patch past that fails `execve` and — under `set -e` — ends the run with `Argument list too long`
+# instead of dropping one record. A diff that rewrites or removes a large file is exactly the change
+# most likely to owe a test or a page, so the reading is lost where it is worth the most.
+review_obligations_reports_on_a_patch_past_the_argument_limit() {
+  local fixture_root="$test_directory/review-obligations-large-patch"
+  local output_file="$test_directory/review-obligations-large-patch-output"
+
+  create_review_obligations_fixture "$fixture_root"
+
+  local filler line
+  filler="$(printf 'x%.0s' {1..64})"
+  {
+    printf 'internal sealed class MailboxWidget;\n'
+    for ((line = 0; line < 4000; line++)); do
+      printf '// %s\n' "$filler"
+    done
+  } > "$fixture_root/src/Application/Emails/MailboxWidget.cs"
+
+  run_review_obligations "$fixture_root" "$output_file"
+
+  assert_excludes 'Argument list too long' "$output_file"
+  assert_contains 'Nothing under tests/ names MailboxWidget.' "$output_file"
+  assert_contains 'None of this is a finding.' "$output_file"
+}
+
 # A migration owes no unit test. `AGENTS.md` makes migrations append-only and generated, so an index
 # that listed them would put the same wrong finding in front of the reviewer on every schema change.
 obligation_index_leaves_migrations_out() {
@@ -7074,6 +7100,7 @@ run_test obligation_index_caps_the_tests_it_lists_for_one_type
 run_test review_obligations_reports_a_source_the_working_tree_leaves_untested
 run_test review_obligations_names_the_untracked_paths_no_diff_contains
 run_test review_obligations_reports_without_gating
+run_test review_obligations_reports_on_a_patch_past_the_argument_limit
 run_test obligation_index_leaves_migrations_out
 run_test group_split_gives_every_changed_file_exactly_one_reader
 run_test group_split_never_exceeds_the_reader_ceiling


### PR DESCRIPTION
## What this changes

`scripts/review-obligations.sh` built each `files.json` record by passing the file's patch to `jq` as a single argv string. Linux caps a *single* argv string at `MAX_ARG_STRLEN` — 32 pages, 128 KiB — however much room the whole argument list has, so a patch past that failed `execve` with `E2BIG`:

```
./scripts/review-obligations.sh: line 75: /usr/bin/jq: Argument list too long
```

`set -euo pipefail` turned that into an exit rather than a dropped record, so the whole obligations reading was lost — on exactly the shape of change most likely to owe a test or a page: the one that removes or rewrites a large file. Observed on the branch behind #1032, whose diff removes 2,100 lines from `src/Infrastructure/Persistence/MailFathomDbContext.cs`.

`jq` already reads a file into a string with `--rawfile`, which passes a path instead of the content and has no size limit. The patch is written to `$work_directory/patch` and read from there.

## Why the record shape is unchanged

`--rawfile` reads the file verbatim, trailing newline and all, where the command substitution it replaces dropped one. `sub("\n+$"; "")` strips it back off, so the record is byte-identical to what the previous composition produced — for a non-empty patch and for a removed file, whose empty patch still becomes `null`. That is what keeps `.github/fathom-review/index-obligations.sh` a single implementation with two callers, so a rule cannot hold in review and lapse in the pipeline.

jq's `$` is Perl-style — end of string, or immediately before a trailing newline — rather than a Ruby line anchor, so `\n+$` cannot reach an interior newline. Verified against `"a\n\n\nb\n"`, which loses only the final one.

## Scope

`.github/fathom-review/index-obligations.sh` is untouched: it is handed the `files.json` GitHub returns and composes no such argument, so only the local adapter ever had this failure.

## Verification

- The limit reproduces: `jq --arg` fails with `Argument list too long` at 140 KB, `jq --rawfile` returns the same string.
- New contract test `review_obligations_reports_on_a_patch_past_the_argument_limit` drives the fixture through a ~276 KB single-file patch and asserts the report is produced rather than the error.
- That test is red against `main`'s script and green against this one: with the fix reverted the suite reports `237 passed, 1 failed`, and the one failure is the new test.
- `scripts/test-agent-workflow.sh`: 238 passed, 0 failed.
- `scripts/verify-full.sh`: passed, build 0 warnings / 0 errors, 10,388 unit tests passed.

## Contract surfaces

No break. The MCP tool contract, the configuration schema, the database schema, and the deployment contract are all untouched.

Closes #1063
