### PR TITLE
[#1137] Give the client MailFathom's own theme, in light, dark, and follow-the-system

### DIFF
--- a/frontend/src/Client/App.xaml
+++ b/frontend/src/Client/App.xaml
@@ -6,6 +6,7 @@ Project repository: https://github.com/Krzysztof318/MailFathom
 <Application x:Class="MailFathom.Client.App"
        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+       xmlns:ut="using:Uno.Themes"
        xmlns:utum="using:Uno.Toolkit.UI.Material">
 
   <Application.Resources>
@@ -13,16 +14,13 @@ Project repository: https://github.com/Krzysztof318/MailFathom
       <ResourceDictionary.MergedDictionaries>
         <!-- Load WinUI resources -->
         <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
-        <utum:MaterialToolkitTheme
-          ColorOverrideSource="ms-appx:///Styles/ColorPaletteOverride.xaml">
-          <!-- NOTE: You can override the default Roboto font by providing your font assets here. -->
-          <!-- <utum:MaterialToolkitTheme.FontOverrideDictionary>
-            <ResourceDictionary>
-              <FontFamily x:Key="MaterialLightFontFamily">ms-appx:///Uno.Fonts.Roboto/Fonts/Roboto-Light.ttf#Roboto</FontFamily>
-              <FontFamily x:Key="MaterialMediumFontFamily">ms-appx:///Uno.Fonts.Roboto/Fonts/Roboto-Medium.ttf#Roboto</FontFamily>
-              <FontFamily x:Key="MaterialRegularFontFamily">ms-appx:///Uno.Fonts.Roboto/Fonts/Roboto-Regular.ttf#Roboto</FontFamily>
-            </ResourceDictionary>
-          </utum:MaterialToolkitTheme.FontOverrideDictionary> -->
+        <utum:MaterialToolkitTheme>
+          <!-- The palette overrides Material's own colours for every key it declares, which is why no seed colour is
+               set beside it: a seed generates the ramps at run time, and this application generated them once and
+               wrote the result down, so the values a screen resolves are the values a reader can measure. -->
+          <utum:MaterialToolkitTheme.Colors>
+            <ut:ThemeColors OverrideSource="ms-appx:///Styles/ColorPaletteOverride.xaml" />
+          </utum:MaterialToolkitTheme.Colors>
         </utum:MaterialToolkitTheme>
       </ResourceDictionary.MergedDictionaries>
 

--- a/frontend/src/Client/App.xaml.cs
+++ b/frontend/src/Client/App.xaml.cs
@@ -63,6 +63,10 @@ public partial class App : Application
                 .UseConfiguration(configure: configuration => configuration.EmbeddedSource<App>())
                 .ConfigureServices((context, services) => services.AddMailFathomDeployment(
                     this.ComposeDeployment(context.Configuration)))
+                // Light, dark, and follow-the-system, with the choice written to the platform's own settings store so
+                // the application starts the way it was left. Nothing here decides which one: AppTheme.System is the
+                // default the service reads back when nothing was ever chosen.
+                .UseThemeSwitching()
                 .UseLogging(configure: (context, logBuilder) =>
                     logBuilder
                         .SetMinimumLevel(

--- a/frontend/src/Client/Assets/Icons/icon.svg
+++ b/frontend/src/Client/Assets/Icons/icon.svg
@@ -1,42 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   width="456"
-   height="456"
-   viewBox="0 0 456 456"
-   version="1.1"
-   id="svg453"
-   sodipodi:docname="icon.svg"
-   inkscape:version="1.2 (dc2aedaf03, 2022-05-15)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs457" />
-  <sodipodi:namedview
-     id="namedview455"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     showgrid="false"
-     inkscape:zoom="1.8574561"
-     inkscape:cx="228.26919"
-     inkscape:cy="228.26919"
-     inkscape:window-width="1920"
-     inkscape:window-height="1027"
-     inkscape:window-x="-8"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg453" />
-  <rect
-     x="0"
-     y="0"
-     width="456"
-     height="456"
-     fill="#FFFFFF"
-     id="rect451" />
+<!--
+  The application icon's background layer: MailFathom's navy ground, sampled from assets/icon-900.png. Android's
+  adaptive icon crops this layer to whatever shape the launcher asks for, so it is a full-bleed fill and nothing else;
+  the mark itself is in icon_foreground.svg, which is drawn over it.
+-->
+<svg width="456" height="456" viewBox="0 0 456 456" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="456" height="456" fill="#010D33" />
 </svg>

--- a/frontend/src/Client/Assets/Icons/icon_foreground.svg
+++ b/frontend/src/Client/Assets/Icons/icon_foreground.svg
@@ -1,137 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   width="450"
-   height="450"
-   viewBox="0 0 50.369617 49.826836"
-   version="1.1"
-   id="svg151"
-   sodipodi:docname="icon_foreground.svg"
-   inkscape:version="1.2 (dc2aedaf03, 2022-05-15)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <sodipodi:namedview
-     id="namedview153"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     showgrid="false"
-     inkscape:zoom="1.250876"
-     inkscape:cx="218.64677"
-     inkscape:cy="175.87674"
-     inkscape:window-width="1920"
-     inkscape:window-height="1027"
-     inkscape:window-x="-8"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="g149" />
-  <defs
-     id="defs105">
-    <path
-       id="aj28a0fd1a"
-       d="M 1.738,0.156 3.927,2.323 2.347,3.919 0.101,1.81 Z" />
-    <path
-       id="fdje57jgic"
-       d="M 2.201,0.066 3.855,1.703 1.69,3.894 0.093,2.311 Z" />
-    <path
-       id="6bg72xwlze"
-       d="M 2.398,0.044 3.994,1.624 1.886,3.869 0.232,2.232 Z" />
-    <path
-       id="eaqjnja8wg"
-       d="M 1.736,0.023 3.981,2.132 2.344,3.786 0.156,1.619 Z" />
-  </defs>
-  <g
-     fill="none"
-     fill-rule="evenodd"
-     id="g149"
-     transform="translate(-2.9304427e-4,-1.6465461e-4)">
-    <g
-       id="g147">
-      <g
-         id="g145">
-        <path
-           fill="#7a67f8"
-           d="M 34.758,38.865 H 34.746 C 31.892,38.86 29.342,36.882 26.152,33.692 l -6.93,-6.873 2.166,-2.188 6.937,6.88 c 3.075,3.074 4.876,4.272 6.427,4.275 h 0.005 c 1.567,0 3.467,-1.262 6.558,-4.353 l 3.541,-3.587 c 1.784,-1.784 2.57,-3.34 2.408,-4.762 -0.13,-1.156 -0.894,-2.397 -2.401,-3.904 L 44.83,19.146 C 43.202,17.414 41.211,15.483 39.131,14.414 38.745,12.437 37.48,10.881 37.3,10.596 c 3.803,0.559 7.197,3.703 9.758,6.424 2.788,2.794 5.803,7.176 -0.018,12.996 l -3.54,3.588 c -3.251,3.25 -5.844,5.261 -8.742,5.261"
-           id="path107" />
-        <path
-           fill="#f85977"
-           d="m 25.399,28.608 6.492,-6.562 c 3.076,-3.076 4.274,-4.877 4.276,-6.428 0.004,-1.567 -1.257,-3.469 -4.352,-6.563 L 28.228,5.515 C 24.58,1.867 22.369,2.699 19.561,5.507 L 19.528,5.54 c -1.54,1.448 -3.237,3.182 -4.346,5.01 -1.031,0.073 -2.361,0.424 -3.997,1.518 0.906,-3.397 3.737,-6.422 6.216,-8.755 2.794,-2.789 7.177,-5.804 12.997,0.017 l 3.588,3.54 c 3.255,3.256 5.266,5.851 5.26,8.754 -0.005,2.854 -1.982,5.404 -5.172,8.594 l -6.489,6.559 z"
-           id="path109" />
-        <path
-           fill="#159bff"
-           d="M 12.522,38.707 C 8.939,37.946 5.746,34.972 3.308,32.382 2.035,31.106 0.321,29.13 0.042,26.663 c -0.274,-2.414 0.8,-4.795 3.283,-7.278 l 3.542,-3.588 c 3.25,-3.25 5.843,-5.261 8.74,-5.261 h 0.013 c 2.854,0.005 5.404,1.983 8.593,5.172 l 7.046,6.976 -2.165,2.19 -7.053,-6.983 c -3.076,-3.076 -4.876,-4.273 -6.427,-4.276 h -0.006 c -1.566,0 -3.466,1.261 -6.557,4.352 L 5.51,21.555 c -1.784,1.784 -2.57,3.34 -2.409,4.762 0.131,1.156 0.894,2.396 2.402,3.904 l 0.033,0.034 c 1.55,1.649 3.43,3.479 5.401,4.573 0.168,1.739 1.2,3.297 1.585,3.88"
-           id="path111" />
-        <path
-           fill="#67e5ad"
-           d="m 26.32,49.827 c -1.925,0 -4.114,-0.886 -6.557,-3.33 l -3.588,-3.54 C 9.167,35.949 9.151,32.546 16.086,25.61 l 6.802,-6.872 2.193,2.162 -6.812,6.882 c -3.076,3.076 -4.273,4.877 -4.276,6.427 -0.003,1.568 1.258,3.47 4.352,6.563 l 3.588,3.541 c 3.646,3.647 5.858,2.816 8.666,0.008 l 0.034,-0.033 c 1.654,-1.555 3.5,-3.46 4.593,-5.437 1.661,-0.14 2.9,-0.841 3.835,-1.438 -0.8,3.537 -3.738,6.69 -6.302,9.102 -1.62,1.618 -3.777,3.312 -6.439,3.312"
-           id="path113" />
-        <g
-           transform="translate(21.154,18.577)"
-           id="g120">
-          <mask
-             id="8jptpqrneb"
-             fill="#ffffff">
-            <use
-               xlink:href="#aj28a0fd1a"
-               id="use115" />
-          </mask>
-          <path
-             d="M 0.101,1.81 1.738,0.156 3.927,2.323 2.347,3.919 Z"
-             mask="url(#8jptpqrneb)"
-             id="path118" />
-        </g>
-        <g
-           transform="translate(27.404,20.981)"
-           id="g127">
-          <mask
-             id="b2iljpfwbd"
-             fill="#ffffff">
-            <use
-               xlink:href="#fdje57jgic"
-               id="use122" />
-          </mask>
-          <path
-             d="M 2.201,0.066 3.855,1.703 1.69,3.894 0.093,2.311 Z"
-             mask="url(#b2iljpfwbd)"
-             id="path125" />
-        </g>
-        <g
-           transform="translate(18.99,24.587)"
-           id="g134">
-          <mask
-             id="gj70tyfpnf"
-             fill="#ffffff">
-            <use
-               xlink:href="#6bg72xwlze"
-               id="use129" />
-          </mask>
-          <path
-             d="M 1.886,3.869 0.232,2.232 2.398,0.044 3.994,1.624 Z"
-             mask="url(#gj70tyfpnf)"
-             id="path132" />
-        </g>
-        <g
-           transform="translate(25.24,26.99)"
-           id="g141">
-          <mask
-             id="z7vhvduckh"
-             fill="#ffffff">
-            <use
-               xlink:href="#eaqjnja8wg"
-               id="use136" />
-          </mask>
-          <path
-             d="M 3.981,2.132 2.344,3.786 0.156,1.619 1.736,0.023 Z"
-             mask="url(#z7vhvduckh)"
-             id="path139" />
-        </g>
-      </g>
-    </g>
+<!--
+  MailFathom's mark: an envelope, the traces that carry what is read out of it, and the star that stands for the model
+  reading it. The colours are the ones sampled from assets/icon-900.png rather than palette keys, because this is the
+  source the palette was derived from and an icon is not themed.
+
+  It is drawn on transparency, inside the safe area an adaptive icon leaves once a launcher crops the background layer
+  to its own shape — everything sits within the central circle of the 450x450 canvas.
+-->
+<svg width="450" height="450" viewBox="0 0 200 200" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <!-- The star, four-pointed, at the top of the mark. -->
+  <path d="M100 20 C102.5 39 109 46 128 48 C109 50 102.5 57 100 76 C97.5 57 91 50 72 48 C91 46 97.5 39 100 20 Z"
+        fill="#F8D848" />
+  <path d="M62 34 C63 42 66 45 74 46 C66 47 63 50 62 58 C61 50 58 47 50 46 C58 45 61 42 62 34 Z"
+        fill="#A8C8F8" />
+  <path d="M141 42 C141.8 48 144 50.5 150 51.5 C144 52.5 141.8 55 141 61 C140.2 55 138 52.5 132 51.5 C138 50.5 140.2 48 141 42 Z"
+        fill="#A8C8F8" />
+
+  <!-- The traces, rising out of the envelope towards the star. -->
+  <g fill="none" stroke="#0068F8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M52 106 L52 88 L38 74" />
+    <path d="M76 106 L76 80" />
+    <path d="M124 106 L124 80" />
+    <path d="M148 106 L148 88 L162 74" />
   </g>
+  <g fill="#0068F8">
+    <circle cx="35" cy="71" r="5" />
+    <circle cx="76" cy="76" r="4.5" />
+    <circle cx="124" cy="76" r="4.5" />
+    <circle cx="165" cy="71" r="5" />
+  </g>
+
+  <!-- The envelope: the body in the carrying blue, its open flap in the pale blue the envelope front is drawn in. -->
+  <rect x="24" y="104" width="152" height="72" rx="14" fill="#0048E0" />
+  <path d="M31 111 L100 156 L169 111"
+        fill="none" stroke="#DCE9FF" stroke-width="14" stroke-linecap="round" stroke-linejoin="round" />
 </svg>

--- a/frontend/src/Client/Assets/Splash/splash_screen.svg
+++ b/frontend/src/Client/Assets/Splash/splash_screen.svg
@@ -1,137 +1,36 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   width="450"
-   height="450"
-   viewBox="0 0 50.369617 49.826836"
-   version="1.1"
-   id="svg151"
-   sodipodi:docname="icon_foreground.svg"
-   inkscape:version="1.2 (dc2aedaf03, 2022-05-15)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <sodipodi:namedview
-     id="namedview153"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     showgrid="false"
-     inkscape:zoom="1.250876"
-     inkscape:cx="218.64677"
-     inkscape:cy="175.87674"
-     inkscape:window-width="1920"
-     inkscape:window-height="1027"
-     inkscape:window-x="-8"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="g149" />
-  <defs
-     id="defs105">
-    <path
-       id="aj28a0fd1a"
-       d="M 1.738,0.156 3.927,2.323 2.347,3.919 0.101,1.81 Z" />
-    <path
-       id="fdje57jgic"
-       d="M 2.201,0.066 3.855,1.703 1.69,3.894 0.093,2.311 Z" />
-    <path
-       id="6bg72xwlze"
-       d="M 2.398,0.044 3.994,1.624 1.886,3.869 0.232,2.232 Z" />
-    <path
-       id="eaqjnja8wg"
-       d="M 1.736,0.023 3.981,2.132 2.344,3.786 0.156,1.619 Z" />
-  </defs>
-  <g
-     fill="none"
-     fill-rule="evenodd"
-     id="g149"
-     transform="translate(-2.9304427e-4,-1.6465461e-4)">
-    <g
-       id="g147">
-      <g
-         id="g145">
-        <path
-           fill="#7a67f8"
-           d="M 34.758,38.865 H 34.746 C 31.892,38.86 29.342,36.882 26.152,33.692 l -6.93,-6.873 2.166,-2.188 6.937,6.88 c 3.075,3.074 4.876,4.272 6.427,4.275 h 0.005 c 1.567,0 3.467,-1.262 6.558,-4.353 l 3.541,-3.587 c 1.784,-1.784 2.57,-3.34 2.408,-4.762 -0.13,-1.156 -0.894,-2.397 -2.401,-3.904 L 44.83,19.146 C 43.202,17.414 41.211,15.483 39.131,14.414 38.745,12.437 37.48,10.881 37.3,10.596 c 3.803,0.559 7.197,3.703 9.758,6.424 2.788,2.794 5.803,7.176 -0.018,12.996 l -3.54,3.588 c -3.251,3.25 -5.844,5.261 -8.742,5.261"
-           id="path107" />
-        <path
-           fill="#f85977"
-           d="m 25.399,28.608 6.492,-6.562 c 3.076,-3.076 4.274,-4.877 4.276,-6.428 0.004,-1.567 -1.257,-3.469 -4.352,-6.563 L 28.228,5.515 C 24.58,1.867 22.369,2.699 19.561,5.507 L 19.528,5.54 c -1.54,1.448 -3.237,3.182 -4.346,5.01 -1.031,0.073 -2.361,0.424 -3.997,1.518 0.906,-3.397 3.737,-6.422 6.216,-8.755 2.794,-2.789 7.177,-5.804 12.997,0.017 l 3.588,3.54 c 3.255,3.256 5.266,5.851 5.26,8.754 -0.005,2.854 -1.982,5.404 -5.172,8.594 l -6.489,6.559 z"
-           id="path109" />
-        <path
-           fill="#159bff"
-           d="M 12.522,38.707 C 8.939,37.946 5.746,34.972 3.308,32.382 2.035,31.106 0.321,29.13 0.042,26.663 c -0.274,-2.414 0.8,-4.795 3.283,-7.278 l 3.542,-3.588 c 3.25,-3.25 5.843,-5.261 8.74,-5.261 h 0.013 c 2.854,0.005 5.404,1.983 8.593,5.172 l 7.046,6.976 -2.165,2.19 -7.053,-6.983 c -3.076,-3.076 -4.876,-4.273 -6.427,-4.276 h -0.006 c -1.566,0 -3.466,1.261 -6.557,4.352 L 5.51,21.555 c -1.784,1.784 -2.57,3.34 -2.409,4.762 0.131,1.156 0.894,2.396 2.402,3.904 l 0.033,0.034 c 1.55,1.649 3.43,3.479 5.401,4.573 0.168,1.739 1.2,3.297 1.585,3.88"
-           id="path111" />
-        <path
-           fill="#67e5ad"
-           d="m 26.32,49.827 c -1.925,0 -4.114,-0.886 -6.557,-3.33 l -3.588,-3.54 C 9.167,35.949 9.151,32.546 16.086,25.61 l 6.802,-6.872 2.193,2.162 -6.812,6.882 c -3.076,3.076 -4.273,4.877 -4.276,6.427 -0.003,1.568 1.258,3.47 4.352,6.563 l 3.588,3.541 c 3.646,3.647 5.858,2.816 8.666,0.008 l 0.034,-0.033 c 1.654,-1.555 3.5,-3.46 4.593,-5.437 1.661,-0.14 2.9,-0.841 3.835,-1.438 -0.8,3.537 -3.738,6.69 -6.302,9.102 -1.62,1.618 -3.777,3.312 -6.439,3.312"
-           id="path113" />
-        <g
-           transform="translate(21.154,18.577)"
-           id="g120">
-          <mask
-             id="8jptpqrneb"
-             fill="#ffffff">
-            <use
-               xlink:href="#aj28a0fd1a"
-               id="use115" />
-          </mask>
-          <path
-             d="M 0.101,1.81 1.738,0.156 3.927,2.323 2.347,3.919 Z"
-             mask="url(#8jptpqrneb)"
-             id="path118" />
-        </g>
-        <g
-           transform="translate(27.404,20.981)"
-           id="g127">
-          <mask
-             id="b2iljpfwbd"
-             fill="#ffffff">
-            <use
-               xlink:href="#fdje57jgic"
-               id="use122" />
-          </mask>
-          <path
-             d="M 2.201,0.066 3.855,1.703 1.69,3.894 0.093,2.311 Z"
-             mask="url(#b2iljpfwbd)"
-             id="path125" />
-        </g>
-        <g
-           transform="translate(18.99,24.587)"
-           id="g134">
-          <mask
-             id="gj70tyfpnf"
-             fill="#ffffff">
-            <use
-               xlink:href="#6bg72xwlze"
-               id="use129" />
-          </mask>
-          <path
-             d="M 1.886,3.869 0.232,2.232 2.398,0.044 3.994,1.624 Z"
-             mask="url(#gj70tyfpnf)"
-             id="path132" />
-        </g>
-        <g
-           transform="translate(25.24,26.99)"
-           id="g141">
-          <mask
-             id="z7vhvduckh"
-             fill="#ffffff">
-            <use
-               xlink:href="#eaqjnja8wg"
-               id="use136" />
-          </mask>
-          <path
-             d="M 3.981,2.132 2.344,3.786 0.156,1.619 1.736,0.023 Z"
-             mask="url(#z7vhvduckh)"
-             id="path139" />
-        </g>
-      </g>
-    </g>
+<!--
+  The splash screen's mark. It is the same drawing as the application icon's foreground, on transparency, and the
+  ground behind it is the navy named by UnoSplashScreenColor in Client.csproj rather than anything painted here.
+
+  That is what makes the splash read the same whichever theme the application starts in: it is the logo's own ground
+  with the logo's own colours on it, decided before any theme is applied and unchanged by a later one.
+-->
+<svg width="450" height="450" viewBox="0 0 200 200" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <!-- The star, four-pointed, at the top of the mark. -->
+  <path d="M100 20 C102.5 39 109 46 128 48 C109 50 102.5 57 100 76 C97.5 57 91 50 72 48 C91 46 97.5 39 100 20 Z"
+        fill="#F8D848" />
+  <path d="M62 34 C63 42 66 45 74 46 C66 47 63 50 62 58 C61 50 58 47 50 46 C58 45 61 42 62 34 Z"
+        fill="#A8C8F8" />
+  <path d="M141 42 C141.8 48 144 50.5 150 51.5 C144 52.5 141.8 55 141 61 C140.2 55 138 52.5 132 51.5 C138 50.5 140.2 48 141 42 Z"
+        fill="#A8C8F8" />
+
+  <!-- The traces, rising out of the envelope towards the star. -->
+  <g fill="none" stroke="#0068F8" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M52 106 L52 88 L38 74" />
+    <path d="M76 106 L76 80" />
+    <path d="M124 106 L124 80" />
+    <path d="M148 106 L148 88 L162 74" />
   </g>
+  <g fill="#0068F8">
+    <circle cx="35" cy="71" r="5" />
+    <circle cx="76" cy="76" r="4.5" />
+    <circle cx="124" cy="76" r="4.5" />
+    <circle cx="165" cy="71" r="5" />
+  </g>
+
+  <!-- The envelope: the body in the carrying blue, its open flap in the pale blue the envelope front is drawn in. -->
+  <rect x="24" y="104" width="152" height="72" rx="14" fill="#0048E0" />
+  <path d="M31 111 L100 156 L169 111"
+        fill="none" stroke="#DCE9FF" stroke-width="14" stroke-linecap="round" stroke-linejoin="round" />
 </svg>

--- a/frontend/src/Client/Client.csproj
+++ b/frontend/src/Client/Client.csproj
@@ -21,12 +21,21 @@
     <ApplicationPublisher>Krzysztof Kasprowicz</ApplicationPublisher>
     <Description>The MailFathom client: a mail application with the model in the middle of it.</Description>
 
+    <!-- The two grounds the Uno resizetizer paints behind the assets under Assets/, both the navy the product mark
+         sits on. They are properties rather than anything drawn in an SVG because the resizetizer composes the icon's
+         background layer and the splash's ground itself, and a colour painted in the file would be cropped or scaled
+         with the drawing instead of filling what is behind it. The splash therefore looks the same whichever theme
+         the application starts in: it is decided before a theme is applied and unchanged by a later one. -->
+    <UnoIconBackgroundColor>#010D33</UnoIconBackgroundColor>
+    <UnoSplashScreenColor>#010D33</UnoSplashScreenColor>
+
     <!-- UnoFeatures is how an Uno single project asks for a capability rather than for a package: the SDK resolves each
          one to the packages and versions its own pin decides. Material is the design system every brush and style here
          resolves against, Configuration is what reads the deployment an installed head reaches out of an embedded
          appsettings.json — the one source a browser head can read too — Toolkit adds the controls the shell is built
          from, Hosting and Logging are the generic-host wiring the application starts through, MVUX is the state model,
-         Navigation is the router, and SkiaRenderer is what makes one rendering path serve every head.
+         Navigation is the router, ThemeService is what puts the application into light or dark and remembers which,
+         and SkiaRenderer is what makes one rendering path serve every head.
          https://aka.platform.uno/singleproject-features -->
     <UnoFeatures>
       Material;
@@ -36,6 +45,7 @@
       Logging;
       MVUX;
       Navigation;
+      ThemeService;
       SkiaRenderer;
     </UnoFeatures>
   </PropertyGroup>

--- a/frontend/src/Client/Platforms/WebAssembly/manifest.webmanifest
+++ b/frontend/src/Client/Platforms/WebAssembly/manifest.webmanifest
@@ -1,10 +1,10 @@
 {
-  "background_color": "#ffffff",
+  "background_color": "#010D33",
   "description": "The MailFathom client: a mail application with the model in the middle of it.",
   "display": "standalone",
   "name": "MailFathom",
   "short_name": "MailFathom",
   "start_url": "/index.html",
-  "theme_color": "#ffffff",
+  "theme_color": "#010D33",
   "scope": "/"
 }

--- a/frontend/src/Client/Presentation/MainModel.cs
+++ b/frontend/src/Client/Presentation/MainModel.cs
@@ -2,14 +2,46 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Collections.Immutable;
+
 namespace MailFathom.Client.Presentation;
 
 /// <summary>
-/// The model behind <see cref="MainPage"/>. The application is empty of features, so the only thing it has to say is
-/// what it is: the product name and the version this build was stamped with.
+/// The model behind <see cref="MainPage"/>. The application is empty of features, so what it has to say is what it
+/// is — the product name and the version this build was stamped with — and which theme it is being shown in.
 /// </summary>
 public partial record MainModel
 {
+    private readonly IThemeService themes;
+
+    /// <summary>Initializes the model over the service that puts the application into a theme.</summary>
+    /// <param name="themes">The theme service, which holds the choice and persists it across restarts.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="themes" /> is <see langword="null" />.</exception>
+    public MainModel(IThemeService themes)
+    {
+        ArgumentNullException.ThrowIfNull(themes);
+
+        this.themes = themes;
+    }
+
     /// <summary>What this build of the client reports about itself.</summary>
     public IFeed<ClientBuild> Build => Feed.Async(_ => ValueTask.FromResult(ClientBuild.Current));
+
+    /// <summary>The three themes the application can be put into, in the order a reader is offered them.</summary>
+    /// <remarks>
+    /// <see cref="AppTheme.System"/> is one of the three rather than a mode beside them: following the operating
+    /// system is a value of the same enum, so a reader who never chooses is already in it.
+    /// </remarks>
+    public IImmutableList<AppTheme> ThemeOptions { get; } =
+        [AppTheme.System, AppTheme.Light, AppTheme.Dark];
+
+    /// <summary>The theme the application is in, and the way it is changed.</summary>
+    /// <remarks>
+    /// The state starts at whatever the service read back — the persisted choice, or <see cref="AppTheme.System"/>
+    /// when nothing was ever chosen — and every write is handed straight to the service, which applies it to the
+    /// visual tree and saves it. That is what makes a two-way binding in the view the whole of the interaction.
+    /// </remarks>
+    public IState<AppTheme> Theme => State
+        .Value(this, () => this.themes.Theme)
+        .ForEach(async (theme, _) => await this.themes.SetThemeAsync(theme).ConfigureAwait(false));
 }

--- a/frontend/src/Client/Presentation/MainPage.xaml
+++ b/frontend/src/Client/Presentation/MainPage.xaml
@@ -18,6 +18,7 @@ Project repository: https://github.com/Krzysztof318/MailFathom
       <Grid.RowDefinitions>
         <RowDefinition Height="Auto" />
         <RowDefinition />
+        <RowDefinition Height="Auto" />
       </Grid.RowDefinitions>
 
       <utu:NavigationBar Content="MailFathom" />
@@ -39,6 +40,16 @@ Project repository: https://github.com/Krzysztof318/MailFathom
           </StackPanel>
         </DataTemplate>
       </mvux:FeedView>
+
+      <!-- Theme selection sits outside the FeedView deliberately: it is the application's own state rather than
+           anything the build feed carries, so it stays reachable while that feed is loading or has failed. -->
+      <ComboBox Grid.Row="2"
+                Margin="16"
+                HorizontalAlignment="Center"
+                Header="Theme"
+                AutomationProperties.Name="Theme"
+                ItemsSource="{Binding ThemeOptions}"
+                SelectedItem="{Binding Theme, Mode=TwoWay}" />
     </Grid>
   </ScrollViewer>
 </Page>

--- a/frontend/src/Client/Styles/ColorPaletteOverride.xaml
+++ b/frontend/src/Client/Styles/ColorPaletteOverride.xaml
@@ -3,67 +3,149 @@ Copyright © 2026 Krzysztof Kasprowicz
 Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 Project repository: https://github.com/Krzysztof318/MailFathom
 -->
+<!--
+  MailFathom's palette. Every colour value in this application is here and nowhere else, and every brush a screen
+  reaches resolves from one of these keys through Uno Material's own resources.
+
+  Where the numbers come from. Four colours are sampled from the product mark in assets/icon-900.png: the navy ground
+  #010D33, the blue #0048E0 that carries the envelope and the circuit traces, the envelope's pale blue #A8C8F8, and
+  the star's gold #F8D848. Each becomes a Material Design 3 tonal palette — its hue and chroma in the HCT colour
+  space, sampled at the tone each semantic role is defined at — so the ramps below are generated from those four
+  rather than chosen one key at a time. Every key Uno's palette declares is redeclared here, in both themes, because a
+  key left out falls back to the template's violet.
+
+  Every pair a reader or a control depends on is measured rather than asserted, and the measurements are in
+  frontend/tests/Client.UnitTests/Styles/ColorPaletteOverrideTests.cs, which reads this file and fails the build below
+  WCAG AA — 4.5:1 for text and 3:1 for an outline or a control state.
+-->
 <ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
   <ResourceDictionary.ThemeDictionaries>
     <ResourceDictionary x:Key="Light">
-      <Color x:Key="PrimaryColor">#5946D2</Color>
+      <!-- Primary — the blue that carries the envelope and the traces in the logo. Tone 40 in light and tone 80 in
+           dark, which is Material's own placement for the role a screen's principal action is drawn in. -->
+      <Color x:Key="PrimaryColor">#124EE5</Color>
       <Color x:Key="OnPrimaryColor">#FFFFFF</Color>
-      <Color x:Key="PrimaryContainerColor">#E5DEFF</Color>
-      <Color x:Key="OnPrimaryContainerColor">#170065</Color>
-      <Color x:Key="SecondaryColor">#6B4EA2</Color>
+      <Color x:Key="PrimaryContainerColor">#DBE1FF</Color>
+      <Color x:Key="OnPrimaryContainerColor">#001454</Color>
+      <Color x:Key="PrimaryInverseColor">#B5C4FF</Color>
+
+      <!-- The two legacy Material 2 variants. Nothing this application writes reaches them; they are here because
+           Uno's palette declares them, and a key left undeclared would resolve to the template's violet. -->
+      <Color x:Key="PrimaryVariantDarkColor">#0037BA</Color>
+      <Color x:Key="PrimaryVariantLightColor">#B5C4FF</Color>
+
+      <!-- Secondary — the envelope's own pale blue. Its tone 80 is that colour exactly, which is why the role reads
+           as the logo in dark and as a quieter version of the primary in light. -->
+      <Color x:Key="SecondaryColor">#40608A</Color>
       <Color x:Key="OnSecondaryColor">#FFFFFF</Color>
-      <Color x:Key="SecondaryContainerColor">#EBDDFF</Color>
-      <Color x:Key="OnSecondaryContainerColor">#220555</Color>
-      <Color x:Key="TertiaryColor">#0061A4</Color>
+      <Color x:Key="SecondaryContainerColor">#D3E4FF</Color>
+      <Color x:Key="OnSecondaryContainerColor">#001C3B</Color>
+
+      <!-- The same two legacy variants for the secondary role. -->
+      <Color x:Key="SecondaryVariantDarkColor">#264871</Color>
+      <Color x:Key="SecondaryVariantLightColor">#A8C8F8</Color>
+
+      <!-- Tertiary — the star's gold, and the one role in this palette that is reserved rather than general. It marks
+           what the model contributed: a generated draft, a suggested answer, a classification the model made.
+           Nothing else takes it. A highlight that is not the model's is drawn in the primary or in a surface
+           variant, because a gold that appears wherever emphasis is wanted stops saying anything at all. -->
+      <Color x:Key="TertiaryColor">#705D00</Color>
       <Color x:Key="OnTertiaryColor">#FFFFFF</Color>
-      <Color x:Key="TertiaryContainerColor">#CFE4FF</Color>
-      <Color x:Key="OnTertiaryContainerColor">#001D36</Color>
-      <Color x:Key="ErrorColor">#B3261E</Color>
-      <Color x:Key="ErrorContainerColor">#F9DEDC</Color>
+      <Color x:Key="TertiaryContainerColor">#FFE258</Color>
+      <Color x:Key="OnTertiaryContainerColor">#221B00</Color>
+
+      <!-- Error — Material's own error hue rather than a brand colour. What a failure looks like is a convention a
+           reader already knows, and spending the brand on it would cost that recognition for nothing. -->
+      <Color x:Key="ErrorColor">#B4261E</Color>
       <Color x:Key="OnErrorColor">#FFFFFF</Color>
-      <Color x:Key="OnErrorContainerColor">#410E0B</Color>
-      <Color x:Key="BackgroundColor">#FCFBFF</Color>
-      <Color x:Key="OnBackgroundColor">#1C1B1F</Color>
+      <Color x:Key="ErrorContainerColor">#FFDAD3</Color>
+      <Color x:Key="OnErrorContainerColor">#410001</Color>
+
+      <!-- Background and surface. The dark ground is the logo's own navy: the neutral ramp is built at the navy's hue
+           with enough chroma that its tone 6 lands there, so the application sits on the colour the mark sits on
+           rather than on grey. In light the same ramp is almost white, because chroma barely shows at tone 99. -->
+      <Color x:Key="BackgroundColor">#FDFBFF</Color>
+      <Color x:Key="OnBackgroundColor">#111A37</Color>
       <Color x:Key="SurfaceColor">#FFFFFF</Color>
-      <Color x:Key="OnSurfaceColor">#1C1B1F</Color>
-      <Color x:Key="SurfaceVariantColor">#F2EFF5</Color>
-      <Color x:Key="OnSurfaceVariantColor">#8B8494</Color>
-      <Color x:Key="OutlineColor">#79747E</Color>
-      <Color x:Key="OnSurfaceInverseColor">#F4EFF4</Color>
-      <Color x:Key="SurfaceInverseColor">#313033</Color>
-      <Color x:Key="PrimaryInverseColor">#C8BFFF</Color>
-      <Color x:Key="SurfaceTintColor">#5946D2</Color>
-      <Color x:Key="OutlineVariantColor">#C9C5D0</Color>
+      <Color x:Key="OnSurfaceColor">#111A37</Color>
+      <Color x:Key="SurfaceVariantColor">#EAEDFF</Color>
+      <Color x:Key="OnSurfaceVariantColor">#414659</Color>
+      <Color x:Key="SurfaceInverseColor">#262F4D</Color>
+      <Color x:Key="OnSurfaceInverseColor">#EEF0FF</Color>
+      <Color x:Key="SurfaceTintColor">#124EE5</Color>
+
+      <!-- Outlines, from a quieter ramp at the same hue, so a border separates from the ground without competing with
+           the blue that carries the brand. -->
+      <Color x:Key="OutlineColor">#71768B</Color>
+      <Color x:Key="OutlineVariantColor">#C1C5DC</Color>
+
+      <!-- The shadow is the brand navy rather than black, and it is heavier in dark, where a shadow has less contrast
+           to work with. -->
+      <Color x:Key="ShadowColor">#33010D33</Color>
     </ResourceDictionary>
+
     <ResourceDictionary x:Key="Dark">
-      <Color x:Key="PrimaryColor">#C7BFFF</Color>
-      <Color x:Key="OnPrimaryColor">#2A009F</Color>
-      <Color x:Key="PrimaryContainerColor">#4129BA</Color>
-      <Color x:Key="OnPrimaryContainerColor">#E4DFFF</Color>
-      <Color x:Key="SecondaryColor">#CDC2DC</Color>
-      <Color x:Key="OnSecondaryColor">#332D41</Color>
-      <Color x:Key="SecondaryContainerColor">#433C52</Color>
-      <Color x:Key="OnSecondaryContainerColor">#EDDFFF</Color>
-      <Color x:Key="TertiaryColor">#9FCAFF</Color>
-      <Color x:Key="OnTertiaryColor">#003258</Color>
-      <Color x:Key="TertiaryContainerColor">#00497D</Color>
-      <Color x:Key="OnTertiaryContainerColor">#D1E4FF</Color>
-      <Color x:Key="ErrorColor">#FFB4AB</Color>
-      <Color x:Key="ErrorContainerColor">#93000A</Color>
-      <Color x:Key="OnErrorColor">#690005</Color>
-      <Color x:Key="OnErrorContainerColor">#FFDAD6</Color>
-      <Color x:Key="BackgroundColor">#1C1B1F</Color>
-      <Color x:Key="OnBackgroundColor">#E5E1E6</Color>
-      <Color x:Key="SurfaceColor">#302D37</Color>
-      <Color x:Key="OnSurfaceColor">#E6E1E5</Color>
-      <Color x:Key="SurfaceVariantColor">#47464F</Color>
-      <Color x:Key="OnSurfaceVariantColor">#C9C5D0</Color>
-      <Color x:Key="OutlineColor">#928F99</Color>
-      <Color x:Key="OnSurfaceInverseColor">#1C1B1F</Color>
-      <Color x:Key="SurfaceInverseColor">#E6E1E5</Color>
-      <Color x:Key="PrimaryInverseColor">#2A009F</Color>
-      <Color x:Key="SurfaceTintColor">#C7BFFF</Color>
-      <Color x:Key="OutlineVariantColor">#57545D</Color>
+      <!-- Primary — the blue that carries the envelope and the traces in the logo. Tone 40 in light and tone 80 in
+           dark, which is Material's own placement for the role a screen's principal action is drawn in. -->
+      <Color x:Key="PrimaryColor">#B5C4FF</Color>
+      <Color x:Key="OnPrimaryColor">#002485</Color>
+      <Color x:Key="PrimaryContainerColor">#0037BA</Color>
+      <Color x:Key="OnPrimaryContainerColor">#DBE1FF</Color>
+      <Color x:Key="PrimaryInverseColor">#124EE5</Color>
+
+      <!-- The two legacy Material 2 variants. Nothing this application writes reaches them; they are here because
+           Uno's palette declares them, and a key left undeclared would resolve to the template's violet. -->
+      <Color x:Key="PrimaryVariantDarkColor">#0037BA</Color>
+      <Color x:Key="PrimaryVariantLightColor">#B5C4FF</Color>
+
+      <!-- Secondary — the envelope's own pale blue. Its tone 80 is that colour exactly, which is why the role reads
+           as the logo in dark and as a quieter version of the primary in light. -->
+      <Color x:Key="SecondaryColor">#A8C8F8</Color>
+      <Color x:Key="OnSecondaryColor">#093159</Color>
+      <Color x:Key="SecondaryContainerColor">#264871</Color>
+      <Color x:Key="OnSecondaryContainerColor">#D3E4FF</Color>
+
+      <!-- The same two legacy variants for the secondary role. -->
+      <Color x:Key="SecondaryVariantDarkColor">#264871</Color>
+      <Color x:Key="SecondaryVariantLightColor">#A8C8F8</Color>
+
+      <!-- Tertiary — the star's gold, and the one role in this palette that is reserved rather than general. It marks
+           what the model contributed: a generated draft, a suggested answer, a classification the model made.
+           Nothing else takes it. A highlight that is not the model's is drawn in the primary or in a surface
+           variant, because a gold that appears wherever emphasis is wanted stops saying anything at all. -->
+      <Color x:Key="TertiaryColor">#E4C535</Color>
+      <Color x:Key="OnTertiaryColor">#3A3000</Color>
+      <Color x:Key="TertiaryContainerColor">#554600</Color>
+      <Color x:Key="OnTertiaryContainerColor">#FFE258</Color>
+
+      <!-- Error — Material's own error hue rather than a brand colour. What a failure looks like is a convention a
+           reader already knows, and spending the brand on it would cost that recognition for nothing. -->
+      <Color x:Key="ErrorColor">#FFB4A8</Color>
+      <Color x:Key="OnErrorColor">#690001</Color>
+      <Color x:Key="ErrorContainerColor">#910809</Color>
+      <Color x:Key="OnErrorContainerColor">#FFDAD3</Color>
+
+      <!-- Background and surface. The dark ground is the logo's own navy: the neutral ramp is built at the navy's hue
+           with enough chroma that its tone 6 lands there, so the application sits on the colour the mark sits on
+           rather than on grey. In light the same ramp is almost white, because chroma barely shows at tone 99. -->
+      <Color x:Key="BackgroundColor">#08122E</Color>
+      <Color x:Key="OnBackgroundColor">#DAE1FF</Color>
+      <Color x:Key="SurfaceColor">#151E3B</Color>
+      <Color x:Key="OnSurfaceColor">#DAE1FF</Color>
+      <Color x:Key="SurfaceVariantColor">#414659</Color>
+      <Color x:Key="OnSurfaceVariantColor">#C1C5DC</Color>
+      <Color x:Key="SurfaceInverseColor">#DAE1FF</Color>
+      <Color x:Key="OnSurfaceInverseColor">#262F4D</Color>
+      <Color x:Key="SurfaceTintColor">#B5C4FF</Color>
+
+      <!-- Outlines, from a quieter ramp at the same hue, so a border separates from the ground without competing with
+           the blue that carries the brand. -->
+      <Color x:Key="OutlineColor">#8C90A6</Color>
+      <Color x:Key="OutlineVariantColor">#414659</Color>
+
+      <!-- The shadow is the brand navy rather than black, and it is heavier in dark, where a shadow has less contrast
+           to work with. -->
+      <Color x:Key="ShadowColor">#8C010D33</Color>
     </ResourceDictionary>
   </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/frontend/src/README.md
+++ b/frontend/src/README.md
@@ -25,8 +25,35 @@ What is inside the two projects:
 | `Client.Backend/Authorization/` | Signing in: discovery, the proof key, the exchange, and the token held in memory for the run |
 
 The application is empty of features. It shows what it is — the product name and the version this build was stamped
-with, read from the assembly rather than written here, so the client and the service report one number.
+with, read from the assembly rather than written here, so the client and the service report one number — and which
+theme it is being shown in.
 
 It reaches MailFathom over the endpoints `backend/src/Host/` exposes and shares nothing else with it: no build file, no
 package manifest, no configuration file, and no type. Which deployment it reaches is the composing host's to state, and
 nothing states it yet. `AGENTS.md` beside this file states why, and states the conventions anything added here follows.
+
+## How it looks
+
+The client wears MailFathom's own colours rather than the Uno template's. Four are sampled from the product mark in
+[`assets/icon-900.png`](../../assets/icon-900.png) — the navy ground, the blue that carries the envelope and the
+circuit traces, the envelope's pale blue, and the star's gold — and each becomes a Material Design 3 tonal palette in
+`Client/Styles/ColorPaletteOverride.xaml`, sampled at the tone every semantic role is defined at. So the file is
+generated from four decisions rather than chosen one key at a time, and every key Uno's palette declares carries a
+value in both the light and the dark dictionary. The gold is the one role that is reserved rather than general: it is
+the tertiary role and it marks what the model contributed, which is why nothing else takes it.
+
+Every pair a reader or a control depends on is measured rather than asserted. The unit suite reads that file and fails
+below WCAG AA — 4.5:1 for text and 3:1 for an outline or a control state — so a value edited to look better and a role
+repointed at another tone both arrive as a failing test naming the pair.
+
+The application offers **light**, **dark**, and **follow the system**, through `Uno.Extensions.Toolkit.IThemeService`
+and its `AppTheme`, which the `ThemeService` feature brings in and `UseThemeSwitching()` registers. Following the
+operating system is a value of that enum rather than a mechanism beside it, so a reader who never chooses is already in
+it, a choice is written to the platform's own settings store and survives a restart on both heads, and `System` tracks
+the operating system flipping while the application is running.
+
+The application icon and the splash screen carry that mark rather than the template's, drawn in the sampled colours
+rather than in palette keys — an icon is not themed, and the palette was derived from those colours rather than the
+other way round. Both grounds are the navy, named by `UnoIconBackgroundColor` and `UnoSplashScreenColor` in
+`Client/Client.csproj` rather than painted in an SVG, because the Uno resizetizer composes the ground itself. The
+splash therefore reads the same whichever theme the application starts in.

--- a/frontend/tests/Client.UnitTests/Client.UnitTests.csproj
+++ b/frontend/tests/Client.UnitTests/Client.UnitTests.csproj
@@ -10,6 +10,19 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- The palette itself, beside the tests that measure it. It is linked rather than copied so there is one file
+         rather than two that have to agree, and it reaches the suite as a file because parsing XAML into a resource
+         dictionary needs a visual tree this host does not have. It is a `None` rather than a `Content` item because
+         Uno's asset pipeline reaches this project through the application reference and puts every `Content` item
+         under a folder named after the assembly, which is how `ms-appx:///` addresses an asset and is not what a
+         `File.Open` beside the test assembly is looking for. -->
+    <None Include="..\..\src\Client\Styles\ColorPaletteOverride.xaml"
+          Link="Styles/ColorPaletteOverride.xaml"
+          TargetPath="Styles/ColorPaletteOverride.xaml"
+          CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Client\Client.csproj" />
     <!-- Named as well as reached through the application, because this suite covers it directly and a reference that
          only arrives transitively is one a later change to the application could take away. -->

--- a/frontend/tests/Client.UnitTests/Presentation/MainModelTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/MainModelTests.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Client.Presentation;
+using MailFathom.Client.UnitTests.TestDoubles;
 
 namespace MailFathom.Client.UnitTests.Presentation;
 
@@ -13,12 +14,96 @@ public sealed class MainModelTests
     public async Task Build_TheScaffoldModel_YieldsTheRunningBuild()
     {
         // Arrange
-        await using var model = new MainModel();
+        await using var model = new MainModel(new StubThemeService());
 
         // Act
         var build = await model.Build;
 
         // Assert
         Assert.Equal(ClientBuild.Current, build);
+    }
+
+    /// <summary>Following the operating system is one of the three choices rather than an absence of one.</summary>
+    [Fact]
+    public async Task ThemeOptions_TheScaffoldModel_OffersSystemLightAndDark()
+    {
+        // Arrange
+        await using var model = new MainModel(new StubThemeService());
+
+        // Act
+        var options = model.ThemeOptions;
+
+        // Assert
+        Assert.Equal([AppTheme.System, AppTheme.Light, AppTheme.Dark], options);
+    }
+
+    /// <summary>The state starts at what the service read back, which is the choice a previous run persisted.</summary>
+    [Fact]
+    public async Task Theme_AServiceHoldingAPersistedChoice_StartsAtThatChoice()
+    {
+        // Arrange
+        var themes = new StubThemeService { Theme = AppTheme.Dark };
+        await using var model = new MainModel(themes);
+
+        // Act
+        var theme = await model.Theme;
+
+        // Assert
+        Assert.Equal(AppTheme.Dark, theme);
+    }
+
+    /// <summary>Writing the state is the whole of changing the theme: the service is what applies and persists it.</summary>
+    /// <remarks>
+    /// The state hands the value over on its own pipeline rather than inside the write, so the assertion waits for the
+    /// service to be reached instead of reading the recording straight after the write, which would be a race.
+    /// </remarks>
+    [Fact]
+    public async Task Theme_WrittenByTheView_IsHandedToTheThemeService()
+    {
+        // Arrange
+        var themes = new StubThemeService();
+        await using var model = new MainModel(themes);
+        _ = await model.Theme;
+        var handedOver = new TaskCompletionSource<AppTheme>(TaskCreationOptions.RunContinuationsAsynchronously);
+        themes.ThemeChanged += (_, theme) =>
+        {
+            if (theme is AppTheme.Light)
+            {
+                handedOver.TrySetResult(theme);
+            }
+        };
+
+        // Act
+        await model.Theme.SetAsync(AppTheme.Light, TestContext.Current.CancellationToken);
+
+        // Assert
+        var applied = await handedOver.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        Assert.Equal(AppTheme.Light, applied);
+    }
+
+    /// <summary>
+    /// The property is expression-bodied, so it is worth stating that it hands back one state rather than building a
+    /// new one per read: a second state would carry a second subscription to the service and would leave the binding
+    /// in the view and anything the model read holding different values of the same thing.
+    /// </summary>
+    [Fact]
+    public async Task Theme_ReadTwice_IsOneState()
+    {
+        // Arrange
+        await using var model = new MainModel(new StubThemeService());
+
+        // Act
+        var (first, second) = (model.Theme, model.Theme);
+
+        // Assert
+        Assert.Same(first, second);
+    }
+
+    /// <summary>A model that could be constructed without a theme service would be one whose theme silently did nothing.</summary>
+    [Fact]
+    public void Constructor_NoThemeService_IsRefused()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new MainModel(null!));
     }
 }

--- a/frontend/tests/Client.UnitTests/Styles/ColorPaletteOverrideTests.cs
+++ b/frontend/tests/Client.UnitTests/Styles/ColorPaletteOverrideTests.cs
@@ -1,0 +1,201 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Globalization;
+using System.Xml.Linq;
+
+namespace MailFathom.Client.UnitTests.Styles;
+
+/// <summary>
+/// Reads <c>Styles/ColorPaletteOverride.xaml</c> and holds it to what a reader depends on.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The palette is the one place a colour value is written in this application, and a screen written against it can
+/// only be as legible as the pairs it resolves. Contrast is therefore measured here rather than asserted in a pull
+/// request: a value edited to look better and a role repointed at a different tone both arrive as a failing test
+/// naming the pair, which is the only reading of it that survives the next change.
+/// </para>
+/// <para>
+/// The file is read rather than the running application's resources, because parsing XAML into a resource dictionary
+/// needs a visual tree and this suite deliberately has none — <c>frontend/tests/AGENTS.md</c> states which cases that
+/// rules out. What is asserted here is the source of every brush, which is what the question is about.
+/// </para>
+/// </remarks>
+public sealed class ColorPaletteOverrideTests
+{
+    private const double TextContrast = 4.5;
+    private const double NonTextContrast = 3.0;
+
+    private static readonly IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> Themes = ReadPalette();
+
+    /// <summary>
+    /// The pairs a reader or a control actually depends on, with the ratio WCAG AA asks of each. Text takes 4.5:1; an
+    /// outline and a control state are non-text contrast and take 3:1.
+    /// </summary>
+    public static TheoryData<string, string, string, double> ContrastObligations()
+    {
+        var obligations = new TheoryData<string, string, string, double>();
+        (string Foreground, string Background, double Minimum)[] pairs =
+        [
+            ("OnBackgroundColor", "BackgroundColor", TextContrast),
+            ("OnSurfaceColor", "SurfaceColor", TextContrast),
+            ("OnSurfaceVariantColor", "SurfaceColor", TextContrast),
+            ("OnSurfaceVariantColor", "SurfaceVariantColor", TextContrast),
+            ("OnPrimaryColor", "PrimaryColor", TextContrast),
+            ("OnPrimaryContainerColor", "PrimaryContainerColor", TextContrast),
+            ("OnSecondaryColor", "SecondaryColor", TextContrast),
+            ("OnSecondaryContainerColor", "SecondaryContainerColor", TextContrast),
+            ("OnTertiaryColor", "TertiaryColor", TextContrast),
+            ("OnTertiaryContainerColor", "TertiaryContainerColor", TextContrast),
+            ("OnErrorColor", "ErrorColor", TextContrast),
+            ("OnErrorContainerColor", "ErrorContainerColor", TextContrast),
+            ("OnSurfaceInverseColor", "SurfaceInverseColor", TextContrast),
+            ("OutlineColor", "SurfaceColor", NonTextContrast),
+            ("OutlineColor", "BackgroundColor", NonTextContrast),
+            ("PrimaryColor", "SurfaceColor", NonTextContrast),
+            ("PrimaryColor", "BackgroundColor", NonTextContrast),
+            ("ErrorColor", "SurfaceColor", NonTextContrast),
+            ("PrimaryInverseColor", "SurfaceInverseColor", NonTextContrast),
+        ];
+
+        foreach (var theme in Themes.Keys)
+        {
+            foreach (var (foreground, background, minimum) in pairs)
+            {
+                obligations.Add(theme, foreground, background, minimum);
+            }
+        }
+
+        return obligations;
+    }
+
+    /// <summary>A key present in one theme and missing from the other is a role that stops resolving when the theme flips.</summary>
+    [Fact]
+    public void ThemeDictionaries_TheTwoThemes_DeclareTheSameRoles()
+    {
+        // Arrange
+        var light = Themes["Light"].Keys.Order(StringComparer.Ordinal);
+        var dark = Themes["Dark"].Keys.Order(StringComparer.Ordinal);
+
+        // Act & Assert
+        Assert.Equal(light, dark);
+    }
+
+    /// <summary>Every value has to be a colour a XAML parser accepts, in the one notation this file writes them in.</summary>
+    [Fact]
+    public void ThemeDictionaries_EveryDeclaredValue_IsAColourLiteral()
+    {
+        // Arrange
+        var values = Themes.SelectMany(theme => theme.Value.Select(entry => (theme.Key, entry.Key, entry.Value)));
+
+        // Act & Assert
+        foreach (var (theme, key, value) in values)
+        {
+            Assert.True(
+                TryParseColour(value, out _),
+                $"{theme}/{key} is '{value}', which is neither #RRGGBB nor #AARRGGBB.");
+        }
+    }
+
+    /// <summary>
+    /// The Uno template's violet is what this palette replaced, so its two signature values reappearing means the file
+    /// was regenerated from the template rather than edited.
+    /// </summary>
+    [Theory]
+    [InlineData("#5946D2")]
+    [InlineData("#C7BFFF")]
+    public void ThemeDictionaries_TheTemplatePalette_SurvivesInNeitherTheme(string templateValue)
+    {
+        // Arrange
+        var values = Themes.SelectMany(theme => theme.Value.Values);
+
+        // Act & Assert
+        Assert.DoesNotContain(templateValue, values, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Each pair a reader depends on, measured against the ratio WCAG AA asks of it.</summary>
+    [Theory]
+    [MemberData(nameof(ContrastObligations))]
+    public void ThemeDictionaries_APairAReaderDependsOn_MeetsWcagAa(
+        string theme,
+        string foreground,
+        string background,
+        double minimum)
+    {
+        // Arrange
+        var values = Themes[theme];
+        Assert.True(values.ContainsKey(foreground), $"{theme} declares no {foreground}.");
+        Assert.True(values.ContainsKey(background), $"{theme} declares no {background}.");
+
+        // Act
+        var ratio = ContrastRatio(values[foreground], values[background]);
+
+        // Assert
+        Assert.True(
+            ratio >= minimum,
+            FormattableString.Invariant(
+                $"{theme}: {foreground} {values[foreground]} on {background} {values[background]} is {ratio:F2}:1, below the {minimum:F1}:1 WCAG AA asks."));
+    }
+
+    private static Dictionary<string, IReadOnlyDictionary<string, string>> ReadPalette()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Styles", "ColorPaletteOverride.xaml");
+        var document = XDocument.Load(path);
+        XNamespace xaml = "http://schemas.microsoft.com/winfx/2006/xaml";
+        XNamespace presentation = "http://schemas.microsoft.com/winfx/2006/xaml/presentation";
+
+        return document
+            .Descendants(presentation + "ResourceDictionary")
+            .Where(dictionary => dictionary.Attribute(xaml + "Key") is not null)
+            .ToDictionary(
+                dictionary => dictionary.Attribute(xaml + "Key")!.Value,
+                dictionary => (IReadOnlyDictionary<string, string>)dictionary
+                    .Elements(presentation + "Color")
+                    .ToDictionary(
+                        colour => colour.Attribute(xaml + "Key")!.Value,
+                        colour => colour.Value.Trim(),
+                        StringComparer.Ordinal),
+                StringComparer.Ordinal);
+    }
+
+    private static bool TryParseColour(string value, out (byte Red, byte Green, byte Blue) colour)
+    {
+        colour = default;
+        if (value.Length is not (7 or 9) || value[0] is not '#')
+        {
+            return false;
+        }
+
+        // An eight-digit literal is #AARRGGBB, so the alpha is dropped: contrast is measured against what a reader
+        // sees, and every colour behind a translucent one here is opaque.
+        var digits = value.Length is 9 ? value[3..] : value[1..];
+        if (!int.TryParse(digits, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var packed))
+        {
+            return false;
+        }
+
+        colour = ((byte)(packed >> 16), (byte)(packed >> 8), (byte)packed);
+        return true;
+    }
+
+    private static double ContrastRatio(string foreground, string background)
+    {
+        var lighter = Math.Max(RelativeLuminance(foreground), RelativeLuminance(background));
+        var darker = Math.Min(RelativeLuminance(foreground), RelativeLuminance(background));
+        return (lighter + 0.05) / (darker + 0.05);
+    }
+
+    private static double RelativeLuminance(string value)
+    {
+        Assert.True(TryParseColour(value, out var colour), $"'{value}' is not a colour literal.");
+        return (0.2126 * Channel(colour.Red)) + (0.7152 * Channel(colour.Green)) + (0.0722 * Channel(colour.Blue));
+
+        static double Channel(byte component)
+        {
+            var normalized = component / 255.0;
+            return normalized <= 0.03928 ? normalized / 12.92 : Math.Pow((normalized + 0.055) / 1.055, 2.4);
+        }
+    }
+}

--- a/frontend/tests/Client.UnitTests/TestDoubles/StubThemeService.cs
+++ b/frontend/tests/Client.UnitTests/TestDoubles/StubThemeService.cs
@@ -1,0 +1,37 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.UnitTests.TestDoubles;
+
+/// <summary>
+/// An <see cref="IThemeService"/> that remembers what it was asked to apply instead of touching a visual tree.
+/// </summary>
+/// <remarks>
+/// The real service reaches <c>Window.Content</c> to set <c>RequestedTheme</c> and the platform's settings store to
+/// persist the choice, neither of which exists in a unit-test host. What a model owes the service is the theme it
+/// hands over, so this keeps the last one and announces every one through <see cref="ThemeChanged"/>.
+/// </remarks>
+internal sealed class StubThemeService : IThemeService
+{
+    /// <inheritdoc />
+    public event EventHandler<AppTheme>? ThemeChanged;
+
+    /// <inheritdoc />
+    public AppTheme Theme { get; set; } = AppTheme.System;
+
+    /// <inheritdoc />
+    public bool IsDark => this.Theme is AppTheme.Dark;
+
+    /// <inheritdoc />
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task<bool> SetThemeAsync(AppTheme theme)
+    {
+        this.Theme = theme;
+        ThemeChanged?.Invoke(this, theme);
+
+        return Task.FromResult(true);
+    }
+}

--- a/frontend/tests/Client.UnitTests/packages.lock.json
+++ b/frontend/tests/Client.UnitTests/packages.lock.json
@@ -1011,6 +1011,7 @@
           "SkiaSharp.Skottie": "[3.119.2, )",
           "SkiaSharp.Views.Uno.WinUI": "[3.119.2, )",
           "Uno.Extensions.Configuration": "[7.2.3, )",
+          "Uno.Extensions.Core.WinUI": "[7.2.3, )",
           "Uno.Extensions.Hosting.WinUI": "[7.2.3, )",
           "Uno.Extensions.Logging.WinUI": "[7.2.3, )",
           "Uno.Extensions.Navigation.Toolkit.WinUI": "[7.2.3, )",


### PR DESCRIPTION
Closes #1137

The client wore the Uno template's violet and had no way to be put into a theme. Both are replaced by decisions the
project took, and the file that carries them is the one place a colour value may be written.

## The palette

`frontend/src/Client/Styles/ColorPaletteOverride.xaml` now declares every one of the thirty-three colour keys
Uno's own palette declares, in a light and a dark dictionary, and no value from the template survives in either.

The numbers are derived rather than picked. Four colours are sampled from the product mark in `assets/icon-900.png`
— the navy ground `#010D33`, the blue `#0048E0` that carries the envelope and the circuit traces, the envelope's
pale blue `#A8C8F8`, and the star's gold `#F8D848` — and each becomes a Material Design 3 tonal palette, sampled at
the tone Material defines each semantic role at (primary at tone 40 in light and 80 in dark, its container at 90 and
30, and so on). So the file follows from four decisions rather than from thirty-three:

| Ramp | Built from | Why |
|---|---|---|
| Primary | `#0048E0` | The blue the mark is carried in; its tone 40 is that colour |
| Secondary | `#A8C8F8` | The envelope's pale blue; its tone 80 is that colour exactly |
| Tertiary | `#F8D848` | The star's gold |
| Error | Material's own error hue | What a failure looks like is a convention a reader already knows |
| Neutral | The navy's hue, at the chroma that lands tone 6 on `#010D33` | So the dark ground is the ground the mark sits on rather than grey |
| Neutral variant | The same hue, quieter | So an outline separates from that ground without competing with the blue |

**The gold has one role and it is written down beside the palette**: it is the tertiary role, and it marks what the
model contributed — a generated draft, a suggested answer, a classification the model made. Nothing else takes it. A
highlight that is not the model's is drawn in the primary or in a surface variant, because a gold that appears
wherever emphasis is wanted stops saying anything at all.

## Contrast, measured

`frontend/tests/Client.UnitTests/Styles/ColorPaletteOverrideTests.cs` reads the palette file itself and holds
nineteen pairs in each theme to WCAG AA — 4.5:1 for text, 3:1 for an outline or a control state. Thirty-eight
measurements, all passing, and a value edited to look better arrives as a failing test naming the pair rather than as
something a later review has to notice.

| Pair | Light | Dark | Needs |
|---|---|---|---|
| body text on the background | 16.64:1 | 14.25:1 | 4.5 |
| body text on a surface | 17.12:1 | 12.65:1 | 4.5 |
| secondary text on a surface | 9.35:1 | 9.59:1 | 4.5 |
| secondary text on a surface variant | 8.04:1 | 5.47:1 | 4.5 |
| label on the primary | 6.47:1 | 7.73:1 | 4.5 |
| label on the primary container | 13.21:1 | 7.19:1 | 4.5 |
| label on the secondary | 6.45:1 | 7.70:1 | 4.5 |
| label on the secondary container | 13.27:1 | 7.26:1 | 4.5 |
| label on the tertiary | 6.45:1 | 7.70:1 | 4.5 |
| label on the tertiary container | 13.29:1 | 7.19:1 | 4.5 |
| label on the error | 6.49:1 | 7.71:1 | 4.5 |
| label on the error container | 13.24:1 | 7.23:1 | 4.5 |
| text on the inverse surface | 11.62:1 | 10.15:1 | 4.5 |
| outline against a surface | 4.50:1 | 5.20:1 | 3.0 |
| outline against the background | 4.38:1 | 5.86:1 | 3.0 |
| primary as a control state on a surface | 6.47:1 | 9.61:1 | 3.0 |
| primary as a control state on the background | 6.29:1 | 10.83:1 | 3.0 |
| error as a control state on a surface | 6.49:1 | 9.64:1 | 3.0 |
| inverse primary on the inverse surface | 7.71:1 | 4.99:1 | 3.0 |

One value is deliberately not the template's: the template's light `OnSurfaceVariantColor` was `#8A8494`, which is
3.6:1 on white and fails AA for the secondary text it is drawn in. The derived ramp puts it at tone 30 instead.

## Light, dark, and follow-the-system

`ThemeService` joins `UnoFeatures`, `UseThemeSwitching()` joins the host, and `MainModel` holds an
`IState<AppTheme>` that starts at whatever the service read back and hands every write straight to it. The service
applies the theme to the visual tree and writes the choice to the platform's own settings store, so it survives a
restart on the desktop head and in the browser, and `AppTheme.System` is one of the three values rather than a mode
beside them — a reader who never chooses is already following the operating system, and the service keeps tracking it
while the application runs.

The one screen there is carries the picker, in its own row outside the `FeedView` so it stays reachable while the
build feed is loading or has failed.

## The mark

`Assets/Icons/icon.svg`, `Assets/Icons/icon_foreground.svg`, and `Assets/Splash/splash_screen.svg` carry MailFathom's
mark — the envelope, the traces rising out of it, and the star — drawn in the sampled colours rather than in palette
keys, because an icon is not themed and those colours are what the palette was derived from. Both grounds are the
navy, named by `UnoIconBackgroundColor` and `UnoSplashScreenColor` rather than painted in an SVG, because the Uno
resizetizer composes the icon's background layer and the splash's ground itself. That is what makes the splash read
the same whichever theme the application starts in: the ground is decided before a theme is applied and unchanged by
a later one. `manifest.webmanifest` declares that navy for `theme_color` and `background_color` instead of white.

## Two things worth naming

- **The palette wiring moves off a deprecated property.** `MaterialToolkitTheme.ColorOverrideSource` is `[Obsolete]`
  in Uno.Themes 7.0.3 — "use `Colors.OverrideSource` on `ThemeColors` instead" — so `App.xaml` now sets
  `MaterialToolkitTheme.Colors` with a `ThemeColors` carrying `OverrideSource`. No seed colour is set beside it: a
  seed would generate the ramps at run time, and this change generated them once and wrote the result down, so the
  values a screen resolves are the values the test above can measure.
- **A commented-out template block went with it.** The `FontOverrideDictionary` example the scaffolding left inside
  `MaterialToolkitTheme` was dead markup in the element this change rewrote. Roboto is unchanged; only the comment is
  gone.

## Breaking changes

None. No configuration key, database column, MCP tool argument, or deployment contract moves.

## Scope

`docs/architecture/solution-structure.md` covers the two project files this change touches, and nothing on it stopped
being true: it describes the client at the level of projects, heads, and package pinning, and a new `UnoFeatures`
entry is exactly what that page says happens instead of a package reference. `THIRD_PARTY_LICENSES.md` already
carries `Uno.Extensions.Core.WinUI`, which is the package the `ThemeService` feature resolves to, so no register row
is owed. `frontend/src/README.md` gains the section describing all of the above.

What the unit suite cannot reach, and what is therefore claimed from a running head rather than asserted: that the
persisted choice survives a restart, and that `System` follows the operating system flipping while the application is
running. Both are `ThemeService`'s own behaviour rather than this change's, and both need a visual tree —
`frontend/tests/AGENTS.md` states why such a case stays out of this suite.
