### PR TITLE
[#1130] Carry the object-storage backend into all three deployment shapes, and say what a backup now is

### DIFF
--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -93,6 +93,64 @@
 # and rebuilding it costs a full IMAP resynchronization.
 # MAILFATHOM_POSTGRES_VOLUME=mailfathom-postgres-data
 
+### Where message content is stored
+#
+# The raw MIME of every message stored next: in PostgreSQL beside the metadata, which is what this deployment does
+# unless you say otherwise, or in an S3-compatible bucket you operate or rent. Everything else — the metadata, the
+# indexes, every job — still runs through PostgreSQL either way, so this is a decision about payload bytes and nothing
+# else. MailFathom runs no object store of its own and this file starts none: the endpoint already exists, and its
+# bucket is created before the first start rather than by anything here.
+#
+# **It decides only where the next write goes.** Every content row names the store holding its own payload, so setting
+# this moves nothing already stored and clearing it re-encodes nothing — mail written to the database stays readable
+# from the database, and mail written to a bucket stays readable from that bucket. Getting content out of one store and
+# into the other is a move an operator runs, and until it has run this deployment reads from both.
+#
+# **Once this reads ObjectStorage, `pg_dump` is no longer a whole backup.** The rows point at objects in the bucket, so
+# the two stores are backed up together and restored database-first; docs/operations/deployment-compose.md states the
+# order and what a row pointing at an object the bucket no longer holds looks like from a client.
+# MAILFATHOM_CONTENT_STORAGE=Database
+#
+# Required, all four, once the line above reads ObjectStorage — MailFathom refuses to start without an address, a
+# bucket, and both halves of a credential rather than acquiring the host's own identity from the environment.
+#
+# The address is the endpoint rather than the bucket, and it is `https`: a request carries a signature and, on a write,
+# the message itself, so a plain `http` address is refused. The prefix is what makes a bucket MailFathom shares with
+# something else safe — leave it empty for one it has to itself, and note that nothing here can check that two
+# deployments sharing a bucket arranged disjoint prefixes. The region is what the request is signed under and defaults
+# to `us-east-1`, which is what an endpoint with no notion of a region accepts. Path-style addressing is on because the
+# alternative needs a wildcard DNS name and a certificate to match it.
+# MAILFATHOM_OBJECT_STORAGE_ENDPOINT=
+# MAILFATHOM_OBJECT_STORAGE_BUCKET=
+# MAILFATHOM_OBJECT_STORAGE_KEY_PREFIX=
+# MAILFATHOM_OBJECT_STORAGE_REGION=
+# MAILFATHOM_OBJECT_STORAGE_PATH_STYLE=true
+#
+# The credential is two files rather than two variables here, for the reason no credential is in this file: it is
+# provisioned like a mailbox password, into the directory MailFathom reads its own secrets from. The identifier is a
+# secret like the secret beside it — it names an identity at the endpoint, and it is half of what an attacker needs:
+#
+#   printf %s '<access key id>' > secrets/mailfathom/mailfathom-object-storage-access-key-id
+#   printf %s '<secret access key>' > secrets/mailfathom/mailfathom-object-storage-secret-access-key
+#   chmod 444 secrets/mailfathom/mailfathom-object-storage-*
+#
+# `printf %s` rather than `echo` so the file holds exactly what the endpoint issued. MailFathom strips one trailing
+# newline when it decodes material as text, so `echo` would work too — but only one, and a signature derived from a
+# credential with a stray byte in it reaches you as every request being rejected rather than as a malformed credential.
+# Both files are read before each request, so rotating a key at the endpoint and replacing the file takes effect on the
+# next call with nothing to restart.
+#
+# An endpoint you run yourself, whose certificate the host's own trust store does not answer for, needs its certificate
+# authority as a third file — and the two `TrustAnchor` lines in compose.yaml uncommented, since an empty reference
+# would be a credential MailFathom cannot read rather than an anchor it does not need:
+#
+#   cp /path/to/ca.pem secrets/mailfathom/mailfathom-object-storage-trust-anchor
+#   chmod 444 secrets/mailfathom/mailfathom-object-storage-trust-anchor
+#
+# The timeouts, the reclamation sweep, and the bounds on moving what is already stored are ordinary configuration and
+# belong in ./config beside the mailboxes, not
+# here — docs/operations/configuration-runtime.md holds every key under `ContentStorage`.
+
 ### The client
 #
 # MailFathom's own client, served by the application as a page at the address the MCP mapping above publishes. Off,

--- a/deploy/compose/compose.yaml
+++ b/deploy/compose/compose.yaml
@@ -107,6 +107,39 @@ services:
       ConnectionStrings__mailfathom: "Host=postgres;Port=5432;Database=${MAILFATHOM_DATABASE:-mailfathom};Username=${MAILFATHOM_DATABASE_ROLE:-mailfathom}"
       Persistence__Password__Name: mailfathom-database-password
       Persistence__Password__SecretReference: file:/run/secrets/mailfathom-database-password
+      # Where the raw MIME of the messages stored next is written: `Database`, which keeps every payload in PostgreSQL
+      # beside the metadata and is what this deployment has always done, or `ObjectStorage`, which writes new payloads
+      # into the S3-compatible bucket named below. Everything else still goes through PostgreSQL either way.
+      #
+      # **It decides only where the next write goes.** Every content row names the store holding its own payload, so
+      # switching moves nothing already stored and switching back re-encodes nothing. And a `pg_dump` stops being a
+      # whole backup the moment this says ObjectStorage: docs/operations/deployment-compose.md § Backup and what
+      # survives removal states the order the two stores are backed up and restored in.
+      #
+      # The settings below are read only under the object backend, so they are set unconditionally like the spam
+      # scanner's address further down and cost a Database deployment nothing. Under ObjectStorage the address, the
+      # bucket, and both credential files are required, and MailFathom refuses to start without them rather than signing
+      # requests as whatever identity the host carries.
+      ContentStorage__Backend: ${MAILFATHOM_CONTENT_STORAGE:-Database}
+      ContentStorage__ObjectStorage__Endpoint: ${MAILFATHOM_OBJECT_STORAGE_ENDPOINT:-}
+      ContentStorage__ObjectStorage__Bucket: ${MAILFATHOM_OBJECT_STORAGE_BUCKET:-}
+      ContentStorage__ObjectStorage__KeyPrefix: ${MAILFATHOM_OBJECT_STORAGE_KEY_PREFIX:-}
+      ContentStorage__ObjectStorage__Region: ${MAILFATHOM_OBJECT_STORAGE_REGION:-}
+      ContentStorage__ObjectStorage__UsePathStyleAddressing: ${MAILFATHOM_OBJECT_STORAGE_PATH_STYLE:-true}
+      # Two files under ./secrets/mailfathom/, like every mailbox password and API key, rather than two Compose secrets:
+      # the identifier names an identity at the endpoint and is half of what an attacker needs, so it is provisioned and
+      # rotated by exactly the machinery its secret is. Both are resolved before every request, so replacing a file
+      # takes effect on the next call with no restart.
+      ContentStorage__ObjectStorage__AccessKeyId__Name: mailfathom-object-storage-access-key-id
+      ContentStorage__ObjectStorage__AccessKeyId__SecretReference: file:/etc/mailfathom/secrets/mailfathom-object-storage-access-key-id
+      ContentStorage__ObjectStorage__SecretAccessKey__Name: mailfathom-object-storage-secret-access-key
+      ContentStorage__ObjectStorage__SecretAccessKey__SecretReference: file:/etc/mailfathom/secrets/mailfathom-object-storage-secret-access-key
+      # The certificate authority that signed the endpoint's certificate, for an endpoint you run yourself. Commented
+      # out rather than defaulted to an empty reference: an endpoint the host already trusts needs none, and a block
+      # present with nothing in it is a credential MailFathom cannot read rather than an anchor it does not need. There
+      # is no setting anywhere that turns validation off instead — see docs/operations/platform-tls-policy.md.
+      #ContentStorage__ObjectStorage__TrustAnchor__Name: mailfathom-object-storage-trust-anchor
+      #ContentStorage__ObjectStorage__TrustAnchor__SecretReference: file:/etc/mailfathom/secrets/mailfathom-object-storage-trust-anchor
       # MailFathom's own client, served by the application as a page at the same address its client surface answers on.
       # The bundle is inside the image, so this pulls nothing and starts no second container; what it needs beside it is
       # ClientEndpoint:Enabled in ./config, since the page is served on that surface's listeners and calls them.

--- a/deploy/helm/mailfathom/README.md
+++ b/deploy/helm/mailfathom/README.md
@@ -37,6 +37,8 @@ database:
   host: postgres.databases.svc.cluster.local
 ```
 
+**Optionally, a bucket.** `contentStorage.backend` decides where the raw MIME of each message is written: PostgreSQL beside the metadata by default, or an S3-compatible endpoint you name. The chart runs no object store and renders nothing at all on the default, so a values document that never mentions this installs exactly what it always did. Selecting the bucket requires an `https` endpoint, a bucket name, and both halves of a credential — as *keys inside the Secret above*, never as values here — and it changes what a backup is: the rows then point at objects in the bucket, so the database and the bucket are backed up together and restored database-first. Switching it is a move rather than a setting, because every stored message records which store holds its own content. [Storing message content in a bucket](https://krzysztof318.github.io/MailFathom/operations/deployment-kubernetes.html#storing-message-content-in-a-bucket) is the page.
+
 ## Installing
 
 ```bash

--- a/deploy/helm/mailfathom/ci/content-storage-values.yaml
+++ b/deploy/helm/mailfathom/ci/content-storage-values.yaml
@@ -1,0 +1,34 @@
+# Copyright © 2026 Krzysztof Kasprowicz
+# Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+# Project repository: https://github.com/Krzysztof318/MailFathom
+
+# The object-storage backend, which is the branch the three values documents beside this one do not render: every one of
+# them leaves `contentStorage.backend` at `database` and therefore renders nothing of this block at all. That is the
+# half of the record that matters — a rendering which selects nothing is byte for byte what the chart produced before
+# the block existed — so this file is what proves the other half is produced by the repository's own verification.
+#
+# Everything else is the smallest values document the chart installs from, so what the golden manifest shows against
+# `defaults.yaml` is the content-storage decision and nothing else.
+image:
+  repository: example/mailfathom
+  tag: 0.1.0-verification
+  allowVersionMismatch: true
+
+secrets:
+  existingSecret: mailfathom-secrets
+
+database:
+  deploy:
+    superuserPasswordSecret: mailfathom-postgres-superuser
+
+# A bucket this deployment shares rather than one it has to itself, so the key prefix, the region, and a trust anchor
+# for an endpoint the cluster does not already trust are all rendered rather than only the two required settings. The
+# credential is two keys inside the Secret above, never a value here: the chart templates no credential.
+contentStorage:
+  backend: objectStorage
+  objectStorage:
+    endpoint: https://objects.mailfathom.example.test
+    bucket: mailfathom-content
+    keyPrefix: production/
+    region: eu-central-1
+    trustAnchorSecretKey: mailfathom-object-storage-trust-anchor

--- a/deploy/helm/mailfathom/ci/golden/content-storage.yaml
+++ b/deploy/helm/mailfathom/ci/golden/content-storage.yaml
@@ -1,0 +1,442 @@
+# Copyright © 2026 Krzysztof Kasprowicz
+# Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+# Project repository: https://github.com/Krzysztof318/MailFathom
+#
+# Rendered from deploy/helm/mailfathom with deploy/helm/mailfathom/ci/content-storage-values.yaml by scripts/render-helm-manifests.sh.
+# Committed so a change in what the chart produces is visible in the diff rather than only a failure to
+# produce anything. Regenerate with: scripts/render-helm-manifests.sh --update
+---
+# Source: mailfathom/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mailfathom
+  labels:
+    helm.sh/chart: mailfathom-0.0.0
+    app.kubernetes.io/name: mailfathom
+    app.kubernetes.io/instance: mailfathom
+    app.kubernetes.io/version: ""
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: mailfathom
+automountServiceAccountToken: false
+---
+# Source: mailfathom/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mailfathom-config
+  labels:
+    helm.sh/chart: mailfathom-0.0.0
+    app.kubernetes.io/name: mailfathom
+    app.kubernetes.io/instance: mailfathom
+    app.kubernetes.io/version: ""
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: mailfathom
+data:
+---
+# Source: mailfathom/templates/postgres-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mailfathom-postgres-init
+  labels:
+    helm.sh/chart: mailfathom-0.0.0
+    app.kubernetes.io/name: mailfathom-postgres
+    app.kubernetes.io/instance: mailfathom
+    app.kubernetes.io/version: "0.8.6-pg18"
+    app.kubernetes.io/component: database
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: mailfathom
+data:
+  10-create-mailfathom-database.sh: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    readonly database_name="${MAILFATHOM_DATABASE:?The MailFathom database name was not set.}"
+    readonly database_role="${MAILFATHOM_DATABASE_ROLE:?The MailFathom database role was not set.}"
+    readonly password_file="${MAILFATHOM_DATABASE_PASSWORD_FILE:?The MailFathom database password file was not named.}"
+
+    if [[ ! -r "$password_file" ]]; then
+      printf 'The MailFathom database password was not mounted at %s.\n' "$password_file" >&2
+      exit 1
+    fi
+
+    # One trailing newline is stripped, because a secret written by an editor almost always ends with one and an
+    # untrimmed byte becomes part of the password. This is the same rule MailFathom's own secret resolution applies,
+    # and the `x` sentinel is what keeps it to one: command substitution strips every trailing newline on its own, so a
+    # password genuinely ending in two would be created here with both removed and presented later with only one.
+    database_password="$(cat -- "$password_file"; printf 'x')"
+    database_password="${database_password%x}"
+    database_password="${database_password%$'\n'}"
+
+    if [[ -z "$database_password" ]]; then
+      printf 'The MailFathom database password at %s is empty.\n' "$password_file" >&2
+      exit 1
+    fi
+
+    # The password reaches psql as a variable rather than as interpolated SQL, so a value containing a quotation mark
+    # cannot end the string it was meant to be inside. `:'name'` is psql's own quoting of a variable as a literal.
+    psql --no-psqlrc --quiet --set ON_ERROR_STOP=1 \
+      --username "$POSTGRES_USER" \
+      --dbname "$POSTGRES_DB" \
+      --set database_role="$database_role" \
+      --set database_name="$database_name" \
+      --set database_password="$database_password" <<'INITIALIZE_ROLE_AND_DATABASE'
+    CREATE ROLE :"database_role" WITH LOGIN PASSWORD :'database_password';
+    CREATE DATABASE :"database_name" WITH OWNER :"database_role";
+    INITIALIZE_ROLE_AND_DATABASE
+
+    # Connected to the new database, still as the superuser, because installing an extension is the second thing an
+    # ordinary role may not do. Nothing else in the schema is created here: the tables, indexes, and constraints are
+    # the release's SQL artifact, and creating any of them now would leave two mechanisms describing one schema.
+    psql --no-psqlrc --quiet --set ON_ERROR_STOP=1 \
+      --username "$POSTGRES_USER" \
+      --dbname "$database_name" \
+      --command 'CREATE EXTENSION IF NOT EXISTS vector;'
+
+    printf 'Created database %s owned by role %s, with the vector extension installed.\n' "$database_name" "$database_role"
+---
+# Source: mailfathom/templates/postgres-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: mailfathom-postgres
+  labels:
+    helm.sh/chart: mailfathom-0.0.0
+    app.kubernetes.io/name: mailfathom-postgres
+    app.kubernetes.io/instance: mailfathom
+    app.kubernetes.io/version: "0.8.6-pg18"
+    app.kubernetes.io/component: database
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: mailfathom
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: mailfathom-postgres
+    app.kubernetes.io/instance: mailfathom
+  ports:
+    - name: postgresql
+      port: 5432
+      targetPort: postgresql
+      protocol: TCP
+---
+# Source: mailfathom/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: mailfathom
+  labels:
+    helm.sh/chart: mailfathom-0.0.0
+    app.kubernetes.io/name: mailfathom
+    app.kubernetes.io/instance: mailfathom
+    app.kubernetes.io/version: ""
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: mailfathom
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: mailfathom
+    app.kubernetes.io/instance: mailfathom
+---
+# Source: mailfathom/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mailfathom
+  labels:
+    helm.sh/chart: mailfathom-0.0.0
+    app.kubernetes.io/name: mailfathom
+    app.kubernetes.io/instance: mailfathom
+    app.kubernetes.io/version: ""
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: mailfathom
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mailfathom
+      app.kubernetes.io/instance: mailfathom
+  template:
+    metadata:
+      annotations:
+        checksum/config: 243a3d43bc74f382c06f3414255c6a7bb191695204d774f59fb700df7b3073d5
+      labels:
+        app.kubernetes.io/name: mailfathom
+        app.kubernetes.io/instance: mailfathom
+    spec:
+      serviceAccountName: mailfathom
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 1654
+        runAsGroup: 1654
+        runAsNonRoot: true
+        runAsUser: 1654
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: mailfathom
+          image: "example/mailfathom:0.1.0-verification"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: health
+              containerPort: 8081
+              protocol: TCP
+          env:
+            - name: ASPNETCORE_ENVIRONMENT
+              value: Production
+            - name: McpEndpoint__Port
+              value: "8080"
+            - name: HealthEndpoints__Port
+              value: "8081"
+            - name: ConfigurationSources__Directory
+              value: "/etc/mailfathom/config"
+            - name: DOTNET_USE_POLLING_FILE_WATCHER
+              value: "1"
+            - name: ConnectionStrings__mailfathom
+              value: "Host=mailfathom-postgres;Port=5432;Database=mailfathom;Username=mailfathom"
+            - name: Persistence__Password__Name
+              value: "mailfathom-database-password"
+            - name: Persistence__Password__SecretReference
+              value: "file:/etc/mailfathom/secrets/mailfathom-database-password"
+            - name: ContentStorage__Backend
+              value: ObjectStorage
+            - name: ContentStorage__ObjectStorage__Endpoint
+              value: "https://objects.mailfathom.example.test"
+            - name: ContentStorage__ObjectStorage__Bucket
+              value: "mailfathom-content"
+            - name: ContentStorage__ObjectStorage__KeyPrefix
+              value: "production/"
+            - name: ContentStorage__ObjectStorage__Region
+              value: "eu-central-1"
+            - name: ContentStorage__ObjectStorage__UsePathStyleAddressing
+              value: "true"
+            - name: ContentStorage__ObjectStorage__AccessKeyId__Name
+              value: "mailfathom-object-storage-access-key-id"
+            - name: ContentStorage__ObjectStorage__AccessKeyId__SecretReference
+              value: "file:/etc/mailfathom/secrets/mailfathom-object-storage-access-key-id"
+            - name: ContentStorage__ObjectStorage__SecretAccessKey__Name
+              value: "mailfathom-object-storage-secret-access-key"
+            - name: ContentStorage__ObjectStorage__SecretAccessKey__SecretReference
+              value: "file:/etc/mailfathom/secrets/mailfathom-object-storage-secret-access-key"
+            - name: ContentStorage__ObjectStorage__TrustAnchor__Name
+              value: "mailfathom-object-storage-trust-anchor"
+            - name: ContentStorage__ObjectStorage__TrustAnchor__SecretReference
+              value: "file:/etc/mailfathom/secrets/mailfathom-object-storage-trust-anchor"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mailfathom/config
+              readOnly: true
+            - name: secrets
+              mountPath: /etc/mailfathom/secrets
+              readOnly: true
+            - name: temporary
+              mountPath: /tmp
+          startupProbe:
+            httpGet:
+              path: /started
+              port: health
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: health
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /alive
+              port: health
+            initialDelaySeconds: 20
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          resources:
+            limits:
+              cpu: "2"
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+      volumes:
+        - name: config
+          configMap:
+            name: mailfathom-config
+        - name: secrets
+          secret:
+            secretName: mailfathom-secrets
+            defaultMode: 0400
+        - name: temporary
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Mi
+---
+# Source: mailfathom/templates/postgres-statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mailfathom-postgres
+  labels:
+    helm.sh/chart: mailfathom-0.0.0
+    app.kubernetes.io/name: mailfathom-postgres
+    app.kubernetes.io/instance: mailfathom
+    app.kubernetes.io/version: "0.8.6-pg18"
+    app.kubernetes.io/component: database
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: mailfathom
+spec:
+  replicas: 1
+  serviceName: mailfathom-postgres
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mailfathom-postgres
+      app.kubernetes.io/instance: mailfathom
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          helm.sh/chart: mailfathom-0.0.0
+          app.kubernetes.io/name: mailfathom-postgres
+          app.kubernetes.io/instance: mailfathom
+          app.kubernetes.io/version: "0.8.6-pg18"
+          app.kubernetes.io/component: database
+          app.kubernetes.io/managed-by: Helm
+          app.kubernetes.io/part-of: mailfathom
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mailfathom-postgres
+        app.kubernetes.io/instance: mailfathom
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 120
+      containers:
+        - name: postgres
+          image: "docker.io/pgvector/pgvector:0.8.6-pg18"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: postgresql
+              containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_USER
+              value: postgres
+            - name: POSTGRES_DB
+              value: postgres
+            - name: POSTGRES_PASSWORD_FILE
+              value: "/etc/mailfathom/postgres-superuser/postgres-superuser-password"
+            - name: MAILFATHOM_DATABASE
+              value: "mailfathom"
+            - name: MAILFATHOM_DATABASE_ROLE
+              value: "mailfathom"
+            - name: MAILFATHOM_DATABASE_PASSWORD_FILE
+              value: "/etc/mailfathom/secrets/mailfathom-database-password"
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql
+            - name: initialization
+              mountPath: /docker-entrypoint-initdb.d
+              readOnly: true
+            - name: secrets
+              mountPath: /etc/mailfathom/secrets
+              readOnly: true
+            - name: superuser
+              mountPath: /etc/mailfathom/postgres-superuser
+              readOnly: true
+            - name: run
+              mountPath: /var/run/postgresql
+            - name: temporary
+              mountPath: /tmp
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - --quiet
+                - --host=127.0.0.1
+                - --username=postgres
+                - --dbname=mailfathom
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          startupProbe:
+            exec:
+              command:
+                - pg_isready
+                - --quiet
+                - --host=127.0.0.1
+                - --username=postgres
+                - --dbname=mailfathom
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 60
+          resources:
+            limits:
+              cpu: "2"
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+      volumes:
+        - name: initialization
+          configMap:
+            name: mailfathom-postgres-init
+            defaultMode: 0555
+        - name: secrets
+          secret:
+            secretName: mailfathom-secrets
+            defaultMode: 0400
+            items:
+              - key: mailfathom-database-password
+                path: mailfathom-database-password
+        - name: superuser
+          secret:
+            secretName: mailfathom-postgres-superuser
+            defaultMode: 0400
+            items:
+              - key: postgres-superuser-password
+                path: postgres-superuser-password
+        - name: run
+          emptyDir: {}
+        - name: temporary
+          emptyDir: {}

--- a/deploy/helm/mailfathom/templates/_helpers.tpl
+++ b/deploy/helm/mailfathom/templates/_helpers.tpl
@@ -189,6 +189,45 @@ while the chart was also deploying one would scan through a service the release 
 {{- end -}}
 
 {{/*
+Content storage is the one block here whose "off" is a different store rather than a workload that does not exist, so
+what it checks is different too: nothing is rendered either way, and what a mistake produces is mail written somewhere
+nobody named. Selecting the bucket therefore requires everything a request needs — an https address, a bucket, and both
+halves of a credential — because MailFathom's own refusal would come from a pod that never became ready, and this one
+comes from `helm install`. The other direction is the analyzer's rule: a bucket named while the database backend is
+selected is a values file that reads as though mail were going somewhere it is not.
+
+The three secret keys are checked against each other because each becomes a `ConfiguredSecret` inside one configuration
+root, where a name is required to be unique — two of them naming one key is refused at startup, and here it also means
+the identifier and the secret are the same file.
+*/}}
+{{- $objectStorage := .Values.contentStorage.objectStorage -}}
+{{- if eq .Values.contentStorage.backend "objectStorage" -}}
+  {{- if not $objectStorage.endpoint -}}
+    {{- fail "contentStorage.objectStorage.endpoint is not set while contentStorage.backend is 'objectStorage'. MailFathom reaches the endpoint at an address the deployment states and resolves none from the node, so name the absolute https address of the S3-compatible service holding your mail." -}}
+  {{- end -}}
+  {{- if not $objectStorage.bucket -}}
+    {{- fail "contentStorage.objectStorage.bucket is not set while contentStorage.backend is 'objectStorage'. Every payload is written into one bucket, which the deployment names and the chart does not create." -}}
+  {{- end -}}
+  {{- if not $objectStorage.accessKeyIdSecretKey -}}
+    {{- fail "contentStorage.objectStorage.accessKeyIdSecretKey is not set while contentStorage.backend is 'objectStorage'. Name the key inside secrets.existingSecret holding the access key identifier: MailFathom presents an explicit credential on every request and never acquires the node's own identity from the environment, so a deployment that configures none is refused rather than signing as whoever the node is." -}}
+  {{- end -}}
+  {{- if not $objectStorage.secretAccessKeySecretKey -}}
+    {{- fail "contentStorage.objectStorage.secretAccessKeySecretKey is not set while contentStorage.backend is 'objectStorage'. Name the key inside secrets.existingSecret holding the secret half of the credential." -}}
+  {{- end -}}
+  {{- $secretKeys := list $objectStorage.accessKeyIdSecretKey $objectStorage.secretAccessKeySecretKey -}}
+  {{- if $objectStorage.trustAnchorSecretKey -}}
+    {{- $secretKeys = append $secretKeys $objectStorage.trustAnchorSecretKey -}}
+  {{- end -}}
+  {{- if ne (len $secretKeys) (len (uniq $secretKeys)) -}}
+    {{- fail (printf "The content-storage secret keys are not distinct: %s. Each becomes a credential of its own inside one configuration root, where MailFathom requires a unique name — and two of them naming one key would make the access key identifier and its secret the same file." (join ", " $secretKeys)) -}}
+  {{- end -}}
+{{- else -}}
+  {{- if or $objectStorage.endpoint $objectStorage.bucket -}}
+    {{- fail "contentStorage.objectStorage names an endpoint or a bucket while contentStorage.backend is 'database'. Nothing would read it, so this deployment writes every payload into PostgreSQL while its values file reads as though mail were going to a bucket. Select the object-storage backend, or remove the endpoint and the bucket." -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 The spam scanner follows the analyzer's shape exactly, and for the same reason: the address is either derived from the
 release or stated, never both, so a deployment cannot scan through a daemon the release did not install. The one thing
 it does not check is the address itself — a host name is any string, and refusing one here would refuse the short names

--- a/deploy/helm/mailfathom/templates/deployment.yaml
+++ b/deploy/helm/mailfathom/templates/deployment.yaml
@@ -114,6 +114,52 @@ spec:
               value: {{ .Values.database.passwordSecretKey | quote }}
             - name: Persistence__Password__SecretReference
               value: {{ printf "file:%s/%s" (trimSuffix "/" .Values.secrets.mountPath) .Values.database.passwordSecretKey | quote }}
+            {{- if eq .Values.contentStorage.backend "objectStorage" }}
+            {{- /*
+              Where the raw MIME of the messages stored next is written, and everything one request to that endpoint
+              needs. Nothing is written on the database backend, which is what keeps a rendering that selected nothing
+              identical to one from a chart that never carried this block.
+
+              The backend and the endpoint are written together for the reason the analyzer's switch and address are:
+              MailFathom refuses to start with the bucket selected and no address, no bucket, or no credential, and the
+              refusal would be about a file an operator did not think they were editing. The credential itself is never
+              in this object — both halves are references into the Secret the pod mounts, resolved before every request,
+              which is why a key rotated behind an unchanged mount reaches the next call with no restart.
+            */}}
+            {{- $objectStorage := .Values.contentStorage.objectStorage }}
+            {{- $secretsDirectory := trimSuffix "/" .Values.secrets.mountPath }}
+            - name: ContentStorage__Backend
+              value: ObjectStorage
+            - name: ContentStorage__ObjectStorage__Endpoint
+              value: {{ $objectStorage.endpoint | quote }}
+            - name: ContentStorage__ObjectStorage__Bucket
+              value: {{ $objectStorage.bucket | quote }}
+            - name: ContentStorage__ObjectStorage__KeyPrefix
+              value: {{ $objectStorage.keyPrefix | quote }}
+            - name: ContentStorage__ObjectStorage__Region
+              value: {{ $objectStorage.region | quote }}
+            - name: ContentStorage__ObjectStorage__UsePathStyleAddressing
+              value: {{ $objectStorage.usePathStyleAddressing | quote }}
+            - name: ContentStorage__ObjectStorage__AccessKeyId__Name
+              value: {{ $objectStorage.accessKeyIdSecretKey | quote }}
+            - name: ContentStorage__ObjectStorage__AccessKeyId__SecretReference
+              value: {{ printf "file:%s/%s" $secretsDirectory $objectStorage.accessKeyIdSecretKey | quote }}
+            - name: ContentStorage__ObjectStorage__SecretAccessKey__Name
+              value: {{ $objectStorage.secretAccessKeySecretKey | quote }}
+            - name: ContentStorage__ObjectStorage__SecretAccessKey__SecretReference
+              value: {{ printf "file:%s/%s" $secretsDirectory $objectStorage.secretAccessKeySecretKey | quote }}
+            {{- with $objectStorage.trustAnchorSecretKey }}
+            {{- /*
+              Only where the deployment named one. An endpoint the cluster's own trust store answers for needs none, and
+              an empty block here would be an unresolvable reference rather than an absent anchor — which MailFathom
+              reports as a credential it could not read rather than as an endpoint it already trusts.
+            */}}
+            - name: ContentStorage__ObjectStorage__TrustAnchor__Name
+              value: {{ . | quote }}
+            - name: ContentStorage__ObjectStorage__TrustAnchor__SecretReference
+              value: {{ printf "file:%s/%s" $secretsDirectory . | quote }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.client.enabled }}
             {{- /*
               The switch that puts the page in front of the mailbox, and — separately — the statement that its hop is

--- a/deploy/helm/mailfathom/values.schema.json
+++ b/deploy/helm/mailfathom/values.schema.json
@@ -243,6 +243,75 @@
       },
       "additionalProperties": false
     },
+    "contentStorage": {
+      "type": "object",
+      "required": [
+        "backend",
+        "objectStorage"
+      ],
+      "properties": {
+        "backend": {
+          "type": "string",
+          "enum": [
+            "database",
+            "objectStorage"
+          ],
+          "description": "Where the raw MIME of the messages stored next is written. 'database' keeps every payload in PostgreSQL beside the metadata, which is what a deployment that configures nothing runs. 'objectStorage' writes new payloads to the S3-compatible endpoint below, and makes a database dump stop being a whole backup."
+        },
+        "objectStorage": {
+          "type": "object",
+          "required": [
+            "endpoint",
+            "bucket",
+            "accessKeyIdSecretKey",
+            "secretAccessKeySecretKey"
+          ],
+          "properties": {
+            "endpoint": {
+              "type": "string",
+              "pattern": "^$|^https://.+",
+              "description": "An absolute https address. A plain http one is refused, because a request carries a signature and, on a write, the message itself."
+            },
+            "bucket": {
+              "type": "string"
+            },
+            "keyPrefix": {
+              "type": "string",
+              "not": {
+                "pattern": "^\\s+$",
+                "description": "Whitespace would write every key under a prefix nobody can type. Leave it empty for a bucket this deployment has to itself."
+              }
+            },
+            "region": {
+              "type": "string"
+            },
+            "usePathStyleAddressing": {
+              "type": "boolean"
+            },
+            "accessKeyIdSecretKey": {
+              "type": "string",
+              "maxLength": 64,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+              "description": "A key inside secrets.existingSecret rather than the identifier itself. The chart templates no credential, so this becomes a file: reference into the Secret the pod already mounts. The pattern and the length are what MailFathom accepts as a secret name."
+            },
+            "secretAccessKeySecretKey": {
+              "type": "string",
+              "maxLength": 64,
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*$",
+              "description": "A key inside secrets.existingSecret rather than the secret itself, read before every request so a rotated key needs no restart."
+            },
+            "trustAnchorSecretKey": {
+              "type": "string",
+              "maxLength": 64,
+              "pattern": "^$|^[A-Za-z0-9][A-Za-z0-9._-]*$",
+              "description": "The certificate authority that signed the endpoint's certificate, as a key inside the same Secret. Empty for an endpoint the cluster already trusts; there is no setting anywhere that turns validation off instead."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
     "secrets": {
       "type": "object",
       "required": [
@@ -294,9 +363,9 @@
               },
               {
                 "not": {
-                  "pattern": "^(ConnectionStrings__|Persistence__Password__|ConfigurationSources__|HealthEndpoints__|ASPNETCORE_|SensitiveContent__Pii__Enabled$|SensitiveContent__PersonalDataAnalyzer__|ClientEndpoint__Application__Enabled$)"
+                  "pattern": "^(ConnectionStrings__|Persistence__Password__|ConfigurationSources__|HealthEndpoints__|ASPNETCORE_|SensitiveContent__Pii__Enabled$|SensitiveContent__PersonalDataAnalyzer__|ClientEndpoint__Application__Enabled$|ContentStorage__Backend$|ContentStorage__ObjectStorage__(Endpoint|Bucket|KeyPrefix|Region|UsePathStyleAddressing|AccessKeyId__|SecretAccessKey__|TrustAnchor__))"
                 },
-                "description": "These settings are the chart's, not an override's. The environment block outranks every mounted file, so re-declaring one of them here would silently replace what the templates emit \u2014 and `ConnectionStrings__mailfathom` is the one that matters: the conventional Npgsql form carries `Password=`, which would put a credential into the rendered Deployment and bypass the mounted-file path entirely. `HealthEndpoints__` is the chart's for a different reason: `probes.port` sets both the container port the kubelet dials and the port the host binds, so moving one of them here would leave all three probes dialling a port nothing listens on and the pod never becoming ready. The personal-data switch and its analyzer block are the chart's for a third: `personalDataScanning` decides whether an analyzer workload exists at all, so an address stated here would send mail content somewhere else while the pod the release installed sat idle. Whether the client is served is the chart's for a fourth: `client.enabled` writes that switch beside the clear-text permission the application requires, and a switch stated here would turn the page on without it and refuse the start. `ClientEndpoint__Application__AllowClearText` is deliberately not one of these \u2014 it is the one an operator whose TLS terminates somewhere the chart cannot read has to state for themselves. Change `database`, `config`, `secrets`, `probes`, `personalDataScanning`, and `client` instead \u2014 the category list and its suppressions are ordinary configuration and belong in `config.files`."
+                "description": "These settings are the chart's, not an override's. The environment block outranks every mounted file, so re-declaring one of them here would silently replace what the templates emit \u2014 and `ConnectionStrings__mailfathom` is the one that matters: the conventional Npgsql form carries `Password=`, which would put a credential into the rendered Deployment and bypass the mounted-file path entirely. `HealthEndpoints__` is the chart's for a different reason: `probes.port` sets both the container port the kubelet dials and the port the host binds, so moving one of them here would leave all three probes dialling a port nothing listens on and the pod never becoming ready. The personal-data switch and its analyzer block are the chart's for a third: `personalDataScanning` decides whether an analyzer workload exists at all, so an address stated here would send mail content somewhere else while the pod the release installed sat idle. Whether the client is served is the chart's for a fourth: `client.enabled` writes that switch beside the clear-text permission the application requires, and a switch stated here would turn the page on without it and refuse the start. Which store holds a payload is the chart's for a fifth: `contentStorage` writes the backend together with the endpoint it needs and the credential references into the mounted Secret, so a backend selected here alone would point mail at a bucket the chart named nothing about \u2014 the timeouts, the reclamation sweep, and the bounds on moving what is already stored are deliberately not among these, because they are tuning rather than deployment shape and belong in `config.files`. `ClientEndpoint__Application__AllowClearText` is deliberately not one of these either \u2014 it is the one an operator whose TLS terminates somewhere the chart cannot read has to state for themselves. Change `database`, `config`, `secrets`, `probes`, `personalDataScanning`, `client`, and `contentStorage` instead \u2014 the category list and its suppressions are ordinary configuration and belong in `config.files`."
               }
             ]
           },

--- a/deploy/helm/mailfathom/values.yaml
+++ b/deploy/helm/mailfathom/values.yaml
@@ -139,6 +139,70 @@ database:
   # written for one deployment reads correctly in the other.
   passwordSecretKey: mailfathom-database-password
 
+### Where message content is stored
+#
+# The raw MIME of every message this deployment stores next: in PostgreSQL beside the metadata, which is the default and
+# what every deployment that has never heard of this setting is already running, or in an S3-compatible bucket you
+# operate or rent. Selecting the bucket changes nothing else — the metadata, the indexes, and every job still run
+# through PostgreSQL — so this is a decision about payload bytes rather than about the database.
+#
+# **It decides only where the next write goes.** Every content row names the store holding its own payload, so turning
+# this on moves nothing already stored and turning it back off re-encodes nothing. Getting content out of one store and
+# into the other is a move an operator runs, not a setting they flip, and until it has run a deployment reads from both.
+#
+# **A `pg_dump` stops being a whole backup the moment this is on.** The rows point at objects in the bucket, so the two
+# stores are backed up and restored together, database first;
+# docs/operations/deployment-kubernetes.md states the order and what a mismatch between them looks like.
+#
+# The chart writes nothing when `backend` is `database`, which is what makes a rendering that sets none of this
+# identical to one from a chart that never carried it. Enabling it requires an `https` endpoint, a bucket, and both
+# halves of a credential — MailFathom presents an explicit credential on every request and never acquires the host's own
+# identity from the environment, so a deployment that named none is refused at startup rather than signing as whoever
+# the node is. The timeouts, the reclamation sweep, and the bounds on moving what is already stored are tuning rather
+# than deployment shape and belong in
+# `config.files`; docs/operations/configuration-runtime.md holds every key.
+contentStorage:
+  # `database` or `objectStorage`.
+  backend: database
+
+  objectStorage:
+    # The endpoint, not the bucket: the bucket is named below and reached by whichever addressing style the flag further
+    # down selects. An absolute `https` address — a plain `http` one is refused, because a request carries a signature
+    # and, on a write, the message itself.
+    endpoint: ""
+
+    # The one bucket every object is written into and read from. It is not created for you.
+    bucket: ""
+
+    # The prefix every key this deployment writes begins with. Empty is a bucket MailFathom has to itself, which is the
+    # ordinary shape; a prefix is what makes a shared bucket safe, and nothing here can check that two deployments
+    # sharing one arranged disjoint prefixes. The reclamation sweep lists beneath this prefix and nowhere else.
+    keyPrefix: ""
+
+    # The region a request is signed under. Empty takes `us-east-1`, which is what an endpoint with no notion of a
+    # region accepts; a request always carries one, because SigV4 puts a region into the credential scope either way.
+    region: ""
+
+    # On by default, because virtual-hosted addressing needs a wildcard DNS name and a certificate to match it, which an
+    # endpoint reached by a Service name inside a cluster has neither of.
+    usePathStyleAddressing: true
+
+    # The two halves of the credential, as **keys inside `secrets.existingSecret`** rather than as values. The chart
+    # templates no credential and creates no Secret, so what is named here is a file in the Secret the pod already
+    # mounts, and MailFathom reads it as `file:<secrets.mountPath>/<key>` before every request — which is what lets a
+    # key rotated behind an unchanged mount reach the next call with no restart to schedule.
+    #
+    # The access key identifier is a secret like the secret beside it. It names an identity at the endpoint, it is one
+    # half of what an attacker needs, and every provider that issues one issues it together with its secret from the
+    # same place.
+    accessKeyIdSecretKey: mailfathom-object-storage-access-key-id
+    secretAccessKeySecretKey: mailfathom-object-storage-secret-access-key
+
+    # The certificate authority that signed the endpoint's certificate, as a key inside the same Secret. Leave it empty
+    # for an endpoint the cluster's own trust store already answers for, which is every hosted provider; name a key for
+    # an endpoint you run yourself. It is the only supported way to reach one — no setting anywhere turns validation off.
+    trustAnchorSecretKey: ""
+
 ### Secrets
 #
 # The chart creates no Secret and templates no credential. It mounts one the operator has already created, read-only,

--- a/deploy/quadlet/mailfathom.container
+++ b/deploy/quadlet/mailfathom.container
@@ -105,6 +105,50 @@ Environment=ConnectionStrings__mailfathom=Host=mailfathom-postgres;Port=5432;Dat
 Environment=Persistence__Password__Name=mailfathom-database-password
 Environment=Persistence__Password__SecretReference=systemd-credential:mailfathom-database-password
 
+# Where the raw MIME of the messages stored next is written, and it is PostgreSQL because these lines are commented out
+# — which is what this deployment has always done. Uncommenting them writes new payloads into the S3-compatible bucket
+# named below instead; everything else still runs through PostgreSQL, so this is a decision about payload bytes alone.
+# MailFathom runs no object store of its own and no unit here starts one: the endpoint already exists and its bucket is
+# created before the first start.
+#
+# **It decides only where the next write goes.** Every content row names the store holding its own payload, so
+# uncommenting these moves nothing already stored and commenting them back re-encodes nothing; until a move has run,
+# this deployment reads from both stores.
+#
+# **With them uncommented a `pg_dump` is no longer a whole backup**, because the rows point at objects in the bucket.
+# docs/operations/deployment-quadlet.md § Backup, and what survives removal states the order the two stores are backed
+# up and restored in, and what a row pointing at an object the bucket no longer holds reaches a client as.
+#
+# The seven lines of the first block are required together: MailFathom refuses to start without an address, a bucket,
+# and both halves of a credential rather than signing requests as whatever identity the host carries. The address is the
+# endpoint rather than the bucket and it is `https` — a request carries a signature and, on a write, the message itself.
+# The two credentials are systemd credentials like the database password, so each needs a LoadCredentialEncrypted= line
+# in the [Service] section below; the identifier is a secret like the secret beside it, because it names an identity at
+# the endpoint and is half of what an attacker needs. Both are read before every request, so re-encrypting one and
+# restarting nothing takes effect on the next call.
+#
+# The prefix, the region, and path-style addressing carry working defaults — an empty prefix is a bucket MailFathom has
+# to itself, an empty region signs as `us-east-1`, and path style is on because the alternative needs a wildcard DNS
+# name and a certificate to match it. The timeouts, the reclamation sweep, and the bounds on moving what is already
+# stored are ordinary configuration and belong in the configuration directory beside this unit;
+# docs/operations/configuration-runtime.md holds every key.
+#Environment=ContentStorage__Backend=ObjectStorage
+#Environment=ContentStorage__ObjectStorage__Endpoint=https://objects.example.test
+#Environment=ContentStorage__ObjectStorage__Bucket=mailfathom-content
+#Environment=ContentStorage__ObjectStorage__AccessKeyId__Name=mailfathom-object-storage-access-key-id
+#Environment=ContentStorage__ObjectStorage__AccessKeyId__SecretReference=systemd-credential:mailfathom-object-storage-access-key-id
+#Environment=ContentStorage__ObjectStorage__SecretAccessKey__Name=mailfathom-object-storage-secret-access-key
+#Environment=ContentStorage__ObjectStorage__SecretAccessKey__SecretReference=systemd-credential:mailfathom-object-storage-secret-access-key
+# Optional, and only where the bucket has one:
+#Environment=ContentStorage__ObjectStorage__KeyPrefix=production/
+#Environment=ContentStorage__ObjectStorage__Region=eu-central-1
+#Environment=ContentStorage__ObjectStorage__UsePathStyleAddressing=true
+# Only for an endpoint you run yourself, whose certificate this host's own trust store does not answer for. Leave both
+# out for a hosted provider: an empty reference is a credential MailFathom cannot read rather than an anchor it does not
+# need, and no setting anywhere turns validation off instead.
+#Environment=ContentStorage__ObjectStorage__TrustAnchor__Name=mailfathom-object-storage-trust-anchor
+#Environment=ContentStorage__ObjectStorage__TrustAnchor__SecretReference=systemd-credential:mailfathom-object-storage-trust-anchor
+
 # MailFathom's own client, off because these two lines are commented out. The bundle travels inside the image, so
 # uncommenting them pulls nothing and installs no second unit; what they need beside them is ClientEndpoint:Enabled in
 # the configuration directory, since the page is served on that surface's listeners and calls them. Uncommenting
@@ -199,6 +243,11 @@ LoadCredentialEncrypted=imap-primary-password:%h/.config/credstore.encrypted/ima
 LoadCredentialEncrypted=mcp-workstation-key:%h/.config/credstore.encrypted/mcp-workstation-key
 # Only when a mailbox authenticates with OAuth. See config/10-mailfathom.json.example.
 #LoadCredentialEncrypted=mailfathom-data-key:%h/.config/credstore.encrypted/mailfathom-data-key
+# Only when message content is stored in a bucket — uncommented together with the ContentStorage lines above. The third
+# is for an endpoint whose certificate this host does not already trust and is left out for a hosted provider.
+#LoadCredentialEncrypted=mailfathom-object-storage-access-key-id:%h/.config/credstore.encrypted/mailfathom-object-storage-access-key-id
+#LoadCredentialEncrypted=mailfathom-object-storage-secret-access-key:%h/.config/credstore.encrypted/mailfathom-object-storage-secret-access-key
+#LoadCredentialEncrypted=mailfathom-object-storage-trust-anchor:%h/.config/credstore.encrypted/mailfathom-object-storage-trust-anchor
 
 # Bound the in-memory exposure that no code-level measure addresses, for the process that decrypts every credential
 # above before handing it on.

--- a/docs/operations/configuration-runtime.md
+++ b/docs/operations/configuration-runtime.md
@@ -71,6 +71,19 @@ content](../features/email-content.md#where-a-payload-is-kept) reads off the sch
 into the bucket is an operator's act rather than a setting; [moving stored content into the
 bucket](moving-stored-content.md) is the operation, and `ContentStorage:Move` below is what bounds its cost.
 
+**A database backup stops being a complete backup while this names a bucket.** The rows point at objects by a locator
+nothing recomputes, so the two stores are one backup taken in two places and a restore brings the database back before
+the bucket — the other order leaves objects nothing points at, which the reclamation sweep below is entitled to delete.
+Each deployment shape states the order in its own terms:
+[Kubernetes](deployment-kubernetes.md#what-you-now-back-up-and-in-which-order),
+[Compose](deployment-compose.md#with-content-in-a-bucket-the-dump-above-is-only-half-of-it), and
+[Quadlet](deployment-quadlet.md#backup-and-what-survives-removal).
+
+Each of those shapes also carries the section in its own idiom, so a deployment sets it there rather than assembling the
+keys below by hand: `contentStorage` in the Helm chart's values, `MAILFATHOM_CONTENT_STORAGE` and the variables beside
+it in Compose's `.env`, and the `ContentStorage` lines in the Quadlet unit. Every one of them writes the credential as a
+reference to material the deployment provisioned, never as a value.
+
 | Key | Type | Default | Constraint | Change |
 | --- | --- | --- | --- | --- |
 | `ContentStorage:Backend` | enum | `Database` | `Database`, `ObjectStorage` | restart |

--- a/docs/operations/deployment-compose.md
+++ b/docs/operations/deployment-compose.md
@@ -353,6 +353,25 @@ docker compose exec -T postgres pg_restore --username mailfathom --dbname mailfa
 
 The files under `secrets/` and `config/` are yours and are never touched by either.
 
+### With content in a bucket, the dump above is only half of it
+
+`MAILFATHOM_CONTENT_STORAGE=ObjectStorage` makes the two stores one backup taken in two places. The content rows point
+at objects in the bucket by a locator nothing recomputes, so a `pg_dump` alone restores a database naming objects it
+does not carry.
+
+1. **Take the dump above**, exactly as before.
+2. **Back up the bucket** — everything beneath `MAILFATHOM_OBJECT_STORAGE_KEY_PREFIX`, or the whole bucket where
+   MailFathom has it to itself. Your provider's own tooling does this; nothing here takes a bucket backup.
+3. **Restore the database first, then the bucket.** In that order the window between them is a database pointing at
+   objects not back yet, which reads as content temporarily unavailable. The other order leaves objects nothing points
+   at, and the reclamation sweep is entitled to delete those once they are older than `MinimumObjectAge` — so restoring
+   the bucket first can destroy part of what you are restoring.
+
+Take both from the same moment where you can. A row whose object is missing is not a corrupt deployment: the read
+reports that message's content as unavailable and names it, every other message keeps working, and
+[when the local copy is unusable](../features/email-content.md#when-the-local-copy-is-unusable) states what a client
+sees. That message is re-fetchable from the mail server like any other; what is not is anything derived from it.
+
 ## Uninstalling
 
 ```bash
@@ -535,12 +554,64 @@ the image's build scores today's mail worse than a fresh one. Nothing derived fr
 host names to third parties switched off, and the image bundles no plugin that reports anything anywhere. Remove
 `frontend` from the service to take the egress away and keep the corpus the image shipped with.
 
+## Storing message content in a bucket
+
+The raw MIME of every message lives in PostgreSQL beside the metadata unless `MAILFATHOM_CONTENT_STORAGE` says
+otherwise. `ObjectStorage` writes new payloads into an S3-compatible bucket instead; the metadata, the indexes, the
+embeddings, and every job still go through PostgreSQL, so this is a decision about payload bytes and about nothing else.
+This file starts no object store and there is no profile that would: the endpoint and its bucket exist before the first
+start.
+
+```dotenv
+MAILFATHOM_CONTENT_STORAGE=ObjectStorage
+MAILFATHOM_OBJECT_STORAGE_ENDPOINT=https://objects.example.test
+MAILFATHOM_OBJECT_STORAGE_BUCKET=mailfathom-content
+```
+
+The credential is two files rather than two variables, for the reason no credential is in `.env`: it goes into
+`./secrets/mailfathom/`, the directory MailFathom reads its own secrets from, beside the mailbox passwords.
+
+```bash
+printf %s '<access key id>' > secrets/mailfathom/mailfathom-object-storage-access-key-id
+printf %s '<secret access key>' > secrets/mailfathom/mailfathom-object-storage-secret-access-key
+chmod 444 secrets/mailfathom/mailfathom-object-storage-*
+```
+
+`printf %s` rather than `echo`, so the file holds exactly what the endpoint issued. MailFathom strips one trailing
+newline when it decodes material as text, so `echo` would work as well — but only one, and a signature derived from a
+credential with a stray byte in it reaches you as every request being rejected rather than as a credential it could not
+read. The access key identifier is a secret like the secret beside it — it names an identity at the endpoint, and it is
+one half of what an attacker needs. Both are read before every request, so rotating a key at the endpoint and replacing
+the file takes effect on the next call with nothing to restart.
+
+MailFathom refuses to start under this backend without an address, a bucket, and both files, rather than acquiring the
+host's own identity from the environment, and it refuses an endpoint that is not `https` — a request carries a signature
+and, on a write, the message itself. An endpoint you run yourself, whose certificate this host's trust store does not
+answer for, needs its authority as a third file and the two `TrustAnchor` lines in `compose.yaml` uncommented; leaving
+them commented is what an endpoint the host already trusts wants, because an empty reference is a credential MailFathom
+cannot read rather than an anchor it does not need. No setting anywhere turns validation off instead — see
+[platform TLS policy](platform-tls-policy.md).
+
+`MAILFATHOM_OBJECT_STORAGE_KEY_PREFIX` is what makes a bucket MailFathom shares with something else safe, and nothing
+here can check that two deployments sharing one arranged disjoint prefixes; the reclamation sweep lists beneath that
+prefix and nowhere else. The timeouts, the sweep, and the bounds on moving what is already stored are ordinary
+configuration and belong in `./config` beside the
+mailboxes — [`ContentStorage`](configuration-runtime.md#contentstorage) holds every key, and
+[where a payload is kept](../features/email-content.md#where-a-payload-is-kept) states what a content row records.
+
+**Switching is a move, not a setting.** The variable decides only where the next write goes: every content row names the
+store holding its own payload, so setting it moves nothing already stored and clearing it re-encodes nothing. Carrying
+what is already in the database into the bucket is an operator's act with its own controls —
+[moving stored content into the bucket](moving-stored-content.md) is that operation. Until it has run, and after a
+partial run, the deployment reads from both stores and keeps needing both: pointing it at a bucket it no longer has
+leaves the deployment unready rather than the mail unreadable.
+
 ## Bounds
 
 `.env.example` documents every knob: log rotation, CPU and memory limits for all four services, the published bind
-address and port, the database and role names, the volume name, the four personal-data settings, and the seven spam
-settings. Each is the value the Compose file already applies, so an unset variable and the documented value mean the same
-thing.
+address and port, the database and role names, the volume name, the four personal-data settings, the seven spam
+settings, and the six content-storage settings. Each is the value the Compose file already applies, so an unset variable
+and the documented value mean the same thing.
 
 The analyzer's memory limit is the one worth reading before it is lowered: it defaults to two gigabytes because the model
 is held for the life of the container, and below roughly one it is killed while loading — which reaches MailFathom as an

--- a/docs/operations/deployment-kubernetes.md
+++ b/docs/operations/deployment-kubernetes.md
@@ -511,6 +511,76 @@ that and MailFathom's own startup gate refuses to come up while the daemon is no
 application pod may restart a few times before the scanner is ready. `resources`, `nodeSelector`, `tolerations`,
 `affinity`, both security contexts, and the digest-pinned image are values under `spamScanning.scanner`.
 
+## Storing message content in a bucket
+
+The raw MIME of every message lives in PostgreSQL beside the metadata unless `contentStorage.backend` says otherwise.
+Setting it to `objectStorage` writes new payloads into an S3-compatible bucket instead; the metadata, the indexes, the
+embeddings, and every job still run through PostgreSQL, so this is a decision about payload bytes and about nothing
+else. The chart runs no object store and installs none: the endpoint and its bucket exist before the install.
+
+Off is the default, and the chart writes nothing at all on it — a rendering that sets none of this is byte for byte a
+rendering from a chart that never carried the block, which `deploy/helm/mailfathom/ci/golden/` records.
+
+```yaml
+contentStorage:
+  backend: objectStorage
+  objectStorage:
+    endpoint: https://objects.example.test
+    bucket: mailfathom-content
+    keyPrefix: production/
+    region: eu-central-1
+    accessKeyIdSecretKey: mailfathom-object-storage-access-key-id
+    secretAccessKeySecretKey: mailfathom-object-storage-secret-access-key
+```
+
+**The credential is two keys inside `secrets.existingSecret`, never a value here.** The chart templates no credential
+and creates no Secret, so what those two settings name is a file in the Secret the pod already mounts, and MailFathom
+reads each as `file:<secrets.mountPath>/<key>` before every request — which is what lets a key rotated behind an
+unchanged mount reach the next call with no restart to schedule. The access key identifier is a secret like the secret
+beside it: it names an identity at the endpoint, and it is one half of what an attacker needs.
+
+`helm install` refuses the object backend without an address, a bucket, and both credential keys, and refuses an
+endpoint that is not `https` — a request carries a signature and, on a write, the message itself. It refuses an endpoint
+or a bucket named while the backend is still `database` as well, because nothing would read it and the values file would
+read as though mail were going somewhere it is not. An endpoint whose certificate the cluster's own trust store does not
+answer for takes `trustAnchorSecretKey`, a third key in the same Secret; there is no setting anywhere that turns
+validation off instead, which [platform TLS policy](platform-tls-policy.md) covers.
+
+`keyPrefix` is what makes a bucket MailFathom shares with something else safe, and nothing in the chart or the
+application can check that two deployments sharing one arranged disjoint prefixes. The reclamation sweep lists beneath
+that prefix and nowhere else. The timeouts, the sweep itself, and the bounds on moving what is already stored are
+tuning rather than deployment shape and belong in
+`config.files`; [`ContentStorage`](configuration-runtime.md#contentstorage) holds every key, and
+[where a payload is kept](../features/email-content.md#where-a-payload-is-kept) states what a content row records.
+
+**Switching is a move, not a setting.** The value decides only where the next write goes: every content row names the
+store holding its own payload, so turning the object backend on moves nothing already stored and turning it back off
+re-encodes nothing. Carrying what a mailbox has accumulated into the bucket is an operator's act with its own controls
+and its own bounds — [moving stored content into the bucket](moving-stored-content.md) is that operation. Until it has
+run, and after a partial run, the deployment reads from both stores and keeps needing both: a bucket this release no
+longer names leaves the pod unready rather than the mail unreadable, which is the honest outcome and what
+[health endpoints](health-endpoints.md) reports.
+
+### What you now back up, and in which order
+
+**A `pg_dump` stops being a complete backup the moment the object backend is on.** The rows point at objects in the
+bucket by a locator nothing recomputes, so the database and the bucket are one backup taken in two places, and a restore
+brings back both.
+
+1. **Back up the database**, exactly as before.
+2. **Back up the bucket** — everything beneath `keyPrefix`, or the whole bucket where MailFathom has it to itself. Your
+   provider's own tooling does this; nothing in MailFathom or the chart takes a bucket backup.
+3. **Restore the database first, then the bucket.** In that order the window between them is a database pointing at
+   objects not back yet, which reads as content temporarily unavailable. The other order leaves objects nothing points
+   at, which the reclamation sweep is entitled to delete once they are older than `MinimumObjectAge` — so restoring the
+   bucket first can destroy part of what you are restoring.
+
+Take both from the same moment where you can. A row whose object is missing is not a corrupt deployment and not a
+mystery: the read reports that message's content as unavailable and names it, every other message keeps working, and
+[when the local copy is unusable](../features/email-content.md#when-the-local-copy-is-unusable) states what a client
+sees. A message whose object is missing is re-fetchable from the mail server like any other; what is not is anything
+derived — the answering audit trail and the embeddings.
+
 ## Scheduling, resources, and placement
 
 `nodeSelector`, `tolerations`, `affinity`, `topologySpreadConstraints`, `priorityClassName`, `resources`,
@@ -522,7 +592,9 @@ them together: a grace period shorter than the drain kills the process with the 
 
 ## Upgrading, rolling back, and uninstalling
 
-Back up the database and apply the new release's `mailfathom-schema-<version>.sql` **before** the upgrade. The new pod
+Back up the database — and the bucket beside it where `contentStorage.backend` is `objectStorage`, for the reason
+[what you now back up](#what-you-now-back-up-and-in-which-order) gives — and apply the new release's
+`mailfathom-schema-<version>.sql` **before** the upgrade. The new pod
 refuses to start against a schema that is behind it, and the old pod keeps serving against a schema that is ahead — so
 that order is the one with no window in which nothing serves.
 

--- a/docs/operations/deployment-quadlet.md
+++ b/docs/operations/deployment-quadlet.md
@@ -345,6 +345,18 @@ Stopping the units leaves the volume. Removing it is `podman volume rm mailfatho
 because rebuilding it costs a full IMAP resynchronization — and everything that is not in the mailbox, the answering
 audit trail and the embeddings, is regenerated rather than refetched.
 
+**With the `ContentStorage` lines uncommented, that dump is only half of it.** The content rows point at objects in the
+bucket by a locator nothing recomputes, so a dump alone restores a database naming objects it does not carry. Back the
+bucket up beside it — everything beneath `KeyPrefix`, or the whole bucket where MailFathom has it to itself, with your
+provider's own tooling, because nothing here takes a bucket backup — and **restore the database first, then the
+bucket**. In that order the window between them is a database pointing at objects not back yet, which reads as content
+temporarily unavailable; the other order leaves objects nothing points at, and the reclamation sweep is entitled to
+delete those once they are older than `MinimumObjectAge`, so restoring the bucket first can destroy part of what you
+are restoring. A row whose object is missing is not a corrupt deployment: that message's content reports as unavailable
+and names itself, every other message keeps working, and
+[when the local copy is unusable](../features/email-content.md#when-the-local-copy-is-unusable) states what a client
+sees.
+
 Stopping them can also report `rootless netns: kill network process: permission denied`, which is the host's AppArmor
 policy refusing a signal rather than a unit that failed to stop. These containers are torn down through the same
 rootless network namespace as the Compose deployment's and end on the same step, so
@@ -462,6 +474,69 @@ blocklist rules that would send sending addresses and URI host names to third pa
 It is also the one unit here granted a capability back. It binds its port as root and runs every scan as an unprivileged
 account, which is what parses the mail, so `SETUID` and `SETGID` are added after all capabilities are dropped; without
 them the daemon refuses to start.
+
+## Storing message content in a bucket
+
+The raw MIME of every message lives in PostgreSQL beside the metadata unless the `ContentStorage` lines in
+`mailfathom.container` are uncommented. Uncommented, new payloads go into an S3-compatible bucket instead; the metadata,
+the indexes, the embeddings, and every job still run through PostgreSQL, so this is a decision about payload bytes and
+about nothing else. No unit here starts an object store: the endpoint and its bucket exist before the first start.
+
+Switching it on is two edits, and each half alone is a deployment that does not start:
+
+```ini
+Environment=ContentStorage__Backend=ObjectStorage
+Environment=ContentStorage__ObjectStorage__Endpoint=https://objects.example.test
+Environment=ContentStorage__ObjectStorage__Bucket=mailfathom-content
+Environment=ContentStorage__ObjectStorage__AccessKeyId__Name=mailfathom-object-storage-access-key-id
+Environment=ContentStorage__ObjectStorage__AccessKeyId__SecretReference=systemd-credential:mailfathom-object-storage-access-key-id
+Environment=ContentStorage__ObjectStorage__SecretAccessKey__Name=mailfathom-object-storage-secret-access-key
+Environment=ContentStorage__ObjectStorage__SecretAccessKey__SecretReference=systemd-credential:mailfathom-object-storage-secret-access-key
+```
+
+The other half is the two credentials, which are systemd credentials like the database password rather than files in a
+directory, so each needs its own `LoadCredentialEncrypted=` line in `[Service]` — both are already there, commented,
+beside the ones this unit already grants. Produce them the way [the credentials](#the-credentials) above produces every
+other one:
+
+```bash
+printf %s '<access key id>' \
+  | systemd-creds --user encrypt --name=mailfathom-object-storage-access-key-id - \
+      ~/.config/credstore.encrypted/mailfathom-object-storage-access-key-id
+
+systemd-ask-password -n \
+  | systemd-creds --user encrypt --name=mailfathom-object-storage-secret-access-key - \
+      ~/.config/credstore.encrypted/mailfathom-object-storage-secret-access-key
+```
+
+The secret half arrives through `systemd-ask-password -n` for the reason the mailbox password does — neither a shell
+history entry nor a file to remember to delete — and `-n` is what keeps a trailing newline out of the material. The
+identifier is piped with `printf %s` for the same reason: MailFathom strips one trailing newline when it decodes
+material as text, so `echo` would work too, but a signature derived from a credential with a stray byte in it reaches
+you as every request being rejected rather than as a credential it could not read. The access key identifier is a
+secret like the secret beside it — it names an identity at the endpoint, and it is one half of what an attacker needs.
+Both are read before every request, so re-encrypting one after a rotation at the endpoint takes effect on the next call.
+
+MailFathom refuses to start under this backend without an address, a bucket, and both credentials rather than acquiring
+the host's own identity from the environment, and it refuses an endpoint that is not `https` — a request carries a
+signature and, on a write, the message itself. An endpoint you run yourself, whose certificate this host's trust store
+does not answer for, takes a third credential and the two `TrustAnchor` lines; leave both out for a hosted provider,
+because an empty reference is a credential MailFathom cannot read rather than an anchor it does not need. No setting
+anywhere turns validation off instead — see [platform TLS policy](platform-tls-policy.md).
+
+`KeyPrefix` is what makes a bucket MailFathom shares with something else safe, and nothing here can check that two
+deployments sharing one arranged disjoint prefixes; the reclamation sweep lists beneath that prefix and nowhere else.
+The timeouts, the sweep, and the bounds on moving what is already stored are ordinary configuration and belong in the
+configuration directory beside the unit —
+[`ContentStorage`](configuration-runtime.md#contentstorage) holds every key, and
+[where a payload is kept](../features/email-content.md#where-a-payload-is-kept) states what a content row records.
+
+**Switching is a move, not a setting.** These lines decide only where the next write goes: every content row names the
+store holding its own payload, so uncommenting them moves nothing already stored and commenting them back re-encodes
+nothing. Carrying what is already in the database into the bucket is an operator's act with its own controls —
+[moving stored content into the bucket](moving-stored-content.md) is that operation. Until it has run, and after a
+partial run, this deployment reads from both stores and keeps needing both: pointing it at a bucket it no longer has
+leaves the unit running and unready rather than the mail unreadable.
 
 ## Bounds
 

--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -88,9 +88,16 @@ downloads the desktop client from the release instead.
   and a setup of your own**: credential provisioning, TLS parameters, and file-permission expectations all differ
   there, nothing in this repository is verified against it, and a defect that reproduces only on Windows is not one
   this project can act on today.
-- **PostgreSQL with the `vector` extension.** The synchronized mail, its indexes, and the raw message content all live
-  there. The Compose deployment, the Quadlet units, and the Helm chart bring their own (`pgvector/pgvector`,
-  PostgreSQL 18); a native process expects yours, and the chart uses yours when you ask it to.
+- **PostgreSQL with the `vector` extension.** The synchronized mail, its indexes, and — unless you choose otherwise —
+  the raw message content all live there. The Compose deployment, the Quadlet units, and the Helm chart bring their own
+  (`pgvector/pgvector`, PostgreSQL 18); a native process expects yours, and the chart uses yours when you ask it to.
+- **An S3-compatible bucket, only if you want the message payloads out of the database.** It is off, and a deployment
+  that never mentions it is the ordinary one. What it changes is where the raw MIME of each message is written; the
+  metadata, the indexes, the embeddings, and every job still run through PostgreSQL either way. MailFathom runs no
+  object store and no deployment shape here starts one, so the endpoint and its bucket exist before the first start,
+  and it needs an `https` address and a credential of its own — an access key identifier and its secret, both
+  provisioned as [secret references](../operations/secret-provisioning.md) like every other credential.
+  [Choosing where message content lives](#choosing-where-message-content-lives) is the rest of it.
 - **An IMAP account to synchronize** and its password or app password, provisioned as a
   [secret reference](../operations/secret-provisioning.md) rather than written into configuration.
 - **A data-encryption key, if any mailbox authenticates with OAuth.** MailFathom seals the refresh tokens it stores
@@ -190,6 +197,36 @@ Build with the SDK pinned in `global.json`. The process is then an ordinary ASP.
 - A mail server whose TLS parameters the machine's own OpenSSL refuses is reached by naming an OpenSSL configuration
   file in the service's environment, which is a pre-start concern no MailFathom setting can replace.
   [The platform TLS policy](../operations/platform-tls-policy.md) has the sample file and the unit fragment.
+
+## Choosing where message content lives
+
+Two stores can hold the raw MIME of your mail, and which one is a decision you take once per deployment rather than per
+message. Configuring nothing keeps every payload in PostgreSQL beside the metadata, which is the shape everything above
+describes. Setting `ContentStorage:Backend` to `ObjectStorage` writes new payloads into an S3-compatible bucket instead
+— useful when the mail is larger than the database you want to operate, or when object storage is what your platform
+already backs up well. Everything else stays where it was.
+
+Each shape carries the setting in its own idiom: `contentStorage` in the Helm chart's values,
+`MAILFATHOM_CONTENT_STORAGE` and the variables beside it in Compose's `.env`, and the `ContentStorage` lines in the
+Quadlet unit.
+[`ContentStorage`](../operations/configuration-runtime.md#contentstorage) is the reference for every key and its bounds.
+
+Two things about it are worth knowing before you choose rather than after.
+
+**Switching is a move, not a setting.** The value decides only where the *next* payload is written. Every stored message
+records which store holds its own content, so turning the bucket on leaves everything already in the database exactly
+where it is and readable, and turning it back off re-encodes nothing. Carrying the mail you already have into the bucket
+is something you run, with its own controls and its own progress — [moving stored content into the
+bucket](../operations/moving-stored-content.md) is that operation. Until it has finished, the deployment needs both
+stores, and pointing it away from one it still has mail in leaves it unready rather than leaving that mail unreadable.
+
+**A database backup stops being a whole backup.** Once payloads are in the bucket, the rows point at objects there, so
+your backup is the database and the bucket together — and a restore brings the database back first and the bucket
+second, because the other order can let the reclamation sweep delete objects the database has not caught up to yet. Each
+deployment page states the order for its own shape:
+[Kubernetes](../operations/deployment-kubernetes.md#what-you-now-back-up-and-in-which-order),
+[Compose](../operations/deployment-compose.md#with-content-in-a-bucket-the-dump-above-is-only-half-of-it), and
+[Quadlet](../operations/deployment-quadlet.md#backup-and-what-survives-removal).
 
 ## Verifying any installation
 


### PR DESCRIPTION
Closes #1130

The object-storage content backend has existed in configuration since #1125 and #1126, and no deployment shape could reach it. An operator on Kubernetes could not set an endpoint, mount a credential, or point the chart at a bucket without forking the chart. This carries the setting into all three shapes, in the idiom each already uses, and states the half that matters more: a PostgreSQL dump stopped being a complete backup.

## The three shapes

Each carries the same settings, written the way that shape already writes configuration and provisions secrets. **The credential is never a literal in any of them** — it is a reference to material the deployment already provisions, and both halves are resolved before every request, so a key rotated behind an unchanged reference reaches the next call with no restart.

| | Where the setting lives | Where the credential comes from |
| --- | --- | --- |
| Helm | a `contentStorage` block in `values.yaml`, constrained in `values.schema.json` | keys inside `secrets.existingSecret`, rendered as `file:<mountPath>/<key>` |
| Compose | `MAILFATHOM_CONTENT_STORAGE` and five variables beside it in `.env` | files under `./secrets/mailfathom/`, like every mailbox password |
| Quadlet | commented `Environment=` lines in `mailfathom.container` | `LoadCredentialEncrypted=` lines, `systemd-credential:` references |

The access key identifier is provisioned as a secret like the secret beside it: it names an identity at the endpoint, and it is one half of what an attacker needs. The trust anchor is a third, optional credential — commented out rather than defaulted to an empty reference in Compose and Quadlet, because an empty block is a credential MailFathom cannot read rather than an anchor it does not need.

## Nothing is enabled by default, and the golden manifests prove it

The chart writes no environment entry at all on the database backend, so `ci/golden/defaults.yaml`, `nightly.yaml`, and `release.yaml` are **byte for byte unchanged** — a rendering that sets none of this is what the chart produced before the block existed. A fourth values document, `ci/content-storage-values.yaml`, renders the enabled shape (shared bucket with a prefix, a region, and a private trust anchor), so both branches are covered by the repository's own verification. Compose and Quadlet default to the database backend as well.

## What the chart refuses at install time

`helm install` now refuses what MailFathom would otherwise refuse from a pod that never became ready:

- the object backend with no endpoint, no bucket, or either credential key missing;
- an endpoint that is not `https` — a request carries a signature and, on a write, the message itself;
- two credential keys naming one file, which would make the identifier and the secret the same material and collides with the name-uniqueness rule inside one configuration root;
- an endpoint or a bucket named while the backend is still `database`, which is a values file that reads as though mail were going somewhere it is not.

`config.extraEnvironment` rejects the keys the chart writes, for the reason it already rejects the analyzer's and the client's. The timeouts, the reclamation sweep, and `ContentStorage:Move` are deliberately **not** among them: they are tuning rather than deployment shape and belong in `config.files`.

## What an operator now backs up

This is the half the issue called the more important one. Once payloads are in a bucket the rows point at objects by a locator nothing recomputes, so the database and the bucket are one backup taken in two places. Each deployment page states it in its own terms, with the restore order and the reason for it:

**Restore the database first, then the bucket.** In that order the window between them is a database pointing at objects not back yet, which reads as content temporarily unavailable. The other order leaves objects nothing points at, and the reclamation sweep is entitled to delete those once they are older than `MinimumObjectAge` — so restoring the bucket first can destroy part of what is being restored.

A mismatch is legible rather than mysterious: a row whose object is missing reports *that message's* content as unavailable and names it, every other message keeps working, and the message itself is re-fetchable from the mail server. `docs/users/installation.md` gains the choice itself, with the constraint that switching backends is a move rather than a setting — pointing at [moving stored content into the bucket](https://github.com/Krzysztof318/MailFathom/blob/main/docs/operations/moving-stored-content.md), which #1128 shipped.

## Contract surfaces

**The deployment contract changes; nothing breaks.** Every new value is additive and defaults to today's behaviour, so an existing values document, `.env`, or unit file installs and starts unchanged. The operator action is only for a deployment that *chooses* the bucket, and it is the backup procedure above rather than an upgrade step.

No new privilege, capability, or Pod Security exception in any of the three assets. No new dependency: the S3 client this configures was registered with #1125, and the endpoint stays the operator's own with its own service terms.

## Verification

- `scripts/render-helm-manifests.sh` — lints and renders all four values documents; the three pre-existing goldens compare byte-identical.
- Eight refusals exercised by hand against the chart (missing endpoint, missing bucket, plain `http`, duplicate credential keys, a bucket named on the database backend, an unknown key, a whitespace prefix, an empty credential key).
- `podman-system-generator --user --dryrun` over `deploy/quadlet/` — no unrecognized key.
- `docker compose config` over `deploy/compose/` — parses, with the ten new entries rendered.
- `scripts/build-docs-site.sh` — `0 error(s)`; the 4 warnings are pre-existing and untouched by this change.
- `scripts/verify-full.sh` — 255 passed, 0 failed. The change reaches neither stack, so no solution was built.
- `scripts/review-obligations.sh` — every page whose marker covers a changed path is in this change, except `personal-data-analyzer-languages.md`, which documents the analyzer language list and says nothing about content storage.

https://github.com/Krzysztof318/MailFathom/issues/1130
