### PR TITLE
[#1278] Make a screen's waiting something it renders, and give the person a way out of it

### DIFF
--- a/frontend/src/AGENTS.md
+++ b/frontend/src/AGENTS.md
@@ -39,8 +39,8 @@ most likely to be lost by accident:
   `VisualStateManager` breakpoints or the Toolkit's responsive markup, never by branching on the running platform.
 - Content stays clear of a notch, a rounded corner, a system bar, and a soft keyboard. `utu:SafeArea.Insets` is what
   says so; a hard-coded margin is what breaks on the next device.
-- Nothing blocks the thread that draws. A `.Result`, a `.Wait()`, or a `Thread.Sleep` in a handler is a frozen window
-  on desktop and a frozen tab in the browser, and `.config/BannedSymbols.txt` refuses the last of those outright.
+- Nothing the person waits on is allowed to look like nothing happening. That is the obligation with the most ways to
+  fail, so it has a section of its own below rather than a line here.
 
 ## MVUX is the state model
 
@@ -63,6 +63,61 @@ framework beside it.
   what makes a loading state and an error state the default rather than something each screen remembers to add.
 - **Awaiting a feed inside a model is normal** (`var value = await SomeState;`); awaiting one inside a view is a sign
   the work belongs in the model.
+
+## Nothing waits in silence, and nothing waits without a way out
+
+A screen that has asked for something and says nothing about it is indistinguishable from one that has stopped working,
+and this is the application where that is hardest to avoid: the mailbox it reads is on somebody else's machine and so is
+the model that leads a person through it, so nearly everything worth showing arrives over a network whose latency
+nothing here controls. Waiting is therefore something a screen *renders* rather than something it *does* — a state with
+a name, a place on the screen, and a way out of it — and it is designed in when the screen is. A loading state added
+after somebody reported the application looking frozen is this rule having been missed rather than followed late.
+
+- **Nothing blocks the thread that draws.** A `.Result`, a `.Wait()`, a `GetAwaiter().GetResult()`, or a `Thread.Sleep`
+  in a handler is a frozen window on desktop and a frozen tab in the browser; `.config/BannedSymbols.txt` refuses the
+  last of those outright and the rest are refused by reading. A long synchronous loop is the same defect with no name to
+  grep for, and the browser head is where it is worst — the section on awaiting below reads the same fact the other way
+  round: that head is single-threaded, so there is no other thread for the work to be on and `ConfigureAwait(false)`
+  moves nothing off it. Work that cannot be broken into awaited steps belongs on the service rather than in a head.
+- **Below about a second, the control that was pressed is the whole of the feedback**, and MVUX gives that away for
+  nothing: a generated command is an `IAsyncCommand`, and the control bound to it is disabled for as long as the method
+  runs, so a press being acted on never reads as a press that was ignored.
+- **A pointer head may add a busy cursor; no head may rely on one.** `ProtectedCursor` is the property that changes it,
+  it is `protected` — so it costs a `UIElement` subclass — it has to be set on the thread that draws, and Uno honours it
+  on WebAssembly, macOS, and Skia desktop. A touch head has no pointer to change at all, and the mobile heads here are
+  absent rather than impossible, so a wait whose only statement is the cursor is a wait that says nothing on a phone.
+- **Past that, the screen shows progress where the work is**, and which control says so follows what is being waited for
+  rather than how long it takes. A screen waiting for what it displays says so through `FeedView`'s `ProgressTemplate`,
+  because a feed already carries the progress axis and `SettingsPage` and `WorkspacePage` already render it. An action
+  somebody took says so through the Toolkit's `LoadingView`, whose `Source` takes the generated command with no adapter
+  in between — `IAsyncCommand` implements `Uno.Toolkit.ILoadable`, so binding the command is the whole of the wiring —
+  with `CompositeLoadableSource` where one region is fed by several commands, and `utu:ProgressExtensions.IsActive`
+  where one answer drives every progress control in a subtree.
+- **A command that carries a `CommandParameter` is the exception, and a silent one.** Such a command runs in parallel
+  for different parameter values, and its `IsExecuting` stays `false` throughout — so a per-item action puts its
+  progress on the item it belongs to, and a `LoadingView` over the list would show nothing at all.
+- **A wait that outgrows what it was expected to take escalates rather than going quiet.** How long something takes is a
+  fact about somebody else's machine, so nothing is classified as short and left there: the progress surface is raised
+  by the wait passing the threshold rather than by the operation having been thought slow, which is also what keeps a
+  fast answer from flashing a spinner on its way past. Escalating arrives at the same place a long operation starts —
+  that surface, and the cancellation below it — rather than at a second, quieter state invented for the case.
+- **Cancellation is offered wherever the work can be abandoned, and the framework's token is not that offer.** MVUX
+  hands a model method one `CancellationToken` and cancels it when the ViewModel is disposed, which is the screen going
+  away rather than a person changing their mind. A Cancel somebody can press is the model's own: a source linked to the
+  token it was handed, that source's token given to the work, and cancelling it exposed as an ordinary method the
+  generator turns into a command like any other. Every call `Client.Backend` makes over the wire takes a token and
+  honours it, so *this cannot be cancelled* is a claim to check in the code rather than a reason to leave the button
+  off.
+- **Preventing interaction is scoped to what must not be touched, and never achieved by freezing.** An overlay covers
+  the region whose controls would be wrong to press while the work runs — `WithheldOverlay` is the precedent for the
+  scope rather than for the look, since it stands over a space for good and so is opaque, where a wait has to leave what
+  it covers legible — and the window around it goes on scrolling, resizing, redrawing, and answering the Cancel. A
+  `ContentDialog` opened in order to stop somebody interacting is what this refuses: it takes the whole window, it
+  carries no progress of its own, and it makes an application that is working look like one that is stuck. A dialog is
+  right when the *question* is modal, never when the *wait* is.
+
+What reads all of this at once is one question, asked of every `await` a screen starts: what does the person see while
+this runs, and what may they do about it. A screen with no answer for one of its awaits is not finished.
 
 ## XAML first
 


### PR DESCRIPTION
## What this changes

`frontend/src/AGENTS.md` said the thread that draws must not be blocked and said nothing about what a person
sees while a screen waits. That left every loading state to be added after a screen already looked frozen,
which is the shape of defect the client stack is most likely to acquire: the mailbox it reads is on somebody
else's machine and so is the model that leads a person through it, so nearly everything worth showing arrives
over a network whose latency nothing here controls.

This adds one section — *Nothing waits in silence, and nothing waits without a way out* — between the MVUX
section and the XAML one, so a screen's waiting is designed in when the screen is. The native-feel bullet that
carried half of the obligation now points at the section instead of restating it, keeping the rule in one place.

No code, no dependency, no configuration. One file, +57/−2.

## What it decides, and what each rule rests on

Every mechanism named is grounded in something that already exists rather than in a convention a reviewer would
have to remember:

| Rule | What it rests on |
|---|---|
| Below about a second, the control that was pressed is the whole of the feedback | A generated command is an `IAsyncCommand`, and Uno disables the bound control for as long as the method runs |
| A pointer head may add a busy cursor; no head may rely on one | `ProtectedCursor` is `protected`, needs a `UIElement` subclass and the UI thread, and Uno honours it on WebAssembly, macOS, and Skia desktop — a touch head has no pointer, and the mobile heads here are absent rather than impossible |
| Past that, progress goes where the work is | `FeedView`'s `ProgressTemplate` for what a screen displays, as `SettingsPage` and `WorkspacePage` already do; the Toolkit's `LoadingView` for an action somebody took, whose `Source` takes the generated command with no adapter because `IAsyncCommand` implements `Uno.Toolkit.ILoadable`; `CompositeLoadableSource` and `utu:ProgressExtensions.IsActive` for the wider cases |
| A command carrying a `CommandParameter` is the silent exception | It runs in parallel per parameter value and its `IsExecuting` stays `false` throughout, so a `LoadingView` over the list would show nothing — the progress belongs on the item |
| A wait that outgrows its expectation escalates | How long something takes is a fact about somebody else's machine, so the surface is raised by the wait passing the threshold rather than by the operation having been classified slow — which also keeps a fast answer from flashing a spinner |
| Cancellation a person can press is the model's own | MVUX cancels the method's token when the ViewModel is disposed, which is the screen going away rather than anybody changing their mind. Every call `Client.Backend` makes over the wire takes a token and honours it |
| Preventing interaction is scoped, never achieved by freezing | An overlay over the region that must not be touched — `WithheldOverlay` is the precedent for the scope, not the look — with the window still scrolling, redrawing, and answering the Cancel |

Verified rather than recalled: `IAsyncCommand : ICommand, INotifyPropertyChanged, Uno.Toolkit.ILoadable` was read
out of the `InterfaceImpl` table of `Uno.Extensions.Reactive.dll` 7.2.3, which is the version the pinned
`Uno.Sdk` 6.6.42 resolves (`UnoExtensionsVersion | 7.2.3` in its own `ReadMe.md`). The cursor, `LoadingView`,
`CompositeLoadableSource`, and `ProgressExtensions` facts come from Uno's current documentation; the
`CommandParameter` caveat from the package's XML documentation.

## Two places this reads the issue rather than transcribing it

Both are deliberate and both follow from something the issue itself asks for:

- **The issue says a busy cursor is sufficient for a short operation.** The section makes the cursor an addition
  a pointer head may make rather than the statement a wait rests on, because `ProtectedCursor` reaches no touch
  head and this file already says the mobile heads are absent rather than impossible. What every head does show
  at that length is the control disabling itself, which MVUX gives for free — so the short case is still
  lightweight, just not silent on a phone.
- **The issue offers "a loading/progress overlay or dialog".** The section keeps the overlay and refuses the
  dialog as a way of holding somebody while work runs, because the issue's next requirement is that no modal or
  blocking pattern make the application appear frozen, and a `ContentDialog` takes the whole window and carries
  no progress of its own. A dialog stays right when the *question* is modal.

## Surfaces

No break. The MCP tool contract, the configuration schema, the database schema, and the deployment contract are
untouched — this changes a contributor-facing contract file and nothing a deployment reads.

## Verification

- `scripts/verify-full.sh` — green on the rebased tree: build 0 warnings 0 errors, 295/295 client unit tests,
  `dotnet format` verifying pass formatted 0 of 213 files, contract suite 255 passed 0 failed, exit 0. Run twice:
  once before the rebase and again after `origin/main` moved to 2763a339, because that commit touches
  `scripts/update-dependencies.sh`, which the contract suite reads.
- `scripts/review-obligations.sh` — no production file under `backend/src/` changed, no `describes:` marker
  covers the changed path, no register trigger moved.
- `$check-docs-licenses` — Docs `pass`, Changelog `n/a`, Licenses `n/a`. Every API the section names comes from
  `Uno.Toolkit` 9.0.3 and `Uno.Extensions` 7.2.3, both already registered as Apache-2.0 and both already
  resolved by the `Toolkit;` and `MVUX;` entries in `UnoFeatures`.

Closes #1278

https://claude.ai/code/session_01XMeNtRjBKDmYDkLRVMEr6b
