### PR TITLE
[#1085] Carry every local instruction file into a worktree, not only the root one

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -4,10 +4,14 @@
 .env
 .env.local
 
-# The personal instructions Claude Code loads after CLAUDE.md, where a fork's contributor states which role
-# their sessions run in. Gitignored, so it otherwise exists only in the checkout it was written in, which is
-# never the worktree the work happens in.
-CLAUDE.local.md
+# The personal instructions somebody writes for their own agent sessions: CLAUDE.local.md at the root, which
+# Claude Code loads after CLAUDE.md and where a fork's contributor states which role their sessions run in, and
+# whatever a second stack keeps beside its own work. Gitignored, so one otherwise exists only in the checkout it
+# was written in, which is never the worktree the work happens in. Matched by suffix rather than by that one
+# name because .gitignore covers the suffix too, and only paths that are also gitignored are copied: the pattern
+# can be exactly as wide as the ignore rule it mirrors, so a local instruction file is carried into a worktree
+# because of what it is rather than because somebody remembered to list it here.
+*.local.md
 
 # Claude Code already resolves .claude/settings.local.json to the main checkout, so a worktree sees
 # the same permissions without this line. It is listed anyway so the file is present on disk for

--- a/docs/operations/agent-workflow.md
+++ b/docs/operations/agent-workflow.md
@@ -442,10 +442,14 @@ instead of adding to it; its global `~/.codex/AGENTS.md` is read before the
 repository's files, and that is where the same sentences go. `.gitignore`
 carries `*.local.md` so neither can reach a commit by accident — no protected
 path catches one, because `CLAUDE.local.md` is not `CLAUDE.md` and the guard
-matches a whole file name. `.worktreeinclude` copies `CLAUDE.local.md` into a
-new worktree for the same reason it copies `.env`: a gitignored file otherwise
+matches a whole file name. `.worktreeinclude` copies `*.local.md` into a new
+worktree for the same reason it copies `.env`: a gitignored file otherwise
 exists only in the checkout it was written in, and the workspace an agent works
-in is not that one.
+in is not that one. It matches the same suffix `.gitignore` does rather than the
+one root name, so a local instruction file kept beside a second stack's own work
+arrives in the worktree as well; only paths that are already gitignored are ever
+copied, which is what lets the pattern be exactly as wide as the ignore rule it
+mirrors.
 
 Four sentences are enough, and what earns a place in one is what an agent would
 otherwise get wrong: which remote is which, that project `4` is unreachable and


### PR DESCRIPTION
## What changed

`.worktreeinclude` now matches `*.local.md` instead of the single path `CLAUDE.local.md`, and `docs/operations/agent-workflow.md` § *The two roles* names the pattern where it describes what a new worktree carries.

`.gitignore` already covers local instruction files by suffix, and says why: the rule holds for whatever the next harness reads instead of being amended for each name. `.worktreeinclude` named one path, so a local instruction file called anything else was copied into no worktree — it existed in the checkout it was written in and nowhere the work happens. A second stack under `frontend/` brings instructions of its own, which belong beside the work rather than in one root file both stacks read.

The comment on the entry records what makes the wider pattern safe: only paths that are also gitignored are copied, so the pattern can be exactly as wide as the ignore rule it mirrors and no wider.

## Verification

- Verified rather than reasoned about, in a throwaway repository against Claude Code 2.1.234: with `*.local.md` in `.worktreeinclude` and in `.gitignore`, a worktree created by `EnterWorktree` carried both `CLAUDE.local.md` and `frontend/AGENTS.local.md`. The implementation enumerates candidates with `git ls-files --others --ignored --exclude-standard --directory` and filters them through the `.worktreeinclude` patterns, which is why a gitignore-syntax glob works and why nothing outside the ignore set can be reached.
- `scripts/test-agent-workflow.sh` — 241 passed, 0 failed. It makes no assertion about the contents of `.worktreeinclude`, only about the protected-paths guard that covers the file name, so nothing there had to move.
- `scripts/verify-full.sh` — passed.
- `scripts/review-obligations.sh` — the only page whose `describes:` marker covers `.worktreeinclude` is `docs/operations/agent-workflow.md`, and it is in this change.

## Public surfaces

No break. The MCP tool contract, the configuration schema, the database schema, and the deployment contract are untouched; this changes which gitignored files a local worktree is given.

## Out of scope

The content of any local instruction file, and `.gitignore`, which already states the rule this aligns to.

Closes #1085.

Issue: https://github.com/Krzysztof318/MailFathom/issues/1085
Pull request: https://github.com/Krzysztof318/MailFathom/pull/1086
