### PR TITLE
[#1285] Say eight where the permissions page counts the commands that read before they act

### DIFF
--- a/docs/operations/permissions.md
+++ b/docs/operations/permissions.md
@@ -146,7 +146,7 @@ Every administrative route publishes the one permission it requires as endpoint 
 [what the endpoint serves](admin-endpoint.md#what-the-endpoint-serves) states it route by route beside what each route
 does. Two consequences of that mapping belong here rather than to any one route.
 
-**Seven `mfctl` commands make two requests and therefore need two permissions**, because what such a command reads is
+**Eight `mfctl` commands make two requests and therefore need two permissions**, because what such a command reads is
 what it puts in front of you or amends from:
 
 | Command | Needs |


### PR DESCRIPTION
`docs/operations/permissions.md` opens its two-request table with "Seven `mfctl` commands make two requests and therefore need two permissions". The table lists eight — `contact update`, `contact add-address`, `contact remove-address`, `contact delete`, `mailbox rewind`, `content move`, `content release`, `embedding activate`. Seven was right until #1282 added the `content release` row and left the number in front of it alone.

One word. The count is what a reader checks their own reading against, so a page listing one more command than it claims makes them wonder which of the eight is not really one.

Found in `Fathom review`'s own approval body on #1282, as a candidate it suppressed for sitting on a file that had not moved since its previous pass. It was right, and the defect had already merged by then, which is why this is a change of its own rather than another commit there.

Closes #1285
