### PR TITLE
[#1097] State the service's address into the client's build, since a browser head reads no process environment

### DIFF
--- a/backend/src/AppHost/OrchestrationContract.cs
+++ b/backend/src/AppHost/OrchestrationContract.cs
@@ -271,6 +271,16 @@ public static class OrchestrationContract
     /// <summary>The one permission the entry above grants, which is what its key holds and the whole of what it reaches.</summary>
     public const string AdminNarrowedPermission = "mailfathom.admin.read";
 
+    /// <summary>The endpoint the MailFathom host serves its client surface on.</summary>
+    /// <remarks>
+    /// A socket of its own rather than the MCP endpoint's, and the difference is the bind address rather than the
+    /// number. This one is on <see cref="DeveloperLoopbackAddress" />, because the only thing that calls it is a
+    /// browser head served on the same machine, and a wildcard beside a specific address on one port is two sockets
+    /// the operating system grants only one of — so sharing would have meant publishing the client surface wherever
+    /// the MCP endpoint is published, or moving that endpoint to loopback as a side effect.
+    /// </remarks>
+    public const string HostClientEndpointName = "client";
+
     /// <summary>The EF Core migration tool resource.</summary>
     public const string MigrationsResourceName = "mailfathom-migrations";
 
@@ -605,6 +615,15 @@ public static class OrchestrationContract
     /// <summary>The configuration key a developer states the client's development server port under to pin it.</summary>
     /// <remarks>Read the way <see cref="PinnedMcpEndpointPortKey" /> is. Pinning it is what a bookmarked browser tab wants; leaving it unset is what lets a second checkout serve a head of its own.</remarks>
     public const string PinnedClientPortKey = "Ports:Client";
+
+    /// <summary>The configuration key a developer states the client surface's port under to pin it.</summary>
+    /// <remarks>
+    /// Read the way <see cref="PinnedMcpEndpointPortKey" /> is. Pinning it is what a request written once against
+    /// <c>/api/client</c> wants; leaving it unset is what lets a second checkout serve the surface of its own. Nothing
+    /// about the browser head depends on it — that head is told the address by the build that produced it — so this
+    /// exists for whoever calls the surface by hand.
+    /// </remarks>
+    public const string PinnedClientEndpointPortKey = "Ports:ClientEndpoint";
 
     /// <summary>The configuration key a developer states <see langword="false" /> under to run the orchestration without the client.</summary>
     /// <remarks>

--- a/backend/src/AppHost/OrchestrationContract.cs
+++ b/backend/src/AppHost/OrchestrationContract.cs
@@ -320,6 +320,40 @@ public static class OrchestrationContract
     /// </remarks>
     public const string ClientServerUrlsVariable = "ASPNETCORE_URLS";
 
+    /// <summary>The address a developer's own machine serves the client on and reaches the service at.</summary>
+    /// <remarks>
+    /// Loopback, because a WebAssembly bundle built in Debug against somebody's own machine is not something anything
+    /// on a local network has any business loading. Stated once rather than beside each of the three things built from
+    /// it, which have to agree with one another: the address the client's development server binds, the browser origin
+    /// the service is configured to answer, and the address the head is built to call. A page served under one
+    /// spelling and permitted under another is a first call refused on a preflight, which reads as a broken client
+    /// rather than as two spellings of one machine.
+    /// </remarks>
+    public const string DeveloperLoopbackAddress = "127.0.0.1";
+
+    /// <summary>The MSBuild property the client's build takes the deployment address it points its head at from.</summary>
+    /// <remarks>
+    /// <para>
+    /// The one name here handed to a build rather than to a process, and the browser is the reason. Every other
+    /// resource in this app model is told where its dependencies are through its own environment; the client resource
+    /// is a development server that serves static files, and the application runs in a tab that reads none of that
+    /// process's environment — measured while <c>#1095</c> was implemented, against the served document, the runtime
+    /// loader, and every boot document beside them.
+    /// </para>
+    /// <para>
+    /// What the process does do is build the bundle the tab downloads, so the address travels into the build instead.
+    /// <c>frontend/src/Client/Client.csproj</c> writes the value of this property into the runtime host configuration,
+    /// which the WebAssembly SDK carries into the boot configuration the page fetches and every head reads back
+    /// without reflection a trimmer could remove. The desktop head takes the same property and reads the same key out
+    /// of its own <c>runtimeconfig.json</c>, so the two heads differ in nothing but which answer they fall back to.
+    /// </para>
+    /// <para>
+    /// Nothing but this app model states it. A publish that states none emits no such option at all, which is what
+    /// keeps a head served from the container image resolving its deployment as the origin it was fetched from.
+    /// </para>
+    /// </remarks>
+    public const string ClientDeploymentAddressProperty = "MailFathomDeploymentAddress";
+
     /// <summary>The IMAP and SMTP server the integration-test topology synchronizes against.</summary>
     /// <remarks>
     /// Present only under <see cref="IntegrationTestingArgument" />. A developer's orchestration synchronizes the

--- a/backend/src/AppHost/Program.cs
+++ b/backend/src/AppHost/Program.cs
@@ -417,14 +417,15 @@ else
     // port for the proxy it would put in front of a resource and refuses an endpoint that declares none while asking
     // for no proxy — and no proxy is what keeps the socket a client reaches the socket Kestrel opened.
     //
-    // All three are found in one call whether or not any is pinned, because that is what makes them different from each
-    // other; a pinned value then replaces the one it was found for and the others stay where they were put. The third
-    // belongs to the client below, and is found here rather than beside it for that reason: a second call would release
-    // these before choosing, and two sockets handed one number is a run that fails on whichever binds second.
-    var foundPorts = OrchestrationContract.FindFreePorts(3);
+    // All four are found in one call whether or not any is pinned, because that is what makes them different from each
+    // other; a pinned value then replaces the one it was found for and the others stay where they were put. The last
+    // one belongs to the client below, and is found here rather than beside it for that reason: a second call would
+    // release these before choosing, and two sockets handed one number is a run that fails on whichever binds second.
+    var foundPorts = OrchestrationContract.FindFreePorts(4);
     var mcpEndpointPort = PinnedPort(OrchestrationContract.PinnedMcpEndpointPortKey) ?? foundPorts[0];
     var healthEndpointsPort = PinnedPort(OrchestrationContract.PinnedHealthEndpointsPortKey) ?? foundPorts[1];
-    var clientPort = PinnedPort(OrchestrationContract.PinnedClientPortKey) ?? foundPorts[2];
+    var clientEndpointPort = PinnedPort(OrchestrationContract.PinnedClientEndpointPortKey) ?? foundPorts[2];
+    var clientPort = PinnedPort(OrchestrationContract.PinnedClientPortKey) ?? foundPorts[3];
 
     mailFathomHost
         // The MCP endpoint's own socket, stated to the app model and injected into the host's own configuration key, so
@@ -473,7 +474,26 @@ else
             port: healthEndpointsPort,
             targetPort: healthEndpointsPort,
             isProxied: false,
-            env: "HealthEndpoints__Port");
+            env: "HealthEndpoints__Port")
+        // The client surface's socket, declared exactly as the MCP endpoint's is and bound exactly as little: both
+        // sections ship disabled, so this run publishes a number and the host binds nothing under it until this
+        // checkout says otherwise. Enabling a surface that reads the mailbox stays a developer's own act here, the way
+        // McpEndpoint:Enabled is — and it is stated in the host's user secrets rather than by this app model, so the
+        // credential that guards it is decided in the same place and at the same time.
+        //
+        // A socket of its own rather than the MCP endpoint's, though every surface's default port would have shared
+        // one. What cannot be shared is the bind address: a wildcard beside a specific address on one port is two
+        // sockets the operating system grants only one of, so sharing would either publish the client surface wherever
+        // the MCP endpoint is published or move that endpoint to loopback as a side effect. On loopback because the
+        // only thing that calls this is a browser head served on this machine.
+        .WithEnvironment("ClientEndpoint__BindAddress", OrchestrationContract.DeveloperLoopbackAddress)
+        .WithEndpoint(
+            name: OrchestrationContract.HostClientEndpointName,
+            scheme: "tcp",
+            port: clientEndpointPort,
+            targetPort: clientEndpointPort,
+            isProxied: false,
+            env: "ClientEndpoint__Port");
 
     // The client, in the one topology it belongs to. What the app model reaches into the other stack with is a
     // directory and a command: no project under frontend/ enters backend/MailFathom.slnx, no backend project references
@@ -494,12 +514,11 @@ else
     {
         // The two origins this pair is wired from, each composed once because both sides read the same one. The
         // client's is what its development server binds and what the service is told to answer as a browser origin;
-        // the service's is what the head is built to call, and it is the socket the MCP endpoint already binds because
-        // the client surface joins that one rather than opening a fourth.
+        // the service's is the client surface's own socket, declared above, which is what the head is built to call.
         var clientOrigin =
             $"http://{OrchestrationContract.DeveloperLoopbackAddress}:{clientPort.ToString(CultureInfo.InvariantCulture)}";
         var serviceAddress =
-            $"http://{OrchestrationContract.DeveloperLoopbackAddress}:{mcpEndpointPort.ToString(CultureInfo.InvariantCulture)}/";
+            $"http://{OrchestrationContract.DeveloperLoopbackAddress}:{clientEndpointPort.ToString(CultureInfo.InvariantCulture)}/";
 
         builder
             .AddExecutable(
@@ -528,24 +547,15 @@ else
                 targetPort: clientPort,
                 isProxied: false);
 
-        // The service's half of the same wiring, stated only where a head exists to call it: a run without the client
-        // opens no surface for one.
+        // The service's half of the same wiring, and the whole of it: the head's own origin as the one browser origin
+        // the client surface answers, rather than the every-origin posture an unstated list means. A local run is the
+        // one place the exact origin is known, so narrowing it costs nothing and answers in advance the preflight a
+        // deployment will also have to answer — which is what leaves turning the surface on a single key rather than a
+        // key and a puzzle about why the first call was refused.
         //
-        // The client surface answers on the MCP endpoint's own socket, which is what every surface's default port
-        // already means — one socket serving each surface at its own prefix, with the port a request arrived on
-        // deciding which prefixes may be asked for there. That keeps the address a developer reads out of the
-        // dashboard the address the head calls, and it is why the head is pointed at that port rather than at a
-        // fourth one this run would have to find and publish.
-        //
-        // The head's own origin is the one browser origin the endpoint answers, rather than the every-origin posture
-        // an unstated list means: a local run is the one place the exact origin is known, so narrowing it costs
-        // nothing and proves the preflight a deployment will also have to answer. Authentication stays unstated, as it
-        // is on the MCP endpoint here — what a person presents to their own client is a decision of its own, and this
-        // wiring decides only where the client points.
-        mailFathomHost
-            .WithEnvironment("ClientEndpoint__Enabled", "true")
-            .WithEnvironment("ClientEndpoint__Port", mcpEndpointPort.ToString(CultureInfo.InvariantCulture))
-            .WithEnvironment("ClientEndpoint__Cors__AllowedOrigins__0", clientOrigin);
+        // Written only where a head exists to make the request. Turning the surface on is not written here at all, for
+        // the reason stated where its socket is declared.
+        mailFathomHost.WithEnvironment("ClientEndpoint__Cors__AllowedOrigins__0", clientOrigin);
     }
 }
 

--- a/backend/src/AppHost/Program.cs
+++ b/backend/src/AppHost/Program.cs
@@ -492,6 +492,15 @@ else
     // an orchestration that already publishes the address as an endpoint does not need to do for the developer.
     if (OrchestrationContract.ResolveClientEnabled(builder.Configuration[OrchestrationContract.ClientEnabledKey]))
     {
+        // The two origins this pair is wired from, each composed once because both sides read the same one. The
+        // client's is what its development server binds and what the service is told to answer as a browser origin;
+        // the service's is what the head is built to call, and it is the socket the MCP endpoint already binds because
+        // the client surface joins that one rather than opening a fourth.
+        var clientOrigin =
+            $"http://{OrchestrationContract.DeveloperLoopbackAddress}:{clientPort.ToString(CultureInfo.InvariantCulture)}";
+        var serviceAddress =
+            $"http://{OrchestrationContract.DeveloperLoopbackAddress}:{mcpEndpointPort.ToString(CultureInfo.InvariantCulture)}/";
+
         builder
             .AddExecutable(
                 OrchestrationContract.ClientResourceName,
@@ -500,21 +509,43 @@ else
                 "run",
                 "--framework",
                 OrchestrationContract.ClientBrowserTargetFramework,
-                "--no-launch-profile")
+                "--no-launch-profile",
+                // Where the service is, handed to the build rather than to the process. The head runs in a browser tab
+                // and reads none of this process's environment, so the one channel that reaches it is the bundle the
+                // build produces: the client's project file writes this property into the runtime host configuration,
+                // and the WebAssembly SDK carries that into the boot configuration the page fetches.
+                $"--property:{OrchestrationContract.ClientDeploymentAddressProperty}={serviceAddress}")
             // The address the development server binds, stated to it and published to the app model as one number, so
             // the endpoint the dashboard links is the endpoint the browser head is served on. Unproxied for the reason
             // the host's sockets are: what the app model publishes is then what a browser connects to.
             //
             // On loopback, because a WebAssembly bundle built in Debug against a developer's own machine is not
             // something anything on a local network has any business loading.
-            .WithEnvironment(
-                OrchestrationContract.ClientServerUrlsVariable,
-                $"http://127.0.0.1:{clientPort.ToString(CultureInfo.InvariantCulture)}")
+            .WithEnvironment(OrchestrationContract.ClientServerUrlsVariable, clientOrigin)
             .WithHttpEndpoint(
                 name: OrchestrationContract.ClientHttpEndpointName,
                 port: clientPort,
                 targetPort: clientPort,
                 isProxied: false);
+
+        // The service's half of the same wiring, stated only where a head exists to call it: a run without the client
+        // opens no surface for one.
+        //
+        // The client surface answers on the MCP endpoint's own socket, which is what every surface's default port
+        // already means — one socket serving each surface at its own prefix, with the port a request arrived on
+        // deciding which prefixes may be asked for there. That keeps the address a developer reads out of the
+        // dashboard the address the head calls, and it is why the head is pointed at that port rather than at a
+        // fourth one this run would have to find and publish.
+        //
+        // The head's own origin is the one browser origin the endpoint answers, rather than the every-origin posture
+        // an unstated list means: a local run is the one place the exact origin is known, so narrowing it costs
+        // nothing and proves the preflight a deployment will also have to answer. Authentication stays unstated, as it
+        // is on the MCP endpoint here — what a person presents to their own client is a decision of its own, and this
+        // wiring decides only where the client points.
+        mailFathomHost
+            .WithEnvironment("ClientEndpoint__Enabled", "true")
+            .WithEnvironment("ClientEndpoint__Port", mcpEndpointPort.ToString(CultureInfo.InvariantCulture))
+            .WithEnvironment("ClientEndpoint__Cors__AllowedOrigins__0", clientOrigin);
     }
 }
 

--- a/backend/tests/AppHost.UnitTests/OrchestrationContractTests.cs
+++ b/backend/tests/AppHost.UnitTests/OrchestrationContractTests.cs
@@ -197,7 +197,7 @@ public sealed class OrchestrationContractTests
 
     /// <summary>Each socket is pinned under a key of its own, which is what lets one be pinned while the others stay allocated.</summary>
     [Fact]
-    public void PinnedPortKeys_TheFourSocketsTheOrdinaryTopologyPublishes_AreStatedSeparately()
+    public void PinnedPortKeys_TheSocketsTheOrdinaryTopologyPublishes_AreStatedSeparately()
     {
         // Act
         string[] keys =
@@ -205,6 +205,7 @@ public sealed class OrchestrationContractTests
             OrchestrationContract.PinnedMcpEndpointPortKey,
             OrchestrationContract.PinnedHealthEndpointsPortKey,
             OrchestrationContract.PinnedPostgresPortKey,
+            OrchestrationContract.PinnedClientEndpointPortKey,
             OrchestrationContract.PinnedClientPortKey,
         ];
 

--- a/backend/tests/AppHost.UnitTests/OrchestrationContractTests.cs
+++ b/backend/tests/AppHost.UnitTests/OrchestrationContractTests.cs
@@ -313,6 +313,46 @@ public sealed class OrchestrationContractTests
         Assert.Contains(OrchestrationContract.ClientEnabledKey, failure.Message, StringComparison.Ordinal);
     }
 
+    /// <summary>The address the client and the service are wired together on is one nothing outside this machine reaches.</summary>
+    /// <remarks>
+    /// The one property of that constant the compiler cannot state. Three things are built from it — the socket the
+    /// client's development server binds, the browser origin the service is configured to answer, and the address the
+    /// head is built to call — so a value that stopped being loopback would publish a Debug WebAssembly bundle to
+    /// every interface of a developer's machine without any of the three disagreeing about it.
+    /// </remarks>
+    [Fact]
+    public void DeveloperLoopbackAddress_IsAnAddressOnlyThisMachineReaches()
+    {
+        // Act
+        var parsed = IPAddress.TryParse(OrchestrationContract.DeveloperLoopbackAddress, out var address);
+
+        // Assert
+        Assert.True(parsed);
+        Assert.True(IPAddress.IsLoopback(address!));
+    }
+
+    /// <summary>The name the deployment address travels into the client's build under has to be one MSBuild will carry.</summary>
+    /// <remarks>
+    /// It is passed as <c>--property:&lt;name&gt;=&lt;value&gt;</c>, and MSBuild takes a property name to be a letter
+    /// or an underscore followed by letters, digits, underscores, or hyphens. A name outside that is not refused: the
+    /// command line is accepted, the property never comes into being, the condition guarding the item in
+    /// <c>frontend/src/Client/Client.csproj</c> is false, and the head is built with no address at all — which arrives
+    /// as a client calling its own development server rather than as anything the run said.
+    /// </remarks>
+    [Fact]
+    public void ClientDeploymentAddressProperty_IsANameMsBuildAcceptsAsAProperty()
+    {
+        // Act
+        var name = OrchestrationContract.ClientDeploymentAddressProperty;
+
+        // Assert
+        Assert.NotEmpty(name);
+        Assert.True(char.IsAsciiLetter(name[0]) || name[0] == '_');
+        Assert.All(name[1..], character => Assert.True(
+            char.IsAsciiLetterOrDigit(character) || character is '_' or '-',
+            $"'{character}' is not a character an MSBuild property name may carry."));
+    }
+
     private static string IdentifierOf(string prefix) =>
         prefix[(OrchestrationContract.EphemeralResourceNamePrefix.Length + GeneratedIdentifierSeparator.Length)..];
 }

--- a/docs/architecture/solution-structure.md
+++ b/docs/architecture/solution-structure.md
@@ -203,8 +203,11 @@ The client reaches MailFathom over the endpoints `Host` exposes and shares no ty
 OAuth code are its own, stated again at this end rather than referenced across the boundary. Which deployment it
 reaches is the composing head's to supply, through `IDeploymentAddressSource`: an installed head reads the `Deployment`
 section out of an embedded `appsettings.json`, and the browser head reads the origin it was served from, because the
-container image serves the bundle from the same origin as the surface it calls. `frontend/src/AGENTS.md` states what
-governs a change there, and `frontend/tests/AGENTS.md` what governs one in its suite.
+container image serves the bundle from the same origin as the surface it calls. One source belongs to neither head and
+is read in front of both: `BuildStatedDeploymentAddress` takes an address the build that produced the head stated,
+which is how a head an orchestration started — served by its own development server beside the service rather than by
+it — is pointed at the socket the service listens on. `frontend/src/AGENTS.md` states what governs a change there, and
+`frontend/tests/AGENTS.md` what governs one in its suite.
 
 That image is the one place the two stacks meet in a build, and it is a file copy rather than a reference. A stage of
 `deploy/docker/Dockerfile` publishes the browser head and copies its output into the runtime image's `wwwroot`; no

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -53,10 +53,11 @@ what stays each surface's own.
 Every key this section takes is in
 [endpoint configuration](configuration-endpoints.md#clientendpoint), with its default and its constraint.
 
-**A local `aspire run` turns it on for you**, on the port the MCP endpoint already binds and with the browser head's own
-origin as the one origin it answers, because that run starts a head that has to reach something. It configures no
-credential, which is the posture every surface has locally.
-[The client resource](local-development.md#the-client-resource) is what does it and what to state to stop it.
+**A local `aspire run` configures everything but this key**: a loopback socket of its own and the browser head's own
+origin as the one origin it answers, because that run starts a head that has to reach something. It does not turn the
+surface on — that stays a developer's act here as much as anywhere else.
+[The client resource](local-development.md#the-client-resource) is what to state locally, and what is already stated
+for you.
 
 ## What it serves
 

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -53,6 +53,11 @@ what stays each surface's own.
 Every key this section takes is in
 [endpoint configuration](configuration-endpoints.md#clientendpoint), with its default and its constraint.
 
+**A local `aspire run` turns it on for you**, on the port the MCP endpoint already binds and with the browser head's own
+origin as the one origin it answers, because that run starts a head that has to reach something. It configures no
+credential, which is the posture every surface has locally.
+[The client resource](local-development.md#the-client-resource) is what does it and what to state to stop it.
+
 ## What it serves
 
 One route, and deliberately one:

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -302,14 +302,25 @@ into the boot document the page fetches, and the client reads it back through `A
 answer for itself. Nothing else states that property, so a bundle built anywhere else carries no such option and a head
 served from a deployment's own container image still resolves the origin it was fetched from.
 
-The origin it is pointed at is the **MCP endpoint's own socket**, because that is where the client surface answers
-here. Starting the client also enables `ClientEndpoint` on the host, on the port the MCP endpoint already binds — which
-is what every surface's default port means, one socket serving each surface at its own prefix — so the address a
-developer reads out of the dashboard is the address the head calls. The head's own origin is written into
-`ClientEndpoint:Cors:AllowedOrigins` as the one browser origin that endpoint answers, which is what makes the first
-cross-origin call a served request rather than a refused preflight. Neither surface is given a credential here, which
-is the posture the MCP endpoint has always had locally; what a person presents to their own client is a decision of its
-own. A run started with `Client:Enabled` false opens no client surface either — there is no head to call it.
+The origin it is pointed at is the **client surface's own socket**, which this topology publishes beside the MCP
+endpoint's and the probes'. It is on `127.0.0.1`, because the only thing that calls it is a head served on this
+machine, and that is also why it is a socket rather than a share of the MCP endpoint's: a wildcard bind beside a
+specific one on a single port is two sockets the operating system grants only one of, so sharing would have published
+the client surface wherever the MCP endpoint is published.
+
+**The surface itself is off until you turn it on**, exactly as `McpEndpoint` is, and for the same reason: enabling a
+listener that reads the mailbox is a developer's own act rather than something starting a head does for them. What the
+orchestration configures is everything else — the port, the loopback bind, and the head's own origin as the one browser
+origin `ClientEndpoint:Cors:AllowedOrigins` answers — so turning it on is one key beside whichever credential you want
+guarding it, and the first cross-origin call is served rather than refused on a preflight:
+
+```bash
+dotnet user-secrets --project backend/src/Host/Host.csproj set "ClientEndpoint:Enabled" "true"
+```
+
+Leave it off and the head still starts, still knows where the service is, and is refused by a socket nothing is
+listening on — which is the same answer a locally started MCP client gets before `McpEndpoint:Enabled` is set. A run
+started with `Client:Enabled` false configures no origin either, because no head exists to make the request.
 
 A **desktop** head takes the same property and reads the same key, so an orchestration could point one the same way.
 Started by hand it is given none, and reads `Deployment:Address` out of
@@ -329,13 +340,16 @@ where a decision about one machine belongs, out of every checkout:
 dotnet user-secrets --project backend/src/AppHost/AppHost.csproj set "Ports:McpEndpoint" "8080"
 dotnet user-secrets --project backend/src/AppHost/AppHost.csproj set "Ports:HealthEndpoints" "8081"
 dotnet user-secrets --project backend/src/AppHost/AppHost.csproj set "Ports:Postgres" "5432"
+dotnet user-secrets --project backend/src/AppHost/AppHost.csproj set "Ports:ClientEndpoint" "8082"
 dotnet user-secrets --project backend/src/AppHost/AppHost.csproj set "Ports:Client" "5000"
 ```
 
 `8080` and `8081` are the ports [the container image](container-image.md) publishes and `5432` is PostgreSQL's own, so
-those three values are what makes a local run answer where a deployment does; `Ports:Client` answers a different want,
-which is a browser tab that survives a restart of the orchestration. Each key is read on its own, so pinning the MCP
-endpoint leaves the probes, the database, and the client on whatever the run takes. A value that is not a port number
+those three values are what makes a local run answer where a deployment does; the last two answer a different want.
+`Ports:Client` is a browser tab that survives a restart of the orchestration, and `Ports:ClientEndpoint` is a request
+written once against `/api/client` — the browser head needs neither, since it is told where the service is by the build
+that produced it. Each key is read on its own, so pinning the MCP endpoint leaves the probes, the database, the client
+surface, and the head on whatever the run takes. A value that is not a port number
 between `1` and `65535` fails the app host at startup naming the key, rather than being ignored and leaving the address
 to move anyway.
 
@@ -370,10 +384,10 @@ because Aspire injects `OTEL_EXPORTER_OTLP_ENDPOINT` into the resources it start
 only place telemetry export is configured at all — a deployment exports nothing until an operator sets the variable
 themselves. [Telemetry](telemetry.md) records what the host emits and where it goes.
 
-A freshly started host synchronizes nothing and serves no MCP endpoint, because both defaults are the shipped ones.
-Configure a development mailbox through user secrets as [development secrets](#development-secrets) below shows, and
-enable the endpoint the same way when a tool call is what is being tested — in Development the `ReferenceOrInline`
-interpretation keeps the credential a one-liner:
+A freshly started host synchronizes nothing and serves neither the MCP endpoint nor the client surface, because every
+one of those defaults is the shipped one. Configure a development mailbox through user secrets as
+[development secrets](#development-secrets) below shows, and enable the endpoint the same way when a tool call is what
+is being tested — in Development the `ReferenceOrInline` interpretation keeps the credential a one-liner:
 
 ```bash
 dotnet user-secrets --project backend/src/Host/Host.csproj set "McpEndpoint:Enabled" "true"

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -290,15 +290,30 @@ The `IntegrationTesting=true` switch that selects the ephemeral topology leaves 
 it decides every other resource there: a suite that tests the service would otherwise build a WebAssembly bundle on
 every run that no test reads.
 
-**What this resource still does not give the client is the service's address.** The browser head resolves its
+**What tells the head where the service is, is the build rather than the process.** The browser head resolves its
 deployment as the origin it was served from, which is exactly right where a deployment serves the bundle itself and
 wrong here: under `aspire run` the head is served by its own dev server on a socket of its own, so the origin it
 resolves is that socket rather than the host beside it. The app model cannot close that by handing over a value
-either — the head runs in a browser, which reads none of the process environment.
-[Issue #1097](https://github.com/Krzysztof318/MailFathom/issues/1097) owns delivering the address into a locally
-started head, and the cross-origin permission that comes with it. A **desktop** head started by hand has no such gap:
-it reads `Deployment:Address` out of `frontend/src/Client/appsettings.development.json`, which only a Debug build
-reads.
+either — the head runs in a browser, which reads none of the process environment. What that process does do is build
+the bundle the browser downloads, so the address travels into the build: the resource is started with
+`--property:MailFathomDeploymentAddress=<origin>`, `frontend/src/Client/Client.csproj` turns that into a runtime host
+configuration option named `MailFathom.Client.DeploymentAddress`, the WebAssembly SDK carries the runtime configuration
+into the boot document the page fetches, and the client reads it back through `AppContext` before the head is asked to
+answer for itself. Nothing else states that property, so a bundle built anywhere else carries no such option and a head
+served from a deployment's own container image still resolves the origin it was fetched from.
+
+The origin it is pointed at is the **MCP endpoint's own socket**, because that is where the client surface answers
+here. Starting the client also enables `ClientEndpoint` on the host, on the port the MCP endpoint already binds — which
+is what every surface's default port means, one socket serving each surface at its own prefix — so the address a
+developer reads out of the dashboard is the address the head calls. The head's own origin is written into
+`ClientEndpoint:Cors:AllowedOrigins` as the one browser origin that endpoint answers, which is what makes the first
+cross-origin call a served request rather than a refused preflight. Neither surface is given a credential here, which
+is the posture the MCP endpoint has always had locally; what a person presents to their own client is a decision of its
+own. A run started with `Client:Enabled` false opens no client surface either — there is no head to call it.
+
+A **desktop** head takes the same property and reads the same key, so an orchestration could point one the same way.
+Started by hand it is given none, and reads `Deployment:Address` out of
+`frontend/src/Client/appsettings.development.json`, which only a Debug build reads.
 
 ### Pinning a port
 

--- a/frontend/src/AGENTS.md
+++ b/frontend/src/AGENTS.md
@@ -266,6 +266,18 @@ written with no scheme is read as HTTPS, since the alternative would turn an omi
 whether a stated clear-text address is acceptable at all stays `Client.Backend`'s rule, which permits loopback and
 refuses everything else.
 
+**One source is not a head's answer, and it is read before them.** `BuildStatedDeploymentAddress` carries whatever the
+build that produced this head stated, and `App` wraps the head's own source in it, so a new head still owes exactly one
+implementation. It exists for the case neither answer above fits: a head an orchestration started is served by a
+development server on a socket of its own while the service listens on another, so the origin it was fetched from is a
+file server and there is no installation to have written anything. The channel is the build, because a browser reads no
+process environment and has no file beside it — `Client.csproj` writes the value of the `MailFathomDeploymentAddress`
+property into a runtime host configuration option, the WebAssembly SDK carries it into the boot document the page
+fetches, and `AppContext` is what reads it back, with no reflection for the trimmer to remove. The desktop head takes
+the same property and reads the same key out of its own `runtimeconfig.json`. A build that states nothing writes no
+option, which is every published artifact:
+[the client resource](../../docs/operations/local-development.md#the-client-resource) is the one thing that states it.
+
 Add a head, and what it owes is an implementation of that interface — not a branch on the running platform, and not a
 second mechanism invented in a screen.
 

--- a/frontend/src/Client/App.xaml.cs
+++ b/frontend/src/Client/App.xaml.cs
@@ -15,10 +15,10 @@ namespace MailFathom.Client;
 /// </summary>
 public partial class App : Application
 {
-    private readonly IDeploymentAddressSource deploymentAddress;
+    private readonly BuildStatedDeploymentAddress deploymentAddress;
 
     /// <summary>Initializes the singleton application object for a head that is installed rather than served.</summary>
-    /// <remarks>The address comes from what the installation states, which is what a desktop head reads. A head served by the deployment it talks to passes its own source instead, exactly as it registers its own sign-in redirect listener.</remarks>
+    /// <remarks>The address comes from what the installation states, which is what a desktop head reads, unless the build that produced this head stated one — see the constructor below. A head served by the deployment it talks to passes its own source instead, exactly as it registers its own sign-in redirect listener.</remarks>
     public App()
         : this(new ConfiguredDeploymentAddress())
     {
@@ -27,11 +27,18 @@ public partial class App : Application
     /// <summary>Initializes the singleton application object for a head that answers the address question itself.</summary>
     /// <param name="deploymentAddress">How this head learns where its deployment is.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="deploymentAddress" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// An address the build stated takes precedence over whatever the head would have answered, and the wrapping
+    /// happens here rather than at each head so that adding one owes an implementation of the interface and nothing
+    /// else. It is not a head's answer: a head started by an orchestration is served from a socket of its own while
+    /// the service listens on another, so neither the origin it was fetched from nor an installation that does not
+    /// exist can say where the deployment is. A build that stated nothing changes nothing.
+    /// </remarks>
     internal App(IDeploymentAddressSource deploymentAddress)
     {
         ArgumentNullException.ThrowIfNull(deploymentAddress);
 
-        this.deploymentAddress = deploymentAddress;
+        this.deploymentAddress = new BuildStatedDeploymentAddress(deploymentAddress);
 
         this.InitializeComponent();
     }

--- a/frontend/src/Client/Client.csproj
+++ b/frontend/src/Client/Client.csproj
@@ -59,6 +59,27 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
+  <!-- Where the service is, when whoever built this head knows and the head could not find out for itself. A browser
+       head reads no process environment, so the orchestration that starts it cannot hand it an address the way it
+       hands one to every other resource — but it does start the build, and what the build writes is what the browser
+       downloads. A runtime host configuration option is that channel: MSBuild writes it into the runtimeconfig, the
+       WebAssembly SDK carries the runtimeconfig into the boot configuration the page fetches, and the type that reads
+       it back — Deployment/BuildStatedDeploymentAddress.cs — asks AppContext.GetData for this key, with no reflection
+       for the trimmer to remove. That type names the key on its own side: the two names are one decision recorded in
+       two files, because a project and the app model that starts it share no build file. The desktop head takes the
+       same property and reads the same key out of its own runtimeconfig.json.
+
+       Emitted only when the property carries a value, which one caller states and no publish does: the local
+       orchestration's client resource, in backend/src/AppHost/Program.cs. An artifact built without it carries no
+       option at all, so a head served from the container image resolves its deployment as the origin it was fetched
+       from exactly as before. Trim="false" because this is an address rather
+       than a feature switch — the trimmer must not read it as a constant to substitute and branch away. -->
+  <ItemGroup Condition="'$(MailFathomDeploymentAddress)' != ''">
+    <RuntimeHostConfigurationOption Include="MailFathom.Client.DeploymentAddress"
+                                    Value="$(MailFathomDeploymentAddress)"
+                                    Trim="false" />
+  </ItemGroup>
+
   <!-- The bootstrapper deploys and loads what it finds embedded under WasmScripts, but the Uno SDK only ever adds one
        file there by itself: Uno.SingleProject.Wasm.targets includes AppManifest.js by name and globs nothing. A second
        script therefore has to be named here, or it stays an ordinary None item, never reaches the bundle, and the

--- a/frontend/src/Client/Deployment/BuildStatedDeploymentAddress.cs
+++ b/frontend/src/Client/Deployment/BuildStatedDeploymentAddress.cs
@@ -1,0 +1,86 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Deployment;
+
+/// <summary>Takes the deployment address the build of this head stated, and asks the head itself when it stated none.</summary>
+/// <remarks>
+/// <para>
+/// Not a head's own answer, which is why it wraps one rather than standing beside the two. Where a head looks for its
+/// deployment is a property of the head — an installed one reads what somebody wrote, a served one already knows — and
+/// this is the case where neither is true: a head started by an orchestration is served by a development server on a
+/// socket of its own while the service listens on another, so the origin it was fetched from is a file server and
+/// there is no installation to have written anything. The one thing that does know is whatever built it.
+/// </para>
+/// <para>
+/// The channel is the runtime host configuration, because a browser reads no process environment and has no file
+/// beside it. <c>Client.csproj</c> writes <see cref="ConfigurationKey" /> from an MSBuild property, the WebAssembly SDK
+/// carries the runtime configuration into the boot document the page fetches, and the desktop head reads the same key
+/// out of its own <c>runtimeconfig.json</c> — one mechanism, both heads, and no reflection for a trimmer to remove.
+/// </para>
+/// <para>
+/// A build that states nothing writes no key, so this is absent from every artifact but one somebody deliberately
+/// pointed: a bundle published into the container image resolves its deployment as the origin it was served from
+/// exactly as it did before this existed.
+/// </para>
+/// </remarks>
+internal sealed class BuildStatedDeploymentAddress : IDeploymentAddressSource
+{
+    /// <summary>The runtime host configuration key the address is written under.</summary>
+    /// <remarks>
+    /// The same name <c>frontend/src/Client/Client.csproj</c> emits, which is one decision recorded in two files
+    /// because no build file is shared between a project and the app model that starts it. A rename reaching only one
+    /// of them arrives as a head that quietly ignored the address it was given rather than as anything a build says.
+    /// </remarks>
+    public const string ConfigurationKey = "MailFathom.Client.DeploymentAddress";
+
+    private readonly IDeploymentAddressSource head;
+    private readonly string? stated;
+
+    /// <summary>Initializes the source over the head that answers when the build stated no address.</summary>
+    /// <param name="head">How this head answers for itself.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="head" /> is <see langword="null" />.</exception>
+    public BuildStatedDeploymentAddress(IDeploymentAddressSource head)
+        : this(head, AppContext.GetData(ConfigurationKey) as string)
+    {
+    }
+
+    /// <summary>Initializes the source over a stated address rather than over the one this build carries.</summary>
+    /// <param name="head">How this head answers for itself.</param>
+    /// <param name="stated">The address the build stated, or <see langword="null" /> when it stated none.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="head" /> is <see langword="null" />.</exception>
+    /// <remarks>What a test states, since the value the constructor above reads belongs to the whole process and a suite that wrote it would be deciding for every other test in the run.</remarks>
+    internal BuildStatedDeploymentAddress(IDeploymentAddressSource head, string? stated)
+    {
+        ArgumentNullException.ThrowIfNull(head);
+
+        this.head = head;
+        this.stated = stated;
+    }
+
+    /// <inheritdoc />
+    /// <exception cref="InvalidOperationException">Thrown when the build stated something that is not an absolute address.</exception>
+    /// <remarks>
+    /// What is refused here is only the shape no route could be resolved against. Whether the address is one this
+    /// client may carry a token to stays <c>Client.Backend</c>'s rule, which judges every head's answer alike: it
+    /// permits clear text to loopback, which is what a local orchestration hands over, and refuses it to anything
+    /// else.
+    /// </remarks>
+    public Uri Resolve(DeploymentSettings settings)
+    {
+        var built = this.stated?.Trim();
+
+        if (string.IsNullOrEmpty(built))
+        {
+            return this.head.Resolve(settings);
+        }
+
+        return Uri.TryCreate(built, UriKind.Absolute, out var address)
+            ? address
+            : throw new InvalidOperationException(
+                $"'{this.stated}' was built into this head as the deployment to reach, under the runtime host "
+                + $"configuration key '{ConfigurationKey}', and is not an absolute address. Whatever built this head "
+                + "has to state an origin — the scheme, host, and port and nothing else.");
+    }
+}

--- a/frontend/src/Client/Deployment/IDeploymentAddressSource.cs
+++ b/frontend/src/Client/Deployment/IDeploymentAddressSource.cs
@@ -10,6 +10,12 @@ namespace MailFathom.Client.Deployment;
 /// answers are genuinely different mechanisms rather than two values of one. A head that is installed reads what
 /// somebody wrote; a head that was downloaded from the deployment already knows, because it is the deployment that
 /// served it. Composition takes whichever the head handed it and knows about neither.
+/// <para>
+/// One implementation here is not a head's answer at all: <see cref="BuildStatedDeploymentAddress" /> carries what the
+/// build stated and wraps the head's own source, which is the case where neither of the two answers above exists —
+/// a head an orchestration started, served from a socket of its own beside the service. <c>App</c> applies it, so a
+/// new head still owes exactly one implementation of this interface.
+/// </para>
 /// </remarks>
 internal interface IDeploymentAddressSource
 {

--- a/frontend/src/Client/Platforms/WebAssembly/PageOriginDeploymentAddress.cs
+++ b/frontend/src/Client/Platforms/WebAssembly/PageOriginDeploymentAddress.cs
@@ -22,6 +22,12 @@ namespace MailFathom.Client.Platforms.WebAssembly;
 /// rather than as a page that reached whoever served it.
 /// </para>
 /// <para>
+/// The one case this is the wrong answer to is a head an orchestration started, where the origin is a development
+/// server and the service listens on another socket. That is not a second reading of this document — nothing here can
+/// know it — and it is answered before this is asked, by
+/// <see cref="BuildStatedDeploymentAddress" />.
+/// </para>
+/// <para>
 /// This type is compiled into the browser head alone, as everything under <c>Platforms/WebAssembly/</c> is, which is
 /// what lets it use the JavaScript interop no other head has a counterpart for.
 /// </para>

--- a/frontend/src/Client/appsettings.development.json
+++ b/frontend/src/Client/appsettings.development.json
@@ -3,11 +3,15 @@
   // published head ever takes anything from this file, and it is not a fallback for an installation that stated
   // nothing.
   //
-  // What it is for is starting a head from the sources. An installed head refuses to start without a deployment to
-  // reach, which is the right answer for somebody's own machine and the wrong one for a contributor opening a window
-  // to look at a screen, so this states an address for that case. Nothing is expected to answer at it: the local
-  // orchestration serves no client surface today, and where a locally started head learns a real address is a question
-  // of its own.
+  // What it is for is starting a head from the sources by hand. An installed head refuses to start without a
+  // deployment to reach, which is the right answer for somebody's own machine and the wrong one for a contributor
+  // opening a window to look at a screen, so this states an address for that case. Nothing is expected to answer at
+  // it: a head started this way is not started beside a service, and the port one run happened to take is not
+  // something a committed file could know.
+  //
+  // A head the local orchestration starts never reaches this. That orchestration states the service's own address
+  // into the build — see Deployment/BuildStatedDeploymentAddress.cs — and what the build stated is read before
+  // anything an installation wrote.
   "Deployment": {
     "Address": "https://localhost:8080"
   }

--- a/frontend/tests/Client.UnitTests/Client.UnitTests.csproj
+++ b/frontend/tests/Client.UnitTests/Client.UnitTests.csproj
@@ -20,6 +20,15 @@
           Link="Styles/ColorPaletteOverride.xaml"
           TargetPath="Styles/ColorPaletteOverride.xaml"
           CopyToOutputDirectory="PreserveNewest" />
+
+    <!-- The application's project file, on the same terms and for the same reason: one of the two ends of a name that
+         crosses from the build into the code is written here, and only reading the file can say the two still agree.
+         A rename that reached one of them alone would leave AppContext.GetData answering null and the head quietly
+         falling back to its own wrong address, which no build failure and no other test would report. -->
+    <None Include="..\..\src\Client\Client.csproj"
+          Link="Build/Client.csproj"
+          TargetPath="Build/Client.csproj"
+          CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/frontend/tests/Client.UnitTests/Deployment/BuildStatedDeploymentAddressTests.cs
+++ b/frontend/tests/Client.UnitTests/Deployment/BuildStatedDeploymentAddressTests.cs
@@ -1,0 +1,134 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Deployment;
+using MailFathom.Client.UnitTests.TestDoubles;
+
+namespace MailFathom.Client.UnitTests.Deployment;
+
+/// <summary>Covers how a head reads the deployment the build that produced it stated.</summary>
+/// <remarks>
+/// Three claims. A stated address has to be taken instead of the head's own answer rather than beside it, because the
+/// case it exists for is one where that answer is wrong — a browser head served by a development server would
+/// otherwise call the file server it was fetched from. A build that stated nothing has to change nothing at all,
+/// because every published artifact is one of those. And a value nothing can be reached at has to fail while the host
+/// is being composed, naming what was written and where it came from, rather than arriving as a window that cannot
+/// explain itself.
+/// </remarks>
+public sealed class BuildStatedDeploymentAddressTests
+{
+    private static readonly DeploymentSettings AnInstallationStatingNothing = new();
+
+    [Fact]
+    public void Resolve_TheBuildStatedAnAddress_IsTheAddressAndTheHeadIsNotAsked()
+    {
+        // Arrange
+        var head = new StubDeploymentAddressSource();
+        var source = new BuildStatedDeploymentAddress(head, "http://127.0.0.1:8080/");
+
+        // Act
+        var address = source.Resolve(AnInstallationStatingNothing);
+
+        // Assert
+        Assert.Equal(new Uri("http://127.0.0.1:8080/"), address);
+        Assert.False(head.WasAsked);
+    }
+
+    /// <summary>Every artifact nobody pointed is this case, so it has to be the head's own answer and nothing else.</summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Resolve_TheBuildStatedNothing_IsWhateverTheHeadAnswers(string? stated)
+    {
+        // Arrange
+        var head = new StubDeploymentAddressSource();
+        var source = new BuildStatedDeploymentAddress(head, stated);
+
+        // Act
+        var address = source.Resolve(AnInstallationStatingNothing);
+
+        // Assert
+        Assert.Equal(StubDeploymentAddressSource.HeadsOwnAnswer, address);
+        Assert.True(head.WasAsked);
+    }
+
+    /// <summary>A value with surrounding whitespace is an address rather than a build that stated nothing.</summary>
+    [Fact]
+    public void Resolve_TheBuildStatedAnAddressWithSurroundingWhitespace_IsTheAddress()
+    {
+        // Arrange
+        var source = new BuildStatedDeploymentAddress(new StubDeploymentAddressSource(), "  https://mail.example.test/  ");
+
+        // Act
+        var address = source.Resolve(AnInstallationStatingNothing);
+
+        // Assert
+        Assert.Equal(new Uri("https://mail.example.test/"), address);
+    }
+
+    /// <summary>What a mistyped property has to arrive as: a failure naming the key and repeating what was written.</summary>
+    /// <remarks>
+    /// Only the shape no route resolves against is refused here. A value that parses into something no deployment
+    /// could be reached at — a scheme this client does not speak, an address carrying more than an origin — is
+    /// <c>Client.Backend</c>'s refusal and is asserted with it, so one rule judges every head's answer alike.
+    /// </remarks>
+    [Theory]
+    [InlineData("ht!tp://mail.example.test")]
+    [InlineData("api/client")]
+    [InlineData("127.0.0.1:8080")]
+    public void Resolve_TheBuildStatedSomethingThatIsNotAnAddress_FailsNamingTheKeyAndTheValue(string stated)
+    {
+        // Arrange
+        var head = new StubDeploymentAddressSource();
+        var source = new BuildStatedDeploymentAddress(head, stated);
+
+        // Act
+        var failure = Assert.Throws<InvalidOperationException>(() => source.Resolve(AnInstallationStatingNothing));
+
+        // Assert
+        Assert.Contains(stated, failure.Message, StringComparison.Ordinal);
+        Assert.Contains(BuildStatedDeploymentAddress.ConfigurationKey, failure.Message, StringComparison.Ordinal);
+        Assert.False(head.WasAsked);
+    }
+
+    /// <summary>The head is what this wraps, so composing it without one is refused rather than deferred to a run that states no address.</summary>
+    [Fact]
+    public void Construct_NoHead_IsRefused()
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentNullException>(() => new BuildStatedDeploymentAddress(null!, "https://mail.example.test/"));
+    }
+
+    /// <summary>The constructor a head actually composes reads the key the build writes, which is the whole of the channel.</summary>
+    /// <remarks>
+    /// It writes process-wide state, which no other test in this suite reads or writes, and puts it back afterwards.
+    /// The alternative is asserting the mechanism nowhere: every other test here states the value directly, so a
+    /// constructor reading the wrong key would pass all of them.
+    /// </remarks>
+    [Fact]
+    public void Resolve_TheKeyTheBuildWrites_IsWhatTheComposedSourceReads()
+    {
+        // Arrange
+        var head = new StubDeploymentAddressSource();
+
+        AppContext.SetData(BuildStatedDeploymentAddress.ConfigurationKey, "http://127.0.0.1:8080/");
+
+        try
+        {
+            var source = new BuildStatedDeploymentAddress(head);
+
+            // Act
+            var address = source.Resolve(AnInstallationStatingNothing);
+
+            // Assert
+            Assert.Equal(new Uri("http://127.0.0.1:8080/"), address);
+            Assert.False(head.WasAsked);
+        }
+        finally
+        {
+            AppContext.SetData(BuildStatedDeploymentAddress.ConfigurationKey, null);
+        }
+    }
+}

--- a/frontend/tests/Client.UnitTests/Deployment/BuildStatedDeploymentAddressTests.cs
+++ b/frontend/tests/Client.UnitTests/Deployment/BuildStatedDeploymentAddressTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Xml.Linq;
 using MailFathom.Client.Deployment;
 using MailFathom.Client.UnitTests.TestDoubles;
 
@@ -99,6 +100,31 @@ public sealed class BuildStatedDeploymentAddressTests
     {
         // Act, Assert
         Assert.Throws<ArgumentNullException>(() => new BuildStatedDeploymentAddress(null!, "https://mail.example.test/"));
+    }
+
+    /// <summary>The name this type reads is the name the build writes, which is one decision recorded in two files.</summary>
+    /// <remarks>
+    /// The project file is parsed rather than trusted, exactly as <c>ColorPaletteOverrideTests</c> parses the palette
+    /// it depends on, because nothing else can say the two ends still agree. A rename reaching only one of them
+    /// compiles, publishes, and starts: <c>AppContext.GetData</c> answers <see langword="null" />, the head falls back
+    /// to its own answer, and a locally orchestrated client calls its own development server with no failure anywhere
+    /// saying why.
+    /// </remarks>
+    [Fact]
+    public void ConfigurationKey_IsTheNameTheClientProjectWritesIntoTheRuntimeHostConfiguration()
+    {
+        // Arrange
+        var project = XDocument.Load(Path.Combine(AppContext.BaseDirectory, "Build", "Client.csproj"));
+
+        // Act
+        var written = project
+            .Descendants("RuntimeHostConfigurationOption")
+            .Select(option => option.Attribute("Include")?.Value)
+            .ToArray();
+
+        // Assert
+        Assert.NotEmpty(written);
+        Assert.Contains(BuildStatedDeploymentAddress.ConfigurationKey, written, StringComparer.Ordinal);
     }
 
     /// <summary>The constructor a head actually composes reads the key the build writes, which is the whole of the channel.</summary>

--- a/frontend/tests/Client.UnitTests/TestDoubles/StubDeploymentAddressSource.cs
+++ b/frontend/tests/Client.UnitTests/TestDoubles/StubDeploymentAddressSource.cs
@@ -1,0 +1,26 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Deployment;
+
+namespace MailFathom.Client.UnitTests.TestDoubles;
+
+/// <summary>A head's own answer to where its deployment is, scripted, and recording whether it was asked at all.</summary>
+/// <remarks>Whether it was asked is the assertion that matters: an address the build stated has to be taken instead of the head's answer rather than beside it, and a source that answered anyway would be a head reaching two deployments depending on which value won.</remarks>
+internal sealed class StubDeploymentAddressSource : IDeploymentAddressSource
+{
+    /// <summary>The address this stub answers with wherever it is asked.</summary>
+    internal static readonly Uri HeadsOwnAnswer = new("https://the-head-answered-for-itself.test/");
+
+    /// <summary>Gets whether the head was asked to answer for itself.</summary>
+    internal bool WasAsked { get; private set; }
+
+    /// <inheritdoc />
+    public Uri Resolve(DeploymentSettings settings)
+    {
+        this.WasAsked = true;
+
+        return HeadsOwnAnswer;
+    }
+}


### PR DESCRIPTION
Closes #1097

## What it does

An Aspire resource is handed the addresses it depends on through its process environment, and the browser head reads
none of it: `mailfathom-client` is a development server that serves static files, and the application runs in a tab.
What that process *does* do is build the bundle the tab downloads — so the address travels into the build instead.

- The app model starts the client with `--property:MailFathomDeploymentAddress=<origin>`.
- `frontend/src/Client/Client.csproj` turns that into a `RuntimeHostConfigurationOption` named
  `MailFathom.Client.DeploymentAddress`, emitted only when the property carries a value.
- The WebAssembly SDK carries the runtime configuration into the boot document the page fetches, and the new
  `BuildStatedDeploymentAddress` reads it back through `AppContext.GetData` — no reflection for the trimmer to remove.
- `App` wraps whichever `IDeploymentAddressSource` a head handed it, so the precedence exists once and a new head still
  owes exactly one implementation of the interface.

**Both heads take the same mechanism.** The desktop head reads the same key out of its own `runtimeconfig.json`; the two
differ only in the answer they fall back to when no build stated one — `ConfiguredDeploymentAddress` for an installed
head, `PageOriginDeploymentAddress` for a served one.

**Nothing reaches a deployment's shape.** Only the local orchestration states that property, so a publish emits no such
option at all: a head served from the container image resolves the origin it was fetched from, exactly as before, and
#1084's decision stands unchanged.

## Where it points, and the preflight

The host publishes a **socket of its own for the client surface**, beside the MCP endpoint's and the probes', bound to
`127.0.0.1` because the only thing that calls it is a head served on this machine. It is a separate socket rather than
a share of the MCP endpoint's port because the bind address cannot be shared: a wildcard bind beside a specific one on
one port is two sockets the operating system grants only one of, so sharing would have published the client surface
wherever the MCP endpoint is published, or moved that endpoint to loopback as a side effect. It is pinnable under
`Ports:ClientEndpoint` for whoever calls `/api/client` by hand; the browser head needs no pin, since the build carries
the address.

**The surface stays off until a developer turns it on**, exactly as `McpEndpoint` does here — this app model sets
`McpEndpoint__Enabled` only in the integration-test topology and on the mutual-TLS host, never in the developer one, so
a plain `aspire run` serves no mailbox surface and starting a head is not a good enough reason to be the first that
does. `ClientEndpoint:Enabled` goes into the host's own user secrets beside whichever credential guards it.

What the orchestration configures is everything else: the port, the loopback bind, and the head's own origin written
into `ClientEndpoint:Cors:AllowedOrigins` as the one browser origin that endpoint answers, rather than the every-origin
posture an unstated list means. The origin and the development server's own address are composed from one
`clientOrigin` string, so they cannot drift apart — which is what makes turning the surface on one key rather than a
key and a puzzle about why the first call was refused on a preflight.

> This is the second revision. The first enabled `ClientEndpoint` automatically on the MCP endpoint's socket with the
> default `0.0.0.0` bind; review raised it as a P1 against the endpoint's own documented "off unless you turn it on"
> invariant and against this app model's own precedent, and it was right.

**One deviation from the issue's wording.** #1097 names `McpEndpoint:Cors:AllowedOrigins`; it was written before the
client surface became a section of its own. `/api/client` answers on the client listener and is `404` on any other, so
permitting the origin on `McpEndpoint` would have configured the wrong surface. The change configures `ClientEndpoint`
instead, on a socket of its own, and the head is pointed at that socket rather than at the MCP endpoint's.

Authentication stays unstated, as it is on the MCP endpoint here: the issue puts it out of scope, and what a person
presents to their own client is a decision of its own.

## Evidence

The channel was measured rather than assumed, because the issue records that a process environment variable reaches
nothing the head serves:

- `dotnet build -f net10.0-browserwasm -p:MailFathomDeploymentAddress=…` writes the value into
  `MailFathom.Client.runtimeconfig.json` under `configProperties`.
- `dotnet run --framework net10.0-browserwasm --no-launch-profile --property:MailFathomDeploymentAddress=…` starts
  `WasmAppHost` against that runtime configuration, and the `_framework/dotnet.<hash>.js` it **serves over HTTP**
  carries the value in its `configProperties` block — which is what the runtime turns into `AppContext` data.

The orchestration itself was not started: `aspire run` takes a PostgreSQL container and this machine runs several
sessions at once, so the app model's own wiring is reviewed rather than executed. `ListenerCompositionTests` is what
states the socket rules the wiring is read against — two surfaces may name one port, and a wildcard bind beside a
specific one on that port is refused.

## Breaking changes

None. No configuration key, MCP tool argument, database column, or deployment contract changes; the new MSBuild
property and runtime-configuration key are additive and nothing but the local orchestration states them.

## Tests

- `frontend/tests/Client.UnitTests/Deployment/BuildStatedDeploymentAddressTests.cs` — a stated address is taken instead
  of the head's own answer and the head is not asked; a build stating nothing changes nothing; a value nothing can be
  reached at fails naming the key and repeating what was written; and the constructor a head actually composes reads
  the key the build writes.
- `backend/tests/AppHost.UnitTests/OrchestrationContractTests.cs` — the address the pair is wired on is loopback, the
  property name is one MSBuild will carry (a name outside that is not refused: the property simply never comes into
  being and the head is built with no address at all), and the client surface's port is pinned under a key of its own.

## Documentation

- `docs/operations/local-development.md` § *The client resource* replaces the paragraph that recorded the gap.
- `docs/operations/client-endpoint.md` says a local run configures everything but the key that turns the endpoint on,
  and points at that section.
- `docs/architecture/solution-structure.md` names the third address source beside the two heads' own.
- `frontend/src/AGENTS.md` § *Running the client* states the mechanism beside the rule that the client is an HTTP client
  of `backend/src/Host` and nothing more.
