### PR TITLE
[#1149] Give the client its three-space shell, in a rail-and-columns and a bottom-navigation composition

### DIFF
--- a/docs/architecture/solution-structure.md
+++ b/docs/architecture/solution-structure.md
@@ -195,6 +195,11 @@ project here and neither build reads the other's files.
   the one copyleft component in its graph is excluded from the publish, what keeps it that way is a measurement nobody
   has taken rather than a licence. [Publishing the client](../operations/client-publishing.md) carries the whole
   posture.
+- `src/Client/Presentation/` holds the shell, the frame the product's three spaces are shown inside, those spaces, and
+  the settings screen, each in a directory of its own with the MVUX model behind it. Every screen is a route rather than
+  content something swaps by hand, which is what makes the system back gesture and the browser's history move through
+  the client's own screens; [the client sources](https://github.com/Krzysztof318/MailFathom/blob/main/frontend/src/README.md)
+  carries the composition and what travels between spaces.
 - `src/Client/Strings/` holds one string table per language the application is readable in, one directory per neutral
   culture. Which of them are offered is `LocalizationConfiguration:Cultures` in the embedded `appsettings.json`, so a
   language reaches a reader only where both the table and that list name it.

--- a/docs/architecture/solution-structure.md
+++ b/docs/architecture/solution-structure.md
@@ -195,12 +195,13 @@ project here and neither build reads the other's files.
   the one copyleft component in its graph is excluded from the publish, what keeps it that way is a measurement nobody
   has taken rather than a licence. [Publishing the client](../operations/client-publishing.md) carries the whole
   posture.
-- `src/Client/Presentation/` holds the shell, the frame the product's three spaces are shown inside, those spaces, and
-  the settings screen. The shell sits directly under it, and `Workspace/`, `Spaces/`, and `Settings/` hold the rest, one
-  directory each. Two of them carry an MVUX model — the frame and settings — while the three spaces are pages with no
-  model yet, because each is filled in by the parent that owns it. Every screen is a route rather than content something
-  swaps by hand, which is what makes the system back gesture and the browser's history move through the client's own
-  screens; [the client sources](https://github.com/Krzysztof318/MailFathom/blob/main/frontend/src/README.md)
+- `src/Client/Presentation/` holds every screen. The shell, the screen that asks which deployment this client reaches,
+  and `ClientRoutes` — where each route is named once — sit directly under it, while `Workspace/`, `Spaces/`, and
+  `Settings/` hold the frame the product's three spaces are shown inside, those spaces, and the settings screen. All of
+  them carry an MVUX model except the three space pages, which have none yet because each is filled in by the parent
+  that owns it. Every screen is a route rather than content something swaps by hand, which is what makes the system back
+  gesture and the browser's history move through the client's own screens;
+  [the client sources](https://github.com/Krzysztof318/MailFathom/blob/main/frontend/src/README.md)
   carries the composition and what travels between spaces.
 - `src/Client/Strings/` holds one string table per language the application is readable in, one directory per neutral
   culture. Which of them are offered is `LocalizationConfiguration:Cultures` in the embedded `appsettings.json`, so a

--- a/docs/architecture/solution-structure.md
+++ b/docs/architecture/solution-structure.md
@@ -196,9 +196,11 @@ project here and neither build reads the other's files.
   has taken rather than a licence. [Publishing the client](../operations/client-publishing.md) carries the whole
   posture.
 - `src/Client/Presentation/` holds the shell, the frame the product's three spaces are shown inside, those spaces, and
-  the settings screen, each in a directory of its own with the MVUX model behind it. Every screen is a route rather than
-  content something swaps by hand, which is what makes the system back gesture and the browser's history move through
-  the client's own screens; [the client sources](https://github.com/Krzysztof318/MailFathom/blob/main/frontend/src/README.md)
+  the settings screen. The shell sits directly under it, and `Workspace/`, `Spaces/`, and `Settings/` hold the rest, one
+  directory each. Two of them carry an MVUX model — the frame and settings — while the three spaces are pages with no
+  model yet, because each is filled in by the parent that owns it. Every screen is a route rather than content something
+  swaps by hand, which is what makes the system back gesture and the browser's history move through the client's own
+  screens; [the client sources](https://github.com/Krzysztof318/MailFathom/blob/main/frontend/src/README.md)
   carries the composition and what travels between spaces.
 - `src/Client/Strings/` holds one string table per language the application is readable in, one directory per neutral
   culture. Which of them are offered is `LocalizationConfiguration:Cultures` in the embedded `appsettings.json`, so a

--- a/docs/operations/client-publishing.md
+++ b/docs/operations/client-publishing.md
@@ -44,7 +44,7 @@ XAML to decide which controls are never referenced and telling the trimmer that 
 this project is the browser head and nothing else.
 
 **No control has to be told to keep, today.** The pass decides from what the XAML names, and every control this
-application uses is named in `App.xaml`, `Presentation/Shell.xaml`, or `Presentation/MainPage.xaml` — there is no
+application uses is named in `App.xaml` or in one of the pages and controls under `Presentation/` — there is no
 `XamlReader` call anywhere in the client and no control resolved from a string at run time. That is the condition under
 which the pass is safe, rather than a fact about it: a control whose only use is dynamic is one the pass cannot see, its
 style is removed, and the failure arrives when the screen loads rather than when the branch builds. If that changes, the

--- a/frontend/src/Client/App.xaml
+++ b/frontend/src/Client/App.xaml
@@ -24,7 +24,13 @@ Project repository: https://github.com/Krzysztof318/MailFathom
         </utum:MaterialToolkitTheme>
       </ResourceDictionary.MergedDictionaries>
 
-      <!-- Add resources here -->
+      <!-- The two widths the client's composition changes at, written once and read by every adaptive trigger that
+           acts on them. Below the first, navigation is a bar along the bottom over one column of workspace; at it,
+           navigation becomes a rail beside the workspace; at the second, the workspace itself opens a companion
+           column. They are window widths rather than platform tests, which is what makes a resized desktop window
+           and a phone the same case. -->
+      <x:Double x:Key="WorkspaceRailWindowWidth">700</x:Double>
+      <x:Double x:Key="WorkspaceWideWindowWidth">1000</x:Double>
 
     </ResourceDictionary>
   </Application.Resources>

--- a/frontend/src/Client/App.xaml.cs
+++ b/frontend/src/Client/App.xaml.cs
@@ -78,7 +78,15 @@ public partial class App : Application
                 // point at which it takes effect, because applying a culture is what Uno does on the next launch
                 // rather than to a visual tree already built. The screen offering it says so.
                 .UseLocalization()
-                .ConfigureServices((context, services) => this.ComposeDeployment(services, context.Configuration))
+                .ConfigureServices((context, services) =>
+                {
+                    this.ComposeDeployment(services, context.Configuration);
+
+                    // What the three spaces share, so that moving between them keeps the question somebody was
+                    // composing and what it would be asked against. One for the run rather than one per model: a
+                    // model is discarded as its view is navigated away from, and so would be anything it held.
+                    services.AddSingleton<IWorkspace, SharedWorkspace>();
+                })
                 // Light, dark, and follow-the-system, with the choice written to the platform's own settings store so
                 // the application starts the way it was left. Nothing here decides which one: AppTheme.System is the
                 // default the service reads back when nothing was ever chosen.

--- a/frontend/src/Client/App.xaml.cs
+++ b/frontend/src/Client/App.xaml.cs
@@ -5,6 +5,9 @@
 using System.Diagnostics.CodeAnalysis;
 using MailFathom.Client.Backend;
 using MailFathom.Client.Deployment;
+using MailFathom.Client.Presentation.Settings;
+using MailFathom.Client.Presentation.Spaces;
+using MailFathom.Client.Presentation.Workspace;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace MailFathom.Client;
@@ -108,7 +111,7 @@ public partial class App : Application
 
                 await navigator.NavigateRouteAsync(
                     this,
-                    pointed ? ClientRoutes.Main : ClientRoutes.Connect);
+                    pointed ? ClientRoutes.Workspace : ClientRoutes.Connect);
             });
     }
 
@@ -150,23 +153,54 @@ public partial class App : Application
             .AddMailFathomDeployment(new DeploymentOptions(settings.ClientId));
     }
 
+    /// <summary>
+    /// Every screen the client is reachable by, as a route rather than as content something swaps by hand.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The three spaces are nested inside the frame that holds them, which is what lets the rail and the bottom
+    /// navigation name the same destinations and move the same content area. Settings sits beside that frame rather
+    /// than inside it: it is not a space, and registering it a level up is what makes going to it a screen somebody
+    /// comes back from — a route nested among the three would be switched to like a fourth space, leaving the
+    /// workspace with nothing behind it to return to.
+    /// </para>
+    /// <para>
+    /// Registering them as routes is also what makes the Android system back gesture and the browser's history move
+    /// through the client's own screens — Uno's navigation is what answers both, and a screen reached by swapping
+    /// content by hand is a screen neither of them knows about.
+    /// </para>
+    /// </remarks>
     private static void RegisterRoutes(IViewRegistry views, IRouteRegistry routes)
     {
         views.Register(
             new ViewMap(ViewModel: typeof(ShellModel)),
-            new ViewMap<MainPage, MainModel>(),
+            new ViewMap<WorkspacePage, WorkspaceModel>(),
+            new ViewMap<DiscoverPage>(),
+            new ViewMap<MailPage>(),
+            new ViewMap<CasesPage>(),
+            new ViewMap<SettingsPage, SettingsModel>(),
             new ViewMap<ConnectPage, ConnectModel>());
 
-        // No default among the two, deliberately. Which of them a launch opens on is what OnLaunched decides from
-        // whether this installation has been pointed at a deployment, and a route marked default here would be the
-        // second answer to that question.
+        // No default among the three the shell holds, deliberately. Which of them a launch opens on is what
+        // OnLaunched decides from whether this installation has been pointed at a deployment, and a route marked
+        // default here would be the second answer to that question. The default inside the frame is a different
+        // question — which space the workspace opens on — and Discover carries it.
         routes.Register(
             new RouteMap(
                 "",
                 View: views.FindByViewModel<ShellModel>(),
                 Nested:
                 [
-                    new RouteMap(ClientRoutes.Main, View: views.FindByViewModel<MainModel>()),
+                    new RouteMap(
+                        ClientRoutes.Workspace,
+                        View: views.FindByViewModel<WorkspaceModel>(),
+                        Nested:
+                        [
+                            new RouteMap(ClientRoutes.Discover, View: views.FindByView<DiscoverPage>(), IsDefault: true),
+                            new RouteMap(ClientRoutes.Mail, View: views.FindByView<MailPage>()),
+                            new RouteMap(ClientRoutes.Cases, View: views.FindByView<CasesPage>()),
+                        ]),
+                    new RouteMap(ClientRoutes.Settings, View: views.FindByViewModel<SettingsModel>()),
                     new RouteMap(ClientRoutes.Connect, View: views.FindByViewModel<ConnectModel>()),
                 ]));
     }

--- a/frontend/src/Client/Presentation/ClientRoutes.cs
+++ b/frontend/src/Client/Presentation/ClientRoutes.cs
@@ -13,8 +13,23 @@ namespace MailFathom.Client.Presentation;
 /// </remarks>
 internal static class ClientRoutes
 {
-    /// <summary>The application itself, which is where a client pointed at a deployment starts.</summary>
-    internal const string Main = "Main";
+    /// <summary>The frame the three spaces are shown inside, which is where a client pointed at a deployment starts.</summary>
+    internal const string Workspace = "Workspace";
+
+    /// <summary>The space a question is asked in, and the one the frame opens on.</summary>
+    internal const string Discover = "Discover";
+
+    /// <summary>The space correspondence is read in.</summary>
+    internal const string Mail = "Mail";
+
+    /// <summary>The space a thread being worked through is followed in.</summary>
+    internal const string Cases = "Cases";
+
+    /// <summary>
+    /// The screen reached from the frame rather than named among the spaces, because it is not one. It sits beside the
+    /// frame rather than inside it, which is what makes going to it a screen somebody comes back from.
+    /// </summary>
+    internal const string Settings = "Settings";
 
     /// <summary>The screen that asks which deployment this client reaches, which is where one pointed nowhere starts.</summary>
     internal const string Connect = "Connect";

--- a/frontend/src/Client/Presentation/ConnectModel.cs
+++ b/frontend/src/Client/Presentation/ConnectModel.cs
@@ -120,7 +120,7 @@ internal sealed partial record ConnectModel
             .NavigateAsync(
                 new NavigationRequest(
                     this,
-                    new Route(Qualifier: Qualifiers.ClearBackStack, Base: ClientRoutes.Main),
+                    new Route(Qualifier: Qualifiers.ClearBackStack, Base: ClientRoutes.Workspace),
                     ct))
             .ConfigureAwait(false);
     }

--- a/frontend/src/Client/Presentation/Settings/SettingsModel.cs
+++ b/frontend/src/Client/Presentation/Settings/SettingsModel.cs
@@ -6,14 +6,14 @@ using System.Collections.Immutable;
 using MailFathom.Client.Backend;
 using Microsoft.Extensions.Localization;
 
-namespace MailFathom.Client.Presentation;
+namespace MailFathom.Client.Presentation.Settings;
 
 /// <summary>
-/// The model behind <see cref="MainPage"/>. The application is empty of features, so what it has to say is what it is
-/// — the product name and the version this build was stamped with — and the two things a reader can already decide
-/// about it: which language it is read in, and which theme it is shown in.
+/// The model behind <see cref="SettingsPage"/>: the two things a reader can decide about the application itself —
+/// which language it is read in, and which theme it is shown in — beside the build it is running and the deployment it
+/// is pointed at, which are what somebody reporting a problem is asked for.
 /// </summary>
-public partial record MainModel
+public partial record SettingsModel
 {
     private readonly ILocalizationService localization;
     private readonly IThemeService themes;
@@ -27,7 +27,7 @@ public partial record MainModel
     /// <param name="address">Which deployment this client is pointed at, which is what the screen names.</param>
     /// <param name="localizer">Where a string resolved here rather than by a <c>x:Uid</c> in the view comes from.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
-    public MainModel(
+    public SettingsModel(
         ILocalizationService localization,
         IThemeService themes,
         DeploymentAddress address,

--- a/frontend/src/Client/Presentation/Settings/SettingsPage.xaml
+++ b/frontend/src/Client/Presentation/Settings/SettingsPage.xaml
@@ -3,33 +3,48 @@ Copyright © 2026 Krzysztof Kasprowicz
 Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 Project repository: https://github.com/Krzysztof318/MailFathom
 -->
-<Page x:Class="MailFathom.Client.Presentation.MainPage"
+<Page x:Class="MailFathom.Client.Presentation.Settings.SettingsPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:local="using:MailFathom.Client.Presentation"
+      xmlns:local="using:MailFathom.Client.Presentation.Settings"
       xmlns:mvux="using:Uno.Extensions.Reactive.UI"
       xmlns:uen="using:Uno.Extensions.Navigation.UI"
       xmlns:utu="using:Uno.Toolkit.UI"
       NavigationCacheMode="Required"
       Background="{ThemeResource BackgroundBrush}">
-  <ScrollViewer IsTabStop="True">
-    <!-- SafeArea keeps the content clear of a notch, a rounded corner, and a system bar, which is the difference
-         between a layout that runs on a phone and one that only fits a window. -->
-    <Grid utu:SafeArea.Insets="VisibleBounds">
-      <Grid.RowDefinitions>
-        <RowDefinition Height="Auto" />
-        <RowDefinition />
-      </Grid.RowDefinitions>
 
-      <!-- Every visible string on this page is reached by x:Uid rather than written here, including this one: the
-           product name is the same in both tables, and a name a page states for itself is a name the next page states
-           again slightly differently. -->
-      <utu:NavigationBar x:Uid="MainPage.NavigationBar.Title" />
+  <!-- Settings is reached from the frame and takes the whole surface rather than opening inside it, so it states its
+       own SafeArea: there is nothing above it left to keep this clear of a notch, a rounded corner, or a system bar. -->
+  <Grid utu:SafeArea.Insets="VisibleBounds">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition />
+    </Grid.RowDefinitions>
 
+    <!-- The way back out, as a navigation rather than as a handler: this is the same request the Android back key and
+         back gesture make, so a screen that answers one answers both. Without it settings is where the application
+         ends, and the system back leaves it. -->
+    <StackPanel Orientation="Horizontal"
+                Padding="16,12"
+                Spacing="12">
+      <Button x:Uid="SettingsPage.Button.Back"
+              uen:Navigation.Request="-"
+              VerticalAlignment="Center"
+              Style="{StaticResource TextBlockButtonStyle}">
+        <SymbolIcon Symbol="Back" />
+      </Button>
+
+      <!-- Every visible string on this page is reached by x:Uid rather than written here. -->
+      <TextBlock x:Uid="SettingsPage.TextBlock.Title"
+                 VerticalAlignment="Center"
+                 Style="{StaticResource TitleLargeTextBlockStyle}" />
+    </StackPanel>
+
+    <ScrollViewer Grid.Row="1"
+                  IsTabStop="True">
       <!-- One column, capped rather than fixed, so the block reads the same in a phone-width window and stops growing
            into a line nobody can follow on a wide desktop one. -->
-      <StackPanel Grid.Row="1"
-                  HorizontalAlignment="Center"
+      <StackPanel HorizontalAlignment="Center"
                   VerticalAlignment="Center"
                   MaxWidth="360"
                   Padding="24"
@@ -43,7 +58,7 @@ Project repository: https://github.com/Krzysztof318/MailFathom
                         Spacing="8">
               <TextBlock Text="{Binding Data.Product}"
                          HorizontalAlignment="Center"
-                         Style="{StaticResource TitleLargeTextBlockStyle}" />
+                         Style="{StaticResource SubtitleTextBlockStyle}" />
               <TextBlock Text="{Binding Data.Version}"
                          HorizontalAlignment="Center"
                          Style="{StaticResource BodyTextBlockStyle}" />
@@ -55,21 +70,21 @@ Project repository: https://github.com/Krzysztof318/MailFathom
              than buried in a setting because somebody running a client against a test deployment and a real one has to
              be able to tell which of them they are looking at without signing in to find out. -->
         <StackPanel Spacing="8">
-          <TextBlock x:Uid="MainPage.TextBlock.Deployment"
+          <TextBlock x:Uid="SettingsPage.TextBlock.Deployment"
                      Style="{StaticResource BodyTextBlockStyle}" />
 
-          <mvux:FeedView Source="{Binding Deployment}">
-            <DataTemplate>
-              <TextBlock Text="{Binding Data}"
-                         Style="{StaticResource BodyStrongTextBlockStyle}"
-                         TextWrapping="Wrap"
-                         IsTextSelectionEnabled="True" />
-            </DataTemplate>
-          </mvux:FeedView>
+          <!-- Bound to the feed's value rather than shown through a FeedView, because MVUX projects a feed of a scalar
+               as the scalar itself: the generated bindable exposes this one as a `string`, and a FeedView handed a
+               string has no feed to render. A FeedView is what a feed of a record is shown through, which is what the
+               build above is. -->
+          <TextBlock Text="{Binding Deployment}"
+                     Style="{StaticResource BodyStrongTextBlockStyle}"
+                     TextWrapping="Wrap"
+                     IsTextSelectionEnabled="True" />
 
           <!-- Declarative navigation rather than a handler: the route is what a reader of this page looks for, and a
                screen reached this way is one the system back gesture moves back through. -->
-          <Button x:Uid="MainPage.Button.ChangeDeployment"
+          <Button x:Uid="SettingsPage.Button.ChangeDeployment"
                   uen:Navigation.Request="Connect"
                   Style="{StaticResource OutlinedButtonStyle}"
                   HorizontalAlignment="Stretch" />
@@ -79,7 +94,7 @@ Project repository: https://github.com/Krzysztof318/MailFathom
              anything the build feed carries, so they stay reachable while that feed is loading or has failed. -->
         <StackPanel Spacing="12">
           <TextBlock x:Name="LanguageLabel"
-                     x:Uid="MainPage.TextBlock.Language"
+                     x:Uid="SettingsPage.TextBlock.Language"
                      Style="{StaticResource BodyTextBlockStyle}" />
 
           <!-- Each language is named in its own words rather than in the one currently on screen, which is what
@@ -94,7 +109,7 @@ Project repository: https://github.com/Krzysztof318/MailFathom
                     AutomationProperties.LabeledBy="{Binding ElementName=LanguageLabel}"
                     HorizontalAlignment="Stretch" />
 
-          <Button x:Uid="MainPage.Button.ApplyLanguage"
+          <Button x:Uid="SettingsPage.Button.ApplyLanguage"
                   Command="{Binding ApplyLanguage}"
                   Style="{StaticResource FilledButtonStyle}"
                   HorizontalAlignment="Stretch" />
@@ -102,14 +117,14 @@ Project repository: https://github.com/Krzysztof318/MailFathom
           <!-- Uno applies a culture while a head starts, so the words already on screen keep the language they were
                built in. This is where the application says that, rather than leaving somebody pressing the button
                again because nothing appeared to happen. -->
-          <InfoBar x:Uid="MainPage.InfoBar.LanguageRestart"
+          <InfoBar x:Uid="SettingsPage.InfoBar.LanguageRestart"
                    IsOpen="{Binding LanguageAwaitsRestart, Mode=TwoWay}"
                    Severity="Informational" />
         </StackPanel>
 
         <StackPanel Spacing="12">
           <TextBlock x:Name="ThemeLabel"
-                     x:Uid="MainPage.TextBlock.Theme"
+                     x:Uid="SettingsPage.TextBlock.Theme"
                      Style="{StaticResource BodyTextBlockStyle}" />
 
           <!-- Named in the model rather than here, because the words are per item and a x:Uid names a control. A
@@ -120,6 +135,6 @@ Project repository: https://github.com/Krzysztof318/MailFathom
                     HorizontalAlignment="Stretch" />
         </StackPanel>
       </StackPanel>
-    </Grid>
-  </ScrollViewer>
+    </ScrollViewer>
+  </Grid>
 </Page>

--- a/frontend/src/Client/Presentation/Settings/SettingsPage.xaml.cs
+++ b/frontend/src/Client/Presentation/Settings/SettingsPage.xaml.cs
@@ -1,0 +1,18 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Presentation.Settings;
+
+/// <summary>
+/// What a reader can decide about the application itself: which language it is read in, and which theme it is shown
+/// in. It names the build it is running beside them, which is what somebody reporting a problem is asked for.
+/// </summary>
+public sealed partial class SettingsPage : Page
+{
+    /// <summary>Initializes the page.</summary>
+    public SettingsPage()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/frontend/src/Client/Presentation/Spaces/CasesPage.xaml
+++ b/frontend/src/Client/Presentation/Spaces/CasesPage.xaml
@@ -1,0 +1,23 @@
+<!--
+Copyright © 2026 Krzysztof Kasprowicz
+Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+Project repository: https://github.com/Krzysztof318/MailFathom
+-->
+<Page x:Class="MailFathom.Client.Presentation.Spaces.CasesPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MailFathom.Client.Presentation.Spaces"
+      xmlns:workspace="using:MailFathom.Client.Presentation.Workspace"
+      NavigationCacheMode="Required">
+
+  <!-- The cases beside the one being worked on where there is room, and the cases alone where there is not. What
+       either column holds is #1189's to decide. -->
+  <workspace:WorkspaceColumns>
+    <workspace:WorkspaceColumns.Primary>
+      <local:SpacePlaceholder x:Uid="CasesPage.Cases" />
+    </workspace:WorkspaceColumns.Primary>
+    <workspace:WorkspaceColumns.Companion>
+      <local:SpacePlaceholder x:Uid="CasesPage.Case" />
+    </workspace:WorkspaceColumns.Companion>
+  </workspace:WorkspaceColumns>
+</Page>

--- a/frontend/src/Client/Presentation/Spaces/CasesPage.xaml.cs
+++ b/frontend/src/Client/Presentation/Spaces/CasesPage.xaml.cs
@@ -1,0 +1,15 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Presentation.Spaces;
+
+/// <summary>Cases: where what was found becomes work knowledge that outlives the question that found it.</summary>
+public sealed partial class CasesPage : Page
+{
+    /// <summary>Initializes the space.</summary>
+    public CasesPage()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/frontend/src/Client/Presentation/Spaces/DiscoverPage.xaml
+++ b/frontend/src/Client/Presentation/Spaces/DiscoverPage.xaml
@@ -1,0 +1,23 @@
+<!--
+Copyright © 2026 Krzysztof Kasprowicz
+Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+Project repository: https://github.com/Krzysztof318/MailFathom
+-->
+<Page x:Class="MailFathom.Client.Presentation.Spaces.DiscoverPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MailFathom.Client.Presentation.Spaces"
+      xmlns:workspace="using:MailFathom.Client.Presentation.Workspace"
+      NavigationCacheMode="Required">
+
+  <!-- Two columns where there is room for them and the answer alone where there is not, which is the frame's
+       composition rather than this space's. What either column holds is #1174's to decide. -->
+  <workspace:WorkspaceColumns>
+    <workspace:WorkspaceColumns.Primary>
+      <local:SpacePlaceholder x:Uid="DiscoverPage.Answer" />
+    </workspace:WorkspaceColumns.Primary>
+    <workspace:WorkspaceColumns.Companion>
+      <local:SpacePlaceholder x:Uid="DiscoverPage.Evidence" />
+    </workspace:WorkspaceColumns.Companion>
+  </workspace:WorkspaceColumns>
+</Page>

--- a/frontend/src/Client/Presentation/Spaces/DiscoverPage.xaml.cs
+++ b/frontend/src/Client/Presentation/Spaces/DiscoverPage.xaml.cs
@@ -1,0 +1,15 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Presentation.Spaces;
+
+/// <summary>Discover: where a question is answered and the mail that answered it stands beside the answer.</summary>
+public sealed partial class DiscoverPage : Page
+{
+    /// <summary>Initializes the space.</summary>
+    public DiscoverPage()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/frontend/src/Client/Presentation/Spaces/MailPage.xaml
+++ b/frontend/src/Client/Presentation/Spaces/MailPage.xaml
@@ -1,0 +1,23 @@
+<!--
+Copyright © 2026 Krzysztof Kasprowicz
+Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+Project repository: https://github.com/Krzysztof318/MailFathom
+-->
+<Page x:Class="MailFathom.Client.Presentation.Spaces.MailPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:MailFathom.Client.Presentation.Spaces"
+      xmlns:workspace="using:MailFathom.Client.Presentation.Workspace"
+      NavigationCacheMode="Required">
+
+  <!-- The list beside what is open on a wide window, and the list alone on a narrow one, where opening something is
+       a screen rather than a second column. What either column holds is #1159's to decide. -->
+  <workspace:WorkspaceColumns>
+    <workspace:WorkspaceColumns.Primary>
+      <local:SpacePlaceholder x:Uid="MailPage.Messages" />
+    </workspace:WorkspaceColumns.Primary>
+    <workspace:WorkspaceColumns.Companion>
+      <local:SpacePlaceholder x:Uid="MailPage.Reading" />
+    </workspace:WorkspaceColumns.Companion>
+  </workspace:WorkspaceColumns>
+</Page>

--- a/frontend/src/Client/Presentation/Spaces/MailPage.xaml.cs
+++ b/frontend/src/Client/Presentation/Spaces/MailPage.xaml.cs
@@ -2,13 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-namespace MailFathom.Client.Presentation;
+namespace MailFathom.Client.Presentation.Spaces;
 
-/// <summary>The application's only screen so far. It names the product and the build it is running.</summary>
-public sealed partial class MainPage : Page
+/// <summary>Mail: the mailbox itself, read the way a mail client is read.</summary>
+public sealed partial class MailPage : Page
 {
-    /// <summary>Initializes the page.</summary>
-    public MainPage()
+    /// <summary>Initializes the space.</summary>
+    public MailPage()
     {
         this.InitializeComponent();
     }

--- a/frontend/src/Client/Presentation/Spaces/SpacePlaceholder.xaml
+++ b/frontend/src/Client/Presentation/Spaces/SpacePlaceholder.xaml
@@ -1,0 +1,33 @@
+<!--
+Copyright © 2026 Krzysztof Kasprowicz
+Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+Project repository: https://github.com/Krzysztof318/MailFathom
+-->
+<UserControl x:Class="MailFathom.Client.Presentation.Spaces.SpacePlaceholder"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="300"
+             d:DesignWidth="400">
+
+  <StackPanel HorizontalAlignment="Center"
+              VerticalAlignment="Center"
+              MaxWidth="360"
+              Padding="24"
+              Spacing="8">
+    <TextBlock Text="{x:Bind Heading, Mode=OneWay}"
+               HorizontalAlignment="Center"
+               TextAlignment="Center"
+               TextWrapping="Wrap"
+               Style="{StaticResource SubtitleTextBlockStyle}"
+               Foreground="{ThemeResource OnSurfaceBrush}" />
+    <TextBlock Text="{x:Bind Detail, Mode=OneWay}"
+               HorizontalAlignment="Center"
+               TextAlignment="Center"
+               TextWrapping="Wrap"
+               Style="{StaticResource BodyTextBlockStyle}"
+               Foreground="{ThemeResource OnSurfaceVariantBrush}" />
+  </StackPanel>
+</UserControl>

--- a/frontend/src/Client/Presentation/Spaces/SpacePlaceholder.xaml.cs
+++ b/frontend/src/Client/Presentation/Spaces/SpacePlaceholder.xaml.cs
@@ -1,0 +1,51 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Presentation.Spaces;
+
+/// <summary>
+/// What a column of a space holds until the space that owns it is built: what it is for, said plainly, rather than a
+/// blank rectangle somebody cannot tell from a failure.
+/// </summary>
+/// <remarks>
+/// It exists so the frame can be seen working — a wide window shows two columns and a narrow one shows the primary
+/// column alone — while what fills either of them stays each space's own decision. A space that has been built carries
+/// its own content and no longer names this control.
+/// </remarks>
+public sealed partial class SpacePlaceholder : UserControl
+{
+    /// <summary>Identifies the <see cref="Heading"/> property.</summary>
+    public static readonly DependencyProperty HeadingProperty = DependencyProperty.Register(
+        nameof(Heading),
+        typeof(string),
+        typeof(SpacePlaceholder),
+        new PropertyMetadata(string.Empty));
+
+    /// <summary>Identifies the <see cref="Detail"/> property.</summary>
+    public static readonly DependencyProperty DetailProperty = DependencyProperty.Register(
+        nameof(Detail),
+        typeof(string),
+        typeof(SpacePlaceholder),
+        new PropertyMetadata(string.Empty));
+
+    /// <summary>Initializes the placeholder.</summary>
+    public SpacePlaceholder()
+    {
+        this.InitializeComponent();
+    }
+
+    /// <summary>What this column is, in a few words.</summary>
+    public string Heading
+    {
+        get => (string)this.GetValue(HeadingProperty);
+        set => this.SetValue(HeadingProperty, value);
+    }
+
+    /// <summary>What will be here, in one sentence.</summary>
+    public string Detail
+    {
+        get => (string)this.GetValue(DetailProperty);
+        set => this.SetValue(DetailProperty, value);
+    }
+}

--- a/frontend/src/Client/Presentation/Workspace/IWorkspace.cs
+++ b/frontend/src/Client/Presentation/Workspace/IWorkspace.cs
@@ -1,0 +1,21 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Presentation.Workspace;
+
+/// <summary>What the three spaces share, so that moving between them keeps what somebody was working on.</summary>
+/// <remarks>
+/// The frame reads both of these — the question somebody is composing, and what it would be asked against — and a
+/// space writes them when somebody types, narrows to an account, opens a folder, or selects something. There is one
+/// of these for the run: a question and a scope held per space would be three of each, and moving between spaces
+/// would silently be a fourth thing to keep in step.
+/// </remarks>
+public interface IWorkspace
+{
+    /// <summary>The question being composed, which travels with somebody between spaces rather than being retyped.</summary>
+    IState<string> Intent { get; }
+
+    /// <summary>The scope every space reads and any of them may narrow.</summary>
+    IState<WorkspaceScope> Scope { get; }
+}

--- a/frontend/src/Client/Presentation/Workspace/SharedWorkspace.cs
+++ b/frontend/src/Client/Presentation/Workspace/SharedWorkspace.cs
@@ -1,0 +1,21 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Presentation.Workspace;
+
+/// <summary>The one workspace a run has, registered for the whole of it.</summary>
+/// <remarks>
+/// Both states are owned by this instance rather than by a model, which is the whole point: a model is built and
+/// discarded as its view is navigated to and away from, and a question or a scope that went with it would be lost
+/// exactly when somebody moved between spaces. Reading either property twice hands back the same state, because MVUX
+/// resolves it against the owner rather than building one per read.
+/// </remarks>
+internal sealed class SharedWorkspace : IWorkspace
+{
+    /// <inheritdoc />
+    public IState<string> Intent => State.Value(this, () => string.Empty);
+
+    /// <inheritdoc />
+    public IState<WorkspaceScope> Scope => State.Value(this, () => WorkspaceScope.Everything);
+}

--- a/frontend/src/Client/Presentation/Workspace/WorkspaceColumns.xaml
+++ b/frontend/src/Client/Presentation/Workspace/WorkspaceColumns.xaml
@@ -1,0 +1,67 @@
+<!--
+Copyright © 2026 Krzysztof Kasprowicz
+Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+Project repository: https://github.com/Krzysztof318/MailFathom
+-->
+<UserControl x:Class="MailFathom.Client.Presentation.Workspace.WorkspaceColumns"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="600"
+             d:DesignWidth="1200">
+
+  <!-- The workspace a space fills. A wide window shows both columns side by side; a narrow one shows the primary
+       column alone, and what would have been beside it is reached as a screen of its own instead. The switch is a
+       window width and nothing else: no code here reads which platform is running, and neither does anything it is
+       nested in. -->
+  <Grid>
+    <VisualStateManager.VisualStateGroups>
+      <VisualStateGroup>
+
+        <!-- The narrow composition is the default state and carries no trigger, so a window narrower than every
+             breakpoint still lands in a state rather than in none. -->
+        <VisualState x:Name="SingleColumn" />
+
+        <VisualState x:Name="TwoColumns">
+          <VisualState.StateTriggers>
+            <AdaptiveTrigger MinWindowWidth="{StaticResource WorkspaceWideWindowWidth}" />
+          </VisualState.StateTriggers>
+          <VisualState.Setters>
+            <Setter Target="CompanionColumn.Width" Value="2*" />
+            <Setter Target="Divider.Visibility" Value="Visible" />
+            <Setter Target="CompanionContent.Visibility" Value="Visible" />
+          </VisualState.Setters>
+        </VisualState>
+      </VisualStateGroup>
+    </VisualStateManager.VisualStateGroups>
+
+    <Grid.ColumnDefinitions>
+      <ColumnDefinition Width="3*" />
+      <ColumnDefinition Width="Auto" />
+      <!-- Zero rather than collapsed, because a column keeps its share of the grid whatever its content does. -->
+      <ColumnDefinition x:Name="CompanionColumn"
+                        Width="0" />
+    </Grid.ColumnDefinitions>
+
+    <ContentPresenter Content="{x:Bind Primary, Mode=OneWay}"
+                      HorizontalContentAlignment="Stretch"
+                      VerticalContentAlignment="Stretch" />
+
+    <!-- A decorative edge rather than an interactive one, which is the role OutlineVariant names. -->
+    <Border x:Name="Divider"
+            Grid.Column="1"
+            Width="1"
+            Visibility="Collapsed"
+            Background="{ThemeResource OutlineVariantBrush}" />
+
+    <ContentPresenter x:Name="CompanionContent"
+                      Grid.Column="2"
+                      MinWidth="280"
+                      Visibility="Collapsed"
+                      Content="{x:Bind Companion, Mode=OneWay}"
+                      HorizontalContentAlignment="Stretch"
+                      VerticalContentAlignment="Stretch" />
+  </Grid>
+</UserControl>

--- a/frontend/src/Client/Presentation/Workspace/WorkspaceColumns.xaml.cs
+++ b/frontend/src/Client/Presentation/Workspace/WorkspaceColumns.xaml.cs
@@ -1,0 +1,57 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Presentation.Workspace;
+
+/// <summary>
+/// The workspace the frame gives a space: one column on a narrow window, and that column beside a companion one on a
+/// wide window.
+/// </summary>
+/// <remarks>
+/// It is the frame's rather than any space's, so that all three read the same at the same width and a later space
+/// inherits the composition instead of restating it. What goes in either column is the space's own decision.
+/// </remarks>
+public sealed partial class WorkspaceColumns : UserControl
+{
+    /// <summary>Identifies the <see cref="Primary"/> property.</summary>
+    public static readonly DependencyProperty PrimaryProperty = DependencyProperty.Register(
+        nameof(Primary),
+        typeof(object),
+        typeof(WorkspaceColumns),
+        new PropertyMetadata(defaultValue: null));
+
+    /// <summary>Identifies the <see cref="Companion"/> property.</summary>
+    public static readonly DependencyProperty CompanionProperty = DependencyProperty.Register(
+        nameof(Companion),
+        typeof(object),
+        typeof(WorkspaceColumns),
+        new PropertyMetadata(defaultValue: null));
+
+    /// <summary>Initializes the workspace.</summary>
+    public WorkspaceColumns()
+    {
+        this.InitializeComponent();
+    }
+
+    /// <summary>What the space is for, shown at every width.</summary>
+    public object? Primary
+    {
+        get => this.GetValue(PrimaryProperty);
+        set => this.SetValue(PrimaryProperty, value);
+    }
+
+    /// <summary>
+    /// What stands beside the primary column when there is room for it, and is not shown when there is not.
+    /// </summary>
+    /// <remarks>
+    /// A narrow window drops the column rather than stacking it, because two things stacked on a phone are one thing
+    /// with something in the way of it. What that content is instead reachable as there is a route, which is what puts
+    /// it on the screen stack the system back gesture moves through.
+    /// </remarks>
+    public object? Companion
+    {
+        get => this.GetValue(CompanionProperty);
+        set => this.SetValue(CompanionProperty, value);
+    }
+}

--- a/frontend/src/Client/Presentation/Workspace/WorkspaceModel.cs
+++ b/frontend/src/Client/Presentation/Workspace/WorkspaceModel.cs
@@ -65,6 +65,10 @@ public partial record WorkspaceModel
         {
             { Account: { } account, Folder: { } folder } => this.localizer[AccountFolderKey, account, folder].Value,
             { Account: { } account } => account,
+
+            // A folder without an account is not a scope anything here builds, and the type refuses nothing, so it is
+            // named rather than dropped: falling through to "everything" would say the opposite of what is in force.
+            { Folder: { } folder } => folder,
             _ => this.localizer[EverythingKey].Value,
         };
 

--- a/frontend/src/Client/Presentation/Workspace/WorkspaceModel.cs
+++ b/frontend/src/Client/Presentation/Workspace/WorkspaceModel.cs
@@ -1,0 +1,75 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using Microsoft.Extensions.Localization;
+
+namespace MailFathom.Client.Presentation.Workspace;
+
+/// <summary>
+/// The model behind <see cref="WorkspacePage"/>, which is the frame the three spaces are shown inside rather than a
+/// space of its own. It owns what sits above them: the question being composed, and what that question would be asked
+/// against.
+/// </summary>
+/// <remarks>
+/// Neither is answered here. Running a question is Discover's work, and narrowing a scope is done by the space
+/// somebody is narrowing in — the frame's part is that both survive moving between spaces, which is why it reads them
+/// from <see cref="IWorkspace"/> rather than holding them itself.
+/// </remarks>
+public partial record WorkspaceModel
+{
+    private const string EverythingKey = "WorkspaceScope.Everything";
+    private const string AccountFolderKey = "WorkspaceScope.AccountFolder";
+    private const string SelectedKey = "WorkspaceScope.Selected";
+
+    private readonly IWorkspace workspace;
+    private readonly IStringLocalizer localizer;
+
+    /// <summary>Initializes the frame over the workspace its spaces share.</summary>
+    /// <param name="workspace">The question and the scope every space reads and writes.</param>
+    /// <param name="localizer">Where the words describing a scope come from, since they are composed rather than per control.</param>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    public WorkspaceModel(IWorkspace workspace, IStringLocalizer localizer)
+    {
+        ArgumentNullException.ThrowIfNull(workspace);
+        ArgumentNullException.ThrowIfNull(localizer);
+
+        this.workspace = workspace;
+        this.localizer = localizer;
+        this.ScopeDescription = workspace.Scope.Select(this.Describe);
+    }
+
+    /// <summary>What somebody is about to ask, held for the run rather than for the screen they typed it on.</summary>
+    public IState<string> Intent => this.workspace.Intent;
+
+    /// <summary>The scope the question would be asked against, as the words the indicator beside the field shows.</summary>
+    /// <remarks>
+    /// Built once rather than per read: the indicator is bound to it, and a second feed per read would leave the view
+    /// and anything the model asked subscribed to two descriptions of one scope.
+    /// </remarks>
+    public IFeed<string> ScopeDescription { get; }
+
+    /// <summary>
+    /// The keys the words above are resolved by, in the one place they are written.
+    /// </summary>
+    /// <remarks>
+    /// A scope is described by composing words rather than by a <c>x:Uid</c> on a control, so these keys are asked
+    /// for from code — which makes a typo in one of them the single way a reader would meet the key itself instead of
+    /// a sentence. The unit suite holds every authored table to naming all three.
+    /// </remarks>
+    internal static IReadOnlyList<string> ScopeResourceKeys { get; } = [EverythingKey, AccountFolderKey, SelectedKey];
+
+    private string Describe(WorkspaceScope scope)
+    {
+        var where = scope switch
+        {
+            { Account: { } account, Folder: { } folder } => this.localizer[AccountFolderKey, account, folder].Value,
+            { Account: { } account } => account,
+            _ => this.localizer[EverythingKey].Value,
+        };
+
+        return scope.Selection.Count is 0
+            ? where
+            : this.localizer[SelectedKey, where, scope.Selection.Count].Value;
+    }
+}

--- a/frontend/src/Client/Presentation/Workspace/WorkspacePage.xaml
+++ b/frontend/src/Client/Presentation/Workspace/WorkspacePage.xaml
@@ -1,0 +1,194 @@
+<!--
+Copyright © 2026 Krzysztof Kasprowicz
+Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+Project repository: https://github.com/Krzysztof318/MailFathom
+-->
+<Page x:Class="MailFathom.Client.Presentation.Workspace.WorkspacePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:uen="using:Uno.Extensions.Navigation.UI"
+      xmlns:utu="using:Uno.Toolkit.UI"
+      NavigationCacheMode="Required"
+      Background="{ThemeResource BackgroundBrush}">
+
+  <!-- SafeArea keeps every composition below clear of a notch, a rounded corner, and a system bar. It is stated once
+       at the root because the toolkit insets an element by how much of it the unsafe area actually covers, so the
+       bottom navigation nested inside adds nothing on top of what is taken here. The soft keyboard is the one mask
+       that cannot be attached to an ordinary element — the toolkit supports `SoftInput` on a SafeArea or a
+       ScrollViewer alone, and warns at run time rather than failing — so it is stated below, around the text this
+       frame owns. -->
+  <Grid uen:Region.Attached="True"
+        utu:SafeArea.Insets="VisibleBounds">
+    <VisualStateManager.VisualStateGroups>
+      <VisualStateGroup>
+
+        <!-- Bottom navigation over one column, which is the composition a window narrower than every breakpoint below
+             lands in. It states a trigger of its own rather than relying on being first: a state no trigger selects is
+             never entered, so a group whose narrowest member carries none falls back to what the elements were
+             authored with instead — which here is the rail, on a phone. -->
+        <VisualState x:Name="Narrow">
+          <VisualState.StateTriggers>
+            <AdaptiveTrigger MinWindowWidth="0" />
+          </VisualState.StateTriggers>
+          <VisualState.Setters>
+            <Setter Target="Spaces.Visibility" Value="Visible" />
+            <Setter Target="Rail.IsPaneToggleButtonVisible" Value="False" />
+            <Setter Target="Rail.IsPaneVisible" Value="False" />
+            <Setter Target="Rail.PaneDisplayMode" Value="LeftMinimal" />
+            <Setter Target="Rail.IsPaneOpen" Value="False" />
+          </VisualState.Setters>
+        </VisualState>
+
+        <VisualState x:Name="Normal">
+          <VisualState.StateTriggers>
+            <AdaptiveTrigger MinWindowWidth="{StaticResource WorkspaceRailWindowWidth}" />
+          </VisualState.StateTriggers>
+          <VisualState.Setters>
+            <Setter Target="Spaces.Visibility" Value="Collapsed" />
+            <Setter Target="Rail.IsPaneToggleButtonVisible" Value="True" />
+            <Setter Target="Rail.IsPaneVisible" Value="True" />
+            <Setter Target="Rail.PaneDisplayMode" Value="LeftCompact" />
+          </VisualState.Setters>
+        </VisualState>
+
+        <!-- The wide composition differs from the one above only in what the workspace beside the rail does with the
+             room, which WorkspaceColumns decides at the same breakpoint. -->
+        <VisualState x:Name="Wide">
+          <VisualState.StateTriggers>
+            <AdaptiveTrigger MinWindowWidth="{StaticResource WorkspaceWideWindowWidth}" />
+          </VisualState.StateTriggers>
+          <VisualState.Setters>
+            <Setter Target="Spaces.Visibility" Value="Collapsed" />
+            <Setter Target="Rail.IsPaneToggleButtonVisible" Value="True" />
+            <Setter Target="Rail.IsPaneVisible" Value="True" />
+            <Setter Target="Rail.PaneDisplayMode" Value="LeftCompact" />
+          </VisualState.Setters>
+        </VisualState>
+      </VisualStateGroup>
+    </VisualStateManager.VisualStateGroups>
+
+    <!-- The rail and the bottom navigation are one navigation rather than two: both are regions, and an item in
+         either names the same route as its counterpart, so whichever the width put in front of somebody moves the
+         same content area. -->
+    <NavigationView x:Name="Rail"
+                    uen:Region.Attached="True"
+                    IsSettingsVisible="False"
+                    IsBackButtonVisible="Collapsed"
+                    PaneDisplayMode="LeftCompact">
+      <NavigationView.MenuItems>
+        <NavigationViewItem x:Uid="Workspace.Rail.Discover"
+                            uen:Region.Name="Discover">
+          <NavigationViewItem.Icon>
+            <SymbolIcon Symbol="Find" />
+          </NavigationViewItem.Icon>
+        </NavigationViewItem>
+        <NavigationViewItem x:Uid="Workspace.Rail.Mail"
+                            uen:Region.Name="Mail">
+          <NavigationViewItem.Icon>
+            <SymbolIcon Symbol="Mail" />
+          </NavigationViewItem.Icon>
+        </NavigationViewItem>
+        <NavigationViewItem x:Uid="Workspace.Rail.Cases"
+                            uen:Region.Name="Cases">
+          <NavigationViewItem.Icon>
+            <SymbolIcon Symbol="Folder" />
+          </NavigationViewItem.Icon>
+        </NavigationViewItem>
+      </NavigationView.MenuItems>
+
+      <NavigationView.Content>
+        <Grid>
+          <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition />
+            <RowDefinition Height="Auto" />
+          </Grid.RowDefinitions>
+
+          <!-- What the frame owns above the spaces: the field the product puts a question in, and the indicator
+               beside it saying what that question would be asked against. Neither runs anything here — the field
+               holds what somebody typed, the indicator reads the scope, and both survive moving between spaces
+               because both live in the workspace rather than in the space on screen. -->
+          <Grid Padding="16,12"
+                ColumnSpacing="12"
+                Background="{ThemeResource SurfaceBrush}">
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition />
+              <ColumnDefinition Width="Auto" />
+              <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <!-- The one place this frame takes typing, and therefore the one place the soft keyboard can cover
+                 something: SafeArea as a control rather than as an attached mask, which is what the `SoftInput` mask
+                 is supported on. A space that takes typing of its own says the same thing around its own field. -->
+            <utu:SafeArea Insets="SoftInput">
+              <TextBox x:Uid="Workspace.TextBox.Intent"
+                       Text="{Binding Intent, Mode=TwoWay}"
+                       MaxWidth="720"
+                       HorizontalAlignment="Stretch" />
+            </utu:SafeArea>
+
+            <!-- Bound to the feed's value rather than displayed through a FeedView, because MVUX projects a feed of a
+                 scalar as the scalar itself: the generated bindable exposes this one as a `string`, and a FeedView
+                 handed a string has no feed to render. A FeedView is what a feed of a record is shown through — as
+                 the settings screen shows its build — and this indicator becomes one the day a scope is resolved
+                 against the deployment and can therefore be loading or failed. -->
+            <Border Grid.Column="1"
+                    Padding="12,6"
+                    CornerRadius="16"
+                    VerticalAlignment="Center"
+                    Background="{ThemeResource SecondaryContainerBrush}">
+              <!-- No x:Uid: the words are the scope itself, resolved in the model because they are composed from what
+                   is in scope rather than fixed per control. -->
+              <TextBlock Text="{Binding ScopeDescription}"
+                         Style="{StaticResource CaptionTextBlockStyle}"
+                         Foreground="{ThemeResource OnSecondaryContainerBrush}"
+                         TextTrimming="CharacterEllipsis"
+                         MaxWidth="280" />
+            </Border>
+
+            <!-- The one destination that is not a space, so it is reached from the frame rather than named beside
+                 the three. It is a route like every other, which is what puts it on the stack the system back
+                 gesture and the browser's history move through. -->
+            <Button x:Uid="Workspace.Button.Settings"
+                    Grid.Column="2"
+                    uen:Navigation.Request="Settings"
+                    VerticalAlignment="Center"
+                    Style="{StaticResource TextBlockButtonStyle}">
+              <SymbolIcon Symbol="Setting" />
+            </Button>
+          </Grid>
+
+          <!-- Left empty deliberately: navigation resolves a registered route and puts the view for it here. -->
+          <Grid Grid.Row="1"
+                uen:Region.Attached="True"
+                uen:Region.Navigator="Visibility" />
+
+          <utu:TabBar x:Name="Spaces"
+                      Grid.Row="2"
+                      uen:Region.Attached="True"
+                      Style="{StaticResource BottomTabBarStyle}"
+                      Visibility="Collapsed">
+            <utu:TabBarItem x:Uid="Workspace.Tab.Discover"
+                            uen:Region.Name="Discover">
+              <utu:TabBarItem.Icon>
+                <SymbolIcon Symbol="Find" />
+              </utu:TabBarItem.Icon>
+            </utu:TabBarItem>
+            <utu:TabBarItem x:Uid="Workspace.Tab.Mail"
+                            uen:Region.Name="Mail">
+              <utu:TabBarItem.Icon>
+                <SymbolIcon Symbol="Mail" />
+              </utu:TabBarItem.Icon>
+            </utu:TabBarItem>
+            <utu:TabBarItem x:Uid="Workspace.Tab.Cases"
+                            uen:Region.Name="Cases">
+              <utu:TabBarItem.Icon>
+                <SymbolIcon Symbol="Folder" />
+              </utu:TabBarItem.Icon>
+            </utu:TabBarItem>
+          </utu:TabBar>
+        </Grid>
+      </NavigationView.Content>
+    </NavigationView>
+  </Grid>
+</Page>

--- a/frontend/src/Client/Presentation/Workspace/WorkspacePage.xaml.cs
+++ b/frontend/src/Client/Presentation/Workspace/WorkspacePage.xaml.cs
@@ -1,0 +1,18 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Presentation.Workspace;
+
+/// <summary>
+/// The frame the three spaces are shown inside: the navigation that moves between them, the field a question is put
+/// in, and the indicator saying what it would be asked against.
+/// </summary>
+public sealed partial class WorkspacePage : Page
+{
+    /// <summary>Initializes the frame.</summary>
+    public WorkspacePage()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/frontend/src/Client/Presentation/Workspace/WorkspaceScope.cs
+++ b/frontend/src/Client/Presentation/Workspace/WorkspaceScope.cs
@@ -1,0 +1,58 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Immutable;
+
+namespace MailFathom.Client.Presentation.Workspace;
+
+/// <summary>
+/// What the next question would be asked against: an account, a folder within it, and whatever is selected there.
+/// </summary>
+/// <remarks>
+/// <para>
+/// It belongs to the frame rather than to any space, because it is the thing that makes Discover, Mail, and Cases one
+/// application: somebody who narrows to a folder in one space and moves to another has not changed what they are
+/// asking about, and a scope each space kept for itself would say they had.
+/// </para>
+/// <para>
+/// Nothing here identifies a person or carries mail content. An account and a folder are names the deployment already
+/// told this client, and a selection is a list of the identifiers it handed over with them — the classification the
+/// root instructions put on mail metadata follows all three, so none of them is logged or written anywhere but memory.
+/// </para>
+/// </remarks>
+public sealed record WorkspaceScope
+{
+    /// <summary>Everything the signed-in person can reach, which is what a run starts scoped to.</summary>
+    public static WorkspaceScope Everything { get; } = new();
+
+    /// <summary>The account in scope, or <see langword="null" /> when every one of them is.</summary>
+    public string? Account { get; init; }
+
+    /// <summary>The folder in scope within <see cref="Account" />, or <see langword="null" /> when the whole account is.</summary>
+    public string? Folder { get; init; }
+
+    /// <summary>What is selected within the scope above, in the order it was selected.</summary>
+    public IImmutableList<string> Selection { get; init; } = ImmutableArray<string>.Empty;
+
+    /// <summary>Whether this scope narrows to anything at all.</summary>
+    public bool NarrowsAnything => this.Account is not null || this.Selection.Count > 0;
+
+    /// <summary>Holds two scopes equal when they name the same thing, rather than when they are the same object.</summary>
+    /// <param name="other">The scope to compare against.</param>
+    /// <returns><see langword="true" /> when both name the same account, folder, and selection.</returns>
+    /// <remarks>
+    /// A record compares its members with the default comparer, and for <see cref="IImmutableList{T}" /> that is
+    /// reference equality — so two scopes built from the same selection would be unequal and every write of an
+    /// unchanged scope would reach the view as a change. The state this record travels in compares values to decide
+    /// whether anything happened, which is why the comparison is stated rather than inherited.
+    /// </remarks>
+    public bool Equals(WorkspaceScope? other) =>
+        other is not null
+        && string.Equals(this.Account, other.Account, StringComparison.Ordinal)
+        && string.Equals(this.Folder, other.Folder, StringComparison.Ordinal)
+        && this.Selection.SequenceEqual(other.Selection, StringComparer.Ordinal);
+
+    /// <inheritdoc />
+    public override int GetHashCode() => HashCode.Combine(this.Account, this.Folder, this.Selection.Count);
+}

--- a/frontend/src/Client/Presentation/Workspace/WorkspaceScope.cs
+++ b/frontend/src/Client/Presentation/Workspace/WorkspaceScope.cs
@@ -36,7 +36,13 @@ public sealed record WorkspaceScope
     public IImmutableList<string> Selection { get; init; } = ImmutableArray<string>.Empty;
 
     /// <summary>Whether this scope narrows to anything at all.</summary>
-    public bool NarrowsAnything => this.Account is not null || this.Selection.Count > 0;
+    /// <remarks>
+    /// Each of the three is asked about rather than only the account, because nothing here refuses a folder named
+    /// without one: the property above says a folder is read within its account, and a reader that assumed the type
+    /// enforced it would answer <see langword="false" /> for a scope that plainly narrows.
+    /// </remarks>
+    public bool NarrowsAnything =>
+        this.Account is not null || this.Folder is not null || this.Selection.Count > 0;
 
     /// <summary>Holds two scopes equal when they name the same thing, rather than when they are the same object.</summary>
     /// <param name="other">The scope to compare against.</param>

--- a/frontend/src/Client/Strings/en/Resources.resw
+++ b/frontend/src/Client/Strings/en/Resources.resw
@@ -121,11 +121,11 @@
     <value>MailFathom</value>
     <comment>The product name. It is the same in every language: a name is not translated.</comment>
   </data>
-  <data name="MainPage.TextBlock.Deployment.Text" xml:space="preserve">
+  <data name="SettingsPage.TextBlock.Deployment.Text" xml:space="preserve">
     <value>Connected to</value>
     <comment>Labels the address of the MailFathom deployment this client reaches. Phrased as the relationship rather than as "Deployment address", which names a setting instead of saying where you are.</comment>
   </data>
-  <data name="MainPage.Button.ChangeDeployment.Content" xml:space="preserve">
+  <data name="SettingsPage.Button.ChangeDeployment.Content" xml:space="preserve">
     <value>Use a different MailFathom</value>
     <comment>Opens the screen that asks for a deployment address. Named for what a person wants rather than for the setting it changes.</comment>
   </data>
@@ -181,23 +181,23 @@
     <value>Something answered there, but it is not a MailFathom. Check the address.</value>
     <comment>Shown when the answer was not MailFathom's own — a captive portal, a proxy, or another service on the port.</comment>
   </data>
-  <data name="MainPage.TextBlock.Language.Text" xml:space="preserve">
+  <data name="SettingsPage.TextBlock.Language.Text" xml:space="preserve">
     <value>Language</value>
     <comment>Labels the control that chooses which language the application is read in, for a reader and for a screen reader.</comment>
   </data>
-  <data name="MainPage.Button.ApplyLanguage.Content" xml:space="preserve">
+  <data name="SettingsPage.Button.ApplyLanguage.Content" xml:space="preserve">
     <value>Use this language</value>
     <comment>Takes the language selected beside it. Phrased as the act rather than as "OK", because nothing is undone by leaving the screen.</comment>
   </data>
-  <data name="MainPage.InfoBar.LanguageRestart.Title" xml:space="preserve">
+  <data name="SettingsPage.InfoBar.LanguageRestart.Title" xml:space="preserve">
     <value>Language saved</value>
     <comment>Shown once a language has been taken. Saved rather than changed, because the words on screen have not changed yet.</comment>
   </data>
-  <data name="MainPage.InfoBar.LanguageRestart.Message" xml:space="preserve">
+  <data name="SettingsPage.InfoBar.LanguageRestart.Message" xml:space="preserve">
     <value>MailFathom reads in the language you chose the next time it starts.</value>
     <comment>Says plainly that the choice takes effect on the next launch, which is when Uno applies a culture.</comment>
   </data>
-  <data name="MainPage.TextBlock.Theme.Text" xml:space="preserve">
+  <data name="SettingsPage.TextBlock.Theme.Text" xml:space="preserve">
     <value>Theme</value>
     <comment>Labels the control that chooses whether the application is shown light, dark, or the way the system is set.</comment>
   </data>
@@ -212,5 +212,105 @@
   <data name="AppTheme.Dark" xml:space="preserve">
     <value>Dark</value>
     <comment>One of the three theme offers.</comment>
+  </data>
+  <data name="Workspace.Rail.Mail.Content" xml:space="preserve">
+    <value>Mail</value>
+    <comment>Names the second of the three spaces, on the navigation rail a wide window shows.</comment>
+  </data>
+  <data name="Workspace.Rail.Cases.Content" xml:space="preserve">
+    <value>Cases</value>
+    <comment>Names the third of the three spaces, on the navigation rail a wide window shows.</comment>
+  </data>
+  <data name="Workspace.Tab.Discover.Content" xml:space="preserve">
+    <value>Discover</value>
+    <comment>The same space as the rail item above, named on the bottom navigation a narrow window shows.</comment>
+  </data>
+  <data name="Workspace.Tab.Mail.Content" xml:space="preserve">
+    <value>Mail</value>
+    <comment>The same space as the rail item above, named on the bottom navigation a narrow window shows.</comment>
+  </data>
+  <data name="Workspace.Tab.Cases.Content" xml:space="preserve">
+    <value>Cases</value>
+    <comment>The same space as the rail item above, named on the bottom navigation a narrow window shows.</comment>
+  </data>
+  <data name="Workspace.TextBox.Intent.PlaceholderText" xml:space="preserve">
+    <value>Ask about your mail</value>
+    <comment>What the field invites, shown while it is empty. An invitation rather than a label, because the label is read by a screen reader below.</comment>
+  </data>
+  <data name="Workspace.TextBox.Intent.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Your question</value>
+    <comment>Names the field to a screen reader, which does not read a placeholder once anything has been typed.</comment>
+  </data>
+  <data name="Workspace.Button.Settings.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Settings</value>
+    <comment>Names the button that opens the settings screen, which carries an icon rather than words.</comment>
+  </data>
+  <data name="WorkspaceScope.Everything" xml:space="preserve">
+    <value>All your mail</value>
+    <comment>What the scope indicator says when nothing has been narrowed. Resolved in the model rather than by a x:Uid, because the indicator is composed from what is in scope.</comment>
+  </data>
+  <data name="WorkspaceScope.AccountFolder" xml:space="preserve">
+    <value>{0} · {1}</value>
+    <comment>An account and a folder within it, in that order. Punctuation rather than words, so the two names stay readable in any language.</comment>
+  </data>
+  <data name="WorkspaceScope.Selected" xml:space="preserve">
+    <value>{0} · {1} selected</value>
+    <comment>What is in scope, and how many things are selected within it. {0} is the scope as the two entries above phrase it and {1} is a count.</comment>
+  </data>
+  <data name="DiscoverPage.Answer.Heading" xml:space="preserve">
+    <value>Discover</value>
+    <comment>Names the primary column of the Discover space while that space is being built.</comment>
+  </data>
+  <data name="DiscoverPage.Answer.Detail" xml:space="preserve">
+    <value>This space is still being built.</value>
+    <comment>Says plainly that the space is empty because nothing has been put in it yet, rather than because something failed.</comment>
+  </data>
+  <data name="DiscoverPage.Evidence.Heading" xml:space="preserve">
+    <value>Evidence</value>
+    <comment>Names the companion column of the Discover space, which a wide window shows beside the answer.</comment>
+  </data>
+  <data name="DiscoverPage.Evidence.Detail" xml:space="preserve">
+    <value>This column is still being built.</value>
+    <comment>The companion column's counterpart to the sentence above.</comment>
+  </data>
+  <data name="MailPage.Messages.Heading" xml:space="preserve">
+    <value>Mail</value>
+    <comment>Names the primary column of the Mail space while that space is being built.</comment>
+  </data>
+  <data name="MailPage.Messages.Detail" xml:space="preserve">
+    <value>This space is still being built.</value>
+    <comment>Says plainly that the space is empty because nothing has been put in it yet, rather than because something failed.</comment>
+  </data>
+  <data name="MailPage.Reading.Heading" xml:space="preserve">
+    <value>Reading</value>
+    <comment>Names the companion column of the Mail space, which a wide window shows beside the list.</comment>
+  </data>
+  <data name="MailPage.Reading.Detail" xml:space="preserve">
+    <value>This column is still being built.</value>
+    <comment>The companion column's counterpart to the sentence above.</comment>
+  </data>
+  <data name="CasesPage.Cases.Heading" xml:space="preserve">
+    <value>Cases</value>
+    <comment>Names the primary column of the Cases space while that space is being built.</comment>
+  </data>
+  <data name="CasesPage.Cases.Detail" xml:space="preserve">
+    <value>This space is still being built.</value>
+    <comment>Says plainly that the space is empty because nothing has been put in it yet, rather than because something failed.</comment>
+  </data>
+  <data name="CasesPage.Case.Heading" xml:space="preserve">
+    <value>Case</value>
+    <comment>Names the companion column of the Cases space, which a wide window shows beside the list.</comment>
+  </data>
+  <data name="CasesPage.Case.Detail" xml:space="preserve">
+    <value>This column is still being built.</value>
+    <comment>The companion column's counterpart to the sentence above.</comment>
+  </data>
+  <data name="SettingsPage.Button.Back.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Back</value>
+    <comment>Names the button that returns to the workspace, which carries an icon rather than words.</comment>
+  </data>
+  <data name="SettingsPage.TextBlock.Title.Text" xml:space="preserve">
+    <value>Settings</value>
+    <comment>Names the screen the frame reaches beside its three spaces.</comment>
   </data>
 </root>

--- a/frontend/src/Client/Strings/en/Resources.resw
+++ b/frontend/src/Client/Strings/en/Resources.resw
@@ -213,6 +213,10 @@
     <value>Dark</value>
     <comment>One of the three theme offers.</comment>
   </data>
+  <data name="Workspace.Rail.Discover.Content" xml:space="preserve">
+    <value>Discover</value>
+    <comment>Names the first of the three spaces, on the navigation rail a wide window shows.</comment>
+  </data>
   <data name="Workspace.Rail.Mail.Content" xml:space="preserve">
     <value>Mail</value>
     <comment>Names the second of the three spaces, on the navigation rail a wide window shows.</comment>

--- a/frontend/src/Client/Strings/pl/Resources.resw
+++ b/frontend/src/Client/Strings/pl/Resources.resw
@@ -213,6 +213,10 @@
     <value>Ciemny</value>
     <comment>One of the three theme offers.</comment>
   </data>
+  <data name="Workspace.Rail.Discover.Content" xml:space="preserve">
+    <value>Odkrywanie</value>
+    <comment>Names the first of the three spaces, on the navigation rail a wide window shows.</comment>
+  </data>
   <data name="Workspace.Rail.Mail.Content" xml:space="preserve">
     <value>Poczta</value>
     <comment>Names the second of the three spaces, on the navigation rail a wide window shows.</comment>

--- a/frontend/src/Client/Strings/pl/Resources.resw
+++ b/frontend/src/Client/Strings/pl/Resources.resw
@@ -121,11 +121,11 @@
     <value>MailFathom</value>
     <comment>The product name. It is the same in every language: a name is not translated.</comment>
   </data>
-  <data name="MainPage.TextBlock.Deployment.Text" xml:space="preserve">
+  <data name="SettingsPage.TextBlock.Deployment.Text" xml:space="preserve">
     <value>Połączono z</value>
     <comment>Labels the address of the MailFathom deployment this client reaches. Phrased as the relationship rather than as "Deployment address", which names a setting instead of saying where you are.</comment>
   </data>
-  <data name="MainPage.Button.ChangeDeployment.Content" xml:space="preserve">
+  <data name="SettingsPage.Button.ChangeDeployment.Content" xml:space="preserve">
     <value>Użyj innego MailFathom</value>
     <comment>Opens the screen that asks for a deployment address. Named for what a person wants rather than for the setting it changes.</comment>
   </data>
@@ -181,23 +181,23 @@
     <value>Coś tam odpowiedziało, ale to nie jest MailFathom. Sprawdź adres.</value>
     <comment>Shown when the answer was not MailFathom's own — a captive portal, a proxy, or another service on the port.</comment>
   </data>
-  <data name="MainPage.TextBlock.Language.Text" xml:space="preserve">
+  <data name="SettingsPage.TextBlock.Language.Text" xml:space="preserve">
     <value>Język</value>
     <comment>Labels the control that chooses which language the application is read in, for a reader and for a screen reader.</comment>
   </data>
-  <data name="MainPage.Button.ApplyLanguage.Content" xml:space="preserve">
+  <data name="SettingsPage.Button.ApplyLanguage.Content" xml:space="preserve">
     <value>Użyj tego języka</value>
     <comment>Takes the language selected beside it. Phrased as the act rather than as "OK", because nothing is undone by leaving the screen.</comment>
   </data>
-  <data name="MainPage.InfoBar.LanguageRestart.Title" xml:space="preserve">
+  <data name="SettingsPage.InfoBar.LanguageRestart.Title" xml:space="preserve">
     <value>Język zapisany</value>
     <comment>Shown once a language has been taken. Saved rather than changed, because the words on screen have not changed yet.</comment>
   </data>
-  <data name="MainPage.InfoBar.LanguageRestart.Message" xml:space="preserve">
+  <data name="SettingsPage.InfoBar.LanguageRestart.Message" xml:space="preserve">
     <value>MailFathom będzie w wybranym języku przy następnym uruchomieniu.</value>
     <comment>Says plainly that the choice takes effect on the next launch, which is when Uno applies a culture.</comment>
   </data>
-  <data name="MainPage.TextBlock.Theme.Text" xml:space="preserve">
+  <data name="SettingsPage.TextBlock.Theme.Text" xml:space="preserve">
     <value>Motyw</value>
     <comment>Labels the control that chooses whether the application is shown light, dark, or the way the system is set.</comment>
   </data>
@@ -212,5 +212,105 @@
   <data name="AppTheme.Dark" xml:space="preserve">
     <value>Ciemny</value>
     <comment>One of the three theme offers.</comment>
+  </data>
+  <data name="Workspace.Rail.Mail.Content" xml:space="preserve">
+    <value>Poczta</value>
+    <comment>Names the second of the three spaces, on the navigation rail a wide window shows.</comment>
+  </data>
+  <data name="Workspace.Rail.Cases.Content" xml:space="preserve">
+    <value>Sprawy</value>
+    <comment>Names the third of the three spaces, on the navigation rail a wide window shows.</comment>
+  </data>
+  <data name="Workspace.Tab.Discover.Content" xml:space="preserve">
+    <value>Odkrywanie</value>
+    <comment>The same space as the rail item above, named on the bottom navigation a narrow window shows.</comment>
+  </data>
+  <data name="Workspace.Tab.Mail.Content" xml:space="preserve">
+    <value>Poczta</value>
+    <comment>The same space as the rail item above, named on the bottom navigation a narrow window shows.</comment>
+  </data>
+  <data name="Workspace.Tab.Cases.Content" xml:space="preserve">
+    <value>Sprawy</value>
+    <comment>The same space as the rail item above, named on the bottom navigation a narrow window shows.</comment>
+  </data>
+  <data name="Workspace.TextBox.Intent.PlaceholderText" xml:space="preserve">
+    <value>Zapytaj o swoją pocztę</value>
+    <comment>What the field invites, shown while it is empty. An invitation rather than a label, because the label is read by a screen reader below.</comment>
+  </data>
+  <data name="Workspace.TextBox.Intent.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Twoje pytanie</value>
+    <comment>Names the field to a screen reader, which does not read a placeholder once anything has been typed.</comment>
+  </data>
+  <data name="Workspace.Button.Settings.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Ustawienia</value>
+    <comment>Names the button that opens the settings screen, which carries an icon rather than words.</comment>
+  </data>
+  <data name="WorkspaceScope.Everything" xml:space="preserve">
+    <value>Cała Twoja poczta</value>
+    <comment>What the scope indicator says when nothing has been narrowed. Resolved in the model rather than by a x:Uid, because the indicator is composed from what is in scope.</comment>
+  </data>
+  <data name="WorkspaceScope.AccountFolder" xml:space="preserve">
+    <value>{0} · {1}</value>
+    <comment>An account and a folder within it, in that order. Punctuation rather than words, so the two names stay readable in any language.</comment>
+  </data>
+  <data name="WorkspaceScope.Selected" xml:space="preserve">
+    <value>{0} · zaznaczono: {1}</value>
+    <comment>What is in scope, and how many things are selected within it. {0} is the scope as the two entries above phrase it and {1} is a count; the Polish wording avoids a plural form the count would have to agree with.</comment>
+  </data>
+  <data name="DiscoverPage.Answer.Heading" xml:space="preserve">
+    <value>Odkrywanie</value>
+    <comment>Names the primary column of the Discover space while that space is being built.</comment>
+  </data>
+  <data name="DiscoverPage.Answer.Detail" xml:space="preserve">
+    <value>Ta przestrzeń jest wciąż budowana.</value>
+    <comment>Says plainly that the space is empty because nothing has been put in it yet, rather than because something failed.</comment>
+  </data>
+  <data name="DiscoverPage.Evidence.Heading" xml:space="preserve">
+    <value>Dowody</value>
+    <comment>Names the companion column of the Discover space, which a wide window shows beside the answer.</comment>
+  </data>
+  <data name="DiscoverPage.Evidence.Detail" xml:space="preserve">
+    <value>Ta kolumna jest wciąż budowana.</value>
+    <comment>The companion column's counterpart to the sentence above.</comment>
+  </data>
+  <data name="MailPage.Messages.Heading" xml:space="preserve">
+    <value>Poczta</value>
+    <comment>Names the primary column of the Mail space while that space is being built.</comment>
+  </data>
+  <data name="MailPage.Messages.Detail" xml:space="preserve">
+    <value>Ta przestrzeń jest wciąż budowana.</value>
+    <comment>Says plainly that the space is empty because nothing has been put in it yet, rather than because something failed.</comment>
+  </data>
+  <data name="MailPage.Reading.Heading" xml:space="preserve">
+    <value>Czytanie</value>
+    <comment>Names the companion column of the Mail space, which a wide window shows beside the list.</comment>
+  </data>
+  <data name="MailPage.Reading.Detail" xml:space="preserve">
+    <value>Ta kolumna jest wciąż budowana.</value>
+    <comment>The companion column's counterpart to the sentence above.</comment>
+  </data>
+  <data name="CasesPage.Cases.Heading" xml:space="preserve">
+    <value>Sprawy</value>
+    <comment>Names the primary column of the Cases space while that space is being built.</comment>
+  </data>
+  <data name="CasesPage.Cases.Detail" xml:space="preserve">
+    <value>Ta przestrzeń jest wciąż budowana.</value>
+    <comment>Says plainly that the space is empty because nothing has been put in it yet, rather than because something failed.</comment>
+  </data>
+  <data name="CasesPage.Case.Heading" xml:space="preserve">
+    <value>Sprawa</value>
+    <comment>Names the companion column of the Cases space, which a wide window shows beside the list.</comment>
+  </data>
+  <data name="CasesPage.Case.Detail" xml:space="preserve">
+    <value>Ta kolumna jest wciąż budowana.</value>
+    <comment>The companion column's counterpart to the sentence above.</comment>
+  </data>
+  <data name="SettingsPage.Button.Back.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Wstecz</value>
+    <comment>Names the button that returns to the workspace, which carries an icon rather than words.</comment>
+  </data>
+  <data name="SettingsPage.TextBlock.Title.Text" xml:space="preserve">
+    <value>Ustawienia</value>
+    <comment>Names the screen the frame reaches beside its three spaces.</comment>
   </data>
 </root>

--- a/frontend/src/README.md
+++ b/frontend/src/README.md
@@ -123,8 +123,14 @@ another. Both are neutral cultures rather than regional variants; a variant arri
 between regions.
 
 A visible string reaches a screen through `x:Uid` rather than being written in a page, which is why no page here
-carries user-visible text. The exception is a string that is per item rather than per control — the three theme
-offers — and that one is resolved in the model through `IStringLocalizer` against the same tables.
+carries user-visible text. What is per item rather than per control is the exception — the three theme offers, and what
+the scope indicator says — and each of those is resolved in the model through `IStringLocalizer` against the same
+tables.
+
+**A `x:Uid` nothing answers is a control with no words on it**, which the application compiles without complaint and a
+head shows without saying why. So the suite reads the authored pages the way it reads the tables, and fails when a name
+a view states is answered by no entry — the failure that holding the tables against each other cannot see, because a
+name missing from both is a name they agree about.
 
 **A chosen language arrives on the next launch, and the screen says so.** Uno applies a culture while a head is
 starting, so the visual tree already built keeps the words it was built with; the choice is written to a settings file

--- a/frontend/src/README.md
+++ b/frontend/src/README.md
@@ -38,12 +38,13 @@ nothing states it yet. `AGENTS.md` beside this file states why, and states the c
 ## How it is put together
 
 The product is three spaces — **Discover**, **Mail**, and **Cases** — and they are one application rather than three.
-What makes them one is the frame around them, which is what `Client/Presentation/Workspace/` holds and what the
-application opens on. The spaces themselves are empty: `Client/Presentation/Spaces/` carries a page per space that says
-so, and each of the three parents that owns a space fills its own page in.
+What makes them one is the frame around them, which is what `Client/Presentation/Workspace/` holds and what a client
+already pointed at a deployment opens on. The spaces themselves are empty: `Client/Presentation/Spaces/` carries a page
+per space that says so, and each of the three parents that owns a space fills its own page in.
 
 **Each space is a route, and so is everything else on screen.** `App.RegisterRoutes` nests `Discover`, `Mail`, and
-`Cases` inside the frame and registers `Settings` beside it, so each is reachable and reloadable by its route — the
+`Cases` inside the frame and registers `Settings` and `Connect` beside it, every one of them named once in
+`ClientRoutes`, so each is reachable and reloadable by its route — the
 browser opened at `/Workspace/Cases` lands on Cases with that space named on the bar. Because Uno's navigation is what
 moved there, the Android system back gesture and back key and the browser's back button all move back through the
 client's own screens rather than out of the application: going to settings and back returns to the space somebody left,
@@ -76,8 +77,9 @@ than by the model of whichever screen is on top. A scope names accounts, folders
 carries the same classification as anything else about mail: it lives in memory and is written nowhere.
 
 **Settings is reached from the frame rather than named among the spaces**, because it is not one. It is the screen that
-says which build is running and carries the two choices below, and it carries the way back out as a navigation request
-rather than as a handler — the same request the system back key makes, so one answer serves both.
+says which build is running and which deployment this client is pointed at, carries the two choices below and the way to
+point it at another deployment, and carries the way back out as a navigation request rather than as a handler — the same
+request the system back key makes, so one answer serves both.
 
 ## How it looks
 

--- a/frontend/src/README.md
+++ b/frontend/src/README.md
@@ -17,7 +17,7 @@ What is inside the two projects:
 | Path | What it holds |
 |---|---|
 | `Client/App.xaml`, `App.xaml.cs` | The composition root: the host every head starts through, logging, and the route registry |
-| `Client/Presentation/` | The shell, the pages, and the MVUX models behind them |
+| `Client/Presentation/` | The shell, the frame the three spaces are shown inside, the spaces themselves, and the MVUX models behind them |
 | `Client/Styles/` | The Material palette every brush resolves from — the one place a colour value is written |
 | `Client/Platforms/` | What belongs to one head only: the two entry points, the browser head's web manifest, linker configuration, and font stylesheet, and its half of the sign-in redirect |
 | `Client/Assets/` | The application icon and the splash screen, from one SVG per head |
@@ -25,13 +25,59 @@ What is inside the two projects:
 | `Client.Backend/` | The typed client, the wire records, and the source-generated readers for them |
 | `Client.Backend/Authorization/` | Signing in: discovery, the proof key, the exchange, and the token held in memory for the run |
 
-The application is empty of features. It shows what it is — the product name and the version this build was stamped
-with, read from the assembly rather than written here, so the client and the service report one number — and the two
-things a reader can already decide about it: which language it is read in, and which theme it is shown in.
+The application is empty of features, and it is no longer empty of structure: it opens on the frame the three spaces
+are shown inside, and the section below says what that frame is. What it can do beyond moving between them is what a
+reader decides about the application itself — which language it is read in, and which theme it is shown in — beside the
+version this build was stamped with, read from the assembly rather than written here so the client and the service
+report one number.
 
 It reaches MailFathom over the endpoints `backend/src/Host/` exposes and shares nothing else with it: no build file, no
 package manifest, no configuration file, and no type. Which deployment it reaches is the composing host's to state, and
 nothing states it yet. `AGENTS.md` beside this file states why, and states the conventions anything added here follows.
+
+## How it is put together
+
+The product is three spaces — **Discover**, **Mail**, and **Cases** — and they are one application rather than three.
+What makes them one is the frame around them, which is what `Client/Presentation/Workspace/` holds and what the
+application opens on. The spaces themselves are empty: `Client/Presentation/Spaces/` carries a page per space that says
+so, and each of the three parents that owns a space fills its own page in.
+
+**Each space is a route, and so is everything else on screen.** `App.RegisterRoutes` nests `Discover`, `Mail`, and
+`Cases` inside the frame and registers `Settings` beside it, so each is reachable and reloadable by its route — the
+browser opened at `/Workspace/Cases` lands on Cases with that space named on the bar. Because Uno's navigation is what
+moved there, the Android system back gesture and back key and the browser's back button all move back through the
+client's own screens rather than out of the application: going to settings and back returns to the space somebody left,
+not to the first one. A screen reached by swapping content by hand would be a screen neither of them knows about, which
+is why nothing here does that.
+
+**Where a route is registered decides whether it can be returned from**, which is why settings is a level up rather
+than a fourth name beside the three. The spaces share one content area and are switched between, so moving among them
+leaves nothing behind to go back to — which is what a bar of tabs means. Settings is entered instead, and entering is
+what puts the workspace behind it.
+
+**The composition follows the width of the window and never the platform.** Below 700 pixels the spaces are named on a
+bar along the bottom and the workspace is one column; at 700 that bar is replaced by a navigation rail beside the
+workspace; at 1000 the workspace itself opens a companion column, so what a space shows beside its main content stands
+next to it instead of being reached as a separate screen. The two widths are `WorkspaceRailWindowWidth` and
+`WorkspaceWideWindowWidth` in `App.xaml`, read by every adaptive trigger that acts on them, and the switch is
+`VisualStateManager` throughout: no code asks which platform is running, so a resized desktop window and a phone are
+the same case. `WorkspaceColumns` is the control that gives a space that workspace, so all three read the same at the
+same width. Content stays clear of a notch, a rounded corner, and a system bar through `utu:SafeArea.Insets`, stated at
+the root of the frame and again on the settings screen, which takes the whole surface rather than opening inside it.
+The soft keyboard is the one mask the toolkit supports on a `SafeArea` or a `ScrollViewer` alone, so it is stated as a
+control around the field this frame takes typing in.
+
+**What travels with somebody between spaces is `IWorkspace`**, registered once for the run. It holds the question being
+composed and the scope that question would be asked against — an account, a folder within it, and what is selected
+there — and the frame shows both above the spaces: the field a question is typed in, and the indicator beside it saying
+what it would be asked against. Neither answers anything here. Asking is Discover's work and narrowing is done by the
+space somebody narrows in; what this settles is that both survive the move, because both are held for the run rather
+than by the model of whichever screen is on top. A scope names accounts, folders, and message identifiers, so it
+carries the same classification as anything else about mail: it lives in memory and is written nowhere.
+
+**Settings is reached from the frame rather than named among the spaces**, because it is not one. It is the screen that
+says which build is running and carries the two choices below, and it carries the way back out as a navigation request
+rather than as a handler — the same request the system back key makes, so one answer serves both.
 
 ## How it looks
 

--- a/frontend/tests/Client.UnitTests/Client.UnitTests.csproj
+++ b/frontend/tests/Client.UnitTests/Client.UnitTests.csproj
@@ -38,6 +38,16 @@
           Link="Strings/%(RecursiveDir)Resources.resw"
           TargetPath="Strings/%(RecursiveDir)Resources.resw"
           CopyToOutputDirectory="PreserveNewest" />
+
+    <!-- Every authored view, on the same terms and for the reason the tables above are here: a `x:Uid` is the other
+         end of a name the tables hold, and only reading both files can say the two still agree. A running head
+         resolves one against the compiled resource map and shows a control with no words on it when nothing answers,
+         which is neither a build failure nor something the tables can notice about themselves. -->
+    <None Include="..\..\src\Client\**\*.xaml"
+          Exclude="..\..\src\Client\bin\**;..\..\src\Client\obj\**"
+          Link="Xaml/%(RecursiveDir)%(Filename)%(Extension)"
+          TargetPath="Xaml/%(RecursiveDir)%(Filename)%(Extension)"
+          CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/frontend/tests/Client.UnitTests/Presentation/Settings/SettingsModelTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Settings/SettingsModelTests.cs
@@ -7,13 +7,14 @@ using System.Reflection;
 using MailFathom.Client.Backend;
 using MailFathom.Client.Backend.Authorization;
 using MailFathom.Client.Presentation;
+using MailFathom.Client.Presentation.Settings;
 using MailFathom.Client.UnitTests.TestDoubles;
 
-namespace MailFathom.Client.UnitTests.Presentation;
+namespace MailFathom.Client.UnitTests.Presentation.Settings;
 
-public sealed class MainModelTests
+public sealed class SettingsModelTests
 {
-    /// <summary>Awaiting a feed is how a model's state is asserted in this stack, and this one proves the MVUX path behind the only screen reaches the running build.</summary>
+    /// <summary>Awaiting a feed is how a model's state is asserted in this stack, and this one proves the MVUX path behind the settings screen reaches the running build.</summary>
     [Fact]
     public async Task Build_TheScaffoldModel_YieldsTheRunningBuild()
     {
@@ -212,10 +213,10 @@ public sealed class MainModelTests
         var localizer = ThemeWords();
 
         // Act & Assert
-        Assert.Throws<ArgumentNullException>(() => new MainModel(null!, themes, address, localizer));
-        Assert.Throws<ArgumentNullException>(() => new MainModel(localization, null!, address, localizer));
-        Assert.Throws<ArgumentNullException>(() => new MainModel(localization, themes, null!, localizer));
-        Assert.Throws<ArgumentNullException>(() => new MainModel(localization, themes, address, null!));
+        Assert.Throws<ArgumentNullException>(() => new SettingsModel(null!, themes, address, localizer));
+        Assert.Throws<ArgumentNullException>(() => new SettingsModel(localization, null!, address, localizer));
+        Assert.Throws<ArgumentNullException>(() => new SettingsModel(localization, themes, null!, localizer));
+        Assert.Throws<ArgumentNullException>(() => new SettingsModel(localization, themes, address, null!));
     }
 
     /// <summary>
@@ -223,11 +224,11 @@ public sealed class MainModelTests
     /// tree. Nothing on its surface or in its fields is a WinUI type, which is what keeps that true as it grows.
     /// </summary>
     [Fact]
-    public void MainModel_TheModelOfferingTheLanguages_NamesNoXamlType()
+    public void SettingsModel_TheModelOfferingTheLanguages_NamesNoXamlType()
     {
         // Arrange
         const BindingFlags Instance = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
-        var model = typeof(MainModel);
+        var model = typeof(SettingsModel);
 
         // Act
         var named = model.GetConstructors().SelectMany(constructor => constructor.GetParameters()).Select(parameter => parameter.ParameterType)
@@ -250,7 +251,7 @@ public sealed class MainModelTests
             type.GetGenericArguments().SelectMany(Unwrap).Append(type);
     }
 
-    private static MainModel ModelOver(
+    private static SettingsModel ModelOver(
         StubLocalizationService? localization = null,
         StubThemeService? themes = null,
         DeploymentAddress? address = null) =>

--- a/frontend/tests/Client.UnitTests/Presentation/Workspace/SharedWorkspaceTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Workspace/SharedWorkspaceTests.cs
@@ -1,0 +1,115 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Immutable;
+using MailFathom.Client.Presentation.Workspace;
+
+namespace MailFathom.Client.UnitTests.Presentation.Workspace;
+
+/// <summary>
+/// The seam that makes the three spaces one application: what one of them writes, the next one reads.
+/// </summary>
+/// <remarks>
+/// Moving between spaces is navigation, which needs a running head and stays out of this suite — what is reachable
+/// here is the thing that survives it, which is where the preservation actually lives. A space holding its own scope
+/// would pass no test below.
+/// </remarks>
+public sealed class SharedWorkspaceTests
+{
+    /// <summary>
+    /// The property is expression-bodied, so it is worth stating that it hands back one state rather than building a
+    /// new one per read: a second state would leave two spaces reading different values of one thing.
+    /// </summary>
+    [Fact]
+    public void Intent_ReadTwice_IsOneState()
+    {
+        // Arrange
+        var workspace = new SharedWorkspace();
+
+        // Act
+        var (first, second) = (workspace.Intent, workspace.Intent);
+
+        // Assert
+        Assert.Same(first, second);
+    }
+
+    /// <summary>The scope is one state per workspace for the reason the question above is.</summary>
+    [Fact]
+    public void Scope_ReadTwice_IsOneState()
+    {
+        // Arrange
+        var workspace = new SharedWorkspace();
+
+        // Act
+        var (first, second) = (workspace.Scope, workspace.Scope);
+
+        // Assert
+        Assert.Same(first, second);
+    }
+
+    /// <summary>A run starts against everything, which is what a first screen is composed over.</summary>
+    [Fact]
+    public async Task Scope_AWorkspaceNothingHasNarrowed_StartsAtEverything()
+    {
+        // Arrange
+        var workspace = new SharedWorkspace();
+
+        // Act
+        var scope = await workspace.Scope;
+
+        // Assert
+        Assert.Equal(WorkspaceScope.Everything, scope);
+    }
+
+    /// <summary>A run starts with nothing typed, rather than with whatever a previous one left.</summary>
+    [Fact]
+    public async Task Intent_AWorkspaceNobodyHasTypedInto_StartsEmpty()
+    {
+        // Arrange
+        var workspace = new SharedWorkspace();
+
+        // Act
+        var intent = await workspace.Intent;
+
+        // Assert
+        Assert.Equal(string.Empty, intent);
+    }
+
+    /// <summary>
+    /// What a space narrowed to is what the workspace then holds, which is the whole of the claim that moving between
+    /// spaces preserves the account, the folder, and the selection.
+    /// </summary>
+    [Fact]
+    public async Task Scope_NarrowedOnce_IsWhatTheWorkspaceHolds()
+    {
+        // Arrange
+        var workspace = new SharedWorkspace();
+        var narrowed = new WorkspaceScope
+        {
+            Account = "work",
+            Folder = "Inbox",
+            Selection = ImmutableArray.Create("117"),
+        };
+
+        // Act
+        await workspace.Scope.UpdateAsync(_ => narrowed, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(narrowed, await workspace.Scope);
+    }
+
+    /// <summary>A question travels with somebody between spaces rather than being retyped in each of them.</summary>
+    [Fact]
+    public async Task Intent_TypedOnce_IsWhatTheWorkspaceHolds()
+    {
+        // Arrange
+        var workspace = new SharedWorkspace();
+
+        // Act
+        await workspace.Intent.SetAsync("what did the auditor ask for", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("what did the auditor ask for", await workspace.Intent);
+    }
+}

--- a/frontend/tests/Client.UnitTests/Presentation/Workspace/WorkspaceModelTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Workspace/WorkspaceModelTests.cs
@@ -82,6 +82,26 @@ public sealed class WorkspaceModelTests
         Assert.Equal("work@example.test · Inbox", await model.ScopeDescription);
     }
 
+    /// <summary>
+    /// A folder named without an account is not a scope anything here builds and is not one the type refuses either,
+    /// so the indicator names it rather than reading as everything, which would say the opposite of what is in force.
+    /// </summary>
+    [Fact]
+    public async Task ScopeDescription_AFolderWithoutAnAccount_IsNamedRatherThanDropped()
+    {
+        // Arrange
+        var workspace = new SharedWorkspace();
+        var model = ModelOver(workspace);
+
+        // Act
+        await workspace.Scope.UpdateAsync(
+            _ => WorkspaceScope.Everything with { Folder = "Inbox" },
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("Inbox", await model.ScopeDescription);
+    }
+
     /// <summary>A selection narrows the scope further, so the indicator says how much of it is in hand.</summary>
     [Fact]
     public async Task ScopeDescription_ASelectionWithinAFolder_CountsIt()

--- a/frontend/tests/Client.UnitTests/Presentation/Workspace/WorkspaceModelTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Workspace/WorkspaceModelTests.cs
@@ -1,0 +1,199 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Immutable;
+using System.Reflection;
+using MailFathom.Client.Presentation.Workspace;
+using MailFathom.Client.UnitTests.TestDoubles;
+
+namespace MailFathom.Client.UnitTests.Presentation.Workspace;
+
+/// <summary>
+/// The frame's own model: the field a question is composed in, and the indicator saying what it would be asked
+/// against.
+/// </summary>
+public sealed class WorkspaceModelTests
+{
+    /// <summary>
+    /// The field holds the workspace's question rather than one of its own, which is what makes the question survive
+    /// a move between spaces instead of ending with the screen it was typed on.
+    /// </summary>
+    [Fact]
+    public async Task Intent_TypedIntoTheField_IsTheWorkspacesOwnQuestion()
+    {
+        // Arrange
+        var workspace = new SharedWorkspace();
+        var model = ModelOver(workspace);
+
+        // Act
+        await model.Intent.SetAsync("which invoices are still unpaid", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Same(workspace.Intent, model.Intent);
+        Assert.Equal("which invoices are still unpaid", await workspace.Intent);
+    }
+
+    /// <summary>Nothing narrowed reads as everything, rather than as a blank where a scope should be.</summary>
+    [Fact]
+    public async Task ScopeDescription_AWorkspaceNothingHasNarrowed_SaysEverything()
+    {
+        // Arrange
+        var model = ModelOver(new SharedWorkspace());
+
+        // Act
+        var description = await model.ScopeDescription;
+
+        // Assert
+        Assert.Equal("All your mail", description);
+    }
+
+    /// <summary>An account alone is named as itself: an account name is not a word to translate.</summary>
+    [Fact]
+    public async Task ScopeDescription_AnAccountAlone_IsNamedAsItself()
+    {
+        // Arrange
+        var workspace = new SharedWorkspace();
+        var model = ModelOver(workspace);
+
+        // Act
+        await workspace.Scope.UpdateAsync(
+            _ => WorkspaceScope.Everything with { Account = "work@example.test" },
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("work@example.test", await model.ScopeDescription);
+    }
+
+    /// <summary>A folder is read within its account, so the indicator names both rather than the narrower of the two.</summary>
+    [Fact]
+    public async Task ScopeDescription_AFolderWithinAnAccount_NamesBoth()
+    {
+        // Arrange
+        var workspace = new SharedWorkspace();
+        var model = ModelOver(workspace);
+
+        // Act
+        await workspace.Scope.UpdateAsync(
+            _ => new WorkspaceScope { Account = "work@example.test", Folder = "Inbox" },
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("work@example.test · Inbox", await model.ScopeDescription);
+    }
+
+    /// <summary>A selection narrows the scope further, so the indicator says how much of it is in hand.</summary>
+    [Fact]
+    public async Task ScopeDescription_ASelectionWithinAFolder_CountsIt()
+    {
+        // Arrange
+        var workspace = new SharedWorkspace();
+        var model = ModelOver(workspace);
+
+        // Act
+        await workspace.Scope.UpdateAsync(
+            _ => new WorkspaceScope
+            {
+                Account = "work@example.test",
+                Folder = "Inbox",
+                Selection = ImmutableArray.Create("117", "118"),
+            },
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("work@example.test · Inbox · 2 selected", await model.ScopeDescription);
+    }
+
+    /// <summary>
+    /// A frame built again over the same workspace — which is what a reload of the client's route is — reads the scope
+    /// a space narrowed to rather than starting over at everything.
+    /// </summary>
+    [Fact]
+    public async Task ScopeDescription_AFrameBuiltAgainOverTheSameWorkspace_ReadsWhatWasNarrowedBefore()
+    {
+        // Arrange
+        var workspace = new SharedWorkspace();
+        var narrowing = ModelOver(workspace);
+        await workspace.Scope.UpdateAsync(
+            _ => new WorkspaceScope { Account = "work@example.test", Folder = "Archive" },
+            TestContext.Current.CancellationToken);
+
+        // Act
+        var rebuilt = ModelOver(workspace);
+
+        // Assert
+        Assert.Equal(await narrowing.ScopeDescription, await rebuilt.ScopeDescription);
+        Assert.Equal("work@example.test · Archive", await rebuilt.ScopeDescription);
+    }
+
+    /// <summary>
+    /// The description is built once rather than per read, because the indicator is bound to it and a second feed per
+    /// read would leave the view and anything the model asked subscribed to two descriptions of one scope.
+    /// </summary>
+    [Fact]
+    public void ScopeDescription_ReadTwice_IsOneFeed()
+    {
+        // Arrange
+        var model = ModelOver(new SharedWorkspace());
+
+        // Act
+        var (first, second) = (model.ScopeDescription, model.ScopeDescription);
+
+        // Assert
+        Assert.Same(first, second);
+    }
+
+    /// <summary>A frame that could be built without the workspace would be a frame whose spaces shared nothing.</summary>
+    [Fact]
+    public void Constructor_AMissingService_IsRefused()
+    {
+        // Arrange
+        var workspace = new SharedWorkspace();
+        var words = ScopeWords();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new WorkspaceModel(null!, words));
+        Assert.Throws<ArgumentNullException>(() => new WorkspaceModel(workspace, null!));
+    }
+
+    /// <summary>
+    /// The frame's model is a plain record reachable without a visual tree, and nothing on its surface or in its
+    /// fields is a WinUI type — which is what keeps the composition above it a view's decision rather than a model's.
+    /// </summary>
+    [Fact]
+    public void WorkspaceModel_TheFramesModel_NamesNoXamlType()
+    {
+        // Arrange
+        const BindingFlags Instance = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+        var model = typeof(WorkspaceModel);
+
+        // Act
+        var named = model.GetConstructors().SelectMany(constructor => constructor.GetParameters()).Select(parameter => parameter.ParameterType)
+            .Concat(model.GetProperties(Instance).Select(property => property.PropertyType))
+            .Concat(model.GetFields(Instance).Select(field => field.FieldType))
+            .Concat(model.GetMethods(Instance).Where(method => method.DeclaringType == model).SelectMany(WrittenBy))
+            .SelectMany(Unwrap)
+            .Where(type => type.Namespace?.StartsWith("Microsoft.UI.Xaml", StringComparison.Ordinal) is true)
+            .Select(type => type.FullName)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        // Assert
+        Assert.Empty(named);
+
+        static IEnumerable<Type> WrittenBy(MethodInfo method) =>
+            method.GetParameters().Select(parameter => parameter.ParameterType).Append(method.ReturnType);
+
+        static IEnumerable<Type> Unwrap(Type type) =>
+            type.GetGenericArguments().SelectMany(Unwrap).Append(type);
+    }
+
+    private static WorkspaceModel ModelOver(IWorkspace workspace) => new(workspace, ScopeWords());
+
+    private static StubStringLocalizer ScopeWords() => new(new Dictionary<string, string>(StringComparer.Ordinal)
+    {
+        ["WorkspaceScope.Everything"] = "All your mail",
+        ["WorkspaceScope.AccountFolder"] = "{0} · {1}",
+        ["WorkspaceScope.Selected"] = "{0} · {1} selected",
+    });
+}

--- a/frontend/tests/Client.UnitTests/Presentation/Workspace/WorkspaceScopeTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Workspace/WorkspaceScopeTests.cs
@@ -1,0 +1,85 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Immutable;
+using MailFathom.Client.Presentation.Workspace;
+
+namespace MailFathom.Client.UnitTests.Presentation.Workspace;
+
+/// <summary>
+/// Holds the scope to being a value rather than an object, which is what the state carrying it between spaces reads
+/// it as when deciding whether anything changed.
+/// </summary>
+public sealed class WorkspaceScopeTests
+{
+    /// <summary>A run starts against everything, because nothing has narrowed it yet.</summary>
+    [Fact]
+    public void Everything_TheScopeARunStartsIn_NamesNoAccountFolderOrSelection()
+    {
+        // Act
+        var scope = WorkspaceScope.Everything;
+
+        // Assert
+        Assert.Null(scope.Account);
+        Assert.Null(scope.Folder);
+        Assert.Empty(scope.Selection);
+        Assert.False(scope.NarrowsAnything);
+    }
+
+    /// <summary>An account in scope is a narrowing, whether or not anything within it is selected.</summary>
+    [Fact]
+    public void NarrowsAnything_AnAccountOrASelection_IsANarrowing()
+    {
+        // Act
+        var account = WorkspaceScope.Everything with { Account = "work" };
+        var selection = WorkspaceScope.Everything with { Selection = ImmutableArray.Create("1") };
+
+        // Assert
+        Assert.True(account.NarrowsAnything);
+        Assert.True(selection.NarrowsAnything);
+    }
+
+    /// <summary>
+    /// Two scopes naming the same thing are the same scope. A record compares an immutable list by reference, so
+    /// without this the state would report a change every time a space rebuilt an identical selection.
+    /// </summary>
+    [Fact]
+    public void Equals_TwoScopesNamingTheSameThing_AreEqualThoughTheirSelectionsAreDistinctObjects()
+    {
+        // Arrange
+        var one = new WorkspaceScope { Account = "work", Folder = "Inbox", Selection = ImmutableArray.Create("a", "b") };
+        var other = new WorkspaceScope { Account = "work", Folder = "Inbox", Selection = ImmutableArray.Create("a", "b") };
+
+        // Assert
+        Assert.NotSame(one.Selection, other.Selection);
+        Assert.Equal(one, other);
+        Assert.Equal(one.GetHashCode(), other.GetHashCode());
+    }
+
+    /// <summary>Order is part of a selection, so a differently ordered one is a different scope.</summary>
+    [Fact]
+    public void Equals_SelectionsDifferingInContentOrOrder_AreNotEqual()
+    {
+        // Arrange
+        var one = WorkspaceScope.Everything with { Selection = ImmutableArray.Create("a", "b") };
+        var reordered = WorkspaceScope.Everything with { Selection = ImmutableArray.Create("b", "a") };
+        var shorter = WorkspaceScope.Everything with { Selection = ImmutableArray.Create("a") };
+
+        // Assert
+        Assert.NotEqual(one, reordered);
+        Assert.NotEqual(one, shorter);
+    }
+
+    /// <summary>A folder is read within its account, so the same folder name under another account is another scope.</summary>
+    [Fact]
+    public void Equals_TheSameFolderUnderAnotherAccount_IsAnotherScope()
+    {
+        // Arrange
+        var work = new WorkspaceScope { Account = "work", Folder = "Inbox" };
+        var personal = new WorkspaceScope { Account = "personal", Folder = "Inbox" };
+
+        // Assert
+        Assert.NotEqual(work, personal);
+    }
+}

--- a/frontend/tests/Client.UnitTests/Presentation/Workspace/WorkspaceScopeTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Workspace/WorkspaceScopeTests.cs
@@ -27,16 +27,21 @@ public sealed class WorkspaceScopeTests
         Assert.False(scope.NarrowsAnything);
     }
 
-    /// <summary>An account in scope is a narrowing, whether or not anything within it is selected.</summary>
+    /// <summary>
+    /// An account in scope is a narrowing, whether or not anything within it is selected — and so is a folder named
+    /// without one, which nothing here refuses and which therefore must not read as everything.
+    /// </summary>
     [Fact]
-    public void NarrowsAnything_AnAccountOrASelection_IsANarrowing()
+    public void NarrowsAnything_AnAccountAFolderOrASelection_IsANarrowing()
     {
         // Act
         var account = WorkspaceScope.Everything with { Account = "work" };
+        var folder = WorkspaceScope.Everything with { Folder = "Inbox" };
         var selection = WorkspaceScope.Everything with { Selection = ImmutableArray.Create("1") };
 
         // Assert
         Assert.True(account.NarrowsAnything);
+        Assert.True(folder.NarrowsAnything);
         Assert.True(selection.NarrowsAnything);
     }
 

--- a/frontend/tests/Client.UnitTests/Strings/AuthoredViews.cs
+++ b/frontend/tests/Client.UnitTests/Strings/AuthoredViews.cs
@@ -1,0 +1,42 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Xml.Linq;
+
+namespace MailFathom.Client.UnitTests.Strings;
+
+/// <summary>
+/// What the client's views ask the string tables for, read from the views themselves.
+/// </summary>
+/// <remarks>
+/// A <c>x:Uid</c> is one end of a name whose other end is a table entry, and nothing holds the two together: the
+/// application compiles the views into a resource map a running head resolves against, and a name nothing answers
+/// reaches somebody as a control with no words on it rather than as a failure. So the views are read here the way the
+/// tables are, from the files the project links beside the test assembly.
+/// </remarks>
+internal static class AuthoredViews
+{
+    private static readonly XNamespace Xaml = "http://schemas.microsoft.com/winfx/2006/xaml";
+
+    /// <summary>Every <c>x:Uid</c> the client's views name, without duplicates.</summary>
+    /// <returns>The uid values, in no particular order.</returns>
+    public static string[] NamedUids()
+    {
+        var root = Path.Combine(AppContext.BaseDirectory, "Xaml");
+        Assert.True(Directory.Exists(root), root);
+
+        var pages = Directory.EnumerateFiles(root, "*.xaml", SearchOption.AllDirectories).ToArray();
+        Assert.NotEmpty(pages);
+
+        return
+        [
+            .. pages
+                .SelectMany(page => XDocument.Load(page).Descendants())
+                .Select(element => element.Attribute(Xaml + "Uid")?.Value)
+                .Where(uid => !string.IsNullOrEmpty(uid))
+                .Select(uid => uid!)
+                .Distinct(StringComparer.Ordinal)
+        ];
+    }
+}

--- a/frontend/tests/Client.UnitTests/Strings/ResourceTableTests.cs
+++ b/frontend/tests/Client.UnitTests/Strings/ResourceTableTests.cs
@@ -4,6 +4,7 @@
 
 using MailFathom.Client.Deployment;
 using MailFathom.Client.Presentation;
+using MailFathom.Client.Presentation.Workspace;
 
 namespace MailFathom.Client.UnitTests.Strings;
 
@@ -97,6 +98,24 @@ public sealed class ResourceTableTests
             .GetValues<DeploymentChoiceOutcome>()
             .Where(outcome => outcome != DeploymentChoiceOutcome.Accepted)
             .Select(outcome => $"ConnectPage.Refusal.{outcome}");
+
+        // Act
+        var table = DeclaredLanguages.TableOf(culture);
+
+        // Assert
+        Assert.All(expected, key => Assert.True(table.ContainsKey(key), key));
+    }
+
+    /// <summary>
+    /// The scope indicator is composed from words rather than named by a <c>x:Uid</c>, so the keys the frame's model
+    /// asks for are the ones this asserts the tables hold — the other place a typo would reach a reader as the key.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Languages))]
+    public void Tables_TheWordsAScopeIsDescribedWith_AreNamedInEveryLanguage(string culture)
+    {
+        // Arrange
+        var expected = WorkspaceModel.ScopeResourceKeys;
 
         // Act
         var table = DeclaredLanguages.TableOf(culture);

--- a/frontend/tests/Client.UnitTests/Strings/ResourceTableTests.cs
+++ b/frontend/tests/Client.UnitTests/Strings/ResourceTableTests.cs
@@ -107,6 +107,30 @@ public sealed class ResourceTableTests
     }
 
     /// <summary>
+    /// Every name a view states is a name a table has to answer. A <c>x:Uid</c> names a control and the entry behind it
+    /// names the property, so what is asserted is that something in the table is written for that control: a uid
+    /// nothing answers reaches somebody as a control with no words on it, which no build reports and which holding the
+    /// tables against each other cannot see, because a name missing from both is a name they agree about.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Languages))]
+    public void Tables_EveryNameTheViewsState_IsAnsweredInEveryLanguage(string culture)
+    {
+        // Arrange
+        var named = AuthoredViews.NamedUids();
+        var table = DeclaredLanguages.TableOf(culture);
+        Assert.NotEmpty(named);
+
+        // Act
+        var unanswered = named
+            .Where(uid => !table.Keys.Any(key => key.StartsWith($"{uid}.", StringComparison.Ordinal)))
+            .Order(StringComparer.Ordinal);
+
+        // Assert
+        Assert.Empty(unanswered);
+    }
+
+    /// <summary>
     /// The scope indicator is composed from words rather than named by a <c>x:Uid</c>, so the keys the frame's model
     /// asks for are the ones this asserts the tables hold — the other place a typo would reach a reader as the key.
     /// </summary>

--- a/frontend/tests/Client.UnitTests/TestDoubles/StubStringLocalizer.cs
+++ b/frontend/tests/Client.UnitTests/TestDoubles/StubStringLocalizer.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Globalization;
 using Microsoft.Extensions.Localization;
 
 namespace MailFathom.Client.UnitTests.TestDoubles;
@@ -30,7 +31,22 @@ internal sealed class StubStringLocalizer : IStringLocalizer
             : new LocalizedString(name, name, resourceNotFound: true);
 
     /// <inheritdoc />
-    public LocalizedString this[string name, params object[] arguments] => this[name];
+    /// <remarks>
+    /// The arguments are formatted into the word rather than dropped, because that is what
+    /// <see cref="IStringLocalizer"/> promises and a model composing a sentence from a format string would otherwise
+    /// be asserted against a stub that cannot fail the way the real table would.
+    /// </remarks>
+    public LocalizedString this[string name, params object[] arguments]
+    {
+        get
+        {
+            var word = this[name];
+
+            return word.ResourceNotFound
+                ? word
+                : new LocalizedString(name, string.Format(CultureInfo.CurrentCulture, word.Value, arguments));
+        }
+    }
 
     /// <inheritdoc />
     public IEnumerable<LocalizedString> GetAllStrings(bool includeParentCultures) =>


### PR DESCRIPTION
Closes #1149

The client opens on a frame rather than on a page. Discover, Mail, and Cases are routes nested inside it, Settings is a
route beside it, and every screen is reached by navigating rather than by swapping content — which is what makes the
Android back gesture, the Android back key, and the browser's back button move through the client's own history instead
of out of the application.

## What is in the change

- **`Presentation/Workspace/`** — the frame. `WorkspacePage` carries the navigation rail and the bottom bar as two
  regions naming the same three routes, the field a question is composed in, the indicator saying what that question
  would be asked against, and the way to settings. `WorkspaceColumns` is the control that gives a space its
  primary-and-companion composition, so all three spaces read the same at the same width. `IWorkspace` /
  `SharedWorkspace` is the seam the question and the scope live on, and `WorkspaceModel` is what the frame binds to.
- **`Presentation/Spaces/`** — a page per space, each saying its space is still being built. The spaces are out of scope
  here by the issue's own wording; what this delivers is that each is reachable, reloadable, and composed the same way.
- **`Presentation/Settings/`** — the screen #1137 delivered, renamed from `MainPage`/`MainModel`, given a header with a
  way back out and a `SafeArea` of its own.

## The composition follows the width and never the platform

Below 700 pixels the spaces are named on a bar along the bottom over one column; at 700 that bar is replaced by a
navigation rail; at 1000 the workspace opens a companion column beside its main content. Both widths are resources in
`App.xaml` and every adaptive trigger reads them, so no code asks which platform is running.

The narrowest visual state carries `AdaptiveTrigger MinWindowWidth="0"` rather than relying on being declared first. A
state no trigger selects is never entered, so a group whose narrowest member carries no trigger falls back to whatever
the elements were authored with — which, before this, put the rail on a phone.

## Where a route is registered decides whether it can be returned from

Settings started as a fourth name beside the three spaces. That made it a tab: the frame switched to it and left nothing
behind, so the back key had nowhere to go and the browser's history never grew an entry. Registering it a level up is
what makes entering it an entry — `history.length` goes to 2, browser back returns to the space that was left, and the
in-frame back button issues the same navigation request the system back key does.

## What travels between spaces

`IWorkspace` is registered once for the run and holds the question being composed and the scope it would be asked
against — an account, a folder within it, and what is selected there. Neither answers anything here: asking is
Discover's work and narrowing is done by the space somebody narrows in. What this settles is that both survive the move,
because both are held for the run rather than by the model of whichever screen is on top. A scope names accounts,
folders, and message identifiers, so it carries the same classification as anything else about mail — it lives in memory
and is written nowhere.

## Evidence

Run against the browser head, `Release`, with the Uno Studio tooling disabled so nothing dev-only is in the frame.

| What the issue asks | What was observed |
| --- | --- |
| Each space is a route, reachable and reloadable | The address bar reads `/Workspace/Discover`, `/Workspace/Mail`, `/Workspace/Cases`; opening `/Workspace/Cases` directly lands on Cases with that space named on the bar |
| Wide renders a rail and a multi-column workspace | At 1440×900: rail with the three spaces, the intent bar, and two columns with a divider |
| Narrow renders bottom navigation over a screen stack | At 420×900: the three spaces on a bar along the bottom, no rail, one column |
| The switch is a breakpoint, and no code reads the platform | `VisualStateManager` and `AdaptiveTrigger` throughout; the same window resized moves between the compositions |
| Back does not leave the application | From settings, `history.back()` returns to `/Workspace/Mail`, the space that was left |
| The question and the scope survive moving between spaces | Typed into the field on Discover, still there after moving to Mail, with the scope indicator unchanged |
| Every brush resolves from the palette | No colour literal under `Presentation/`; every brush is a `ThemeResource` |

Two behaviours cannot be shown from a browser and are stated rather than demonstrated: the Android back gesture and key,
which Uno's `BackButtonService` answers with the same navigation the back button here issues, and `utu:SafeArea`, which
has nothing to inset on a desktop browser.

Running the frame is also what found two defects that no build reported — the toolkit refusing the `SoftInput` mask on
an ordinary element, and the frame's own scope indicator rendering nothing because MVUX projects a feed of a scalar as
the scalar rather than as a feed, which a `FeedView` cannot render. Both are fixed here.

## Breaking changes

None. No configuration key, database column, MCP tool argument, or deployment contract moves. The client is not yet
something an operator installs, so a renamed page is internal.

## Verification

- `scripts/verify-full.sh` — passed; 187 client unit tests, 255 workflow contract assertions.
- `scripts/review-obligations.sh` — Documentation: `frontend/src/README.md` covered; Tests and Registers trigger none.
- `$check-docs-licenses` — Docs `pass`, Changelog `n/a`, Licenses `n/a` (no dependency added, upgraded, or newly called).
