### PR TITLE
[#1103] Open the repository in VS Code and load both stacks, instead of neither

### DIFF
--- a/MailFathom.code-workspace
+++ b/MailFathom.code-workspace
@@ -1,0 +1,207 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+//
+// The VS Code entry point for this repository, because the repository root is not a solution directory. Each stack
+// owns its own solution — backend/MailFathom.slnx and frontend/MailFathom.Client.slnx — so a root opened on its own
+// loads neither: C# Dev Kit finds no project, and the Uno Platform extension reports `Uno SDK not found`, which names
+// the state it ended in rather than the step that failed. Open this file instead, with `code MailFathom.code-workspace`
+// or File → Open Workspace from File.
+//
+// This is a VS Code file and nothing else reads it. Rider and Visual Studio open a solution directly and neither has
+// the problem it solves. `.vscode/` stays gitignored, which is why every section below is inline here rather than in
+// a per-user file the repository would have to start tracking.
+{
+  // The order of these three is a contract rather than a preference, and `scripts/test-agent-workflow.sh` asserts it.
+  // The Uno Platform extension resolves the solution from `workspace.workspaceFolders[0]` and from nowhere else, and
+  // when it finds none there it scans that one directory for project files without descending into it. So the client
+  // has to be first: with `backend` first the extension would find a solution that names no Uno project and stop, and
+  // client work would be unavailable in the editor. Nothing is lost by the ordering, because C# Dev Kit reads every
+  // folder and its Solution Explorer switches between the two solutions.
+  //
+  // The third entry is the repository itself, for everything belonging to neither stack — `docs/`, `deploy/`,
+  // `scripts/`, `.github/`, and the root files. `files.exclude` below keeps the two stacks from appearing twice under
+  // it.
+  "folders": [
+    {
+      "name": "client",
+      "path": "frontend"
+    },
+    {
+      "name": "service",
+      "path": "backend"
+    },
+    {
+      "name": "repository",
+      "path": "."
+    }
+  ],
+
+  "settings": {
+    // Applied per folder root, so this hides the two stacks from the `repository` entry and reaches nothing inside
+    // `frontend` or `backend`, neither of which contains a directory by either name. Quick Open and search still find
+    // every file in both, through the folders that own them.
+    "files.exclude": {
+      "backend": true,
+      "frontend": true
+    },
+    // The lock files, the golden manifests, and the generated site are read rather than edited, and a search that
+    // returns them buries the file that was actually being looked for.
+    "search.exclude": {
+      "**/packages.lock.json": true,
+      "deploy/helm/mailfathom/ci/golden": true,
+      "docfx/_site": true
+    },
+    // The build already enforces this through `.editorconfig`, `EnforceCodeStyleInBuild`, and `TreatWarningsAsErrors`.
+    // Applying it on save is what keeps a formatting failure out of the gate rather than into it.
+    "editor.formatOnSave": true,
+    "[csharp]": {
+      "editor.defaultFormatter": "ms-dotnettools.csharp"
+    },
+    // `.slnx` is the solution format both stacks use, and VS Code has no built-in association for it.
+    "files.associations": {
+      "*.slnx": "xml",
+      "*.code-workspace": "jsonc"
+    },
+    // Both stacks pin the SDK through the root `global.json`, so nothing here should reach for another one.
+    "dotnet.dotnetPath": "",
+    "dotnet.server.useOmnisharp": false
+  },
+
+  "extensions": {
+    // What a fresh machine is prompted to install. C# Dev Kit loads the solutions, the Uno extension owns the client's
+    // XAML, its Hot Reload, and its debugger, and the YAML extension is for the workflows and the Helm chart. None of
+    // them is a dependency of what MailFathom ships — they are editor tooling, and the third-party register covers
+    // what the product carries rather than what a contributor's editor loads.
+    "recommendations": [
+      "ms-dotnettools.csdevkit",
+      "ms-dotnettools.csharp",
+      "unoplatform.vscode",
+      "redhat.vscode-yaml"
+    ]
+  },
+
+  "launch": {
+    "version": "0.2.0",
+    "configurations": [
+      // The Skia desktop head, which is one target framework serving Windows, Linux, and macOS. `coreclr` is the
+      // debugger type for it; the Uno extension's own `Uno` type is for the mono-based heads, which is why the two
+      // configurations below do not match. The pre-launch task name is the shape that extension contributes:
+      // `Uno: {target framework} | {configuration}`.
+      {
+        "name": "Client: desktop head",
+        "type": "coreclr",
+        "request": "launch",
+        "preLaunchTask": "Uno: net10.0-desktop | Debug",
+        "program": "${workspaceFolder:client}/src/Client/bin/Debug/net10.0-desktop/MailFathom.Client.dll",
+        "cwd": "${workspaceFolder:client}/src/Client",
+        "console": "internalConsole",
+        "stopAtEntry": false
+      },
+      // The browser head. It builds the WebAssembly bundle and serves it, so it takes appreciably longer than the
+      // desktop head on a cold build and needs the `wasm-tools` workload installed.
+      {
+        "name": "Client: browser head",
+        "type": "Uno",
+        "request": "launch",
+        "preLaunchTask": "Uno: net10.0-browserwasm | Debug"
+      },
+      // The whole local system: PostgreSQL, the migration run, the service, and the browser head of the client, in the
+      // order the app model declares. This is the same thing `dotnet run --project backend/src/AppHost/AppHost.csproj`
+      // starts, with a debugger attached to the app host itself rather than to the resources it launches.
+      {
+        "name": "Service: app host with the whole orchestration",
+        "type": "coreclr",
+        "request": "launch",
+        "preLaunchTask": "build the app host",
+        "program": "${workspaceFolder:service}/src/AppHost/bin/Debug/net10.0/MailFathom.AppHost.dll",
+        "cwd": "${workspaceFolder:service}/src/AppHost",
+        "console": "internalConsole",
+        "stopAtEntry": false,
+        "env": {
+          "DOTNET_ENVIRONMENT": "Development"
+        },
+        // The dashboard address is the first thing the app host writes, and opening it is what makes the run usable.
+        "serverReadyAction": {
+          "action": "openExternally",
+          "pattern": "\\blogin\\?t=[a-z0-9]+"
+        }
+      },
+      // The orchestration without the client, which is what `Client__Enabled` turns off. Useful when the change under
+      // test is in the service and building a WebAssembly bundle on every start is a minute nobody is spending well.
+      {
+        "name": "Service: app host without the client",
+        "type": "coreclr",
+        "request": "launch",
+        "preLaunchTask": "build the app host",
+        "program": "${workspaceFolder:service}/src/AppHost/bin/Debug/net10.0/MailFathom.AppHost.dll",
+        "cwd": "${workspaceFolder:service}/src/AppHost",
+        "console": "internalConsole",
+        "stopAtEntry": false,
+        "env": {
+          "DOTNET_ENVIRONMENT": "Development",
+          "Client__Enabled": "false"
+        },
+        "serverReadyAction": {
+          "action": "openExternally",
+          "pattern": "\\blogin\\?t=[a-z0-9]+"
+        }
+      }
+    ]
+  },
+
+  "tasks": {
+    "version": "2.0.0",
+    "tasks": [
+      // The client's own build tasks are contributed by the Uno extension rather than declared here, because the set
+      // of them follows the target frameworks `frontend/src/Client/Client.csproj` declares and a copy would go stale
+      // the moment a head is added. What is declared here is everything that extension has no opinion about.
+      {
+        "label": "build the app host",
+        "detail": "Builds backend/src/AppHost, which is what the two service launch configurations run.",
+        "type": "process",
+        "command": "dotnet",
+        "args": [
+          "build",
+          "${workspaceFolder:service}/src/AppHost/AppHost.csproj"
+        ],
+        "problemMatcher": "$msCompile",
+        "group": "build"
+      },
+      {
+        "label": "verify: fast loop",
+        "detail": "scripts/verify-fast.sh — the loop to run while implementing.",
+        "type": "shell",
+        "command": "./scripts/verify-fast.sh",
+        "options": {
+          "cwd": "${workspaceFolder:repository}"
+        },
+        "problemMatcher": [],
+        "group": "test"
+      },
+      {
+        "label": "verify: full gate",
+        "detail": "scripts/verify-full.sh — the gate to pass before committing. Stage the task's files first.",
+        "type": "shell",
+        "command": "./scripts/verify-full.sh",
+        "options": {
+          "cwd": "${workspaceFolder:repository}"
+        },
+        "problemMatcher": [],
+        "group": "test"
+      },
+      {
+        "label": "test the client",
+        "detail": "Runs frontend/tests, which is the suite the client's own gate runs.",
+        "type": "process",
+        "command": "dotnet",
+        "args": [
+          "test",
+          "${workspaceFolder:client}/MailFathom.Client.slnx"
+        ],
+        "problemMatcher": "$msCompile",
+        "group": "test"
+      }
+    ]
+  }
+}

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -1,6 +1,6 @@
 # Local development
 
-<!-- describes: scripts/**, global.json, .config/dotnet-tools.json, .config/typos.toml, .config/CodeCoverage.proj, .config/testconfig.json, frontend/MailFathom.Client.slnx, frontend/Directory.Packages.props, backend/src/AppHost/**, backend/src/Infrastructure/Persistence/MailFathomDbContextDesignTimeFactory.cs, .github/workflows/**, backend/tests/IntegrationTests/ProviderAdapters/**, backend/tools/** -->
+<!-- describes: scripts/**, global.json, MailFathom.code-workspace, .config/dotnet-tools.json, .config/typos.toml, .config/CodeCoverage.proj, .config/testconfig.json, frontend/MailFathom.Client.slnx, frontend/Directory.Packages.props, backend/src/AppHost/**, backend/src/Infrastructure/Persistence/MailFathomDbContextDesignTimeFactory.cs, .github/workflows/**, backend/tests/IntegrationTests/ProviderAdapters/**, backend/tools/** -->
 
 Use the .NET SDK pinned in `global.json`. Test execution is configured for Microsoft Testing Platform through the repository-level `global.json` test runner setting.
 
@@ -9,6 +9,46 @@ Use the .NET SDK pinned in `global.json`. Test execution is configured for Micro
 A development machine also needs **OpenSSL 3.0 or later**, because every TLS connection a running MailFathom makes — to the mail server, to PostgreSQL — is handshaked by the system library rather than by .NET, and its security policy decides which servers are reachable at all. **1.1.1 is the hard floor**: .NET 10 requires it on Unix and [fails to start](https://learn.microsoft.com/en-us/dotnet/core/compatibility/cryptography/10.0/openssl-version-requirement) without it. **Anything between 1.1.1 and 3.0 may work and may not** — it is out of upstream support and nothing in this repository is verified against it, so treat a failure that reproduces only there as an environment problem rather than a defect.
 
 Nothing has to be configured for a mail server that clears the distribution's default policy, which is nearly all of them: a checkout that sets nothing runs at that full-strength policy and negotiates the newest TLS both ends support. Relaxing it is an opt-in for one process — a development mailbox on a server the policy refuses is what [the platform TLS policy](platform-tls-policy.md) is for, and it applies to the host however the host is started.
+
+## Opening the repository in an editor
+
+**The repository root is not a solution directory.** Each stack owns its own — `backend/MailFathom.slnx` and
+`frontend/MailFathom.Client.slnx` — so the root holds no `.sln`, no `.slnx`, and no `.csproj`, and `dotnet restore` run
+there fails with `MSB1003` for the same reason an editor opened there loads nothing.
+
+Rider and Visual Studio open a solution rather than a directory, so neither notices. **VS Code opens a directory**, and
+opening the root gives an editor with no project loaded and one confusing error: the Uno Platform extension reports
+`Uno SDK not found`, which names the state it ended in rather than the step that failed. Its own log has the sequence —
+no solution in the opened folder, a scan of that folder that finds no project, then that message. The Uno SDK is not
+the problem; `global.json` names it and the package restores.
+
+Open `MailFathom.code-workspace` at the repository root instead:
+
+```bash
+code MailFathom.code-workspace
+```
+
+It opens `frontend/`, `backend/`, and the repository itself as three folders, recommends the extensions both stacks
+need, and carries launch configurations for the client's two heads and for the Aspire app host with and without the
+client. `.vscode/` stays gitignored, so everything the repository decides is in that one file and everything a
+contributor decides stays theirs.
+
+**The client is listed first, and that is a contract rather than a preference.** The Uno Platform extension resolves
+its solution from `workspace.workspaceFolders[0]` and from nowhere else; where it finds none it scans that one
+directory without descending. Listing `backend/` first would hand it a solution naming no Uno project, and client work
+would be unavailable in the editor with no indication of why. `scripts/test-agent-workflow.sh` asserts the order, so a
+future edit cannot quietly undo it. C# Dev Kit reads every folder regardless, and its Solution Explorer switches
+between the two solutions.
+
+Two things follow from the Uno extension's own behavior once it is loaded. It reports `Multiple (2) projects are
+loaded, select one using the UI in the status bar` — the client and its unit-test project — and picking
+`Client.csproj` there is what starts the Dev Server. And **signing in to Uno Platform Studio needs a desktop session**,
+which a headless server does not have. The Dev Server says so itself: *this application cannot run without an active
+X11 environment (the DISPLAY environment variable is not set); running in a container or in a Remote VS Code mode is
+not yet supported.* Signing in from an editor running on a machine with a display is the supported answer, and
+forwarding X11 to one — the sign-in window is an ordinary X client — is the other. Nothing about building, testing, or
+running the client depends on it: the licence gates two tools of the Uno App MCP and nothing else, and Hot Reload, the
+Toolkit, and the rest of the App MCP are free-tier.
 
 ## Commands
 

--- a/scripts/test-agent-workflow.sh
+++ b/scripts/test-agent-workflow.sh
@@ -7275,6 +7275,63 @@ every_browser_asset_carries_the_license_header() {
   (( failures == 0 ))
 }
 
+# MailFathom.code-workspace is what a contributor opens, because the repository root is not a solution
+# directory: each stack owns its own solution and a root opened on its own loads neither. Two things
+# about that file are contracts rather than preferences, and both are asserted here because both fail
+# silently — as an editor that loads nothing rather than as a build that stops.
+#
+# The first is the order of the folders. The Uno Platform extension resolves its solution from
+# `workspace.workspaceFolders[0]` and from nowhere else, and where it finds none it scans that one
+# directory for project files without descending. So `frontend` has to be listed first; with `backend`
+# there instead the extension would find a solution naming no Uno project, report `Uno SDK not found`,
+# and leave the client unavailable in the editor. Nothing else notices, which is why this does.
+#
+# The second is the licensing header. A `.code-workspace` is JSON with comments, so it carries the
+# module form of the three lines — the same `//` form a script under docfx/ uses — and no glob above
+# reaches it.
+the_editor_workspace_opens_the_client_first() {
+  local workspace="$source_repository_root/MailFathom.code-workspace"
+  local expected actual first_folder
+
+  if [[ ! -f "$workspace" ]]; then
+    printf 'MailFathom.code-workspace is missing; it is the documented way to open this repository\n' >&2
+    return 1
+  fi
+
+  expected="$(module_license_header)"
+  actual="$(head -n 3 "$workspace")"
+  if [[ "$actual" != "$expected" ]]; then
+    printf 'MailFathom.code-workspace does not open with the license header\n' >&2
+    return 1
+  fi
+
+  first_folder="$(awk '
+    /"folders"/ { in_folders = 1; next }
+    in_folders && /"path"/ {
+      match($0, /"path"[[:space:]]*:[[:space:]]*"[^"]*"/)
+      chunk = substr($0, RSTART, RLENGTH)
+      sub(/.*:[[:space:]]*"/, "", chunk)
+      sub(/"$/, "", chunk)
+      print chunk
+      exit
+    }
+  ' "$workspace")"
+
+  if [[ "$first_folder" != "frontend" ]]; then
+    printf 'MailFathom.code-workspace lists "%s" first. The Uno Platform extension reads workspaceFolders[0], so frontend has to be\n' \
+      "$first_folder" >&2
+    return 1
+  fi
+
+  if [[ ! -f "$source_repository_root/frontend/MailFathom.Client.slnx" ]] ||
+     [[ ! -f "$source_repository_root/backend/MailFathom.slnx" ]]; then
+    printf 'MailFathom.code-workspace names a folder whose solution is not where it says\n' >&2
+    return 1
+  fi
+
+  return 0
+}
+
 # The Podman Quadlet sources under deploy/quadlet/. A systemd unit file is an INI document whose
 # comment character is `#`, so it carries the same three lines a workflow does rather than a form of
 # its own — but no glob above reaches it, and Quadlet reads the extension rather than the content, so
@@ -7672,6 +7729,7 @@ run_test every_yaml_file_carries_the_license_header
 run_test every_browser_asset_carries_the_license_header
 run_test every_container_unit_carries_the_license_header
 run_test every_xaml_file_carries_the_license_header
+run_test the_editor_workspace_opens_the_client_first
 run_test every_shell_script_carries_the_license_header
 run_test every_skill_declares_its_license
 run_test no_tracked_text_file_carries_a_nul_byte


### PR DESCRIPTION
Closes #1103

## What changes

The repository root stopped being a solution directory when #1081 moved `MailFathom.slnx` under `backend/` and #1082 put the client's solution under `frontend/`. Opening the root in VS Code has loaded neither stack since: C# Dev Kit finds no project, and the Uno Platform extension reports `Uno SDK not found`, which names the state it ended in rather than the step that failed. Its own log has the real sequence — no solution in the opened folder, a scan of that folder that finds no project, then that message. `dotnet restore` at the root fails the same way with `MSB1003`.

`MailFathom.code-workspace` at the root answers it. It opens `frontend/`, `backend/`, and the repository itself as three folders, carries launch configurations for the client's two heads and for the app host with and without the client, and declares the tasks that are not the Uno extension's to contribute. `.vscode/` stays gitignored, so everything the repository decides is in that one file and everything a contributor decides stays theirs.

**The one thing decided rather than derived is the folder order, and it is asserted rather than commented.** The Uno Platform extension resolves its solution from `workspace.workspaceFolders[0]` and from nowhere else — `Ae()` and `Helper.getSolutionDir()` in its bundle both read index zero — and where it finds no solution there it scans that one directory with a non-recursive `readdirSync`. So `frontend` has to be listed first; with `backend` there instead the extension would be handed a solution naming no Uno project and client work would be unavailable in the editor, with nothing to say why. `the_editor_workspace_opens_the_client_first` in `scripts/test-agent-workflow.sh` holds the order, the licensing header, and the two solution paths, so a later edit cannot quietly undo any of them. C# Dev Kit reads every folder regardless and its Solution Explorer switches between the two solutions.

Two further things the documentation now records, both found while diagnosing this rather than decided here. The extension reports `Multiple (2) projects are loaded, select one using the UI in the status bar` once a folder loads, and picking `Client.csproj` is what starts the Dev Server. And signing in to Uno Platform Studio needs a desktop session — the Dev Server refuses with *this application cannot run without an active X11 environment ... running in a container or in a Remote VS Code mode is not yet supported* — which matters to nobody's build, because the licence gates two tools of the Uno App MCP and nothing else.

## How it was verified

`bash scripts/verify-full.sh` passes on this branch rebased onto `59a1b0b7`: 252 contract assertions, none failing, and the run recorded its digest under `artifacts/verify/`. The new assertion is among them, and it was watched fail first — with `backend` listed first it reports the folder it found and stops.

The workspace file was parsed as JSONC to confirm the comments do not break it, and `git check-ignore` confirms `.gitignore` does not cover it.

**What could not be verified here:** the four launch configurations, by actually starting them. This machine is a headless server, so there is no editor to press F5 in. The debugger types and the pre-launch task names come from the Uno extension's own manifest — `type: "Uno"` for the mono-based heads and `coreclr` for Skia, with `Uno: {target framework} | {configuration}` as the task shape its configuration snippet documents — and the assembly paths from `AssemblyName` in each stack's `Directory.Build.props`. That is derivation rather than a run, and a reviewer with a display should treat it as the thing to check.

## Checklist

- [x] `bash scripts/verify-full.sh` passes on this branch, rebased onto current `main`.
- [x] Behavior changes are covered by unit tests, and the coverage gate passes.
- [x] Affected documentation is updated in this change set.
- [x] `bash scripts/review-obligations.sh` was run, and every row it reported is answered — by a test, by a page, or by why nothing is owed there.
- [x] `CHANGELOG.md` is untouched — it is written by the release pull request alone.
- [x] Every new C# file carries the repository's standard header, applied by `scripts/verify-fast.sh` rather than typed, and no file gained a second copyright line, an author tag, a name, or a contact detail.
- [x] Nothing here is under terms MailFathom could not distribute under Apache-2.0. A new dependency, service, container image, or externally sourced sample has its row in `THIRD_PARTY_LICENSES.md` in this change set.
- [x] No credential, token, private key, real mailbox data, or personal information is in the diff.

Issue: https://github.com/Krzysztof318/MailFathom/issues/1103
Pull request: https://github.com/Krzysztof318/MailFathom/pull/1104
