### PR TITLE
[#983] Resolve every account a caller names against their own owner, and prove the identifier reads refuse as absent

### DIFF
--- a/backend/src/Application/Mail/Delivery/Drafts/AuthoredMailDrafting.cs
+++ b/backend/src/Application/Mail/Delivery/Drafts/AuthoredMailDrafting.cs
@@ -16,7 +16,7 @@ namespace MailFathom.Application.Mail.Delivery.Drafts;
 /// <remarks>
 /// <para>
 /// It is the sibling of <see cref="Submission.AuthoredMailSubmission" /> and composes the same three steps in the same
-/// order: the account a caller named is resolved against the accounts this deployment serves, the people named become
+/// order: the account a caller named is resolved against the accounts the caller's owner owns, the people named become
 /// addresses, and the addresses and the text become MIME. What replaces the outbox at the end is the draft book, which
 /// stores the message instead of queueing it.
 /// </para>
@@ -32,13 +32,13 @@ namespace MailFathom.Application.Mail.Delivery.Drafts;
 /// server would turn out to say. What that server does decide is asked again where the promotion writes the send.
 /// </para>
 /// </remarks>
-/// <param name="accountCatalog">Says which accounts this deployment serves, and therefore which one a caller may name.</param>
+/// <param name="accountCatalog">Says which accounts the caller's owner owns, and therefore which one a caller may name.</param>
 /// <param name="recipientResolver">Turns the people the author named into addresses, asking the contact book for the ones named as somebody.</param>
 /// <param name="composer">Builds the MIME, and decides every header this system owns rather than the author.</param>
 /// <param name="drafts">Writes the record and the message down together, and brings the drafts folder into step.</param>
 /// <param name="authorization">Answers whether the caller that reached this holds the grant that lets it draft.</param>
 public sealed class AuthoredMailDrafting(
-    IDeploymentMailAccountCatalog accountCatalog,
+    ICallerMailAccountCatalog accountCatalog,
     NamedRecipientResolver recipientResolver,
     IAuthoredEmailComposer composer,
     MailDraftBook drafts,
@@ -49,8 +49,8 @@ public sealed class AuthoredMailDrafting(
     /// <param name="cancellationToken">Cancels the reads and the writes.</param>
     /// <returns>The draft as it stands once the mailbox has been brought into step with it.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="request" /> is <see langword="null" />.</exception>
-    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the caller does not hold <see cref="MailFathomPermission.MailDraftsWrite" />.</exception>
-    /// <exception cref="MailAccountNotAccessibleException">Thrown when the request names an account this deployment does not serve.</exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the caller does not hold <see cref="MailFathomPermission.MailDraftsWrite" />, or is acting for no owner.</exception>
+    /// <exception cref="MailAccountNotAccessibleException">Thrown when the request names an account the caller's owner does not own, which includes every account this deployment does not serve.</exception>
     /// <exception cref="MailDraftRefusedException">Thrown when a recipient names nobody, a field cannot be composed, a bound is exceeded, the account configures no address to send from, or the draft being revised is not one of this account's.</exception>
     public async Task<MailDraftRecord> SaveAsync(
         MailDraftRequest request,
@@ -60,7 +60,10 @@ public sealed class AuthoredMailDrafting(
 
         authorization.RequirePermission(MailFathomPermission.MailDraftsWrite);
 
-        var account = accountCatalog.ServedAccounts.FirstOrDefault(served => served.IsNamedBy(request.Account))
+        // Resolved against the accounts the caller's owner owns for the reason the send is, and a draft lands in a
+        // folder rather than in the world: one written into another owner's account is a message that person may read
+        // in their own mailbox as their own.
+        var account = accountCatalog.OwnedAccounts.FirstOrDefault(owned => owned.IsNamedBy(request.Account))
             ?? throw new MailAccountNotAccessibleException(request.Account);
 
         // Ahead of the resolution rather than left to it, because the reads it performs carry what the caller supplied

--- a/backend/src/Application/Mail/Delivery/Governance/RecipientVouching.cs
+++ b/backend/src/Application/Mail/Delivery/Governance/RecipientVouching.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Contacts;
 using MailFathom.Application.Mail.Delivery.Composition;
@@ -16,9 +17,10 @@ namespace MailFathom.Application.Mail.Delivery.Governance;
 /// <para>
 /// Two things vouch for an address, and both are the owner's rather than any caller's. The contact book holds the
 /// people this mailbox corresponds with — whether the owner wrote them down or collection recorded them from mail that
-/// arrived — and the deployment's own accounts hold the mailboxes it reads on their behalf. An address in neither is one
-/// this installation has no trace of at all, which is what the address inside an injected instruction looks like: a
-/// message telling an agent to write to its author's accomplice is naming somebody the mailbox has never heard of.
+/// arrived — and the owner's own accounts hold the mailboxes this deployment reads on their behalf. An address in
+/// neither is one this installation has no trace of at all, which is what the address inside an injected instruction
+/// looks like: a message telling an agent to write to its author's accomplice is naming somebody the mailbox has never
+/// heard of.
 /// </para>
 /// <para>
 /// It is asked only about addresses a caller supplied as text. A recipient resolved out of the book is vouched for by
@@ -37,11 +39,11 @@ namespace MailFathom.Application.Mail.Delivery.Governance;
 /// </para>
 /// </remarks>
 /// <param name="contacts">Reads which of a set of addresses the book already holds.</param>
-/// <param name="accounts">Says which accounts this deployment serves.</param>
+/// <param name="accounts">Says which accounts the caller's owner owns.</param>
 /// <param name="senderIdentities">Says which address each of those accounts sends as.</param>
 public sealed class RecipientVouching(
     IContactDirectory contacts,
-    IDeploymentMailAccountCatalog accounts,
+    ICallerMailAccountCatalog accounts,
     IOutgoingSenderIdentityReader senderIdentities)
 {
     /// <summary>Counts the recipients a caller named itself that nothing this deployment holds vouches for.</summary>
@@ -49,6 +51,7 @@ public sealed class RecipientVouching(
     /// <param name="cancellationToken">Cancels the reads of the book.</param>
     /// <returns>How many of the addresses the caller supplied are ones this deployment has no trace of.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="recipients" /> is <see langword="null" />.</exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the work in hand is acting for no owner, since what vouches for an address is an owner's own.</exception>
     /// <remarks>
     /// Text that names no mailbox at all is not counted here. Whether an address parses is the composition's question
     /// and it refuses one that does not, so counting unparsable text would refuse a send for a reason the caller is
@@ -105,13 +108,15 @@ public sealed class RecipientVouching(
         }
     }
 
-    /// <summary>Reads the mailboxes this deployment sends as, which are the owner's own and never a stranger's.</summary>
+    /// <summary>Reads the mailboxes this caller's owner sends as, which are their own and never a stranger's.</summary>
     /// <remarks>
     /// Read from configuration rather than from the database, so an installation that has synchronized nothing still
-    /// vouches for its own addresses. An account this deployment serves without a sending identity contributes none,
-    /// which is the honest answer: nothing here knows what a read-only account's own address is.
+    /// vouches for its own addresses. It is the caller's owner's accounts rather than the deployment's, because an
+    /// address vouched for by a mailbox this caller may not read is an answer about somebody else's correspondents. An
+    /// account without a sending identity contributes none, which is the honest answer: nothing here knows what a
+    /// read-only account's own address is.
     /// </remarks>
-    private HashSet<EmailAddress> OwnAddresses() => accounts.ServedAccounts
+    private HashSet<EmailAddress> OwnAddresses() => accounts.OwnedAccounts
         .Select(account => senderIdentities.FindSenderIdentity(account.Id))
         .OfType<OutgoingSenderIdentity>()
         .Select(identity => identity.Address)

--- a/backend/src/Application/Mail/Delivery/Governance/RecipientVouching.cs
+++ b/backend/src/Application/Mail/Delivery/Governance/RecipientVouching.cs
@@ -12,7 +12,7 @@ using MailFathom.Domain.Emails;
 
 namespace MailFathom.Application.Mail.Delivery.Governance;
 
-/// <summary>Answers how many of the addresses a caller wrote down nothing this deployment holds can vouch for.</summary>
+/// <summary>Answers how many of the addresses a caller wrote down neither the book nor the caller's owner's mailboxes vouch for.</summary>
 /// <remarks>
 /// <para>
 /// Two things vouch for an address, and both are the owner's rather than any caller's. The contact book holds the
@@ -46,10 +46,10 @@ public sealed class RecipientVouching(
     ICallerMailAccountCatalog accounts,
     IOutgoingSenderIdentityReader senderIdentities)
 {
-    /// <summary>Counts the recipients a caller named itself that nothing this deployment holds vouches for.</summary>
+    /// <summary>Counts the recipients a caller named itself that neither the book nor their owner's mailboxes vouch for.</summary>
     /// <param name="recipients">Everybody the message is addressed to, whoever put them there.</param>
     /// <param name="cancellationToken">Cancels the reads of the book.</param>
-    /// <returns>How many of the addresses the caller supplied are ones this deployment has no trace of.</returns>
+    /// <returns>How many of the addresses the caller supplied are ones neither the book nor the caller's owner's mailboxes hold.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="recipients" /> is <see langword="null" />.</exception>
     /// <exception cref="PrincipalNotAuthorizedException">Thrown when the work in hand is acting for no owner, since what vouches for an address is an owner's own.</exception>
     /// <remarks>

--- a/backend/src/Application/Mail/Delivery/Scheduling/RecurringMailSubmission.cs
+++ b/backend/src/Application/Mail/Delivery/Scheduling/RecurringMailSubmission.cs
@@ -43,7 +43,7 @@ namespace MailFathom.Application.Mail.Delivery.Scheduling;
 /// </remarks>
 public sealed class RecurringMailSubmission
 {
-    private readonly IDeploymentMailAccountCatalog accountCatalog;
+    private readonly ICallerMailAccountCatalog accountCatalog;
     private readonly NamedRecipientResolver recipientResolver;
     private readonly IAuthoredEmailComposer composer;
     private readonly IRecurringSendStore recurringSends;
@@ -52,7 +52,7 @@ public sealed class RecurringMailSubmission
     private readonly AccessAuthorization authorization;
 
     /// <summary>Initializes the use case from the accounts it serves and the two writes it commits together.</summary>
-    /// <param name="accountCatalog">Says which accounts this deployment serves, and therefore which one a caller may name.</param>
+    /// <param name="accountCatalog">Says which accounts the caller's owner owns, and therefore which one a caller may name.</param>
     /// <param name="recipientResolver">Turns the people the author named into the addresses every occurrence is offered to.</param>
     /// <param name="composer">Builds the draft, and decides every header this system owns rather than the author.</param>
     /// <param name="recurringSends">Holds the declaration and its idempotency identity.</param>
@@ -61,7 +61,7 @@ public sealed class RecurringMailSubmission
     /// <param name="authorization">Answers whether the caller that reached this holds the grant that lets it send.</param>
     /// <exception cref="ArgumentNullException">Thrown when a collaborator is <see langword="null" />.</exception>
     public RecurringMailSubmission(
-        IDeploymentMailAccountCatalog accountCatalog,
+        ICallerMailAccountCatalog accountCatalog,
         NamedRecipientResolver recipientResolver,
         IAuthoredEmailComposer composer,
         IRecurringSendStore recurringSends,
@@ -91,8 +91,8 @@ public sealed class RecurringMailSubmission
     /// <param name="cancellationToken">Cancels the reads and the write.</param>
     /// <returns>The declaration, whether this call created it or an identical earlier one did.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="request" /> is <see langword="null" />.</exception>
-    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the caller does not hold <see cref="MailFathomPermission.MailSend" />.</exception>
-    /// <exception cref="MailAccountNotAccessibleException">Thrown when the request names an account this deployment does not serve.</exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the caller does not hold <see cref="MailFathomPermission.MailSend" />, or is acting for no owner.</exception>
+    /// <exception cref="MailAccountNotAccessibleException">Thrown when the request names an account the caller's owner does not own, which includes every account this deployment does not serve.</exception>
     /// <exception cref="MailSubmissionRefusedException">Thrown when the repetition is unreadable, a recipient names nobody, a field cannot be composed, a bound is exceeded, or the account configures no address to send from.</exception>
     /// <exception cref="PersistenceConcurrencyConflictException">Thrown when the write lost its race for the same identity on every allowed attempt.</exception>
     public async Task<RecurringSend> DeclareAsync(
@@ -103,7 +103,10 @@ public sealed class RecurringMailSubmission
 
         this.authorization.RequirePermission(MailFathomPermission.MailSend);
 
-        var account = this.accountCatalog.ServedAccounts.FirstOrDefault(served => served.IsNamedBy(request.Account))
+        // Resolved against the accounts the caller's owner owns for the reason the single send is, and here the
+        // exposure repeats: a declaration written against somebody else's account would send as them on every occasion
+        // the schedule names rather than once.
+        var account = this.accountCatalog.OwnedAccounts.FirstOrDefault(owned => owned.IsNamedBy(request.Account))
             ?? throw new MailAccountNotAccessibleException(request.Account);
 
         // First of the three, because it is the only one that costs nothing: a repetition nobody can resolve is

--- a/backend/src/Application/Mail/Delivery/Submission/AuthoredMailSubmission.cs
+++ b/backend/src/Application/Mail/Delivery/Submission/AuthoredMailSubmission.cs
@@ -49,7 +49,7 @@ namespace MailFathom.Application.Mail.Delivery.Submission;
 /// later meets it whatever it did first.
 /// </para>
 /// </remarks>
-/// <param name="accountCatalog">Says which accounts this deployment serves, and therefore which one a caller may name.</param>
+/// <param name="accountCatalog">Says which accounts the caller's owner owns, and therefore which one a caller may name.</param>
 /// <param name="recipientResolver">Turns the people the author named into the addresses a message is offered to.</param>
 /// <param name="composer">Builds the MIME, and decides every header this system owns rather than the author.</param>
 /// <param name="outbox">Writes the record and the message down together, and says the account has something to send.</param>
@@ -57,7 +57,7 @@ namespace MailFathom.Application.Mail.Delivery.Submission;
 /// <param name="authorization">Answers whether the caller that reached this holds the grant that lets it send.</param>
 /// <param name="timeProvider">Says whether a time the author named is still one a message can be held until.</param>
 public sealed class AuthoredMailSubmission(
-    IDeploymentMailAccountCatalog accountCatalog,
+    ICallerMailAccountCatalog accountCatalog,
     NamedRecipientResolver recipientResolver,
     IAuthoredEmailComposer composer,
     MailOutbox outbox,
@@ -70,8 +70,8 @@ public sealed class AuthoredMailSubmission(
     /// <param name="cancellationToken">Cancels the reads and the write.</param>
     /// <returns>The durable record the message was written down as, whether this call created it or an identical earlier one did.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="request" /> is <see langword="null" />.</exception>
-    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the caller does not hold <see cref="MailFathomPermission.MailSend" />.</exception>
-    /// <exception cref="MailAccountNotAccessibleException">Thrown when the request names an account this deployment does not serve.</exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the caller does not hold <see cref="MailFathomPermission.MailSend" />, or is acting for no owner.</exception>
+    /// <exception cref="MailAccountNotAccessibleException">Thrown when the request names an account the caller's owner does not own, which includes every account this deployment does not serve.</exception>
     /// <exception cref="MailSubmissionRefusedException">Thrown when a recipient names nobody, a field cannot be composed, a bound is exceeded, the account configures no address to send from, or the message is asked to leave at a time that has passed.</exception>
     /// <exception cref="OutgoingMailRefusedException">Thrown when a recipient is one this deployment may not write to, when this caller has reached a ceiling of its own, or when a recipient it named is one nothing here vouches for.</exception>
     public async Task<OutgoingEmailRecord> SubmitAsync(
@@ -82,7 +82,11 @@ public sealed class AuthoredMailSubmission(
 
         authorization.RequirePermission(MailFathomPermission.MailSend);
 
-        var account = accountCatalog.ServedAccounts.FirstOrDefault(served => served.IsNamedBy(request.Account))
+        // Resolved against the accounts the caller's owner owns rather than against the deployment's, because a send
+        // names the mailbox mail leaves as: an account belonging to somebody else would put this caller's message into
+        // the world under that person's address. It is refused with the failure an unserved account gets, so a refusal
+        // cannot tell a caller that the account exists.
+        var account = accountCatalog.OwnedAccounts.FirstOrDefault(owned => owned.IsNamedBy(request.Account))
             ?? throw new MailAccountNotAccessibleException(request.Account);
 
         // Before the contact book is read and before anything is composed, because a time that has gone is the

--- a/backend/tests/Application.UnitTests/Application.UnitTests.csproj
+++ b/backend/tests/Application.UnitTests/Application.UnitTests.csproj
@@ -17,6 +17,7 @@
          the same way wherever one is arranged rather than once per suite. -->
     <Compile Include="..\shared\AccessAuthorizations.cs" Link="AccessAuthorizations.cs" />
     <Compile Include="..\shared\SyntheticMailOwner.cs" Link="SyntheticMailOwner.cs" />
+    <Compile Include="..\shared\OwnedMailAccountCatalogs.cs" Link="OwnedMailAccountCatalogs.cs" />
     <Compile Include="..\shared\OutgoingMailGovernors.cs" Link="OutgoingMailGovernors.cs" />
     <Compile Include="..\shared\AuthoredSendGovernors.cs" Link="AuthoredSendGovernors.cs" />
     <Compile Include="..\shared\StubMailFolderParticipation.cs" Link="StubMailFolderParticipation.cs" />

--- a/backend/tests/Application.UnitTests/Emails/DownloadAttachment/EmailAttachmentDownloadReaderTests.cs
+++ b/backend/tests/Application.UnitTests/Emails/DownloadAttachment/EmailAttachmentDownloadReaderTests.cs
@@ -37,11 +37,14 @@ public sealed class EmailAttachmentDownloadReaderTests
 {
     private const string ServedAccountId = "primary";
 
+    /// <summary>The one attachment of the one email every capability in this suite is minted for.</summary>
+    private const string AuthorizedObject = "/attachments/0198f0aa-0000-7000-8000-000000000000/0";
+
     private static readonly byte[] StoredRawMime = Encoding.UTF8.GetBytes("From: sender@example.test\r\n\r\nBody");
 
     /// <summary>The principal the download route states once it has verified a link, which is what this use case admits.</summary>
     private static readonly AuthorizedPrincipal RedeemedCapability =
-        AuthorizedPrincipal.SignedCapability(SyntheticMailOwner.Deployment, "/attachments/0198f0aa-0000-7000-8000-000000000000/0");
+        AuthorizedPrincipal.SignedCapability(SyntheticMailOwner.Deployment, AuthorizedObject);
 
     [Fact]
     public async Task OpenAsync_AttachmentOfAServedEmail_OpensItThroughTheStoredCopy()
@@ -120,6 +123,31 @@ public sealed class EmailAttachmentDownloadReaderTests
         // Arrange
         var summary = SyntheticEmailSummaries.Create(accountId: "retired");
         var reader = ReaderOver(summary, accountCatalog: CatalogServing(MailAccountId.Create(ServedAccountId)));
+
+        // Act
+        await using var attachment = await reader.OpenAsync(
+            new AttachmentDownloadTicket(summary.StoredEmailId, AttachmentPosition: 0),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Null(attachment);
+    }
+
+    /// <summary>
+    /// A capability carries the owner it was minted for, so one redeemed for another owner reaches nothing: holding the
+    /// link is not holding the mail, and the refusal is the one a deleted message gets.
+    /// </summary>
+    [Fact]
+    public async Task OpenAsync_EmailOfAnAccountTheTicketsOwnerDoesNotOwn_Refuses()
+    {
+        // Arrange
+        var summary = SyntheticEmailSummaries.Create();
+        var authorization = AuthorizationOver(
+            AuthorizedPrincipal.SignedCapability(SyntheticMailOwner.Another, AuthorizedObject));
+        var reader = ReaderOver(
+            summary,
+            accountCatalog: OwnedMailAccountCatalogs.For(authorization, SyntheticServedAccount.Of(summary.AccountId)),
+            authorization: authorization);
 
         // Act
         await using var attachment = await reader.OpenAsync(

--- a/backend/tests/Application.UnitTests/Emails/DownloadAttachment/EmailAttachmentDownloadReaderTests.cs
+++ b/backend/tests/Application.UnitTests/Emails/DownloadAttachment/EmailAttachmentDownloadReaderTests.cs
@@ -134,11 +134,19 @@ public sealed class EmailAttachmentDownloadReaderTests
     }
 
     /// <summary>
-    /// A capability carries the owner it was minted for, so one redeemed for another owner reaches nothing: holding the
-    /// link is not holding the mail, and the refusal is the one a deleted message gets.
+    /// The use case answers for whichever owner the redeeming principal names, so an account that owner does not own
+    /// reaches nothing, and the refusal is the one a deleted message gets.
     /// </summary>
+    /// <remarks>
+    /// Which owner a redemption names is the route's decision rather than the ticket's, and today it is the
+    /// deployment's own: <c>AttachmentDownloadTicket</c> records no owner, and
+    /// <c>EmailAttachmentDownloadEndpoint</c> states the one owner a deployment declaring its accounts in
+    /// configuration holds. ADR 0014's ticket-borne ownership is what replaces that once an account can belong to a
+    /// second owner. So this holds the use case to the owner it is handed rather than asserting that a redemption can
+    /// hand it somebody else's.
+    /// </remarks>
     [Fact]
-    public async Task OpenAsync_EmailOfAnAccountTheTicketsOwnerDoesNotOwn_Refuses()
+    public async Task OpenAsync_EmailOfAnAccountTheRedeemingPrincipalsOwnerDoesNotOwn_Refuses()
     {
         // Arrange
         var summary = SyntheticEmailSummaries.Create();

--- a/backend/tests/Application.UnitTests/Emails/GetEmailContent/EmailContentReaderTests.cs
+++ b/backend/tests/Application.UnitTests/Emails/GetEmailContent/EmailContentReaderTests.cs
@@ -696,6 +696,36 @@ public sealed class EmailContentReaderTests
         Assert.Equal(MailFathomErrorCode.StoredEmailNotFound, failure.ErrorCode);
     }
 
+    /// <summary>
+    /// Mail in an account another owner owns is refused by the same answer, so holding an identifier is not a way to
+    /// read somebody else's correspondence.
+    /// </summary>
+    [Fact]
+    public async Task ReadContentAsync_EmailOfAnAccountTheCallersOwnerDoesNotOwn_IsReportedAsNotFound()
+    {
+        // Arrange
+        var summary = SyntheticEmailSummaries.Create();
+        var authorization = AccessAuthorizations.ForOwnerGranted(
+            SyntheticMailOwner.Another,
+            MailFathomPermission.MailRead);
+        var reader = ReaderOver(
+            summary,
+            RendererReturning(RenderingOf()),
+            accountCatalog: OwnedMailAccountCatalogs.For(authorization, SyntheticServedAccount.Of(summary.AccountId)),
+            authorization: authorization);
+
+        // Act
+        var result = await reader.ReadContentAsync(
+            RequestFor([summary.StoredEmailId]),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        // The code an identifier naming nothing is answered with, which is what keeps "not yours" from being told apart
+        // from "not here".
+        var failure = FailureOf(Assert.Single(result.Emails));
+        Assert.Equal(MailFathomErrorCode.StoredEmailNotFound, failure.ErrorCode);
+    }
+
     /// <summary>A folder an operator withheld from tools is unreadable by identifier too, and refused the same way as mail that is not there.</summary>
     [Fact]
     public async Task ReadContentAsync_EmailOfAFolderWithheldFromTools_IsReportedAsNotFound()

--- a/backend/tests/Application.UnitTests/Emails/Mailboxes/MailboxScopeResolverTests.cs
+++ b/backend/tests/Application.UnitTests/Emails/Mailboxes/MailboxScopeResolverTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using MailFathom.Application.Access;
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Folders;
@@ -688,28 +687,12 @@ public sealed class MailboxScopeResolverTests
     private static MailboxScopeResolver ResolverFor(
         MailOwnerId owner,
         IMailFolderParticipationReader folderParticipation,
-        params ServedMailAccount[] servedAccounts)
-    {
-        var servedCatalog = Substitute.For<IDeploymentMailAccountCatalog>();
-        servedCatalog.ServedAccounts.Returns(
-        [
-            .. servedAccounts.OrderBy(account => account.Id.Value, StringComparer.Ordinal),
-        ]);
-
-        var deploymentOwner = Substitute.For<IDeploymentMailOwnerSource>();
-        deploymentOwner.Owner.Returns(SyntheticMailOwner.Deployment);
-
-        var ownedCatalog = new OwnedMailAccountCatalog(
-            servedCatalog,
-            deploymentOwner,
-            AccessAuthorizations.ForOwnerGranted(owner));
-
-        return new MailboxScopeResolver(
-            ownedCatalog,
+        params ServedMailAccount[] servedAccounts) =>
+        new(
+            OwnedMailAccountCatalogs.For(AccessAuthorizations.ForOwnerGranted(owner), servedAccounts),
             folderParticipation,
             StubJunkMailFolderCatalog.None,
             StubMailFolderMappings.Nothing.Resolver);
-    }
 
     private static MailboxScopeResolver Resolver(
         IMailFolderParticipationReader folderParticipation,

--- a/backend/tests/Application.UnitTests/Mail/Delivery/Authoring/StoredEmailResponseAuthoringTests.cs
+++ b/backend/tests/Application.UnitTests/Mail/Delivery/Authoring/StoredEmailResponseAuthoringTests.cs
@@ -5,7 +5,6 @@
 using System.Security.Cryptography;
 using System.Text;
 using MailFathom.Application.Access;
-using MailFathom.Application.Accounts;
 using MailFathom.Application.Contacts;
 using MailFathom.Application.EmailContent.Attachments;
 using MailFathom.Application.EmailContent.Rendering;
@@ -521,6 +520,30 @@ public sealed class StoredEmailResponseAuthoringTests
             MailFathomErrorCode.AnsweredEmailNotFound);
     }
 
+    /// <summary>
+    /// Mail in an account another owner owns is refused identically, so answering it is not a way to read what is in
+    /// it: the quotation a reply would carry is the message itself.
+    /// </summary>
+    [Fact]
+    public async Task AuthorAsync_EmailOfAnAccountTheCallersOwnerDoesNotOwn_IsRefusedAsNoSuchEmail()
+    {
+        // Arrange
+        var authoring = AuthoringOver(
+            Rendering(),
+            authorization: AccessAuthorizations.ForOwnerGranted(
+                SyntheticMailOwner.Another,
+                MailFathomPermission.MailRead));
+
+        // Act
+        var response = await authoring.AuthorAsync(Request(), TestContext.Current.CancellationToken);
+
+        // Assert
+        AssertRefused(
+            response,
+            AuthoredResponseRefusalReason.AnsweredEmailNotFound,
+            MailFathomErrorCode.AnsweredEmailNotFound);
+    }
+
     /// <summary>An identity this deployment holds nothing for is refused identically, so nobody learns what exists by asking.</summary>
     [Fact]
     public async Task AuthorAsync_EmailThisDeploymentDoesNotHold_IsRefusedAsNoSuchEmail()
@@ -1015,6 +1038,7 @@ public sealed class StoredEmailResponseAuthoringTests
         AccessAuthorization? authorization = null)
     {
         var answered = summary ?? SyntheticEmailSummaries.Create();
+        var callerAuthorization = authorization ?? AccessAuthorizations.ForCallerGranted(MailFathomPermission.MailRead);
 
         return new StoredEmailResponseAuthoring(
             summaryReader ?? SummaryReaderReturning(answered),
@@ -1023,7 +1047,7 @@ public sealed class StoredEmailResponseAuthoringTests
             attachmentContentReader ?? Substitute.For<IEmailAttachmentContentReader>(),
             repairRequestStore ?? new RecordingEmailContentRepairRequestStore(),
             new MailboxScopeResolver(
-                CatalogServing(answered.AccountId),
+                OwnedMailAccountCatalogs.For(callerAuthorization, SyntheticServedAccount.Of(answered.AccountId)),
                 folderParticipation ?? StubMailFolderParticipation.Mapping(
                     new MailFolderIdentity(answered.AccountId, answered.FolderAlias)),
                 StubJunkMailFolderCatalog.None,
@@ -1031,7 +1055,7 @@ public sealed class StoredEmailResponseAuthoringTests
             senderIdentities ?? SenderIdentitiesFor(answered.AccountId),
             new NamedRecipientResolver(contacts ?? new InMemoryContactBookStore()),
             bounds ?? Bounds(),
-            authorization ?? AccessAuthorizations.ForCallerGranted(MailFathomPermission.MailRead));
+            callerAuthorization);
     }
 
     private static IStoredEmailSummaryReader SummaryReaderReturning(EmailSummary? summary)
@@ -1085,14 +1109,6 @@ public sealed class StoredEmailResponseAuthoringTests
             .Returns(OutgoingSenderIdentity.Create(accountId, address));
 
         return senderIdentities;
-    }
-
-    private static ICallerMailAccountCatalog CatalogServing(MailAccountId accountId)
-    {
-        var catalog = Substitute.For<ICallerMailAccountCatalog>();
-        catalog.OwnedAccounts.Returns([SyntheticServedAccount.Of(accountId)]);
-
-        return catalog;
     }
 
     private static OutgoingEmailBounds Bounds(int maxBodyCharacters = 4096) => new()

--- a/backend/tests/Application.UnitTests/Mail/Delivery/Drafts/AuthoredMailDraftingTests.cs
+++ b/backend/tests/Application.UnitTests/Mail/Delivery/Drafts/AuthoredMailDraftingTests.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Text;
+using MailFathom.Application.Access;
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Mail.Delivery;
 using MailFathom.Application.Mail.Delivery.Addressing;
@@ -81,6 +82,41 @@ public sealed class AuthoredMailDraftingTests
 
         // Assert
         await Assert.ThrowsAsync<MailAccountNotAccessibleException>(refusal);
+        Assert.Empty(harness.Drafts.Drafts);
+    }
+
+    /// <summary>
+    /// An account another owner owns is refused exactly as one nobody serves, so a caller cannot leave a message in
+    /// somebody else's own Drafts folder for them to read as theirs.
+    /// </summary>
+    [Fact]
+    public async Task SaveAsync_AnAccountTheCallersOwnerDoesNotOwn_IsRefusedAndWritesNoDraft()
+    {
+        // Arrange
+        var harness = Harness(new InMemoryOutgoingEmailStore());
+        var drafting = DraftingOver(
+            harness,
+            authorization: AccessAuthorizations.ForOwnerGranted(
+                SyntheticMailOwner.Another,
+                MailFathomPermission.MailDraftsWrite));
+
+        // Act
+        var refusal = () => drafting.SaveAsync(
+            new MailDraftRequest
+            {
+                Account = MailAccountSelector.For(Account),
+                Subject = "a draft",
+                PlainTextBody = "Hello.",
+                Author = OutgoingEmailRequester.Command("mfctl-4f2a"),
+            },
+            CancellationToken.None);
+
+        // Assert
+        var refused = await Assert.ThrowsAsync<MailAccountNotAccessibleException>(refusal);
+
+        // The refusal repeats what the caller named and nothing else, which is what keeps an account another owner owns
+        // from being told apart from one this deployment never served.
+        Assert.Equal(MailAccountSelector.For(Account), refused.RequestedAccount);
         Assert.Empty(harness.Drafts.Drafts);
     }
 
@@ -178,16 +214,17 @@ public sealed class AuthoredMailDraftingTests
     private static AuthoredMailDrafting DraftingOver(
         MailDraftHarness harness,
         InMemoryContactBookStore? book = null,
-        IAuthoredEmailComposer? composer = null)
+        IAuthoredEmailComposer? composer = null,
+        AccessAuthorization? authorization = null)
     {
-        var accountCatalog = Substitute.For<IDeploymentMailAccountCatalog>();
-        accountCatalog.ServedAccounts.Returns([SyntheticServedAccount.Of(Account)]);
+        var callerAuthorization =
+            authorization ?? AccessAuthorizations.ForCallerGranted(MailFathomPermission.MailDraftsWrite);
 
         return new AuthoredMailDrafting(
-            accountCatalog,
+            OwnedMailAccountCatalogs.For(callerAuthorization, SyntheticServedAccount.Of(Account)),
             new NamedRecipientResolver(book ?? new InMemoryContactBookStore()),
             composer ?? ComposingAuthoredEmails.ThatComposesDrafts(ComposedMime),
             harness.Book,
-            AccessAuthorizations.ForCallerGranted(MailFathomPermission.MailDraftsWrite));
+            callerAuthorization);
     }
 }

--- a/backend/tests/Application.UnitTests/Mail/Delivery/Governance/RecipientVouchingTests.cs
+++ b/backend/tests/Application.UnitTests/Mail/Delivery/Governance/RecipientVouchingTests.cs
@@ -3,10 +3,11 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Globalization;
-using MailFathom.Application.Accounts;
+using MailFathom.Application.Access;
 using MailFathom.Application.Mail.Delivery.Composition;
 using MailFathom.Application.Mail.Delivery.Governance;
 using MailFathom.Application.UnitTests.TestDoubles;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Contacts;
 using MailFathom.Domain.Delivery;
@@ -74,6 +75,28 @@ public sealed class RecipientVouchingTests
         Assert.Equal(0, unvouched);
     }
 
+    /// <summary>
+    /// A mailbox another owner sends as vouches for nothing here, because what vouches for an address is the caller's
+    /// own accounts rather than every account this deployment happens to serve.
+    /// </summary>
+    [Fact]
+    public async Task CountUnvouchedAsync_AddressAnotherOwnersAccountSendsAs_IsCounted()
+    {
+        // Arrange
+        var vouching = Vouching(
+            new InMemoryContactBookStore(),
+            ownAddress: "owner@example.test",
+            AccessAuthorizations.ForOwnerGranted(SyntheticMailOwner.Another, MailFathomPermission.MailSend));
+
+        // Act
+        var unvouched = await vouching.CountUnvouchedAsync(
+            [NamedByCaller("owner@example.test")],
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, unvouched);
+    }
+
     /// <summary>An address this system derived itself is not the caller's word, so a plain reply is never judged by this.</summary>
     [Theory]
     [InlineData(AuthoredRecipientProvenance.DerivedFromAnsweredEmail)]
@@ -135,10 +158,14 @@ public sealed class RecipientVouchingTests
         Assert.Equal(1, book.BatchedLookupCount);
     }
 
-    private static RecipientVouching Vouching(InMemoryContactBookStore book, string? ownAddress = null)
+    private static RecipientVouching Vouching(
+        InMemoryContactBookStore book,
+        string? ownAddress = null,
+        AccessAuthorization? authorization = null)
     {
-        var accounts = Substitute.For<IDeploymentMailAccountCatalog>();
-        accounts.ServedAccounts.Returns([SyntheticServedAccount.Of(Account)]);
+        var accounts = OwnedMailAccountCatalogs.For(
+            authorization ?? AccessAuthorizations.ForCallerGranted(MailFathomPermission.MailSend),
+            SyntheticServedAccount.Of(Account));
 
         var senderIdentities = Substitute.For<IOutgoingSenderIdentityReader>();
         senderIdentities.FindSenderIdentity(Account).Returns(

--- a/backend/tests/Application.UnitTests/Mail/Delivery/Scheduling/RecurringMailSubmissionTests.cs
+++ b/backend/tests/Application.UnitTests/Mail/Delivery/Scheduling/RecurringMailSubmissionTests.cs
@@ -187,6 +187,31 @@ public sealed class RecurringMailSubmissionTests
             () => submission.DeclareAsync(request, TestContext.Current.CancellationToken));
     }
 
+    /// <summary>
+    /// An account another owner owns is refused exactly as one nobody serves, so a repetition cannot be declared
+    /// against a mailbox this caller may not even read — which would otherwise send as that owner on every occasion.
+    /// </summary>
+    [Fact]
+    public async Task DeclareAsync_AnAccountTheCallersOwnerDoesNotOwn_IsRefusedAndDeclaresNothing()
+    {
+        // Arrange
+        var store = new InMemoryRecurringSendStore();
+        var submission = SubmissionOver(
+            store,
+            out _,
+            AccessAuthorizations.ForOwnerGranted(SyntheticMailOwner.Another, MailFathomPermission.MailSend));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<MailAccountNotAccessibleException>(
+            () => submission.DeclareAsync(
+                RequestFor("Daily at 09:00"),
+                TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailAccountSelector.For(Account), refusal.RequestedAccount);
+        Assert.Empty(store.Declarations);
+    }
+
     /// <summary>Stopping a declaration stops every occasion still to come, and the row it leaves says when.</summary>
     [Fact]
     public async Task CancelAsync_AnActiveDeclaration_StopsEveryOccasionStillToCome()
@@ -351,8 +376,8 @@ public sealed class RecurringMailSubmissionTests
     {
         contentStore = ContentStores.Substituted();
 
-        var accountCatalog = Substitute.For<IDeploymentMailAccountCatalog>();
-        accountCatalog.ServedAccounts.Returns([SyntheticServedAccount.Of(Account)]);
+        var callerAuthorization = authorization ?? AccessAuthorizations.ForCallerGranted(MailFathomPermission.MailSend);
+        var accountCatalog = OwnedMailAccountCatalogs.For(callerAuthorization, SyntheticServedAccount.Of(Account));
 
         var conflictsLeft = conflictingAttempts;
         var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
@@ -378,7 +403,7 @@ public sealed class RecurringMailSubmissionTests
                 sessionFactory,
                 new PersistenceConcurrencyOptions(),
                 TimeProvider.System),
-            authorization ?? AccessAuthorizations.ForCallerGranted(MailFathomPermission.MailSend));
+            callerAuthorization);
     }
 
 }

--- a/backend/tests/Application.UnitTests/Mail/Delivery/Submission/AuthoredMailSubmissionTests.cs
+++ b/backend/tests/Application.UnitTests/Mail/Delivery/Submission/AuthoredMailSubmissionTests.cs
@@ -209,6 +209,38 @@ public sealed class AuthoredMailSubmissionTests
     }
 
     /// <summary>
+    /// An account belonging to another owner is refused exactly as one nobody serves, so mail cannot leave as somebody
+    /// whose mailbox this caller may not even read.
+    /// </summary>
+    [Fact]
+    public async Task SubmitAsync_AnAccountTheCallersOwnerDoesNotOwn_RefusesAndWritesNothing()
+    {
+        // Arrange
+        var store = new InMemoryOutgoingEmailStore();
+        var submission = SubmissionOver(
+            store,
+            out var composer,
+            out var signal,
+            authorization: AccessAuthorizations.ForOwnerGranted(
+                SyntheticMailOwner.Another,
+                MailFathomPermission.MailSend));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<MailAccountNotAccessibleException>(
+            () => submission.SubmitAsync(RequestTo("anna@example.test"), TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomErrorCode.MailAccountNotAccessible, refusal.ErrorCode);
+
+        // The refusal repeats what the caller named and says nothing else, which is what keeps an account another owner
+        // owns from being told apart from one this deployment never served.
+        Assert.Equal(MailAccountSelector.For(Account), refusal.RequestedAccount);
+        Assert.Empty(store.OpenRequests);
+        Assert.Equal(0, signal.Depth);
+        composer.DidNotReceiveWithAnyArgs().Compose(default, default!, default!, default!);
+    }
+
+    /// <summary>
     /// A list longer than a record could ever hold is refused before the book is read, because the reads carry what the
     /// caller supplied and the resolution treats that length as a defect in whoever called it.
     /// </summary>
@@ -594,8 +626,9 @@ public sealed class AuthoredMailSubmissionTests
         composer = ComposingAuthoredEmails.ThatComposes(ComposedMime);
         signal = new MailOutboxSignal(capacity: 8);
 
-        var accountCatalog = Substitute.For<IDeploymentMailAccountCatalog>();
-        accountCatalog.ServedAccounts.Returns([SyntheticServedAccount.Of(Account)]);
+        var accountCatalog = OwnedMailAccountCatalogs.For(
+            authorization ?? AccessAuthorizations.ForCallerGranted(MailFathomPermission.MailSend),
+            SyntheticServedAccount.Of(Account));
 
         var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
         sessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>()).Returns(_ =>

--- a/backend/tests/Application.UnitTests/Mail/Mutations/Authoring/MailFlagChangeRecorderTests.cs
+++ b/backend/tests/Application.UnitTests/Mail/Mutations/Authoring/MailFlagChangeRecorderTests.cs
@@ -3,7 +3,6 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Access;
-using MailFathom.Application.Accounts;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Mail.Mutations.Authoring;
 using MailFathom.Application.Mail.Mutations.Authoring.Failures;
@@ -128,6 +127,30 @@ public sealed class MailFlagChangeRecorderTests
         // Arrange
         var records = new InMemoryMailboxMutationRecordStore();
         var recorder = RecorderOver(records, target: null);
+        var change = AuthoredMailFlagChange.Create(LocalEmail, seen: true, null, null, null);
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<MailFlagChangeTargetNotFoundException>(() =>
+            recorder.RecordAsync(change, Requester, TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomErrorCode.StoredEmailNotFound, refusal.ErrorCode);
+        Assert.Equal(0, records.OpenedRecordCount);
+    }
+
+    /// <summary>
+    /// An email in an account another owner owns answers as one no row carries, so a flag cannot be written onto
+    /// somebody else's mail and the refusal says nothing about it existing.
+    /// </summary>
+    [Fact]
+    public async Task RecordAsync_AnEmailInAnAccountTheCallersOwnerDoesNotOwn_IsRefusedAsNotFound()
+    {
+        // Arrange
+        var records = new InMemoryMailboxMutationRecordStore();
+        var recorder = RecorderOver(
+            records,
+            TargetIn(Inbox),
+            AccessAuthorizations.ForOwnerGranted(SyntheticMailOwner.Another, MailFathomPermission.MailFlagsWrite));
         var change = AuthoredMailFlagChange.Create(LocalEmail, seen: true, null, null, null);
 
         // Act
@@ -288,8 +311,9 @@ public sealed class MailFlagChangeRecorderTests
         Func<IPersistenceSession>? sessionFactory = null,
         FakeTimeProvider? clock = null)
     {
-        var accountCatalog = Substitute.For<ICallerMailAccountCatalog>();
-        accountCatalog.OwnedAccounts.Returns([SyntheticServedAccount.Of(Account)]);
+        var callerAuthorization =
+            authorization ?? AccessAuthorizations.ForCallerGranted(MailFathomPermission.MailFlagsWrite);
+        var accountCatalog = OwnedMailAccountCatalogs.For(callerAuthorization, SyntheticServedAccount.Of(Account));
 
         var targets = Substitute.For<IAuthoredMailboxTargetReader>();
         targets.FindAsync(Arg.Any<StoredEmailId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(target));
@@ -302,7 +326,7 @@ public sealed class MailFlagChangeRecorderTests
                 : sessionFactory());
 
         return new MailFlagChangeRecorder(
-            authorization ?? AccessAuthorizations.ForCallerGranted(MailFathomPermission.MailFlagsWrite),
+            callerAuthorization,
             new MailboxScopeResolver(
                 accountCatalog,
                 StubMailFolderParticipation

--- a/backend/tests/Boundaries.UnitTests/MailboxReadBoundaryTests.cs
+++ b/backend/tests/Boundaries.UnitTests/MailboxReadBoundaryTests.cs
@@ -2,12 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using ArchUnitNET.Domain;
 using ArchUnitNET.Fluent;
 using ArchUnitNET.xUnitV3;
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Emails.Search;
 using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Emails.Threads;
+using MailFathom.Application.Mail.Delivery.Governance;
+using MailFathom.Application.Mail.Delivery.Submission;
 using Xunit;
 using static ArchUnitNET.Fluent.ArchRuleDefinition;
 
@@ -36,7 +39,10 @@ public sealed class MailboxReadBoundaryTests
         @"^MailFathom\.Infrastructure\.Persistence\.Emails\.StoredEmailSelectionPredicate$";
 
     /// <summary>The protocol boundary, whose every tool answers one caller acting for one owner.</summary>
-    private const string ProtocolBoundaryPattern = @"^MailFathom\.Mcp\.";
+    private const string ProtocolBoundaryNamespace = "MailFathom.Mcp.";
+
+    /// <summary>What the traversal below follows, which is this solution's own code and nothing it is built on.</summary>
+    private const string SolutionNamespace = "MailFathom.";
 
     [Theory]
     [InlineData(typeof(IStoredEmailTimelineReader))]
@@ -67,32 +73,82 @@ public sealed class MailboxReadBoundaryTests
 
     /// <summary>
     /// The two account catalogs are told apart by the members they publish rather than by a flag, and this holds one
-    /// half of that separation: nothing in the protocol assembly names the deployment-wide catalog itself, so a tool
-    /// cannot read every account the deployment serves without going through a use case that already decided to.
+    /// half of that separation: nothing an MCP call reaches names the deployment-wide catalog, so no tool can answer
+    /// one caller out of every account the deployment serves.
     /// </summary>
     /// <remarks>
-    /// It is a rule about the protocol assembly's own dependencies and not about what the use cases it composes reach.
-    /// A use case behind a tool may still hold the deployment-wide catalog, and one does today —
-    /// <c>AuthoredMailSubmission</c>, whose account resolution ADR 0014 moves in its next delivery step — so this rule
-    /// being green is not the statement that no MCP call can reach the deployment's whole account set. Widening it to
-    /// the composed use cases is what would say that, and it is the step that becomes true rather than merely
-    /// assertable once the send resolves through the caller-scoped port.
+    /// <para>
+    /// It is stated over everything a call reaches rather than over the protocol assembly's own dependencies, because
+    /// a tool composes a use case and that use case composes others. <c>send_email</c> resolves its account one hop
+    /// away in <c>AuthoredMailSubmission</c>, and vouches for its recipients two hops further down in
+    /// <c>RecipientVouching</c>, so a rule reading the assembly's own dependencies alone would be green while a use
+    /// case behind a tool read the deployment's whole account set.
+    /// </para>
+    /// <para>
+    /// The traversal follows this solution's own types and stops at everything it is built on, which is what keeps the
+    /// closure the composition rather than the framework. It admits the caller-scoped adapter by never reaching it: the
+    /// implementation that holds both catalogs is named by the container rather than by any use case, so a tool reaches
+    /// the port and never the type behind it.
+    /// </para>
     /// </remarks>
     [Fact]
-    public void DeploymentWideAccountCatalog_InWhatTheProtocolAssemblyItselfDependsOn_IsAbsent()
+    public void DeploymentWideAccountCatalog_InEverythingAnMcpCallReaches_IsAbsent()
     {
         // Arrange
-        IArchRule theProtocolBoundaryNamesOnlyTheCallerScopedCatalog = Types()
+        var reachedFromTheProtocolBoundary = ReachedFromTheProtocolBoundary();
+
+        // The guard: a closure that stopped at the assembly's own types would satisfy the rule while proving nothing,
+        // so the two the ADR names — the send one hop out and the vouching two further — are asserted to be in it.
+        Assert.Contains(
+            reachedFromTheProtocolBoundary,
+            type => type.FullName == typeof(AuthoredMailSubmission).FullName);
+        Assert.Contains(
+            reachedFromTheProtocolBoundary,
+            type => type.FullName == typeof(RecipientVouching).FullName);
+
+        IArchRule nothingAnMcpCallReachesNamesTheDeploymentCatalog = Types()
             .That()
-            .HaveFullNameMatching(ProtocolBoundaryPattern)
+            .Are(reachedFromTheProtocolBoundary)
             .Should()
             .NotDependOnAny(typeof(IDeploymentMailAccountCatalog))
             .Because(
-                "every MCP tool answers one caller acting for one owner, so a tool that named the accounts the "
-                    + "deployment serves would publish one person's mailbox to another's request; this holds the "
-                    + "protocol assembly's own dependencies rather than what the use cases it composes reach");
+                "every MCP tool answers one caller acting for one owner, so a use case behind one that named the "
+                    + "accounts the deployment serves would resolve one person's mailbox for another's request; the "
+                    + "caller-scoped catalog is what a caller-facing resolution reads");
 
         // Act & Assert
-        theProtocolBoundaryNamesOnlyTheCallerScopedCatalog.Check(CompiledBoundaries.Solution);
+        nothingAnMcpCallReachesNamesTheDeploymentCatalog.Check(CompiledBoundaries.Solution);
+    }
+
+    /// <summary>Walks out from the protocol assembly to every type of this solution an MCP call can reach.</summary>
+    /// <remarks>
+    /// Breadth rather than depth, because what matters is membership rather than the path that found it, and a
+    /// composition graph with a cycle in it would not terminate without the set the walk already visited.
+    /// </remarks>
+    private static IReadOnlyList<IType> ReachedFromTheProtocolBoundary()
+    {
+        var reached = new HashSet<IType>();
+        var pending = new Queue<IType>(
+            CompiledBoundaries.Solution.Types.Where(type =>
+                type.FullName.StartsWith(ProtocolBoundaryNamespace, StringComparison.Ordinal)));
+
+        while (pending.Count > 0)
+        {
+            var type = pending.Dequeue();
+
+            if (!reached.Add(type))
+            {
+                continue;
+            }
+
+            foreach (var target in type.Dependencies
+                .Select(dependency => dependency.Target)
+                .Where(target => target.FullName.StartsWith(SolutionNamespace, StringComparison.Ordinal)))
+            {
+                pending.Enqueue(target);
+            }
+        }
+
+        return [.. reached];
     }
 }

--- a/backend/tests/SharedSources.UnitTests/OwnedMailAccountCatalogsTests.cs
+++ b/backend/tests/SharedSources.UnitTests/OwnedMailAccountCatalogsTests.cs
@@ -1,0 +1,95 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Domain.Access;
+using MailFathom.Domain.Accounts;
+using MailFathom.TestSupport;
+using Xunit;
+
+namespace MailFathom.SharedSources.UnitTests;
+
+/// <summary>Covers the caller-scoped catalog several suites arrange the owner axis with.</summary>
+/// <remarks>
+/// Every test that asserts one owner cannot reach another's mailbox is arranged through this helper, so a helper that
+/// answered with nothing whoever asked would make all of them pass while proving the opposite of what they claim. Both
+/// answers are asserted here rather than in each suite for that reason.
+/// </remarks>
+public sealed class OwnedMailAccountCatalogsTests
+{
+    private static readonly MailAccountId Work = MailAccountId.Create("work");
+
+    [Fact]
+    public void OwnedAccounts_ForTheOwnerEveryConfiguredAccountBelongsTo_AreTheAccountsServed()
+    {
+        // Arrange
+        var catalog = OwnedMailAccountCatalogs.For(
+            AccessAuthorizations.ForOwnerGranted(SyntheticMailOwner.Deployment),
+            SyntheticServedAccount.Of(Work));
+
+        // Act
+        var owned = catalog.OwnedAccounts;
+
+        // Assert
+        Assert.Equal(Work, Assert.Single(owned).Id);
+    }
+
+    [Fact]
+    public void OwnedAccounts_ForAnotherOwner_AreNone()
+    {
+        // Arrange
+        var catalog = OwnedMailAccountCatalogs.For(
+            AccessAuthorizations.ForOwnerGranted(SyntheticMailOwner.Another),
+            SyntheticServedAccount.Of(Work));
+
+        // Act
+        var owned = catalog.OwnedAccounts;
+
+        // Assert
+        Assert.Empty(owned);
+    }
+
+    /// <summary>A principal acting for nobody is refused rather than answered, so the two never look alike in a test.</summary>
+    [Fact]
+    public void OwnedAccounts_ForAPrincipalActingForNoOwner_AreRefused()
+    {
+        // Arrange
+        var catalog = OwnedMailAccountCatalogs.For(
+            AccessAuthorizations.ForAdministratorGranted(MailFathomPermission.AdminOperate),
+            SyntheticServedAccount.Of(Work));
+
+        // Act & Assert
+        Assert.Throws<PrincipalNotAuthorizedException>(() => catalog.OwnedAccounts);
+    }
+
+    /// <summary>The switch is the deployment's and says nothing about who owns what, so it reaches every caller.</summary>
+    [Fact]
+    public void SynchronizationEnabled_WhicheverOwnerAsks_IsTheDeploymentsOwnAnswer()
+    {
+        // Arrange
+        var catalog = OwnedMailAccountCatalogs.For(
+            AccessAuthorizations.ForOwnerGranted(SyntheticMailOwner.Another),
+            SyntheticServedAccount.Of(Work));
+
+        // Act & Assert
+        Assert.True(catalog.SynchronizationEnabled);
+    }
+
+    /// <summary>The order is the deployment's own, so a scope a test resolves from this set is the canonical one.</summary>
+    [Fact]
+    public void OwnedAccounts_HoweverATestNamedThem_AreOrderedByIdentifier()
+    {
+        // Arrange
+        var catalog = OwnedMailAccountCatalogs.For(
+            AccessAuthorizations.ForOwnerGranted(SyntheticMailOwner.Deployment),
+            SyntheticServedAccount.Of("private"),
+            SyntheticServedAccount.Of("archive"));
+
+        // Act
+        var owned = catalog.OwnedAccounts;
+
+        // Assert
+        Assert.Equal(["archive", "private"], owned.Select(account => account.Id.Value));
+    }
+}

--- a/backend/tests/shared/AuthoredSendGovernors.cs
+++ b/backend/tests/shared/AuthoredSendGovernors.cs
@@ -36,7 +36,7 @@ internal static class AuthoredSendGovernors
     /// <param name="settings">What to do about a recipient nothing here vouches for, or <see langword="null" /> to admit one.</param>
     /// <param name="ledger">What this caller has already been admitted for, or <see langword="null" /> for no ceiling at all.</param>
     /// <param name="contacts">The book an address is vouched against, or <see langword="null" /> for an empty one.</param>
-    /// <param name="accounts">The accounts this deployment serves, or <see langword="null" /> for none.</param>
+    /// <param name="accounts">The accounts the caller's owner owns, or <see langword="null" /> for none.</param>
     /// <param name="senderIdentities">The addresses those accounts send as, or <see langword="null" /> for none.</param>
     /// <param name="auditor">Where the record of the send goes, or <see langword="null" /> to drop it.</param>
     /// <param name="authorization">The caller the send runs for, or <see langword="null" /> for one granted the send capability.</param>
@@ -47,7 +47,7 @@ internal static class AuthoredSendGovernors
         AuthoredSendSettings? settings = null,
         AuthoredSendUsageLedger? ledger = null,
         IContactDirectory? contacts = null,
-        IDeploymentMailAccountCatalog? accounts = null,
+        ICallerMailAccountCatalog? accounts = null,
         IOutgoingSenderIdentityReader? senderIdentities = null,
         IAuthoredSendAuditor? auditor = null,
         AccessAuthorization? authorization = null,
@@ -57,7 +57,7 @@ internal static class AuthoredSendGovernors
             settings ?? AuthoredSendSettings.Permissive,
             new RecipientVouching(
                 contacts ?? new VouchingNobody(),
-                accounts ?? new ServingNobody(),
+                accounts ?? new OwningNobody(),
                 senderIdentities ?? new SendingAsNobody()),
             ledger ?? new AuthoredSendUsageLedger(
                 AuthoredSendCeilings.Unbounded,
@@ -95,10 +95,10 @@ internal static class AuthoredSendGovernors
             Task.FromResult(new ContactPage([], null));
     }
 
-    /// <summary>A deployment serving no account, which vouches for no address of its own.</summary>
-    private sealed class ServingNobody : IDeploymentMailAccountCatalog
+    /// <summary>An owner owning no account, which vouches for no address of their own.</summary>
+    private sealed class OwningNobody : ICallerMailAccountCatalog
     {
-        public IReadOnlyList<ServedMailAccount> ServedAccounts { get; } = [];
+        public IReadOnlyList<ServedMailAccount> OwnedAccounts { get; } = [];
 
         public bool SynchronizationEnabled => false;
     }

--- a/backend/tests/shared/OwnedMailAccountCatalogs.cs
+++ b/backend/tests/shared/OwnedMailAccountCatalogs.cs
@@ -1,0 +1,50 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Application.Accounts;
+using MailFathom.Domain.Access;
+
+namespace MailFathom.TestSupport;
+
+/// <summary>Builds the caller-scoped catalog a use case reads, over the accounts a deployment serves.</summary>
+/// <remarks>
+/// It composes the real <see cref="OwnedMailAccountCatalog" /> rather than substituting the port, because a test about
+/// the owner axis that stubbed the answer would be asserting its own arrangement: what makes an account somebody else's
+/// is the comparison that type performs between the owner a caller was admitted for and the owner every configured
+/// account belongs to. A test that needs accounts served and says nothing about the owner substitutes the port instead.
+/// </remarks>
+internal static class OwnedMailAccountCatalogs
+{
+    /// <summary>Builds the catalog a caller admitted under one authorization reads.</summary>
+    /// <param name="authorization">The authorization the use case under test is reached with, which names the owner acted for.</param>
+    /// <param name="servedAccounts">The accounts this deployment serves, every one of which belongs to its own owner.</param>
+    /// <returns>The catalog, answering with every served account for the deployment's owner and with none for anybody else.</returns>
+    /// <remarks>
+    /// The accounts are ordered the way the deployment's own catalog orders them, because a scope resolved from this set
+    /// is canonical and a test that arranged them any other way would be proving something the process never sees.
+    /// </remarks>
+    internal static ICallerMailAccountCatalog For(
+        AccessAuthorization authorization,
+        params ServedMailAccount[] servedAccounts) =>
+        new OwnedMailAccountCatalog(
+            new DeploymentServing([.. servedAccounts.OrderBy(account => account.Id.Value, StringComparer.Ordinal)]),
+            new OwnedByTheDeployment(),
+            authorization);
+
+    /// <summary>The deployment's own catalog, answering with the accounts a test named.</summary>
+    private sealed class DeploymentServing(IReadOnlyList<ServedMailAccount> servedAccounts)
+        : IDeploymentMailAccountCatalog
+    {
+        public bool SynchronizationEnabled => true;
+
+        public IReadOnlyList<ServedMailAccount> ServedAccounts { get; } = servedAccounts;
+    }
+
+    /// <summary>The one owner every configured account belongs to while accounts are declared in a file.</summary>
+    private sealed class OwnedByTheDeployment : IDeploymentMailOwnerSource
+    {
+        public MailOwnerId Owner => SyntheticMailOwner.Deployment;
+    }
+}

--- a/docs/features/mail-delivery.md
+++ b/docs/features/mail-delivery.md
@@ -591,10 +591,17 @@ scanner switched on nothing here runs, and an enqueue costs exactly what it did 
 ## Asking for a message to be sent
 
 `AuthoredMailSubmission` is the one use case a boundary reaches to send a message that answers nothing, and it composes
-the three steps above it rather than adding a fourth: the account a caller named is resolved against the accounts this
-deployment serves, the people named become addresses, the addresses and the text become MIME, and the MIME and the
+the three steps above it rather than adding a fourth: the account a caller named is resolved against the accounts the
+caller's owner owns, the people named become addresses, the addresses and the text become MIME, and the MIME and the
 request become the durable record. Composing them in one place is what keeps a second entrypoint from doing two of the
 three and inventing the middle one, and it is what `send_email` calls and the whole of what that tool does.
+
+The account resolution is the caller's owner's rather than the deployment's wherever a caller names one, which is the
+send, the draft, and the repeating send alike, and it is what vouches for a recipient as one of the caller's own
+addresses. An account the caller's owner does not own is refused exactly as one this deployment does not serve — the
+same failure, with nothing in it that separates *not yours* from *not here* — so a refusal enumerates neither the
+accounts another person owns nor whether the name was one at all. A send is where getting this wrong costs most: mail
+would leave as somebody else rather than merely be shown to the wrong reader.
 
 **Nothing here transmits, and no configuration makes it.** The use case holds no delivery session and no factory for
 one, so there is nothing in it that could open a submission channel; what it answers with is the record, at the stage a


### PR DESCRIPTION
Closes #983

Every path that resolves a mail account for a caller now resolves it against the accounts the
caller's owner owns, and the four reads that reach an email by its stored identifier are each proven
to answer an email of somebody else's account as absent.

**The four identifier reads.** `MailboxScopeResolver.IsReadableByTools` already reads the
caller-scoped catalog — it acquired that when #982 split `IMailAccountCatalog` in two and pointed the
resolver at the caller-scoped half — so what this change owed was the proof per path rather than the
mechanism. `EmailContentReader`, `EmailAttachmentDownloadReader`, `StoredEmailResponseAuthoring`, and
`MailFlagChangeRecorder` each gain a test that arranges the real `OwnedMailAccountCatalog` over a
caller admitted for another owner and asserts the refusal is the one an identifier naming nothing
gets: `53002` for the content read, `null` for the attachment, `AnsweredEmailNotFound` for the reply,
`53002` for the flag change. Nothing in any of them separates *not yours* from *not here*. The
attachment download is bounded by the redeeming principal rather than by a caller: it refuses when the
owner that principal names does not own the account. Which owner a redemption names is the route's
decision and today it is the deployment's own — `AttachmentDownloadTicket` records none — which is
exact while accounts are declared in configuration, and ADR 0014's ticket-borne ownership is what
replaces it once an account can belong to a second owner.

**The four resolutions that named an account.** `AuthoredMailSubmission`, `AuthoredMailDrafting`,
`RecurringMailSubmission`, and `RecipientVouching` each read `IDeploymentMailAccountCatalog` and now
read `ICallerMailAccountCatalog`. The send is the reason the issue is not only about reads — a caller
holding `MailSend` could name another owner's account and mail would leave as them — and the draft
and the repetition are the same exposure written into somebody's own Drafts folder and repeated on
every occasion a schedule names. The vouching answers a caller which recipients this installation has
a trace of, and that answer is now drawn from the caller's own mailboxes rather than from every
mailbox the deployment reads. An account the caller's owner does not own is refused exactly as one
the deployment does not serve, and each path is proven to write nothing: no outgoing record, no
draft, no declaration.

**The boundary rule that could not yet be stated.** `MailboxReadBoundaryTests` held the protocol
assembly to never naming the deployment-wide catalog itself, and its remarks recorded the limit:
`AuthoredMailSubmission` sat behind `send_email` holding that port, so the rule being green was not
the statement that no MCP call reaches the deployment's whole account set. It now walks the closure
of this solution's types an MCP call reaches and holds all of it, with the send one hop out and the
vouching two further asserted to be inside the closure so it cannot pass by reaching nothing.

**No contract moves.** No MCP tool argument, result, or error code changes; `53001` already reads
*an account identifier nobody configured, or one belonging to someone else — the two are deliberately
one answer*. No configuration key, no database schema, no deployment contract. On a deployment
serving one owner — which the startup gate #982 added still enforces — behaviour is unchanged, which
is why this is not a changelog-worthy break.

The ownership question costs no database round trip: the caller's accounts are the configured set
compared against one owner, read in memory per request.
