### PR TITLE
[#1147] Let a person point the client at a deployment, and keep that address across restarts

### DIFF
--- a/.config/typos.toml
+++ b/.config/typos.toml
@@ -39,20 +39,33 @@
 # repository is deliberately not in English. `AGENTS.md` puts every artifact in English and the
 # client's localized resource tables are the one thing that rule is not about: what a person reads in
 # the application is read in their own language. A dictionary of English has nothing true to say
-# about those files — Polish `adres` is not a misspelling of `address` — so they are excluded whole
-# rather than word by word, which would fill the vocabulary above with another language's spellings
-# and silence those spellings everywhere else too. The English table stays checked, because it is the
-# one the rest of this repository is written in.
+# about those files: the Polish noun for a network address differs from the English one by two
+# letters, which the checker reads as a misspelling of it. They are excluded whole rather than word
+# by word, because a word admitted above is admitted everywhere, and filling the vocabulary with
+# another language's spellings would stop those spellings being caught in English prose. The English
+# table stays checked, because it is the language the rest of this repository is written in.
 #
 # None of them is a place to put a genuine typo that is inconvenient to fix. What this file says of a
 # string is that it is correct, is deliberate, is not prose, or is not English, and a reader has to
 # be able to trust that it means one of them.
 
 [files]
-# The client's non-English resource tables, for the reason above. A language added to the client adds
-# a line here, deliberately: each one is a statement that this particular file is not English, rather
-# than a pattern that would quietly stop checking the English table beside them.
-extend-exclude = ["frontend/src/Client/Strings/pl/Resources.resw"]
+# The client's non-English resource tables, for the reason above. The negation is what keeps the
+# English one checked, and it has to come second: these are gitignore patterns, so the last one to
+# match a path decides. A language added to the client needs no edit here — it is excluded the day
+# its directory appears, and `en` goes on being read.
+#
+# This is half of the exclusion and `.github/workflows/typo-check.yml` carries the other half, which
+# is not one decision written twice but the two ways `typos` is reached. This field applies to the
+# walk it does when it is given a directory, which is the whole-checkout fallback that workflow
+# takes on a pull request too large to enumerate; a path named on the command line is read whether
+# any of this says so or not. `--force-exclude` is the flag that would make one statement cover
+# both, and `crate-ci/typos` passes none through, so that workflow's file-collection step drops the
+# same paths with the same pattern and says why there.
+extend-exclude = [
+  "frontend/src/Client/Strings/*/*.resw",
+  "!frontend/src/Client/Strings/en/*.resw",
+]
 
 # Hidden files are checked, which is not the default. Most of the prose that decides how this
 # repository works lives behind a leading dot — the workflows under `.github/`, the skills under

--- a/.config/typos.toml
+++ b/.config/typos.toml
@@ -35,11 +35,25 @@
 # expression or the sample it belongs to, and it leaves when that data does — which for the corpus
 # means a refresh that drops a rule, not a change of mind about a spelling.
 #
-# None of the three is a place to put a genuine typo that is inconvenient to fix. An entry here says
-# the string is correct, is deliberate, or is not prose, and a reader has to be able to trust that it
-# means one of them.
+# A fourth kind is not an entry at all but an exclusion, and it exists because one small part of this
+# repository is deliberately not in English. `AGENTS.md` puts every artifact in English and the
+# client's localized resource tables are the one thing that rule is not about: what a person reads in
+# the application is read in their own language. A dictionary of English has nothing true to say
+# about those files — Polish `adres` is not a misspelling of `address` — so they are excluded whole
+# rather than word by word, which would fill the vocabulary above with another language's spellings
+# and silence those spellings everywhere else too. The English table stays checked, because it is the
+# one the rest of this repository is written in.
+#
+# None of them is a place to put a genuine typo that is inconvenient to fix. What this file says of a
+# string is that it is correct, is deliberate, is not prose, or is not English, and a reader has to
+# be able to trust that it means one of them.
 
 [files]
+# The client's non-English resource tables, for the reason above. A language added to the client adds
+# a line here, deliberately: each one is a statement that this particular file is not English, rather
+# than a pattern that would quietly stop checking the English table beside them.
+extend-exclude = ["frontend/src/Client/Strings/pl/Resources.resw"]
+
 # Hidden files are checked, which is not the default. Most of the prose that decides how this
 # repository works lives behind a leading dot — the workflows under `.github/`, the skills under
 # `.agents/`, `.editorconfig` — and skipping it would leave the check blind to the files a workflow

--- a/.github/workflows/typo-check.yml
+++ b/.github/workflows/typo-check.yml
@@ -119,16 +119,35 @@ jobs:
             exit 0
           fi
 
-          # An image holds no prose, and `typos` will read one anyway. Its own binary detection and
-          # the exclusions in `.config/typos.toml` both belong to the walk it does when it is given a
-          # directory; a path named on the command line is read whether or not it looks like text, so
-          # a changed PNG arrives as a page of corrections against compressed bytes nobody wrote. The
-          # formats are listed rather than detected, because the question here is which files this
-          # repository carries that are not written in words.
+          # Two kinds of file are dropped here rather than left to the configuration, and both for the
+          # same reason: `typos` applies its own binary detection and the exclusions in
+          # `.config/typos.toml` to the walk it does when it is given a directory, while a path named
+          # on the command line is read whether either of them says so or not. `--force-exclude`
+          # would change that, and `crate-ci/typos` passes no such flag through, so a list this step
+          # builds has to be a list of files worth reading.
+          #
+          # An image holds no prose, and a changed PNG handed over as a path arrives as a page of
+          # corrections against compressed bytes nobody wrote. The formats are listed rather than
+          # detected, because the question here is which files this repository carries that are not
+          # written in words.
+          #
+          # The client's non-English resource tables are the other kind, and the question there is
+          # not whether the file is prose but which language it is in. Everything this repository
+          # writes is in English and what a person reads in the application is the one thing that
+          # rule is not about, so an English dictionary has nothing true to say about those tables:
+          # the Polish noun for a network address differs from the English one by two letters, which
+          # is a correction the checker offers and nobody wants. The English table beside them stays
+          # in the list, because it is the language the rest of the repository is written in.
+          # `.config/typos.toml` excludes the same paths from the whole-checkout fallback above.
           readable_paths=()
           for changed_path in "${changed_paths[@]}"; do
             case "${changed_path,,}" in
               *.png | *.jpg | *.jpeg | *.gif | *.ico | *.webp | *.woff | *.woff2 | *.pdf) continue ;;
+            esac
+
+            case "$changed_path" in
+              frontend/src/Client/Strings/en/*) ;;
+              frontend/src/Client/Strings/*/*.resw) continue ;;
             esac
 
             readable_paths+=("$changed_path")
@@ -137,7 +156,7 @@ jobs:
           changed_paths=("${readable_paths[@]}")
 
           if (( ${#changed_paths[@]} == 0 )); then
-            echo 'Every file this pull request changes is an image, so there is nothing to spell-check.'
+            echo 'Every file this pull request changes is an image or a non-English resource table, so there is nothing to spell-check.'
             echo 'files=' >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -120,7 +120,8 @@ issued to.
 setting. The reason is discovery rather than OAuth: the client is configured with an address and finds the
 protected-resource metadata document by appending the prefix it is about to call, which reaches the document's RFC 9728
 location exactly when the resource names the same prefix. It matters more here than on the administrative surface,
-because the reader is a page that cannot be told the address by hand.
+because the reader is given an origin and nothing else — the client refuses an address carrying anything beneath one —
+so every other address it uses is one it derived rather than one anybody could correct.
 
 The document is published at the root, beneath `/.well-known/oauth-protected-resource`, and it follows its surface: it
 answers on the client listener and is `404` on any other. It is served to a caller holding nothing, which is the whole

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -306,6 +306,12 @@ into the boot document the page fetches, and the client reads it back through `A
 answer for itself. Nothing else states that property, so a bundle built anywhere else carries no such option and a head
 served from a deployment's own container image still resolves the origin it was fetched from.
 
+What the build states is not the last word, and that is deliberate: a deployment address somebody chose on the client's
+own first screen is kept per user and read before it. So an orchestrated head opens on the service beside it without
+anybody typing anything, and a developer who points that head at another deployment keeps pointing at it across
+restarts until they change it back. Clearing that choice is the platform's own settings store rather than anything
+here — a fresh browser profile, or clearing site data for the head's origin.
+
 The origin it is pointed at is the **client surface's own socket**, which this topology publishes beside the MCP
 endpoint's and the probes'. It is on `127.0.0.1`, because the only thing that calls it is a head served on this
 machine, and that is also why it is a socket rather than a share of the MCP endpoint's: a wildcard bind beside a

--- a/frontend/src/AGENTS.md
+++ b/frontend/src/AGENTS.md
@@ -288,6 +288,11 @@ an address is stored, before one is probed, and again when the client is pointed
 address, an origin and nothing beneath it, and clear text only to this machine, because every request carries the
 signed-in credential. A value written with no scheme is read as HTTPS by `DeploymentAddressText`, which the screen and
 the configuration reader share, since the alternative would turn an omission into a credential on the wire.
+`DeploymentAddressRule.Describe` is the other half of owning the rule: every refusal is raised as an exception by
+somebody and an exception message is read into a log, so the message that refuses an address for carrying embedded
+credentials is exactly the one most likely to name a secret. It names the scheme and the authority and nothing else —
+composed rather than taken from `GetLeftPart(UriPartial.Authority)`, which keeps the user information — and names
+nothing at all of a value that is not an absolute address.
 
 **Nothing is kept until something has answered.** `DeploymentProbe` asks the candidate for `/api/client/session` on a
 transport carrying no credential — the address is a machine nobody has vouched for yet — and believes it only when the

--- a/frontend/src/AGENTS.md
+++ b/frontend/src/AGENTS.md
@@ -256,33 +256,64 @@ records what the client resource costs, what it needs installed, and how to run 
 the browser head needs the `wasm-tools` workload; the Uno SDK is pinned in the repository-root `global.json` and
 restored like any other.
 
-**Where the deployment is, is answered per head, through `IDeploymentAddressSource`.** `AddMailFathomDeployment` still
-takes the address as an argument and `Client.Backend` still has no default; what composition does is ask the head. A
-head that was *installed* reads what somebody wrote: `App.ComposeDeployment` reads the two `Deployment` keys **by name**
-out of the embedded `appsettings.json` and hands them to `ConfiguredDeploymentAddress`, which resolves the address and
-refuses an installation that states none — while the host is being composed, naming the setting, rather than opening a
-window pointed at a guess. By name rather than bound onto the record, because binding is reflection over properties and
-the browser head is trimmed, which is the reason this stack source-generates every serializer it uses. A head that was *served* already knows: the browser head
-hands `PageOriginDeploymentAddress`, which reads `globalThis.location.origin` through `[JSImport]`, because MailFathom
-serves the bundle from the same origin as the surface it calls and a browser head reads no environment anyway. A value
-written with no scheme is read as HTTPS, since the alternative would turn an omission into a token on the wire;
-whether a stated clear-text address is acceptable at all stays `Client.Backend`'s rule, which permits loopback and
-refuses everything else.
+**Which deployment the client reaches is a person's decision, and `DeploymentChoice` is the whole of it.** Four things
+can hold an answer and they are read in one order, highest first:
 
-**One source is not a head's answer, and it is read before them.** `BuildStatedDeploymentAddress` carries whatever the
-build that produced this head stated, and `App` wraps the head's own source in it, so a new head still owes exactly one
-implementation. It exists for the case neither answer above fits: a head an orchestration started is served by a
-development server on a socket of its own while the service listens on another, so the origin it was fetched from is a
-file server and there is no installation to have written anything. The channel is the build, because a browser reads no
-process environment and has no file beside it — `Client.csproj` writes the value of the `MailFathomDeploymentAddress`
-property into a runtime host configuration option, the WebAssembly SDK carries it into the boot document the page
-fetches, and `AppContext` is what reads it back, with no reflection for the trimmer to remove. The desktop head takes
-the same property and reads the same key out of its own `runtimeconfig.json`. A build that states nothing writes no
-option, which is every published artifact:
+1. **What somebody chose**, kept in `IDeploymentChoiceStore` — `ApplicationData.Current.LocalSettings` behind it, which
+   is a per-user preferences store on a desktop and the browser's own storage for the page's origin in the browser
+   head. It is read first because it is the most recent thing anybody actually decided, and it is what makes starting
+   the client again opening it rather than configuring it.
+2. **What the build stated**, through `BuildStatedDeploymentAddress`.
+3. **What the head knows for itself**, through `IDeploymentAddressSource` — `ConfiguredDeploymentAddress` on an
+   installed head, reading the `Deployment` keys **by name** out of the embedded `appsettings.json`;
+   `PageOriginDeploymentAddress` on the browser head, reading `globalThis.location.origin` through `[JSImport]`,
+   because MailFathom serves the bundle from the same origin as the surface it calls. By name rather than bound onto
+   the record, because binding is reflection over properties and the browser head is trimmed, which is the reason this
+   stack source-generates every serializer it uses.
+4. **Nobody**, which is an ordinary state rather than a failure. `App.OnLaunched` opens `ConnectPage` instead of the
+   application, and a person says where their MailFathom is. What used to happen here — a head refusing to start
+   because nothing was configured — is gone: a window that cannot explain itself was only ever the least bad answer
+   while there was no screen to ask on.
+
+**A stated address that cannot be honoured still fails loudly.** Unreadable text in `appsettings.json` fails in
+`ConfiguredDeploymentAddress`, naming the setting; an address the rule below refuses fails in `DeploymentChoice.Restore`,
+naming the address. Only *absence* is answered by asking. Two answers are held to a weaker standard, and both for the
+same reason — nobody wrote them, so nobody can go and correct them. A kept choice that no longer passes the rule is
+forgotten rather than fatal. A page origin that does not pass it is no answer at all: `PageOriginDeploymentAddress`
+judges it and reports nothing, so a bundle served over clear text from something that is not this machine opens the
+screen that asks instead of failing at launch over a fact its reader could do nothing about.
+
+**One rule judges every address, wherever it came from.** `DeploymentAddressRule.Judge` is it, and it is applied before
+an address is stored, before one is probed, and again when the client is pointed at one: an absolute `http` or `https`
+address, an origin and nothing beneath it, and clear text only to this machine, because every request carries the
+signed-in credential. A value written with no scheme is read as HTTPS by `DeploymentAddressText`, which the screen and
+the configuration reader share, since the alternative would turn an omission into a credential on the wire.
+
+**Nothing is kept until something has answered.** `DeploymentProbe` asks the candidate for `/api/client/session` on a
+transport carrying no credential — the address is a machine nobody has vouched for yet — and believes it only when the
+answer is MailFathom's own document naming MailFathom. A deployment that refuses an unauthenticated caller is still a
+deployment, because that is what a correctly configured one does; the probe reports that as reached-but-guarded rather
+than as not MailFathom. This is what turns a typing mistake into a sentence on the screen a person is still looking at
+rather than an authentication failure after they have entered a password.
+
+**Pointing the client elsewhere ends the session.** `DeploymentAddress` holds the current address and drops the access
+token when it moves, because a credential belongs to an owner on one deployment and means nothing on another. It is
+also why `DeploymentClient`, `DeploymentSignIn`, and `DeploymentProbe` ask `IHttpClientFactory` for a transport per
+exchange instead of holding one: a captured transport keeps the base address it was created with, and the client would
+go on reaching the deployment somebody had just left.
+
+**The build-stated source exists for the case none of the head answers fits.** A head an orchestration started is served
+by a development server on a socket of its own while the service listens on another, so the origin it was fetched from
+is a file server and there is no installation to have written anything. The channel is the build, because a browser
+reads no process environment and has no file beside it — `Client.csproj` writes the value of the
+`MailFathomDeploymentAddress` property into a runtime host configuration option, the WebAssembly SDK carries it into the
+boot document the page fetches, and `AppContext` is what reads it back, with no reflection for the trimmer to remove.
+The desktop head takes the same property and reads the same key out of its own `runtimeconfig.json`. A build that states
+nothing writes no option, which is every published artifact:
 [the client resource](../../docs/operations/local-development.md#the-client-resource) is the one thing that states it.
 
-Add a head, and what it owes is an implementation of that interface — not a branch on the running platform, and not a
-second mechanism invented in a screen.
+Add a head, and what it owes is an implementation of `IDeploymentAddressSource` — not a branch on the running platform,
+and not a second mechanism invented in a screen.
 
 ## Reaching the backend
 
@@ -302,12 +333,15 @@ what keeps that from being a rule somebody has to enforce by reading.
 - **Serialization is source-generated.** The browser head is trimmed, and a reflection-based `ReadFromJsonAsync` is
   removed by the trimmer rather than reported; `.config/BannedSymbols.txt` already refuses those overloads. One
   `JsonSerializerContext` covers every document the client reads.
-- **Where the deployment is, is the composing host's to state**, never this assembly's. `AddMailFathomDeployment` takes
-  the address and the timeout as arguments; there is no default address anywhere and nothing composes one from a
-  literal, because a client that guessed would reach somebody else's deployment on a mistyped value. What it does
-  refuse is a clear-text address to anything but this machine: every request carries the signed-in token, so `http` to
-  a routable host would hand it to whatever is on the path. `backend/src/Host/Configuration/DeploymentOptions.cs`
-  draws the same line about the address that deployment publishes, and for the same reason.
+- **Where the deployment is, is nobody's to state here**, and `AddMailFathomDeployment` does not take it. What it takes
+  is `DeploymentOptions` — the registered client identifier and the timeout — and it registers `DeploymentAddress`,
+  which starts pointed at nothing and is pointed by whoever composes the application. There is no default address
+  anywhere and nothing composes one from a literal, because a client that guessed would reach somebody else's
+  deployment on a mistyped value. What this assembly does own is the rule that judges one: `DeploymentAddressRule`
+  refuses a clear-text address to anything but this machine, because every request carries the signed-in credential and
+  `http` to a routable host would hand it to whatever is on the path, and it refuses anything carrying more than an
+  origin. `backend/src/Host/Configuration/DeploymentOptions.cs` draws the same line about the address that deployment
+  publishes, and for the same reason.
 - **Everything the backend returns about mail is personal data**, and the root instructions' classification follows it
   across the wire: it is not logged, not written to local storage without a stated reason, and not put in a telemetry
   event. A failure message never carries a deployment's own answer back either — the body is text from a machine this

--- a/frontend/src/Client.Backend/Authorization/AccessTokenStore.cs
+++ b/frontend/src/Client.Backend/Authorization/AccessTokenStore.cs
@@ -43,4 +43,13 @@ public sealed class AccessTokenStore
 
         this.current = accessToken;
     }
+
+    /// <summary>Drops whatever is held, which ends the session without asking the deployment anything.</summary>
+    /// <remarks>
+    /// What <see cref="DeploymentAddress" /> calls when the client is pointed at another deployment. A token was issued
+    /// by one authorization server for one deployment's audience, so carrying it to a second would present a credential
+    /// that means nothing there — and the honest reading of a person moving to another deployment is that this session
+    /// is over rather than that it travels.
+    /// </remarks>
+    internal void Forget() => this.current = null;
 }

--- a/frontend/src/Client.Backend/Authorization/DeploymentSignIn.cs
+++ b/frontend/src/Client.Backend/Authorization/DeploymentSignIn.cs
@@ -27,54 +27,30 @@ namespace MailFathom.Client.Backend.Authorization;
 /// </remarks>
 public sealed class DeploymentSignIn
 {
-    private readonly HttpClient deployment;
-    private readonly HttpClient authorizationServer;
+    private readonly IHttpClientFactory transports;
     private readonly DeploymentOptions options;
     private readonly ISignInRedirectListenerFactory listeners;
     private readonly AccessTokenStore tokens;
 
     /// <summary>Initializes the sign-in over the transports, the head's redirect listener, and the token store.</summary>
     /// <param name="transports">Supplies the two configured clients this flow talks to.</param>
-    /// <param name="options">Which deployment, and as which registered client.</param>
+    /// <param name="options">As which registered client this application signs in.</param>
     /// <param name="listeners">How this head catches the redirect.</param>
     /// <param name="tokens">Where the issued token is held for this run.</param>
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <remarks>The transports are asked for per sign-in rather than held, so the deployment this reaches is whichever one <see cref="DeploymentAddress" /> carries when somebody signs in rather than the one the host was composed against.</remarks>
     public DeploymentSignIn(
         IHttpClientFactory transports,
         DeploymentOptions options,
         ISignInRedirectListenerFactory listeners,
         AccessTokenStore tokens)
-        : this(
-            (transports ?? throw new ArgumentNullException(nameof(transports))).CreateClient(DeploymentHttpClients.Deployment),
-            transports.CreateClient(DeploymentHttpClients.AuthorizationServer),
-            options,
-            listeners,
-            tokens)
     {
-    }
-
-    /// <summary>Initializes the sign-in over transports supplied directly, which is how a test stubs them.</summary>
-    /// <param name="deployment">Aimed at the deployment.</param>
-    /// <param name="authorizationServer">Aimed at the authorization server.</param>
-    /// <param name="options">Which deployment, and as which registered client.</param>
-    /// <param name="listeners">How this head catches the redirect.</param>
-    /// <param name="tokens">Where the issued token is held for this run.</param>
-    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
-    internal DeploymentSignIn(
-        HttpClient deployment,
-        HttpClient authorizationServer,
-        DeploymentOptions options,
-        ISignInRedirectListenerFactory listeners,
-        AccessTokenStore tokens)
-    {
-        ArgumentNullException.ThrowIfNull(deployment);
-        ArgumentNullException.ThrowIfNull(authorizationServer);
+        ArgumentNullException.ThrowIfNull(transports);
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(listeners);
         ArgumentNullException.ThrowIfNull(tokens);
 
-        this.deployment = deployment;
-        this.authorizationServer = authorizationServer;
+        this.transports = transports;
         this.options = options;
         this.listeners = listeners;
         this.tokens = tokens;
@@ -86,7 +62,10 @@ public sealed class DeploymentSignIn
     /// <exception cref="DeploymentFailure">Thrown when discovery, the person's approval, or the exchange did not produce a token.</exception>
     public async Task SignInAsync(CancellationToken cancellationToken = default)
     {
-        var authorization = await new DeploymentAuthorizationDiscovery(this.deployment, this.authorizationServer)
+        var deployment = this.transports.CreateClient(DeploymentHttpClients.Deployment);
+        var authorizationServer = this.transports.CreateClient(DeploymentHttpClients.AuthorizationServer);
+
+        var authorization = await new DeploymentAuthorizationDiscovery(deployment, authorizationServer)
             .ReadAsync(cancellationToken)
             .ConfigureAwait(false);
 
@@ -101,7 +80,13 @@ public sealed class DeploymentSignIn
         var authorizationCode = ReadAuthorizationCode(redirect, pending);
 
         var issued = await this
-            .RedeemAsync(authorization, pending, listener.RedirectUri, authorizationCode, cancellationToken)
+            .RedeemAsync(
+                authorizationServer,
+                authorization,
+                pending,
+                listener.RedirectUri,
+                authorizationCode,
+                cancellationToken)
             .ConfigureAwait(false);
 
         this.tokens.Accept(issued);
@@ -207,6 +192,7 @@ public sealed class DeploymentSignIn
 
     /// <summary>Exchanges the authorization code the redirect carried for an access token.</summary>
     private async Task<string> RedeemAsync(
+        HttpClient authorizationServer,
         DeploymentAuthorization authorization,
         PendingSignIn pending,
         Uri redirectUri,
@@ -229,7 +215,7 @@ public sealed class DeploymentSignIn
         };
 
         using var response = await DeploymentExchange
-            .SendAsync(this.authorizationServer, request, cancellationToken)
+            .SendAsync(authorizationServer, request, cancellationToken)
             .ConfigureAwait(false);
 
         // The status code is not the verdict. RFC 6749 requires a rejected grant to arrive as 400 with a

--- a/frontend/src/Client.Backend/DeploymentAddress.cs
+++ b/frontend/src/Client.Backend/DeploymentAddress.cs
@@ -73,7 +73,8 @@ public sealed class DeploymentAddress
         if (refusal != DeploymentAddressRefusal.None)
         {
             throw new ArgumentException(
-                $"'{address}' is not an address this client may be pointed at ({refusal}).",
+                $"{DeploymentAddressRule.Describe(address)} is not an address this client may be pointed at "
+                + $"({refusal}).",
                 nameof(address));
         }
 

--- a/frontend/src/Client.Backend/DeploymentAddress.cs
+++ b/frontend/src/Client.Backend/DeploymentAddress.cs
@@ -1,0 +1,93 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Backend.Authorization;
+
+namespace MailFathom.Client.Backend;
+
+/// <summary>Which deployment this client is pointed at, for as long as it is pointed there.</summary>
+/// <remarks>
+/// <para>
+/// The one value in this assembly that a person decides at run time rather than an installation states, which is why it
+/// is held here rather than on <see cref="DeploymentOptions" />. Nothing here has a default and nothing composes one
+/// from a literal: a client that guessed would reach somebody else's deployment, and until something points it
+/// somewhere <see cref="Current" /> is <see langword="null" /> and no route can be resolved at all.
+/// </para>
+/// <para>
+/// It is read every time a transport is created rather than captured when the host is composed, which is what makes
+/// pointing the client elsewhere something a running window can do. That is also why every caller that talks to a
+/// deployment asks <see cref="IHttpClientFactory" /> for a transport per exchange instead of holding one: a captured
+/// transport would keep the address it was created with, and the client would go on reaching the deployment somebody
+/// had just left.
+/// </para>
+/// <para>
+/// Ending the session is part of pointing it elsewhere rather than something each caller remembers. A credential
+/// belongs to an owner on one deployment and means nothing on another, so it is dropped here, where the change is —
+/// stated as a reference this type holds rather than as a rule a reviewer has to check for at every call site.
+/// </para>
+/// </remarks>
+public sealed class DeploymentAddress
+{
+    private readonly AccessTokenStore tokens;
+    private readonly Lock guard = new();
+    private Uri? current;
+
+    /// <summary>Initializes the address with the credential store whose session it ends when the deployment changes.</summary>
+    /// <param name="tokens">Where the signed-in credential is held for this run.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="tokens" /> is <see langword="null" />.</exception>
+    public DeploymentAddress(AccessTokenStore tokens)
+    {
+        ArgumentNullException.ThrowIfNull(tokens);
+
+        this.tokens = tokens;
+    }
+
+    /// <summary>Gets the deployment this client is pointed at, or <see langword="null" /> where nothing has pointed it yet.</summary>
+    /// <remarks>Null is a state a first run is genuinely in rather than a failure: nobody has said where their MailFathom is, and the client's answer to that is to ask.</remarks>
+    public Uri? Current
+    {
+        get
+        {
+            lock (this.guard)
+            {
+                return this.current;
+            }
+        }
+    }
+
+    /// <summary>Gets whether this client knows which deployment it reaches.</summary>
+    public bool IsPointed => this.Current is not null;
+
+    /// <summary>Points the client at a deployment, ending any session held against a different one.</summary>
+    /// <param name="address">The deployment's base address, which every route is resolved against.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="address" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">Thrown when the address is not one this client may be pointed at, as <see cref="DeploymentAddressRule" /> decides.</exception>
+    /// <remarks>Pointing it at the address it already carries changes nothing, session included, so re-reading what was persisted at every start does not sign anybody out.</remarks>
+    public void PointAt(Uri address)
+    {
+        ArgumentNullException.ThrowIfNull(address);
+
+        var refusal = DeploymentAddressRule.Judge(address);
+
+        if (refusal != DeploymentAddressRefusal.None)
+        {
+            throw new ArgumentException(
+                $"'{address}' is not an address this client may be pointed at ({refusal}).",
+                nameof(address));
+        }
+
+        bool moved;
+
+        lock (this.guard)
+        {
+            moved = this.current is not null && this.current != address;
+            this.current = address;
+        }
+
+        if (moved)
+        {
+            this.tokens.Forget();
+        }
+    }
+}

--- a/frontend/src/Client.Backend/DeploymentAddressRule.cs
+++ b/frontend/src/Client.Backend/DeploymentAddressRule.cs
@@ -76,6 +76,40 @@ public static class DeploymentAddressRule
                 : DeploymentAddressRefusal.None;
     }
 
+    /// <summary>Names an address in the one form that is safe to put in a message.</summary>
+    /// <param name="address">The address a message is about to be written about.</param>
+    /// <returns>A phrase naming it, which is the whole subject of the sentence rather than a value to quote again.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="address" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// <para>
+    /// Every refusal this rule produces is raised as an exception by somebody, and an exception message is read into a
+    /// log. <see cref="DeploymentAddressRefusal.MoreThanAnOrigin" /> exists partly to catch an address carrying
+    /// embedded credentials, so the one message most likely to name a secret is the one that refuses an address for
+    /// carrying one — which is why naming an address is a decision taken here rather than at each place that writes a
+    /// sentence about one.
+    /// </para>
+    /// <para>
+    /// The scheme and the authority, composed rather than taken from
+    /// <see cref="Uri.GetLeftPart(UriPartial)" />: measured on .NET 10, <c>UriPartial.Authority</c> keeps the user
+    /// information, so <c>https://user:secret@mail.example/</c> comes back from it with the secret still in it.
+    /// <see cref="Uri.Authority" /> is the part that does not, and the scheme is written in front of it because the
+    /// scheme is exactly what one of these refusals is about.
+    /// </para>
+    /// <para>
+    /// An address that is not absolute has no scheme or authority to read, and its original text could be anything at
+    /// all, so it is not named. Nothing is lost by that: the only refusal it can carry is
+    /// <see cref="DeploymentAddressRefusal.NotAWebAddress" />, which is the whole of what a reader needs.
+    /// </para>
+    /// </remarks>
+    public static string Describe(Uri address)
+    {
+        ArgumentNullException.ThrowIfNull(address);
+
+        return address.IsAbsoluteUri
+            ? $"'{address.Scheme}://{address.Authority}'"
+            : "That value";
+    }
+
     /// <summary>Decides whether an address names this machine, which is where clear text is a posture rather than an exposure.</summary>
     /// <remarks>
     /// <see cref="Uri.IsLoopback" /> answers for an address literal and for the reserved name; a host that resolves to

--- a/frontend/src/Client.Backend/DeploymentAddressRule.cs
+++ b/frontend/src/Client.Backend/DeploymentAddressRule.cs
@@ -1,0 +1,88 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Net;
+
+namespace MailFathom.Client.Backend;
+
+/// <summary>Why an address is not one this client may be pointed at.</summary>
+/// <remarks>
+/// A reason rather than a message, because the two readers of this rule show it differently: a composing host raises
+/// it as an exception naming the setting somebody wrote, and a screen shows a person a sentence in the language they
+/// are reading in. A message decided here would be the wrong one for one of them.
+/// </remarks>
+public enum DeploymentAddressRefusal
+{
+    /// <summary>The address is one this client may be pointed at.</summary>
+    None = 0,
+
+    /// <summary>It is not an absolute <c>http</c> or <c>https</c> address, so no route could be resolved against it.</summary>
+    NotAWebAddress = 1,
+
+    /// <summary>It is clear text to a host that is not this machine, and every request this client sends carries the signed-in credential.</summary>
+    ClearTextOffThisMachine = 2,
+
+    /// <summary>It carries more than an origin — a path, a query, a fragment, or embedded credentials.</summary>
+    MoreThanAnOrigin = 3,
+}
+
+/// <summary>What makes an address one this client may be pointed at, decided in one place for every head.</summary>
+/// <remarks>
+/// <para>
+/// Stated once because it is judged twice and the two must never disagree: before a person's typed address is stored,
+/// and again when whatever was stored is composed into the transports. A rule applied at only one of those points is a
+/// client that accepts an address on one path and refuses it on the other.
+/// </para>
+/// <para>
+/// It says nothing about whether a deployment is actually there. That is a question only the network can answer, and
+/// <see cref="DeploymentProbe" /> is what asks it.
+/// </para>
+/// </remarks>
+public static class DeploymentAddressRule
+{
+    /// <summary>Judges whether an address is one this client may be pointed at.</summary>
+    /// <param name="address">The candidate, which may be <see langword="null" />.</param>
+    /// <returns><see cref="DeploymentAddressRefusal.None" /> when it may be used, and why not otherwise.</returns>
+    public static DeploymentAddressRefusal Judge(Uri? address)
+    {
+        if (address is null
+            || !address.IsAbsoluteUri
+            || (address.Scheme != Uri.UriSchemeHttps && address.Scheme != Uri.UriSchemeHttp))
+        {
+            return DeploymentAddressRefusal.NotAWebAddress;
+        }
+
+        // Every request this client sends carries the signed-in credential, so clear text to anything but this machine
+        // hands that credential to whatever is on the path. Loopback is where clear text is a development posture
+        // rather than an exposure, which is the same line backend/src/Host/Configuration/DeploymentOptions.cs draws
+        // about the address a deployment publishes.
+        if (address.Scheme == Uri.UriSchemeHttp && !IsLoopback(address))
+        {
+            return DeploymentAddressRefusal.ClearTextOffThisMachine;
+        }
+
+        // An origin, not a mount point. MailFathom serves its client surface at /api/client and derives the resource
+        // identifier a token is issued for from that same prefix, so there is no sub-path deployment to support — and a
+        // path written here would be dropped silently when a route resolves against it, which is a deployment somebody
+        // configured and never reached, with nothing saying why. Embedded credentials are refused by the same check
+        // rather than by one of their own: this client authenticates with the credential it presents on each request,
+        // so one written into an address is a secret nothing here would use and everything here would carry.
+        return address.AbsolutePath != "/"
+            || !string.IsNullOrEmpty(address.Query)
+            || !string.IsNullOrEmpty(address.Fragment)
+            || !string.IsNullOrEmpty(address.UserInfo)
+                ? DeploymentAddressRefusal.MoreThanAnOrigin
+                : DeploymentAddressRefusal.None;
+    }
+
+    /// <summary>Decides whether an address names this machine, which is where clear text is a posture rather than an exposure.</summary>
+    /// <remarks>
+    /// <see cref="Uri.IsLoopback" /> answers for an address literal and for the reserved name; a host that resolves to
+    /// a loopback address elsewhere is not one, and treating it as one would let DNS decide whether the credential
+    /// travels in clear text.
+    /// </remarks>
+    private static bool IsLoopback(Uri address) =>
+        address.IsLoopback
+        || (IPAddress.TryParse(address.Host, out var literal) && IPAddress.IsLoopback(literal));
+}

--- a/frontend/src/Client.Backend/DeploymentClient.cs
+++ b/frontend/src/Client.Backend/DeploymentClient.cs
@@ -4,13 +4,14 @@
 
 namespace MailFathom.Client.Backend;
 
-/// <summary>The client's one way of asking a MailFathom deployment something.</summary>
+/// <summary>The client's one way of asking the deployment it is pointed at something.</summary>
 /// <remarks>
 /// <para>
-/// A typed client over a transport the composing host configured with the deployment's address and a timeout, so no
-/// route here is ever an absolute address and nothing in this assembly decides where the deployment is. The bearer
-/// token, when there is one, is attached by the handler in the pipeline rather than by any method below — which is
-/// what keeps a route from being written without one by accident.
+/// A transport is asked for per exchange rather than held, which is what makes the deployment this reaches follow
+/// <see cref="DeploymentAddress" /> instead of whatever it was when the host was composed. No route here is ever an
+/// absolute address and nothing in this assembly decides where the deployment is. The bearer token, when there is one,
+/// is attached by the handler in the pipeline rather than by any method below — which is what keeps a route from being
+/// written without one by accident.
 /// </para>
 /// <para>
 /// It carries exactly one route today, deliberately. <c>/api/client/session</c> reports what the deployment made of the
@@ -19,31 +20,49 @@ namespace MailFathom.Client.Backend;
 /// </remarks>
 public sealed class DeploymentClient
 {
-    private readonly HttpClient transport;
+    private readonly IHttpClientFactory transports;
 
-    /// <summary>Initializes the client over a configured transport.</summary>
-    /// <param name="transport">The transport, whose base address and timeout the host stated.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="transport" /> is <see langword="null" />.</exception>
-    public DeploymentClient(HttpClient transport)
+    /// <summary>Initializes the client over the transports this assembly registered.</summary>
+    /// <param name="transports">Supplies the transport aimed at the deployment, configured as each one is created.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="transports" /> is <see langword="null" />.</exception>
+    public DeploymentClient(IHttpClientFactory transports)
     {
-        ArgumentNullException.ThrowIfNull(transport);
+        ArgumentNullException.ThrowIfNull(transports);
 
-        this.transport = transport;
+        this.transports = transports;
     }
 
     /// <summary>Asks the deployment what it makes of the credential this client is presenting.</summary>
     /// <param name="cancellationToken">Cancels the request.</param>
     /// <returns>What the deployment reports about the caller.</returns>
     /// <exception cref="DeploymentFailure">Thrown when the deployment refused, was unreachable, did not answer in time, or answered with something else.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when nothing has pointed this client at a deployment yet.</exception>
     /// <remarks>
     /// A caller holding no token still gets an answer, because the route requires no permission at the other end: it
-    /// reports an anonymous caller with an empty grant. That is what makes it usable as a reachability check before
-    /// anybody has signed in.
+    /// reports an anonymous caller with an empty grant. That is what makes it usable as a reachability check once
+    /// somebody has chosen a deployment; asking an address nobody has chosen yet is <see cref="DeploymentProbe" />.
     /// </remarks>
     public Task<DeploymentSession> ReadSessionAsync(CancellationToken cancellationToken = default) =>
         DeploymentExchange.ReadAsync(
-            this.transport,
+            this.Transport(),
             new HttpRequestMessage(HttpMethod.Get, DeploymentRoutes.SessionPath),
             DeploymentJsonContext.Default.DeploymentSession,
             cancellationToken);
+
+    /// <summary>Takes a transport aimed at wherever the client is pointed right now.</summary>
+    /// <remarks>
+    /// Not disposed, which is the documented shape for a client an <see cref="IHttpClientFactory" /> produced: the
+    /// handler behind it is pooled and outlives the client, so disposing one buys nothing and returning the same
+    /// instance twice is something a factory is allowed to do.
+    /// </remarks>
+    private HttpClient Transport()
+    {
+        var transport = this.transports.CreateClient(DeploymentHttpClients.Deployment);
+
+        return transport.BaseAddress is not null
+            ? transport
+            : throw new InvalidOperationException(
+                "This client has not been pointed at a deployment, so there is nothing to resolve a route against. "
+                + $"Point {nameof(DeploymentAddress)} at one before asking the deployment anything.");
+    }
 }

--- a/frontend/src/Client.Backend/DeploymentHttpClients.cs
+++ b/frontend/src/Client.Backend/DeploymentHttpClients.cs
@@ -4,18 +4,23 @@
 
 namespace MailFathom.Client.Backend;
 
-/// <summary>The two transports this assembly registers, named so the sign-in can ask for each by what it is for.</summary>
+/// <summary>The three transports this assembly registers, named so each caller can ask for the one it is entitled to.</summary>
 /// <remarks>
-/// Two rather than one, because they aim at two machines with two sets of settings. The deployment's transport carries
-/// the base address the host stated and the handler that attaches this run's access token; the authorization server's
-/// carries neither — every address it is given is absolute and derived from the issuer the deployment named, and a
-/// bearer token issued for MailFathom is not something to present to somebody's identity provider.
+/// Three rather than one, because they aim at three kinds of machine under three sets of terms. The deployment's
+/// transport is aimed at wherever the client is currently pointed and carries the handler that attaches this run's
+/// access token; the authorization server's carries neither a base address nor a token — every address it is given is
+/// absolute and derived from the issuer the deployment named, and a bearer token issued for MailFathom is not something
+/// to present to somebody's identity provider; and the probe's carries no token either, because it is aimed at an
+/// address nobody has vouched for yet and is how this client finds out what is there.
 /// </remarks>
 internal static class DeploymentHttpClients
 {
-    /// <summary>The transport aimed at the deployment, whose base address the composing host supplied.</summary>
+    /// <summary>The transport aimed at the deployment this client is pointed at.</summary>
     internal const string Deployment = "MailFathom.Deployment";
 
     /// <summary>The transport used for the authorization server's own discovery and token endpoints.</summary>
     internal const string AuthorizationServer = "MailFathom.AuthorizationServer";
+
+    /// <summary>The transport a candidate address is asked on, before anything is pointed at it.</summary>
+    internal const string DeploymentProbe = "MailFathom.DeploymentProbe";
 }

--- a/frontend/src/Client.Backend/DeploymentOptions.cs
+++ b/frontend/src/Client.Backend/DeploymentOptions.cs
@@ -2,16 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Net;
-
 namespace MailFathom.Client.Backend;
 
-/// <summary>Which MailFathom deployment this client reaches, and as which registered client it signs in to one.</summary>
+/// <summary>What an installation states about reaching a deployment, other than which one it reaches.</summary>
 /// <remarks>
 /// <para>
-/// Every value here comes from whoever composes the application. Nothing in this assembly has a default address, and
-/// there is deliberately no fallback to a literal: a client that guesses where its deployment is would reach somebody
-/// else's on a mistyped configuration, and MailFathom is a single-tenant service somebody runs for their own mail.
+/// Every value here comes from whoever composes the application, and none of them names a deployment. Where the
+/// deployment is is a person's decision rather than an installation's, so it is held by <see cref="DeploymentAddress" />
+/// and can change while the client runs; what is left here is what stays true whichever deployment is reached.
 /// </para>
 /// <para>
 /// The client identifier is public information, unlike a client secret, which this application holds none of and could
@@ -28,78 +26,26 @@ public sealed record DeploymentOptions
     /// </remarks>
     public static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
 
-    /// <summary>Initializes the options one deployment is reached under.</summary>
-    /// <param name="address">The deployment's base address, which every route is resolved against.</param>
+    /// <summary>Initializes the options a deployment is reached under.</summary>
     /// <param name="clientId">The client identifier registered with the deployment's authorization server.</param>
     /// <param name="timeout">How long a single request may take, or <see langword="null" /> for <see cref="DefaultTimeout" />.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="address" /> or <paramref name="clientId" /> is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException">Thrown when the address is not an absolute web address, is clear text to a host that is not loopback, or carries more than an origin, or when the client identifier is blank.</exception>
+    /// <exception cref="ArgumentException">Thrown when the client identifier is blank.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when the timeout is not positive.</exception>
-    public DeploymentOptions(Uri address, string clientId, TimeSpan? timeout = null)
+    public DeploymentOptions(string clientId, TimeSpan? timeout = null)
     {
-        ArgumentNullException.ThrowIfNull(address);
         ArgumentException.ThrowIfNullOrWhiteSpace(clientId);
-
-        if (!address.IsAbsoluteUri
-            || (address.Scheme != Uri.UriSchemeHttps && address.Scheme != Uri.UriSchemeHttp))
-        {
-            throw new ArgumentException(
-                $"'{address}' is not an absolute http or https address, so no route could be resolved against it.",
-                nameof(address));
-        }
-
-        // The registration puts the access token on every request sent to this address, so clear text to anything but
-        // this machine hands the token to whatever is on the path. Loopback is where clear text is a development
-        // posture rather than an exposure, which is the same line backend/src/Host/Configuration/DeploymentOptions.cs
-        // draws about the address that deployment publishes.
-        if (address.Scheme == Uri.UriSchemeHttp && !IsLoopback(address))
-        {
-            throw new ArgumentException(
-                $"'{address}' is clear text to a host that is not loopback. Every request this client sends carries the signed-in token, so state an https address.",
-                nameof(address));
-        }
-
-        // An origin, not a mount point. MailFathom serves its client surface at /api/client and derives the resource
-        // identifier a token is issued for from that same prefix, so there is no sub-path deployment to support — and a
-        // path written here would be dropped silently when a route resolves against it, which is a deployment somebody
-        // configured and never reached, with nothing saying why. Embedded credentials are refused by the same check
-        // rather than by one of their own: this client authenticates with the token it was issued, so a password in an
-        // address is a credential nothing here would use and everything here would carry.
-        if (address.AbsolutePath != "/"
-            || !string.IsNullOrEmpty(address.Query)
-            || !string.IsNullOrEmpty(address.Fragment)
-            || !string.IsNullOrEmpty(address.UserInfo))
-        {
-            throw new ArgumentException(
-                $"'{address}' carries more than an origin. MailFathom serves the client surface at '{DeploymentRoutes.Prefix}', so state the scheme, host, and port and nothing else.",
-                nameof(address));
-        }
 
         var resolvedTimeout = timeout ?? DefaultTimeout;
 
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(resolvedTimeout, TimeSpan.Zero, nameof(timeout));
 
-        this.Address = address;
         this.ClientId = clientId;
         this.Timeout = resolvedTimeout;
     }
-
-    /// <summary>Gets the deployment's base address.</summary>
-    public Uri Address { get; }
 
     /// <summary>Gets the client identifier presented to the authorization server.</summary>
     public string ClientId { get; }
 
     /// <summary>Gets how long a single request to the deployment may take.</summary>
     public TimeSpan Timeout { get; }
-
-    /// <summary>Decides whether an address names this machine, which is where clear text is a posture rather than an exposure.</summary>
-    /// <remarks>
-    /// <see cref="Uri.IsLoopback" /> answers for an address literal and for the reserved name; a host that resolves to
-    /// a loopback address elsewhere is not one, and treating it as one would let DNS decide whether the token travels
-    /// in clear text.
-    /// </remarks>
-    private static bool IsLoopback(Uri address) =>
-        address.IsLoopback
-        || (IPAddress.TryParse(address.Host, out var literal) && IPAddress.IsLoopback(literal));
 }

--- a/frontend/src/Client.Backend/DeploymentProbe.cs
+++ b/frontend/src/Client.Backend/DeploymentProbe.cs
@@ -1,0 +1,118 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Net;
+
+namespace MailFathom.Client.Backend;
+
+/// <summary>What a candidate address turned out to be.</summary>
+/// <param name="Session">What the deployment reported about an unauthenticated caller, or <see langword="null" /> where its client surface refused one.</param>
+/// <remarks>
+/// Two shapes rather than one, because a deployment that requires signing in is the ordinary case and it cannot report
+/// anything to a caller holding no credential. Both mean the address is worth keeping; they differ in how much was
+/// proved, which is what <see cref="IsGuarded" /> says.
+/// </remarks>
+public sealed record DeploymentReach(DeploymentSession? Session)
+{
+    /// <summary>Gets whether the address answered by refusing an unauthenticated caller rather than by describing itself.</summary>
+    public bool IsGuarded => this.Session is null;
+}
+
+/// <summary>Asks an address whether a MailFathom deployment is there, before anything is pointed at it.</summary>
+/// <remarks>
+/// <para>
+/// The half of judging an address that only the network can answer. <see cref="DeploymentAddressRule" /> decides
+/// whether an address is one this client may carry a credential to; this decides whether anything is there, so a
+/// mistyped host arrives as "nothing answered" while somebody is still typing rather than as an authentication failure
+/// after they have entered a password.
+/// </para>
+/// <para>
+/// It presents no credential. The transport it uses carries no token handler, deliberately: a candidate address is a
+/// machine nobody has vouched for yet, and the point of asking is to find out what it is — sending this run's
+/// credential to it first would hand the session to whatever answered.
+/// </para>
+/// <para>
+/// Reaching it is not enough to be believed. Anything can answer <c>200</c> on a port, so an answer has to be
+/// MailFathom's own session document naming MailFathom; a captive portal, a proxy, or somebody else's service arrives
+/// as <see cref="DeploymentFailureReason.Unusable" /> rather than as a deployment.
+/// </para>
+/// <para>
+/// <strong>A refusal is an answer too.</strong> The client surface carries whatever authentication its deployment
+/// configured, and a deployment configured the way MailFathom's own documentation asks refuses an unauthenticated
+/// caller outright — so <c>401</c> and <c>403</c> are what a correctly configured deployment says here, and treating
+/// them as "not MailFathom" would refuse every address that is one. What such an answer proves is weaker and this says
+/// so rather than pretending otherwise: something is at that address and it is guarding a MailFathom client surface.
+/// Whether it is MailFathom is settled by signing in, which is the next thing a person does.
+/// </para>
+/// </remarks>
+public sealed class DeploymentProbe
+{
+    /// <summary>What a MailFathom deployment names itself in the session document.</summary>
+    /// <remarks>
+    /// This end of the same agreement <c>backend/src/Host/Api/ClientApiEndpoints.cs</c> states when it composes the
+    /// response. Written here as a literal for the reason <see cref="DeploymentRoutes" /> gives about the paths beside
+    /// it: two ends stating one contract, rather than a constant shared across the two stacks.
+    /// </remarks>
+    internal const string ServiceName = "MailFathom";
+
+    private readonly IHttpClientFactory transports;
+
+    /// <summary>Initializes the probe over the transports this assembly registered.</summary>
+    /// <param name="transports">Supplies the credential-free transport a candidate is asked on.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="transports" /> is <see langword="null" />.</exception>
+    public DeploymentProbe(IHttpClientFactory transports)
+    {
+        ArgumentNullException.ThrowIfNull(transports);
+
+        this.transports = transports;
+    }
+
+    /// <summary>Asks a candidate address what is there.</summary>
+    /// <param name="candidate">The address a person typed, or one an installation stated.</param>
+    /// <param name="cancellationToken">Abandons the question, which is not the same thing as it timing out.</param>
+    /// <returns>What answered, and how much it proved.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="candidate" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">Thrown when the candidate is not an address this client may be pointed at.</exception>
+    /// <exception cref="DeploymentFailure">Thrown when nothing answered, nothing answered in time, or what answered is not a MailFathom deployment.</exception>
+    public async Task<DeploymentReach> ReachAsync(Uri candidate, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+
+        var refusal = DeploymentAddressRule.Judge(candidate);
+
+        if (refusal != DeploymentAddressRefusal.None)
+        {
+            throw new ArgumentException(
+                $"'{candidate}' is not an address this client may be pointed at ({refusal}).",
+                nameof(candidate));
+        }
+
+        var transport = this.transports.CreateClient(DeploymentHttpClients.DeploymentProbe);
+
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            new Uri(candidate, DeploymentRoutes.SessionPath));
+
+        using var response = await DeploymentExchange
+            .SendAsync(transport, request, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+        {
+            return new DeploymentReach(null);
+        }
+
+        DeploymentExchange.RefuseUnusableStatus(response);
+
+        var answer = await DeploymentExchange
+            .ReadBodyAsync(response, DeploymentJsonContext.Default.DeploymentSession, cancellationToken)
+            .ConfigureAwait(false);
+
+        return string.Equals(answer.Service, ServiceName, StringComparison.Ordinal)
+            ? new DeploymentReach(answer)
+            : throw new DeploymentFailure(
+                DeploymentFailureReason.Unusable,
+                "Something answered at that address, but it is not a MailFathom deployment.");
+    }
+}

--- a/frontend/src/Client.Backend/DeploymentProbe.cs
+++ b/frontend/src/Client.Backend/DeploymentProbe.cs
@@ -84,7 +84,8 @@ public sealed class DeploymentProbe
         if (refusal != DeploymentAddressRefusal.None)
         {
             throw new ArgumentException(
-                $"'{candidate}' is not an address this client may be pointed at ({refusal}).",
+                $"{DeploymentAddressRule.Describe(candidate)} is not an address this client may be pointed at "
+                + $"({refusal}).",
                 nameof(candidate));
         }
 

--- a/frontend/src/Client.Backend/DeploymentRegistration.cs
+++ b/frontend/src/Client.Backend/DeploymentRegistration.cs
@@ -12,16 +12,18 @@ namespace MailFathom.Client.Backend;
 /// <summary>Puts everything the client needs to reach one deployment into a service collection.</summary>
 public static class DeploymentRegistration
 {
-    /// <summary>Registers the transports, the sign-in, and the token store for one deployment.</summary>
+    /// <summary>Registers the transports, the sign-in, the credential store, and the address they all follow.</summary>
     /// <param name="services">The collection to add to.</param>
-    /// <param name="options">Which deployment, and as which registered client.</param>
+    /// <param name="options">What the installation states about reaching a deployment, which is not which one.</param>
     /// <returns>The same collection, so registration composes.</returns>
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
     /// <remarks>
     /// <para>
-    /// The address and the timeout are the caller's to state and are stated once, here. Nothing in this assembly has a
-    /// default address and nothing composes one from a literal, so a deployment that moves is a change to whatever the
-    /// host reads its options from rather than to any code below.
+    /// No address is stated here, and none is composed from a literal. Which deployment this client reaches is
+    /// <see cref="DeploymentAddress" />'s, decided by whoever is using the application and changeable while it runs, so
+    /// the transport's base address is read from it as each transport is created rather than fixed when the host is
+    /// composed. A client registered before anybody has chosen is registered pointed at nothing, which is the accurate
+    /// state of a first run.
     /// </para>
     /// <para>
     /// The redirect listener is registered <em>if nothing already has</em>, with the loopback implementation the desktop
@@ -38,16 +40,23 @@ public static class DeploymentRegistration
 
         services.AddSingleton(options);
         services.AddSingleton<AccessTokenStore>();
+        services.AddSingleton<DeploymentAddress>();
         services.AddTransient<AccessTokenHandler>();
         services.TryAddSingleton<ISignInRedirectListenerFactory, LoopbackSignInRedirectListenerFactory>();
         services.AddSingleton<DeploymentSignIn>();
+        services.AddSingleton<DeploymentClient>();
+        services.AddSingleton<DeploymentProbe>();
 
         services
-            .AddHttpClient<DeploymentClient>(
+            .AddHttpClient(
                 DeploymentHttpClients.Deployment,
-                transport =>
+                (provider, transport) =>
                 {
-                    transport.BaseAddress = options.Address;
+                    // Read here rather than captured above, because this delegate runs once per transport created and
+                    // the address a person is pointed at can have moved since the host was built. A transport created
+                    // before anybody chose carries no base address at all, and a relative route resolved against it
+                    // fails loudly rather than reaching somewhere nobody named.
+                    transport.BaseAddress = provider.GetRequiredService<DeploymentAddress>().Current;
                     transport.Timeout = options.Timeout;
                     transport.MaxResponseContentBufferSize = DeploymentExchange.MaxDocumentBytes;
                 })
@@ -58,6 +67,18 @@ public static class DeploymentRegistration
         // somebody's identity provider, and the proof key is what authenticates this client there.
         services.AddHttpClient(
             DeploymentHttpClients.AuthorizationServer,
+            transport =>
+            {
+                transport.Timeout = options.Timeout;
+                transport.MaxResponseContentBufferSize = DeploymentExchange.MaxDocumentBytes;
+            });
+
+        // Neither a base address nor a token handler, and the second of those is the point: this transport is aimed at
+        // an address somebody has just typed, which is a machine nobody has vouched for yet. Attaching the session's
+        // credential to a request whose whole purpose is to find out what answers would hand that credential over to
+        // whatever did.
+        services.AddHttpClient(
+            DeploymentHttpClients.DeploymentProbe,
             transport =>
             {
                 transport.Timeout = options.Timeout;

--- a/frontend/src/Client/App.xaml.cs
+++ b/frontend/src/Client/App.xaml.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics.CodeAnalysis;
 using MailFathom.Client.Backend;
 using MailFathom.Client.Deployment;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace MailFathom.Client;
 
@@ -74,8 +75,7 @@ public partial class App : Application
                 // point at which it takes effect, because applying a culture is what Uno does on the next launch
                 // rather than to a visual tree already built. The screen offering it says so.
                 .UseLocalization()
-                .ConfigureServices((context, services) => services.AddMailFathomDeployment(
-                    this.ComposeDeployment(context.Configuration)))
+                .ConfigureServices((context, services) => this.ComposeDeployment(services, context.Configuration))
                 // Light, dark, and follow-the-system, with the choice written to the platform's own settings store so
                 // the application starts the way it was left. Nothing here decides which one: AppTheme.System is the
                 // default the service reads back when nothing was ever chosen.
@@ -97,26 +97,42 @@ public partial class App : Application
 #endif
         this.MainWindow.SetWindowIcon();
 
-        this.Host = await builder.NavigateAsync<Shell>();
+        // Where the client starts is decided here rather than by a route's default, because it is the one thing about
+        // this application that cannot be known until something has been read: an installation that has been pointed at
+        // a deployment opens on the application, and one that has not opens on the screen that asks. Nothing in between
+        // — a shell that starts and then fails at its first request is exactly what this replaces.
+        this.Host = await builder.NavigateAsync<Shell>(
+            async (services, navigator) =>
+            {
+                var pointed = services.GetRequiredService<DeploymentChoice>().Restore();
+
+                await navigator.NavigateRouteAsync(
+                    this,
+                    pointed ? ClientRoutes.Main : ClientRoutes.Connect);
+            });
     }
 
-    /// <summary>Reads which deployment this head reaches, and as which registered client.</summary>
+    /// <summary>Registers everything that decides which deployment this head reaches, and how it is reached.</summary>
     /// <remarks>
     /// <para>
-    /// The composition root's whole part in it. Where the deployment is, is the head's answer and what to present is
-    /// the installation's, and neither is decided in <c>Client.Backend</c>: that assembly has no default address and
-    /// composes none from a literal, so a client that reached the wrong deployment would have been sent there by
-    /// something readable rather than by a constant nobody saw. A head that cannot answer says so here, while the host
-    /// is being built, rather than opening a window that fails at its first request.
+    /// The composition root's whole part in it. Nothing here names a deployment and <c>Client.Backend</c> has no
+    /// default address and composes none from a literal, so a client that reached the wrong one would have been sent
+    /// there by something readable — a file somebody wrote, a build somebody ran, or an address somebody typed.
     /// </para>
     /// <para>
-    /// The two values are read by name rather than bound onto the record. Binding is reflection over properties, and
+    /// What each of the three registrations is for: the settings are what an installation stated, the source is what
+    /// this head knows for itself, and the store is where a person's own choice outlives a restart.
+    /// <see cref="DeploymentChoice" /> is where they meet, and it is asked once, after the host is built and before
+    /// anything is navigated to.
+    /// </para>
+    /// <para>
+    /// The stated values are read by name rather than bound onto the record. Binding is reflection over properties, and
     /// the browser head is trimmed — the same reason this stack source-generates every serializer it uses — so a bound
     /// section is one the trimmer can quietly empty. Two keys are not worth a source-generated binder either, and
     /// reading them is the shape that cannot be trimmed away.
     /// </para>
     /// </remarks>
-    private DeploymentOptions ComposeDeployment(IConfiguration configuration)
+    private void ComposeDeployment(IServiceCollection services, IConfiguration configuration)
     {
         var stated = configuration.GetSection(DeploymentSettings.SectionName);
 
@@ -126,22 +142,32 @@ public partial class App : Application
             ClientId = stated[nameof(DeploymentSettings.ClientId)] ?? string.Empty,
         };
 
-        return new DeploymentOptions(this.deploymentAddress.Resolve(settings), settings.ClientId);
+        services
+            .AddSingleton(settings)
+            .AddSingleton<IDeploymentAddressSource>(this.deploymentAddress)
+            .AddSingleton<IDeploymentChoiceStore, LocalSettingsDeploymentChoiceStore>()
+            .AddSingleton<DeploymentChoice>()
+            .AddMailFathomDeployment(new DeploymentOptions(settings.ClientId));
     }
 
     private static void RegisterRoutes(IViewRegistry views, IRouteRegistry routes)
     {
         views.Register(
             new ViewMap(ViewModel: typeof(ShellModel)),
-            new ViewMap<MainPage, MainModel>());
+            new ViewMap<MainPage, MainModel>(),
+            new ViewMap<ConnectPage, ConnectModel>());
 
+        // No default among the two, deliberately. Which of them a launch opens on is what OnLaunched decides from
+        // whether this installation has been pointed at a deployment, and a route marked default here would be the
+        // second answer to that question.
         routes.Register(
             new RouteMap(
                 "",
                 View: views.FindByViewModel<ShellModel>(),
                 Nested:
                 [
-                    new RouteMap("Main", View: views.FindByViewModel<MainModel>(), IsDefault: true),
+                    new RouteMap(ClientRoutes.Main, View: views.FindByViewModel<MainModel>()),
+                    new RouteMap(ClientRoutes.Connect, View: views.FindByViewModel<ConnectModel>()),
                 ]));
     }
 }

--- a/frontend/src/Client/Deployment/BuildStatedDeploymentAddress.cs
+++ b/frontend/src/Client/Deployment/BuildStatedDeploymentAddress.cs
@@ -67,7 +67,7 @@ internal sealed class BuildStatedDeploymentAddress : IDeploymentAddressSource
     /// permits clear text to loopback, which is what a local orchestration hands over, and refuses it to anything
     /// else.
     /// </remarks>
-    public Uri Resolve(DeploymentSettings settings)
+    public Uri? Resolve(DeploymentSettings settings)
     {
         var built = this.stated?.Trim();
 

--- a/frontend/src/Client/Deployment/ConfiguredDeploymentAddress.cs
+++ b/frontend/src/Client/Deployment/ConfiguredDeploymentAddress.cs
@@ -9,51 +9,38 @@ namespace MailFathom.Client.Deployment;
 /// <para>
 /// The desktop head's answer, and the answer for any head that is installed rather than served. There is deliberately
 /// no fallback: an application that quietly reached <c>localhost</c>, or the address of whoever wrote this file, would
-/// be a mail client pointed somewhere nobody chose — so an installation stating nothing fails while it is starting,
-/// naming the setting and where to write it, rather than opening a window that cannot explain itself.
+/// be a mail client pointed somewhere nobody chose.
 /// </para>
 /// <para>
-/// HTTPS is the default rather than a requirement stated twice. A value written without a scheme is read as HTTPS,
-/// because that is what a deployment reached across a network is served over and because the alternative — reading it
-/// as clear text — would turn an omission into an exposure. Whether a stated clear-text address is acceptable at all is
-/// <c>Client.Backend</c>'s rule and not repeated here: it permits loopback, which is where clear text is a development
-/// posture, and refuses everything else because every request this client sends carries the signed-in token.
+/// An installation stating nothing is not a failure any more. It used to be one, because the address was the whole of
+/// what a head could know and a window it could not explain was worse than a message; now a person can say where their
+/// MailFathom is while the application is running, so an installation that states nothing is simply one nobody has
+/// configured, and the honest answer is <see langword="null" /> — the client asks. What is still a failure is an
+/// installation that stated something unreadable, which is a value somebody wrote and would otherwise never learn was
+/// ignored.
+/// </para>
+/// <para>
+/// The scheme an address written without one is read as, and the reason it is HTTPS, are
+/// <see cref="DeploymentAddressText" />'s and are shared with the screen a person types into.
 /// </para>
 /// </remarks>
 internal sealed class ConfiguredDeploymentAddress : IDeploymentAddressSource
 {
-    /// <summary>What a value with no scheme is read as.</summary>
-    private const string DefaultScheme = "https";
-
     /// <inheritdoc />
-    public Uri Resolve(DeploymentSettings settings)
+    public Uri? Resolve(DeploymentSettings settings)
     {
         ArgumentNullException.ThrowIfNull(settings);
 
-        var stated = settings.Address.Trim();
-
-        if (stated.Length == 0)
+        if (settings.Address.Trim().Length == 0)
         {
-            throw new InvalidOperationException(
-                $"This installation states no MailFathom deployment to reach. Write the address of yours as "
-                + $"'{DeploymentSettings.SectionName}:{nameof(DeploymentSettings.Address)}' — for example "
-                + "'https://mail.example.test' — in the appsettings.json this application reads.");
+            return null;
         }
 
-        // Scheme-relative and schemeless are the same case here: the deployment is named by an origin, so anything
-        // before the host that is not a scheme is not something this can repair.
-        var addressed = stated.Contains("://", StringComparison.Ordinal)
-            ? stated
-            : $"{DefaultScheme}://{stated.TrimStart('/')}";
-
-        if (!Uri.TryCreate(addressed, UriKind.Absolute, out var address))
-        {
-            throw new InvalidOperationException(
+        return DeploymentAddressText.TryRead(settings.Address, out var address)
+            ? address
+            : throw new InvalidOperationException(
                 $"'{settings.Address}' is not an address this application can reach a deployment at. Write "
                 + $"'{DeploymentSettings.SectionName}:{nameof(DeploymentSettings.Address)}' as an origin — the scheme, "
                 + "host, and port and nothing else — for example 'https://mail.example.test'.");
-        }
-
-        return address;
     }
 }

--- a/frontend/src/Client/Deployment/DeploymentAddressText.cs
+++ b/frontend/src/Client/Deployment/DeploymentAddressText.cs
@@ -1,0 +1,52 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace MailFathom.Client.Deployment;
+
+/// <summary>How an address somebody wrote becomes one this client can be pointed at.</summary>
+/// <remarks>
+/// <para>
+/// Written once because it is read in two places that must agree: a value in an installation's own configuration file
+/// and a value somebody typed into the screen that asks for one. Two readers with two ideas of what
+/// <c>mail.example.test</c> means would be a client that reached a different deployment depending on where the same
+/// text was written.
+/// </para>
+/// <para>
+/// HTTPS is the default rather than a requirement stated twice. A value written without a scheme is read as HTTPS,
+/// because that is what a deployment reached across a network is served over and because the alternative — reading it
+/// as clear text — would turn an omission into an exposure. Whether the result may be used at all is
+/// <c>DeploymentAddressRule</c>'s question and is not answered here, so one rule judges every address whoever wrote it.
+/// </para>
+/// </remarks>
+internal static class DeploymentAddressText
+{
+    /// <summary>What a value with no scheme is read as.</summary>
+    private const string DefaultScheme = "https";
+
+    /// <summary>Reads written text as the address it names.</summary>
+    /// <param name="written">What somebody wrote, which may be blank or nonsense.</param>
+    /// <param name="address">The address it names, where it names one.</param>
+    /// <returns><see langword="true" /> when the text names an absolute address; <see langword="false" /> when it is blank or unreadable.</returns>
+    internal static bool TryRead(string? written, [NotNullWhen(true)] out Uri? address)
+    {
+        var stated = written?.Trim() ?? string.Empty;
+
+        if (stated.Length == 0)
+        {
+            address = null;
+
+            return false;
+        }
+
+        // Scheme-relative and schemeless are the same case here: the deployment is named by an origin, so anything
+        // before the host that is not a scheme is not something this can repair.
+        var addressed = stated.Contains("://", StringComparison.Ordinal)
+            ? stated
+            : $"{DefaultScheme}://{stated.TrimStart('/')}";
+
+        return Uri.TryCreate(addressed, UriKind.Absolute, out address);
+    }
+}

--- a/frontend/src/Client/Deployment/DeploymentChoice.cs
+++ b/frontend/src/Client/Deployment/DeploymentChoice.cs
@@ -1,0 +1,195 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Backend;
+
+namespace MailFathom.Client.Deployment;
+
+/// <summary>What became of an address somebody offered the client.</summary>
+/// <remarks>
+/// One closed set rather than two, because a person typing an address does not care which layer refused it: whether the
+/// text was not an address, whether it was one this client may not carry a credential to, or whether nothing answered
+/// there, what they get is one sentence and another try. The screen maps each of these to exactly one string, which is
+/// why a case added here is a string owed in every language rather than a message composed at the point of failure.
+/// </remarks>
+internal enum DeploymentChoiceOutcome
+{
+    /// <summary>The client is now pointed at that deployment, and will be again when it next starts.</summary>
+    Accepted = 0,
+
+    /// <summary>The text does not name an address at all.</summary>
+    NotAnAddress = 1,
+
+    /// <summary>It is clear text to somewhere that is not this machine, which would hand the sign-in to whatever is on the path.</summary>
+    ClearTextOffThisMachine = 2,
+
+    /// <summary>It carries more than an origin — a path, a query, a fragment, or a credential written into it.</summary>
+    MoreThanAnOrigin = 3,
+
+    /// <summary>Nothing answered there.</summary>
+    Unreachable = 4,
+
+    /// <summary>Something is there and did not answer in time.</summary>
+    TimedOut = 5,
+
+    /// <summary>Something answered, and it is not a MailFathom deployment.</summary>
+    NotADeployment = 6,
+}
+
+/// <summary>Which deployment this installation reaches, and how somebody changes it.</summary>
+/// <remarks>
+/// <para>
+/// The whole of the answer, assembled from the three things that can hold one. A person's own choice outlives every
+/// restart and is read first, because it is the most recent thing anybody actually decided. What a build stated comes
+/// next, which is how a local orchestration hands its head an address nobody typed. What the head knows for itself is
+/// last: a file beside an installed application, or the origin a browser head was served from. When none of them
+/// answers, this installation is one nobody has pointed anywhere yet — which is a state rather than a failure, and the
+/// client's answer to it is to ask.
+/// </para>
+/// <para>
+/// Changing it is the same act as choosing it the first time, deliberately: one path, judged and proved the same way,
+/// so a second deployment is reached by exactly what reached the first. Ending the session that belonged to the
+/// previous one is <see cref="DeploymentAddress" />'s and happens as part of pointing the client elsewhere.
+/// </para>
+/// </remarks>
+internal sealed class DeploymentChoice
+{
+    private readonly IDeploymentChoiceStore store;
+    private readonly IDeploymentAddressSource head;
+    private readonly DeploymentSettings settings;
+    private readonly DeploymentAddress address;
+    private readonly DeploymentProbe probe;
+
+    /// <summary>Initializes the choice over what keeps it, what the head knows, and what proves an address.</summary>
+    /// <param name="store">Where a person's choice is kept between runs.</param>
+    /// <param name="head">What this head knows before anybody has chosen.</param>
+    /// <param name="settings">What the installation stated, for the heads that read it.</param>
+    /// <param name="address">The address every transport follows.</param>
+    /// <param name="probe">How a candidate is proved before it is kept.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    public DeploymentChoice(
+        IDeploymentChoiceStore store,
+        IDeploymentAddressSource head,
+        DeploymentSettings settings,
+        DeploymentAddress address,
+        DeploymentProbe probe)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(head);
+        ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(address);
+        ArgumentNullException.ThrowIfNull(probe);
+
+        this.store = store;
+        this.head = head;
+        this.settings = settings;
+        this.address = address;
+        this.probe = probe;
+    }
+
+    /// <summary>Points the client at whatever was decided before this run.</summary>
+    /// <returns><see langword="true" /> when the client is now pointed somewhere; <see langword="false" /> when nobody has said where.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when a build or an installation stated an address this client may not be pointed at.</exception>
+    /// <remarks>
+    /// The two kinds of stated address are held to different standards on purpose. Something a build or an installation
+    /// wrote is a statement somebody made and can correct, so one this client may not carry a credential to fails
+    /// loudly here rather than being dropped — a configured deployment that was quietly ignored is the worst of the
+    /// three outcomes. A kept choice is not a statement anybody can go and read, so one that no longer passes the rule
+    /// is simply forgotten and the person is asked again.
+    /// </remarks>
+    public bool Restore()
+    {
+        var chosen = this.store.Read();
+
+        if (chosen is not null && DeploymentAddressRule.Judge(chosen) == DeploymentAddressRefusal.None)
+        {
+            this.address.PointAt(chosen);
+
+            return true;
+        }
+
+        var stated = this.head.Resolve(this.settings);
+
+        if (stated is null)
+        {
+            return false;
+        }
+
+        var refusal = DeploymentAddressRule.Judge(stated);
+
+        if (refusal != DeploymentAddressRefusal.None)
+        {
+            throw new InvalidOperationException(
+                $"'{stated}' was stated as the MailFathom deployment this head reaches, and is not one this client may "
+                + $"be pointed at ({refusal}). Every request carries the signed-in credential, so the address has to be "
+                + "an origin — the scheme, host, and port and nothing else — and https to anything but this machine.");
+        }
+
+        this.address.PointAt(stated);
+
+        return true;
+    }
+
+    /// <summary>Judges, proves, keeps, and points the client at an address somebody wrote.</summary>
+    /// <param name="written">What they wrote, which may be blank or nonsense.</param>
+    /// <param name="cancellationToken">Abandons the attempt.</param>
+    /// <returns>What became of it.</returns>
+    /// <remarks>
+    /// Nothing is kept until something has answered at the address, which is what turns a typing mistake into a
+    /// sentence on the screen a person is already looking at rather than into an authentication failure after they have
+    /// entered a password. The order is deliberate the other way round too: the rule is applied before anything is
+    /// sent, so an address this client may not carry a credential to is never contacted at all.
+    /// </remarks>
+    public async ValueTask<DeploymentChoiceOutcome> ChooseAsync(
+        string? written,
+        CancellationToken cancellationToken = default)
+    {
+        if (!DeploymentAddressText.TryRead(written, out var candidate))
+        {
+            return DeploymentChoiceOutcome.NotAnAddress;
+        }
+
+        var refused = Refused(DeploymentAddressRule.Judge(candidate));
+
+        if (refused is not null)
+        {
+            return refused.Value;
+        }
+
+        try
+        {
+            await this.probe.ReachAsync(candidate, cancellationToken).ConfigureAwait(false);
+        }
+        catch (DeploymentFailure failure)
+        {
+            return Unreached(failure.Reason);
+        }
+
+        this.store.Write(candidate);
+        this.address.PointAt(candidate);
+
+        return DeploymentChoiceOutcome.Accepted;
+    }
+
+    /// <summary>Says what the rule's refusal is, in the terms the screen speaks.</summary>
+    private static DeploymentChoiceOutcome? Refused(DeploymentAddressRefusal refusal) => refusal switch
+    {
+        DeploymentAddressRefusal.None => null,
+        DeploymentAddressRefusal.ClearTextOffThisMachine => DeploymentChoiceOutcome.ClearTextOffThisMachine,
+        DeploymentAddressRefusal.MoreThanAnOrigin => DeploymentChoiceOutcome.MoreThanAnOrigin,
+        _ => DeploymentChoiceOutcome.NotAnAddress,
+    };
+
+    /// <summary>Says what an exchange that produced no answer is, in the same terms.</summary>
+    /// <remarks>
+    /// A refused credential cannot arrive here — the probe presents none, and reads a refusal as a deployment guarding
+    /// its client surface — so it falls in with the answer nothing can be made of, which is what it would be.
+    /// </remarks>
+    private static DeploymentChoiceOutcome Unreached(DeploymentFailureReason reason) => reason switch
+    {
+        DeploymentFailureReason.Unreachable => DeploymentChoiceOutcome.Unreachable,
+        DeploymentFailureReason.TimedOut => DeploymentChoiceOutcome.TimedOut,
+        _ => DeploymentChoiceOutcome.NotADeployment,
+    };
+}

--- a/frontend/src/Client/Deployment/DeploymentChoice.cs
+++ b/frontend/src/Client/Deployment/DeploymentChoice.cs
@@ -121,9 +121,10 @@ internal sealed class DeploymentChoice
         if (refusal != DeploymentAddressRefusal.None)
         {
             throw new InvalidOperationException(
-                $"'{stated}' was stated as the MailFathom deployment this head reaches, and is not one this client may "
-                + $"be pointed at ({refusal}). Every request carries the signed-in credential, so the address has to be "
-                + "an origin — the scheme, host, and port and nothing else — and https to anything but this machine.");
+                $"{DeploymentAddressRule.Describe(stated)} was stated as the MailFathom deployment this head reaches, "
+                + $"and is not one this client may be pointed at ({refusal}). Every request carries the signed-in "
+                + "credential, so the address has to be an origin — the scheme, host, and port and nothing else — and "
+                + "https to anything but this machine.");
         }
 
         this.address.PointAt(stated);

--- a/frontend/src/Client/Deployment/DeploymentSettings.cs
+++ b/frontend/src/Client/Deployment/DeploymentSettings.cs
@@ -14,8 +14,10 @@ namespace MailFathom.Client.Deployment;
 /// the origin it was fetched from and this section's <see cref="Address" /> says nothing to it.
 /// </para>
 /// <para>
-/// Read once, while the host is being composed. Nothing re-reads it: which deployment an installation talks to is not
-/// something a running window changes.
+/// Read once, while the host is being composed, and it is where the client <em>starts</em> rather than where it stays.
+/// A person can point the application at a deployment while it is running, and what they choose is kept where a
+/// restart finds it and is read before this — so an installation that stated an address is one that has been given a
+/// first answer, not one that has been fixed to it.
 /// </para>
 /// </remarks>
 internal sealed record DeploymentSettings
@@ -27,11 +29,12 @@ internal sealed record DeploymentSettings
     /// <remarks>
     /// An origin — scheme, host, and port — and nothing beneath it: MailFathom serves its client surface at a prefix
     /// this application already knows, so there is no sub-path deployment to state one for. A path written here is
-    /// refused rather than dropped — <c>DeploymentOptions</c> throws while the host is being composed, naming the
-    /// address — which is the loud half of the same rule that refuses an address stating nothing at all.
+    /// refused rather than dropped — the client fails while it is starting, naming the address — which is the loud half
+    /// of a rule whose quiet half is an installation stating nothing at all, since that one is answered by asking
+    /// whoever is using the application instead.
     /// A value with no scheme is read as HTTPS, which is the only scheme a deployment reached across a network may use;
-    /// clear text is refused for anything but this machine, and refused by <c>Client.Backend</c> rather than here, so
-    /// one rule judges every head.
+    /// clear text is refused for anything but this machine, by <c>DeploymentAddressRule</c> rather than here, so one
+    /// rule judges every address whoever wrote it.
     /// </remarks>
     public string Address { get; init; } = string.Empty;
 

--- a/frontend/src/Client/Deployment/IDeploymentAddressSource.cs
+++ b/frontend/src/Client/Deployment/IDeploymentAddressSource.cs
@@ -16,12 +16,23 @@ namespace MailFathom.Client.Deployment;
 /// a head an orchestration started, served from a socket of its own beside the service. <c>App</c> applies it, so a
 /// new head still owes exactly one implementation of this interface.
 /// </para>
+/// <para>
+/// What none of them is, is the last word. A person's own choice is read before any of these and outlives every
+/// restart — <see cref="DeploymentChoice" /> is where the two meet — so a source here answers what this head knows
+/// before anybody has said anything.
+/// </para>
 /// </remarks>
 internal interface IDeploymentAddressSource
 {
     /// <summary>Resolves the deployment's base address for this head.</summary>
     /// <param name="settings">What the installation stated, which a head is free to have no use for.</param>
-    /// <returns>The absolute address every route is resolved against.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when the head needs a stated address and the installation states none it can use.</exception>
-    Uri Resolve(DeploymentSettings settings);
+    /// <returns>The absolute address every route is resolved against, or <see langword="null" /> where this head has nothing to say.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when something did state an address and it is not one anything could be reached at.</exception>
+    /// <remarks>
+    /// Nothing to say and something unusable to say are deliberately different answers. A head nobody has configured is
+    /// the ordinary state of a first run, and the client asks a person rather than failing; a head configured with an
+    /// address that cannot be parsed was configured wrongly, and quietly asking as though nothing had been written
+    /// would leave whoever wrote it with no way to find out it was ignored.
+    /// </remarks>
+    Uri? Resolve(DeploymentSettings settings);
 }

--- a/frontend/src/Client/Deployment/IDeploymentChoiceStore.cs
+++ b/frontend/src/Client/Deployment/IDeploymentChoiceStore.cs
@@ -1,0 +1,31 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Deployment;
+
+/// <summary>Where the deployment somebody chose is kept, so that starting the client again is opening it.</summary>
+/// <remarks>
+/// <para>
+/// A seam because the thing behind it is a platform store that no unit test can reach — a per-user preferences file on
+/// a desktop, the browser's own storage for the origin the page came from — while everything decided around it is
+/// ordinary logic that ought to be tested. What is written is an address and nothing else: no credential, no mailbox,
+/// nothing a deployment answered, so it carries none of the classification the rest of this client's data does.
+/// </para>
+/// <para>
+/// Per user rather than per installation, and that is the platform's own answer rather than one this application
+/// arranges. A desktop head writes into the account's own application data, so two people sharing a machine keep two
+/// answers; a browser head writes into storage scoped to the origin it was served from, which is that browser profile's
+/// and nobody else's.
+/// </para>
+/// </remarks>
+internal interface IDeploymentChoiceStore
+{
+    /// <summary>Reads the deployment chosen before this run.</summary>
+    /// <returns>What was chosen, or <see langword="null" /> where nobody has chosen yet or what was kept is no longer readable as an address.</returns>
+    Uri? Read();
+
+    /// <summary>Keeps a deployment as the one this installation reaches from now on.</summary>
+    /// <param name="address">The chosen deployment's base address.</param>
+    void Write(Uri address);
+}

--- a/frontend/src/Client/Deployment/IDeploymentChoiceStore.cs
+++ b/frontend/src/Client/Deployment/IDeploymentChoiceStore.cs
@@ -27,5 +27,6 @@ internal interface IDeploymentChoiceStore
 
     /// <summary>Keeps a deployment as the one this installation reaches from now on.</summary>
     /// <param name="address">The chosen deployment's base address.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="address" /> is <see langword="null" />.</exception>
     void Write(Uri address);
 }

--- a/frontend/src/Client/Deployment/LocalSettingsDeploymentChoiceStore.cs
+++ b/frontend/src/Client/Deployment/LocalSettingsDeploymentChoiceStore.cs
@@ -1,0 +1,43 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Deployment;
+
+/// <summary>Keeps the chosen deployment in the settings store the platform already has.</summary>
+/// <remarks>
+/// <para>
+/// <see cref="ApplicationData.LocalSettings" /> rather than a file this application invents, because every head already
+/// has one and each maps it to what that platform actually uses: a per-user preferences store on a desktop and the
+/// browser's own storage for the page's origin in the browser head. So "per user" and "survives a restart" are the
+/// platform's guarantees rather than something written here, and the same two lines of code are correct on all of them.
+/// </para>
+/// <para>
+/// The value is written as the text of the address rather than as anything serialized. A settings store holds simple
+/// values, the browser head publishes trimmed, and a single origin has no shape worth a serializer — reading it back is
+/// the same parse a person's typed address goes through, which is also why a value that is no longer readable is
+/// treated as nothing having been chosen rather than as a failure to start.
+/// </para>
+/// </remarks>
+internal sealed class LocalSettingsDeploymentChoiceStore : IDeploymentChoiceStore
+{
+    /// <summary>The name the chosen address is kept under.</summary>
+    /// <remarks>Qualified, because the container is shared with every other setting this application and its framework keep — Uno's own theme choice is in there beside it.</remarks>
+    internal const string SettingName = "MailFathom.Deployment.Address";
+
+    /// <inheritdoc />
+    public Uri? Read() =>
+        ApplicationData.Current.LocalSettings.Values.TryGetValue(SettingName, out var kept)
+        && kept is string written
+        && Uri.TryCreate(written, UriKind.Absolute, out var address)
+            ? address
+            : null;
+
+    /// <inheritdoc />
+    public void Write(Uri address)
+    {
+        ArgumentNullException.ThrowIfNull(address);
+
+        ApplicationData.Current.LocalSettings.Values[SettingName] = address.AbsoluteUri;
+    }
+}

--- a/frontend/src/Client/Platforms/WebAssembly/PageOriginDeploymentAddress.cs
+++ b/frontend/src/Client/Platforms/WebAssembly/PageOriginDeploymentAddress.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Runtime.InteropServices.JavaScript;
+using MailFathom.Client.Backend;
 using MailFathom.Client.Deployment;
 
 namespace MailFathom.Client.Platforms.WebAssembly;
@@ -22,6 +23,13 @@ namespace MailFathom.Client.Platforms.WebAssembly;
 /// rather than as a page that reached whoever served it.
 /// </para>
 /// <para>
+/// A person's own choice is a different thing, and it does win over this. A bundle served from somewhere that is not a
+/// deployment — a static host, a file server, a page kept open from one — has an origin that answers nothing, and that
+/// origin being wrong is exactly what they would be correcting. So this is what the head knows and what a first visit
+/// takes, rather than the last word; reaching a deployment that did not serve the page needs that deployment to permit
+/// this origin as a cross-origin caller, which is the operator's decision and not one this can arrange.
+/// </para>
+/// <para>
 /// The one case this is the wrong answer to is a head an orchestration started, where the origin is a development
 /// server and the service listens on another socket. That is not a second reading of this document — nothing here can
 /// know it — and it is answered before this is asked, by
@@ -35,8 +43,27 @@ namespace MailFathom.Client.Platforms.WebAssembly;
 internal sealed partial class PageOriginDeploymentAddress : IDeploymentAddressSource
 {
     /// <inheritdoc />
-    /// <remarks>The origin carries a trailing slash, so it is an origin and not a document: the address every route is resolved against has to be a base, and <c>Client.Backend</c> refuses one carrying anything more than that.</remarks>
-    public Uri Resolve(DeploymentSettings settings) => new(Origin());
+    /// <remarks>
+    /// <para>
+    /// An origin and not a document, which is what the address every route is resolved against has to be —
+    /// <see cref="DeploymentAddressRule" /> refuses one carrying anything more.
+    /// </para>
+    /// <para>
+    /// The origin is judged here rather than handed on unjudged, and that is what keeps the loud half of
+    /// <see cref="DeploymentChoice.Restore" /> loud. An address a person or a build <em>stated</em> and that this
+    /// client may not be pointed at is a mistake somebody can go and correct, so it fails while the application is
+    /// starting and names itself. An origin is neither: nobody wrote it, and a bundle served over clear text from
+    /// something that is not this machine — a page opened from a colleague's development server, a static host on a
+    /// local network — would take the whole application down at launch over a fact its reader could do nothing about.
+    /// So an origin this client may not carry a credential to is an origin this head has no answer from, and the
+    /// person is asked instead, which is the one thing that can actually resolve it.
+    /// </para>
+    /// </remarks>
+    public Uri? Resolve(DeploymentSettings settings) =>
+        Uri.TryCreate(Origin(), UriKind.Absolute, out var origin)
+        && DeploymentAddressRule.Judge(origin) == DeploymentAddressRefusal.None
+            ? origin
+            : null;
 
     [JSImport("globalThis.mailFathomDeployment.origin")]
     private static partial string Origin();

--- a/frontend/src/Client/Presentation/ClientRoutes.cs
+++ b/frontend/src/Client/Presentation/ClientRoutes.cs
@@ -1,0 +1,21 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Presentation;
+
+/// <summary>The routes this application is reachable by, named once.</summary>
+/// <remarks>
+/// A route is a string in three places — where it is registered, where a model navigates to it, and where a XAML
+/// <c>Navigation.Request</c> names it — and only the first two can be held together by a compiler. A route renamed in
+/// one of those and not the others fails at run time as a navigation that does nothing, which is why the two C# ends
+/// read from here; the XAML end states the same word and is what a reader of the page sees.
+/// </remarks>
+internal static class ClientRoutes
+{
+    /// <summary>The application itself, which is where a client pointed at a deployment starts.</summary>
+    internal const string Main = "Main";
+
+    /// <summary>The screen that asks which deployment this client reaches, which is where one pointed nowhere starts.</summary>
+    internal const string Connect = "Connect";
+}

--- a/frontend/src/Client/Presentation/ConnectModel.cs
+++ b/frontend/src/Client/Presentation/ConnectModel.cs
@@ -1,0 +1,132 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Backend;
+using MailFathom.Client.Deployment;
+using Microsoft.Extensions.Localization;
+
+namespace MailFathom.Client.Presentation;
+
+/// <summary>
+/// The model behind <see cref="ConnectPage"/>: where a person says which MailFathom is theirs, and where they say it
+/// again when it is a different one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// One screen for both, because they are one act. A first start has nothing to reach and asks; somebody moving between
+/// a test deployment and a real one comes back here and is asked the same question, with the address they are on
+/// already in the box so that changing it is an edit rather than a retyping.
+/// </para>
+/// <para>
+/// Nothing is stored until something has answered at the address. That is what the third of this screen's reasons for
+/// existing is: a person who mistypes is told the client cannot reach it while they are still on this screen, rather
+/// than being handed an authentication failure for what was a connection problem.
+/// </para>
+/// </remarks>
+internal sealed partial record ConnectModel
+{
+    private readonly DeploymentChoice choice;
+    private readonly DeploymentAddress address;
+    private readonly INavigator navigator;
+    private readonly IStringLocalizer localizer;
+
+    /// <summary>Initializes the model over what decides an address and where the client goes once one is decided.</summary>
+    /// <param name="choice">Which deployment this installation reaches, and how it is changed.</param>
+    /// <param name="address">Where the client is pointed now, which is what the box opens on.</param>
+    /// <param name="navigator">Where the person goes once an address has been accepted.</param>
+    /// <param name="localizer">Where the sentence explaining a refusal comes from.</param>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    public ConnectModel(
+        DeploymentChoice choice,
+        DeploymentAddress address,
+        INavigator navigator,
+        IStringLocalizer localizer)
+    {
+        ArgumentNullException.ThrowIfNull(choice);
+        ArgumentNullException.ThrowIfNull(address);
+        ArgumentNullException.ThrowIfNull(navigator);
+        ArgumentNullException.ThrowIfNull(localizer);
+
+        this.choice = choice;
+        this.address = address;
+        this.navigator = navigator;
+        this.localizer = localizer;
+    }
+
+    /// <summary>The address as it is being written, which opens on whatever the client is pointed at.</summary>
+    /// <remarks>An installation nobody has pointed anywhere opens on an empty box rather than on a suggestion, for the reason nothing in this client composes a default address: a value offered here is one somebody would accept without reading it.</remarks>
+    public IState<string> Address => State.Value(this, () => this.address.Current?.AbsoluteUri ?? string.Empty);
+
+    /// <summary>Why the last attempt was not accepted, or empty where nothing has been refused.</summary>
+    /// <remarks>
+    /// A sentence rather than the failure itself. Everything <c>Client.Backend</c> raises carries an English message
+    /// written for a log, and one of them can carry text from a machine this process does not own, so the screen says
+    /// what happened in the language being read in and the outcome is what chooses which sentence.
+    /// </remarks>
+    public IState<string> Refusal => State.Value(this, () => string.Empty);
+
+    /// <summary>Whether anything was refused, which is what puts the sentence on the screen.</summary>
+    /// <remarks>
+    /// Derived from the sentence rather than kept beside it: two values saying the same thing are two values that can
+    /// disagree, and the one that would be wrong is the one deciding whether a message is shown at all. It reads a
+    /// blank as nothing having been refused because MVUX carries one that way — a state set to an empty string reaches
+    /// a reader as no value rather than as an empty one — and both readings mean the same thing here.
+    /// </remarks>
+    public IFeed<bool> IsRefused => this.Refusal.Select(refusal => !string.IsNullOrEmpty(refusal));
+
+    /// <summary>Whether the client is asking the address what is there.</summary>
+    /// <remarks>Reaching an address that is not answering takes as long as the configured timeout, which is long enough that a screen saying nothing would read as one that had stopped working.</remarks>
+    public IState<bool> IsAsking => State.Value(this, () => false);
+
+    /// <summary>Whether the address may be offered, which it may not be while the last one is still being asked.</summary>
+    public IFeed<bool> CanAsk => this.IsAsking.Select(asking => !asking);
+
+    /// <summary>Takes the address that has been written, and moves on where something answered at it.</summary>
+    /// <param name="ct">Abandons the attempt.</param>
+    /// <returns>A task completing once the address has been accepted or refused.</returns>
+    public async ValueTask Connect(CancellationToken ct)
+    {
+        await this.IsAsking.SetAsync(true, ct).ConfigureAwait(false);
+        await this.Refusal.SetAsync(string.Empty, ct).ConfigureAwait(false);
+
+        try
+        {
+            var outcome = await this.choice
+                .ChooseAsync(await this.Address, ct)
+                .ConfigureAwait(false);
+
+            if (outcome != DeploymentChoiceOutcome.Accepted)
+            {
+                await this.Refusal.SetAsync(this.Explain(outcome), ct).ConfigureAwait(false);
+
+                return;
+            }
+        }
+        finally
+        {
+            await this.IsAsking.SetAsync(false, ct).ConfigureAwait(false);
+        }
+
+        // The back stack is cleared rather than added to: the screen behind this one belonged to a deployment the
+        // client has just stopped reaching, and the system back gesture returning to it would offer a way back into an
+        // application pointed somewhere it no longer is.
+        //
+        // The request is built and handed to the interface rather than composed by one of the NavigatorExtensions
+        // helpers. Those exist to turn a view-model type into a route, which is work this does not need — the route is
+        // named — and they do it by resolving IRouteResolver out of a service provider they reach through the
+        // navigator, which is the whole navigation graph rather than the seam a model should depend on.
+        await this.navigator
+            .NavigateAsync(
+                new NavigationRequest(
+                    this,
+                    new Route(Qualifier: Qualifiers.ClearBackStack, Base: ClientRoutes.Main),
+                    ct))
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>Says what became of an address in the language the person is reading in.</summary>
+    /// <remarks>The resource name is composed from the outcome, so a case added to that set is a missing string the resource-table test names rather than a message that quietly falls back to a key.</remarks>
+    private string Explain(DeploymentChoiceOutcome outcome) =>
+        this.localizer[$"ConnectPage.Refusal.{outcome}"];
+}

--- a/frontend/src/Client/Presentation/ConnectPage.xaml
+++ b/frontend/src/Client/Presentation/ConnectPage.xaml
@@ -1,0 +1,79 @@
+<!--
+Copyright © 2026 Krzysztof Kasprowicz
+Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+Project repository: https://github.com/Krzysztof318/MailFathom
+-->
+<Page x:Class="MailFathom.Client.Presentation.ConnectPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MailFathom.Client.Presentation"
+      xmlns:utu="using:Uno.Toolkit.UI"
+      NavigationCacheMode="Required"
+      Background="{ThemeResource BackgroundBrush}">
+  <ScrollViewer IsTabStop="True">
+    <!-- SafeArea keeps the content clear of a notch, a rounded corner, and a system bar. SoftInput is what this screen
+         adds over the others: it is the one screen whose whole purpose is typing, so the keyboard must not come up over
+         the box being typed into. -->
+    <Grid utu:SafeArea.Insets="VisibleBounds,SoftInput">
+      <Grid.RowDefinitions>
+        <RowDefinition Height="Auto" />
+        <RowDefinition />
+      </Grid.RowDefinitions>
+
+      <utu:NavigationBar x:Uid="ConnectPage.NavigationBar.Title" />
+
+      <!-- One column, capped rather than fixed, so the block reads the same in a phone-width window and stops growing
+           into a line nobody can follow on a wide desktop one. -->
+      <StackPanel Grid.Row="1"
+                  HorizontalAlignment="Center"
+                  VerticalAlignment="Center"
+                  MaxWidth="420"
+                  Padding="24"
+                  Spacing="20">
+
+        <TextBlock x:Uid="ConnectPage.TextBlock.Lead"
+                   Style="{StaticResource BodyTextBlockStyle}"
+                   TextWrapping="Wrap" />
+
+        <StackPanel Spacing="8">
+          <TextBlock x:Name="AddressLabel"
+                     x:Uid="ConnectPage.TextBlock.Address"
+                     Style="{StaticResource BodyTextBlockStyle}" />
+
+          <!-- Two-way, because what is typed is the state the model reads when the button is pressed rather than
+               something read off the control. The label above names the control to a screen reader as well as to a
+               reader, which is why it is bound rather than repeated. -->
+          <TextBox x:Uid="ConnectPage.TextBox.Address"
+                   Text="{Binding Address, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                   AutomationProperties.LabeledBy="{Binding ElementName=AddressLabel}"
+                   InputScope="Url"
+                   IsSpellCheckEnabled="False"
+                   HorizontalAlignment="Stretch" />
+
+          <TextBlock x:Uid="ConnectPage.TextBlock.AddressHint"
+                     Style="{StaticResource CaptionTextBlockStyle}"
+                     TextWrapping="Wrap" />
+        </StackPanel>
+
+        <!-- The refusal, in the language being read in. It is Error rather than Informational because nothing was kept
+             and nothing was reached: the address is still waiting to be corrected. -->
+        <InfoBar x:Uid="ConnectPage.InfoBar.Refusal"
+                 IsOpen="{Binding IsRefused}"
+                 IsClosable="False"
+                 Message="{Binding Refusal}"
+                 Severity="Error" />
+
+        <Button x:Uid="ConnectPage.Button.Connect"
+                Command="{Binding Connect}"
+                IsEnabled="{Binding CanAsk}"
+                Style="{StaticResource FilledButtonStyle}"
+                HorizontalAlignment="Stretch" />
+
+        <!-- Reaching an address that is not answering takes as long as the configured timeout, so the screen says it is
+             still asking rather than appearing to have ignored the press. -->
+        <ProgressRing IsActive="{Binding IsAsking}"
+                      HorizontalAlignment="Center" />
+      </StackPanel>
+    </Grid>
+  </ScrollViewer>
+</Page>

--- a/frontend/src/Client/Presentation/ConnectPage.xaml.cs
+++ b/frontend/src/Client/Presentation/ConnectPage.xaml.cs
@@ -1,0 +1,16 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Presentation;
+
+/// <summary>The screen that asks which MailFathom deployment this client reaches.</summary>
+/// <remarks>It is the first screen a fresh installation reaches and the one somebody returns to in order to point the client elsewhere; which of the two is happening is the address already in the box, and nothing here needs to know.</remarks>
+internal sealed partial class ConnectPage : Page
+{
+    /// <summary>Initializes the page.</summary>
+    public ConnectPage()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/frontend/src/Client/Presentation/MainModel.cs
+++ b/frontend/src/Client/Presentation/MainModel.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Collections.Immutable;
+using MailFathom.Client.Backend;
 using Microsoft.Extensions.Localization;
 
 namespace MailFathom.Client.Presentation;
@@ -16,28 +17,45 @@ public partial record MainModel
 {
     private readonly ILocalizationService localization;
     private readonly IThemeService themes;
+    private readonly DeploymentAddress address;
     private readonly IImmutableList<AppLanguage> languages;
     private readonly IImmutableList<AppThemeOption> themeOptions;
 
-    /// <summary>Initializes the model over the two services a reader's choices are held by.</summary>
+    /// <summary>Initializes the model over the services a reader's choices are held by, and over the deployment reached.</summary>
     /// <param name="localization">Which languages the application is readable in, and which one it is being read in.</param>
     /// <param name="themes">The theme service, which holds the choice and persists it across restarts.</param>
+    /// <param name="address">Which deployment this client is pointed at, which is what the screen names.</param>
     /// <param name="localizer">Where a string resolved here rather than by a <c>x:Uid</c> in the view comes from.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
-    public MainModel(ILocalizationService localization, IThemeService themes, IStringLocalizer localizer)
+    public MainModel(
+        ILocalizationService localization,
+        IThemeService themes,
+        DeploymentAddress address,
+        IStringLocalizer localizer)
     {
         ArgumentNullException.ThrowIfNull(localization);
         ArgumentNullException.ThrowIfNull(themes);
+        ArgumentNullException.ThrowIfNull(address);
         ArgumentNullException.ThrowIfNull(localizer);
 
         this.localization = localization;
         this.themes = themes;
+        this.address = address;
         this.languages = [.. localization.SupportedCultures.Select(AppLanguage.FromCulture)];
         this.themeOptions = [.. AppThemeOption.Offered.Select(theme => AppThemeOption.Named(theme, localizer))];
     }
 
     /// <summary>What this build of the client reports about itself.</summary>
     public IFeed<ClientBuild> Build => Feed.Async(_ => ValueTask.FromResult(ClientBuild.Current));
+
+    /// <summary>The deployment this client is pointed at, as it would be typed.</summary>
+    /// <remarks>
+    /// A person running a client against more than one deployment has to be able to tell which one they are looking at
+    /// without signing in to find out, and it is what makes the way to change it findable rather than remembered. It is
+    /// read once, because pointing the client elsewhere leaves this screen and comes back to a new one.
+    /// </remarks>
+    public IFeed<string> Deployment =>
+        Feed.Async(_ => ValueTask.FromResult(this.address.Current?.AbsoluteUri ?? string.Empty));
 
     /// <summary>
     /// The languages this application can be read in, in the order the configuration names them, carrying which of

--- a/frontend/src/Client/Presentation/MainPage.xaml
+++ b/frontend/src/Client/Presentation/MainPage.xaml
@@ -8,6 +8,7 @@ Project repository: https://github.com/Krzysztof318/MailFathom
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:local="using:MailFathom.Client.Presentation"
       xmlns:mvux="using:Uno.Extensions.Reactive.UI"
+      xmlns:uen="using:Uno.Extensions.Navigation.UI"
       xmlns:utu="using:Uno.Toolkit.UI"
       NavigationCacheMode="Required"
       Background="{ThemeResource BackgroundBrush}">
@@ -49,6 +50,30 @@ Project repository: https://github.com/Krzysztof318/MailFathom
             </StackPanel>
           </DataTemplate>
         </mvux:FeedView>
+
+        <!-- Which deployment this client reaches, and the way to point it at another one. It is on the screen rather
+             than buried in a setting because somebody running a client against a test deployment and a real one has to
+             be able to tell which of them they are looking at without signing in to find out. -->
+        <StackPanel Spacing="8">
+          <TextBlock x:Uid="MainPage.TextBlock.Deployment"
+                     Style="{StaticResource BodyTextBlockStyle}" />
+
+          <mvux:FeedView Source="{Binding Deployment}">
+            <DataTemplate>
+              <TextBlock Text="{Binding Data}"
+                         Style="{StaticResource BodyStrongTextBlockStyle}"
+                         TextWrapping="Wrap"
+                         IsTextSelectionEnabled="True" />
+            </DataTemplate>
+          </mvux:FeedView>
+
+          <!-- Declarative navigation rather than a handler: the route is what a reader of this page looks for, and a
+               screen reached this way is one the system back gesture moves back through. -->
+          <Button x:Uid="MainPage.Button.ChangeDeployment"
+                  uen:Navigation.Request="Connect"
+                  Style="{StaticResource OutlinedButtonStyle}"
+                  HorizontalAlignment="Stretch" />
+        </StackPanel>
 
         <!-- Both pickers sit outside the FeedView deliberately: they are the application's own state rather than
              anything the build feed carries, so they stay reachable while that feed is loading or has failed. -->

--- a/frontend/src/Client/Strings/en/Resources.resw
+++ b/frontend/src/Client/Strings/en/Resources.resw
@@ -121,6 +121,66 @@
     <value>MailFathom</value>
     <comment>The product name. It is the same in every language: a name is not translated.</comment>
   </data>
+  <data name="MainPage.TextBlock.Deployment.Text" xml:space="preserve">
+    <value>Connected to</value>
+    <comment>Labels the address of the MailFathom deployment this client reaches. Phrased as the relationship rather than as "Deployment address", which names a setting instead of saying where you are.</comment>
+  </data>
+  <data name="MainPage.Button.ChangeDeployment.Content" xml:space="preserve">
+    <value>Use a different MailFathom</value>
+    <comment>Opens the screen that asks for a deployment address. Named for what a person wants rather than for the setting it changes.</comment>
+  </data>
+  <data name="ConnectPage.NavigationBar.Title.Content" xml:space="preserve">
+    <value>Your MailFathom</value>
+    <comment>Titles the screen that asks which deployment this client reaches. Possessive, because a deployment is somebody's own server rather than a service they sign up to.</comment>
+  </data>
+  <data name="ConnectPage.TextBlock.Lead.Text" xml:space="preserve">
+    <value>MailFathom runs on a server you control. Tell this application where yours is, and it will start there from now on.</value>
+    <comment>Says why the screen is asking, for somebody who has just installed the client and may not know that no address is assumed.</comment>
+  </data>
+  <data name="ConnectPage.TextBlock.Address.Text" xml:space="preserve">
+    <value>Address</value>
+    <comment>Labels the box the deployment address is written in, for a reader and for a screen reader.</comment>
+  </data>
+  <data name="ConnectPage.TextBox.Address.PlaceholderText" xml:space="preserve">
+    <value>mail.example.com</value>
+    <comment>An example of the shape rather than a suggestion: it is a reserved example domain, so nobody reaches anything by leaving it as it is.</comment>
+  </data>
+  <data name="ConnectPage.TextBlock.AddressHint.Text" xml:space="preserve">
+    <value>The address and nothing after it. Written without https:// it is read as https://.</value>
+    <comment>States the two things about the shape somebody could otherwise only learn from a refusal: no path, and what an omitted scheme means.</comment>
+  </data>
+  <data name="ConnectPage.Button.Connect.Content" xml:space="preserve">
+    <value>Connect</value>
+    <comment>Takes the address written above and checks that a MailFathom answers there. Phrased as the act, and nothing is kept unless it succeeds.</comment>
+  </data>
+  <data name="ConnectPage.InfoBar.Refusal.Title" xml:space="preserve">
+    <value>Not connected</value>
+    <comment>Heads the sentence explaining why an address was not taken. States the outcome; the message beside it states the cause.</comment>
+  </data>
+  <data name="ConnectPage.Refusal.NotAnAddress" xml:space="preserve">
+    <value>That is not an address. Write the server's name, such as mail.example.com.</value>
+    <comment>Shown when the text cannot be read as an address at all. Repeats the shape rather than the text, which the person can still see.</comment>
+  </data>
+  <data name="ConnectPage.Refusal.ClearTextOffThisMachine" xml:space="preserve">
+    <value>That address is not secured. Everything this application sends carries your sign-in, so write an https:// address.</value>
+    <comment>Shown for clear text to anything but this machine. Says why rather than only that it is refused, because the person chose http:// deliberately.</comment>
+  </data>
+  <data name="ConnectPage.Refusal.MoreThanAnOrigin" xml:space="preserve">
+    <value>Write the address and nothing after it — no path, and no sign-in written into it.</value>
+    <comment>Shown when the address carries a path, a query, a fragment, or embedded credentials.</comment>
+  </data>
+  <data name="ConnectPage.Refusal.Unreachable" xml:space="preserve">
+    <value>Nothing answered at that address. Check that it is right and that this device is online.</value>
+    <comment>Shown when the connection failed outright. Names both causes, because from here they are indistinguishable.</comment>
+  </data>
+  <data name="ConnectPage.Refusal.TimedOut" xml:space="preserve">
+    <value>That address did not answer in time. Try again in a moment.</value>
+    <comment>Shown when something is there and was too slow. Worth retrying unchanged, which is what separates it from the message above.</comment>
+  </data>
+  <data name="ConnectPage.Refusal.NotADeployment" xml:space="preserve">
+    <value>Something answered there, but it is not a MailFathom. Check the address.</value>
+    <comment>Shown when the answer was not MailFathom's own — a captive portal, a proxy, or another service on the port.</comment>
+  </data>
   <data name="MainPage.TextBlock.Language.Text" xml:space="preserve">
     <value>Language</value>
     <comment>Labels the control that chooses which language the application is read in, for a reader and for a screen reader.</comment>

--- a/frontend/src/Client/Strings/pl/Resources.resw
+++ b/frontend/src/Client/Strings/pl/Resources.resw
@@ -121,6 +121,66 @@
     <value>MailFathom</value>
     <comment>The product name. It is the same in every language: a name is not translated.</comment>
   </data>
+  <data name="MainPage.TextBlock.Deployment.Text" xml:space="preserve">
+    <value>Połączono z</value>
+    <comment>Labels the address of the MailFathom deployment this client reaches. Phrased as the relationship rather than as "Deployment address", which names a setting instead of saying where you are.</comment>
+  </data>
+  <data name="MainPage.Button.ChangeDeployment.Content" xml:space="preserve">
+    <value>Użyj innego MailFathom</value>
+    <comment>Opens the screen that asks for a deployment address. Named for what a person wants rather than for the setting it changes.</comment>
+  </data>
+  <data name="ConnectPage.NavigationBar.Title.Content" xml:space="preserve">
+    <value>Twój MailFathom</value>
+    <comment>Titles the screen that asks which deployment this client reaches. Possessive, because a deployment is somebody's own server rather than a service they sign up to.</comment>
+  </data>
+  <data name="ConnectPage.TextBlock.Lead.Text" xml:space="preserve">
+    <value>MailFathom działa na serwerze, który należy do Ciebie. Podaj tej aplikacji adres swojego, a od teraz będzie się od niego zaczynać.</value>
+    <comment>Says why the screen is asking, for somebody who has just installed the client and may not know that no address is assumed.</comment>
+  </data>
+  <data name="ConnectPage.TextBlock.Address.Text" xml:space="preserve">
+    <value>Adres</value>
+    <comment>Labels the box the deployment address is written in, for a reader and for a screen reader.</comment>
+  </data>
+  <data name="ConnectPage.TextBox.Address.PlaceholderText" xml:space="preserve">
+    <value>mail.example.com</value>
+    <comment>An example of the shape rather than a suggestion: it is a reserved example domain, so nobody reaches anything by leaving it as it is.</comment>
+  </data>
+  <data name="ConnectPage.TextBlock.AddressHint.Text" xml:space="preserve">
+    <value>Sam adres, bez niczego po nim. Zapisany bez https:// jest odczytywany jako https://.</value>
+    <comment>States the two things about the shape somebody could otherwise only learn from a refusal: no path, and what an omitted scheme means.</comment>
+  </data>
+  <data name="ConnectPage.Button.Connect.Content" xml:space="preserve">
+    <value>Połącz</value>
+    <comment>Takes the address written above and checks that a MailFathom answers there. Phrased as the act, and nothing is kept unless it succeeds.</comment>
+  </data>
+  <data name="ConnectPage.InfoBar.Refusal.Title" xml:space="preserve">
+    <value>Brak połączenia</value>
+    <comment>Heads the sentence explaining why an address was not taken. States the outcome; the message beside it states the cause.</comment>
+  </data>
+  <data name="ConnectPage.Refusal.NotAnAddress" xml:space="preserve">
+    <value>To nie jest adres. Wpisz nazwę serwera, na przykład mail.example.com.</value>
+    <comment>Shown when the text cannot be read as an address at all. Repeats the shape rather than the text, which the person can still see.</comment>
+  </data>
+  <data name="ConnectPage.Refusal.ClearTextOffThisMachine" xml:space="preserve">
+    <value>Ten adres nie jest zabezpieczony. Wszystko, co ta aplikacja wysyła, niesie Twoje logowanie, więc wpisz adres https://.</value>
+    <comment>Shown for clear text to anything but this machine. Says why rather than only that it is refused, because the person chose http:// deliberately.</comment>
+  </data>
+  <data name="ConnectPage.Refusal.MoreThanAnOrigin" xml:space="preserve">
+    <value>Wpisz sam adres, bez niczego po nim — bez ścieżki i bez wpisanego w niego logowania.</value>
+    <comment>Shown when the address carries a path, a query, a fragment, or embedded credentials.</comment>
+  </data>
+  <data name="ConnectPage.Refusal.Unreachable" xml:space="preserve">
+    <value>Pod tym adresem nic nie odpowiedziało. Sprawdź, czy jest poprawny i czy to urządzenie ma połączenie.</value>
+    <comment>Shown when the connection failed outright. Names both causes, because from here they are indistinguishable.</comment>
+  </data>
+  <data name="ConnectPage.Refusal.TimedOut" xml:space="preserve">
+    <value>Ten adres nie odpowiedział na czas. Spróbuj ponownie za chwilę.</value>
+    <comment>Shown when something is there and was too slow. Worth retrying unchanged, which is what separates it from the message above.</comment>
+  </data>
+  <data name="ConnectPage.Refusal.NotADeployment" xml:space="preserve">
+    <value>Coś tam odpowiedziało, ale to nie jest MailFathom. Sprawdź adres.</value>
+    <comment>Shown when the answer was not MailFathom's own — a captive portal, a proxy, or another service on the port.</comment>
+  </data>
   <data name="MainPage.TextBlock.Language.Text" xml:space="preserve">
     <value>Język</value>
     <comment>Labels the control that chooses which language the application is read in, for a reader and for a screen reader.</comment>

--- a/frontend/src/Client/appsettings.development.json
+++ b/frontend/src/Client/appsettings.development.json
@@ -3,8 +3,8 @@
   // published head ever takes anything from this file, and it is not a fallback for an installation that stated
   // nothing.
   //
-  // What it is for is starting a head from the sources by hand. An installed head refuses to start without a
-  // deployment to reach, which is the right answer for somebody's own machine and the wrong one for a contributor
+  // What it is for is starting a head from the sources by hand. A head with no deployment to reach opens on the screen
+  // that asks for one, which is the right answer for somebody's own machine and one step in the way of a contributor
   // opening a window to look at a screen, so this states an address for that case. Nothing is expected to answer at
   // it: a head started this way is not started beside a service, and the port one run happened to take is not
   // something a committed file could know.

--- a/frontend/src/Client/appsettings.json
+++ b/frontend/src/Client/appsettings.json
@@ -11,14 +11,16 @@
     "Cultures": [ "en", "pl" ]
   },
 
-  // Which MailFathom deployment this application reaches. It is read by every head, and one of the two values below
-  // means nothing to the browser head: that head is served by the deployment it talks to, so its address is the origin
-  // it was fetched from and no installation states one.
+  // Which MailFathom deployment this application starts against. It is read by every head, and one of the two values
+  // below means nothing to the browser head: that head is served by the deployment it talks to, so its address is the
+  // origin it was fetched from and no installation states one.
   "Deployment": {
     // The deployment's address, as an origin: the scheme, host, and port and nothing beneath them. Empty here on
     // purpose — only whoever installed this application knows which server holds their mail, and an application that
-    // guessed would reach somebody else's. An installed head started without one says so while it is starting and
-    // names this setting. A value written without a scheme is read as HTTPS.
+    // guessed would reach somebody else's. A head started without one asks for it on its first screen rather than
+    // failing, and what somebody answers there is kept and read before this on every later start. A value written
+    // without a scheme is read as HTTPS; one that cannot be read at all fails while the application is starting,
+    // because a setting that was quietly ignored is worse than one that was refused.
     "Address": "",
 
     // The name this application is registered under with the deployment's authorization server. It is public

--- a/frontend/tests/Client.UnitTests/Backend/DeploymentAddressRuleTests.cs
+++ b/frontend/tests/Client.UnitTests/Backend/DeploymentAddressRuleTests.cs
@@ -1,0 +1,95 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Backend;
+
+namespace MailFathom.Client.UnitTests.Backend;
+
+/// <summary>What makes an address one this client may be pointed at, which is judged before anything is stored or sent.</summary>
+/// <remarks>
+/// The clear-text rule is the one that matters most and is the least obvious: every request this client sends carries
+/// the signed-in credential, so an address this rule let through would be one somebody's sign-in travels to in the
+/// open. It is stated once and read by everything that takes an address — what an installation wrote, what a build
+/// stated, and what a person typed — which is what these assertions are protecting.
+/// </remarks>
+public sealed class DeploymentAddressRuleTests
+{
+    [Fact]
+    public void Judge_AnOrigin_IsAnAddressThisClientMayBePointedAt()
+    {
+        // Act
+        var refusal = DeploymentAddressRule.Judge(new Uri("https://mail.example/"));
+
+        // Assert
+        Assert.Equal(DeploymentAddressRefusal.None, refusal);
+    }
+
+    [Fact]
+    public void Judge_NoAddressAtAll_IsRefusedRatherThanThrowing()
+    {
+        // Act, Assert
+        // The rule is asked about candidates, and "nothing was written" is one of them.
+        Assert.Equal(DeploymentAddressRefusal.NotAWebAddress, DeploymentAddressRule.Judge(null));
+    }
+
+    [Fact]
+    public void Judge_ARelativeAddress_IsRefusedBecauseNoRouteCouldResolveAgainstIt()
+    {
+        // Act
+        var refusal = DeploymentAddressRule.Judge(new Uri("/api/client", UriKind.Relative));
+
+        // Assert
+        Assert.Equal(DeploymentAddressRefusal.NotAWebAddress, refusal);
+    }
+
+    [Fact]
+    public void Judge_AnAddressThatIsNotWebAddressable_IsRefused()
+    {
+        // Act
+        var refusal = DeploymentAddressRule.Judge(new Uri("file:///home/somebody/mail"));
+
+        // Assert
+        Assert.Equal(DeploymentAddressRefusal.NotAWebAddress, refusal);
+    }
+
+    [Theory]
+    [InlineData("http://mail.example/")]
+    [InlineData("http://192.0.2.10:8080/")]
+    public void Judge_AClearTextAddressToAnotherHost_IsRefusedBecauseEveryRequestCarriesTheCredential(string address)
+    {
+        // Act
+        var refusal = DeploymentAddressRule.Judge(new Uri(address));
+
+        // Assert
+        Assert.Equal(DeploymentAddressRefusal.ClearTextOffThisMachine, refusal);
+    }
+
+    [Theory]
+    [InlineData("http://localhost:5000/")]
+    [InlineData("http://127.0.0.1:5000/")]
+    [InlineData("http://[::1]:5000/")]
+    public void Judge_AClearTextAddressOnThisMachine_IsAllowedAsTheDevelopmentPostureItIs(string address)
+    {
+        // Act
+        var refusal = DeploymentAddressRule.Judge(new Uri(address));
+
+        // Assert
+        Assert.Equal(DeploymentAddressRefusal.None, refusal);
+    }
+
+    /// <summary>A route resolves against the origin, so a path here would never be reached and nothing would say so — and a credential written into the address would be carried on every request instead of being dropped.</summary>
+    [Theory]
+    [InlineData("https://mail.example/mailfathom/")]
+    [InlineData("https://mail.example/?tenant=mail")]
+    [InlineData("https://mail.example/#mail")]
+    [InlineData("https://somebody:secret@mail.example/")]
+    public void Judge_AnAddressCarryingMoreThanAnOrigin_IsRefusedRatherThanSilentlyDropped(string address)
+    {
+        // Act
+        var refusal = DeploymentAddressRule.Judge(new Uri(address));
+
+        // Assert
+        Assert.Equal(DeploymentAddressRefusal.MoreThanAnOrigin, refusal);
+    }
+}

--- a/frontend/tests/Client.UnitTests/Backend/DeploymentAddressRuleTests.cs
+++ b/frontend/tests/Client.UnitTests/Backend/DeploymentAddressRuleTests.cs
@@ -92,4 +92,52 @@ public sealed class DeploymentAddressRuleTests
         // Assert
         Assert.Equal(DeploymentAddressRefusal.MoreThanAnOrigin, refusal);
     }
+
+    /// <summary>The one message most likely to name a secret is the one refusing an address for carrying one.</summary>
+    /// <remarks>
+    /// <c>GetLeftPart(UriPartial.Authority)</c> is the obvious way to write this and it keeps the user information, so
+    /// the assertion is on the secret's absence rather than on the shape of the answer.
+    /// </remarks>
+    [Theory]
+    [InlineData("https://user:secret@mail.example/", "'https://mail.example'")]
+    [InlineData("http://user:secret@mail.example:8443/path?q=1#f", "'http://mail.example:8443'")]
+    [InlineData("https://user@mail.example/", "'https://mail.example'")]
+    public void Describe_AnAddressCarryingEmbeddedCredentials_NamesNeitherTheUserNorTheSecret(
+        string address,
+        string expected)
+    {
+        // Act
+        var described = DeploymentAddressRule.Describe(new Uri(address));
+
+        // Assert
+        Assert.Equal(expected, described);
+        Assert.DoesNotContain("secret", described, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("user", described, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Describe_AnOrigin_NamesIt()
+    {
+        // Act, Assert
+        Assert.Equal("'https://mail.example:8443'", DeploymentAddressRule.Describe(new Uri("https://mail.example:8443/")));
+    }
+
+    /// <summary>Its original text could be anything at all, and the refusal it can carry says the whole of what a reader needs.</summary>
+    [Fact]
+    public void Describe_SomethingThatIsNotAnAbsoluteAddress_NamesNothingOfIt()
+    {
+        // Act
+        var described = DeploymentAddressRule.Describe(new Uri("/api/client?token=secret", UriKind.Relative));
+
+        // Assert
+        Assert.Equal("That value", described);
+        Assert.DoesNotContain("secret", described, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Describe_NoAddressAtAll_IsRefused()
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentNullException>(() => DeploymentAddressRule.Describe(null!));
+    }
 }

--- a/frontend/tests/Client.UnitTests/Backend/DeploymentAddressTests.cs
+++ b/frontend/tests/Client.UnitTests/Backend/DeploymentAddressTests.cs
@@ -107,6 +107,29 @@ public sealed class DeploymentAddressTests
         Assert.False(pointed.IsPointed);
     }
 
+    /// <summary>The judgement comes before anything is written, so a refused address moves nobody and signs nobody out.</summary>
+    /// <remarks>
+    /// The ordering is what this asserts rather than the refusal, which the theory above already covers. A client
+    /// already reaching a deployment with somebody signed in against it is the state where getting the order wrong
+    /// costs something: mutating first and judging afterwards would leave the client pointed at an address it just
+    /// refused, and forgetting first would end a session over a value that never took effect.
+    /// </remarks>
+    [Fact]
+    public void PointAt_ARefusedAddressWhileAlreadyPointed_LeavesBothTheAddressAndTheSessionAlone()
+    {
+        // Arrange
+        var tokens = new AccessTokenStore();
+        var address = new DeploymentAddress(tokens);
+
+        address.PointAt(new Uri("https://mail.example/"));
+        tokens.Accept("issued-by-that-deployment");
+
+        // Act, Assert
+        Assert.Throws<ArgumentException>("address", () => address.PointAt(new Uri("http://other.example/")));
+        Assert.Equal(new Uri("https://mail.example/"), address.Current);
+        Assert.True(tokens.IsSignedIn);
+    }
+
     [Fact]
     public void Construct_NoCredentialStore_IsRefused()
     {

--- a/frontend/tests/Client.UnitTests/Backend/DeploymentAddressTests.cs
+++ b/frontend/tests/Client.UnitTests/Backend/DeploymentAddressTests.cs
@@ -130,6 +130,24 @@ public sealed class DeploymentAddressTests
         Assert.True(tokens.IsSignedIn);
     }
 
+    /// <summary>An exception message is read into a log, and the refusal most likely to carry a secret is the one for an address carrying one.</summary>
+    [Fact]
+    public void PointAt_AnAddressCarryingEmbeddedCredentials_RefusesItWithoutNamingTheSecret()
+    {
+        // Arrange
+        var address = new DeploymentAddress(new AccessTokenStore());
+
+        // Act
+        var failure = Assert.Throws<ArgumentException>(
+            "address",
+            () => address.PointAt(new Uri("https://somebody:secret@mail.example/")));
+
+        // Assert
+        Assert.DoesNotContain("secret", failure.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("somebody", failure.Message, StringComparison.Ordinal);
+        Assert.Contains("https://mail.example", failure.Message, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void Construct_NoCredentialStore_IsRefused()
     {

--- a/frontend/tests/Client.UnitTests/Backend/DeploymentAddressTests.cs
+++ b/frontend/tests/Client.UnitTests/Backend/DeploymentAddressTests.cs
@@ -1,0 +1,116 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Backend;
+using MailFathom.Client.Backend.Authorization;
+
+namespace MailFathom.Client.UnitTests.Backend;
+
+/// <summary>Where the client is pointed, and what moving it does to the session held against where it was.</summary>
+/// <remarks>
+/// The session claim is the one worth reading twice. A credential belongs to an owner on one deployment and means
+/// nothing on another, so moving the client has to end it — and it has to end it <em>here</em> rather than at each
+/// caller, because a caller that forgot would leave one deployment's token on a client now aimed at somebody else's
+/// server.
+/// </remarks>
+public sealed class DeploymentAddressTests
+{
+    [Fact]
+    public void Current_NothingHasPointedIt_IsNowhereRatherThanADefault()
+    {
+        // Arrange
+        var address = new DeploymentAddress(new AccessTokenStore());
+
+        // Act, Assert
+        Assert.Null(address.Current);
+        Assert.False(address.IsPointed);
+    }
+
+    [Fact]
+    public void PointAt_ADeployment_IsWhereTheClientIsPointed()
+    {
+        // Arrange
+        var address = new DeploymentAddress(new AccessTokenStore());
+
+        // Act
+        address.PointAt(new Uri("https://mail.example/"));
+
+        // Assert
+        Assert.Equal(new Uri("https://mail.example/"), address.Current);
+        Assert.True(address.IsPointed);
+    }
+
+    [Fact]
+    public void PointAt_AnotherDeployment_EndsTheSessionHeldAgainstTheFirst()
+    {
+        // Arrange
+        var tokens = new AccessTokenStore();
+        var address = new DeploymentAddress(tokens);
+
+        address.PointAt(new Uri("https://mail.example/"));
+        tokens.Accept("issued-by-the-first-deployment");
+
+        // Act
+        address.PointAt(new Uri("https://other.example/"));
+
+        // Assert
+        Assert.False(tokens.IsSignedIn);
+    }
+
+    /// <summary>Every start re-reads what was kept, so pointing the client where it already is must not sign anybody out.</summary>
+    [Fact]
+    public void PointAt_TheDeploymentItAlreadyReaches_LeavesTheSessionAlone()
+    {
+        // Arrange
+        var tokens = new AccessTokenStore();
+        var address = new DeploymentAddress(tokens);
+
+        address.PointAt(new Uri("https://mail.example/"));
+        tokens.Accept("issued-by-that-deployment");
+
+        // Act
+        address.PointAt(new Uri("https://mail.example/"));
+
+        // Assert
+        Assert.True(tokens.IsSignedIn);
+    }
+
+    /// <summary>The first pointing of a run is not a move, so a client composed and then pointed keeps whatever it was handed.</summary>
+    [Fact]
+    public void PointAt_TheFirstDeploymentOfARun_LeavesTheSessionAlone()
+    {
+        // Arrange
+        var tokens = new AccessTokenStore();
+        var address = new DeploymentAddress(tokens);
+
+        tokens.Accept("issued-before-anything-was-pointed");
+
+        // Act
+        address.PointAt(new Uri("https://mail.example/"));
+
+        // Assert
+        Assert.True(tokens.IsSignedIn);
+    }
+
+    [Theory]
+    [InlineData("http://mail.example/")]
+    [InlineData("https://mail.example/mailfathom/")]
+    [InlineData("file:///home/somebody/mail")]
+    public void PointAt_AnAddressTheRuleRefuses_IsRefusedHereToo(string address)
+    {
+        // Arrange
+        var pointed = new DeploymentAddress(new AccessTokenStore());
+
+        // Act, Assert
+        Assert.Throws<ArgumentException>("address", () => pointed.PointAt(new Uri(address)));
+        Assert.False(pointed.IsPointed);
+    }
+
+    [Fact]
+    public void Construct_NoCredentialStore_IsRefused()
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentNullException>(() => new DeploymentAddress(null!));
+    }
+}

--- a/frontend/tests/Client.UnitTests/Backend/DeploymentOptionsTests.cs
+++ b/frontend/tests/Client.UnitTests/Backend/DeploymentOptionsTests.cs
@@ -6,72 +6,18 @@ using MailFathom.Client.Backend;
 
 namespace MailFathom.Client.UnitTests.Backend;
 
-/// <summary>That the address a deployment is reached at is the host's to state, and is refused when it is unusable.</summary>
+/// <summary>That what an installation states about reaching a deployment is refused where it is unusable.</summary>
+/// <remarks>Which deployment is reached is not among those values and is not asserted here: it is decided at run time and is <c>DeploymentAddressTests</c>'s subject, with the rule that judges it in <c>DeploymentAddressRuleTests</c>.</remarks>
 public sealed class DeploymentOptionsTests
 {
     [Fact]
     public void Constructor_NoTimeoutStated_TakesTheDefaultRatherThanNone()
     {
         // Arrange, Act
-        var options = new DeploymentOptions(new Uri("https://mail.example/"), "the-client");
+        var options = new DeploymentOptions("the-client");
 
         // Assert
         Assert.Equal(DeploymentOptions.DefaultTimeout, options.Timeout);
-    }
-
-    [Fact]
-    public void Constructor_ARelativeAddress_IsRefusedWhereItIsStatedRatherThanAtTheFirstRequest()
-    {
-        // Arrange, Act, Assert
-        Assert.Throws<ArgumentException>(
-            "address",
-            () => new DeploymentOptions(new Uri("/api/client", UriKind.Relative), "the-client"));
-    }
-
-    [Fact]
-    public void Constructor_AnAddressThatIsNotWebAddressable_IsRefused()
-    {
-        // Arrange, Act, Assert
-        Assert.Throws<ArgumentException>(
-            "address",
-            () => new DeploymentOptions(new Uri("file:///home/somebody/mail"), "the-client"));
-    }
-
-    [Theory]
-    [InlineData("http://mail.example/")]
-    [InlineData("http://192.0.2.10:8080/")]
-    public void Constructor_AClearTextAddressToAnotherHost_IsRefusedBecauseEveryRequestCarriesTheToken(string address)
-    {
-        // Arrange, Act, Assert
-        Assert.Throws<ArgumentException>("address", () => new DeploymentOptions(new Uri(address), "the-client"));
-    }
-
-    [Theory]
-    [InlineData("http://localhost:5000/")]
-    [InlineData("http://127.0.0.1:5000/")]
-    [InlineData("http://[::1]:5000/")]
-    public void Constructor_AClearTextAddressOnThisMachine_IsAllowedAsTheDevelopmentPostureItIs(string address)
-    {
-        // Arrange, Act
-        var options = new DeploymentOptions(new Uri(address), "the-client");
-
-        // Assert
-        Assert.Equal(new Uri(address), options.Address);
-    }
-
-    [Theory]
-    [InlineData("https://mail.example/mailfathom/")]
-    [InlineData("https://mail.example/?tenant=mail")]
-    [InlineData("https://mail.example/#mail")]
-    [InlineData("https://somebody:secret@mail.example/")]
-    public void Constructor_AnAddressCarryingMoreThanAnOrigin_IsRefusedRatherThanSilentlyDropped(string address)
-    {
-        // Arrange, Act, Assert
-        // A route resolves against the origin, so a path written here would never be reached and nothing would say so,
-        // and a credential written into the address would be carried on every request instead of being dropped.
-        Assert.Throws<ArgumentException>(
-            "address",
-            () => new DeploymentOptions(new Uri(address), "the-client"));
     }
 
     [Theory]
@@ -80,9 +26,7 @@ public sealed class DeploymentOptionsTests
     public void Constructor_ABlankClientIdentifier_IsRefused(string clientId)
     {
         // Arrange, Act, Assert
-        Assert.Throws<ArgumentException>(
-            "clientId",
-            () => new DeploymentOptions(new Uri("https://mail.example/"), clientId));
+        Assert.Throws<ArgumentException>("clientId", () => new DeploymentOptions(clientId));
     }
 
     [Fact]
@@ -91,6 +35,6 @@ public sealed class DeploymentOptionsTests
         // Arrange, Act, Assert
         Assert.Throws<ArgumentOutOfRangeException>(
             "timeout",
-            () => new DeploymentOptions(new Uri("https://mail.example/"), "the-client", TimeSpan.Zero));
+            () => new DeploymentOptions("the-client", TimeSpan.Zero));
     }
 }

--- a/frontend/tests/Client.UnitTests/Backend/DeploymentProbeTests.cs
+++ b/frontend/tests/Client.UnitTests/Backend/DeploymentProbeTests.cs
@@ -171,6 +171,23 @@ public sealed class DeploymentProbeTests : IDisposable
         Assert.Empty(this.answers.Requests);
     }
 
+    /// <summary>Nothing is sent and nothing is said: the candidate is refused before contact, and the message names no credential written into it.</summary>
+    [Fact]
+    public async Task ReachAsync_ACandidateCarryingEmbeddedCredentials_RefusesItWithoutNamingTheSecret()
+    {
+        // Act
+        var failure = await Assert.ThrowsAsync<ArgumentException>(
+            "candidate",
+            () => this.probe.ReachAsync(
+                new Uri("https://somebody:secret@mail.example/"),
+                TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.DoesNotContain("secret", failure.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("somebody", failure.Message, StringComparison.Ordinal);
+        Assert.Empty(this.answers.Requests);
+    }
+
     [Fact]
     public async Task ReachAsync_NoCandidate_IsRefused()
     {

--- a/frontend/tests/Client.UnitTests/Backend/DeploymentProbeTests.cs
+++ b/frontend/tests/Client.UnitTests/Backend/DeploymentProbeTests.cs
@@ -1,0 +1,181 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Net;
+using MailFathom.Client.Backend;
+using MailFathom.Client.UnitTests.TestDoubles;
+
+namespace MailFathom.Client.UnitTests.Backend;
+
+/// <summary>What an address turns out to be when it is asked, before anything is kept or signed in to.</summary>
+/// <remarks>
+/// Three claims carry the feature. Something has to answer, and answer the way MailFathom does, or a mistyped address
+/// would be kept and arrive later as an authentication failure. A deployment that refuses an unauthenticated caller is
+/// still a deployment, because that is what a correctly configured one does and refusing every one of them would make
+/// this screen unusable against a real installation. And no credential is presented, because the whole point of asking
+/// is that nobody knows yet what is at the other end.
+/// </remarks>
+public sealed class DeploymentProbeTests : IDisposable
+{
+    private static readonly Uri Candidate = new("https://mail.example/");
+
+    private readonly StubTransport answers;
+    private readonly HttpClient transport;
+    private readonly DeploymentProbe probe;
+
+    /// <summary>Builds a probe over a transport a test scripts through <see cref="Answer" />.</summary>
+    public DeploymentProbeTests()
+    {
+        this.answers = new StubTransport(request => this.Answer(request));
+        this.transport = new HttpClient(this.answers);
+        this.probe = new DeploymentProbe(
+            new StubHttpClientFactory(
+                new Dictionary<string, HttpClient>(StringComparer.Ordinal)
+                {
+                    [DeploymentHttpClients.DeploymentProbe] = this.transport,
+                }));
+    }
+
+    /// <summary>How the address under test answers, which each test replaces.</summary>
+    private Func<HttpRequestMessage, HttpResponseMessage> Answer { get; set; } =
+        _ => StubTransport.JsonResponse("{}");
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        this.transport.Dispose();
+        this.answers.Dispose();
+    }
+
+    [Fact]
+    public async Task ReachAsync_AMailFathomDeployment_IsReachedAndDescribesItself()
+    {
+        // Arrange
+        this.Answer = _ => StubTransport.JsonResponse(
+            """{"service":"MailFathom","version":"0.8.0","credential":"anonymous","permissions":[]}""");
+
+        // Act
+        var reach = await this.probe.ReachAsync(Candidate, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(reach.IsGuarded);
+        Assert.Equal("0.8.0", reach.Session?.Version);
+    }
+
+    /// <summary>The route the client surface publishes, resolved against the candidate rather than against a base address nothing has set yet.</summary>
+    [Fact]
+    public async Task ReachAsync_ACandidate_IsAskedTheSessionRouteBeneathIt()
+    {
+        // Arrange
+        this.Answer = _ => StubTransport.JsonResponse("""{"service":"MailFathom","version":"0.8.0","credential":"anonymous","permissions":[]}""");
+
+        // Act
+        await this.probe.ReachAsync(new Uri("https://mail.example:8443/"), TestContext.Current.CancellationToken);
+
+        // Assert
+        var asked = Assert.Single(this.answers.Requests);
+        Assert.Equal(new Uri("https://mail.example:8443/api/client/session"), asked.RequestUri);
+    }
+
+    /// <summary>Nobody has vouched for this address yet, so the session's credential must not be offered to it.</summary>
+    [Fact]
+    public async Task ReachAsync_ACandidate_IsAskedWithoutACredential()
+    {
+        // Arrange
+        this.Answer = _ => StubTransport.JsonResponse("""{"service":"MailFathom","version":"0.8.0","credential":"anonymous","permissions":[]}""");
+
+        // Act
+        await this.probe.ReachAsync(Candidate, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Null(Assert.Single(this.answers.Requests).Authorization);
+    }
+
+    /// <summary>What a deployment configured the way MailFathom's own documentation asks answers, which has to read as a deployment.</summary>
+    [Theory]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.Forbidden)]
+    public async Task ReachAsync_ADeploymentGuardingItsClientSurface_IsReachedWithoutDescribingItself(
+        HttpStatusCode status)
+    {
+        // Arrange
+        this.Answer = _ => new HttpResponseMessage(status);
+
+        // Act
+        var reach = await this.probe.ReachAsync(Candidate, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(reach.IsGuarded);
+        Assert.Null(reach.Session);
+    }
+
+    /// <summary>Anything can answer on a port, so the answer naming another product is not a deployment however well formed it is.</summary>
+    [Fact]
+    public async Task ReachAsync_SomethingElseAnsweringTheRoute_IsNotADeployment()
+    {
+        // Arrange
+        this.Answer = _ => StubTransport.JsonResponse(
+            """{"service":"SomebodyElse","version":"3.1","credential":"anonymous","permissions":[]}""");
+
+        // Act
+        var failure = await Assert.ThrowsAsync<DeploymentFailure>(
+            () => this.probe.ReachAsync(Candidate, TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(DeploymentFailureReason.Unusable, failure.Reason);
+    }
+
+    /// <summary>A captive portal or a proxy answers with a page rather than with this document, and that is the same verdict.</summary>
+    [Fact]
+    public async Task ReachAsync_AnAnswerThatIsNotTheDocument_IsNotADeployment()
+    {
+        // Arrange
+        this.Answer = _ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("<html>Sign in to the hotel network</html>"),
+        };
+
+        // Act
+        var failure = await Assert.ThrowsAsync<DeploymentFailure>(
+            () => this.probe.ReachAsync(Candidate, TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(DeploymentFailureReason.Unusable, failure.Reason);
+    }
+
+    [Fact]
+    public async Task ReachAsync_NothingAtTheAddress_IsUnreachable()
+    {
+        // Arrange
+        this.Answer = _ => throw new HttpRequestException("no route to host");
+
+        // Act
+        var failure = await Assert.ThrowsAsync<DeploymentFailure>(
+            () => this.probe.ReachAsync(Candidate, TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(DeploymentFailureReason.Unreachable, failure.Reason);
+    }
+
+    /// <summary>The rule runs before anything is sent, so an address this client may not carry a credential to is never contacted at all.</summary>
+    [Fact]
+    public async Task ReachAsync_AnAddressTheRuleRefuses_IsNotContacted()
+    {
+        // Act
+        await Assert.ThrowsAsync<ArgumentException>(
+            "candidate",
+            () => this.probe.ReachAsync(new Uri("http://mail.example/"), TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Empty(this.answers.Requests);
+    }
+
+    [Fact]
+    public async Task ReachAsync_NoCandidate_IsRefused()
+    {
+        // Act, Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => this.probe.ReachAsync(null!, TestContext.Current.CancellationToken));
+    }
+}

--- a/frontend/tests/Client.UnitTests/Deployment/ConfiguredDeploymentAddressTests.cs
+++ b/frontend/tests/Client.UnitTests/Deployment/ConfiguredDeploymentAddressTests.cs
@@ -8,10 +8,11 @@ namespace MailFathom.Client.UnitTests.Deployment;
 
 /// <summary>Covers how an installed head reads the deployment it was told to reach.</summary>
 /// <remarks>
-/// Three claims, and the first two matter more than they look. An installation stating nothing fails rather than
-/// reaching a default, because the default anyone would pick is somebody else's deployment; and a value with no scheme
-/// is read as HTTPS, because reading it as clear text would turn an omission into a token handed to whatever is on the
-/// path. Whether a clear-text address is acceptable at all is <c>Client.Backend</c>'s rule and is asserted with it.
+/// The two claims that matter are the two ways of saying nothing usable, and they are deliberately different answers.
+/// An installation that stated no address at all is the ordinary state of a fresh one, so it answers nothing and the
+/// client asks whoever is using it; an installation that stated something unreadable is a value somebody wrote and
+/// would otherwise never learn was ignored, so it fails. The third claim is that a value with no scheme is read as
+/// HTTPS, because reading it as clear text would turn an omission into a sign-in handed to whatever is on the path.
 /// </remarks>
 public sealed class ConfiguredDeploymentAddressTests
 {
@@ -45,27 +46,23 @@ public sealed class ConfiguredDeploymentAddressTests
         Assert.Equal(new Uri("https://mail.example.test"), address);
     }
 
-    /// <summary>The failure a head with no deployment has to end on, naming the setting rather than opening a window that cannot explain itself.</summary>
+    /// <summary>A fresh installation is one nobody has configured, and the client's answer to that is to ask rather than to fail.</summary>
     [Theory]
     [InlineData("")]
     [InlineData("   ")]
-    public void Resolve_AnInstallationStatingNoAddress_FailsNamingTheSetting(string stated)
+    public void Resolve_AnInstallationStatingNoAddress_HasNothingToSay(string stated)
     {
         // Arrange
         var source = new ConfiguredDeploymentAddress();
 
         // Act
-        var failure = Assert.Throws<InvalidOperationException>(
-            () => source.Resolve(new DeploymentSettings { Address = stated }));
+        var address = source.Resolve(new DeploymentSettings { Address = stated });
 
         // Assert
-        Assert.Contains(
-            $"{DeploymentSettings.SectionName}:{nameof(DeploymentSettings.Address)}",
-            failure.Message,
-            StringComparison.Ordinal);
+        Assert.Null(address);
     }
 
-    /// <summary>A mistyped address is the same failure rather than a silent fallback, and the message repeats what was written so it can be found.</summary>
+    /// <summary>A mistyped address is a failure rather than a silent fallback, and the message repeats what was written so it can be found.</summary>
     [Fact]
     public void Resolve_AnAddressNothingCanBeReachedAt_FailsRepeatingWhatWasWritten()
     {
@@ -79,6 +76,10 @@ public sealed class ConfiguredDeploymentAddressTests
 
         // Assert
         Assert.Contains(stated, failure.Message, StringComparison.Ordinal);
+        Assert.Contains(
+            $"{DeploymentSettings.SectionName}:{nameof(DeploymentSettings.Address)}",
+            failure.Message,
+            StringComparison.Ordinal);
     }
 
     [Fact]

--- a/frontend/tests/Client.UnitTests/Deployment/DeploymentAddressTextTests.cs
+++ b/frontend/tests/Client.UnitTests/Deployment/DeploymentAddressTextTests.cs
@@ -1,0 +1,65 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Deployment;
+
+namespace MailFathom.Client.UnitTests.Deployment;
+
+/// <summary>How written text becomes an address, which has to be the same reading wherever it was written.</summary>
+/// <remarks>The HTTPS default is the claim with a consequence: somebody typing their server's name into a screen and somebody writing it into a configuration file get the same address, and neither of them gets clear text by omitting a scheme.</remarks>
+public sealed class DeploymentAddressTextTests
+{
+    [Theory]
+    [InlineData("mail.example.test", "https://mail.example.test/")]
+    [InlineData("//mail.example.test", "https://mail.example.test/")]
+    [InlineData("  mail.example.test  ", "https://mail.example.test/")]
+    [InlineData("mail.example.test:8443", "https://mail.example.test:8443/")]
+    public void TryRead_TextWithoutAScheme_IsReadAsHttps(string written, string expected)
+    {
+        // Act
+        var read = DeploymentAddressText.TryRead(written, out var address);
+
+        // Assert
+        Assert.True(read);
+        Assert.Equal(new Uri(expected), address);
+    }
+
+    [Theory]
+    [InlineData("https://mail.example.test/")]
+    [InlineData("http://127.0.0.1:8080/")]
+    public void TryRead_TextStatingItsScheme_KeepsIt(string written)
+    {
+        // Act
+        var read = DeploymentAddressText.TryRead(written, out var address);
+
+        // Assert
+        Assert.True(read);
+        Assert.Equal(new Uri(written), address);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryRead_NothingWritten_NamesNoAddress(string? written)
+    {
+        // Act
+        var read = DeploymentAddressText.TryRead(written, out var address);
+
+        // Assert
+        Assert.False(read);
+        Assert.Null(address);
+    }
+
+    [Fact]
+    public void TryRead_TextThatIsNotAnAddress_NamesNoAddress()
+    {
+        // Act
+        var read = DeploymentAddressText.TryRead("ht!tp://mail.example.test", out var address);
+
+        // Assert
+        Assert.False(read);
+        Assert.Null(address);
+    }
+}

--- a/frontend/tests/Client.UnitTests/Deployment/DeploymentChoiceTests.cs
+++ b/frontend/tests/Client.UnitTests/Deployment/DeploymentChoiceTests.cs
@@ -1,0 +1,258 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Backend;
+using MailFathom.Client.Backend.Authorization;
+using MailFathom.Client.Deployment;
+using MailFathom.Client.UnitTests.TestDoubles;
+
+namespace MailFathom.Client.UnitTests.Deployment;
+
+/// <summary>Which deployment an installation reaches: what it starts pointed at, and what changing it does.</summary>
+/// <remarks>
+/// The order the three sources are read in is the whole of the first half. A person's own choice outlives a restart and
+/// beats everything, because it is the most recent thing anybody decided; what a build stated comes next, which is how
+/// a local orchestration hands its head an address; and what the head knows for itself is last. The second half is that
+/// nothing is kept until something has answered — a mistyped address must not survive to become an authentication
+/// failure later.
+/// </remarks>
+public sealed class DeploymentChoiceTests : IDisposable
+{
+    private const string AnAnsweringDeployment =
+        """{"service":"MailFathom","version":"0.8.0","credential":"anonymous","permissions":[]}""";
+
+    private static readonly DeploymentSettings AnInstallationStatingNothing = new();
+
+    private readonly StubTransport answers;
+    private readonly HttpClient transport;
+    private readonly DeploymentProbe probe;
+
+    /// <summary>Builds the probe every choice here is proved through.</summary>
+    public DeploymentChoiceTests()
+    {
+        this.answers = new StubTransport(request => this.Answer(request));
+        this.transport = new HttpClient(this.answers);
+        this.probe = new DeploymentProbe(
+            new StubHttpClientFactory(
+                new Dictionary<string, HttpClient>(StringComparer.Ordinal)
+                {
+                    [DeploymentHttpClients.DeploymentProbe] = this.transport,
+                }));
+    }
+
+    /// <summary>How a candidate address answers, which each test replaces.</summary>
+    private Func<HttpRequestMessage, HttpResponseMessage> Answer { get; set; } =
+        _ => StubTransport.JsonResponse(AnAnsweringDeployment);
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        this.transport.Dispose();
+        this.answers.Dispose();
+    }
+
+    /// <summary>The point of keeping it: a second launch opens on the deployment the first one was pointed at.</summary>
+    [Fact]
+    public void Restore_AChoiceKeptFromAnEarlierRun_IsWhereTheClientIsPointedAndTheHeadIsNotAsked()
+    {
+        // Arrange
+        var head = new StubDeploymentAddressSource();
+        var address = new DeploymentAddress(new AccessTokenStore());
+        var choice = this.ChoiceOver(new StubDeploymentChoiceStore(new Uri("https://kept.example/")), head, address);
+
+        // Act
+        var pointed = choice.Restore();
+
+        // Assert
+        Assert.True(pointed);
+        Assert.Equal(new Uri("https://kept.example/"), address.Current);
+        Assert.False(head.WasAsked);
+    }
+
+    [Fact]
+    public void Restore_NothingKept_TakesWhateverTheHeadAnswers()
+    {
+        // Arrange
+        var address = new DeploymentAddress(new AccessTokenStore());
+        var choice = this.ChoiceOver(new StubDeploymentChoiceStore(), new StubDeploymentAddressSource(), address);
+
+        // Act
+        var pointed = choice.Restore();
+
+        // Assert
+        Assert.True(pointed);
+        Assert.Equal(StubDeploymentAddressSource.HeadsOwnAnswer, address.Current);
+    }
+
+    /// <summary>The state a fresh installation is genuinely in, which is what puts a person in front of the screen that asks.</summary>
+    [Fact]
+    public void Restore_NothingKeptAndAHeadThatKnowsNothing_PointsTheClientNowhere()
+    {
+        // Arrange
+        var address = new DeploymentAddress(new AccessTokenStore());
+        var choice = this.ChoiceOver(
+            new StubDeploymentChoiceStore(),
+            new StubDeploymentAddressSource(answer: null),
+            address);
+
+        // Act
+        var pointed = choice.Restore();
+
+        // Assert
+        Assert.False(pointed);
+        Assert.False(address.IsPointed);
+    }
+
+    /// <summary>A configured deployment that was quietly ignored is the worst of the outcomes, so a stated address the rule refuses fails loudly.</summary>
+    [Fact]
+    public void Restore_AStatedAddressTheRuleRefuses_FailsRatherThanBeingDropped()
+    {
+        // Arrange
+        var address = new DeploymentAddress(new AccessTokenStore());
+        var choice = this.ChoiceOver(
+            new StubDeploymentChoiceStore(),
+            new StubDeploymentAddressSource(new Uri("http://mail.example/")),
+            address);
+
+        // Act
+        var failure = Assert.Throws<InvalidOperationException>(() => choice.Restore());
+
+        // Assert
+        Assert.Contains("http://mail.example/", failure.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>A kept choice is not a statement anybody can go and read, so one that no longer passes is forgotten rather than fatal.</summary>
+    [Fact]
+    public void Restore_AKeptChoiceTheRuleNoLongerAllows_FallsBackToTheHead()
+    {
+        // Arrange
+        var address = new DeploymentAddress(new AccessTokenStore());
+        var choice = this.ChoiceOver(
+            new StubDeploymentChoiceStore(new Uri("http://kept.example/")),
+            new StubDeploymentAddressSource(),
+            address);
+
+        // Act
+        var pointed = choice.Restore();
+
+        // Assert
+        Assert.True(pointed);
+        Assert.Equal(StubDeploymentAddressSource.HeadsOwnAnswer, address.Current);
+    }
+
+    [Fact]
+    public async Task ChooseAsync_AnAddressAMailFathomAnswersAt_IsPointedAtAndKeptForTheNextRun()
+    {
+        // Arrange
+        var store = new StubDeploymentChoiceStore();
+        var address = new DeploymentAddress(new AccessTokenStore());
+        var choice = this.ChoiceOver(store, new StubDeploymentAddressSource(), address);
+
+        // Act
+        var outcome = await choice.ChooseAsync("mail.example", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(DeploymentChoiceOutcome.Accepted, outcome);
+        Assert.Equal(new Uri("https://mail.example/"), address.Current);
+        Assert.Equal(new Uri("https://mail.example/"), store.Kept);
+    }
+
+    /// <summary>Nothing is kept until something has answered, which is what stops a typing mistake surviving the screen.</summary>
+    [Fact]
+    public async Task ChooseAsync_AnAddressNothingAnswersAt_KeepsNothingAndLeavesTheClientWhereItWas()
+    {
+        // Arrange
+        var store = new StubDeploymentChoiceStore();
+        var address = new DeploymentAddress(new AccessTokenStore());
+        var choice = this.ChoiceOver(store, new StubDeploymentAddressSource(), address);
+
+        this.Answer = _ => throw new HttpRequestException("no route to host");
+
+        // Act
+        var outcome = await choice.ChooseAsync("mail.example", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(DeploymentChoiceOutcome.Unreachable, outcome);
+        Assert.Null(store.Kept);
+        Assert.False(address.IsPointed);
+    }
+
+    [Fact]
+    public async Task ChooseAsync_SomethingThatIsNotAMailFathom_IsRefusedAsSuch()
+    {
+        // Arrange
+        var store = new StubDeploymentChoiceStore();
+        var choice = this.ChoiceOver(
+            store,
+            new StubDeploymentAddressSource(),
+            new DeploymentAddress(new AccessTokenStore()));
+
+        this.Answer = _ => StubTransport.JsonResponse(
+            """{"service":"SomebodyElse","version":"3.1","credential":"anonymous","permissions":[]}""");
+
+        // Act
+        var outcome = await choice.ChooseAsync("mail.example", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(DeploymentChoiceOutcome.NotADeployment, outcome);
+        Assert.Null(store.Kept);
+    }
+
+    /// <summary>The rule runs before anything is sent, so each refusal is a sentence on the screen rather than a request.</summary>
+    /// <remarks>The outcome is named rather than passed, because the set it belongs to is internal to the client and a public theory parameter cannot carry it. <c>nameof</c> keeps a renamed case a compile error rather than a test that quietly stops asserting anything.</remarks>
+    [Theory]
+    [InlineData("", nameof(DeploymentChoiceOutcome.NotAnAddress))]
+    [InlineData("ht!tp://mail.example", nameof(DeploymentChoiceOutcome.NotAnAddress))]
+    [InlineData("http://mail.example", nameof(DeploymentChoiceOutcome.ClearTextOffThisMachine))]
+    [InlineData("https://mail.example/mailfathom", nameof(DeploymentChoiceOutcome.MoreThanAnOrigin))]
+    [InlineData("https://somebody:secret@mail.example", nameof(DeploymentChoiceOutcome.MoreThanAnOrigin))]
+    public async Task ChooseAsync_AnAddressTheRuleRefuses_SaysWhyAndContactsNothing(
+        string written,
+        string expected)
+    {
+        // Arrange
+        var store = new StubDeploymentChoiceStore();
+        var choice = this.ChoiceOver(
+            store,
+            new StubDeploymentAddressSource(),
+            new DeploymentAddress(new AccessTokenStore()));
+
+        // Act
+        var outcome = await choice.ChooseAsync(written, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(expected, outcome.ToString());
+        Assert.Empty(this.answers.Requests);
+        Assert.Null(store.Kept);
+    }
+
+    /// <summary>A credential belongs to an owner on one deployment and means nothing on another, so moving ends the session.</summary>
+    [Fact]
+    public async Task ChooseAsync_AnotherDeployment_EndsTheSessionHeldAgainstTheFirst()
+    {
+        // Arrange
+        var tokens = new AccessTokenStore();
+        var address = new DeploymentAddress(tokens);
+        var choice = this.ChoiceOver(
+            new StubDeploymentChoiceStore(new Uri("https://first.example/")),
+            new StubDeploymentAddressSource(),
+            address);
+
+        choice.Restore();
+        tokens.Accept("issued-by-the-first-deployment");
+
+        // Act
+        await choice.ChooseAsync("second.example", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(tokens.IsSignedIn);
+        Assert.Equal(new Uri("https://second.example/"), address.Current);
+    }
+
+    private DeploymentChoice ChoiceOver(
+        IDeploymentChoiceStore store,
+        IDeploymentAddressSource head,
+        DeploymentAddress address) =>
+        new(store, head, AnInstallationStatingNothing, address, this.probe);
+}

--- a/frontend/tests/Client.UnitTests/Deployment/DeploymentChoiceTests.cs
+++ b/frontend/tests/Client.UnitTests/Deployment/DeploymentChoiceTests.cs
@@ -119,7 +119,27 @@ public sealed class DeploymentChoiceTests : IDisposable
         var failure = Assert.Throws<InvalidOperationException>(() => choice.Restore());
 
         // Assert
-        Assert.Contains("http://mail.example/", failure.Message, StringComparison.Ordinal);
+        Assert.Contains("http://mail.example", failure.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>A stated address fails loudly, and loudly is into a log — so what it names is the origin and never a credential written into it.</summary>
+    [Fact]
+    public void Restore_AStatedAddressCarryingEmbeddedCredentials_FailsWithoutNamingTheSecret()
+    {
+        // Arrange
+        var address = new DeploymentAddress(new AccessTokenStore());
+        var choice = this.ChoiceOver(
+            new StubDeploymentChoiceStore(),
+            new StubDeploymentAddressSource(new Uri("https://somebody:secret@mail.example/")),
+            address);
+
+        // Act
+        var failure = Assert.Throws<InvalidOperationException>(() => choice.Restore());
+
+        // Assert
+        Assert.DoesNotContain("secret", failure.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("somebody", failure.Message, StringComparison.Ordinal);
+        Assert.Contains("https://mail.example", failure.Message, StringComparison.Ordinal);
     }
 
     /// <summary>A kept choice is not a statement anybody can go and read, so one that no longer passes is forgotten rather than fatal.</summary>

--- a/frontend/tests/Client.UnitTests/Presentation/ConnectModelTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/ConnectModelTests.cs
@@ -1,0 +1,206 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Backend;
+using MailFathom.Client.Backend.Authorization;
+using MailFathom.Client.Deployment;
+using MailFathom.Client.Presentation;
+using MailFathom.Client.UnitTests.TestDoubles;
+
+namespace MailFathom.Client.UnitTests.Presentation;
+
+/// <summary>What the screen that asks for a deployment does with what is written into it.</summary>
+/// <remarks>
+/// The claims are the three a person notices. The box opens on the deployment they are already reaching, so changing it
+/// is an edit rather than a retyping; a refusal keeps them on this screen with a sentence rather than moving them on;
+/// and an accepted address moves them off it, once and with nothing behind it to go back to.
+/// </remarks>
+public sealed class ConnectModelTests : IDisposable
+{
+    private const string AnAnsweringDeployment =
+        """{"service":"MailFathom","version":"0.8.0","credential":"anonymous","permissions":[]}""";
+
+    private readonly StubTransport answers;
+    private readonly HttpClient transport;
+    private readonly DeploymentProbe probe;
+
+    /// <summary>Builds the probe every address on this screen is proved through.</summary>
+    public ConnectModelTests()
+    {
+        this.answers = new StubTransport(request => this.Answer(request));
+        this.transport = new HttpClient(this.answers);
+        this.probe = new DeploymentProbe(
+            new StubHttpClientFactory(
+                new Dictionary<string, HttpClient>(StringComparer.Ordinal)
+                {
+                    [DeploymentHttpClients.DeploymentProbe] = this.transport,
+                }));
+    }
+
+    /// <summary>How a candidate address answers, which each test replaces.</summary>
+    private Func<HttpRequestMessage, HttpResponseMessage> Answer { get; set; } =
+        _ => StubTransport.JsonResponse(AnAnsweringDeployment);
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        this.transport.Dispose();
+        this.answers.Dispose();
+    }
+
+    [Fact]
+    public async Task Address_AClientAlreadyPointedSomewhere_OpensOnWhereItIsPointed()
+    {
+        // Arrange
+        var address = new DeploymentAddress(new AccessTokenStore());
+        address.PointAt(new Uri("https://mail.example/"));
+
+        await using var model = this.ModelOver(address: address);
+
+        // Act
+        var written = await model.Address;
+
+        // Assert
+        Assert.Equal("https://mail.example/", written);
+    }
+
+    /// <summary>Nothing in this client composes a default address, and a value offered here is one somebody would accept without reading it.</summary>
+    [Fact]
+    public async Task Address_AFreshInstallation_OpensOnAnEmptyBoxRatherThanOnASuggestion()
+    {
+        // Arrange
+        await using var model = this.ModelOver();
+
+        // Act
+        var written = await model.Address;
+
+        // Assert
+        Assert.Equal(string.Empty, written);
+    }
+
+    [Fact]
+    public async Task Connect_AnAddressAMailFathomAnswersAt_PointsTheClientAtItAndLeavesTheScreen()
+    {
+        // Arrange
+        var address = new DeploymentAddress(new AccessTokenStore());
+        var navigator = new StubNavigator();
+
+        await using var model = this.ModelOver(address: address, navigator: navigator);
+
+        await model.Address.SetAsync("mail.example", TestContext.Current.CancellationToken);
+
+        // Act
+        await model.Connect(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(new Uri("https://mail.example/"), address.Current);
+        Assert.NotEmpty(navigator.Requests);
+        Assert.False(await model.IsRefused);
+    }
+
+    /// <summary>The person is told the client cannot reach it while they are still here, rather than later and as an authentication failure.</summary>
+    [Fact]
+    public async Task Connect_AnAddressNothingAnswersAt_SaysSoAndStaysOnTheScreen()
+    {
+        // Arrange
+        var navigator = new StubNavigator();
+
+        await using var model = this.ModelOver(navigator: navigator);
+
+        this.Answer = _ => throw new HttpRequestException("no route to host");
+
+        await model.Address.SetAsync("mail.example", TestContext.Current.CancellationToken);
+
+        // Act
+        await model.Connect(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("nothing answered", await model.Refusal);
+        Assert.True(await model.IsRefused);
+        Assert.Empty(navigator.Requests);
+    }
+
+    /// <summary>Asking takes as long as the timeout, and the screen has to be able to say it is still asking.</summary>
+    [Fact]
+    public async Task IsAsking_AnAttemptThatHasFinished_IsOverWhicheverWayItWent()
+    {
+        // Arrange
+        await using var model = this.ModelOver();
+
+        this.Answer = _ => throw new HttpRequestException("no route to host");
+
+        await model.Address.SetAsync("mail.example", TestContext.Current.CancellationToken);
+
+        // Act
+        await model.Connect(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(await model.IsAsking);
+        Assert.True(await model.CanAsk);
+    }
+
+    /// <summary>A second attempt starts from nothing having been refused, so a stale sentence does not sit beside a fresh failure.</summary>
+    [Fact]
+    public async Task Connect_ASecondAttempt_ReplacesWhatTheFirstOneSaid()
+    {
+        // Arrange
+        await using var model = this.ModelOver();
+
+        this.Answer = _ => throw new HttpRequestException("no route to host");
+        await model.Address.SetAsync("mail.example", TestContext.Current.CancellationToken);
+        await model.Connect(TestContext.Current.CancellationToken);
+
+        this.Answer = _ => StubTransport.JsonResponse(AnAnsweringDeployment);
+
+        // Act
+        await model.Connect(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(await model.IsRefused);
+    }
+
+    [Fact]
+    public void Constructor_AMissingService_IsRefused()
+    {
+        // Arrange
+        var choice = this.ChoiceOver(new DeploymentAddress(new AccessTokenStore()));
+        var address = new DeploymentAddress(new AccessTokenStore());
+        var navigator = new StubNavigator();
+        var localizer = RefusalWords();
+
+        // Act, Assert
+        Assert.Throws<ArgumentNullException>(() => new ConnectModel(null!, address, navigator, localizer));
+        Assert.Throws<ArgumentNullException>(() => new ConnectModel(choice, null!, navigator, localizer));
+        Assert.Throws<ArgumentNullException>(() => new ConnectModel(choice, address, null!, localizer));
+        Assert.Throws<ArgumentNullException>(() => new ConnectModel(choice, address, navigator, null!));
+    }
+
+    private static StubStringLocalizer RefusalWords() => new(new Dictionary<string, string>(StringComparer.Ordinal)
+    {
+        ["ConnectPage.Refusal.NotAnAddress"] = "not an address",
+        ["ConnectPage.Refusal.ClearTextOffThisMachine"] = "not secured",
+        ["ConnectPage.Refusal.MoreThanAnOrigin"] = "more than an origin",
+        ["ConnectPage.Refusal.Unreachable"] = "nothing answered",
+        ["ConnectPage.Refusal.TimedOut"] = "no answer in time",
+        ["ConnectPage.Refusal.NotADeployment"] = "not a MailFathom",
+    });
+
+    private ConnectModel ModelOver(DeploymentAddress? address = null, StubNavigator? navigator = null)
+    {
+        var pointed = address ?? new DeploymentAddress(new AccessTokenStore());
+
+        return new ConnectModel(
+            this.ChoiceOver(pointed),
+            pointed,
+            navigator ?? new StubNavigator(),
+            RefusalWords());
+    }
+
+    private DeploymentChoice ChoiceOver(DeploymentAddress address) => new(
+        new StubDeploymentChoiceStore(),
+        new StubDeploymentAddressSource(answer: null),
+        new DeploymentSettings(),
+        address,
+        this.probe);
+}

--- a/frontend/tests/Client.UnitTests/Presentation/MainModelTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/MainModelTests.cs
@@ -4,6 +4,8 @@
 
 using System.Globalization;
 using System.Reflection;
+using MailFathom.Client.Backend;
+using MailFathom.Client.Backend.Authorization;
 using MailFathom.Client.Presentation;
 using MailFathom.Client.UnitTests.TestDoubles;
 
@@ -23,6 +25,23 @@ public sealed class MainModelTests
 
         // Assert
         Assert.Equal(ClientBuild.Current, build);
+    }
+
+    /// <summary>Which deployment is being looked at has to be readable without signing in to find out.</summary>
+    [Fact]
+    public async Task Deployment_AClientPointedAtADeployment_NamesIt()
+    {
+        // Arrange
+        var address = new DeploymentAddress(new AccessTokenStore());
+        address.PointAt(new Uri("https://mail.example/"));
+
+        await using var model = ModelOver(address: address);
+
+        // Act
+        var deployment = await model.Deployment;
+
+        // Assert
+        Assert.Equal("https://mail.example/", deployment);
     }
 
     /// <summary>The screen offers what the configuration named and nothing else, in the order it named it.</summary>
@@ -189,12 +208,14 @@ public sealed class MainModelTests
         // Arrange
         var localization = new StubLocalizationService("en", "en", "pl");
         var themes = new StubThemeService();
+        var address = new DeploymentAddress(new AccessTokenStore());
         var localizer = ThemeWords();
 
         // Act & Assert
-        Assert.Throws<ArgumentNullException>(() => new MainModel(null!, themes, localizer));
-        Assert.Throws<ArgumentNullException>(() => new MainModel(localization, null!, localizer));
-        Assert.Throws<ArgumentNullException>(() => new MainModel(localization, themes, null!));
+        Assert.Throws<ArgumentNullException>(() => new MainModel(null!, themes, address, localizer));
+        Assert.Throws<ArgumentNullException>(() => new MainModel(localization, null!, address, localizer));
+        Assert.Throws<ArgumentNullException>(() => new MainModel(localization, themes, null!, localizer));
+        Assert.Throws<ArgumentNullException>(() => new MainModel(localization, themes, address, null!));
     }
 
     /// <summary>
@@ -231,8 +252,13 @@ public sealed class MainModelTests
 
     private static MainModel ModelOver(
         StubLocalizationService? localization = null,
-        StubThemeService? themes = null) =>
-        new(localization ?? new StubLocalizationService("en", "en", "pl"), themes ?? new StubThemeService(), ThemeWords());
+        StubThemeService? themes = null,
+        DeploymentAddress? address = null) =>
+        new(
+            localization ?? new StubLocalizationService("en", "en", "pl"),
+            themes ?? new StubThemeService(),
+            address ?? new DeploymentAddress(new AccessTokenStore()),
+            ThemeWords());
 
     private static StubStringLocalizer ThemeWords() => new(new Dictionary<string, string>(StringComparer.Ordinal)
     {

--- a/frontend/tests/Client.UnitTests/Strings/ResourceTableTests.cs
+++ b/frontend/tests/Client.UnitTests/Strings/ResourceTableTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Client.Deployment;
 using MailFathom.Client.Presentation;
 
 namespace MailFathom.Client.UnitTests.Strings;
@@ -74,6 +75,28 @@ public sealed class ResourceTableTests
     {
         // Arrange
         var expected = AppThemeOption.Offered.Select(AppThemeOption.ResourceKeyFor);
+
+        // Act
+        var table = DeclaredLanguages.TableOf(culture);
+
+        // Assert
+        Assert.All(expected, key => Assert.True(table.ContainsKey(key), key));
+    }
+
+    /// <summary>
+    /// The reason an address was refused is turned into a resource name in code rather than named by a <c>x:Uid</c>, so
+    /// the keys the model composes are the ones this asserts the tables hold — and a case added to that set with no
+    /// string behind it would reach somebody who has just mistyped their server's address as the key itself.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Languages))]
+    public void Tables_EveryWayAnAddressCanBeRefused_IsExplainedInEveryLanguage(string culture)
+    {
+        // Arrange
+        var expected = Enum
+            .GetValues<DeploymentChoiceOutcome>()
+            .Where(outcome => outcome != DeploymentChoiceOutcome.Accepted)
+            .Select(outcome => $"ConnectPage.Refusal.{outcome}");
 
         // Act
         var table = DeclaredLanguages.TableOf(culture);

--- a/frontend/tests/Client.UnitTests/TestDoubles/DeploymentHarness.cs
+++ b/frontend/tests/Client.UnitTests/TestDoubles/DeploymentHarness.cs
@@ -27,6 +27,7 @@ internal sealed class DeploymentHarness : IDisposable
 
     private readonly HttpClient deploymentTransport;
     private readonly HttpClient authorizationServerTransport;
+    private readonly HttpClient probeTransport;
     private readonly AccessTokenHandler? tokenHandler;
 
     /// <summary>Builds a deployment answering from a script, reached with or without a signed-in token.</summary>
@@ -42,7 +43,9 @@ internal sealed class DeploymentHarness : IDisposable
     {
         this.Deployment = new StubTransport(deployment);
         this.AuthorizationServer = new StubTransport(authorizationServer ?? (_ => StubTransport.JsonResponse("{}")));
+        this.Probed = new StubTransport(deployment);
         this.Listener = new StubSignInRedirectListener(redirect ?? (_ => new SignInRedirect(null, null, null)));
+        this.probeTransport = new HttpClient(this.Probed);
 
         if (throughTokenHandler)
         {
@@ -56,12 +59,22 @@ internal sealed class DeploymentHarness : IDisposable
 
         this.authorizationServerTransport = new HttpClient(this.AuthorizationServer);
 
-        this.Client = new DeploymentClient(this.deploymentTransport);
+        // The probe is aimed by absolute address rather than by a base one, exactly as the registration leaves it, so
+        // the same scripted deployment answers it.
+        this.Transports = new StubHttpClientFactory(
+            new Dictionary<string, HttpClient>(StringComparer.Ordinal)
+            {
+                [DeploymentHttpClients.Deployment] = this.deploymentTransport,
+                [DeploymentHttpClients.AuthorizationServer] = this.authorizationServerTransport,
+                [DeploymentHttpClients.DeploymentProbe] = this.probeTransport,
+            });
+
+        this.Client = new DeploymentClient(this.Transports);
+        this.Probe = new DeploymentProbe(this.Transports);
 
         this.SignIn = new DeploymentSignIn(
-            this.deploymentTransport,
-            this.authorizationServerTransport,
-            new DeploymentOptions(DeploymentAddress, "the-client"),
+            this.Transports,
+            new DeploymentOptions("the-client"),
             this.Listener,
             this.Tokens);
     }
@@ -71,6 +84,16 @@ internal sealed class DeploymentHarness : IDisposable
 
     /// <summary>Gets what the authorization server was asked, in order.</summary>
     internal StubTransport AuthorizationServer { get; }
+
+    /// <summary>Gets what the candidate address was asked while it was being probed, in order.</summary>
+    /// <remarks>Separate from <see cref="Deployment" /> although it answers the same way, because what a test asserts about a probe is that it carried no credential — which is only visible if the two are not the same recording.</remarks>
+    internal StubTransport Probed { get; }
+
+    /// <summary>Gets the factory the client, the sign-in, and the probe take their transports from.</summary>
+    internal StubHttpClientFactory Transports { get; }
+
+    /// <summary>Gets the probe under test.</summary>
+    internal DeploymentProbe Probe { get; }
 
     /// <summary>Gets the stand-in for the head's redirect listener.</summary>
     internal StubSignInRedirectListener Listener { get; }
@@ -89,9 +112,11 @@ internal sealed class DeploymentHarness : IDisposable
     {
         this.deploymentTransport.Dispose();
         this.authorizationServerTransport.Dispose();
+        this.probeTransport.Dispose();
         this.tokenHandler?.Dispose();
         this.Deployment.Dispose();
         this.AuthorizationServer.Dispose();
+        this.Probed.Dispose();
         this.Listener.Dispose();
     }
 }

--- a/frontend/tests/Client.UnitTests/TestDoubles/StubDeploymentAddressSource.cs
+++ b/frontend/tests/Client.UnitTests/TestDoubles/StubDeploymentAddressSource.cs
@@ -7,20 +7,32 @@ using MailFathom.Client.Deployment;
 namespace MailFathom.Client.UnitTests.TestDoubles;
 
 /// <summary>A head's own answer to where its deployment is, scripted, and recording whether it was asked at all.</summary>
-/// <remarks>Whether it was asked is the assertion that matters: an address the build stated has to be taken instead of the head's answer rather than beside it, and a source that answered anyway would be a head reaching two deployments depending on which value won.</remarks>
+/// <remarks>Whether it was asked is the assertion that matters: an address a person chose, or one the build stated, has to be taken instead of the head's answer rather than beside it, and a source that answered anyway would be a head reaching two deployments depending on which value won.</remarks>
 internal sealed class StubDeploymentAddressSource : IDeploymentAddressSource
 {
-    /// <summary>The address this stub answers with wherever it is asked.</summary>
+    /// <summary>The address this stub answers with where it answers at all.</summary>
     internal static readonly Uri HeadsOwnAnswer = new("https://the-head-answered-for-itself.test/");
+
+    private readonly Uri? answer;
+
+    /// <summary>Initializes a head that answers with <see cref="HeadsOwnAnswer" />.</summary>
+    internal StubDeploymentAddressSource()
+        : this(HeadsOwnAnswer)
+    {
+    }
+
+    /// <summary>Initializes a head answering with a stated address, or with nothing at all.</summary>
+    /// <param name="answer">What the head knows, or <see langword="null" /> for a head nobody configured.</param>
+    internal StubDeploymentAddressSource(Uri? answer) => this.answer = answer;
 
     /// <summary>Gets whether the head was asked to answer for itself.</summary>
     internal bool WasAsked { get; private set; }
 
     /// <inheritdoc />
-    public Uri Resolve(DeploymentSettings settings)
+    public Uri? Resolve(DeploymentSettings settings)
     {
         this.WasAsked = true;
 
-        return HeadsOwnAnswer;
+        return this.answer;
     }
 }

--- a/frontend/tests/Client.UnitTests/TestDoubles/StubDeploymentChoiceStore.cs
+++ b/frontend/tests/Client.UnitTests/TestDoubles/StubDeploymentChoiceStore.cs
@@ -1,0 +1,30 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Deployment;
+
+namespace MailFathom.Client.UnitTests.TestDoubles;
+
+/// <summary>The platform store a choice outlives a restart in, standing in for one no test process has.</summary>
+/// <remarks>Reading back what was written is what makes a restart assertable here: a test writes through the choice and reads the store, which is the same thing the next launch does.</remarks>
+internal sealed class StubDeploymentChoiceStore : IDeploymentChoiceStore
+{
+    /// <summary>Initializes a store holding nothing, which is what a fresh installation has.</summary>
+    internal StubDeploymentChoiceStore()
+    {
+    }
+
+    /// <summary>Initializes a store already holding a choice, which is what a second launch reads.</summary>
+    /// <param name="kept">What was chosen before.</param>
+    internal StubDeploymentChoiceStore(Uri? kept) => this.Kept = kept;
+
+    /// <summary>Gets what the store holds, which is what a later launch would read.</summary>
+    internal Uri? Kept { get; private set; }
+
+    /// <inheritdoc />
+    public Uri? Read() => this.Kept;
+
+    /// <inheritdoc />
+    public void Write(Uri address) => this.Kept = address;
+}

--- a/frontend/tests/Client.UnitTests/TestDoubles/StubHttpClientFactory.cs
+++ b/frontend/tests/Client.UnitTests/TestDoubles/StubHttpClientFactory.cs
@@ -1,0 +1,35 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.UnitTests.TestDoubles;
+
+/// <summary>Hands out the transports a test scripted, by the names the registration gives them.</summary>
+/// <remarks>
+/// The seam the client and the sign-in now reach their transports through. They ask for one per exchange rather than
+/// holding one, which is what lets a deployment address change while the application runs, so a test has to supply the
+/// factory rather than the client — and asking twice has to yield something usable twice, which is why the same
+/// instance comes back rather than a new one whose handler nothing owns.
+/// </remarks>
+internal sealed class StubHttpClientFactory : IHttpClientFactory
+{
+    private readonly IReadOnlyDictionary<string, HttpClient> transports;
+
+    /// <summary>Initializes the factory over the transports a test scripted.</summary>
+    /// <param name="transports">Each transport, under the name the registration would have given it.</param>
+    internal StubHttpClientFactory(IReadOnlyDictionary<string, HttpClient> transports) =>
+        this.transports = transports;
+
+    /// <summary>Gets the names that were asked for, in order.</summary>
+    internal List<string> Asked { get; } = [];
+
+    /// <inheritdoc />
+    public HttpClient CreateClient(string name)
+    {
+        this.Asked.Add(name);
+
+        return this.transports.TryGetValue(name, out var transport)
+            ? transport
+            : throw new InvalidOperationException($"No transport was scripted under the name '{name}'.");
+    }
+}

--- a/frontend/tests/Client.UnitTests/TestDoubles/StubNavigator.cs
+++ b/frontend/tests/Client.UnitTests/TestDoubles/StubNavigator.cs
@@ -1,0 +1,27 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.UnitTests.TestDoubles;
+
+/// <summary>Records where a model asked to go, instead of moving a frame nothing here has.</summary>
+/// <remarks>Whether a screen navigated at all is the assertion worth making from a unit test: moving a frame needs a running head and belongs to whatever UI suite is added later, but a model that leaves a screen only when an address was accepted is ordinary logic and is asserted here.</remarks>
+internal sealed class StubNavigator : INavigator
+{
+    /// <summary>Gets the requests the model made, in order.</summary>
+    internal List<NavigationRequest> Requests { get; } = [];
+
+    /// <inheritdoc />
+    public Route? Route => Uno.Extensions.Navigation.Route.Empty;
+
+    /// <inheritdoc />
+    public Task<bool> CanNavigate(Route route) => Task.FromResult(true);
+
+    /// <inheritdoc />
+    public Task<NavigationResponse?> NavigateAsync(NavigationRequest request)
+    {
+        this.Requests.Add(request);
+
+        return Task.FromResult<NavigationResponse?>(null);
+    }
+}


### PR DESCRIPTION
Closes #1147

A head that was not told where its MailFathom is used to start and then fail at its first request. It now asks, on a screen of its own, and keeps the answer.

## What decides which deployment the client reaches

`DeploymentChoice` is the whole of it, and it reads four sources highest first:

1. **What somebody chose**, kept behind `IDeploymentChoiceStore` — `ApplicationData.Current.LocalSettings` under it, which is a per-user preferences store on a desktop and the browser's own storage for the page's origin in the browser head. Per user and across restarts are the platform's guarantees rather than something invented here.
2. **What the build stated**, unchanged, through `BuildStatedDeploymentAddress`.
3. **What the head knows for itself** — `appsettings.json` on an installed head, `globalThis.location.origin` on the browser one.
4. **Nobody**, which is now an ordinary state. `App.OnLaunched` opens `ConnectPage` instead of the application.

Where an address came from decides how loudly it fails. Unreadable text in `appsettings.json` still fails while the application is starting and names the setting; an address a build or an installation *stated* that the rule refuses fails in `Restore` and names the address. The two answers nobody wrote are held to a weaker standard for that reason: a kept choice that no longer passes is forgotten, and a page origin that does not pass is no answer at all — a bundle served over clear text from something that is not this machine opens the screen that asks rather than taking the application down at launch over a fact its reader could do nothing about.

## Judging an address, and proving one

`DeploymentAddressRule.Judge` is the one place an address is judged — before it is stored, before it is probed, and again when the client is pointed at it. An absolute `http` or `https` address, an origin and nothing beneath it, and clear text only to this machine, because every request carries the signed-in credential. `DeploymentAddressText` is the shared reading of written text, so `mail.example` means the same thing in a configuration file and in the box on the screen; a value with no scheme is HTTPS, since the alternative turns an omission into a credential on the wire.

`DeploymentProbe` then asks the candidate for `/api/client/session` on a transport carrying **no** credential — a candidate address is a machine nobody has vouched for yet — and believes it only when MailFathom's own document names MailFathom. **`401` and `403` are answers, not refusals of the address**: a deployment configured the way this project's own documentation asks refuses an unauthenticated caller, so treating that as "not MailFathom" would reject every real deployment. The probe reports it as reached-but-guarded. Nothing is kept until something has answered, which is what turns a typing mistake into a sentence on the screen a person is still looking at rather than an authentication failure after they have entered a password.

## Moving the client ends the session

`DeploymentAddress` holds where the client is pointed and drops the access token when it moves, stated as a reference that type holds rather than as a rule every call site has to remember. That is also why `DeploymentClient`, `DeploymentSignIn`, and `DeploymentProbe` now take `IHttpClientFactory` and ask for a transport per exchange: a captured transport keeps the base address it was created with, and the client would go on reaching the deployment somebody had just left.

`DeploymentOptions` no longer carries an address, and nothing in `Client.Backend` composes one from a literal.

## Acceptance

| Item | Where |
|---|---|
| Desktop head reads a configured address, persists it per user, survives a restart | `ConfiguredDeploymentAddress`, `LocalSettingsDeploymentChoiceStore`, `DeploymentChoice.Restore` |
| Browser head resolves from its origin where that is correct, takes an explicit address where it is not | `PageOriginDeploymentAddress`, which now judges its own origin; a chosen address is read before it |
| A first start with no address puts a person in front of one screen | `App.OnLaunched` → `ConnectPage`, no route marked `IsDefault` |
| Validated before stored: reachable, answering as MailFathom, clear text refused off this machine | `DeploymentProbe`, `DeploymentAddressRule` |
| Changing it without reinstalling, clearing what was signed in against the previous one | `MainPage` → `Connect`, `DeploymentAddress.PointAt` → `AccessTokenStore.Forget` |
| Nothing in `Client.Backend` gains a default address | `DeploymentOptions` lost `Address`; `DeploymentRegistration` states none |

Out of scope, as the issue says: signing in (#1148) and several deployments at once. The mechanism #1097 needs is this one.

## Two things worth a reviewer's attention

- **`ConnectModel` calls `INavigator.NavigateAsync(NavigationRequest)` directly** rather than one of the `NavigatorExtensions` helpers. Those turn a view-model type into a route — work this does not need, since the route is named — and they do it by resolving `IRouteResolver` out of a service provider reached through the navigator, which a unit-tested model cannot supply. The request is built explicitly with `Qualifiers.ClearBackStack`, because the screen behind this one belongs to a deployment the client has just stopped reaching.
- **No visual evidence.** The Uno App MCP reported `toolCount: 0` for this worktree, and the only running Dev Server belongs to a concurrent session's worktree, which this one must not touch. What is asserted is asserted by the unit suite; the XAML has not been rendered.

## The typo check, and why it took two commits

The Polish resource table this change adds strings to failed `Typo check`: an English dictionary reads the Polish noun for a network address as a misspelling of the English one. The first fix stated the exclusion in `.config/typos.toml` alone and was inert, which is worth recording because the reason is not obvious. Measured against `typos` 1.48.0, the version the action pins:

- `files.extend-exclude` applies to the walk `typos` does when it is given a directory. A path named on the command line is read regardless — and `Typo check` hands it the paths a pull request changed. `--force-exclude` is the flag that would cover both, and `crate-ci/typos` exposes no input that passes it.
- `[type.NAME] extend-glob` matches the **file name**, not the path: `*.resw` matches, `**/Strings/pl/*.resw` does not. So a type override could only have said "every `.resw`", which would have stopped checking the English table too.

So the exclusion is stated at both ends — the workflow's file-collection step, beside the images it already drops for exactly this reason, and the config for the whole-checkout fallback — with the same pattern in both: every language table, with `en` re-included by a gitignore negation. Adding a language needs no edit at either end. Verified with the pinned binary against a fixture carrying a deliberate typo in both tables: `pl` is skipped, `en` still reports.

## Verification

- `scripts/verify-fast.sh` — pass.
- `scripts/verify-full.sh` — pass, over exactly this content, after rebasing onto `origin/main`.
- Client suite: 221 tests, 0 failed. Both heads and the reference target build clean at 0 warnings.
- `typos` 1.48.0 by hand, in both invocation modes, over the whole checkout and over this pull request's changed paths — 0 findings.
- `scripts/review-obligations.sh` — no backend production file changed, no `describes:` marker covers a changed path. `docs/operations/client-endpoint.md` was corrected anyway: it claimed the client "cannot be told the address by hand", which stopped being true here.
