### PR TITLE
[#1161] Page a folder's mail into a bounded window whose selection is the client's scope

### DIFF
--- a/docs/architecture/solution-structure.md
+++ b/docs/architecture/solution-structure.md
@@ -198,10 +198,12 @@ project here and neither build reads the other's files.
 - `src/Client/Presentation/` holds every screen. The shell, the screen that asks which deployment this client reaches,
   and `ClientRoutes` — where each route is named once — sit directly under it, while `Workspace/`, `Spaces/`, and
   `Settings/` hold the frame the product's three spaces are shown inside, those spaces, and the settings screen.
-  `Mailboxes/` sits beside them and is not a screen: it is the tree of accounts and folders the frame shows in its
-  pane, which is what narrows the scope every space then reads. All of
-  them carry an MVUX model except the three space pages, which have none yet because each is filled in by the parent
-  that owns it. Every screen is a route rather than content something swaps by hand, which is what makes the system back
+  Two directories sit beside them and are not screens. `Mailboxes/` is the tree of accounts and folders the frame shows
+  in its pane, which is what narrows the scope every space then reads; `Messages/` is the message list of whatever place
+  that scope names — a bounded window over the deployment's keyset-paged timeline, registered once for the run, whose
+  selection is written back into that same scope for every other space to read. Every screen carries an MVUX model
+  except the Discover and Cases pages, which have none yet because each is filled in by the parent that owns it. Every
+  screen is a route rather than content something swaps by hand, which is what makes the system back
   gesture and the browser's history move through the client's own screens;
   [the client sources](https://github.com/Krzysztof318/MailFathom/blob/main/frontend/src/README.md)
   carries the composition and what travels between spaces.

--- a/frontend/src/AGENTS.md
+++ b/frontend/src/AGENTS.md
@@ -416,13 +416,15 @@ what keeps that from being a rule somebody has to enforce by reading.
   process does not own, and a screen that repeated it would be putting an attacker's words in MailFathom's voice.
 - **The surface it reaches is `/api/client`**, the backend's third transport surface, served only where a deployment
   enabled `ClientEndpoint`. It is not the MCP endpoint and not the administrative one: a credential admitted by either
-  of those authenticates nothing here. This client calls three of its routes today — `GET /api/client/session`,
+  of those authenticates nothing here. This client calls four of its routes today — `GET /api/client/session`,
   reporting the running version and the grant the caller's credential carries and nothing that identifies that
   credential; `GET /api/client/accounts`, reporting the signed-in owner's own mailboxes and how current the copy of
-  each one is; and `GET /api/client/folders`, reporting the folder hierarchy beneath each of those mailboxes with the
-  role the service gave each folder and how much mail it holds. The surface publishes more than the client has reached
-  yet, so [the client endpoint](../../docs/operations/client-endpoint.md) rather than this file is what says what is
-  there. No route reaches a mail server, so no screen here can wait on IMAP or set the remote `\Seen` flag.
+  each one is; `GET /api/client/folders`, reporting the folder hierarchy beneath each of those mailboxes with the
+  role the service gave each folder and how much mail it holds; and `GET /api/client/emails`, serving one page of the
+  message list by cursor, which is the route the mail screen then spends its time in. The surface publishes more than
+  the client has reached yet, so [the client endpoint](../../docs/operations/client-endpoint.md) rather than this file
+  is what says what is there. No route reaches a mail server, so no screen here can wait on IMAP or set the remote
+  `\Seen` flag.
 - **Signing in is authorization code with PKCE**, which is the grant `mfctl` performs against the administrative
   surface and for the same reason: a desktop binary and a WebAssembly bundle are both readable by whoever runs them, so
   this is a public client and holds no secret. Where to sign in is discovered rather than configured — the deployment's

--- a/frontend/src/Client.Backend/DeploymentClient.cs
+++ b/frontend/src/Client.Backend/DeploymentClient.cs
@@ -4,6 +4,7 @@
 
 using MailFathom.Client.Backend.Accounts;
 using MailFathom.Client.Backend.Folders;
+using MailFathom.Client.Backend.Timeline;
 
 namespace MailFathom.Client.Backend;
 
@@ -17,9 +18,10 @@ namespace MailFathom.Client.Backend;
 /// written without one by accident.
 /// </para>
 /// <para>
-/// The three routes it carries are the ones a client reads before it draws anything: what the deployment made of the
-/// caller, which mailboxes that caller has beside a statement of how current each copy is, and the folders those
-/// mailboxes hold. None of them reaches a mail server, so no screen here can wait on IMAP or set the remote
+/// Three of the four routes it carries are the ones a client reads before it draws anything: what the deployment made
+/// of the caller, which mailboxes that caller has beside a statement of how current each copy is, and the folders those
+/// mailboxes hold. The fourth is the one a mail screen then spends its time in — one page of the message list, asked
+/// for by cursor. None of them reaches a mail server, so no screen here can wait on IMAP or set the remote
 /// <c>\Seen</c> flag.
 /// </para>
 /// </remarks>
@@ -87,6 +89,33 @@ public sealed class DeploymentClient
             new HttpRequestMessage(HttpMethod.Get, DeploymentRoutes.MailFoldersPath),
             DeploymentJsonContext.Default.DeploymentMailFolders,
             cancellationToken);
+
+    /// <summary>Asks the deployment for one page of the owner's message list.</summary>
+    /// <param name="query">The place, the filters, the order, and where the page continues from.</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
+    /// <returns>The page, and the cursor continuing it at each end where one exists.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="query" /> is <see langword="null" />.</exception>
+    /// <exception cref="DeploymentFailure">Thrown when the deployment refused, was unreachable, did not answer in time, or answered with something else.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when nothing has pointed this client at a deployment yet.</exception>
+    /// <remarks>
+    /// A cursor the deployment will not honour — one it never issued, or one issued for a list the request no longer
+    /// describes — arrives as <see cref="DeploymentFailureReason.RequestRefused" /> rather than as a defect, because it
+    /// is a value this client sent and can therefore stop sending.
+    /// </remarks>
+    public Task<DeploymentMailTimelinePage> ReadMailTimelineAsync(
+        MailTimelineQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        return DeploymentExchange.ReadAsync(
+            this.Transport(),
+            new HttpRequestMessage(
+                HttpMethod.Get,
+                $"{DeploymentRoutes.MailTimelinePath}{query.QueryString()}"),
+            DeploymentJsonContext.Default.DeploymentMailTimelinePage,
+            cancellationToken);
+    }
 
     /// <summary>Takes a transport aimed at wherever the client is pointed right now.</summary>
     /// <remarks>

--- a/frontend/src/Client.Backend/DeploymentExchange.cs
+++ b/frontend/src/Client.Backend/DeploymentExchange.cs
@@ -162,8 +162,11 @@ internal static class DeploymentExchange
     /// <exception cref="DeploymentFailure">Thrown when the status is not a success.</exception>
     /// <remarks>
     /// <c>401</c> and <c>403</c> are separated from the rest because they are the one case the person can act on: the
-    /// sign-in has ended, or the credential was never granted this. Everything else is a deployment that is not
-    /// answering the way its contract says, which is somebody's defect rather than a person's next step.
+    /// sign-in has ended, or the credential was never granted this. <c>400</c> is separated for the opposite reason —
+    /// it is the client's own request the deployment would not serve, so the caller that composed it can compose
+    /// another, and answering it as a defect would leave a screen stuck on a value nobody typed. Everything else is a
+    /// deployment that is not answering the way its contract says, which is somebody's defect rather than a person's
+    /// next step.
     /// </remarks>
     internal static void RefuseUnusableStatus(HttpResponseMessage response)
     {
@@ -172,12 +175,17 @@ internal static class DeploymentExchange
             return;
         }
 
-        throw response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden
-            ? new DeploymentFailure(
+        throw response.StatusCode switch
+        {
+            HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden => new DeploymentFailure(
                 DeploymentFailureReason.CredentialRefused,
-                "MailFathom did not accept this sign-in. Sign in again.")
-            : new DeploymentFailure(
+                "MailFathom did not accept this sign-in. Sign in again."),
+            HttpStatusCode.BadRequest => new DeploymentFailure(
+                DeploymentFailureReason.RequestRefused,
+                "MailFathom would not serve this request as it was asked."),
+            _ => new DeploymentFailure(
                 DeploymentFailureReason.Unusable,
-                "MailFathom answered in a way this version does not understand.");
+                "MailFathom answered in a way this version does not understand."),
+        };
     }
 }

--- a/frontend/src/Client.Backend/DeploymentFailure.cs
+++ b/frontend/src/Client.Backend/DeploymentFailure.cs
@@ -6,10 +6,11 @@ namespace MailFathom.Client.Backend;
 
 /// <summary>Why one exchange with a deployment did not produce an answer.</summary>
 /// <remarks>
-/// Four cases rather than a status code, because what a screen does about them differs and nothing else about the
+/// Five cases rather than a status code, because what a screen does about them differs and nothing else about the
 /// answer does: a refused credential asks the person to sign in again, an unreachable deployment asks them to check
-/// their connection, a timeout is worth retrying unchanged, and an unusable answer is a defect somebody has to be told
-/// about rather than something the person can act on.
+/// their connection, a timeout is worth retrying unchanged, a refused request is something the client asked for and can
+/// therefore ask differently, and an unusable answer is a defect somebody has to be told about rather than something
+/// the person can act on.
 /// </remarks>
 public enum DeploymentFailureReason
 {
@@ -24,6 +25,15 @@ public enum DeploymentFailureReason
 
     /// <summary>Something answered, but not with what the contract says it answers with.</summary>
     Unusable = 3,
+
+    /// <summary>The deployment understood the request and would not serve it as asked.</summary>
+    /// <remarks>
+    /// Kept apart from <see cref="Unusable" /> because the two lead to opposite acts. This is the client's own request
+    /// being wrong rather than the deployment being wrong, so the caller that composed it is the one that can ask
+    /// differently — a message list handed a cursor issued for a list somebody has since re-sorted drops the cursor and
+    /// reads from the leading end, where reporting a defect would strand the screen on a value nobody typed.
+    /// </remarks>
+    RequestRefused = 4,
 }
 
 /// <summary>One exchange with a deployment that did not produce an answer, stated as something a screen can act on.</summary>

--- a/frontend/src/Client.Backend/DeploymentJsonContext.cs
+++ b/frontend/src/Client.Backend/DeploymentJsonContext.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Serialization;
 using MailFathom.Client.Backend.Accounts;
 using MailFathom.Client.Backend.Authorization;
 using MailFathom.Client.Backend.Folders;
+using MailFathom.Client.Backend.Timeline;
 
 namespace MailFathom.Client.Backend;
 
@@ -27,6 +28,7 @@ namespace MailFathom.Client.Backend;
 [JsonSerializable(typeof(DeploymentSession))]
 [JsonSerializable(typeof(DeploymentMailAccounts))]
 [JsonSerializable(typeof(DeploymentMailFolders))]
+[JsonSerializable(typeof(DeploymentMailTimelinePage))]
 [JsonSerializable(typeof(ProtectedResourceMetadata))]
 [JsonSerializable(typeof(AuthorizationServerMetadata))]
 [JsonSerializable(typeof(OAuthTokenResponse))]

--- a/frontend/src/Client.Backend/DeploymentRoutes.cs
+++ b/frontend/src/Client.Backend/DeploymentRoutes.cs
@@ -38,6 +38,14 @@ internal static class DeploymentRoutes
     /// </remarks>
     internal const string MailFoldersPath = $"{Prefix}/folders";
 
+    /// <summary>Where a deployment serves one page of the owner's message list, keyset-paged in either direction.</summary>
+    /// <remarks>
+    /// The route a mail screen spends its time in. It is asked with a query string composed from
+    /// <see cref="Timeline.MailTimelineQuery" /> rather than with a path of its own, because everything that narrows a
+    /// list is a filter over the same walk rather than a different resource.
+    /// </remarks>
+    internal const string MailTimelinePath = $"{Prefix}/emails";
+
     /// <summary>Where a deployment publishes what a client must obtain before it holds any credential.</summary>
     internal const string ProtectedResourceMetadataPath = $"/.well-known/oauth-protected-resource{Prefix}";
 }

--- a/frontend/src/Client.Backend/Timeline/DeploymentMailMessage.cs
+++ b/frontend/src/Client.Backend/Timeline/DeploymentMailMessage.cs
@@ -1,0 +1,66 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Backend.Timeline;
+
+/// <summary>One message of the list, as a deployment reports it.</summary>
+/// <param name="Id">The stable local identity of the message, which every later request names it by.</param>
+/// <param name="Account">The account the message was read from, as the accounts route names it.</param>
+/// <param name="Folder">The folder alias the message was read from, as the folders route names it.</param>
+/// <param name="ThreadId">The conversation the message belongs to, or <see langword="null" /> where nothing has placed it in one.</param>
+/// <param name="Subject">The subject, or <see langword="null" /> where the message carried none.</param>
+/// <param name="ReceivedAt">When the last receiving hop recorded the message, which is what the list is ordered by, or <see langword="null" /> where no header carried a usable date.</param>
+/// <param name="SentAt">When the message says it was sent, or <see langword="null" /> where no header carried a usable date.</param>
+/// <param name="SenderAddress">The sender's address as the message wrote it, or <see langword="null" /> where no usable sender was found.</param>
+/// <param name="SenderDisplayName">The display name the sender wrote, or <see langword="null" /> where the header carried none.</param>
+/// <param name="ToAddresses">The <c>To</c> addresses in header order, which is what a row of sent mail names instead of a sender.</param>
+/// <param name="Unread">Whether the mail server last reported the message without <c>\Seen</c>.</param>
+/// <param name="Flagged">Whether the mail server last reported it with <c>\Flagged</c>.</param>
+/// <param name="Answered">Whether the mail server last reported it with <c>\Answered</c>.</param>
+/// <param name="HasAttachments">Whether the message carries anything besides its body and its inline resources.</param>
+/// <param name="AttachmentCount">How many of those there are.</param>
+/// <param name="SizeOctets">The size the mail server reported for the message.</param>
+/// <param name="Preview">The opening of the message's own text, bounded, or <see langword="null" /> where nothing has extracted the message yet.</param>
+/// <remarks>
+/// <para>
+/// Everything a row draws arrives in the page that drew it, which is the whole point of this record being as wide as it
+/// is: a list that asked a second route for a sender or a preview would be a request per visible row, and a list that
+/// asked for bodies would be a megabyte to draw fifty lines. There is no body here and no raw MIME.
+/// </para>
+/// <para>
+/// The three flags are the states a row draws rather than the observation they came from. A message no synchronization
+/// run has read flags for reads as read, unflagged, and unanswered — which is what a folder still being backfilled
+/// shows, and why how current a copy is belongs to the mailbox tree rather than to a row here.
+/// </para>
+/// <para>
+/// All of it is this owner's own correspondence and carries the classification the root instructions put on mail: it is
+/// put in front of that owner alone, and it reaches no log, no telemetry, and no local store.
+/// </para>
+/// </remarks>
+public sealed record DeploymentMailMessage(
+    Guid Id,
+    string Account,
+    string Folder,
+    Guid? ThreadId,
+    string? Subject,
+    DateTimeOffset? ReceivedAt,
+    DateTimeOffset? SentAt,
+    string? SenderAddress,
+    string? SenderDisplayName,
+    IReadOnlyList<string> ToAddresses,
+    bool Unread,
+    bool Flagged,
+    bool Answered,
+    bool HasAttachments,
+    int AttachmentCount,
+    long SizeOctets,
+    string? Preview)
+{
+    /// <summary>Gets the recipients, reading a document that named none as a message addressed to nobody this row draws.</summary>
+    /// <remarks>
+    /// A missing member deserializes to <see langword="null" /> rather than to an empty list, and every reader wants the
+    /// same answer for the two. Said once here rather than at each reader, as the folders document already says it.
+    /// </remarks>
+    public IReadOnlyList<string> Recipients => this.ToAddresses ?? [];
+}

--- a/frontend/src/Client.Backend/Timeline/DeploymentMailTimelinePage.cs
+++ b/frontend/src/Client.Backend/Timeline/DeploymentMailTimelinePage.cs
@@ -1,0 +1,34 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Backend.Timeline;
+
+/// <summary>One page of the message list, and the cursors that continue it at either end.</summary>
+/// <param name="Emails">The rows, in the order the request asked the list to be sorted in.</param>
+/// <param name="NextCursor">The cursor the following page is asked with, or <see langword="null" /> at the end of the list.</param>
+/// <param name="PreviousCursor">The cursor the preceding page is asked with, or <see langword="null" /> at the beginning of the list.</param>
+/// <param name="PageSize">How many rows the read ran under, which is what the request asked for or the default it took.</param>
+/// <remarks>
+/// <para>
+/// Both cursors are holdable and neither is a position the deployment remembers, so a client may keep one while the
+/// screen is closed and continue from it afterwards — against a deployment that has restarted in between. An absent one
+/// is that end of the list having been reached rather than a hint to ask again.
+/// </para>
+/// <para>
+/// A page that came back empty carries no cursor at either end, because a cursor names a row and there is none. A
+/// client that reached an end keeps whatever it was holding rather than being handed something back.
+/// </para>
+/// </remarks>
+public sealed record DeploymentMailTimelinePage(
+    IReadOnlyList<DeploymentMailMessage> Emails,
+    string? NextCursor,
+    string? PreviousCursor,
+    int PageSize)
+{
+    /// <summary>A page that was never read, which is what a list holds before it has asked for anything.</summary>
+    public static DeploymentMailTimelinePage Nothing { get; } = new([], NextCursor: null, PreviousCursor: null, 0);
+
+    /// <summary>Gets the rows, reading a document that named none as a page that holds nothing.</summary>
+    public IReadOnlyList<DeploymentMailMessage> Rows => this.Emails ?? [];
+}

--- a/frontend/src/Client.Backend/Timeline/MailTimelineOrder.cs
+++ b/frontend/src/Client.Backend/Timeline/MailTimelineOrder.cs
@@ -1,0 +1,21 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Backend.Timeline;
+
+/// <summary>Which end of the message list leads.</summary>
+/// <remarks>
+/// The client's own copy of the two words the timeline route publishes, for the reason every wire record here is the
+/// client's own: the contract is the format rather than a type shared across the two stacks. A value is written onto
+/// the wire by <see cref="MailTimelineQuery" /> rather than by <see cref="Enum.ToString()" />, so renaming a member
+/// here cannot silently change what a request says.
+/// </remarks>
+public enum MailTimelineOrder
+{
+    /// <summary>The newest mail first, which is what a list nobody has reordered shows.</summary>
+    NewestFirst = 0,
+
+    /// <summary>The oldest mail first.</summary>
+    OldestFirst = 1,
+}

--- a/frontend/src/Client.Backend/Timeline/MailTimelinePageDirection.cs
+++ b/frontend/src/Client.Backend/Timeline/MailTimelinePageDirection.cs
@@ -1,0 +1,20 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Backend.Timeline;
+
+/// <summary>Which way a page continues from the cursor it is asked with.</summary>
+/// <remarks>
+/// Both directions read the same sorted list rather than two lists: a cursor names a row of that list together with
+/// the filters and the order it was read under, so a page collected while scrolling down is what a page read while
+/// scrolling back continues from.
+/// </remarks>
+public enum MailTimelinePageDirection
+{
+    /// <summary>The page lying after the cursor, which is what a request naming no direction takes.</summary>
+    Forward = 0,
+
+    /// <summary>The page lying before the cursor, which the deployment refuses without one.</summary>
+    Backward = 1,
+}

--- a/frontend/src/Client.Backend/Timeline/MailTimelineQuery.cs
+++ b/frontend/src/Client.Backend/Timeline/MailTimelineQuery.cs
@@ -1,0 +1,131 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Globalization;
+
+namespace MailFathom.Client.Backend.Timeline;
+
+/// <summary>One page of the message list, as this client asks for it.</summary>
+/// <remarks>
+/// <para>
+/// The place, what the list keeps, the order it is read in, and where the page continues from, in the one record a
+/// screen composes. A page is asked for by cursor rather than by number, so reading message forty thousand costs what
+/// reading message one costs and a screen that was left and returned to continues rather than starting over.
+/// </para>
+/// <para>
+/// A cursor names the row it was taken at <em>and</em> the list it was taken from, so a request that carries a cursor
+/// has to carry the same place, filters, and order the cursor was issued under — the deployment refuses the pair
+/// rather than quietly answering with the leading page. That is why all of it is one record: a screen that changed a
+/// filter and kept a cursor would be composing a request that cannot be served.
+/// </para>
+/// <para>
+/// Nothing here names what the list is sorted by. The route accepts one column and takes it where a request names
+/// none, so stating it would be this client asserting a value it has no second choice for.
+/// </para>
+/// </remarks>
+public sealed record MailTimelineQuery
+{
+    /// <summary>The account the list is drawn from, or <see langword="null" /> for every account the owner owns.</summary>
+    public string? Account { get; init; }
+
+    /// <summary>
+    /// The folder the list is drawn from — an alias, or a special-use role written as <c>role:Inbox</c> — or
+    /// <see langword="null" /> for every folder.
+    /// </summary>
+    /// <remarks>
+    /// The role form is what makes <em>sent</em> mean sent from any mailbox rather than one mailbox's own sent folder,
+    /// which is a narrowing the mailbox tree offers and no single alias expresses.
+    /// </remarks>
+    public string? Folder { get; init; }
+
+    /// <summary>Whether the junk folder takes part, which it does not unless a request asks.</summary>
+    public bool IncludeJunk { get; init; }
+
+    /// <summary>Keeps only unread mail, only read mail, or <see langword="null" /> for both.</summary>
+    public bool? Unread { get; init; }
+
+    /// <summary>Keeps only flagged mail, only unflagged mail, or <see langword="null" /> for both.</summary>
+    public bool? Flagged { get; init; }
+
+    /// <summary>Keeps only mail carrying attachments, only mail carrying none, or <see langword="null" /> for both.</summary>
+    public bool? HasAttachments { get; init; }
+
+    /// <summary>Which end of the list leads.</summary>
+    public MailTimelineOrder Order { get; init; } = MailTimelineOrder.NewestFirst;
+
+    /// <summary>Which way the page continues from <see cref="Cursor" />.</summary>
+    public MailTimelinePageDirection Direction { get; init; } = MailTimelinePageDirection.Forward;
+
+    /// <summary>How many rows the page may hold, or <see langword="null" /> for the deployment's own default.</summary>
+    public int? PageSize { get; init; }
+
+    /// <summary>The cursor a previous page returned, or <see langword="null" /> for the leading end of the list.</summary>
+    /// <remarks>A backward page without one is refused by the deployment, because there is no row to read away from.</remarks>
+    public string? Cursor { get; init; }
+
+    /// <summary>The word the wire carries for the newest-first order.</summary>
+    internal const string NewestFirstOrder = "newestFirst";
+
+    /// <summary>The word the wire carries for the oldest-first order.</summary>
+    internal const string OldestFirstOrder = "oldestFirst";
+
+    /// <summary>The word the wire carries for a page after its cursor.</summary>
+    internal const string ForwardDirection = "forward";
+
+    /// <summary>The word the wire carries for a page before its cursor.</summary>
+    internal const string BackwardDirection = "backward";
+
+    /// <summary>Writes this query as the query string the timeline route is asked with.</summary>
+    /// <returns>The query string, beginning with <c>?</c>, or an empty string where nothing is stated.</returns>
+    /// <remarks>
+    /// A value nobody stated is left out rather than sent empty. The route reads an empty parameter as an absent one,
+    /// so both spellings work — but a request that says only what it means is the one a reader of a log or a proxy can
+    /// tell apart from a request that narrowed to nothing on purpose.
+    /// </remarks>
+    internal string QueryString()
+    {
+        var stated = new List<string>(9);
+
+        Add(stated, "account", this.Account);
+        Add(stated, "folder", this.Folder);
+
+        if (this.IncludeJunk)
+        {
+            Add(stated, "includeJunk", Written(true));
+        }
+
+        Add(stated, "unread", Written(this.Unread));
+        Add(stated, "flagged", Written(this.Flagged));
+        Add(stated, "hasAttachments", Written(this.HasAttachments));
+        Add(stated, "order", Written(this.Order));
+        Add(stated, "direction", Written(this.Direction));
+        Add(stated, "pageSize", this.PageSize?.ToString(CultureInfo.InvariantCulture));
+        Add(stated, "cursor", this.Cursor);
+
+        return stated.Count is 0 ? string.Empty : $"?{string.Join('&', stated)}";
+    }
+
+    /// <summary>States one parameter, escaping the value for the query string it is written into.</summary>
+    /// <remarks>
+    /// A folder alias and a cursor are both values this client received rather than composed, and an alias is a name a
+    /// mail server chose — so neither may be written raw into a URL, whatever either happens to look like today.
+    /// </remarks>
+    private static void Add(List<string> stated, string name, string? value)
+    {
+        if (!string.IsNullOrEmpty(value))
+        {
+            stated.Add($"{name}={Uri.EscapeDataString(value)}");
+        }
+    }
+
+    private static string? Written(bool? kept) => kept is { } wanted ? Written(wanted) : null;
+
+    private static string Written(bool wanted) => wanted ? "true" : "false";
+
+    private static string Written(MailTimelineOrder order) =>
+        order is MailTimelineOrder.OldestFirst ? OldestFirstOrder : NewestFirstOrder;
+
+    private static string Written(MailTimelinePageDirection direction) =>
+        direction is MailTimelinePageDirection.Backward ? BackwardDirection : ForwardDirection;
+}

--- a/frontend/src/Client/App.xaml.cs
+++ b/frontend/src/Client/App.xaml.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using MailFathom.Client.Backend;
 using MailFathom.Client.Deployment;
 using MailFathom.Client.Presentation.Mailboxes;
+using MailFathom.Client.Presentation.Messages;
 using MailFathom.Client.Presentation.Settings;
 using MailFathom.Client.Presentation.Spaces;
 using MailFathom.Client.Presentation.Spaces.Mail;
@@ -96,6 +97,13 @@ public partial class App : Application
                     // is what makes starting the client again opening it rather than finding one's way back.
                     services.AddSingleton<IMailboxTreeMemory, LocalSettingsMailboxTreeMemory>();
                     services.AddSingleton<IMailboxTree, DeploymentMailboxTree>();
+
+                    // The mail that tree is narrowed to, on the same terms and for the same reason: a list held per
+                    // model would read the folder's first page again every time somebody moved between spaces, and
+                    // would forget how far they had scrolled while doing it. Where it was left outlives the run for
+                    // the place the tree reopens on, and outlives only the run for every other place it visited.
+                    services.AddSingleton<IMessageListMemory, LocalSettingsMessageListMemory>();
+                    services.AddSingleton<IMessageList, DeploymentMessageList>();
 
                     // What the deployment allows this caller, for the same reason and on the same terms. It is the
                     // one place that answers whether something may be offered, so every screen reads one answer

--- a/frontend/src/Client/Presentation/Messages/DeploymentMessageList.cs
+++ b/frontend/src/Client/Presentation/Messages/DeploymentMessageList.cs
@@ -1,0 +1,341 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Immutable;
+using MailFathom.Client.Backend;
+using MailFathom.Client.Backend.Timeline;
+using MailFathom.Client.Presentation.Workspace;
+using MailFathom.Client.Session;
+using Microsoft.Extensions.Localization;
+
+namespace MailFathom.Client.Presentation.Messages;
+
+/// <summary>The message list as one deployment pages it, and as one person left it.</summary>
+/// <remarks>
+/// <para>
+/// The list is read off the session and the workspace scope rather than beside them, which is one subscription and one
+/// act for the person: the session already asks the deployment again when the signed-in identity changes, when the
+/// client is pointed somewhere else, and when a lost connection comes back, and the list follows every one of those
+/// without a second timer, a second retry curve, or a second button. The root instructions refuse nested retry storms,
+/// and a list that retried on top of the session's own bounded attempts would be one.
+/// </para>
+/// <para>
+/// It reloads on the <em>place</em> rather than on the scope, and that is load-bearing rather than an optimization: the
+/// list writes what is selected back into the scope, so a list keyed on the whole scope would read a folder again every
+/// time somebody clicked a row in it.
+/// </para>
+/// <para>
+/// What is loaded is a bounded window over the timeline rather than everything that has been paged. Scrolling on takes
+/// a page and drops the far one, and scrolling back asks for the dropped one again — which is why the request that
+/// produced each page travels with it. The same value is what is written down when a folder is left, so returning is a
+/// continuation rather than a jump to the top.
+/// </para>
+/// </remarks>
+internal sealed class DeploymentMessageList : IMessageList
+{
+    /// <summary>How many rows one page holds.</summary>
+    /// <remarks>
+    /// Stated rather than left to the deployment's default, because the default is a tool's page size and this is a
+    /// screen's: a list drawn a screenful at a time is a request per flick of a scroll. It is within what the surface
+    /// accepts, and the window's own bound is what keeps the total loaded from following it upwards.
+    /// </remarks>
+    internal const int PageSize = 50;
+
+    private readonly DeploymentClient deployment;
+    private readonly IClientSession session;
+    private readonly IWorkspace workspace;
+    private readonly IMessageListMemory memory;
+    private readonly TimeProvider clock;
+    private readonly IStringLocalizer words;
+    private readonly IState<MessageListArrangement> arranged;
+    private readonly IState<int> asked;
+    private readonly IState<bool> pagingFailed;
+    private readonly IState<MessageWindow> loaded;
+
+    private MessagePlace? openedPlace;
+
+    /// <summary>Initializes the list over what serves it, where it is drawn from, and where it was left.</summary>
+    /// <param name="deployment">Where a page of the owner's mail is asked for.</param>
+    /// <param name="session">What the deployment allows this caller, and whether it can be reached at all.</param>
+    /// <param name="workspace">The scope the list is drawn from and the selection it writes back into.</param>
+    /// <param name="memory">Where the position and the arrangement outlive the folder being left and the run itself.</param>
+    /// <param name="clock">What a message's date is written relative to.</param>
+    /// <param name="words">Where the sentences a row is composed from come from.</param>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    public DeploymentMessageList(
+        DeploymentClient deployment,
+        IClientSession session,
+        IWorkspace workspace,
+        IMessageListMemory memory,
+        TimeProvider clock,
+        IStringLocalizer words)
+    {
+        ArgumentNullException.ThrowIfNull(deployment);
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(workspace);
+        ArgumentNullException.ThrowIfNull(memory);
+        ArgumentNullException.ThrowIfNull(clock);
+        ArgumentNullException.ThrowIfNull(words);
+
+        this.deployment = deployment;
+        this.session = session;
+        this.workspace = workspace;
+        this.memory = memory;
+        this.clock = clock;
+        this.words = words;
+
+        // Held as a state rather than read as the session's own feed, for the reason every other reader of it holds
+        // one: a feed is read from the start by whoever subscribes, and the projections below would otherwise each be
+        // a reader of their own.
+        var standing = State.FromFeed(this, session.Standing);
+
+        // The place rather than the scope, so a row being clicked is not a folder being opened again.
+        var place = workspace.Scope.Select(MessagePlace.Of);
+
+        this.arranged = State.Value(this, () => MessageListArrangement.Default);
+        this.pagingFailed = State.Value(this, () => false);
+
+        // Why a counter beside the two triggers above: a session that answers a second time with the same grant is one
+        // message MVUX does not republish, so a person pressing the button on a read that failed while the session was
+        // fine would otherwise press something that did nothing. Arranging the list differently reaches the read the
+        // same way, because a new arrangement invalidates every cursor held under the old one.
+        this.asked = State.Value(this, () => 0);
+
+        this.loaded = State.FromFeed(
+            this,
+            Feed.Combine(standing, place, this.asked).SelectAsync(this.OpenAsync));
+
+        this.Chosen = State<IImmutableList<MessageRow>>.Empty(this);
+        this.Rows = this.loaded.Select(this.Draw).AsListFeed().Selection(this.Chosen);
+        this.Arrangement = this.arranged;
+        this.HasMoreAfter = this.loaded.Select(static window => window.HasMoreAfter);
+        this.HasMoreBefore = this.loaded.Select(static window => window.HasMoreBefore);
+        this.PagingFailed = this.pagingFailed;
+
+        // What makes the selection the application's rather than the control's. MVUX owns the subscription's lifetime,
+        // so it ends with this instance.
+        this.Chosen.ForEach(this.NarrowAsync);
+    }
+
+    /// <inheritdoc />
+    public IListFeed<MessageRow> Rows { get; }
+
+    /// <inheritdoc />
+    public IState<IImmutableList<MessageRow>> Chosen { get; }
+
+    /// <inheritdoc />
+    public IFeed<MessageListArrangement> Arrangement { get; }
+
+    /// <inheritdoc />
+    public IFeed<bool> HasMoreAfter { get; }
+
+    /// <inheritdoc />
+    public IFeed<bool> HasMoreBefore { get; }
+
+    /// <inheritdoc />
+    public IFeed<bool> PagingFailed { get; }
+
+    /// <inheritdoc />
+    public ValueTask ShowMoreAsync(CancellationToken cancellationToken) =>
+        this.PageAsync(MailTimelinePageDirection.Forward, cancellationToken);
+
+    /// <inheritdoc />
+    public ValueTask ShowEarlierAsync(CancellationToken cancellationToken) =>
+        this.PageAsync(MailTimelinePageDirection.Backward, cancellationToken);
+
+    /// <inheritdoc />
+    public async ValueTask ArrangeAsync(
+        MessageListArrangement arrangement,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(arrangement);
+
+        await this.arranged.UpdateAsync(_ => arrangement, cancellationToken).ConfigureAwait(false);
+
+        await this.asked.UpdateAsync(static asked => asked + 1, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask AskAgainAsync(CancellationToken cancellationToken)
+    {
+        this.session.Refresh();
+
+        await this.asked.UpdateAsync(static asked => asked + 1, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Reads the first page of the place in force, once the session that decides whether it may be read has arrived.</summary>
+    /// <remarks>
+    /// Neither the standing nor the counter is read: what they are here for is when this runs rather than what it asks
+    /// for. Which page is read is the place's — a place somebody is arriving at reopens where it was left, and a place
+    /// they are already in is being read again on purpose and therefore from its leading end.
+    /// </remarks>
+    private async ValueTask<MessageWindow> OpenAsync(
+        (SessionStanding Standing, MessagePlace Place, int Asked) trigger,
+        CancellationToken cancellationToken)
+    {
+        var place = trigger.Place;
+        var arriving = !place.Equals(this.openedPlace);
+        var remembered = this.memory.Read(place.RememberedAs);
+
+        var arrangement = arriving
+            ? remembered.Arrangement
+            : await this.arranged.Value(cancellationToken).ConfigureAwait(false) ?? MessageListArrangement.Default;
+
+        this.openedPlace = place;
+
+        await this.arranged.UpdateAsync(_ => arrangement, cancellationToken).ConfigureAwait(false);
+        await this.pagingFailed.UpdateAsync(static _ => false, cancellationToken).ConfigureAwait(false);
+
+        var page = await this.ReopeningAsync(
+            place,
+            arrangement,
+            arriving ? remembered.Cursor : null,
+            arriving ? remembered.Direction : MailTimelinePageDirection.Forward,
+            cancellationToken).ConfigureAwait(false);
+
+        var window = MessageWindow.Opening(place, arrangement, page);
+
+        this.Remember(window);
+
+        return window;
+    }
+
+    /// <summary>Reads a page from a remembered cursor, falling back to the leading end where the cursor is refused.</summary>
+    /// <remarks>
+    /// A cursor names the list it was taken from, so one written down under an arrangement this deployment no longer
+    /// serves the same way — a folder re-indexed, a version that orders differently — is refused rather than honoured.
+    /// That is a position to give up rather than an error to show: nobody typed it, and the list somebody asked for
+    /// still exists. Only a cursor is retried this way, because it is the only value here this client did not compose.
+    /// </remarks>
+    private async ValueTask<MessagePage> ReopeningAsync(
+        MessagePlace place,
+        MessageListArrangement arrangement,
+        string? cursor,
+        MailTimelinePageDirection direction,
+        CancellationToken cancellationToken)
+    {
+        if (cursor is null)
+        {
+            // Forward rather than the direction handed in: a read from the leading end has no row to read away from,
+            // which the deployment refuses rather than answers, and the pair is only ever remembered together.
+            return await this.ReadAsync(
+                place,
+                arrangement,
+                cursor: null,
+                MailTimelinePageDirection.Forward,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        try
+        {
+            return await this.ReadAsync(place, arrangement, cursor, direction, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (DeploymentFailure refusal) when (refusal.Reason is DeploymentFailureReason.RequestRefused)
+        {
+            return await this.ReadAsync(
+                place,
+                arrangement,
+                cursor: null,
+                MailTimelinePageDirection.Forward,
+                cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>Asks the deployment for one page and keeps the request that produced it.</summary>
+    private async ValueTask<MessagePage> ReadAsync(
+        MessagePlace place,
+        MessageListArrangement arrangement,
+        string? cursor,
+        MailTimelinePageDirection direction,
+        CancellationToken cancellationToken)
+    {
+        var answered = await this.deployment.ReadMailTimelineAsync(
+            arrangement.QueryFor(place, cursor, direction, PageSize),
+            cancellationToken).ConfigureAwait(false);
+
+        return MessagePage.Of(answered, cursor, direction);
+    }
+
+    /// <summary>Takes one more page onto the window at the end being scrolled towards.</summary>
+    /// <remarks>
+    /// A page that did not arrive is reported beside the list rather than as the list's own failure, because what is
+    /// already drawn is still true: putting the whole list into an error state would take a folder's worth of mail off
+    /// the screen over one request.
+    /// </remarks>
+    private async ValueTask PageAsync(
+        MailTimelinePageDirection direction,
+        CancellationToken cancellationToken)
+    {
+        if (await this.loaded.Value(cancellationToken).ConfigureAwait(false) is not { } window)
+        {
+            return;
+        }
+
+        var cursor = direction is MailTimelinePageDirection.Forward
+            ? window.ForwardCursor
+            : window.BackwardCursor;
+
+        if (cursor is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var page = await this.ReadAsync(window.Place, window.Arrangement, cursor, direction, cancellationToken)
+                .ConfigureAwait(false);
+
+            await this.loaded.UpdateAsync(
+                loaded => loaded?.Extended(page, direction, window.Place, window.Arrangement),
+                cancellationToken).ConfigureAwait(false);
+
+            await this.pagingFailed.UpdateAsync(static _ => false, cancellationToken).ConfigureAwait(false);
+        }
+        catch (DeploymentFailure)
+        {
+            await this.pagingFailed.UpdateAsync(static _ => true, cancellationToken).ConfigureAwait(false);
+
+            return;
+        }
+
+        if (await this.loaded.Value(cancellationToken).ConfigureAwait(false) is { } extended)
+        {
+            this.Remember(extended);
+        }
+    }
+
+    /// <summary>Writes what is selected in the list into the scope every other space reads.</summary>
+    /// <remarks>
+    /// The scope's own place is left exactly as it was: what a selection changes is what is selected, and rewriting the
+    /// account or the folder from here would be the list telling the tree where somebody is.
+    /// </remarks>
+    private async ValueTask NarrowAsync(
+        IImmutableList<MessageRow>? chosen,
+        CancellationToken cancellationToken)
+    {
+        IImmutableList<string> selected = [.. (chosen ?? []).Select(static row => row.Key)];
+
+        await this.workspace.Scope.UpdateAsync(
+            scope => (scope ?? WorkspaceScope.Everything) with { Selection = selected },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Keeps where the list is, which is the request that reopens its leading page.</summary>
+    private void Remember(MessageWindow window) => this.memory.Write(
+        new RememberedMessageList(
+            window.Place.RememberedAs,
+            window.LeadingPage?.ReadCursor,
+            window.LeadingPage?.ReadDirection ?? MailTimelinePageDirection.Forward,
+            window.Arrangement));
+
+    private IImmutableList<MessageRow> Draw(MessageWindow window) =>
+        MessageListShape.Of(
+
+            // One instant for the whole list rather than one per row, so two messages that arrived together are never
+            // dated as having arrived on different days.
+            window,
+            this.clock.GetUtcNow(),
+            this.words);
+}

--- a/frontend/src/Client/Presentation/Messages/DeploymentMessageList.cs
+++ b/frontend/src/Client/Presentation/Messages/DeploymentMessageList.cs
@@ -266,10 +266,11 @@ internal sealed class DeploymentMessageList : IMessageList
     /// the screen over one request.
     /// </para>
     /// <para>
-    /// Everything the read says afterwards is said about the window it was started for, so each of them is written only
-    /// while that is still the window loaded. A request in flight when somebody opens another folder is answered by a
-    /// list that has already reopened and cleared its own indicator, and letting the abandoned read finish onto it
-    /// would clear a failure it never saw or raise one over mail that arrived.
+    /// Everything the read says afterwards is said about the reading it was started during, so each of them is written
+    /// only while that reading is still the one loaded. A request in flight when somebody opens another folder — or asks
+    /// for this one to be read again — is answered by a list that has already opened afresh, and letting the abandoned
+    /// read finish onto it would splice a page onto a window that holds nothing of it, or move an indicator over a
+    /// reading it never saw.
     /// </para>
     /// </remarks>
     private async ValueTask PageAsync(
@@ -308,7 +309,7 @@ internal sealed class DeploymentMessageList : IMessageList
         }
 
         await this.loaded.UpdateAsync(
-            loaded => loaded?.Extended(page, direction, window.Place, window.Arrangement),
+            loaded => loaded?.Extended(page, direction, window),
             cancellationToken).ConfigureAwait(false);
 
         if (await this.StillLoadedAsync(window, cancellationToken).ConfigureAwait(false) is not { } extended)
@@ -331,7 +332,7 @@ internal sealed class DeploymentMessageList : IMessageList
     {
         var current = await this.loaded.Value(cancellationToken).ConfigureAwait(false);
 
-        return current?.IsOf(window.Place, window.Arrangement) is true ? current : null;
+        return current?.IsOf(window) is true ? current : null;
     }
 
     /// <summary>Writes what is selected in the list into the scope every other space reads.</summary>

--- a/frontend/src/Client/Presentation/Messages/DeploymentMessageList.cs
+++ b/frontend/src/Client/Presentation/Messages/DeploymentMessageList.cs
@@ -260,9 +260,17 @@ internal sealed class DeploymentMessageList : IMessageList
 
     /// <summary>Takes one more page onto the window at the end being scrolled towards.</summary>
     /// <remarks>
+    /// <para>
     /// A page that did not arrive is reported beside the list rather than as the list's own failure, because what is
     /// already drawn is still true: putting the whole list into an error state would take a folder's worth of mail off
     /// the screen over one request.
+    /// </para>
+    /// <para>
+    /// Everything the read says afterwards is said about the window it was started for, so each of them is written only
+    /// while that is still the window loaded. A request in flight when somebody opens another folder is answered by a
+    /// list that has already reopened and cleared its own indicator, and letting the abandoned read finish onto it
+    /// would clear a failure it never saw or raise one over mail that arrived.
+    /// </para>
     /// </remarks>
     private async ValueTask PageAsync(
         MailTimelinePageDirection direction,
@@ -282,28 +290,48 @@ internal sealed class DeploymentMessageList : IMessageList
             return;
         }
 
+        MessagePage page;
+
         try
         {
-            var page = await this.ReadAsync(window.Place, window.Arrangement, cursor, direction, cancellationToken)
+            page = await this.ReadAsync(window.Place, window.Arrangement, cursor, direction, cancellationToken)
                 .ConfigureAwait(false);
-
-            await this.loaded.UpdateAsync(
-                loaded => loaded?.Extended(page, direction, window.Place, window.Arrangement),
-                cancellationToken).ConfigureAwait(false);
-
-            await this.pagingFailed.UpdateAsync(static _ => false, cancellationToken).ConfigureAwait(false);
         }
         catch (DeploymentFailure)
         {
-            await this.pagingFailed.UpdateAsync(static _ => true, cancellationToken).ConfigureAwait(false);
+            if (await this.StillLoadedAsync(window, cancellationToken).ConfigureAwait(false) is not null)
+            {
+                await this.pagingFailed.UpdateAsync(static _ => true, cancellationToken).ConfigureAwait(false);
+            }
 
             return;
         }
 
-        if (await this.loaded.Value(cancellationToken).ConfigureAwait(false) is { } extended)
+        await this.loaded.UpdateAsync(
+            loaded => loaded?.Extended(page, direction, window.Place, window.Arrangement),
+            cancellationToken).ConfigureAwait(false);
+
+        if (await this.StillLoadedAsync(window, cancellationToken).ConfigureAwait(false) is not { } extended)
         {
-            this.Remember(extended);
+            return;
         }
+
+        await this.pagingFailed.UpdateAsync(static _ => false, cancellationToken).ConfigureAwait(false);
+
+        this.Remember(extended);
+    }
+
+    /// <summary>Reads the loaded window back, where it is still of the list a read was started for.</summary>
+    /// <param name="window">The window that read was started from.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The window loaded now, or <see langword="null" /> where the list has moved on to another one.</returns>
+    private async ValueTask<MessageWindow?> StillLoadedAsync(
+        MessageWindow window,
+        CancellationToken cancellationToken)
+    {
+        var current = await this.loaded.Value(cancellationToken).ConfigureAwait(false);
+
+        return current?.IsOf(window.Place, window.Arrangement) is true ? current : null;
     }
 
     /// <summary>Writes what is selected in the list into the scope every other space reads.</summary>

--- a/frontend/src/Client/Presentation/Messages/IMessageList.cs
+++ b/frontend/src/Client/Presentation/Messages/IMessageList.cs
@@ -1,0 +1,75 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Immutable;
+
+namespace MailFathom.Client.Presentation.Messages;
+
+/// <summary>The one message list a run has, drawn from wherever the mailbox tree says somebody is.</summary>
+/// <remarks>
+/// <para>
+/// One for the run rather than one per screen, for the reason the tree and the workspace are: a model is built and
+/// discarded as its view is navigated to and away from, so a list each screen kept would forget where it had scrolled
+/// the moment somebody moved between spaces — and would ask the deployment for the same page again while doing it.
+/// </para>
+/// <para>
+/// What is selected here is the workspace's scope rather than a state of this list's own. The product's <em>select and
+/// ask</em> gesture is the whole reason: a question asked about four messages is asked about whatever the scope says is
+/// selected, so a selection only the list knew about would be a selection nothing else could act on.
+/// </para>
+/// </remarks>
+public interface IMessageList
+{
+    /// <summary>The loaded lines of the list, in the order it is read in.</summary>
+    /// <remarks>
+    /// A list feed rather than a feed of a list, so the three states this genuinely has are the framework's rather than
+    /// each one remembered by a view: the page under way, the read that failed, and the place holding no mail to draw.
+    /// </remarks>
+    IListFeed<MessageRow> Rows { get; }
+
+    /// <summary>What is selected in the list, which the workspace scope is written from.</summary>
+    /// <remarks>
+    /// Held as a state the selector writes rather than as something composed from clicks, because a multi-selection is
+    /// the platform's own gesture — the modifiers, the range, the drag, and the touch selection mode all belong to the
+    /// control, and a list that reimplemented them would feel like neither platform.
+    /// </remarks>
+    IState<IImmutableList<MessageRow>> Chosen { get; }
+
+    /// <summary>The order the list is read in and what it keeps, as the controls offering both are drawn from.</summary>
+    IFeed<MessageListArrangement> Arrangement { get; }
+
+    /// <summary>Whether there is more mail after what is loaded.</summary>
+    IFeed<bool> HasMoreAfter { get; }
+
+    /// <summary>Whether there is more mail before what is loaded, which there is once the window has moved on.</summary>
+    IFeed<bool> HasMoreBefore { get; }
+
+    /// <summary>Whether the last attempt to take another page did not arrive.</summary>
+    /// <remarks>Its own answer rather than the list's error state, because a page that failed leaves what is already drawn on the screen — putting the whole list into an error would take a folder's worth of mail away over one request.</remarks>
+    IFeed<bool> PagingFailed { get; }
+
+    /// <summary>Takes the next page onto the end of what is loaded.</summary>
+    /// <param name="cancellationToken">Abandons the page.</param>
+    /// <returns>A task completing once the page has arrived or the attempt has been reported.</returns>
+    ValueTask ShowMoreAsync(CancellationToken cancellationToken);
+
+    /// <summary>Takes the previous page back onto the start of what is loaded.</summary>
+    /// <param name="cancellationToken">Abandons the page.</param>
+    /// <returns>A task completing once the page has arrived or the attempt has been reported.</returns>
+    /// <remarks>What the window being bounded costs and what makes it affordable: the pages scrolled past are asked for again rather than kept.</remarks>
+    ValueTask ShowEarlierAsync(CancellationToken cancellationToken);
+
+    /// <summary>Reads the list again under a different order or different filters.</summary>
+    /// <param name="arrangement">How the list is to be arranged.</param>
+    /// <param name="cancellationToken">Abandons the change.</param>
+    /// <returns>A task completing once the list is being read again.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="arrangement" /> is <see langword="null" />.</exception>
+    /// <remarks>Every cursor held under the old arrangement names a list that no longer exists, so the list is read from its leading end rather than continued.</remarks>
+    ValueTask ArrangeAsync(MessageListArrangement arrangement, CancellationToken cancellationToken);
+
+    /// <summary>Asks the deployment again, which is what a person presses when the list did not arrive.</summary>
+    /// <param name="cancellationToken">Abandons the ask.</param>
+    /// <returns>A task completing once the ask has been made.</returns>
+    ValueTask AskAgainAsync(CancellationToken cancellationToken);
+}

--- a/frontend/src/Client/Presentation/Messages/IMessageListMemory.cs
+++ b/frontend/src/Client/Presentation/Messages/IMessageListMemory.cs
@@ -1,0 +1,37 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Presentation.Messages;
+
+/// <summary>Where a message list's position and arrangement outlive both the folder being left and the run itself.</summary>
+/// <remarks>
+/// <para>
+/// A seam for the reason the mailbox tree's memory is one: what is behind it is a platform store no unit test can
+/// reach, while everything decided around it is ordinary logic that ought to be tested.
+/// </para>
+/// <para>
+/// Two lifetimes rather than one, which is what makes this its own interface instead of a second call on the tree's.
+/// Moving between folders and back has to return to each of them, so the run remembers several places; a restart has to
+/// return to the one somebody was in, which is the one the tree reopens on, so a store that kept every place a run
+/// visited would be growing a list of a person's folders on their disk for a value only one of them will be read from.
+/// </para>
+/// <para>
+/// What is written is a cursor, a folder alias, an account identifier, and a role — mail metadata, and therefore
+/// personal data. It is kept where the platform keeps one person's own preferences, on that person's own device, and it
+/// is never sent anywhere, logged, or put in telemetry.
+/// </para>
+/// </remarks>
+public interface IMessageListMemory
+{
+    /// <summary>Reads where a place was left.</summary>
+    /// <param name="placeKey">The place, as <see cref="MessagePlace.RememberedAs" /> composes it.</param>
+    /// <returns>What was remembered, or <see cref="RememberedMessageList.Nothing" /> where nothing was or what was kept is no longer readable.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="placeKey" /> is <see langword="null" /> or empty.</exception>
+    RememberedMessageList Read(string placeKey);
+
+    /// <summary>Keeps where a place is now.</summary>
+    /// <param name="remembered">The position and arrangement to keep.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="remembered" /> is <see langword="null" />.</exception>
+    void Write(RememberedMessageList remembered);
+}

--- a/frontend/src/Client/Presentation/Messages/LocalSettingsMessageListMemory.cs
+++ b/frontend/src/Client/Presentation/Messages/LocalSettingsMessageListMemory.cs
@@ -1,0 +1,179 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Backend.Timeline;
+
+namespace MailFathom.Client.Presentation.Messages;
+
+/// <summary>Keeps a list's position for the run, and the one somebody is in for the next one.</summary>
+/// <remarks>
+/// <para>
+/// <see cref="ApplicationData.LocalSettings" /> for the place that outlives the process, for the reason the mailbox
+/// tree's arrangement is kept there: every head already has one and each maps it to what that platform actually uses —
+/// a per-user preferences store on a desktop and the browser's own storage for the page's origin in the browser head.
+/// </para>
+/// <para>
+/// Every other place a run visited is kept in <see cref="VisitedPlaces" /> and nowhere else. Moving between two
+/// folders has to return to each of them, which needs several places; starting the client again returns to the one the
+/// tree reopens on, which needs one. That split is the whole reason this type composes the two rather than being one
+/// of them.
+/// </para>
+/// <para>
+/// The persisted values are written as plain text rather than as anything serialized, because a settings store holds
+/// simple values and the browser head publishes trimmed. An entry that is no longer readable is treated as nothing
+/// having been remembered, which is the same answer a first run gives and is never a failure to start — and a cursor a
+/// deployment no longer honours is refused by that deployment rather than judged here, which is why nothing below
+/// inspects one.
+/// </para>
+/// </remarks>
+internal sealed class LocalSettingsMessageListMemory : IMessageListMemory
+{
+    /// <summary>The name the place the persisted entry belongs to is kept under.</summary>
+    /// <remarks>Qualified, because the container is shared with every other setting this application and its framework keep.</remarks>
+    internal const string PlaceSettingName = "MailFathom.Messages.Place";
+
+    /// <summary>The name the cursor the list reopens at is kept under.</summary>
+    internal const string CursorSettingName = "MailFathom.Messages.Cursor";
+
+    /// <summary>The name the direction that cursor is asked in is kept under.</summary>
+    internal const string DirectionSettingName = "MailFathom.Messages.Direction";
+
+    /// <summary>The name the order the list is read in is kept under.</summary>
+    internal const string OrderSettingName = "MailFathom.Messages.Order";
+
+    /// <summary>The name the filters the list keeps are kept under, as one entry.</summary>
+    internal const string KeepsSettingName = "MailFathom.Messages.Keeps";
+
+    private const string NewestFirst = "newestFirst";
+    private const string OldestFirst = "oldestFirst";
+    private const string Forward = "forward";
+    private const string Backward = "backward";
+    private const string KeepsUnread = "unread";
+    private const string KeepsFlagged = "flagged";
+    private const string KeepsAttachments = "attachments";
+    private const string KeepsJunk = "junk";
+    private const char KeepsSeparator = ' ';
+
+    private readonly VisitedPlaces visited = new();
+
+    /// <inheritdoc />
+    public RememberedMessageList Read(string placeKey)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(placeKey);
+
+        return this.visited.Read(placeKey) ?? Persisted(placeKey) ?? RememberedMessageList.Nothing(placeKey);
+    }
+
+    /// <inheritdoc />
+    public void Write(RememberedMessageList remembered)
+    {
+        ArgumentNullException.ThrowIfNull(remembered);
+
+        this.visited.Keep(remembered);
+
+        Persist(remembered);
+    }
+
+    /// <summary>Writes the filters as one value, in a form a reader of the store can tell apart from a cursor.</summary>
+    /// <param name="arrangement">What the list keeps.</param>
+    /// <returns>The filters as one entry, empty where the list keeps everything.</returns>
+    internal static string JoinedKeeps(MessageListArrangement arrangement)
+    {
+        ArgumentNullException.ThrowIfNull(arrangement);
+
+        var kept = new List<string>(4);
+
+        if (arrangement.UnreadOnly)
+        {
+            kept.Add(KeepsUnread);
+        }
+
+        if (arrangement.FlaggedOnly)
+        {
+            kept.Add(KeepsFlagged);
+        }
+
+        if (arrangement.WithAttachmentsOnly)
+        {
+            kept.Add(KeepsAttachments);
+        }
+
+        if (arrangement.IncludeJunk)
+        {
+            kept.Add(KeepsJunk);
+        }
+
+        return string.Join(KeepsSeparator, kept);
+    }
+
+    /// <summary>Reads the arrangement back out of the two values it was written as.</summary>
+    /// <param name="order">What the order was written as, or <see langword="null" /> where nothing was written.</param>
+    /// <param name="keeps">What the filters were written as, or <see langword="null" /> where nothing was.</param>
+    /// <returns>The arrangement, taking the default for anything the store did not answer.</returns>
+    /// <remarks>
+    /// A closed mapping rather than <see cref="Enum.TryParse{TEnum}(string, bool, out TEnum)" />, which would also read
+    /// a number and a comma-separated list as members — neither of which anything here ever wrote.
+    /// </remarks>
+    internal static MessageListArrangement ArrangementOf(string? order, string? keeps)
+    {
+        var kept = keeps?.Split(KeepsSeparator, StringSplitOptions.RemoveEmptyEntries) ?? [];
+
+        return new MessageListArrangement
+        {
+            Order = string.Equals(order, OldestFirst, StringComparison.Ordinal)
+                ? MailTimelineOrder.OldestFirst
+                : MailTimelineOrder.NewestFirst,
+            UnreadOnly = kept.Contains(KeepsUnread, StringComparer.Ordinal),
+            FlaggedOnly = kept.Contains(KeepsFlagged, StringComparer.Ordinal),
+            WithAttachmentsOnly = kept.Contains(KeepsAttachments, StringComparer.Ordinal),
+            IncludeJunk = kept.Contains(KeepsJunk, StringComparer.Ordinal),
+        };
+    }
+
+    /// <summary>Reads what the store holds, where it holds it for the place being asked about.</summary>
+    private static RememberedMessageList? Persisted(string placeKey) =>
+        string.Equals(Kept(PlaceSettingName), placeKey, StringComparison.Ordinal)
+            ? new RememberedMessageList(
+                placeKey,
+                Kept(CursorSettingName),
+                string.Equals(Kept(DirectionSettingName), Backward, StringComparison.Ordinal)
+                    ? MailTimelinePageDirection.Backward
+                    : MailTimelinePageDirection.Forward,
+                ArrangementOf(Kept(OrderSettingName), Kept(KeepsSettingName)))
+            : null;
+
+    private static void Persist(RememberedMessageList remembered)
+    {
+        Keep(PlaceSettingName, remembered.PlaceKey);
+        Keep(CursorSettingName, remembered.Cursor);
+        Keep(
+            DirectionSettingName,
+            remembered.Direction is MailTimelinePageDirection.Backward ? Backward : Forward);
+        Keep(
+            OrderSettingName,
+            remembered.Arrangement.Order is MailTimelineOrder.OldestFirst ? OldestFirst : NewestFirst);
+        Keep(KeepsSettingName, JoinedKeeps(remembered.Arrangement));
+    }
+
+    private static string? Kept(string name) =>
+        ApplicationData.Current.LocalSettings.Values.TryGetValue(name, out var kept) && kept is string written
+        && !string.IsNullOrEmpty(written)
+            ? written
+            : null;
+
+    /// <summary>Keeps a value, removing the entry rather than writing an empty one where there is nothing to keep.</summary>
+    private static void Keep(string name, string? value)
+    {
+        var settings = ApplicationData.Current.LocalSettings.Values;
+
+        if (string.IsNullOrEmpty(value))
+        {
+            settings.Remove(name);
+
+            return;
+        }
+
+        settings[name] = value;
+    }
+}

--- a/frontend/src/Client/Presentation/Messages/MessageListArrangement.cs
+++ b/frontend/src/Client/Presentation/Messages/MessageListArrangement.cs
@@ -1,0 +1,85 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Backend.Timeline;
+
+namespace MailFathom.Client.Presentation.Messages;
+
+/// <summary>How a message list is arranged: the order it is read in, and what it keeps.</summary>
+/// <remarks>
+/// <para>
+/// One record rather than five properties spread over a model, because it is one thing on screen and one thing in a
+/// request: a cursor names the list it was taken from, so changing any part of this invalidates every cursor held
+/// under it and the list is read again from its leading end. Keeping the parts together is what makes that one
+/// decision rather than five places to remember it.
+/// </para>
+/// <para>
+/// It is remembered with the place rather than for the application, because how somebody reads their inbox and how
+/// they read an archive are different questions. A place nobody has arranged reads newest first and keeps everything,
+/// which is what a mail client does before it is told otherwise.
+/// </para>
+/// </remarks>
+public sealed record MessageListArrangement
+{
+    /// <summary>How a list nobody has arranged is read.</summary>
+    public static MessageListArrangement Default { get; } = new();
+
+    /// <summary>Which end of the list leads.</summary>
+    public MailTimelineOrder Order { get; init; } = MailTimelineOrder.NewestFirst;
+
+    /// <summary>Whether only unread mail is kept.</summary>
+    public bool UnreadOnly { get; init; }
+
+    /// <summary>Whether only flagged mail is kept.</summary>
+    public bool FlaggedOnly { get; init; }
+
+    /// <summary>Whether only mail carrying an attachment is kept.</summary>
+    public bool WithAttachmentsOnly { get; init; }
+
+    /// <summary>Whether junk mail takes part where the place would otherwise leave it out.</summary>
+    public bool IncludeJunk { get; init; }
+
+    /// <summary>Gets whether the list is read oldest first, which is what the control offering the order is bound to.</summary>
+    /// <remarks>Stated as its own affirmative rather than read backwards from the order, so a two-way binding has a boolean to write and nothing has to invert one.</remarks>
+    public bool OldestFirst => this.Order is MailTimelineOrder.OldestFirst;
+
+    /// <summary>Gets whether anything here narrows the list, which is what the indicator on the filter control is shown on.</summary>
+    public bool KeepsLessThanEverything =>
+        this.UnreadOnly || this.FlaggedOnly || this.WithAttachmentsOnly || this.IncludeJunk;
+
+    /// <summary>Composes the request one page of this list is asked for with.</summary>
+    /// <param name="place">Where the list is drawn from.</param>
+    /// <param name="cursor">The cursor the page continues from, or <see langword="null" /> for the leading end.</param>
+    /// <param name="direction">Which way the page continues from that cursor.</param>
+    /// <param name="pageSize">How many rows the page may hold.</param>
+    /// <returns>The query.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="place" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// A filter that keeps everything is left unstated rather than sent as "both", so a request says what somebody
+    /// narrowed and nothing else. The role a place names is written as the folder, because a special-use role taken
+    /// across mailboxes is a folder reference on this surface rather than a parameter of its own.
+    /// </remarks>
+    public MailTimelineQuery QueryFor(
+        MessagePlace place,
+        string? cursor,
+        MailTimelinePageDirection direction,
+        int pageSize)
+    {
+        ArgumentNullException.ThrowIfNull(place);
+
+        return new MailTimelineQuery
+        {
+            Account = place.Account,
+            Folder = place.Role is { } role ? $"role:{role}" : place.Folder,
+            IncludeJunk = this.IncludeJunk || place.IsChosenFolder,
+            Unread = this.UnreadOnly ? true : null,
+            Flagged = this.FlaggedOnly ? true : null,
+            HasAttachments = this.WithAttachmentsOnly ? true : null,
+            Order = this.Order,
+            Direction = direction,
+            PageSize = pageSize,
+            Cursor = cursor,
+        };
+    }
+}

--- a/frontend/src/Client/Presentation/Messages/MessageListShape.cs
+++ b/frontend/src/Client/Presentation/Messages/MessageListShape.cs
@@ -1,0 +1,171 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Immutable;
+using System.Globalization;
+using MailFathom.Client.Backend.Timeline;
+using Microsoft.Extensions.Localization;
+
+namespace MailFathom.Client.Presentation.Messages;
+
+/// <summary>Reduces a loaded window of mail to the lines the list draws.</summary>
+/// <remarks>
+/// <para>
+/// A pure reduction of what the deployment answered, where the place puts a correspondent, when the reading is
+/// happening, and the words the application is read in — so the whole of what a row says is reachable by an ordinary
+/// unit test rather than only by looking at a running head.
+/// </para>
+/// <para>
+/// It composes rather than formats in the view for the reason the mailbox tree does: a binding cannot choose between a
+/// time and a date, cannot stand a sentence in for a subject nobody wrote, and cannot compose the one line a screen
+/// reader is given instead of the six controls a sighted reader sees.
+/// </para>
+/// </remarks>
+internal static class MessageListShape
+{
+    /// <summary>Draws the loaded window as the list's rows.</summary>
+    /// <param name="window">What has been loaded, in the order the list is read in.</param>
+    /// <param name="now">When the reading is happening, which is what decides whether a message is dated by its time or by its day.</param>
+    /// <param name="words">Where the sentences a row is composed from come from.</param>
+    /// <returns>The rows, in the order the list is read in.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    internal static IImmutableList<MessageRow> Of(
+        MessageWindow window,
+        DateTimeOffset now,
+        IStringLocalizer words)
+    {
+        ArgumentNullException.ThrowIfNull(window);
+        ArgumentNullException.ThrowIfNull(words);
+
+        return [.. window.Messages.Select(message => Draw(message, window.Place, now, words))];
+    }
+
+    /// <summary>Draws one message as the line the list shows for it.</summary>
+    private static MessageRow Draw(
+        DeploymentMailMessage message,
+        MessagePlace place,
+        DateTimeOffset now,
+        IStringLocalizer words)
+    {
+        var correspondent = Correspondent(message, place, words);
+        var subject = string.IsNullOrWhiteSpace(message.Subject) ? words[MessageWords.NoSubjectKey].Value : message.Subject;
+        var received = Received(message.ReceivedAt, now, words);
+
+        return new MessageRow(
+            message.Id.ToString("D", CultureInfo.InvariantCulture),
+            correspondent,
+            subject,
+            message.Preview ?? string.Empty,
+            received,
+            Announced(correspondent, subject, received, message, words),
+            message.Unread,
+            message.Flagged,
+            message.Answered,
+            message.HasAttachments,
+            message.AttachmentCount);
+    }
+
+    /// <summary>Names who the message is with, which is not the same question in a sent folder as in an inbox.</summary>
+    /// <remarks>
+    /// The display name the sender wrote is preferred over their address, because it is what a person recognizes and
+    /// what every mail client shows. A message with neither is drawn under a sentence rather than under a blank, since
+    /// a row with nothing in that column reads as a row that failed to load.
+    /// </remarks>
+    private static string Correspondent(
+        DeploymentMailMessage message,
+        MessagePlace place,
+        IStringLocalizer words) =>
+        place.ShowsRecipients
+            ? Recipients(message.Recipients, words)
+            : Named(message.SenderDisplayName, message.SenderAddress) ?? Recipients(message.Recipients, words);
+
+    /// <summary>Names the recipients as the first of them beside how many others there are.</summary>
+    private static string Recipients(IReadOnlyList<string> recipients, IStringLocalizer words) => recipients switch
+    {
+        [] => words[MessageWords.NoSenderKey].Value,
+        [var only] => only,
+        [var first, ..] => words[MessageWords.MoreRecipientsKey, first, recipients.Count - 1].Value,
+    };
+
+    /// <summary>Takes the display name where the header carried one and the address otherwise.</summary>
+    private static string? Named(string? displayName, string? address) =>
+        string.IsNullOrWhiteSpace(displayName)
+            ? (string.IsNullOrWhiteSpace(address) ? null : address)
+            : displayName;
+
+    /// <summary>
+    /// Writes when the message arrived: its time on the day it arrived, its day and month within the year, and its
+    /// whole date before that.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The three bands are what a mail list has always shown, and each is written with the reader's own culture rather
+    /// than with a pattern this application invented — a date is one of the few things every language writes
+    /// differently and nobody has to be taught.
+    /// </para>
+    /// <para>
+    /// Both instants are read in the reader's own time zone before their days are compared, because "today" is a
+    /// question about where the reader is rather than about the offset a mail server wrote into a header.
+    /// </para>
+    /// </remarks>
+    private static string Received(DateTimeOffset? receivedAt, DateTimeOffset now, IStringLocalizer words)
+    {
+        if (receivedAt is not { } arrived)
+        {
+            return words[MessageWords.NoDateKey].Value;
+        }
+
+        var local = arrived.ToLocalTime();
+        var today = now.ToLocalTime();
+
+        if (local.Date == today.Date)
+        {
+            return local.ToString("t", CultureInfo.CurrentCulture);
+        }
+
+        return local.Year == today.Year
+            ? local.ToString("m", CultureInfo.CurrentCulture)
+            : local.ToString("d", CultureInfo.CurrentCulture);
+    }
+
+    /// <summary>Composes the one sentence a screen reader is given for the row.</summary>
+    /// <remarks>
+    /// A list of six unlabelled controls per row is what a screen reader would otherwise read out fifty times over, so
+    /// the row states itself once and the controls inside it are drawn rather than announced. The three flags and the
+    /// attachment are appended rather than folded into the sentence, because each is absent from most rows.
+    /// </remarks>
+    private static string Announced(
+        string correspondent,
+        string subject,
+        string received,
+        DeploymentMailMessage message,
+        IStringLocalizer words)
+    {
+        var announced = words[MessageWords.AnnouncementKey, correspondent, subject, received].Value;
+
+        var marks = new List<string>(4);
+
+        if (message.Unread)
+        {
+            marks.Add(words[MessageWords.UnreadKey].Value);
+        }
+
+        if (message.Flagged)
+        {
+            marks.Add(words[MessageWords.FlaggedKey].Value);
+        }
+
+        if (message.Answered)
+        {
+            marks.Add(words[MessageWords.AnsweredKey].Value);
+        }
+
+        if (message.HasAttachments)
+        {
+            marks.Add(words[MessageWords.AttachmentsKey].Value);
+        }
+
+        return marks.Count is 0 ? announced : $"{announced} {string.Join(' ', marks)}";
+    }
+}

--- a/frontend/src/Client/Presentation/Messages/MessagePage.cs
+++ b/frontend/src/Client/Presentation/Messages/MessagePage.cs
@@ -1,0 +1,63 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Immutable;
+using MailFathom.Client.Backend.Timeline;
+
+namespace MailFathom.Client.Presentation.Messages;
+
+/// <summary>One page a deployment answered with, together with the request that produced it.</summary>
+/// <param name="Messages">The rows, in the order the list is sorted in.</param>
+/// <param name="NextCursor">The cursor reading the page after this one, or <see langword="null" /> at the end of the list.</param>
+/// <param name="PreviousCursor">The cursor reading the page before this one, or <see langword="null" /> at the beginning of the list.</param>
+/// <param name="ReadCursor">The cursor this page was asked with, or <see langword="null" /> where it was read from the leading end.</param>
+/// <param name="ReadDirection">Which way this page was asked for from <paramref name="ReadCursor" />.</param>
+/// <remarks>
+/// <para>
+/// A page keeps the request that produced it because that pair is the only thing that reproduces it exactly. The two
+/// cursors a page answers with name its own first and last row, and neither of them, asked in either direction, reads
+/// the page they came from — so a list that remembered only those could reopen next to where somebody was rather than
+/// at it. The pair here reopens the page itself.
+/// </para>
+/// <para>
+/// The rows are this owner's own correspondence and carry the classification of everything else about mail: they are
+/// held for as long as the window holds this page and are written nowhere.
+/// </para>
+/// </remarks>
+internal sealed record MessagePage(
+    IImmutableList<DeploymentMailMessage> Messages,
+    string? NextCursor,
+    string? PreviousCursor,
+    string? ReadCursor,
+    MailTimelinePageDirection ReadDirection)
+{
+    /// <summary>Reads what a deployment answered as a page of the window.</summary>
+    /// <param name="answered">What the deployment served.</param>
+    /// <param name="readCursor">The cursor the page was asked with.</param>
+    /// <param name="readDirection">The direction the page was asked in.</param>
+    /// <returns>The page.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="answered" /> is <see langword="null" />.</exception>
+    internal static MessagePage Of(
+        DeploymentMailTimelinePage answered,
+        string? readCursor,
+        MailTimelinePageDirection readDirection)
+    {
+        ArgumentNullException.ThrowIfNull(answered);
+
+        return new MessagePage(
+            [.. answered.Rows],
+            answered.NextCursor,
+            answered.PreviousCursor,
+            readCursor,
+            readDirection);
+    }
+
+    /// <summary>Gets whether the deployment answered this page with no mail at all.</summary>
+    /// <remarks>
+    /// Its own question because an empty page is not a page to keep: it carries no cursor at either end, so adding one
+    /// to a window would take the window's own cursors away with it. What it does establish is that the list ends
+    /// there, which is what the window does with it instead.
+    /// </remarks>
+    internal bool IsEmpty => this.Messages.Count is 0;
+}

--- a/frontend/src/Client/Presentation/Messages/MessagePlace.cs
+++ b/frontend/src/Client/Presentation/Messages/MessagePlace.cs
@@ -1,0 +1,72 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Backend.Folders;
+using MailFathom.Client.Presentation.Workspace;
+
+namespace MailFathom.Client.Presentation.Messages;
+
+/// <summary>Where a message list is drawn from: the account, the folder, or the role the workspace is narrowed to.</summary>
+/// <param name="Account">The account in scope, or <see langword="null" /> when every one of them is.</param>
+/// <param name="Folder">The folder alias in scope, or <see langword="null" /> when the whole account is.</param>
+/// <param name="Role">The special-use role in scope across accounts, or <see langword="null" /> when no role is.</param>
+/// <remarks>
+/// <para>
+/// The scope without what is selected inside it, which is the whole reason it exists. The list writes the selection
+/// back into <see cref="IWorkspace.Scope" />, so a list keyed on the scope itself would reload every time somebody
+/// clicked a row in it. Keyed on this instead, it reloads exactly when somebody goes somewhere else.
+/// </para>
+/// <para>
+/// It is also what the remembered position is filed under, so returning to a folder returns to where the list was
+/// rather than to the top of it.
+/// </para>
+/// </remarks>
+public sealed record MessagePlace(string? Account, string? Folder, string? Role)
+{
+    /// <summary>Everything the signed-in person can reach, which is where a run that has narrowed nothing draws from.</summary>
+    public static MessagePlace Everything { get; } = new(Account: null, Folder: null, Role: null);
+
+    /// <summary>What separates the three parts of <see cref="RememberedAs" />.</summary>
+    /// <remarks>
+    /// A unit separator, because the two names on either side of it are a mail server's own and this application does
+    /// not get to constrain what characters they hold. It is the same character the tree composes a row key with.
+    /// </remarks>
+    private const char PartSeparator = '\u001F';
+
+    /// <summary>Reads the place out of a workspace scope, leaving whatever is selected inside it behind.</summary>
+    /// <param name="scope">The scope in force.</param>
+    /// <returns>The place the list is drawn from.</returns>
+    public static MessagePlace Of(WorkspaceScope? scope) =>
+        scope is null ? Everything : new MessagePlace(scope.Account, scope.Folder, scope.Role);
+
+    /// <summary>Gets what this place is remembered by, which is the three names as one value.</summary>
+    /// <remarks>Named for what it is for rather than as a key, because a record here carrying one would be generated an identity MVUX matches list items by — and a place is not a row.</remarks>
+    public string RememberedAs => $"{this.Account}{PartSeparator}{this.Folder}{PartSeparator}{this.Role}";
+
+    /// <summary>Gets whether this place is one somebody chose rather than a whole mailbox or every mailbox at once.</summary>
+    /// <remarks>
+    /// What decides whether junk mail takes part without being asked for. A folder or a role somebody selected is a
+    /// place they went to, and leaving its mail out would draw the junk folder as an empty folder; an account and the
+    /// unified list are places junk is kept out of until a filter says otherwise, which is how every other read on this
+    /// surface behaves.
+    /// </remarks>
+    public bool IsChosenFolder => this.Folder is not null || this.Role is not null;
+
+    /// <summary>Gets whether a row here names who the message went to rather than who it came from.</summary>
+    /// <remarks>
+    /// Mail somebody sent is drawn by its recipients, because every row of it came from the same person and a column of
+    /// one's own name says nothing. It is answered from the role rather than from the message, because a message does
+    /// not know which of its addresses the reader is — and it is answered only where the workspace named a role, since
+    /// a folder chosen by its alias reaches this client without one. A sent folder opened by its alias therefore draws
+    /// its senders until the scope carries the role of the folder it names.
+    /// </remarks>
+    public bool ShowsRecipients =>
+        this.Role is not null
+        && (this.NamesRole(MailFolderRole.Sent)
+            || this.NamesRole(MailFolderRole.Drafts)
+            || this.NamesRole(MailFolderRole.Outbox));
+
+    private bool NamesRole(MailFolderRole role) =>
+        string.Equals(this.Role, role.ToString(), StringComparison.Ordinal);
+}

--- a/frontend/src/Client/Presentation/Messages/MessageReading.cs
+++ b/frontend/src/Client/Presentation/Messages/MessageReading.cs
@@ -1,0 +1,21 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Presentation.Messages;
+
+/// <summary>One reading of a message list, shared by every window the pages of that reading are held in.</summary>
+/// <remarks>
+/// <para>
+/// What tells one reading of a list from the next. A place and an arrangement say which list is being read and cannot
+/// say how many times it has been: somebody asking for a folder to be read again is asking for a new reading of the
+/// same list, and a page still in flight from the reading they abandoned belongs to neither the window nor the
+/// indicator the new one opened with.
+/// </para>
+/// <para>
+/// Reference identity rather than a value, because a value composed from anything the two readings share would make
+/// them equal. It is created where a reading begins and carried by every window derived from it, so a page can be
+/// held against the reading it was asked under rather than against a description that fits both.
+/// </para>
+/// </remarks>
+internal sealed class MessageReading;

--- a/frontend/src/Client/Presentation/Messages/MessageRow.cs
+++ b/frontend/src/Client/Presentation/Messages/MessageRow.cs
@@ -1,0 +1,70 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Globalization;
+
+namespace MailFathom.Client.Presentation.Messages;
+
+/// <summary>One line of the message list, with everything the view draws it from and nothing else.</summary>
+/// <param name="Key">The message's own identity, which is what this row is matched by across a redraw and what the scope names it by.</param>
+/// <param name="Correspondent">Who the message is with — its sender, or its recipients where the place is mail this owner sent.</param>
+/// <param name="Subject">What the message is about, or the words standing in for a message that carried no subject.</param>
+/// <param name="Preview">The opening of the message's own text, and empty where nothing has extracted it yet.</param>
+/// <param name="Received">When it arrived, written the way the reader's own language writes a time today and a date before that.</param>
+/// <param name="Announcement">The whole row as one sentence, which is what a screen reader is given instead of six controls.</param>
+/// <param name="IsUnread">Whether the mail server last reported the message without <c>\Seen</c>.</param>
+/// <param name="IsFlagged">Whether it last reported it with <c>\Flagged</c>.</param>
+/// <param name="IsAnswered">Whether it last reported it with <c>\Answered</c>.</param>
+/// <param name="HasAttachments">Whether the message carries anything besides its body and its inline resources.</param>
+/// <param name="AttachmentCount">How many of those there are.</param>
+/// <remarks>
+/// <para>
+/// Everything on it was drawn from the page that carried the message, so a list of fifty rows is one request. Nothing
+/// here is a body and nothing is fetched per row: a screen that asked for a sender or a preview separately would be a
+/// request per visible line, which is the shape this record exists to make impossible.
+/// </para>
+/// <para>
+/// Whether the row is the one in force is deliberately absent. Selection belongs to the list control and is mirrored
+/// into the workspace scope, so a row carrying its own copy would be a second opinion about the same fact — and one
+/// that had to be redrawn on every click.
+/// </para>
+/// <para>
+/// It is <c>partial</c> because <paramref name="Key" /> makes it eligible for MVUX's key-equality generation, which is
+/// what carries a row's identity across a redraw: a page taken onto the window updates the rows it changed and leaves
+/// the containers of the rest alone, and what was selected stays selected. The generator refuses to run on a sealed
+/// record that is not partial and says so as <c>KE0001</c>.
+/// </para>
+/// <para>
+/// Every word on it is this owner's own correspondence. It is put in front of that owner alone and reaches no log, no
+/// telemetry, and no local store — which is why what is written down when a folder is left is a cursor and never a row.
+/// </para>
+/// </remarks>
+public sealed partial record MessageRow(
+    string Key,
+    string Correspondent,
+    string Subject,
+    string Preview,
+    string Received,
+    string Announcement,
+    bool IsUnread,
+    bool IsFlagged,
+    bool IsAnswered,
+    bool HasAttachments,
+    int AttachmentCount)
+{
+    /// <summary>Gets whether there is an opening of the message's own text to draw.</summary>
+    /// <remarks>
+    /// A message this deployment holds but has not extracted yet has none, which is an ordinary state of a folder still
+    /// being taken in rather than a message with nothing in it. The row draws one line less rather than an empty one.
+    /// </remarks>
+    public bool HasPreview => this.Preview.Length > 0;
+
+    /// <summary>Gets whether the number of attachments is worth drawing beside the mark saying there are any.</summary>
+    /// <remarks>One attachment is what the mark already says; a number beside it would be the same fact written twice.</remarks>
+    public bool ShowsAttachmentCount => this.AttachmentCount > 1;
+
+    /// <summary>Gets how many attachments there are, as the reader's own language writes a number.</summary>
+    /// <remarks>Composed here rather than bound as a number, because a binding to a number formats it with the framework's default rather than with the culture the application is being read in.</remarks>
+    public string AttachmentCountText => this.AttachmentCount.ToString("N0", CultureInfo.CurrentCulture);
+}

--- a/frontend/src/Client/Presentation/Messages/MessageWindow.cs
+++ b/frontend/src/Client/Presentation/Messages/MessageWindow.cs
@@ -1,0 +1,178 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Immutable;
+using MailFathom.Client.Backend.Timeline;
+
+namespace MailFathom.Client.Presentation.Messages;
+
+/// <summary>The part of a message list that is loaded: a bounded run of pages, and the cursors continuing it.</summary>
+/// <remarks>
+/// <para>
+/// A window rather than everything that has been paged, and that is the whole design. A folder holds as much mail as it
+/// holds, and a list that kept every page somebody scrolled past would hold a mailbox's worth of objects on a phone —
+/// so the window keeps <see cref="MaximumPages" /> of them and drops the far one as it takes a near one. The count of
+/// loaded rows is therefore a property of this type rather than of how long somebody scrolled.
+/// </para>
+/// <para>
+/// Dropping a page is only safe because a page keeps the request that produced it: the page that becomes the far end
+/// carries the cursor that reads back towards what was dropped, so scrolling back is asking for it again rather than
+/// having kept it. That is why paging runs in both directions here where a list that only ever grew would need one.
+/// </para>
+/// <para>
+/// The place and the arrangement travel on the window because a page arriving for a list somebody has already left is
+/// an ordinary race rather than an error: a request in flight when the folder changed is answered by a window that
+/// declines to take it, without the caller having to hold a token to compare.
+/// </para>
+/// </remarks>
+internal sealed record MessageWindow
+{
+    /// <summary>How many pages the window holds before it drops one from the far end.</summary>
+    /// <remarks>
+    /// Four rather than a number of rows, because a page is the unit a cursor names and a window cut mid-page could not
+    /// be scrolled back into. At the page size the list asks for it is a few hundred rows: enough that a reader
+    /// scrolling steadily never reaches the seam, and bounded whatever the folder holds.
+    /// </remarks>
+    internal const int MaximumPages = 4;
+
+    private MessageWindow(
+        MessagePlace place,
+        MessageListArrangement arrangement,
+        IImmutableList<MessagePage> pages)
+    {
+        this.Place = place;
+        this.Arrangement = arrangement;
+        this.Pages = pages;
+
+        // Materialized once here rather than projected on each read, because the view binds it, the shape reduces it,
+        // and a deferred query would walk every page again for each of them.
+        this.Messages = [.. pages.SelectMany(page => page.Messages)];
+    }
+
+    /// <summary>Gets where the loaded pages were drawn from.</summary>
+    internal MessagePlace Place { get; }
+
+    /// <summary>Gets the order and the filters the loaded pages were read under.</summary>
+    internal MessageListArrangement Arrangement { get; }
+
+    /// <summary>Gets the loaded pages, in the order the list is read in.</summary>
+    internal IImmutableList<MessagePage> Pages { get; }
+
+    /// <summary>Gets every loaded row, in the order the list is read in.</summary>
+    internal IImmutableList<DeploymentMailMessage> Messages { get; }
+
+    /// <summary>Opens a window on the first page of a list.</summary>
+    /// <param name="place">Where the list is drawn from.</param>
+    /// <param name="arrangement">The order and the filters it is read under.</param>
+    /// <param name="page">The page that was read.</param>
+    /// <returns>The window, holding no page where the deployment answered with nothing.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    internal static MessageWindow Opening(
+        MessagePlace place,
+        MessageListArrangement arrangement,
+        MessagePage page)
+    {
+        ArgumentNullException.ThrowIfNull(place);
+        ArgumentNullException.ThrowIfNull(arrangement);
+        ArgumentNullException.ThrowIfNull(page);
+
+        return new MessageWindow(
+            place,
+            arrangement,
+            page.IsEmpty ? [] : [page]);
+    }
+
+    /// <summary>Opens a window that has read nothing, which is what a list holds before a place has been asked for.</summary>
+    /// <param name="place">Where the list would be drawn from.</param>
+    /// <param name="arrangement">The order and the filters it would be read under.</param>
+    /// <returns>The empty window.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    internal static MessageWindow Nothing(MessagePlace place, MessageListArrangement arrangement)
+    {
+        ArgumentNullException.ThrowIfNull(place);
+        ArgumentNullException.ThrowIfNull(arrangement);
+
+        return new MessageWindow(place, arrangement, []);
+    }
+
+    /// <summary>Gets the cursor the page after this window is asked with, or <see langword="null" /> at the end of the list.</summary>
+    internal string? ForwardCursor => this.Pages.Count is 0 ? null : this.Pages[^1].NextCursor;
+
+    /// <summary>Gets the cursor the page before this window is asked with, or <see langword="null" /> at its beginning.</summary>
+    internal string? BackwardCursor => this.Pages.Count is 0 ? null : this.Pages[0].PreviousCursor;
+
+    /// <summary>Gets whether there is more mail after what is loaded.</summary>
+    internal bool HasMoreAfter => this.ForwardCursor is not null;
+
+    /// <summary>Gets whether there is more mail before what is loaded.</summary>
+    internal bool HasMoreBefore => this.BackwardCursor is not null;
+
+    /// <summary>Gets whether this window has nothing to draw.</summary>
+    internal bool IsEmpty => this.Messages.Count is 0;
+
+    /// <summary>Gets the request that reopens the leading page of this window, or <see langword="null" /> where none is loaded.</summary>
+    /// <remarks>What is written down when somebody leaves the folder, and what puts them back where they were when they return.</remarks>
+    internal MessagePage? LeadingPage => this.Pages.Count is 0 ? null : this.Pages[0];
+
+    /// <summary>Takes one more page onto the window, dropping the far one where the bound is reached.</summary>
+    /// <param name="page">The page that was read.</param>
+    /// <param name="direction">Which end of the window it was read from.</param>
+    /// <param name="place">Where the read was asked for, which has to be this window's own.</param>
+    /// <param name="arrangement">What the read ran under, which has to be this window's own.</param>
+    /// <returns>The extended window, or this one unchanged where the page belongs to a list this window is no longer of.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    /// <remarks>
+    /// A page that came back empty is the list having ended between two requests rather than a page to keep: mail can be
+    /// expunged, so a cursor that named a row can outlive it. The cursor at that end is dropped instead, which stops the
+    /// list asking for the same nothing again.
+    /// </remarks>
+    internal MessageWindow Extended(
+        MessagePage page,
+        MailTimelinePageDirection direction,
+        MessagePlace place,
+        MessageListArrangement arrangement)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+        ArgumentNullException.ThrowIfNull(place);
+        ArgumentNullException.ThrowIfNull(arrangement);
+
+        if (this.Place != place || this.Arrangement != arrangement)
+        {
+            return this;
+        }
+
+        if (page.IsEmpty)
+        {
+            return this.WithoutTheCursorAt(direction);
+        }
+
+        return direction is MailTimelinePageDirection.Forward
+            ? this.With(Bounded(this.Pages.Add(page), droppedFromTheStart: true))
+            : this.With(Bounded(this.Pages.Insert(0, page), droppedFromTheStart: false));
+    }
+
+    /// <summary>Keeps the window within its bound by dropping the page furthest from the one just taken.</summary>
+    private static IImmutableList<MessagePage> Bounded(
+        IImmutableList<MessagePage> pages,
+        bool droppedFromTheStart) =>
+        pages.Count <= MaximumPages
+            ? pages
+            : pages.RemoveAt(droppedFromTheStart ? 0 : pages.Count - 1);
+
+    /// <summary>Marks the end the empty page was read from as the end of the list.</summary>
+    private MessageWindow WithoutTheCursorAt(MailTimelinePageDirection direction)
+    {
+        if (this.Pages.Count is 0)
+        {
+            return this;
+        }
+
+        return direction is MailTimelinePageDirection.Forward
+            ? this.With(this.Pages.SetItem(this.Pages.Count - 1, this.Pages[^1] with { NextCursor = null }))
+            : this.With(this.Pages.SetItem(0, this.Pages[0] with { PreviousCursor = null }));
+    }
+
+    private MessageWindow With(IImmutableList<MessagePage> pages) =>
+        new(this.Place, this.Arrangement, pages);
+}

--- a/frontend/src/Client/Presentation/Messages/MessageWindow.cs
+++ b/frontend/src/Client/Presentation/Messages/MessageWindow.cs
@@ -21,9 +21,9 @@ namespace MailFathom.Client.Presentation.Messages;
 /// having kept it. That is why paging runs in both directions here where a list that only ever grew would need one.
 /// </para>
 /// <para>
-/// The place and the arrangement travel on the window because a page arriving for a list somebody has already left is
-/// an ordinary race rather than an error: a request in flight when the folder changed is answered by a window that
-/// declines to take it, without the caller having to hold a token to compare.
+/// The reading travels on the window because a page arriving for a list somebody has already left, or for one they
+/// asked to be read again, is an ordinary race rather than an error: a request in flight when either happened is
+/// answered by a window that declines to take it, without the caller having to hold a token to compare.
 /// </para>
 /// </remarks>
 internal sealed record MessageWindow
@@ -39,10 +39,12 @@ internal sealed record MessageWindow
     private MessageWindow(
         MessagePlace place,
         MessageListArrangement arrangement,
+        MessageReading reading,
         IImmutableList<MessagePage> pages)
     {
         this.Place = place;
         this.Arrangement = arrangement;
+        this.Reading = reading;
         this.Pages = pages;
 
         // Materialized once here rather than projected on each read, because the view binds it, the shape reduces it,
@@ -55,6 +57,9 @@ internal sealed record MessageWindow
 
     /// <summary>Gets the order and the filters the loaded pages were read under.</summary>
     internal MessageListArrangement Arrangement { get; }
+
+    /// <summary>Gets the reading these pages were taken during, which a later reading of the same list does not share.</summary>
+    internal MessageReading Reading { get; }
 
     /// <summary>Gets the loaded pages, in the order the list is read in.</summary>
     internal IImmutableList<MessagePage> Pages { get; }
@@ -80,6 +85,7 @@ internal sealed record MessageWindow
         return new MessageWindow(
             place,
             arrangement,
+            new MessageReading(),
             page.IsEmpty ? [] : [page]);
     }
 
@@ -93,7 +99,7 @@ internal sealed record MessageWindow
         ArgumentNullException.ThrowIfNull(place);
         ArgumentNullException.ThrowIfNull(arrangement);
 
-        return new MessageWindow(place, arrangement, []);
+        return new MessageWindow(place, arrangement, new MessageReading(), []);
     }
 
     /// <summary>Gets the cursor the page after this window is asked with, or <see langword="null" /> at the end of the list.</summary>
@@ -115,24 +121,28 @@ internal sealed record MessageWindow
     /// <remarks>What is written down when somebody leaves the folder, and what puts them back where they were when they return.</remarks>
     internal MessagePage? LeadingPage => this.Pages.Count is 0 ? null : this.Pages[0];
 
-    /// <summary>Answers whether this window is of a given list.</summary>
-    /// <param name="place">Where a read was asked for.</param>
-    /// <param name="arrangement">What that read ran under.</param>
-    /// <returns><see langword="true" /> where this window is of that same list.</returns>
+    /// <summary>Answers whether this window is of the reading a read was started during.</summary>
+    /// <param name="read">The window that read was started from.</param>
+    /// <returns><see langword="true" /> where this window belongs to that same reading.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="read" /> is <see langword="null" />.</exception>
     /// <remarks>
-    /// What a caller asks before acting on a read it started: a window loaded for a different place or under a
-    /// different arrangement is a list somebody has already left, and everything the abandoned read would have said
-    /// about it is stale.
+    /// What a caller asks before acting on a read it started. The reading rather than the place is what it is held
+    /// against, because a list somebody asked to be read again is loaded afresh under the place and the arrangement it
+    /// already had — so a page in flight from before that would pass a comparison of the two and be spliced onto a
+    /// window that deliberately holds nothing of it.
     /// </remarks>
-    internal bool IsOf(MessagePlace place, MessageListArrangement arrangement) =>
-        this.Place == place && this.Arrangement == arrangement;
+    internal bool IsOf(MessageWindow read)
+    {
+        ArgumentNullException.ThrowIfNull(read);
+
+        return ReferenceEquals(this.Reading, read.Reading);
+    }
 
     /// <summary>Takes one more page onto the window, dropping the far one where the bound is reached.</summary>
     /// <param name="page">The page that was read.</param>
     /// <param name="direction">Which end of the window it was read from.</param>
-    /// <param name="place">Where the read was asked for, which has to be this window's own.</param>
-    /// <param name="arrangement">What the read ran under, which has to be this window's own.</param>
-    /// <returns>The extended window, or this one unchanged where the page belongs to a list this window is no longer of.</returns>
+    /// <param name="read">The window the read was started from, whose reading has to be this window's own.</param>
+    /// <returns>The extended window, or this one unchanged where the page belongs to a reading this window is not of.</returns>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     /// <remarks>
     /// A page that came back empty is the list having ended between two requests rather than a page to keep: mail can be
@@ -142,14 +152,12 @@ internal sealed record MessageWindow
     internal MessageWindow Extended(
         MessagePage page,
         MailTimelinePageDirection direction,
-        MessagePlace place,
-        MessageListArrangement arrangement)
+        MessageWindow read)
     {
         ArgumentNullException.ThrowIfNull(page);
-        ArgumentNullException.ThrowIfNull(place);
-        ArgumentNullException.ThrowIfNull(arrangement);
+        ArgumentNullException.ThrowIfNull(read);
 
-        if (!this.IsOf(place, arrangement))
+        if (!this.IsOf(read))
         {
             return this;
         }
@@ -186,5 +194,5 @@ internal sealed record MessageWindow
     }
 
     private MessageWindow With(IImmutableList<MessagePage> pages) =>
-        new(this.Place, this.Arrangement, pages);
+        new(this.Place, this.Arrangement, this.Reading, pages);
 }

--- a/frontend/src/Client/Presentation/Messages/MessageWindow.cs
+++ b/frontend/src/Client/Presentation/Messages/MessageWindow.cs
@@ -115,6 +115,18 @@ internal sealed record MessageWindow
     /// <remarks>What is written down when somebody leaves the folder, and what puts them back where they were when they return.</remarks>
     internal MessagePage? LeadingPage => this.Pages.Count is 0 ? null : this.Pages[0];
 
+    /// <summary>Answers whether this window is of a given list.</summary>
+    /// <param name="place">Where a read was asked for.</param>
+    /// <param name="arrangement">What that read ran under.</param>
+    /// <returns><see langword="true" /> where this window is of that same list.</returns>
+    /// <remarks>
+    /// What a caller asks before acting on a read it started: a window loaded for a different place or under a
+    /// different arrangement is a list somebody has already left, and everything the abandoned read would have said
+    /// about it is stale.
+    /// </remarks>
+    internal bool IsOf(MessagePlace place, MessageListArrangement arrangement) =>
+        this.Place == place && this.Arrangement == arrangement;
+
     /// <summary>Takes one more page onto the window, dropping the far one where the bound is reached.</summary>
     /// <param name="page">The page that was read.</param>
     /// <param name="direction">Which end of the window it was read from.</param>
@@ -137,7 +149,7 @@ internal sealed record MessageWindow
         ArgumentNullException.ThrowIfNull(place);
         ArgumentNullException.ThrowIfNull(arrangement);
 
-        if (this.Place != place || this.Arrangement != arrangement)
+        if (!this.IsOf(place, arrangement))
         {
             return this;
         }

--- a/frontend/src/Client/Presentation/Messages/MessageWords.cs
+++ b/frontend/src/Client/Presentation/Messages/MessageWords.cs
@@ -1,0 +1,61 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Presentation.Messages;
+
+/// <summary>The words a message row is written in, and the one place their entries are named.</summary>
+/// <remarks>
+/// A row is composed from what a deployment answered rather than fixed per control, so its sentences are asked for from
+/// code instead of through a <c>x:Uid</c> — which makes a name written here the single way a reader would meet a
+/// resource key on the screen instead of a sentence. The unit suite holds every authored table to answering all of them.
+/// </remarks>
+internal static class MessageWords
+{
+    /// <summary>The entry standing in for a message whose sender no header carried.</summary>
+    internal const string NoSenderKey = "Messages.NoSender";
+
+    /// <summary>The entry standing in for a message carrying no subject.</summary>
+    internal const string NoSubjectKey = "Messages.NoSubject";
+
+    /// <summary>The entry standing in for a message no header dated.</summary>
+    internal const string NoDateKey = "Messages.NoDate";
+
+    /// <summary>The entry naming the first recipient beside how many others there are, which takes both.</summary>
+    internal const string MoreRecipientsKey = "Messages.MoreRecipients";
+
+    /// <summary>The entry a row's whole announcement is composed through, which takes the correspondent, the subject, and the date.</summary>
+    internal const string AnnouncementKey = "Messages.Announcement";
+
+    /// <summary>The entry announcing that a row has not been read.</summary>
+    internal const string UnreadKey = "Messages.Announcement.Unread";
+
+    /// <summary>The entry announcing that a row is flagged.</summary>
+    internal const string FlaggedKey = "Messages.Announcement.Flagged";
+
+    /// <summary>The entry announcing that a row has been answered.</summary>
+    internal const string AnsweredKey = "Messages.Announcement.Answered";
+
+    /// <summary>The entry announcing that a row carries an attachment.</summary>
+    internal const string AttachmentsKey = "Messages.Announcement.Attachments";
+
+    /// <summary>
+    /// Every entry a row asks the tables for, which is what the suite holds each authored table to answering.
+    /// </summary>
+    /// <remarks>
+    /// Named as one list rather than asserted key by key, so an entry added to a row and nowhere else is reported by the
+    /// suite rather than met by a reader as the key itself.
+    /// </remarks>
+    internal static IReadOnlyList<string> ResourceKeys { get; } =
+    [
+        NoSenderKey,
+        NoSubjectKey,
+        NoDateKey,
+        MoreRecipientsKey,
+        AnnouncementKey,
+        UnreadKey,
+        FlaggedKey,
+        AnsweredKey,
+        AttachmentsKey,
+    ];
+}

--- a/frontend/src/Client/Presentation/Messages/RememberedMessageList.cs
+++ b/frontend/src/Client/Presentation/Messages/RememberedMessageList.cs
@@ -1,0 +1,37 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Backend.Timeline;
+
+namespace MailFathom.Client.Presentation.Messages;
+
+/// <summary>Where a message list was left, so that coming back to a folder is coming back rather than starting over.</summary>
+/// <param name="PlaceKey">The place this was written for, as <see cref="MessagePlace.RememberedAs" /> composes it.</param>
+/// <param name="Cursor">The cursor the leading loaded page was asked with, or <see langword="null" /> where it was read from the leading end of the list.</param>
+/// <param name="Direction">Which way that page was asked for from <paramref name="Cursor" />.</param>
+/// <param name="Arrangement">The order and the filters the list was read under, which the cursor was issued against.</param>
+/// <remarks>
+/// <para>
+/// The cursor and the arrangement travel together because neither is usable without the other: a cursor names the list
+/// it was taken from, so a deployment refuses one presented against different filters. Remembering the pair is what
+/// makes returning a continuation instead of a refusal.
+/// </para>
+/// <para>
+/// The position is remembered to the page rather than to the pixel. A page is the unit a cursor names, so reopening
+/// puts somebody back among the mail they were reading; where inside that page the list had been scrolled is not
+/// written down, and the list opens at its top.
+/// </para>
+/// </remarks>
+public sealed record RememberedMessageList(
+    string PlaceKey,
+    string? Cursor,
+    MailTimelinePageDirection Direction,
+    MessageListArrangement Arrangement)
+{
+    /// <summary>A place nobody has read yet, which opens at the leading end of the list arranged as a list arrives.</summary>
+    /// <param name="placeKey">The place being opened.</param>
+    /// <returns>What a first visit remembers, which is nothing beyond where it is.</returns>
+    public static RememberedMessageList Nothing(string placeKey) =>
+        new(placeKey, Cursor: null, MailTimelinePageDirection.Forward, MessageListArrangement.Default);
+}

--- a/frontend/src/Client/Presentation/Messages/VisitedPlaces.cs
+++ b/frontend/src/Client/Presentation/Messages/VisitedPlaces.cs
@@ -1,0 +1,90 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Presentation.Messages;
+
+/// <summary>Where every place one run has read mail in is remembered, bounded, for as long as the run lasts.</summary>
+/// <remarks>
+/// <para>
+/// Moving between two folders and back has to return to each of them, which is several places; starting the client
+/// again has to return to the one somebody was in, which is one. This is the first of those, and it is deliberately
+/// not the second: keeping every folder a run walked through in a store on somebody's disk would be writing a list of
+/// their mailbox out to serve a value only one entry of it is ever read for.
+/// </para>
+/// <para>
+/// It is bounded because a run has no other bound. Somebody walking a deeply nested mailbox visits as many places as
+/// it has folders, and every one of them would otherwise be held for as long as the process lives.
+/// </para>
+/// <para>
+/// Its own type rather than a field on the store, so the bound and the order it drops in are reachable by an ordinary
+/// unit test — what is behind the store is a platform API no test can reach.
+/// </para>
+/// </remarks>
+internal sealed class VisitedPlaces
+{
+    /// <summary>How many places are kept before the one written longest ago is dropped.</summary>
+    /// <remarks>Enough that moving between the folders somebody actually works in never loses one, and bounded whatever their mailbox holds.</remarks>
+    internal const int Maximum = 16;
+
+    private readonly Lock guard = new();
+    private readonly Dictionary<string, RememberedMessageList> remembered = new(StringComparer.Ordinal);
+    private readonly List<string> inWriteOrder = [];
+
+    /// <summary>Gets how many places are being remembered, which never passes <see cref="Maximum" />.</summary>
+    internal int Count
+    {
+        get
+        {
+            lock (this.guard)
+            {
+                return this.inWriteOrder.Count;
+            }
+        }
+    }
+
+    /// <summary>Reads where a place was left in this run.</summary>
+    /// <param name="placeKey">The place, as <see cref="MessagePlace.RememberedAs" /> composes it.</param>
+    /// <returns>What was kept, or <see langword="null" /> where this run has not been there or has dropped it.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="placeKey" /> is <see langword="null" /> or empty.</exception>
+    internal RememberedMessageList? Read(string placeKey)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(placeKey);
+
+        lock (this.guard)
+        {
+            return this.remembered.GetValueOrDefault(placeKey);
+        }
+    }
+
+    /// <summary>Keeps where a place is now, dropping the one written longest ago once the bound is reached.</summary>
+    /// <param name="visited">The position and arrangement to keep.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="visited" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// Writing a place again moves it to the newest end rather than leaving it where it first appeared, so the folder
+    /// somebody keeps returning to is never the one dropped to make room for one they passed through once.
+    /// </remarks>
+    internal void Keep(RememberedMessageList visited)
+    {
+        ArgumentNullException.ThrowIfNull(visited);
+
+        lock (this.guard)
+        {
+            if (this.remembered.Remove(visited.PlaceKey))
+            {
+                this.inWriteOrder.Remove(visited.PlaceKey);
+            }
+
+            this.remembered[visited.PlaceKey] = visited;
+            this.inWriteOrder.Add(visited.PlaceKey);
+
+            if (this.inWriteOrder.Count <= Maximum)
+            {
+                return;
+            }
+
+            this.remembered.Remove(this.inWriteOrder[0]);
+            this.inWriteOrder.RemoveAt(0);
+        }
+    }
+}

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailModel.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailModel.cs
@@ -185,6 +185,6 @@ public partial record MailModel
     {
         var arrangement = await this.messages.Arrangement ?? MessageListArrangement.Default;
 
-        await this.messages.ArrangeAsync(change(arrangement), cancellationToken);
+        await this.messages.ArrangeAsync(change(arrangement), cancellationToken).ConfigureAwait(false);
     }
 }

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailModel.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailModel.cs
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Collections.Immutable;
+using MailFathom.Client.Backend.Timeline;
+using MailFathom.Client.Presentation.Messages;
 using MailFathom.Client.Session;
 
 namespace MailFathom.Client.Presentation.Spaces.Mail;
@@ -15,20 +18,42 @@ namespace MailFathom.Client.Presentation.Spaces.Mail;
 /// mailboxes drawn here beside it would be the same answer twice, the second already stale relative to the first.
 /// </para>
 /// <para>
-/// What is left is the space's own reading of the session: whether correspondence may be put in front of this caller
-/// at all, read here rather than derived from a request the deployment refused.
+/// What this space owns is the list of that folder's mail and the controls that arrange it, and it owns neither by
+/// holding one: the list is the run's own, for the reason the tree and the workspace are, so leaving the space and
+/// coming back is finding the list where it was rather than reading its first page again.
+/// </para>
+/// <para>
+/// Beside that is the space's own reading of the session: whether correspondence may be put in front of this caller at
+/// all, read here rather than derived from a request the deployment refused.
 /// </para>
 /// </remarks>
 public partial record MailModel
 {
-    /// <summary>Initializes the space over what decides whether it may be offered.</summary>
+    private readonly IMessageList messages;
+
+    /// <summary>Initializes the space over what decides whether it may be offered, and the list it is read through.</summary>
     /// <param name="session">What the deployment allows this caller.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="session" /> is <see langword="null" />.</exception>
-    public MailModel(IClientSession session)
+    /// <param name="messages">The run's own message list, drawn from wherever the mailbox tree says somebody is.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    public MailModel(IClientSession session, IMessageList messages)
     {
         ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(messages);
+
+        this.messages = messages;
 
         this.WithholdsMail = session.Standing.Select(standing => standing.Withholds(ClientCapability.Mail));
+
+        this.ReadsOldestFirst = messages.Arrangement.Select(static arrangement => arrangement.OldestFirst);
+        this.KeepsUnreadOnly = messages.Arrangement.Select(static arrangement => arrangement.UnreadOnly);
+        this.KeepsFlaggedOnly = messages.Arrangement.Select(static arrangement => arrangement.FlaggedOnly);
+        this.KeepsWithAttachmentsOnly =
+            messages.Arrangement.Select(static arrangement => arrangement.WithAttachmentsOnly);
+        this.KeepsJunk = messages.Arrangement.Select(static arrangement => arrangement.IncludeJunk);
+        this.KeepsLessThanEverything =
+            messages.Arrangement.Select(static arrangement => arrangement.KeepsLessThanEverything);
+        this.KeepsEverything =
+            messages.Arrangement.Select(static arrangement => !arrangement.KeepsLessThanEverything);
     }
 
     /// <summary>Whether this session keeps the space correspondence is read in from being put in front of this caller.</summary>
@@ -38,4 +63,128 @@ public partial record MailModel
     /// screen before the session had answered.
     /// </remarks>
     public IFeed<bool> WithholdsMail { get; }
+
+    /// <summary>The loaded lines of the folder's mail, in the order the list is read in.</summary>
+    /// <remarks>The run's own list read through this model rather than one built here, so moving between spaces keeps where it was scrolled and costs no second page.</remarks>
+    public IListFeed<MessageRow> Messages => this.messages.Rows;
+
+    /// <summary>What is selected in the list, which is what the rest of the client reads as the scope of a question.</summary>
+    public IState<IImmutableList<MessageRow>> Chosen => this.messages.Chosen;
+
+    /// <summary>Whether there is more mail after what is loaded.</summary>
+    public IFeed<bool> HasMoreAfter => this.messages.HasMoreAfter;
+
+    /// <summary>Whether there is more mail before what is loaded, which there is once the window has moved on.</summary>
+    public IFeed<bool> HasMoreBefore => this.messages.HasMoreBefore;
+
+    /// <summary>Whether the last attempt to take another page did not arrive.</summary>
+    public IFeed<bool> PagingFailed => this.messages.PagingFailed;
+
+    /// <summary>Whether the list is read oldest first.</summary>
+    public IFeed<bool> ReadsOldestFirst { get; }
+
+    /// <summary>Whether the list keeps only unread mail.</summary>
+    public IFeed<bool> KeepsUnreadOnly { get; }
+
+    /// <summary>Whether the list keeps only flagged mail.</summary>
+    public IFeed<bool> KeepsFlaggedOnly { get; }
+
+    /// <summary>Whether the list keeps only mail carrying an attachment.</summary>
+    public IFeed<bool> KeepsWithAttachmentsOnly { get; }
+
+    /// <summary>Whether the list lets junk mail take part where the place would otherwise leave it out.</summary>
+    public IFeed<bool> KeepsJunk { get; }
+
+    /// <summary>Whether anything the list keeps narrows it, which is what the mark on the filters is shown on.</summary>
+    /// <remarks>Stated so a list showing less than the folder holds says so on the control that did it, rather than reading as a folder with less mail in it than it has.</remarks>
+    public IFeed<bool> KeepsLessThanEverything { get; }
+
+    /// <summary>Whether the list keeps everything the place holds, which is what an empty folder is said on.</summary>
+    /// <remarks>
+    /// Stated beside its opposite rather than derived from it in the view, because the two lead to different sentences
+    /// and the converter that turns a decision into a visibility shows a control on an outright yes and on nothing
+    /// else: a place holding no mail and a place whose mail this list is keeping out are not the same thing to be told,
+    /// and neither may be announced while the answer is still on its way.
+    /// </remarks>
+    public IFeed<bool> KeepsEverything { get; }
+
+    /// <summary>Takes the next page onto the end of the list.</summary>
+    /// <param name="cancellationToken">Abandons the page.</param>
+    /// <returns>A task completing once the page has arrived or the attempt has been reported.</returns>
+    /// <remarks>It carries no parameter, so the command generated from it reports its own progress and the control bound to it is disabled while the page is on its way.</remarks>
+    public ValueTask ShowMore(CancellationToken cancellationToken) =>
+        this.messages.ShowMoreAsync(cancellationToken);
+
+    /// <summary>Takes the previous page back onto the start of the list.</summary>
+    /// <param name="cancellationToken">Abandons the page.</param>
+    /// <returns>A task completing once the page has arrived or the attempt has been reported.</returns>
+    public ValueTask ShowEarlier(CancellationToken cancellationToken) =>
+        this.messages.ShowEarlierAsync(cancellationToken);
+
+    /// <summary>Asks the deployment for the list again, which is what a person presses when it did not arrive.</summary>
+    /// <param name="cancellationToken">Abandons the ask.</param>
+    /// <returns>A task completing once the ask has been made.</returns>
+    public ValueTask RetryMessages(CancellationToken cancellationToken) =>
+        this.messages.AskAgainAsync(cancellationToken);
+
+    /// <summary>Reads the list from the other end of the timeline.</summary>
+    /// <param name="cancellationToken">Abandons the change.</param>
+    /// <returns>A task completing once the list is being read again.</returns>
+    public ValueTask ReverseOrder(CancellationToken cancellationToken) =>
+        this.ArrangeAsync(
+            arrangement => arrangement with
+            {
+                Order = arrangement.Order is MailTimelineOrder.OldestFirst
+                    ? MailTimelineOrder.NewestFirst
+                    : MailTimelineOrder.OldestFirst,
+            },
+            cancellationToken);
+
+    /// <summary>Keeps only unread mail, or stops doing so.</summary>
+    /// <param name="cancellationToken">Abandons the change.</param>
+    /// <returns>A task completing once the list is being read again.</returns>
+    public ValueTask ToggleUnreadOnly(CancellationToken cancellationToken) =>
+        this.ArrangeAsync(
+            arrangement => arrangement with { UnreadOnly = !arrangement.UnreadOnly },
+            cancellationToken);
+
+    /// <summary>Keeps only flagged mail, or stops doing so.</summary>
+    /// <param name="cancellationToken">Abandons the change.</param>
+    /// <returns>A task completing once the list is being read again.</returns>
+    public ValueTask ToggleFlaggedOnly(CancellationToken cancellationToken) =>
+        this.ArrangeAsync(
+            arrangement => arrangement with { FlaggedOnly = !arrangement.FlaggedOnly },
+            cancellationToken);
+
+    /// <summary>Keeps only mail carrying an attachment, or stops doing so.</summary>
+    /// <param name="cancellationToken">Abandons the change.</param>
+    /// <returns>A task completing once the list is being read again.</returns>
+    public ValueTask ToggleWithAttachmentsOnly(CancellationToken cancellationToken) =>
+        this.ArrangeAsync(
+            arrangement => arrangement with { WithAttachmentsOnly = !arrangement.WithAttachmentsOnly },
+            cancellationToken);
+
+    /// <summary>Lets junk mail take part in the list, or stops doing so.</summary>
+    /// <param name="cancellationToken">Abandons the change.</param>
+    /// <returns>A task completing once the list is being read again.</returns>
+    /// <remarks>It changes nothing in a junk folder somebody opened on purpose, which takes part whatever this says.</remarks>
+    public ValueTask ToggleJunk(CancellationToken cancellationToken) =>
+        this.ArrangeAsync(
+            arrangement => arrangement with { IncludeJunk = !arrangement.IncludeJunk },
+            cancellationToken);
+
+    /// <summary>Applies one change to how the list is arranged and reads it again under the result.</summary>
+    /// <remarks>
+    /// The change is composed from what is in force rather than from what a control shows, because the two can differ
+    /// for as long as a read is under way — and a toggle that wrote what its own visual state said would then undo the
+    /// change beside it.
+    /// </remarks>
+    private async ValueTask ArrangeAsync(
+        Func<MessageListArrangement, MessageListArrangement> change,
+        CancellationToken cancellationToken)
+    {
+        var arrangement = await this.messages.Arrangement ?? MessageListArrangement.Default;
+
+        await this.messages.ArrangeAsync(change(arrangement), cancellationToken);
+    }
 }

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailPage.xaml
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailPage.xaml
@@ -6,19 +6,310 @@ Project repository: https://github.com/Krzysztof318/MailFathom
 <Page x:Class="MailFathom.Client.Presentation.Spaces.Mail.MailPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mvux="using:Uno.Extensions.Reactive.UI"
+      xmlns:utu="using:Uno.Toolkit.UI"
+      xmlns:messages="using:MailFathom.Client.Presentation.Messages"
       xmlns:spaces="using:MailFathom.Client.Presentation.Spaces"
       xmlns:workspace="using:MailFathom.Client.Presentation.Workspace"
       NavigationCacheMode="Required">
 
   <Grid>
     <!-- The list beside what is open on a wide window, and the list alone on a narrow one, where opening something is
-         a screen rather than a second column. What either column holds is #1159's to decide.
+         a screen rather than a second column. What the companion column holds is #1159's to decide.
 
          Which mailbox and which folder the list is of is not asked here: the tree in the frame is the client's scope
          selector, and this space reads the scope it wrote. -->
     <workspace:WorkspaceColumns>
       <workspace:WorkspaceColumns.Primary>
-        <spaces:SpacePlaceholder x:Uid="MailPage.Messages" />
+        <Grid>
+          <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition />
+            <RowDefinition Height="Auto" />
+          </Grid.RowDefinitions>
+
+          <!-- How the list is arranged, above the list rather than behind a menu: what a list is keeping out is the
+               thing most easily mistaken for a folder holding less than it does, so the controls that did it are on
+               screen beside the mail they narrowed. Each is a command rather than a two-way binding, because changing
+               any of them reads the list again from its leading end — the cursors held under the old arrangement name
+               a list that no longer exists. -->
+          <ScrollViewer Grid.Row="0"
+                        HorizontalScrollBarVisibility="Auto"
+                        VerticalScrollBarVisibility="Disabled"
+                        HorizontalScrollMode="Auto"
+                        VerticalScrollMode="Disabled">
+            <StackPanel Orientation="Horizontal"
+                        Padding="12,8"
+                        Spacing="8">
+              <ToggleButton x:Uid="MailPage.Toggle.Order"
+                            Command="{Binding ReverseOrder}"
+                            IsChecked="{Binding ReadsOldestFirst, Mode=OneWay}">
+                <FontIcon Glyph="&#xE8CB;"
+                          FontSize="14" />
+              </ToggleButton>
+
+              <ToggleButton x:Uid="MailPage.Toggle.Unread"
+                            Command="{Binding ToggleUnreadOnly}"
+                            IsChecked="{Binding KeepsUnreadOnly, Mode=OneWay}">
+                <FontIcon Glyph="&#xE8BD;"
+                          FontSize="14" />
+              </ToggleButton>
+
+              <ToggleButton x:Uid="MailPage.Toggle.Flagged"
+                            Command="{Binding ToggleFlaggedOnly}"
+                            IsChecked="{Binding KeepsFlaggedOnly, Mode=OneWay}">
+                <FontIcon Glyph="&#xE7C1;"
+                          FontSize="14" />
+              </ToggleButton>
+
+              <ToggleButton x:Uid="MailPage.Toggle.Attachments"
+                            Command="{Binding ToggleWithAttachmentsOnly}"
+                            IsChecked="{Binding KeepsWithAttachmentsOnly, Mode=OneWay}">
+                <FontIcon Glyph="&#xE723;"
+                          FontSize="14" />
+              </ToggleButton>
+
+              <ToggleButton x:Uid="MailPage.Toggle.Junk"
+                            Command="{Binding ToggleJunk}"
+                            IsChecked="{Binding KeepsJunk, Mode=OneWay}">
+                <FontIcon Glyph="&#xE74D;"
+                          FontSize="14" />
+              </ToggleButton>
+
+              <!-- The touch way into a multiple selection, and the way back out of one. A long press on a row sets it
+                   too, so the gesture a phone reader expects and a control they can see are one state rather than
+                   two. -->
+              <ToggleButton x:Name="SelectingToggle"
+                            x:Uid="MailPage.Toggle.Selecting"
+                            Checked="OnSelectingMany"
+                            Unchecked="OnSelectingOne">
+                <FontIcon Glyph="&#xE762;"
+                          FontSize="14" />
+              </ToggleButton>
+
+              <!-- A list showing less than the folder holds says so, rather than reading as a folder with less mail
+                   in it. -->
+              <TextBlock x:Uid="MailPage.TextBlock.Narrowed"
+                         VerticalAlignment="Center"
+                         Style="{StaticResource CaptionTextBlockStyle}"
+                         Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                         Visibility="{Binding KeepsLessThanEverything, Converter={StaticResource AffirmedVisibility}}" />
+            </StackPanel>
+          </ScrollViewer>
+
+          <!-- The window is bounded, so the pages somebody scrolled past are asked for again rather than kept. This is
+               where they are asked for: it is present only once there is something before what is loaded, which on a
+               list nobody has scrolled is never. -->
+          <Button x:Uid="MailPage.Button.ShowEarlier"
+                  Grid.Row="1"
+                  Margin="12,0,12,4"
+                  HorizontalAlignment="Stretch"
+                  Command="{Binding ShowEarlier}"
+                  Style="{StaticResource TextBlockButtonStyle}"
+                  Visibility="{Binding HasMoreBefore, Converter={StaticResource AffirmedVisibility}}" />
+
+          <Grid Grid.Row="2">
+            <!-- One virtualized list over a bounded window. The panel realizes the rows on screen rather than the rows
+                 loaded, and the window bounds what is loaded rather than what has been scrolled past, so message forty
+                 thousand of a folder costs what message one costs. Every row carries its own key, so a page arriving
+                 updates the rows it changed and leaves the containers of the rest — and what was selected stays
+                 selected.
+
+                 Extended is the selection a pointer expects: the modifiers, the range, the drag, and the keyboard all
+                 belong to the control rather than to anything written here, and a touch head reaches a multiple
+                 selection through the long press below. What comes out of it is the workspace scope, which is what
+                 makes selecting four messages the scope of the next question rather than a highlight. -->
+            <ListView x:Name="MessageRows"
+                      x:Uid="MailPage.List.Messages"
+                      ItemsSource="{Binding Messages}"
+                      SelectionMode="Extended"
+                      IsItemClickEnabled="False"
+                      Holding="OnRowHeld"
+                      Padding="4,0,4,12">
+              <ListView.ItemTemplate>
+                <DataTemplate x:DataType="messages:MessageRow">
+                  <!-- The row states itself once for a screen reader and draws itself in parts for everybody else. The
+                       parts are raw to the accessibility tree deliberately: read out separately they would be six
+                       fragments per row and fifty rows of them. -->
+                  <Grid Padding="4,8"
+                        ColumnSpacing="8"
+                        AutomationProperties.Name="{x:Bind Announcement}">
+                    <Grid.ColumnDefinitions>
+                      <ColumnDefinition Width="Auto" />
+                      <ColumnDefinition />
+                      <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <!-- Unread is a mark rather than a word, and absent rather than drawn faint where the message has
+                         been read. -->
+                    <Border Width="8"
+                            Height="8"
+                            CornerRadius="4"
+                            VerticalAlignment="Top"
+                            Margin="0,6,0,0"
+                            AutomationProperties.AccessibilityView="Raw"
+                            Background="{ThemeResource PrimaryBrush}"
+                            Visibility="{x:Bind IsUnread, Converter={StaticResource AffirmedVisibility}}" />
+
+                    <StackPanel Grid.Column="1"
+                                Spacing="2">
+                      <TextBlock Text="{x:Bind Correspondent}"
+                                 Style="{StaticResource BodyStrongTextBlockStyle}"
+                                 Foreground="{ThemeResource OnSurfaceBrush}"
+                                 AutomationProperties.AccessibilityView="Raw"
+                                 TextTrimming="CharacterEllipsis" />
+
+                      <TextBlock Text="{x:Bind Subject}"
+                                 Style="{StaticResource BodyTextBlockStyle}"
+                                 Foreground="{ThemeResource OnSurfaceBrush}"
+                                 AutomationProperties.AccessibilityView="Raw"
+                                 TextTrimming="CharacterEllipsis" />
+
+                      <!-- A message this deployment holds but has not extracted yet draws one line less rather than an
+                           empty one. -->
+                      <TextBlock Text="{x:Bind Preview}"
+                                 Style="{StaticResource CaptionTextBlockStyle}"
+                                 Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                                 AutomationProperties.AccessibilityView="Raw"
+                                 TextTrimming="CharacterEllipsis"
+                                 Visibility="{x:Bind HasPreview, Converter={StaticResource AffirmedVisibility}}" />
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="2"
+                                Spacing="2"
+                                HorizontalAlignment="Right">
+                      <TextBlock Text="{x:Bind Received}"
+                                 HorizontalAlignment="Right"
+                                 Style="{StaticResource CaptionTextBlockStyle}"
+                                 Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                                 AutomationProperties.AccessibilityView="Raw" />
+
+                      <StackPanel Orientation="Horizontal"
+                                  HorizontalAlignment="Right"
+                                  Spacing="4">
+                        <FontIcon Glyph="&#xE172;"
+                                  FontSize="12"
+                                  AutomationProperties.AccessibilityView="Raw"
+                                  Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                                  Visibility="{x:Bind IsAnswered, Converter={StaticResource AffirmedVisibility}}" />
+
+                        <FontIcon Glyph="&#xE7C1;"
+                                  FontSize="12"
+                                  AutomationProperties.AccessibilityView="Raw"
+                                  Foreground="{ThemeResource TertiaryBrush}"
+                                  Visibility="{x:Bind IsFlagged, Converter={StaticResource AffirmedVisibility}}" />
+
+                        <FontIcon Glyph="&#xE723;"
+                                  FontSize="12"
+                                  AutomationProperties.AccessibilityView="Raw"
+                                  Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                                  Visibility="{x:Bind HasAttachments, Converter={StaticResource AffirmedVisibility}}" />
+
+                        <!-- One attachment is what the mark already says, so the number appears only where there is
+                             more than one of them. -->
+                        <TextBlock Text="{x:Bind AttachmentCountText}"
+                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                   AutomationProperties.AccessibilityView="Raw"
+                                   Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                                   Visibility="{x:Bind ShowsAttachmentCount, Converter={StaticResource AffirmedVisibility}}" />
+                      </StackPanel>
+                    </StackPanel>
+                  </Grid>
+                </DataTemplate>
+              </ListView.ItemTemplate>
+            </ListView>
+
+            <!-- The three states the list genuinely has, rendered by the feed rather than remembered by this page. Its
+                 value template draws nothing, because the list above is what draws a list that arrived — the same
+                 arrangement the frame uses for the session it is composed over. -->
+            <mvux:FeedView Source="{Binding Messages}">
+              <mvux:FeedView.ValueTemplate>
+                <DataTemplate>
+                  <Border Height="0" />
+                </DataTemplate>
+              </mvux:FeedView.ValueTemplate>
+
+              <mvux:FeedView.ProgressTemplate>
+                <DataTemplate>
+                  <ProgressBar IsIndeterminate="True"
+                               VerticalAlignment="Top"
+                               HorizontalAlignment="Stretch" />
+                </DataTemplate>
+              </mvux:FeedView.ProgressTemplate>
+
+              <!-- Two sentences rather than one, because they lead to different acts. A place this list is keeping mail
+                   out of is widened by pressing one of the controls above; a place with nothing in it is either a
+                   folder holding no mail or a copy MailFathom has not taken in yet, and which of those it is, is said
+                   per folder by the mailbox pane rather than repeated here. -->
+              <mvux:FeedView.NoneTemplate>
+                <DataTemplate>
+                  <StackPanel Padding="16"
+                              Spacing="8"
+                              VerticalAlignment="Top">
+                    <InfoBar x:Uid="MailPage.InfoBar.NoMessages"
+                             IsOpen="{Binding Parent.KeepsEverything}"
+                             IsClosable="False"
+                             Severity="Informational" />
+
+                    <InfoBar x:Uid="MailPage.InfoBar.NoKeptMessages"
+                             IsOpen="{Binding Parent.KeepsLessThanEverything}"
+                             IsClosable="False"
+                             Severity="Informational" />
+                  </StackPanel>
+                </DataTemplate>
+              </mvux:FeedView.NoneTemplate>
+
+              <!-- What it means and what to try, in this application's own words: the failure carries an English
+                   message written for a log, and one of its cases can carry text from a machine this process does not
+                   own. Asking again is reached through the template's parent, because it is the list's act rather than
+                   this view's. -->
+              <mvux:FeedView.ErrorTemplate>
+                <DataTemplate>
+                  <InfoBar x:Uid="MailPage.InfoBar.MessagesUnavailable"
+                           Margin="16"
+                           VerticalAlignment="Top"
+                           IsOpen="True"
+                           IsClosable="False"
+                           Severity="Error">
+                    <InfoBar.ActionButton>
+                      <Button x:Uid="MailPage.Button.RetryMessages"
+                              Command="{Binding Parent.RetryMessages}" />
+                    </InfoBar.ActionButton>
+                  </InfoBar>
+                </DataTemplate>
+              </mvux:FeedView.ErrorTemplate>
+            </mvux:FeedView>
+          </Grid>
+
+          <StackPanel Grid.Row="3"
+                      Padding="12,4,12,8"
+                      Spacing="4">
+            <!-- A page that did not arrive is said beside the list rather than instead of it, because what is already
+                 drawn is still true. -->
+            <InfoBar x:Uid="MailPage.InfoBar.PageUnavailable"
+                     IsOpen="{Binding PagingFailed}"
+                     IsClosable="False"
+                     Severity="Warning" />
+
+            <!-- The command carries no parameter, so the loading view reads its own progress from it and the button is
+                 disabled while the page is on its way. -->
+            <utu:LoadingView Source="{Binding ShowMore}"
+                             Visibility="{Binding HasMoreAfter, Converter={StaticResource AffirmedVisibility}}">
+              <utu:LoadingView.Content>
+                <Button x:Uid="MailPage.Button.ShowMore"
+                        HorizontalAlignment="Stretch"
+                        Command="{Binding ShowMore}"
+                        Style="{StaticResource TextBlockButtonStyle}" />
+              </utu:LoadingView.Content>
+
+              <utu:LoadingView.LoadingContent>
+                <ProgressBar IsIndeterminate="True"
+                             HorizontalAlignment="Stretch" />
+              </utu:LoadingView.LoadingContent>
+            </utu:LoadingView>
+          </StackPanel>
+        </Grid>
       </workspace:WorkspaceColumns.Primary>
       <workspace:WorkspaceColumns.Companion>
         <spaces:SpacePlaceholder x:Uid="MailPage.Reading" />

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailPage.xaml.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailPage.xaml.cs
@@ -2,14 +2,55 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using Microsoft.UI.Input;
+using Microsoft.UI.Xaml.Input;
+
 namespace MailFathom.Client.Presentation.Spaces.Mail;
 
 /// <summary>Mail: the mailbox itself, read the way a mail client is read.</summary>
+/// <remarks>
+/// The handlers below are the list control's own behaviour rather than the space's: which selection mode a selector is
+/// in is a fact about this window and this input device, not about the mail somebody is reading. What comes <em>out</em>
+/// of a selection is the model's, and it goes into the workspace scope — so nothing here reads or writes what is
+/// selected.
+/// </remarks>
 public sealed partial class MailPage : Page
 {
     /// <summary>Initializes the space.</summary>
     public MailPage()
     {
         this.InitializeComponent();
+    }
+
+    /// <summary>Puts the list into the selection a touch head reaches by pressing and holding a row.</summary>
+    /// <param name="sender">The list the gesture happened on.</param>
+    /// <param name="args">The gesture, which is acted on once it has completed rather than while it is being made.</param>
+    /// <remarks>
+    /// The gesture sets the control that shows the mode rather than the list itself, so a person who arrived by holding
+    /// a row and a person who arrived by pressing the control are in one state with one way out of it. A pointer head
+    /// raises no holding gesture at all, which is why the modifiers stay the whole of what a mouse needs.
+    /// </remarks>
+    private void OnRowHeld(object sender, HoldingRoutedEventArgs args)
+    {
+        if (args is { HoldingState: HoldingState.Completed })
+        {
+            this.SelectingToggle.IsChecked = true;
+        }
+    }
+
+    /// <summary>Offers the selection several rows at a time, which is what a tap does in this mode.</summary>
+    private void OnSelectingMany(object sender, RoutedEventArgs args) =>
+        this.MessageRows.SelectionMode = ListViewSelectionMode.Multiple;
+
+    /// <summary>Returns the list to the selection a pointer expects, keeping nothing that was chosen in the other one.</summary>
+    /// <remarks>
+    /// The selection is cleared rather than carried across, because the two modes mean different things by a tap: rows
+    /// gathered one at a time would otherwise stay selected under a mode where the next click replaces them, which is a
+    /// scope somebody would ask a question against without having meant to.
+    /// </remarks>
+    private void OnSelectingOne(object sender, RoutedEventArgs args)
+    {
+        this.MessageRows.SelectedItems.Clear();
+        this.MessageRows.SelectionMode = ListViewSelectionMode.Extended;
     }
 }

--- a/frontend/src/Client/Strings/en/Resources.resw
+++ b/frontend/src/Client/Strings/en/Resources.resw
@@ -277,13 +277,81 @@
     <value>This column is still being built.</value>
     <comment>The companion column's counterpart to the sentence above.</comment>
   </data>
-  <data name="MailPage.Messages.Heading" xml:space="preserve">
-    <value>Mail</value>
-    <comment>Names the primary column of the Mail space while that space is being built.</comment>
+  <data name="MailPage.List.Messages.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Messages in this place</value>
+    <comment>Names the list itself, so a screen reader announces what the rows belong to before it reads one.</comment>
   </data>
-  <data name="MailPage.Messages.Detail" xml:space="preserve">
-    <value>This space is still being built.</value>
-    <comment>Says plainly that the space is empty because nothing has been put in it yet, rather than because something failed.</comment>
+  <data name="MailPage.Toggle.Order.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Read oldest first</value>
+    <comment>Names the control that reads the list from the other end of the timeline, which carries an icon rather than words.</comment>
+  </data>
+  <data name="MailPage.Toggle.Unread.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Keep only unread mail</value>
+    <comment>Names the filter that keeps unread mail alone. Icon-only, like every other control on this bar.</comment>
+  </data>
+  <data name="MailPage.Toggle.Flagged.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Keep only flagged mail</value>
+    <comment>Names the filter that keeps flagged mail alone.</comment>
+  </data>
+  <data name="MailPage.Toggle.Attachments.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Keep only mail with attachments</value>
+    <comment>Names the filter that keeps mail carrying an attachment alone.</comment>
+  </data>
+  <data name="MailPage.Toggle.Junk.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Include junk mail</value>
+    <comment>Names the filter that lets junk mail take part. A junk folder opened on purpose takes part whatever this says.</comment>
+  </data>
+  <data name="MailPage.Toggle.Selecting.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Select several messages</value>
+    <comment>Names the control that puts the list into a selection several rows at a time, which a touch head also reaches by holding a row.</comment>
+  </data>
+  <data name="MailPage.TextBlock.Narrowed.Text" xml:space="preserve">
+    <value>Filtered</value>
+    <comment>Says that the list is showing less than the place holds, so a filtered folder is not mistaken for an emptier one.</comment>
+  </data>
+  <data name="MailPage.Button.ShowEarlier.Content" xml:space="preserve">
+    <value>Show earlier mail</value>
+    <comment>Asks for the pages before what is loaded, which the bounded window gave up rather than kept.</comment>
+  </data>
+  <data name="MailPage.Button.ShowMore.Content" xml:space="preserve">
+    <value>Show more mail</value>
+    <comment>Asks for the next page of the list.</comment>
+  </data>
+  <data name="MailPage.InfoBar.NoMessages.Title" xml:space="preserve">
+    <value>Nothing here</value>
+    <comment>Heads the state a place with no mail to draw is shown. It is a state rather than a failure, so it is not worded as one.</comment>
+  </data>
+  <data name="MailPage.InfoBar.NoMessages.Message" xml:space="preserve">
+    <value>There is no mail to show here. Either this place holds none, or MailFathom has not taken it in yet — the mailbox pane says how current this copy is.</value>
+    <comment>Names both readings of an empty list and points at where the difference between them is actually said, which is per folder in the tree.</comment>
+  </data>
+  <data name="MailPage.InfoBar.NoKeptMessages.Title" xml:space="preserve">
+    <value>Nothing matches</value>
+    <comment>Heads the state a filtered list with nothing left in it is shown, which is a different thing from a place holding nothing.</comment>
+  </data>
+  <data name="MailPage.InfoBar.NoKeptMessages.Message" xml:space="preserve">
+    <value>Nothing here is kept by what this list is filtering for. Turn a filter off above to see the rest.</value>
+    <comment>Says what to press rather than leaving somebody looking at an empty folder they have filtered themselves into.</comment>
+  </data>
+  <data name="MailPage.InfoBar.MessagesUnavailable.Title" xml:space="preserve">
+    <value>This list could not be read</value>
+    <comment>Heads the state a failed read of the list is shown.</comment>
+  </data>
+  <data name="MailPage.InfoBar.MessagesUnavailable.Message" xml:space="preserve">
+    <value>MailFathom did not answer with the mail for this place. Try again, and look at the mailbox pane if it keeps failing.</value>
+    <comment>Says what to try in this application's own words rather than repeating a message written for a log.</comment>
+  </data>
+  <data name="MailPage.Button.RetryMessages.Content" xml:space="preserve">
+    <value>Try again</value>
+    <comment>Asks the deployment for the list again, which is what a person presses when it did not arrive.</comment>
+  </data>
+  <data name="MailPage.InfoBar.PageUnavailable.Title" xml:space="preserve">
+    <value>That page did not arrive</value>
+    <comment>Heads a page that failed, which leaves the mail already drawn on the screen rather than replacing it.</comment>
+  </data>
+  <data name="MailPage.InfoBar.PageUnavailable.Message" xml:space="preserve">
+    <value>What is already shown is still current. Ask for the page again.</value>
+    <comment>Says that nothing was lost, because a warning over a list that is still correct otherwise reads as the list being wrong.</comment>
   </data>
   <data name="MailPage.Reading.Heading" xml:space="preserve">
     <value>Reading</value>
@@ -528,5 +596,41 @@
   <data name="Mailboxes.Freshness.LongerAgo" xml:space="preserve">
     <value>Nothing taken in for over a week</value>
     <comment>The widest gap band. It states the gap without calling the copy stale, which is the reader's judgement rather than the client's.</comment>
+  </data>
+  <data name="Messages.NoSender" xml:space="preserve">
+    <value>Unknown sender</value>
+    <comment>Stands in for a message whose sender no header carried, so the column reads as a message rather than as a row that failed to load.</comment>
+  </data>
+  <data name="Messages.NoSubject" xml:space="preserve">
+    <value>(no subject)</value>
+    <comment>Stands in for a message carrying no subject, on the same terms.</comment>
+  </data>
+  <data name="Messages.NoDate" xml:space="preserve">
+    <value>No date</value>
+    <comment>Stands in for a message no header dated, which the timeline still orders by what it recorded.</comment>
+  </data>
+  <data name="Messages.MoreRecipients" xml:space="preserve">
+    <value>{0} +{1}</value>
+    <comment>Names the first recipient beside how many others there are, for a row of mail this owner sent. {0} is that recipient and {1} is the count of the rest.</comment>
+  </data>
+  <data name="Messages.Announcement" xml:space="preserve">
+    <value>{0}. {1}. {2}.</value>
+    <comment>The whole row as one sentence for a screen reader: {0} is who the message is with, {1} is what it is about, and {2} is when it arrived.</comment>
+  </data>
+  <data name="Messages.Announcement.Unread" xml:space="preserve">
+    <value>Unread.</value>
+    <comment>Appended to the sentence above where the row has not been read, since the mark that says so is drawn rather than announced.</comment>
+  </data>
+  <data name="Messages.Announcement.Flagged" xml:space="preserve">
+    <value>Flagged.</value>
+    <comment>Appended on the same terms for a flagged row.</comment>
+  </data>
+  <data name="Messages.Announcement.Answered" xml:space="preserve">
+    <value>Answered.</value>
+    <comment>Appended on the same terms for a row that has been answered.</comment>
+  </data>
+  <data name="Messages.Announcement.Attachments" xml:space="preserve">
+    <value>Has attachments.</value>
+    <comment>Appended on the same terms for a row carrying an attachment.</comment>
   </data>
 </root>

--- a/frontend/src/Client/Strings/pl/Resources.resw
+++ b/frontend/src/Client/Strings/pl/Resources.resw
@@ -277,13 +277,81 @@
     <value>Ta kolumna jest wciąż budowana.</value>
     <comment>The companion column's counterpart to the sentence above.</comment>
   </data>
-  <data name="MailPage.Messages.Heading" xml:space="preserve">
-    <value>Poczta</value>
-    <comment>Names the primary column of the Mail space while that space is being built.</comment>
+  <data name="MailPage.List.Messages.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Wiadomości w tym miejscu</value>
+    <comment>Names the list itself, so a screen reader announces what the rows belong to before it reads one.</comment>
   </data>
-  <data name="MailPage.Messages.Detail" xml:space="preserve">
-    <value>Ta przestrzeń jest wciąż budowana.</value>
-    <comment>Says plainly that the space is empty because nothing has been put in it yet, rather than because something failed.</comment>
+  <data name="MailPage.Toggle.Order.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Czytaj od najstarszych</value>
+    <comment>Names the control that reads the list from the other end of the timeline, which carries an icon rather than words.</comment>
+  </data>
+  <data name="MailPage.Toggle.Unread.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Zostaw tylko nieprzeczytane</value>
+    <comment>Names the filter that keeps unread mail alone. Icon-only, like every other control on this bar.</comment>
+  </data>
+  <data name="MailPage.Toggle.Flagged.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Zostaw tylko oznaczone</value>
+    <comment>Names the filter that keeps flagged mail alone.</comment>
+  </data>
+  <data name="MailPage.Toggle.Attachments.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Zostaw tylko z załącznikami</value>
+    <comment>Names the filter that keeps mail carrying an attachment alone.</comment>
+  </data>
+  <data name="MailPage.Toggle.Junk.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Uwzględnij niechcianą pocztę</value>
+    <comment>Names the filter that lets junk mail take part. A junk folder opened on purpose takes part whatever this says.</comment>
+  </data>
+  <data name="MailPage.Toggle.Selecting.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Zaznacz kilka wiadomości</value>
+    <comment>Names the control that puts the list into a selection several rows at a time, which a touch head also reaches by holding a row.</comment>
+  </data>
+  <data name="MailPage.TextBlock.Narrowed.Text" xml:space="preserve">
+    <value>Filtrowane</value>
+    <comment>Says that the list is showing less than the place holds, so a filtered folder is not mistaken for an emptier one.</comment>
+  </data>
+  <data name="MailPage.Button.ShowEarlier.Content" xml:space="preserve">
+    <value>Pokaż wcześniejszą pocztę</value>
+    <comment>Asks for the pages before what is loaded, which the bounded window gave up rather than kept.</comment>
+  </data>
+  <data name="MailPage.Button.ShowMore.Content" xml:space="preserve">
+    <value>Pokaż więcej poczty</value>
+    <comment>Asks for the next page of the list.</comment>
+  </data>
+  <data name="MailPage.InfoBar.NoMessages.Title" xml:space="preserve">
+    <value>Nic tutaj nie ma</value>
+    <comment>Heads the state a place with no mail to draw is shown. It is a state rather than a failure, so it is not worded as one.</comment>
+  </data>
+  <data name="MailPage.InfoBar.NoMessages.Message" xml:space="preserve">
+    <value>Nie ma tu poczty do pokazania. Albo to miejsce nic nie zawiera, albo MailFathom jeszcze jej nie pobrał — panel skrzynek mówi, jak aktualna jest ta kopia.</value>
+    <comment>Names both readings of an empty list and points at where the difference between them is actually said, which is per folder in the tree.</comment>
+  </data>
+  <data name="MailPage.InfoBar.NoKeptMessages.Title" xml:space="preserve">
+    <value>Nic nie pasuje</value>
+    <comment>Heads the state a filtered list with nothing left in it is shown, which is a different thing from a place holding nothing.</comment>
+  </data>
+  <data name="MailPage.InfoBar.NoKeptMessages.Message" xml:space="preserve">
+    <value>Żadna wiadomość w tym miejscu nie przechodzi przez filtry tej listy. Wyłącz filtr powyżej, aby zobaczyć resztę.</value>
+    <comment>Says what to press rather than leaving somebody looking at an empty folder they have filtered themselves into.</comment>
+  </data>
+  <data name="MailPage.InfoBar.MessagesUnavailable.Title" xml:space="preserve">
+    <value>Nie udało się odczytać tej listy</value>
+    <comment>Heads the state a failed read of the list is shown.</comment>
+  </data>
+  <data name="MailPage.InfoBar.MessagesUnavailable.Message" xml:space="preserve">
+    <value>MailFathom nie odpowiedział pocztą dla tego miejsca. Spróbuj ponownie, a jeśli to się powtarza, sprawdź panel skrzynek.</value>
+    <comment>Says what to try in this application's own words rather than repeating a message written for a log.</comment>
+  </data>
+  <data name="MailPage.Button.RetryMessages.Content" xml:space="preserve">
+    <value>Spróbuj ponownie</value>
+    <comment>Asks the deployment for the list again, which is what a person presses when it did not arrive.</comment>
+  </data>
+  <data name="MailPage.InfoBar.PageUnavailable.Title" xml:space="preserve">
+    <value>Ta strona nie dotarła</value>
+    <comment>Heads a page that failed, which leaves the mail already drawn on the screen rather than replacing it.</comment>
+  </data>
+  <data name="MailPage.InfoBar.PageUnavailable.Message" xml:space="preserve">
+    <value>To, co już widać, jest nadal aktualne. Poproś o tę stronę jeszcze raz.</value>
+    <comment>Says that nothing was lost, because a warning over a list that is still correct otherwise reads as the list being wrong.</comment>
   </data>
   <data name="MailPage.Reading.Heading" xml:space="preserve">
     <value>Czytanie</value>
@@ -528,5 +596,41 @@
   <data name="Mailboxes.Freshness.LongerAgo" xml:space="preserve">
     <value>Od ponad tygodnia nic nie pobrano</value>
     <comment>The widest gap band. It states the gap without calling the copy stale, which is the reader's judgement rather than the client's.</comment>
+  </data>
+  <data name="Messages.NoSender" xml:space="preserve">
+    <value>Nieznany nadawca</value>
+    <comment>Stands in for a message whose sender no header carried, so the column reads as a message rather than as a row that failed to load.</comment>
+  </data>
+  <data name="Messages.NoSubject" xml:space="preserve">
+    <value>(bez tematu)</value>
+    <comment>Stands in for a message carrying no subject, on the same terms.</comment>
+  </data>
+  <data name="Messages.NoDate" xml:space="preserve">
+    <value>Bez daty</value>
+    <comment>Stands in for a message no header dated, which the timeline still orders by what it recorded.</comment>
+  </data>
+  <data name="Messages.MoreRecipients" xml:space="preserve">
+    <value>{0} +{1}</value>
+    <comment>Names the first recipient beside how many others there are, for a row of mail this owner sent. {0} is that recipient and {1} is the count of the rest.</comment>
+  </data>
+  <data name="Messages.Announcement" xml:space="preserve">
+    <value>{0}. {1}. {2}.</value>
+    <comment>The whole row as one sentence for a screen reader: {0} is who the message is with, {1} is what it is about, and {2} is when it arrived.</comment>
+  </data>
+  <data name="Messages.Announcement.Unread" xml:space="preserve">
+    <value>Nieprzeczytana.</value>
+    <comment>Appended to the sentence above where the row has not been read, since the mark that says so is drawn rather than announced.</comment>
+  </data>
+  <data name="Messages.Announcement.Flagged" xml:space="preserve">
+    <value>Oznaczona.</value>
+    <comment>Appended on the same terms for a flagged row.</comment>
+  </data>
+  <data name="Messages.Announcement.Answered" xml:space="preserve">
+    <value>Odpowiedziana.</value>
+    <comment>Appended on the same terms for a row that has been answered.</comment>
+  </data>
+  <data name="Messages.Announcement.Attachments" xml:space="preserve">
+    <value>Ma załączniki.</value>
+    <comment>Appended on the same terms for a row carrying an attachment.</comment>
   </data>
 </root>

--- a/frontend/src/README.md
+++ b/frontend/src/README.md
@@ -25,11 +25,11 @@ What is inside the two projects:
 | `Client.Backend/` | The typed client, the wire records, and the source-generated readers for them |
 | `Client.Backend/Authorization/` | Signing in: discovery, the proof key, the exchange, and the token held in memory for the run |
 
-The application is empty of features, and it is no longer empty of structure: it opens on the frame the three spaces
-are shown inside, and the section below says what that frame is. What it can do beyond moving between them is what a
-reader decides about the application itself — which language it is read in, and which theme it is shown in — beside the
-version this build was stamped with, read from the assembly rather than written here so the client and the service
-report one number.
+The application opens on the frame the three spaces are shown inside, and the section below says what that frame is.
+One of the three reads something today: Mail draws the mail of wherever the tree says somebody is. The other two are
+still empty, and what the application can do beside them is what a reader decides about it — which language it is read
+in, and which theme it is shown in — beside the version this build was stamped with, read from the assembly rather than
+written here so the client and the service report one number.
 
 It reaches MailFathom over the endpoints `backend/src/Host/` exposes and shares nothing else with it: no build file, no
 package manifest, no configuration file, and no type. Which deployment it reaches is the composing host's to state, and
@@ -39,8 +39,9 @@ nothing states it yet. `AGENTS.md` beside this file states why, and states the c
 
 The product is three spaces — **Discover**, **Mail**, and **Cases** — and they are one application rather than three.
 What makes them one is the frame around them, which is what `Client/Presentation/Workspace/` holds and what a client
-already pointed at a deployment opens on. The spaces themselves are empty: `Client/Presentation/Spaces/` carries a page
-per space that says so, and each of the three parents that owns a space fills its own page in.
+already pointed at a deployment opens on. `Client/Presentation/Spaces/` carries a page per space; Mail's holds the
+message list described below, and Discover's and Cases' say they are empty until the parent that owns each fills its
+own page in.
 
 **Each space is a route, and so is everything else on screen.** `App.RegisterRoutes` nests `Discover`, `Mail`, and
 `Cases` inside the frame and registers `Settings` and `Connect` beside it, every one of them named once in
@@ -94,6 +95,39 @@ written: a selection names mail somebody was reading a moment ago rather than wh
 may be gone by the next run. What is written is a folder alias, a hierarchy path, and an account identifier, which are
 mail metadata and therefore personal data — held on the device, in the store the platform gives this application alone,
 never logged and never sent anywhere.
+
+**The mail of that place is one list, and it is the run's own.** `Client/Presentation/Messages/` holds it, and
+`IMessageList` is registered once for the run beside the tree and the workspace — so leaving Mail and coming back finds
+the list where it was rather than reading its first page again. It follows the *place* the scope names rather than the
+whole scope, which is load-bearing rather than an optimization: the list writes what is selected back into that same
+scope, and a list keyed on the whole of one would read the folder again on every click.
+
+**What is loaded is a bounded window rather than everything somebody has scrolled past.** A page is asked for by cursor
+in either direction, four of them are held at once, and taking a page at one end drops the one at the other — so the
+number of rows the client holds is a property of the window rather than of how long the list has been scrolled, whatever
+the folder holds. Dropping a page is safe because each one keeps the request that produced it: the page that becomes the
+far end carries the cursor that reads back towards what went. That same value is what is written down when a folder is
+left, so returning is a continuation rather than a jump to the top — remembered to the page rather than to the pixel,
+since a page is the unit a cursor names. Every place one run visited is kept in memory, bounded; the one somebody is in
+outlives the run in `ApplicationData.LocalSettings`, as a cursor and an arrangement and never as a row. A cursor a
+deployment no longer honours is a position to give up rather than an error to show, so the list quietly opens at the
+leading end instead.
+
+**A row is drawn from the page that carried it and from nothing else** — sender or recipients, subject, date, read,
+flagged and answered marks, whether there is an attachment, and the opening of the message's own text — so fifty rows
+are one request rather than fifty. It carries the message's own identity as its key, which is what lets a refresh update
+the rows that changed and leave the containers of the rest alone, and it states itself once as a sentence for a screen
+reader instead of as six unlabelled controls. How the list is arranged — which end leads, and whether it keeps only
+unread, only flagged, only mail carrying an attachment, or lets junk take part — is shown on the controls that did it
+and is remembered with the place, because a cursor is only honoured against the filters and the order it was issued
+under.
+
+**What is selected is the application's rather than the control's.** The list mirrors its selection into
+`IWorkspace.Scope`, which is what lets a question in Discover be asked about mail somebody picked in Mail; on a pointer
+head that is the ordinary extended selection with its modifiers and its drag, and on a touch head a press and hold puts
+the list into a selecting mode that is visible and can be left. Loading, a read that failed, a folder holding no mail,
+and a folder whose mail this list is keeping out are four rendered states rather than one blank list — the last two are
+told apart in words, and how current the copy is stays the tree's to say.
 
 **Settings is reached from the frame rather than named among the spaces**, because it is not one. It is the screen that
 says which build is running and which deployment this client is pointed at, carries the two choices below and the way to

--- a/frontend/tests/Client.UnitTests/Backend/Timeline/DeploymentMailTimelineTests.cs
+++ b/frontend/tests/Client.UnitTests/Backend/Timeline/DeploymentMailTimelineTests.cs
@@ -1,0 +1,198 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Net;
+using MailFathom.Client.Backend;
+using MailFathom.Client.Backend.Timeline;
+using MailFathom.Client.UnitTests.TestDoubles;
+
+namespace MailFathom.Client.UnitTests.Backend.Timeline;
+
+/// <summary>What the client makes of one page of the message list a deployment serves.</summary>
+public sealed class DeploymentMailTimelineTests
+{
+    private const string OnePage =
+        """
+        {
+          "emails": [
+            {
+              "id": "8a1e0f24-2b3c-4d5e-9f60-112233445566",
+              "account": "work",
+              "folder": "INBOX",
+              "threadId": "0d2f5ab1-7c88-4e11-92aa-556677889900",
+              "subject": "Quarterly review",
+              "receivedAt": "2026-08-25T11:50:00+00:00",
+              "sentAt": "2026-08-25T11:49:00+00:00",
+              "senderAddress": "someone@example.test",
+              "senderDisplayName": "Someone",
+              "toAddresses": [ "owner@example.test" ],
+              "unread": true,
+              "flagged": true,
+              "answered": false,
+              "hasAttachments": true,
+              "attachmentCount": 2,
+              "sizeOctets": 40960,
+              "preview": "The numbers for the quarter are"
+            }
+          ],
+          "nextCursor": "after-the-page",
+          "previousCursor": null,
+          "pageSize": 50
+        }
+        """;
+
+    /// <summary>Every field of the contract is read, because a row is drawn out of each of them and out of nothing else.</summary>
+    [Fact]
+    public async Task ReadMailTimelineAsync_ADeploymentAnswering_ReadsEveryFieldOfTheContract()
+    {
+        // Arrange
+        using var harness = new DeploymentHarness(_ => StubTransport.JsonResponse(OnePage));
+
+        // Act
+        var page = await harness.Client.ReadMailTimelineAsync(
+            new MailTimelineQuery(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("after-the-page", page.NextCursor);
+        Assert.Null(page.PreviousCursor);
+        Assert.Equal(50, page.PageSize);
+
+        var message = Assert.Single(page.Rows);
+        Assert.Equal(Guid.Parse("8a1e0f24-2b3c-4d5e-9f60-112233445566"), message.Id);
+        Assert.Equal("work", message.Account);
+        Assert.Equal("INBOX", message.Folder);
+        Assert.Equal(Guid.Parse("0d2f5ab1-7c88-4e11-92aa-556677889900"), message.ThreadId);
+        Assert.Equal("Quarterly review", message.Subject);
+        Assert.Equal(new DateTimeOffset(2026, 8, 25, 11, 50, 0, TimeSpan.Zero), message.ReceivedAt);
+        Assert.Equal(new DateTimeOffset(2026, 8, 25, 11, 49, 0, TimeSpan.Zero), message.SentAt);
+        Assert.Equal("someone@example.test", message.SenderAddress);
+        Assert.Equal("Someone", message.SenderDisplayName);
+        Assert.Equal(["owner@example.test"], message.Recipients);
+        Assert.True(message.Unread);
+        Assert.True(message.Flagged);
+        Assert.False(message.Answered);
+        Assert.True(message.HasAttachments);
+        Assert.Equal(2, message.AttachmentCount);
+        Assert.Equal(40960, message.SizeOctets);
+        Assert.Equal("The numbers for the quarter are", message.Preview);
+    }
+
+    /// <summary>The route is the client surface's own, and it carries what the query narrowed to.</summary>
+    [Fact]
+    public async Task ReadMailTimelineAsync_ARequestNarrowingSomewhere_GoesToTheClientSurfaceCarryingIt()
+    {
+        // Arrange
+        using var harness = new DeploymentHarness(_ => StubTransport.JsonResponse(OnePage));
+
+        // Act
+        await harness.Client.ReadMailTimelineAsync(
+            new MailTimelineQuery { Account = "work", Folder = "INBOX", PageSize = 50 },
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var asked = Assert.Single(harness.Deployment.Requests).RequestUri;
+        Assert.NotNull(asked);
+        Assert.Equal("/api/client/emails", asked.AbsolutePath);
+        Assert.Equal("?account=work&folder=INBOX&order=newestFirst&direction=forward&pageSize=50", asked.Query);
+    }
+
+    /// <summary>A document naming no row reads as a page holding nothing rather than as a shape a caller has to remember.</summary>
+    [Fact]
+    public async Task ReadMailTimelineAsync_ADocumentNamingNoRow_ReadsAsEmptyRatherThanFailing()
+    {
+        // Arrange
+        using var harness = new DeploymentHarness(_ => StubTransport.JsonResponse("""{"pageSize":25}"""));
+
+        // Act
+        var page = await harness.Client.ReadMailTimelineAsync(
+            new MailTimelineQuery(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(page.Rows);
+        Assert.Null(page.NextCursor);
+        Assert.Null(page.PreviousCursor);
+    }
+
+    /// <summary>
+    /// A cursor the deployment will not honour is the client's own request being refused rather than a defect, which
+    /// is what lets a list give up a remembered position instead of showing somebody an error about a value they
+    /// never typed.
+    /// </summary>
+    [Fact]
+    public async Task ReadMailTimelineAsync_ACursorTheDeploymentRefuses_ReachesTheCallerAsARefusedRequest()
+    {
+        // Arrange
+        using var harness = new DeploymentHarness(
+            _ => StubTransport.JsonResponse("{}", HttpStatusCode.BadRequest));
+
+        // Act
+        var failure = await Assert.ThrowsAsync<DeploymentFailure>(
+            () => harness.Client.ReadMailTimelineAsync(
+                new MailTimelineQuery { Cursor = "stale" },
+                TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(DeploymentFailureReason.RequestRefused, failure.Reason);
+    }
+
+    /// <summary>A credential the deployment will not serve is kept apart from a place that holds no mail.</summary>
+    [Fact]
+    public async Task ReadMailTimelineAsync_ACredentialWithoutTheGrant_IsRefusedRatherThanAnsweredWithNothing()
+    {
+        // Arrange
+        using var harness = new DeploymentHarness(
+            _ => StubTransport.JsonResponse("{}", HttpStatusCode.Forbidden));
+
+        // Act
+        var failure = await Assert.ThrowsAsync<DeploymentFailure>(
+            () => harness.Client.ReadMailTimelineAsync(
+                new MailTimelineQuery(),
+                TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(DeploymentFailureReason.CredentialRefused, failure.Reason);
+    }
+
+    /// <summary>A read with nothing to describe would be a request composed from nowhere.</summary>
+    [Fact]
+    public async Task ReadMailTimelineAsync_NoQuery_IsRefused()
+    {
+        // Arrange
+        using var harness = new DeploymentHarness(_ => StubTransport.JsonResponse(OnePage));
+
+        // Act, Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => harness.Client.ReadMailTimelineAsync(null!, TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>A message reported with no recipients reads as a message addressed to nobody this row draws.</summary>
+    [Fact]
+    public void Recipients_AMessageReportedWithNone_FallsBackToNothingRatherThanFailing()
+    {
+        // Arrange
+        var message = new DeploymentMailMessage(
+            Guid.Empty,
+            "work",
+            "INBOX",
+            ThreadId: null,
+            Subject: null,
+            ReceivedAt: null,
+            SentAt: null,
+            SenderAddress: null,
+            SenderDisplayName: null,
+            ToAddresses: null!,
+            Unread: false,
+            Flagged: false,
+            Answered: false,
+            HasAttachments: false,
+            AttachmentCount: 0,
+            SizeOctets: 0,
+            Preview: null);
+
+        // Act, Assert
+        Assert.Empty(message.Recipients);
+    }
+}

--- a/frontend/tests/Client.UnitTests/Backend/Timeline/MailTimelineQueryTests.cs
+++ b/frontend/tests/Client.UnitTests/Backend/Timeline/MailTimelineQueryTests.cs
@@ -1,0 +1,110 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Backend.Timeline;
+
+namespace MailFathom.Client.UnitTests.Backend.Timeline;
+
+/// <summary>What one page of the list is asked for as, which is the whole of what this client says about a request.</summary>
+public sealed class MailTimelineQueryTests
+{
+    /// <summary>A query stating nothing narrows nothing, which is the unified list read from its leading end.</summary>
+    [Fact]
+    public void QueryString_AQueryNarrowingNothing_StatesOnlyTheOrderAndTheDirection()
+    {
+        // Act
+        var written = new MailTimelineQuery().QueryString();
+
+        // Assert
+        Assert.Equal("?order=newestFirst&direction=forward", written);
+    }
+
+    /// <summary>
+    /// A filter keeping everything is left out rather than sent as "both", so a request says what somebody narrowed
+    /// and nothing else.
+    /// </summary>
+    [Fact]
+    public void QueryString_AFilterKeepingEverything_IsLeftUnstated()
+    {
+        // Arrange
+        var query = new MailTimelineQuery { Unread = null, Flagged = false, IncludeJunk = false };
+
+        // Act
+        var written = query.QueryString();
+
+        // Assert
+        Assert.DoesNotContain("unread", written, StringComparison.Ordinal);
+        Assert.DoesNotContain("includeJunk", written, StringComparison.Ordinal);
+        Assert.Contains("flagged=false", written, StringComparison.Ordinal);
+    }
+
+    /// <summary>Every value the request carries reaches the wire under the name the surface publishes.</summary>
+    [Fact]
+    public void QueryString_AQueryStatingEverything_WritesEachValueUnderItsPublishedName()
+    {
+        // Arrange
+        var query = new MailTimelineQuery
+        {
+            Account = "work",
+            Folder = "INBOX",
+            IncludeJunk = true,
+            Unread = true,
+            Flagged = true,
+            HasAttachments = true,
+            Order = MailTimelineOrder.OldestFirst,
+            Direction = MailTimelinePageDirection.Backward,
+            PageSize = 50,
+            Cursor = "the-cursor",
+        };
+
+        // Act
+        var written = query.QueryString();
+
+        // Assert
+        Assert.Equal(
+            "?account=work&folder=INBOX&includeJunk=true&unread=true&flagged=true&hasAttachments=true"
+            + "&order=oldestFirst&direction=backward&pageSize=50&cursor=the-cursor",
+            written);
+    }
+
+    /// <summary>
+    /// A folder alias is a name a mail server chose and a cursor is a value this client received, so neither may be
+    /// written raw into a URL whatever either happens to look like today.
+    /// </summary>
+    [Fact]
+    public void QueryString_ValuesThisClientDidNotCompose_AreEscapedForTheQueryString()
+    {
+        // Arrange
+        var query = new MailTimelineQuery { Folder = "Projects & plans/2024", Cursor = "a+b=c&d" };
+
+        // Act
+        var written = query.QueryString();
+
+        // Assert
+        Assert.Contains("folder=Projects%20%26%20plans%2F2024", written, StringComparison.Ordinal);
+        Assert.Contains("cursor=a%2Bb%3Dc%26d", written, StringComparison.Ordinal);
+    }
+
+    /// <summary>A role taken across mailboxes is written as the folder, because that is what it is on this surface.</summary>
+    [Fact]
+    public void QueryString_ARoleWrittenAsAFolder_KeepsTheSchemeTheSurfaceReads()
+    {
+        // Act
+        var written = new MailTimelineQuery { Folder = "role:Inbox" }.QueryString();
+
+        // Assert
+        Assert.Contains("folder=role%3AInbox", written, StringComparison.Ordinal);
+    }
+
+    /// <summary>A page size is written the way a machine reads a number rather than the way a reader's culture does.</summary>
+    [Fact]
+    public void QueryString_APageSize_IsWrittenInvariantly()
+    {
+        // Act
+        var written = new MailTimelineQuery { PageSize = 1000 }.QueryString();
+
+        // Assert
+        Assert.Contains("pageSize=1000", written, StringComparison.Ordinal);
+    }
+}

--- a/frontend/tests/Client.UnitTests/Presentation/Messages/DeploymentMessageListTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Messages/DeploymentMessageListTests.cs
@@ -1,0 +1,532 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Net;
+using MailFathom.Client.Backend;
+using MailFathom.Client.Backend.Timeline;
+using MailFathom.Client.Presentation.Messages;
+using MailFathom.Client.Presentation.Workspace;
+using MailFathom.Client.Session;
+using MailFathom.Client.UnitTests.TestDoubles;
+
+namespace MailFathom.Client.UnitTests.Presentation.Messages;
+
+/// <summary>The list over one deployment: what it reads, what paging it does, and what it writes back.</summary>
+public sealed class DeploymentMessageListTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 25, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>The list opens on the leading page of the place in force, which is one request for a screenful.</summary>
+    [Fact]
+    public async Task Rows_ADeploymentAnswering_DrawsThePageItServed()
+    {
+        // Arrange
+        using var over = new ListOver(_ => Answer(Page(1, 3, next: "after-3", previous: null)));
+
+        // Act
+        var rows = await over.List.Rows;
+
+        // Assert
+        Assert.NotNull(rows);
+        Assert.Equal([MailMessages.Key(1), MailMessages.Key(2), MailMessages.Key(3)], rows.Select(row => row.Key));
+
+        var asked = Assert.Single(over.Harness.Deployment.Requests).RequestUri;
+        Assert.Equal("/api/client/emails", asked.AbsolutePath);
+        Assert.Contains($"pageSize={DeploymentMessageList.PageSize}", asked.Query, StringComparison.Ordinal);
+        Assert.DoesNotContain("cursor=", asked.Query, StringComparison.Ordinal);
+    }
+
+    /// <summary>The place somebody narrowed to is what the deployment is asked about, rather than every mailbox.</summary>
+    [Fact]
+    public async Task Rows_AScopeNarrowedToAFolder_AsksTheDeploymentAboutThatFolder()
+    {
+        // Arrange
+        using var over = new ListOver(_ => Answer(Page(1, 1, next: null, previous: null)));
+        await over.List.Rows;
+
+        // Act
+        await over.Workspace.Scope.UpdateAsync(
+            _ => new WorkspaceScope { Account = "work", Folder = "INBOX" },
+            TestContext.Current.CancellationToken);
+
+        await over.Until(() =>
+            ValueTask.FromResult(over.Asked.Any(query => query.Contains("folder=INBOX", StringComparison.Ordinal))));
+
+        // Assert
+        Assert.Contains(
+            over.Asked,
+            query => query.Contains("account=work", StringComparison.Ordinal)
+                && query.Contains("folder=INBOX", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The list reads the place rather than the scope, which is load-bearing rather than an optimization: it writes
+    /// what is selected back into the same scope, so keying it on the whole of one would read the folder again on every
+    /// click.
+    /// </summary>
+    [Fact]
+    public async Task Rows_AScopeWhoseSelectionChanged_DoesNotReadTheFolderAgain()
+    {
+        // Arrange
+        using var over = new ListOver(_ => Answer(Page(1, 3, next: null, previous: null)));
+        var rows = await over.List.Rows;
+
+        // Act
+        await over.List.Chosen.UpdateAsync(
+            _ => ImmutableList.Create(rows![0]),
+            TestContext.Current.CancellationToken);
+
+        await over.Until(async () => (await over.Workspace.Scope)?.Selection.Count is 1);
+
+        // Assert
+        Assert.Single(over.Harness.Deployment.Requests);
+    }
+
+    /// <summary>
+    /// What is selected in the list is the application's scope rather than the control's, which is what lets the rest
+    /// of the client act on it.
+    /// </summary>
+    [Fact]
+    public async Task Chosen_RowsSomebodySelected_ReachTheWorkspaceAsWhatIsInScope()
+    {
+        // Arrange
+        using var over = new ListOver(_ => Answer(Page(1, 3, next: null, previous: null)));
+        var rows = await over.List.Rows;
+
+        // Act
+        await over.List.Chosen.UpdateAsync(
+            _ => ImmutableList.Create(rows![0], rows[2]),
+            TestContext.Current.CancellationToken);
+
+        await over.Until(async () => (await over.Workspace.Scope)?.Selection.Count is 2);
+
+        // Assert
+        var scope = await over.Workspace.Scope;
+        Assert.Equal([MailMessages.Key(1), MailMessages.Key(3)], scope!.Selection);
+    }
+
+    /// <summary>Scrolling on takes the next page onto what is loaded, asked for with the cursor the last one answered with.</summary>
+    [Fact]
+    public async Task ShowMoreAsync_MoreMailAfterWhatIsLoaded_TakesThePageOntoTheList()
+    {
+        // Arrange
+        using var over = new ListOver(request => Answer(
+            Cursor(request) is null
+                ? Page(1, 2, next: "after-2", previous: null)
+                : Page(3, 2, next: null, previous: "before-3")));
+
+        await over.List.Rows;
+
+        // Act
+        await over.List.ShowMoreAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var rows = await over.List.Rows;
+        Assert.Equal(
+            [MailMessages.Key(1), MailMessages.Key(2), MailMessages.Key(3), MailMessages.Key(4)],
+            rows!.Select(row => row.Key));
+        Assert.Contains("cursor=after-2", over.Asked[^1], StringComparison.Ordinal);
+        Assert.Contains("direction=forward", over.Asked[^1], StringComparison.Ordinal);
+    }
+
+    /// <summary>Scrolling back asks the other way, which is how a window that dropped a page gets it again.</summary>
+    [Fact]
+    public async Task ShowEarlierAsync_MoreMailBeforeWhatIsLoaded_AsksForItTheOtherWay()
+    {
+        // Arrange
+        using var over = new ListOver(request => Answer(
+            Cursor(request) is null
+                ? Page(3, 2, next: null, previous: "before-3")
+                : Page(1, 2, next: "after-2", previous: null)));
+
+        await over.List.Rows;
+
+        // Act
+        await over.List.ShowEarlierAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var rows = await over.List.Rows;
+        Assert.Equal(
+            [MailMessages.Key(1), MailMessages.Key(2), MailMessages.Key(3), MailMessages.Key(4)],
+            rows!.Select(row => row.Key));
+        Assert.Contains("cursor=before-3", over.Asked[^1], StringComparison.Ordinal);
+        Assert.Contains("direction=backward", over.Asked[^1], StringComparison.Ordinal);
+    }
+
+    /// <summary>At the end of the list there is no cursor to ask with, so the deployment is not asked at all.</summary>
+    [Fact]
+    public async Task ShowMoreAsync_AtTheEndOfTheList_AsksTheDeploymentForNothing()
+    {
+        // Arrange
+        using var over = new ListOver(_ => Answer(Page(1, 2, next: null, previous: null)));
+        await over.List.Rows;
+
+        // Act
+        await over.List.ShowMoreAsync(TestContext.Current.CancellationToken);
+        await over.List.ShowEarlierAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Single(over.Harness.Deployment.Requests);
+        Assert.False(await over.List.HasMoreAfter);
+        Assert.False(await over.List.HasMoreBefore);
+    }
+
+    /// <summary>
+    /// A page that did not arrive is reported beside the list rather than as the list's own failure: what is already
+    /// drawn is still true, and putting the whole list into an error state would take a folder's worth of mail off the
+    /// screen over one request.
+    /// </summary>
+    [Fact]
+    public async Task ShowMoreAsync_APageThatDidNotArrive_IsReportedBesideTheListRatherThanAsIt()
+    {
+        // Arrange
+        using var over = new ListOver(request => Cursor(request) is null
+            ? Answer(Page(1, 2, next: "after-2", previous: null))
+            : StubTransport.JsonResponse("{}", HttpStatusCode.InternalServerError));
+
+        await over.List.Rows;
+
+        // Act
+        await over.List.ShowMoreAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var rows = await over.List.Rows;
+        Assert.Equal([MailMessages.Key(1), MailMessages.Key(2)], rows!.Select(row => row.Key));
+        Assert.True(await over.List.PagingFailed);
+    }
+
+    /// <summary>Coming back to a folder is coming back: the leading page it was left on is what is asked for again.</summary>
+    [Fact]
+    public async Task Rows_APlaceSomebodyHasBeenInBefore_ReopensWhereItWasLeft()
+    {
+        // Arrange
+        using var over = new ListOver(
+            _ => Answer(Page(9, 2, next: "after-10", previous: "before-9")),
+            new RememberedMessageList(
+                MessagePlace.Everything.RememberedAs,
+                "after-8",
+                MailTimelinePageDirection.Forward,
+                MessageListArrangement.Default));
+
+        // Act
+        var rows = await over.List.Rows;
+
+        // Assert
+        Assert.Equal([MailMessages.Key(9), MailMessages.Key(10)], rows!.Select(row => row.Key));
+        Assert.Contains("cursor=after-8", Assert.Single(over.Asked), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A cursor the deployment no longer honours is a position to give up rather than an error to show: nobody typed
+    /// it, and the list somebody asked for still exists.
+    /// </summary>
+    [Fact]
+    public async Task Rows_ACursorTheDeploymentRefuses_OpensAtTheLeadingEndInstead()
+    {
+        // Arrange
+        using var over = new ListOver(
+            request => Cursor(request) is null
+                ? Answer(Page(1, 2, next: "after-2", previous: null))
+                : StubTransport.JsonResponse("{}", HttpStatusCode.BadRequest),
+            new RememberedMessageList(
+                MessagePlace.Everything.RememberedAs,
+                "issued-under-another-arrangement",
+                MailTimelinePageDirection.Forward,
+                MessageListArrangement.Default));
+
+        // Act
+        var rows = await over.List.Rows;
+
+        // Assert
+        Assert.Equal([MailMessages.Key(1), MailMessages.Key(2)], rows!.Select(row => row.Key));
+        Assert.Equal(2, over.Asked.Count);
+        Assert.DoesNotContain("cursor=", over.Asked[^1], StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A remembered position naming no cursor is the leading end of the list, which is read forward whatever direction
+    /// was written beside it: there is no row to read away from, and the deployment refuses such a page rather than
+    /// answering it.
+    /// </summary>
+    [Fact]
+    public async Task Rows_ARememberedPositionNamingNoCursor_IsReadForwardWhateverWasWrittenBesideIt()
+    {
+        // Arrange
+        using var over = new ListOver(
+            request => Answer(Page(1, 2, next: null, previous: null)),
+            new RememberedMessageList(
+                MessagePlace.Everything.RememberedAs,
+                Cursor: null,
+                MailTimelinePageDirection.Backward,
+                MessageListArrangement.Default));
+
+        // Act
+        var rows = await over.List.Rows;
+
+        // Assert
+        Assert.Equal([MailMessages.Key(1), MailMessages.Key(2)], rows!.Select(row => row.Key));
+        Assert.Contains("direction=forward", Assert.Single(over.Asked), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A place is reopened under the arrangement it was left in, because a cursor is only honoured against the filters
+    /// and the order it was issued under.
+    /// </summary>
+    [Fact]
+    public async Task Rows_APlaceLeftUnderAnArrangement_ReopensUnderTheSameOne()
+    {
+        // Arrange
+        using var over = new ListOver(
+            _ => Answer(Page(1, 2, next: null, previous: null)),
+            new RememberedMessageList(
+                MessagePlace.Everything.RememberedAs,
+                Cursor: null,
+                MailTimelinePageDirection.Forward,
+                new MessageListArrangement { Order = MailTimelineOrder.OldestFirst, UnreadOnly = true }));
+
+        // Act
+        await over.List.Rows;
+
+        // Assert
+        var asked = Assert.Single(over.Asked);
+        Assert.Contains("order=oldestFirst", asked, StringComparison.Ordinal);
+        Assert.Contains("unread=true", asked, StringComparison.Ordinal);
+        Assert.Equal(
+            new MessageListArrangement { Order = MailTimelineOrder.OldestFirst, UnreadOnly = true },
+            await over.List.Arrangement);
+    }
+
+    /// <summary>
+    /// Arranging the list differently reads it again, because a new arrangement invalidates every cursor held under
+    /// the old one.
+    /// </summary>
+    [Fact]
+    public async Task ArrangeAsync_AListArrangedDifferently_ReadsItAgainUnderTheNewArrangement()
+    {
+        // Arrange
+        using var over = new ListOver(_ => Answer(Page(1, 2, next: null, previous: null)));
+        await over.List.Rows;
+
+        // Act
+        await over.List.ArrangeAsync(
+            MessageListArrangement.Default with { FlaggedOnly = true },
+            TestContext.Current.CancellationToken);
+
+        await over.Until(() => ValueTask.FromResult(over.Harness.Deployment.Requests.Count > 1));
+
+        // Assert
+        Assert.Contains("flagged=true", over.Asked[^1], StringComparison.Ordinal);
+        Assert.Equal(MessageListArrangement.Default with { FlaggedOnly = true }, await over.List.Arrangement);
+    }
+
+    /// <summary>What was left is written down as the request that reopens the leading page, and not as a row.</summary>
+    [Fact]
+    public async Task Rows_AListThatHasBeenPaged_WritesDownTheRequestThatReopensIt()
+    {
+        // Arrange
+        using var over = new ListOver(request => Answer(
+            Cursor(request) is null
+                ? Page(1, 2, next: "after-2", previous: null)
+                : Page(3, 2, next: null, previous: "before-3")));
+
+        await over.List.Rows;
+
+        // Act
+        await over.List.ShowMoreAsync(TestContext.Current.CancellationToken);
+        // Assert
+        var written = over.Memory.Written[^1];
+        Assert.Equal(MessagePlace.Everything.RememberedAs, written.PlaceKey);
+        Assert.Null(written.Cursor);
+        Assert.Equal(MailTimelinePageDirection.Forward, written.Direction);
+        Assert.Equal(MessageListArrangement.Default, written.Arrangement);
+    }
+
+    /// <summary>Asking again is one act: the session reads the deployment again, and the list follows it.</summary>
+    [Fact]
+    public async Task AskAgainAsync_AReadSomebodyAskedForAgain_ReachesTheSessionAndTheDeployment()
+    {
+        // Arrange
+        using var over = new ListOver(_ => Answer(Page(1, 2, next: null, previous: null)));
+        await over.List.Rows;
+
+        // Act
+        await over.List.AskAgainAsync(TestContext.Current.CancellationToken);
+        await over.Until(() => ValueTask.FromResult(over.Harness.Deployment.Requests.Count > 1));
+
+        // Assert
+        Assert.Equal(1, over.Session.Refreshes);
+        Assert.True(over.Harness.Deployment.Requests.Count > 1);
+    }
+
+    /// <summary>A list built over nothing would be one that could not say what it reads or where it draws it from.</summary>
+    [Fact]
+    public void Construction_AMissingCollaborator_IsRefused()
+    {
+        // Arrange
+        using var harness = new DeploymentHarness(_ => Answer(Page(1, 1, next: null, previous: null)));
+        using var session = Session();
+        var memory = new StubMessageListMemory();
+        var workspace = new SharedWorkspace(new StubMailboxTreeMemory());
+        var clock = new StubClock(Now);
+        var words = Words();
+
+        // Act, Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            new DeploymentMessageList(null!, session, workspace, memory, clock, words));
+        Assert.Throws<ArgumentNullException>(() =>
+            new DeploymentMessageList(harness.Client, null!, workspace, memory, clock, words));
+        Assert.Throws<ArgumentNullException>(() =>
+            new DeploymentMessageList(harness.Client, session, null!, memory, clock, words));
+        Assert.Throws<ArgumentNullException>(() =>
+            new DeploymentMessageList(harness.Client, session, workspace, null!, clock, words));
+        Assert.Throws<ArgumentNullException>(() =>
+            new DeploymentMessageList(harness.Client, session, workspace, memory, null!, words));
+        Assert.Throws<ArgumentNullException>(() =>
+            new DeploymentMessageList(harness.Client, session, workspace, memory, clock, null!));
+    }
+
+    private static StubClientSession Session() =>
+        new(SessionStanding.Of(new DeploymentSession("MailFathom", "0.8.0", ["mailfathom.mail.read"])));
+
+    private static StubStringLocalizer Words() => new(new Dictionary<string, string>(StringComparer.Ordinal)
+    {
+        [MessageWords.NoSenderKey] = "Unknown sender",
+        [MessageWords.NoSubjectKey] = "No subject",
+        [MessageWords.NoDateKey] = "No date",
+        [MessageWords.MoreRecipientsKey] = "{0} and {1} more",
+        [MessageWords.AnnouncementKey] = "{0}, {1}, {2}",
+        [MessageWords.UnreadKey] = "unread",
+        [MessageWords.FlaggedKey] = "flagged",
+        [MessageWords.AnsweredKey] = "answered",
+        [MessageWords.AttachmentsKey] = "attachment",
+    });
+
+    private static HttpResponseMessage Answer(string page) => StubTransport.JsonResponse(page);
+
+    /// <summary>Reads the cursor a request carried, which is what tells one page of a script apart from the next.</summary>
+    private static string? Cursor(HttpRequestMessage request)
+    {
+        var query = request.RequestUri?.Query ?? string.Empty;
+
+        return query
+            .TrimStart('?')
+            .Split('&')
+            .FirstOrDefault(stated => stated.StartsWith("cursor=", StringComparison.Ordinal))?["cursor=".Length..];
+    }
+
+    /// <summary>Writes a page of mail as the deployment serves one.</summary>
+    private static string Page(int first, int count, string? next, string? previous)
+    {
+        var emails = Enumerable
+            .Range(first, count)
+            .Select(number =>
+                $$"""
+                  {
+                    "id": "{{MailMessages.Key(number)}}",
+                    "account": "work",
+                    "folder": "INBOX",
+                    "subject": "Message {{number.ToString(CultureInfo.InvariantCulture)}}",
+                    "receivedAt": "2026-08-25T11:50:00+00:00",
+                    "senderAddress": "someone@example.test",
+                    "senderDisplayName": "Someone",
+                    "toAddresses": [ "owner@example.test" ],
+                    "unread": false,
+                    "flagged": false,
+                    "answered": false,
+                    "hasAttachments": false,
+                    "attachmentCount": 0,
+                    "sizeOctets": 1024,
+                    "preview": "The opening of it"
+                  }
+                  """);
+
+        return $$"""
+                 {
+                   "emails": [ {{string.Join(",", emails)}} ],
+                   "nextCursor": {{Written(next)}},
+                   "previousCursor": {{Written(previous)}},
+                   "pageSize": 50
+                 }
+                 """;
+    }
+
+    private static string Written(string? cursor) => cursor is null ? "null" : $"\"{cursor}\"";
+
+    /// <summary>One list and everything it is composed over, owned together so a test states its arrangement once.</summary>
+    private sealed class ListOver : IDisposable
+    {
+        internal ListOver(
+            Func<HttpRequestMessage, HttpResponseMessage> deployment,
+            params RememberedMessageList[] remembered)
+        {
+            this.Harness = new DeploymentHarness(deployment);
+            this.Session = DeploymentMessageListTests.Session();
+            this.Memory = new StubMessageListMemory(remembered);
+            this.Workspace = new SharedWorkspace(new StubMailboxTreeMemory());
+
+            this.List = new DeploymentMessageList(
+                this.Harness.Client,
+                this.Session,
+                this.Workspace,
+                this.Memory,
+                new StubClock(Now),
+                Words());
+        }
+
+        internal DeploymentHarness Harness { get; }
+
+        internal StubClientSession Session { get; }
+
+        internal StubMessageListMemory Memory { get; }
+
+        internal SharedWorkspace Workspace { get; }
+
+        internal DeploymentMessageList List { get; }
+
+        /// <summary>Gets the query string of every request the deployment was asked, in order.</summary>
+        internal IReadOnlyList<string> Asked =>
+            [.. this.Harness.Deployment.Requests.Select(request => request.RequestUri.Query)];
+
+        /// <summary>Waits until a consequence of a feed re-evaluating has happened, or fails the test.</summary>
+        /// <param name="settled">What is being waited for.</param>
+        /// <returns>The wait.</returns>
+        /// <remarks>
+        /// <para>
+        /// Only the four acts that reach the list through a feed rather than through a call are waited on: writing the
+        /// scope, writing what is selected, and the two that ask the list to be read again. Each of those is finished
+        /// by MVUX re-evaluating a feed on a thread of its own, and no await a test holds is the one that finishes it.
+        /// Everything the list does inside an awaited method — every page, and everything written down beside one —
+        /// is asserted straight after that await instead.
+        /// </para>
+        /// <para>
+        /// Polling rather than a recorded feed, because the package that records one does not compile against the Uno
+        /// version this stack pins; <c>frontend/tests/AGENTS.md</c> carries that and names the model's own surface as
+        /// the seam until it does. The bound is generous and only reached by a failing test, so a run costs the wait
+        /// itself rather than the bound.
+        /// </para>
+        /// </remarks>
+        internal async Task Until(Func<ValueTask<bool>> settled)
+        {
+            for (var attempt = 0; attempt < 400; attempt++)
+            {
+                if (await settled())
+                {
+                    return;
+                }
+
+                await Task.Delay(10, TestContext.Current.CancellationToken);
+            }
+
+            Assert.Fail("The list did not settle on what the test was waiting for.");
+        }
+
+        public void Dispose()
+        {
+            this.Session.Dispose();
+            this.Harness.Dispose();
+        }
+    }
+}

--- a/frontend/tests/Client.UnitTests/Presentation/Messages/DeploymentMessageListTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Messages/DeploymentMessageListTests.cs
@@ -19,6 +19,9 @@ public sealed class DeploymentMessageListTests
 {
     private static readonly DateTimeOffset Now = new(2026, 8, 25, 12, 0, 0, TimeSpan.Zero);
 
+    /// <summary>How long a test waits on a request it is holding open before it gives up rather than hanging the run.</summary>
+    private static readonly TimeSpan Patience = TimeSpan.FromSeconds(30);
+
     /// <summary>The list opens on the leading page of the place in force, which is one request for a screenful.</summary>
     [Fact]
     public async Task Rows_ADeploymentAnswering_DrawsThePageItServed()
@@ -196,6 +199,59 @@ public sealed class DeploymentMessageListTests
         var rows = await over.List.Rows;
         Assert.Equal([MailMessages.Key(1), MailMessages.Key(2)], rows!.Select(row => row.Key));
         Assert.True(await over.List.PagingFailed);
+    }
+
+    /// <summary>
+    /// A page that failed for a folder somebody has already left says nothing about the one they are in: the abandoned
+    /// read is the loser of an ordinary race, and reporting it beside the new folder would put a warning over mail that
+    /// arrived.
+    /// </summary>
+    [Fact]
+    public async Task ShowMoreAsync_APageThatFailedForAPlaceSomebodyLeft_IsNotReportedBesideTheNewOne()
+    {
+        // Arrange
+        var cancellation = TestContext.Current.CancellationToken;
+
+        using var reached = new ManualResetEventSlim(false);
+        using var released = new ManualResetEventSlim(false);
+
+        using var over = new ListOver(request =>
+        {
+            if (Cursor(request) is not null)
+            {
+                reached.Set();
+                released.Wait(Patience, cancellation);
+
+                return StubTransport.JsonResponse("{}", HttpStatusCode.InternalServerError);
+            }
+
+            return request.RequestUri!.Query.Contains("folder=INBOX", StringComparison.Ordinal)
+                ? Answer(Page(5, 2, next: null, previous: null))
+                : Answer(Page(1, 2, next: "after-2", previous: null));
+        });
+
+        await over.List.Rows;
+
+        // The read is started on a thread of its own because the scripted deployment holds the request open on the one
+        // that made it, which is how a test states that a page is still in flight.
+        var paging = Task.Run(
+            async () => await over.List.ShowMoreAsync(TestContext.Current.CancellationToken),
+            TestContext.Current.CancellationToken);
+
+        Assert.True(reached.Wait(Patience, cancellation));
+
+        // Act
+        await over.Workspace.Scope.UpdateAsync(
+            _ => new WorkspaceScope { Account = "work", Folder = "INBOX" },
+            TestContext.Current.CancellationToken);
+
+        await over.Until(async () => await over.List.Rows is [{ } first, _] && first.Key == MailMessages.Key(5));
+
+        released.Set();
+        await paging;
+
+        // Assert
+        Assert.False(await over.List.PagingFailed);
     }
 
     /// <summary>Coming back to a folder is coming back: the leading page it was left on is what is asked for again.</summary>

--- a/frontend/tests/Client.UnitTests/Presentation/Messages/DeploymentMessageListTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Messages/DeploymentMessageListTests.cs
@@ -254,6 +254,59 @@ public sealed class DeploymentMessageListTests
         Assert.False(await over.List.PagingFailed);
     }
 
+    /// <summary>
+    /// Asking for a list to be read again opens it afresh under the place and the arrangement it already had, so a page
+    /// still in flight from before belongs to neither the window nor the indicator that reopening produced.
+    /// </summary>
+    [Fact]
+    public async Task ShowMoreAsync_APageFromBeforeTheListWasReadAgain_IsNotSplicedOntoIt()
+    {
+        // Arrange
+        var cancellation = TestContext.Current.CancellationToken;
+
+        using var reached = new ManualResetEventSlim(false);
+        using var released = new ManualResetEventSlim(false);
+
+        var openings = 0;
+
+        // The second opening answers with other mail, so the reopened list is the one the assertion can see rather than
+        // one the test has to infer from a request count.
+        using var over = new ListOver(request =>
+        {
+            if (Cursor(request) is null)
+            {
+                return Answer(Interlocked.Increment(ref openings) is 1
+                    ? Page(1, 2, next: "after-2", previous: null)
+                    : Page(5, 2, next: "after-6", previous: null));
+            }
+
+            reached.Set();
+            released.Wait(Patience, cancellation);
+
+            return Answer(Page(9, 2, next: null, previous: "before-9"));
+        });
+
+        await over.List.Rows;
+
+        var paging = Task.Run(
+            async () => await over.List.ShowMoreAsync(TestContext.Current.CancellationToken),
+            TestContext.Current.CancellationToken);
+
+        Assert.True(reached.Wait(Patience, cancellation));
+
+        // Act
+        await over.List.AskAgainAsync(TestContext.Current.CancellationToken);
+
+        await over.Until(async () => await over.List.Rows is [{ } first, _] && first.Key == MailMessages.Key(5));
+
+        released.Set();
+        await paging;
+
+        // Assert
+        var rows = await over.List.Rows;
+        Assert.Equal([MailMessages.Key(5), MailMessages.Key(6)], rows!.Select(row => row.Key));
+    }
+
     /// <summary>Coming back to a folder is coming back: the leading page it was left on is what is asked for again.</summary>
     [Fact]
     public async Task Rows_APlaceSomebodyHasBeenInBefore_ReopensWhereItWasLeft()

--- a/frontend/tests/Client.UnitTests/Presentation/Messages/LocalSettingsMessageListMemoryTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Messages/LocalSettingsMessageListMemoryTests.cs
@@ -1,0 +1,132 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Backend.Timeline;
+using MailFathom.Client.Presentation.Messages;
+
+namespace MailFathom.Client.UnitTests.Presentation.Messages;
+
+/// <summary>How an arrangement is written down, and what it reads back as on the run after this one.</summary>
+/// <remarks>
+/// What the store itself does is not asserted here: <c>ApplicationData.LocalSettings</c> is a platform API a
+/// unit-test host has none of, so what a test can reach is the pair of translations either side of it — which is also
+/// where every value that could be written wrongly actually lives.
+/// </remarks>
+public sealed class LocalSettingsMessageListMemoryTests
+{
+    /// <summary>A list keeping everything writes no filters at all, which is what a first run also reads.</summary>
+    [Fact]
+    public void JoinedKeeps_AListKeepingEverything_WritesNothing()
+    {
+        // Act, Assert
+        Assert.Equal(string.Empty, LocalSettingsMessageListMemory.JoinedKeeps(MessageListArrangement.Default));
+    }
+
+    /// <summary>Every filter somebody put in force is written, because each of them is one the list reopens under.</summary>
+    [Fact]
+    public void JoinedKeeps_AListNarrowedEveryWay_WritesEachFilter()
+    {
+        // Arrange
+        var narrowed = new MessageListArrangement
+        {
+            UnreadOnly = true,
+            FlaggedOnly = true,
+            WithAttachmentsOnly = true,
+            IncludeJunk = true,
+        };
+
+        // Act
+        var written = LocalSettingsMessageListMemory.JoinedKeeps(narrowed);
+
+        // Assert
+        Assert.Equal("unread flagged attachments junk", written);
+    }
+
+    /// <summary>What was written reads back as itself, which is the only property either half is worth having.</summary>
+    [Theory]
+    [InlineData(MailTimelineOrder.NewestFirst, false, false, false, false)]
+    [InlineData(MailTimelineOrder.OldestFirst, false, false, false, false)]
+    [InlineData(MailTimelineOrder.NewestFirst, true, false, false, false)]
+    [InlineData(MailTimelineOrder.OldestFirst, false, true, false, false)]
+    [InlineData(MailTimelineOrder.NewestFirst, false, false, true, false)]
+    [InlineData(MailTimelineOrder.OldestFirst, false, false, false, true)]
+    [InlineData(MailTimelineOrder.OldestFirst, true, true, true, true)]
+    public void ArrangementOf_WhatWasWritten_ReadsBackAsTheSameArrangement(
+        MailTimelineOrder order,
+        bool unreadOnly,
+        bool flaggedOnly,
+        bool withAttachmentsOnly,
+        bool includeJunk)
+    {
+        // Arrange
+        var arrangement = new MessageListArrangement
+        {
+            Order = order,
+            UnreadOnly = unreadOnly,
+            FlaggedOnly = flaggedOnly,
+            WithAttachmentsOnly = withAttachmentsOnly,
+            IncludeJunk = includeJunk,
+        };
+
+        // Act
+        var read = LocalSettingsMessageListMemory.ArrangementOf(
+            order is MailTimelineOrder.OldestFirst ? "oldestFirst" : "newestFirst",
+            LocalSettingsMessageListMemory.JoinedKeeps(arrangement));
+
+        // Assert
+        Assert.Equal(arrangement, read);
+    }
+
+    /// <summary>
+    /// A store that answers nothing is a first run rather than a failure to start, so it reads as the arrangement a
+    /// list arrives with.
+    /// </summary>
+    [Fact]
+    public void ArrangementOf_AStoreHoldingNothing_ReadsAsTheArrangementAListArrivesWith()
+    {
+        // Act, Assert
+        Assert.Equal(MessageListArrangement.Default, LocalSettingsMessageListMemory.ArrangementOf(null, null));
+        Assert.Equal(
+            MessageListArrangement.Default,
+            LocalSettingsMessageListMemory.ArrangementOf(string.Empty, string.Empty));
+    }
+
+    /// <summary>
+    /// An entry nothing here ever wrote claims nothing about the list. The mapping is closed for that reason: parsing
+    /// the enumeration would read a number, a member name, and a comma-separated list as answers as well.
+    /// </summary>
+    [Fact]
+    public void ArrangementOf_AnEntryNothingHereWrote_ClaimsNothingAboutTheList()
+    {
+        // Act
+        var numbered = LocalSettingsMessageListMemory.ArrangementOf("1", "1");
+        var named = LocalSettingsMessageListMemory.ArrangementOf("OldestFirst", "UnreadOnly");
+
+        // Assert
+        Assert.Equal(MessageListArrangement.Default, numbered);
+        Assert.Equal(MessageListArrangement.Default, named);
+    }
+
+    /// <summary>A place nobody has read yet opens at the leading end of the list, arranged as a list arrives.</summary>
+    [Fact]
+    public void Nothing_APlaceNobodyHasReadYet_OpensAtTheLeadingEnd()
+    {
+        // Act
+        var nothing = RememberedMessageList.Nothing("workINBOX");
+
+        // Assert
+        Assert.Equal("workINBOX", nothing.PlaceKey);
+        Assert.Null(nothing.Cursor);
+        Assert.Equal(MailTimelinePageDirection.Forward, nothing.Direction);
+        Assert.Equal(MessageListArrangement.Default, nothing.Arrangement);
+    }
+
+    /// <summary>Writing the filters of no arrangement at all would be writing a value composed from nothing.</summary>
+    [Fact]
+    public void JoinedKeeps_NoArrangement_IsRefused()
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentNullException>(() => LocalSettingsMessageListMemory.JoinedKeeps(null!));
+    }
+}

--- a/frontend/tests/Client.UnitTests/Presentation/Messages/MessageListArrangementTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Messages/MessageListArrangementTests.cs
@@ -1,0 +1,150 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Backend.Timeline;
+using MailFathom.Client.Presentation.Messages;
+
+namespace MailFathom.Client.UnitTests.Presentation.Messages;
+
+/// <summary>How the list is arranged, and the request one page of it is asked for with.</summary>
+public sealed class MessageListArrangementTests
+{
+    /// <summary>A list nobody has arranged reads newest first and keeps everything, which is what a mail client does.</summary>
+    [Fact]
+    public void Default_AListNobodyHasArranged_ReadsNewestFirstAndKeepsEverything()
+    {
+        // Act
+        var arrangement = MessageListArrangement.Default;
+
+        // Assert
+        Assert.Equal(MailTimelineOrder.NewestFirst, arrangement.Order);
+        Assert.False(arrangement.OldestFirst);
+        Assert.False(arrangement.KeepsLessThanEverything);
+    }
+
+    /// <summary>Each of the four filters narrows the list, so each of them says so on the control that did it.</summary>
+    [Fact]
+    public void KeepsLessThanEverything_AnyFilterInForce_SaysSo()
+    {
+        // Act, Assert
+        Assert.True((MessageListArrangement.Default with { UnreadOnly = true }).KeepsLessThanEverything);
+        Assert.True((MessageListArrangement.Default with { FlaggedOnly = true }).KeepsLessThanEverything);
+        Assert.True((MessageListArrangement.Default with { WithAttachmentsOnly = true }).KeepsLessThanEverything);
+        Assert.True((MessageListArrangement.Default with { IncludeJunk = true }).KeepsLessThanEverything);
+    }
+
+    /// <summary>Reading from the other end is the order rather than a second reading, so both halves say the same thing.</summary>
+    [Fact]
+    public void OldestFirst_AnOrderReadFromTheOtherEnd_IsStatedAsItsOwnAffirmative()
+    {
+        // Act, Assert
+        Assert.True((MessageListArrangement.Default with { Order = MailTimelineOrder.OldestFirst }).OldestFirst);
+        Assert.False(MessageListArrangement.Default.OldestFirst);
+    }
+
+    /// <summary>An account and a folder reach the request as themselves, beside where the page continues from.</summary>
+    [Fact]
+    public void QueryFor_APlaceNamingAnAccountAndAFolder_AsksForThatFolder()
+    {
+        // Arrange
+        var place = new MessagePlace("work", "INBOX", Role: null);
+
+        // Act
+        var query = MessageListArrangement.Default.QueryFor(
+            place,
+            "the-cursor",
+            MailTimelinePageDirection.Backward,
+            50);
+
+        // Assert
+        Assert.Equal("work", query.Account);
+        Assert.Equal("INBOX", query.Folder);
+        Assert.Equal("the-cursor", query.Cursor);
+        Assert.Equal(MailTimelinePageDirection.Backward, query.Direction);
+        Assert.Equal(50, query.PageSize);
+    }
+
+    /// <summary>A role taken across mailboxes is written as a folder reference, which is what it is on this surface.</summary>
+    [Fact]
+    public void QueryFor_APlaceNamingARole_AsksForItAsAFolderReference()
+    {
+        // Arrange
+        var place = new MessagePlace(Account: null, Folder: null, "Sent");
+
+        // Act
+        var query = MessageListArrangement.Default.QueryFor(place, cursor: null, MailTimelinePageDirection.Forward, 50);
+
+        // Assert
+        Assert.Equal("role:Sent", query.Folder);
+        Assert.Null(query.Account);
+    }
+
+    /// <summary>
+    /// Junk takes part in a folder somebody opened on purpose and stays out of a list nobody narrowed, which is what
+    /// keeps a junk folder from being served as an empty one.
+    /// </summary>
+    [Fact]
+    public void QueryFor_APlaceSomebodyChose_LetsItsJunkTakePartWithoutBeingAsked()
+    {
+        // Act
+        var chosen = MessageListArrangement.Default.QueryFor(
+            new MessagePlace("work", "JUNK", Role: null),
+            cursor: null,
+            MailTimelinePageDirection.Forward,
+            50);
+
+        var everything = MessageListArrangement.Default.QueryFor(
+            MessagePlace.Everything,
+            cursor: null,
+            MailTimelinePageDirection.Forward,
+            50);
+
+        var asked = (MessageListArrangement.Default with { IncludeJunk = true }).QueryFor(
+            MessagePlace.Everything,
+            cursor: null,
+            MailTimelinePageDirection.Forward,
+            50);
+
+        // Assert
+        Assert.True(chosen.IncludeJunk);
+        Assert.False(everything.IncludeJunk);
+        Assert.True(asked.IncludeJunk);
+    }
+
+    /// <summary>A filter keeping everything is unstated, so a request says what somebody narrowed and nothing else.</summary>
+    [Fact]
+    public void QueryFor_AFilterKeepingEverything_LeavesTheParameterUnstated()
+    {
+        // Act
+        var kept = new MessageListArrangement
+        {
+            UnreadOnly = true,
+            FlaggedOnly = true,
+            WithAttachmentsOnly = true,
+        }.QueryFor(MessagePlace.Everything, cursor: null, MailTimelinePageDirection.Forward, 50);
+
+        var everything = MessageListArrangement.Default.QueryFor(
+            MessagePlace.Everything,
+            cursor: null,
+            MailTimelinePageDirection.Forward,
+            50);
+
+        // Assert
+        Assert.True(kept.Unread);
+        Assert.True(kept.Flagged);
+        Assert.True(kept.HasAttachments);
+        Assert.Null(everything.Unread);
+        Assert.Null(everything.Flagged);
+        Assert.Null(everything.HasAttachments);
+    }
+
+    /// <summary>A request composed from nowhere would be one asking a deployment about no place at all.</summary>
+    [Fact]
+    public void QueryFor_NoPlace_IsRefused()
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            MessageListArrangement.Default.QueryFor(null!, cursor: null, MailTimelinePageDirection.Forward, 50));
+    }
+}

--- a/frontend/tests/Client.UnitTests/Presentation/Messages/MessageListShapeTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Messages/MessageListShapeTests.cs
@@ -1,0 +1,276 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Globalization;
+using MailFathom.Client.Backend.Timeline;
+using MailFathom.Client.Presentation.Messages;
+using MailFathom.Client.UnitTests.TestDoubles;
+
+namespace MailFathom.Client.UnitTests.Presentation.Messages;
+
+/// <summary>What a loaded window reads as on the screen, which is the whole of what a row says.</summary>
+public sealed class MessageListShapeTests
+{
+    private static readonly MessagePlace Inbox = new("work", "INBOX", Role: null);
+
+    private static readonly MessagePlace Sent = new(Account: null, Folder: null, "Sent");
+
+    private static readonly DateTimeOffset Now = new(new DateTime(2026, 8, 25, 12, 0, 0, DateTimeKind.Local));
+
+    /// <summary>A row is drawn under the name the sender wrote, which is what a reader recognizes them by.</summary>
+    [Fact]
+    public void Of_ASenderWhoWroteTheirName_DrawsTheNameRatherThanTheAddress()
+    {
+        // Act
+        var row = Single(MailMessages.Message(1, senderDisplayName: "Someone", senderAddress: "someone@example.test"));
+
+        // Assert
+        Assert.Equal("Someone", row.Correspondent);
+    }
+
+    /// <summary>A header carrying no name falls back to the address, which is still something a reader recognizes.</summary>
+    [Fact]
+    public void Of_ASenderWhoWroteNoName_DrawsTheAddress()
+    {
+        // Act
+        var row = Single(MailMessages.Message(1, senderDisplayName: " ", senderAddress: "someone@example.test"));
+
+        // Assert
+        Assert.Equal("someone@example.test", row.Correspondent);
+    }
+
+    /// <summary>A message nothing names either end of is drawn under a sentence, because a blank column reads as a row that failed.</summary>
+    [Fact]
+    public void Of_AMessageNamingNobodyAtAll_DrawsTheSentenceStandingInForOne()
+    {
+        // Act
+        var row = Single(MailMessages.Message(
+            1,
+            senderDisplayName: null,
+            senderAddress: null,
+            recipients: []));
+
+        // Assert
+        Assert.Equal("Unknown sender", row.Correspondent);
+    }
+
+    /// <summary>Mail this owner sent is drawn by who it went to, because every row of it came from the same person.</summary>
+    [Fact]
+    public void Of_APlaceHoldingMailThisOwnerSent_DrawsTheRecipient()
+    {
+        // Act
+        var row = Single(
+            MailMessages.Message(1, recipients: ["someone@example.test"]),
+            Sent);
+
+        // Assert
+        Assert.Equal("someone@example.test", row.Correspondent);
+    }
+
+    /// <summary>Mail that went to several people is drawn by the first of them beside how many others there were.</summary>
+    [Fact]
+    public void Of_AMessageThatWentToSeveralPeople_DrawsTheFirstBesideHowManyOthers()
+    {
+        // Act
+        var row = Single(
+            MailMessages.Message(1, recipients: ["first@example.test", "second@example.test", "third@example.test"]),
+            Sent);
+
+        // Assert
+        Assert.Equal("first@example.test and 2 more", row.Correspondent);
+    }
+
+    /// <summary>A message nobody gave a subject is drawn under a sentence rather than under an empty line.</summary>
+    [Fact]
+    public void Of_AMessageCarryingNoSubject_DrawsTheSentenceStandingInForOne()
+    {
+        // Act
+        var row = Single(MailMessages.Message(1, subject: "  "));
+
+        // Assert
+        Assert.Equal("No subject", row.Subject);
+    }
+
+    /// <summary>Mail that arrived today is dated by its time, which is what tells two of today's messages apart.</summary>
+    [Fact]
+    public void Of_AMessageThatArrivedToday_IsDatedByItsTime()
+    {
+        // Arrange
+        var arrived = new DateTimeOffset(new DateTime(2026, 8, 25, 9, 41, 0, DateTimeKind.Local));
+
+        // Act
+        var row = Single(MailMessages.Message(1, receivedAt: arrived));
+
+        // Assert
+        Assert.Equal(arrived.ToLocalTime().ToString("t", CultureInfo.CurrentCulture), row.Received);
+    }
+
+    /// <summary>Mail from earlier this year is dated by its day and month, and older mail by its whole date.</summary>
+    [Fact]
+    public void Of_AMessageOlderThanToday_IsDatedByItsDayAndByItsYearOnceThatChanges()
+    {
+        // Arrange
+        var thisYear = new DateTimeOffset(new DateTime(2026, 3, 2, 9, 41, 0, DateTimeKind.Local));
+        var yearsBack = new DateTimeOffset(new DateTime(2024, 11, 18, 9, 41, 0, DateTimeKind.Local));
+
+        // Act
+        var earlier = Single(MailMessages.Message(1, receivedAt: thisYear));
+        var older = Single(MailMessages.Message(1, receivedAt: yearsBack));
+
+        // Assert
+        Assert.Equal(thisYear.ToLocalTime().ToString("m", CultureInfo.CurrentCulture), earlier.Received);
+        Assert.Equal(yearsBack.ToLocalTime().ToString("d", CultureInfo.CurrentCulture), older.Received);
+    }
+
+    /// <summary>A message no header dated is drawn under a sentence, since a row has to say something in that column.</summary>
+    [Fact]
+    public void Of_AMessageNoHeaderDated_DrawsTheSentenceStandingInForADate()
+    {
+        // Act
+        var row = Single(MailMessages.Message(1, receivedAt: null));
+
+        // Assert
+        Assert.Equal("No date", row.Received);
+    }
+
+    /// <summary>
+    /// The row states itself once for a screen reader, which is what a list of fifty rows of six unlabelled controls
+    /// would otherwise be read out as. What is true of the message is appended; what is not is absent.
+    /// </summary>
+    [Fact]
+    public void Of_ARowWithMarksOnIt_AnnouncesItselfAsOneSentenceCarryingThem()
+    {
+        // Arrange
+        var arrived = new DateTimeOffset(new DateTime(2026, 8, 25, 9, 41, 0, DateTimeKind.Local));
+
+        // Act
+        var marked = Single(MailMessages.Message(
+            1,
+            receivedAt: arrived,
+            subject: "Quarterly review",
+            senderDisplayName: "Someone",
+            unread: true,
+            flagged: true,
+            answered: true,
+            attachmentCount: 2));
+
+        var plain = Single(MailMessages.Message(
+            1,
+            receivedAt: arrived,
+            subject: "Quarterly review",
+            senderDisplayName: "Someone"));
+
+        // Assert
+        var dated = arrived.ToLocalTime().ToString("t", CultureInfo.CurrentCulture);
+        Assert.Equal(
+            $"Someone, Quarterly review, {dated} unread flagged answered attachment",
+            marked.Announcement);
+        Assert.Equal($"Someone, Quarterly review, {dated}", plain.Announcement);
+    }
+
+    /// <summary>Every mark the deployment reported reaches the row, because the view draws each of them separately.</summary>
+    [Fact]
+    public void Of_AMessageTheDeploymentMarked_CarriesEachMarkOntoTheRow()
+    {
+        // Act
+        var row = Single(MailMessages.Message(
+            1,
+            unread: true,
+            flagged: true,
+            answered: true,
+            attachmentCount: 3,
+            preview: "The numbers for the quarter are"));
+
+        // Assert
+        Assert.Equal(MailMessages.Key(1), row.Key);
+        Assert.True(row.IsUnread);
+        Assert.True(row.IsFlagged);
+        Assert.True(row.IsAnswered);
+        Assert.True(row.HasAttachments);
+        Assert.True(row.ShowsAttachmentCount);
+        Assert.Equal(3.ToString("N0", CultureInfo.CurrentCulture), row.AttachmentCountText);
+        Assert.True(row.HasPreview);
+        Assert.Equal("The numbers for the quarter are", row.Preview);
+    }
+
+    /// <summary>
+    /// A message this deployment holds but has not extracted the text of yet has no preview, which is a folder still
+    /// being taken in rather than a message with nothing in it — so the row draws one line less rather than an empty one.
+    /// </summary>
+    [Fact]
+    public void Of_AMessageNothingHasExtractedYet_HasNoPreviewToDraw()
+    {
+        // Act
+        var row = Single(MailMessages.Message(1, preview: null, attachmentCount: 1));
+
+        // Assert
+        Assert.Equal(string.Empty, row.Preview);
+        Assert.False(row.HasPreview);
+        Assert.True(row.HasAttachments);
+        Assert.False(row.ShowsAttachmentCount);
+    }
+
+    /// <summary>The rows are drawn in the order the window holds them, which is the order the deployment sorted them in.</summary>
+    [Fact]
+    public void Of_AWindowOfSeveralPages_DrawsEveryRowInTheOrderItIsRead()
+    {
+        // Arrange
+        var window = MessageWindow.Opening(
+            Inbox,
+            MessageListArrangement.Default,
+            new MessagePage(
+                [MailMessages.Message(1), MailMessages.Message(2), MailMessages.Message(3)],
+                NextCursor: null,
+                PreviousCursor: null,
+                ReadCursor: null,
+                MailTimelinePageDirection.Forward));
+
+        // Act
+        var rows = MessageListShape.Of(window, Now, Words());
+
+        // Assert
+        Assert.Equal([MailMessages.Key(1), MailMessages.Key(2), MailMessages.Key(3)], rows.Select(row => row.Key));
+    }
+
+    /// <summary>A shape drawn from nothing would be a list drawn from no window and no words.</summary>
+    [Fact]
+    public void Of_NoWindowOrNoWords_IsRefused()
+    {
+        // Arrange
+        var window = MessageWindow.Nothing(Inbox, MessageListArrangement.Default);
+
+        // Act, Assert
+        Assert.Throws<ArgumentNullException>(() => MessageListShape.Of(null!, Now, Words()));
+        Assert.Throws<ArgumentNullException>(() => MessageListShape.Of(window, Now, null!));
+    }
+
+    private static MessageRow Single(DeploymentMailMessage message, MessagePlace? place = null)
+    {
+        var window = MessageWindow.Opening(
+            place ?? Inbox,
+            MessageListArrangement.Default,
+            new MessagePage(
+                [message],
+                NextCursor: null,
+                PreviousCursor: null,
+                ReadCursor: null,
+                MailTimelinePageDirection.Forward));
+
+        return MessageListShape.Of(window, Now, Words()).Single();
+    }
+
+    private static StubStringLocalizer Words() => new(
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [MessageWords.NoSenderKey] = "Unknown sender",
+            [MessageWords.NoSubjectKey] = "No subject",
+            [MessageWords.NoDateKey] = "No date",
+            [MessageWords.MoreRecipientsKey] = "{0} and {1} more",
+            [MessageWords.AnnouncementKey] = "{0}, {1}, {2}",
+            [MessageWords.UnreadKey] = "unread",
+            [MessageWords.FlaggedKey] = "flagged",
+            [MessageWords.AnsweredKey] = "answered",
+            [MessageWords.AttachmentsKey] = "attachment",
+        });
+}

--- a/frontend/tests/Client.UnitTests/Presentation/Messages/MessagePlaceTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Messages/MessagePlaceTests.cs
@@ -1,0 +1,97 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Immutable;
+using MailFathom.Client.Presentation.Messages;
+using MailFathom.Client.Presentation.Workspace;
+
+namespace MailFathom.Client.UnitTests.Presentation.Messages;
+
+/// <summary>Where a list is drawn from, read out of the scope without what is selected inside it.</summary>
+public sealed class MessagePlaceTests
+{
+    /// <summary>
+    /// What is selected is not part of the place, which is the whole reason the type exists: a list keyed on the whole
+    /// scope would read the folder again every time somebody clicked a row in it.
+    /// </summary>
+    [Fact]
+    public void Of_TwoScopesDifferingOnlyInWhatIsSelected_NameOnePlace()
+    {
+        // Arrange
+        var scope = new WorkspaceScope { Account = "work", Folder = "INBOX" };
+        var withSomethingSelected = scope with { Selection = ImmutableArray.Create("117", "118") };
+
+        // Act, Assert
+        Assert.Equal(MessagePlace.Of(scope), MessagePlace.Of(withSomethingSelected));
+    }
+
+    /// <summary>The three names a scope narrows by are the three a place carries.</summary>
+    [Fact]
+    public void Of_AScopeNarrowingSomewhere_CarriesTheAccountTheFolderAndTheRole()
+    {
+        // Act
+        var place = MessagePlace.Of(new WorkspaceScope { Account = "work", Folder = "INBOX", Role = "Inbox" });
+
+        // Assert
+        Assert.Equal(new MessagePlace("work", "INBOX", "Inbox"), place);
+    }
+
+    /// <summary>A scope nothing has answered yet is every mailbox rather than a place describing nowhere.</summary>
+    [Fact]
+    public void Of_NoScopeAtAll_IsEverything()
+    {
+        // Act, Assert
+        Assert.Equal(MessagePlace.Everything, MessagePlace.Of(null));
+        Assert.Equal(MessagePlace.Everything, MessagePlace.Of(WorkspaceScope.Everything));
+    }
+
+    /// <summary>Two places are told apart by what they are remembered as, whichever of the three names differs.</summary>
+    [Fact]
+    public void RememberedAs_PlacesDifferingInAnyOfTheirNames_AreRememberedApart()
+    {
+        // Arrange
+        var keys = new[]
+        {
+            MessagePlace.Everything,
+            new MessagePlace("work", Folder: null, Role: null),
+            new MessagePlace("work", "INBOX", Role: null),
+            new MessagePlace(Account: null, Folder: null, "Inbox"),
+        }.Select(place => place.RememberedAs);
+
+        // Act, Assert
+        Assert.Equal(4, keys.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    /// <summary>
+    /// A folder or a role somebody chose is a place they went to, so its junk takes part without being asked for —
+    /// which is what keeps a junk folder from being drawn as an empty one.
+    /// </summary>
+    [Fact]
+    public void IsChosenFolder_AFolderOrARole_IsOneAndAnAccountIsNot()
+    {
+        // Act, Assert
+        Assert.True(new MessagePlace("work", "JUNK", Role: null).IsChosenFolder);
+        Assert.True(new MessagePlace(Account: null, Folder: null, "Junk").IsChosenFolder);
+        Assert.False(new MessagePlace("work", Folder: null, Role: null).IsChosenFolder);
+        Assert.False(MessagePlace.Everything.IsChosenFolder);
+    }
+
+    /// <summary>
+    /// Mail somebody sent is drawn by who it went to, because every row of it came from the same person. It is
+    /// answered from the role, so a folder chosen by its alias — which reaches this client without one — keeps drawing
+    /// senders.
+    /// </summary>
+    [Theory]
+    [InlineData("Sent", true)]
+    [InlineData("Drafts", true)]
+    [InlineData("Outbox", true)]
+    [InlineData("Inbox", false)]
+    [InlineData("Archive", false)]
+    [InlineData(null, false)]
+    public void ShowsRecipients_ARoleMailIsSentUnder_DrawsRecipientsRatherThanSenders(string? role, bool expected)
+    {
+        // Act, Assert
+        Assert.Equal(expected, new MessagePlace(Account: null, Folder: null, role).ShowsRecipients);
+    }
+}

--- a/frontend/tests/Client.UnitTests/Presentation/Messages/MessageWindowTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Messages/MessageWindowTests.cs
@@ -60,8 +60,7 @@ public sealed class MessageWindowTests
         var extended = window.Extended(
             Page(3, next: "after-3", previous: "before-3", readCursor: "after-1"),
             MailTimelinePageDirection.Forward,
-            Inbox,
-            MessageListArrangement.Default);
+            window);
 
         // Assert
         Assert.Equal(
@@ -85,8 +84,7 @@ public sealed class MessageWindowTests
         var extended = window.Extended(
             Page(1, next: "after-1", previous: null, readCursor: "before-3"),
             MailTimelinePageDirection.Backward,
-            Inbox,
-            MessageListArrangement.Default);
+            window);
 
         // Assert
         Assert.Equal(
@@ -119,8 +117,7 @@ public sealed class MessageWindowTests
                     previous: $"before-{page + 1}",
                     readCursor: $"after-{page}"),
                 MailTimelinePageDirection.Forward,
-                Inbox,
-                MessageListArrangement.Default);
+                window);
         }
 
         // Assert
@@ -147,8 +144,7 @@ public sealed class MessageWindowTests
         var extended = window.Extended(
             EmptyPage(),
             MailTimelinePageDirection.Forward,
-            Inbox,
-            MessageListArrangement.Default);
+            window);
 
         // Assert
         Assert.Equal(2, extended.Messages.Count);
@@ -169,24 +165,49 @@ public sealed class MessageWindowTests
             MessageListArrangement.Default,
             Page(1, next: "after-1", previous: null, readCursor: null));
 
+        var elsewhereWindow = MessageWindow.Opening(
+            new MessagePlace("home", "INBOX", Role: null),
+            MessageListArrangement.Default,
+            Page(1, next: "after-1", previous: null, readCursor: null));
+
+        var rearrangedWindow = MessageWindow.Opening(
+            Inbox,
+            MessageListArrangement.Default with { UnreadOnly = true },
+            Page(1, next: "after-1", previous: null, readCursor: null));
+
         var page = Page(3, next: "after-3", previous: "before-3", readCursor: "after-1");
 
         // Act
-        var elsewhere = window.Extended(
-            page,
-            MailTimelinePageDirection.Forward,
-            new MessagePlace("home", "INBOX", Role: null),
-            MessageListArrangement.Default);
-
-        var rearranged = window.Extended(
-            page,
-            MailTimelinePageDirection.Forward,
-            Inbox,
-            MessageListArrangement.Default with { UnreadOnly = true });
+        var elsewhere = window.Extended(page, MailTimelinePageDirection.Forward, elsewhereWindow);
+        var rearranged = window.Extended(page, MailTimelinePageDirection.Forward, rearrangedWindow);
 
         // Assert
         Assert.Equal(2, elsewhere.Messages.Count);
         Assert.Equal(2, rearranged.Messages.Count);
+    }
+
+    /// <summary>
+    /// A list somebody asked to be read again is opened afresh under the place and the arrangement it already had, so
+    /// the reading rather than either of those is what a page in flight is held against.
+    /// </summary>
+    [Fact]
+    public void Extended_APageFromAnEarlierReadingOfTheSameList_IsDeclinedRatherThanTaken()
+    {
+        // Arrange
+        var leading = Page(1, next: "after-1", previous: null, readCursor: null);
+        var read = MessageWindow.Opening(Inbox, MessageListArrangement.Default, leading);
+        var reopened = MessageWindow.Opening(Inbox, MessageListArrangement.Default, leading);
+
+        // Act
+        var extended = reopened.Extended(
+            Page(3, next: "after-3", previous: "before-3", readCursor: "after-1"),
+            MailTimelinePageDirection.Forward,
+            read);
+
+        // Assert
+        Assert.Equal(2, extended.Messages.Count);
+        Assert.False(reopened.IsOf(read));
+        Assert.True(reopened.IsOf(reopened));
     }
 
     /// <summary>
@@ -206,8 +227,7 @@ public sealed class MessageWindowTests
         var extended = window.Extended(
             Page(3, next: null, previous: "before-3", readCursor: "after-1"),
             MailTimelinePageDirection.Forward,
-            Inbox,
-            MessageListArrangement.Default);
+            window);
 
         // Assert
         Assert.Null(extended.LeadingPage?.ReadCursor);

--- a/frontend/tests/Client.UnitTests/Presentation/Messages/MessageWindowTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Messages/MessageWindowTests.cs
@@ -1,0 +1,244 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Backend.Timeline;
+using MailFathom.Client.Presentation.Messages;
+using MailFathom.Client.UnitTests.TestDoubles;
+
+namespace MailFathom.Client.UnitTests.Presentation.Messages;
+
+/// <summary>The bounded part of a list that is loaded, and what taking a page onto it does.</summary>
+public sealed class MessageWindowTests
+{
+    private static readonly MessagePlace Inbox = new("work", "INBOX", Role: null);
+
+    /// <summary>A window opens on the page it was given, with the cursors that page answered with.</summary>
+    [Fact]
+    public void Opening_AFirstPage_HoldsItAndTheCursorsThatContinueIt()
+    {
+        // Arrange
+        var page = Page(1, next: "after-1", previous: null, readCursor: null);
+
+        // Act
+        var window = MessageWindow.Opening(Inbox, MessageListArrangement.Default, page);
+
+        // Assert
+        Assert.Equal(2, window.Messages.Count);
+        Assert.Equal("after-1", window.ForwardCursor);
+        Assert.Null(window.BackwardCursor);
+        Assert.True(window.HasMoreAfter);
+        Assert.False(window.HasMoreBefore);
+        Assert.False(window.IsEmpty);
+    }
+
+    /// <summary>A place holding no mail opens on no page at all, which is a state rather than a page to keep.</summary>
+    [Fact]
+    public void Opening_APageWithNothingInIt_HoldsNothing()
+    {
+        // Act
+        var window = MessageWindow.Opening(Inbox, MessageListArrangement.Default, EmptyPage());
+
+        // Assert
+        Assert.True(window.IsEmpty);
+        Assert.Null(window.ForwardCursor);
+        Assert.Null(window.BackwardCursor);
+        Assert.Null(window.LeadingPage);
+    }
+
+    /// <summary>Taking a page forward appends its rows and moves the cursor the next page is asked with.</summary>
+    [Fact]
+    public void Extended_APageTakenForward_AppendsItAndMovesTheForwardCursor()
+    {
+        // Arrange
+        var window = MessageWindow.Opening(
+            Inbox,
+            MessageListArrangement.Default,
+            Page(1, next: "after-1", previous: null, readCursor: null));
+
+        // Act
+        var extended = window.Extended(
+            Page(3, next: "after-3", previous: "before-3", readCursor: "after-1"),
+            MailTimelinePageDirection.Forward,
+            Inbox,
+            MessageListArrangement.Default);
+
+        // Assert
+        Assert.Equal(
+            [MailMessages.Identity(1), MailMessages.Identity(2), MailMessages.Identity(3), MailMessages.Identity(4)],
+            extended.Messages.Select(message => message.Id));
+        Assert.Equal("after-3", extended.ForwardCursor);
+        Assert.Null(extended.BackwardCursor);
+    }
+
+    /// <summary>Taking a page backward puts its rows in front and moves the cursor the previous page is asked with.</summary>
+    [Fact]
+    public void Extended_APageTakenBackward_PrependsItAndMovesTheBackwardCursor()
+    {
+        // Arrange
+        var window = MessageWindow.Opening(
+            Inbox,
+            MessageListArrangement.Default,
+            Page(3, next: "after-3", previous: "before-3", readCursor: "after-1"));
+
+        // Act
+        var extended = window.Extended(
+            Page(1, next: "after-1", previous: null, readCursor: "before-3"),
+            MailTimelinePageDirection.Backward,
+            Inbox,
+            MessageListArrangement.Default);
+
+        // Assert
+        Assert.Equal(
+            [MailMessages.Identity(1), MailMessages.Identity(2), MailMessages.Identity(3), MailMessages.Identity(4)],
+            extended.Messages.Select(message => message.Id));
+        Assert.Null(extended.BackwardCursor);
+        Assert.Equal("after-3", extended.ForwardCursor);
+    }
+
+    /// <summary>
+    /// The window is bounded, so scrolling on drops the far page rather than holding a folder's worth of mail. What
+    /// makes that safe is the page that becomes the far end carrying the cursor that reads back towards what went.
+    /// </summary>
+    [Fact]
+    public void Extended_MorePagesThanTheBound_DropsTheFarOneAndKeepsAWayBackToIt()
+    {
+        // Arrange
+        var window = MessageWindow.Opening(
+            Inbox,
+            MessageListArrangement.Default,
+            Page(1, next: "after-1", previous: null, readCursor: null));
+
+        // Act
+        for (var page = 1; page <= MessageWindow.MaximumPages; page++)
+        {
+            window = window.Extended(
+                Page(
+                    (page * 2) + 1,
+                    next: $"after-{page + 1}",
+                    previous: $"before-{page + 1}",
+                    readCursor: $"after-{page}"),
+                MailTimelinePageDirection.Forward,
+                Inbox,
+                MessageListArrangement.Default);
+        }
+
+        // Assert
+        Assert.Equal(MessageWindow.MaximumPages, window.Pages.Count);
+        Assert.Equal(MessageWindow.MaximumPages * 2, window.Messages.Count);
+        Assert.True(window.HasMoreBefore);
+        Assert.DoesNotContain(MailMessages.Identity(1), window.Messages.Select(message => message.Id));
+    }
+
+    /// <summary>
+    /// A page that came back empty is the list having ended between two requests rather than a page to keep: mail can
+    /// be expunged, so a cursor that named a row can outlive it. Keeping it would take the window's own cursors away.
+    /// </summary>
+    [Fact]
+    public void Extended_AnEmptyPage_MarksThatEndOfTheListRatherThanBeingKept()
+    {
+        // Arrange
+        var window = MessageWindow.Opening(
+            Inbox,
+            MessageListArrangement.Default,
+            Page(1, next: "after-1", previous: "before-1", readCursor: null));
+
+        // Act
+        var extended = window.Extended(
+            EmptyPage(),
+            MailTimelinePageDirection.Forward,
+            Inbox,
+            MessageListArrangement.Default);
+
+        // Assert
+        Assert.Equal(2, extended.Messages.Count);
+        Assert.False(extended.HasMoreAfter);
+        Assert.True(extended.HasMoreBefore);
+    }
+
+    /// <summary>
+    /// A page arriving for a list somebody has already left is an ordinary race rather than an error, so the window
+    /// declines it — which is what keeps a request in flight from putting another folder's mail on the screen.
+    /// </summary>
+    [Fact]
+    public void Extended_APageForAnotherPlaceOrArrangement_IsDeclinedRatherThanTaken()
+    {
+        // Arrange
+        var window = MessageWindow.Opening(
+            Inbox,
+            MessageListArrangement.Default,
+            Page(1, next: "after-1", previous: null, readCursor: null));
+
+        var page = Page(3, next: "after-3", previous: "before-3", readCursor: "after-1");
+
+        // Act
+        var elsewhere = window.Extended(
+            page,
+            MailTimelinePageDirection.Forward,
+            new MessagePlace("home", "INBOX", Role: null),
+            MessageListArrangement.Default);
+
+        var rearranged = window.Extended(
+            page,
+            MailTimelinePageDirection.Forward,
+            Inbox,
+            MessageListArrangement.Default with { UnreadOnly = true });
+
+        // Assert
+        Assert.Equal(2, elsewhere.Messages.Count);
+        Assert.Equal(2, rearranged.Messages.Count);
+    }
+
+    /// <summary>
+    /// The leading page keeps the request that produced it, which is what reopens the window where it was: neither
+    /// cursor a page answers with reads the page it came from.
+    /// </summary>
+    [Fact]
+    public void LeadingPage_AWindowThatHasMovedOn_KeepsTheRequestThatReopensIt()
+    {
+        // Arrange
+        var window = MessageWindow.Opening(
+            Inbox,
+            MessageListArrangement.Default,
+            Page(1, next: "after-1", previous: null, readCursor: null));
+
+        // Act
+        var extended = window.Extended(
+            Page(3, next: null, previous: "before-3", readCursor: "after-1"),
+            MailTimelinePageDirection.Forward,
+            Inbox,
+            MessageListArrangement.Default);
+
+        // Assert
+        Assert.Null(extended.LeadingPage?.ReadCursor);
+        Assert.Equal(MailTimelinePageDirection.Forward, extended.LeadingPage?.ReadDirection);
+    }
+
+    /// <summary>A window built over nothing would be one that could not say where its pages came from.</summary>
+    [Fact]
+    public void Opening_AMissingPlaceOrArrangement_IsRefused()
+    {
+        // Arrange
+        var page = Page(1, next: null, previous: null, readCursor: null);
+
+        // Act, Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            MessageWindow.Opening(null!, MessageListArrangement.Default, page));
+        Assert.Throws<ArgumentNullException>(() => MessageWindow.Opening(Inbox, null!, page));
+        Assert.Throws<ArgumentNullException>(() =>
+            MessageWindow.Opening(Inbox, MessageListArrangement.Default, null!));
+        Assert.Throws<ArgumentNullException>(() => MessageWindow.Nothing(null!, MessageListArrangement.Default));
+        Assert.Throws<ArgumentNullException>(() => MessageWindow.Nothing(Inbox, null!));
+    }
+
+    private static MessagePage Page(int first, string? next, string? previous, string? readCursor) =>
+        new(
+            [MailMessages.Message(first), MailMessages.Message(first + 1)],
+            next,
+            previous,
+            readCursor,
+            MailTimelinePageDirection.Forward);
+
+    private static MessagePage EmptyPage() =>
+        new([], NextCursor: null, PreviousCursor: null, ReadCursor: "after-1", MailTimelinePageDirection.Forward);
+}

--- a/frontend/tests/Client.UnitTests/Presentation/Messages/VisitedPlacesTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Messages/VisitedPlacesTests.cs
@@ -1,0 +1,119 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Backend.Timeline;
+using MailFathom.Client.Presentation.Messages;
+
+namespace MailFathom.Client.UnitTests.Presentation.Messages;
+
+/// <summary>What one run remembers of the places it read mail in, and what it drops to stay bounded.</summary>
+public sealed class VisitedPlacesTests
+{
+    /// <summary>Leaving a folder and coming back to it is coming back, which is the whole of what this holds.</summary>
+    [Fact]
+    public void Read_APlaceThisRunHasBeenIn_ReadsBackWhereItWasLeft()
+    {
+        // Arrange
+        var visited = new VisitedPlaces();
+        var left = At("workINBOX", "after-the-third-page");
+
+        // Act
+        visited.Keep(left);
+
+        // Assert
+        Assert.Equal(left, visited.Read("workINBOX"));
+    }
+
+    /// <summary>A place this run has not been in is remembered as nothing rather than as somewhere else.</summary>
+    [Fact]
+    public void Read_APlaceThisRunHasNotBeenIn_RemembersNothing()
+    {
+        // Arrange
+        var visited = new VisitedPlaces();
+        visited.Keep(At("workINBOX", "after-the-third-page"));
+
+        // Act, Assert
+        Assert.Null(visited.Read("workArchive"));
+    }
+
+    /// <summary>Reading a folder again writes over where it was, because the newer position is where somebody now is.</summary>
+    [Fact]
+    public void Keep_APlaceWrittenAgain_ReadsBackAsTheNewerPosition()
+    {
+        // Arrange
+        var visited = new VisitedPlaces();
+        visited.Keep(At("workINBOX", "after-the-third-page"));
+
+        // Act
+        visited.Keep(At("workINBOX", "after-the-ninth-page"));
+
+        // Assert
+        Assert.Equal("after-the-ninth-page", visited.Read("workINBOX")?.Cursor);
+        Assert.Equal(1, visited.Count);
+    }
+
+    /// <summary>
+    /// A run has no bound of its own — a deeply nested mailbox has as many places as it has folders — so this one does,
+    /// and what it drops is the place written longest ago.
+    /// </summary>
+    [Fact]
+    public void Keep_MorePlacesThanTheBound_DropsTheOneWrittenLongestAgo()
+    {
+        // Arrange
+        var visited = new VisitedPlaces();
+
+        // Act
+        for (var folder = 0; folder <= VisitedPlaces.Maximum; folder++)
+        {
+            visited.Keep(At($"workFolder-{folder}", $"after-{folder}"));
+        }
+
+        // Assert
+        Assert.Equal(VisitedPlaces.Maximum, visited.Count);
+        Assert.Null(visited.Read("workFolder-0"));
+        Assert.NotNull(visited.Read("workFolder-1"));
+        Assert.NotNull(visited.Read($"workFolder-{VisitedPlaces.Maximum}"));
+    }
+
+    /// <summary>
+    /// The folder somebody keeps returning to is never the one dropped to make room for one they passed through once,
+    /// which is what makes the bound safe to have at all.
+    /// </summary>
+    [Fact]
+    public void Keep_APlaceReturnedTo_MovesToTheNewestEndRatherThanStayingWhereItFirstAppeared()
+    {
+        // Arrange
+        var visited = new VisitedPlaces();
+        visited.Keep(At("workINBOX", "after-the-third-page"));
+
+        for (var folder = 1; folder < VisitedPlaces.Maximum; folder++)
+        {
+            visited.Keep(At($"workFolder-{folder}", $"after-{folder}"));
+        }
+
+        // Act
+        visited.Keep(At("workINBOX", "after-the-ninth-page"));
+        visited.Keep(At("workOne-More", "after-one-more"));
+
+        // Assert
+        Assert.Equal("after-the-ninth-page", visited.Read("workINBOX")?.Cursor);
+        Assert.Null(visited.Read("workFolder-1"));
+    }
+
+    /// <summary>A place with no name to be remembered under would be one nothing could ever read back.</summary>
+    [Fact]
+    public void Read_NoPlaceName_IsRefused()
+    {
+        // Arrange
+        var visited = new VisitedPlaces();
+
+        // Act, Assert
+        Assert.Throws<ArgumentNullException>(() => visited.Read(null!));
+        Assert.Throws<ArgumentException>(() => visited.Read(string.Empty));
+        Assert.Throws<ArgumentNullException>(() => visited.Keep(null!));
+    }
+
+    private static RememberedMessageList At(string placeKey, string cursor) =>
+        new(placeKey, cursor, MailTimelinePageDirection.Forward, MessageListArrangement.Default);
+}

--- a/frontend/tests/Client.UnitTests/Presentation/Spaces/Mail/MailModelTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Spaces/Mail/MailModelTests.cs
@@ -3,6 +3,8 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Client.Backend;
+using MailFathom.Client.Backend.Timeline;
+using MailFathom.Client.Presentation.Messages;
 using MailFathom.Client.Presentation.Spaces.Mail;
 using MailFathom.Client.Session;
 using MailFathom.Client.UnitTests.TestDoubles;
@@ -21,23 +23,207 @@ public sealed class MailModelTests
     {
         // Arrange
         using var withheld = SessionOffering("mailfathom.mail.ask");
-        await using var withheldModel = new MailModel(withheld);
+        await using var withheldModel = new MailModel(withheld, new StubMessageList());
 
         using var offered = SessionOffering("mailfathom.mail.read");
-        await using var offeredModel = new MailModel(offered);
+        await using var offeredModel = new MailModel(offered, new StubMessageList());
 
         // Act, Assert
         Assert.True(await withheldModel.WithholdsMail);
         Assert.False(await offeredModel.WithholdsMail);
     }
 
-    /// <summary>A space that could be built without the session would be one that cannot say whether it may be shown.</summary>
+    /// <summary>
+    /// The list is the run's own read through this space rather than one built here, so leaving the space and coming
+    /// back finds it where it was instead of reading its first page again.
+    /// </summary>
+    [Fact]
+    public async Task Messages_TheRunsOwnList_IsReadThroughRatherThanCopied()
+    {
+        // Arrange
+        using var session = SessionOffering("mailfathom.mail.read");
+        var list = new StubMessageList(Row(1), Row(2));
+        await using var model = new MailModel(session, list);
+
+        // Act
+        var rows = await model.Messages;
+
+        // Assert
+        Assert.Equal([MailMessages.Key(1), MailMessages.Key(2)], rows!.Select(row => row.Key));
+        Assert.Same(list.Chosen, model.Chosen);
+        Assert.Same(list.PagingFailed, model.PagingFailed);
+    }
+
+    /// <summary>Both ends of the loaded window are reported, because each is a control of its own on the screen.</summary>
+    [Fact]
+    public async Task HasMoreAfter_AWindowWithMailEitherSideOfIt_ReportsEachEndSeparately()
+    {
+        // Arrange
+        using var session = SessionOffering("mailfathom.mail.read");
+        var list = new StubMessageList(Row(1)) { More = true, Earlier = false };
+        await using var model = new MailModel(session, list);
+
+        // Act, Assert
+        Assert.True(await model.HasMoreAfter);
+        Assert.False(await model.HasMoreBefore);
+    }
+
+    /// <summary>Each of the arrangement's parts is stated on its own, because each is a control somebody presses.</summary>
+    [Fact]
+    public async Task ReadsOldestFirst_AListArrangedEveryWay_StatesEachPartOnItsOwn()
+    {
+        // Arrange
+        using var session = SessionOffering("mailfathom.mail.read");
+        var list = new StubMessageList();
+        await using var model = new MailModel(session, list);
+
+        await list.ArrangeAsync(
+            new MessageListArrangement
+            {
+                Order = MailTimelineOrder.OldestFirst,
+                UnreadOnly = true,
+                FlaggedOnly = true,
+                WithAttachmentsOnly = true,
+                IncludeJunk = true,
+            },
+            TestContext.Current.CancellationToken);
+
+        // Act, Assert
+        Assert.True(await model.ReadsOldestFirst);
+        Assert.True(await model.KeepsUnreadOnly);
+        Assert.True(await model.KeepsFlaggedOnly);
+        Assert.True(await model.KeepsWithAttachmentsOnly);
+        Assert.True(await model.KeepsJunk);
+        Assert.True(await model.KeepsLessThanEverything);
+        Assert.False(await model.KeepsEverything);
+    }
+
+    /// <summary>
+    /// A place holding no mail and a place whose mail this list is keeping out are not the same thing to be told, so
+    /// both are stated as their own affirmative rather than one being read backwards in the view.
+    /// </summary>
+    [Fact]
+    public async Task KeepsEverything_AListNobodyNarrowed_IsStatedBesideItsOppositeRatherThanDerivedFromIt()
+    {
+        // Arrange
+        using var session = SessionOffering("mailfathom.mail.read");
+        await using var model = new MailModel(session, new StubMessageList());
+
+        // Act, Assert
+        Assert.True(await model.KeepsEverything);
+        Assert.False(await model.KeepsLessThanEverything);
+    }
+
+    /// <summary>Every control the space carries is the list's own act, which is what keeps the space free of one.</summary>
+    [Fact]
+    public async Task ShowMore_TheControlsTheSpaceCarries_ReachTheList()
+    {
+        // Arrange
+        using var session = SessionOffering("mailfathom.mail.read");
+        var list = new StubMessageList();
+        await using var model = new MailModel(session, list);
+
+        // Act
+        await model.ShowMore(TestContext.Current.CancellationToken);
+        await model.ShowEarlier(TestContext.Current.CancellationToken);
+        await model.RetryMessages(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(1, list.Forwards);
+        Assert.Equal(1, list.Backwards);
+        Assert.Equal(1, list.Asks);
+    }
+
+    /// <summary>Reading from the other end is one control, so pressing it twice reads the list the way it started.</summary>
+    [Fact]
+    public async Task ReverseOrder_AListReadFromTheOtherEnd_ReadsItBackTheOriginalWayWhenPressedAgain()
+    {
+        // Arrange
+        using var session = SessionOffering("mailfathom.mail.read");
+        var list = new StubMessageList();
+        await using var model = new MailModel(session, list);
+
+        // Act
+        await model.ReverseOrder(TestContext.Current.CancellationToken);
+        await model.ReverseOrder(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(
+            [MailTimelineOrder.OldestFirst, MailTimelineOrder.NewestFirst],
+            list.Arranged.Select(arrangement => arrangement.Order));
+    }
+
+    /// <summary>
+    /// A filter is composed from what is in force rather than from what a control shows, which is what keeps one toggle
+    /// from undoing the change beside it.
+    /// </summary>
+    [Fact]
+    public async Task ToggleUnreadOnly_AFilterPutInForceBesideAnother_LeavesTheOtherWhereItWas()
+    {
+        // Arrange
+        using var session = SessionOffering("mailfathom.mail.read");
+        var list = new StubMessageList();
+        await using var model = new MailModel(session, list);
+
+        // Act
+        await model.ToggleUnreadOnly(TestContext.Current.CancellationToken);
+        await model.ToggleFlaggedOnly(TestContext.Current.CancellationToken);
+        await model.ToggleWithAttachmentsOnly(TestContext.Current.CancellationToken);
+        await model.ToggleJunk(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(
+            new MessageListArrangement
+            {
+                UnreadOnly = true,
+                FlaggedOnly = true,
+                WithAttachmentsOnly = true,
+                IncludeJunk = true,
+            },
+            list.Arranged[^1]);
+    }
+
+    /// <summary>A filter put in force is taken out of force by the same control, because one control does both.</summary>
+    [Fact]
+    public async Task ToggleUnreadOnly_AFilterPressedTwice_IsTakenOutOfForceAgain()
+    {
+        // Arrange
+        using var session = SessionOffering("mailfathom.mail.read");
+        var list = new StubMessageList();
+        await using var model = new MailModel(session, list);
+
+        // Act
+        await model.ToggleUnreadOnly(TestContext.Current.CancellationToken);
+        await model.ToggleUnreadOnly(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal([true, false], list.Arranged.Select(arrangement => arrangement.UnreadOnly));
+    }
+
+    /// <summary>A space that could be built without either of these would be one that can say neither what it shows nor whether it may.</summary>
     [Fact]
     public void Constructor_AMissingService_IsRefused()
     {
+        // Arrange
+        using var session = SessionOffering("mailfathom.mail.read");
+
         // Act, Assert
-        Assert.Throws<ArgumentNullException>(() => new MailModel(null!));
+        Assert.Throws<ArgumentNullException>(() => new MailModel(null!, new StubMessageList()));
+        Assert.Throws<ArgumentNullException>(() => new MailModel(session, null!));
     }
+
+    private static MessageRow Row(int number) => new(
+        MailMessages.Key(number),
+        "Someone",
+        "Quarterly review",
+        Preview: string.Empty,
+        "09:41",
+        "Someone, Quarterly review, 09:41",
+        IsUnread: false,
+        IsFlagged: false,
+        IsAnswered: false,
+        HasAttachments: false,
+        AttachmentCount: 0);
 
     private static StubClientSession SessionOffering(params string[] permissions) =>
         new(SessionStanding.Of(new DeploymentSession("MailFathom", "0.8.0", permissions)));

--- a/frontend/tests/Client.UnitTests/Strings/ResourceTableTests.cs
+++ b/frontend/tests/Client.UnitTests/Strings/ResourceTableTests.cs
@@ -6,6 +6,7 @@ using MailFathom.Client.Backend;
 using MailFathom.Client.Deployment;
 using MailFathom.Client.Presentation;
 using MailFathom.Client.Presentation.Mailboxes;
+using MailFathom.Client.Presentation.Messages;
 using MailFathom.Client.Presentation.Workspace;
 
 namespace MailFathom.Client.UnitTests.Strings;
@@ -234,6 +235,25 @@ public sealed class ResourceTableTests
         // Assert
         Assert.True(table.ContainsKey(MailboxWords.EverythingKey), MailboxWords.EverythingKey);
         Assert.True(table.ContainsKey(MailboxWords.UnifiedRoleKey), MailboxWords.UnifiedRoleKey);
+    }
+
+    /// <summary>
+    /// A message row is composed from what a deployment answered rather than fixed per control, so its sentences are
+    /// asked for from code instead of through a <c>x:Uid</c> — which makes each of them a name a reader would meet on
+    /// the screen as the key itself.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Languages))]
+    public void Tables_TheWordsAMessageRowIsComposedFrom_AreNamedInEveryLanguage(string culture)
+    {
+        // Arrange
+        var expected = MessageWords.ResourceKeys;
+
+        // Act
+        var table = DeclaredLanguages.TableOf(culture);
+
+        // Assert
+        Assert.All(expected, key => Assert.True(table.ContainsKey(key), key));
     }
 
     private static IEnumerable<string> KeysOf(string culture) =>

--- a/frontend/tests/Client.UnitTests/TestDoubles/MailMessages.cs
+++ b/frontend/tests/Client.UnitTests/TestDoubles/MailMessages.cs
@@ -1,0 +1,72 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Globalization;
+using MailFathom.Client.Backend.Timeline;
+
+namespace MailFathom.Client.UnitTests.TestDoubles;
+
+/// <summary>The mail a test arranges a list out of, composed once rather than at each arrangement.</summary>
+/// <remarks>
+/// A row of the timeline carries seventeen fields and a test is usually about one of them, so composing one by hand in
+/// each arrangement would bury what the test is actually saying. Everything here is invented: no address, subject, or
+/// preview below belongs to anybody.
+/// </remarks>
+internal static class MailMessages
+{
+    /// <summary>Composes one message, defaulting everything a test is not about.</summary>
+    /// <param name="number">What makes this message's identity its own, written into the identifier.</param>
+    /// <param name="receivedAt">When it arrived, or <see langword="null" /> where no header dated it.</param>
+    /// <param name="subject">What it is about, or <see langword="null" /> where it carried no subject.</param>
+    /// <param name="senderDisplayName">The name the sender wrote, or <see langword="null" /> where the header carried none.</param>
+    /// <param name="senderAddress">The address the sender wrote, or <see langword="null" /> where none was found.</param>
+    /// <param name="recipients">Who it went to.</param>
+    /// <param name="unread">Whether the mail server last reported it without <c>\Seen</c>.</param>
+    /// <param name="flagged">Whether it last reported it with <c>\Flagged</c>.</param>
+    /// <param name="answered">Whether it last reported it with <c>\Answered</c>.</param>
+    /// <param name="attachmentCount">How many attachments it carries.</param>
+    /// <param name="preview">The opening of its own text, or <see langword="null" /> where nothing has extracted it.</param>
+    /// <returns>The message.</returns>
+    internal static DeploymentMailMessage Message(
+        int number,
+        DateTimeOffset? receivedAt = null,
+        string? subject = "Quarterly review",
+        string? senderDisplayName = "Someone",
+        string? senderAddress = "someone@example.test",
+        IReadOnlyList<string>? recipients = null,
+        bool unread = false,
+        bool flagged = false,
+        bool answered = false,
+        int attachmentCount = 0,
+        string? preview = null) =>
+        new(
+            Identity(number),
+            "work",
+            "INBOX",
+            ThreadId: null,
+            subject,
+            receivedAt,
+            receivedAt,
+            senderAddress,
+            senderDisplayName,
+            recipients ?? ["owner@example.test"],
+            unread,
+            flagged,
+            answered,
+            attachmentCount > 0,
+            attachmentCount,
+            SizeOctets: 1024,
+            preview);
+
+    /// <summary>Names the identity a numbered message carries, so a test can assert a row without repeating a value.</summary>
+    /// <param name="number">The number the message was composed with.</param>
+    /// <returns>The identifier.</returns>
+    internal static Guid Identity(int number) =>
+        Guid.ParseExact(number.ToString("D32", CultureInfo.InvariantCulture), "N");
+
+    /// <summary>Names the key the list draws for a numbered message, which is its identity written out.</summary>
+    /// <param name="number">The number the message was composed with.</param>
+    /// <returns>The row key.</returns>
+    internal static string Key(int number) => Identity(number).ToString("D", CultureInfo.InvariantCulture);
+}

--- a/frontend/tests/Client.UnitTests/TestDoubles/StubMessageList.cs
+++ b/frontend/tests/Client.UnitTests/TestDoubles/StubMessageList.cs
@@ -1,0 +1,103 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Immutable;
+using MailFathom.Client.Presentation.Messages;
+
+namespace MailFathom.Client.UnitTests.TestDoubles;
+
+/// <summary>A list that answers with what a test handed it and records what was asked of it.</summary>
+/// <remarks>
+/// The Mail space hands every one of these on rather than deciding any of them, so what its tests need is a list that
+/// says whether it was reached and under what arrangement — the behaviour of a real one is asserted where it is built.
+/// </remarks>
+internal sealed class StubMessageList : IMessageList
+{
+    private readonly IState<MessageListArrangement> arranged;
+
+    /// <summary>Builds a list drawing the rows a test states.</summary>
+    /// <param name="rows">What the list answers with.</param>
+    internal StubMessageList(params MessageRow[] rows)
+    {
+        IImmutableList<MessageRow> drawn = [.. rows];
+
+        this.Rows = Feed.Async(_ => ValueTask.FromResult(drawn)).AsListFeed();
+        this.Chosen = State<IImmutableList<MessageRow>>.Empty(this);
+        this.arranged = State.Value(this, () => MessageListArrangement.Default);
+        this.Arrangement = this.arranged;
+        this.HasMoreAfter = Feed.Async(_ => ValueTask.FromResult(this.More));
+        this.HasMoreBefore = Feed.Async(_ => ValueTask.FromResult(this.Earlier));
+        this.PagingFailed = Feed.Async(_ => ValueTask.FromResult(false));
+    }
+
+    /// <summary>Gets or sets whether the stub reports more mail after what is loaded.</summary>
+    internal bool More { get; set; }
+
+    /// <summary>Gets or sets whether the stub reports more mail before what is loaded.</summary>
+    internal bool Earlier { get; set; }
+
+    /// <summary>Gets how many times the list was asked for another page forward.</summary>
+    internal int Forwards { get; private set; }
+
+    /// <summary>Gets how many times the list was asked for another page backward.</summary>
+    internal int Backwards { get; private set; }
+
+    /// <summary>Gets how many times the list was asked to read the deployment again.</summary>
+    internal int Asks { get; private set; }
+
+    /// <summary>Gets every arrangement the list was asked to read under, in order.</summary>
+    internal List<MessageListArrangement> Arranged { get; } = [];
+
+    /// <inheritdoc />
+    public IListFeed<MessageRow> Rows { get; }
+
+    /// <inheritdoc />
+    public IState<IImmutableList<MessageRow>> Chosen { get; }
+
+    /// <inheritdoc />
+    public IFeed<MessageListArrangement> Arrangement { get; }
+
+    /// <inheritdoc />
+    public IFeed<bool> HasMoreAfter { get; }
+
+    /// <inheritdoc />
+    public IFeed<bool> HasMoreBefore { get; }
+
+    /// <inheritdoc />
+    public IFeed<bool> PagingFailed { get; }
+
+    /// <inheritdoc />
+    public ValueTask ShowMoreAsync(CancellationToken cancellationToken)
+    {
+        this.Forwards++;
+
+        return ValueTask.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public ValueTask ShowEarlierAsync(CancellationToken cancellationToken)
+    {
+        this.Backwards++;
+
+        return ValueTask.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask ArrangeAsync(
+        MessageListArrangement arrangement,
+        CancellationToken cancellationToken)
+    {
+        this.Arranged.Add(arrangement);
+
+        await this.arranged.UpdateAsync(_ => arrangement, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public ValueTask AskAgainAsync(CancellationToken cancellationToken)
+    {
+        this.Asks++;
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/frontend/tests/Client.UnitTests/TestDoubles/StubMessageListMemory.cs
+++ b/frontend/tests/Client.UnitTests/TestDoubles/StubMessageListMemory.cs
@@ -1,0 +1,42 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Presentation.Messages;
+
+namespace MailFathom.Client.UnitTests.TestDoubles;
+
+/// <summary>A stand-in for where a list's position outlives the folder being left and the run itself.</summary>
+/// <remarks>
+/// Half of the real one is <c>ApplicationData.LocalSettings</c>, which no unit test can reach; the other half is the
+/// run's own bounded map, which <c>VisitedPlaces</c> owns and its own tests cover. Holding every place in memory here
+/// is what a test of the list needs of both: what a run keeps, and what a return to a folder opens on.
+/// </remarks>
+internal sealed class StubMessageListMemory : IMessageListMemory
+{
+    private readonly Dictionary<string, RememberedMessageList> remembered = new(StringComparer.Ordinal);
+
+    /// <summary>Builds a store already holding what previous runs left, or holding nothing.</summary>
+    /// <param name="remembered">What a read of each of those places answers with.</param>
+    internal StubMessageListMemory(params RememberedMessageList[] remembered)
+    {
+        foreach (var place in remembered)
+        {
+            this.remembered[place.PlaceKey] = place;
+        }
+    }
+
+    /// <summary>Gets everything the store was asked to keep, in order.</summary>
+    internal List<RememberedMessageList> Written { get; } = [];
+
+    /// <inheritdoc />
+    public RememberedMessageList Read(string placeKey) =>
+        this.remembered.GetValueOrDefault(placeKey) ?? RememberedMessageList.Nothing(placeKey);
+
+    /// <inheritdoc />
+    public void Write(RememberedMessageList remembered)
+    {
+        this.remembered[remembered.PlaceKey] = remembered;
+        this.Written.Add(remembered);
+    }
+}


### PR DESCRIPTION
Closes #1161

Mail was the space that said it was still being built. It now draws the mail of wherever the mailbox tree says
somebody is — a virtualized list over a bounded, keyset-paged window, whose selection is the scope the rest of the
client reads.

## Where the pieces are

`frontend/src/Client.Backend/Timeline/` is the fourth route this client calls, `GET /api/client/emails`.
`MailTimelineQuery` composes the whole request as one record, because a cursor names the list it was taken from and a
screen that changed a filter while keeping a cursor would be composing a request that cannot be served.

`frontend/src/Client/Presentation/Messages/` is the list. `IMessageList` is registered once for the run beside the
tree and the workspace, so leaving Mail and coming back finds the list where it was rather than reading its first page
again.

## What the change actually decides

**A bounded window, not just a virtualized list.** A list that merely virtualizes its containers still holds every row
it has paged. `MessageWindow` keeps four pages and drops the far one as it takes a near one, so the count of loaded
rows is a property of the type rather than of how long somebody scrolled. Dropping a page is only safe because each one
keeps the request that produced it: the two cursors a page answers with name its own first and last row, so neither
reopens the page it came from, and `MessagePage` carries the `(cursor, direction)` pair that does. That is also why
paging runs both ways here where a list that only ever grew would need one direction.

**Continuity is that same pair written down.** `IMessageListMemory` keeps it per place — `VisitedPlaces` holds every
place one run visited, bounded at sixteen, and `ApplicationData.LocalSettings` holds the one the tree reopens on, so a
restart returns to where somebody was without growing a list of their folders on their disk. The arrangement travels
with the cursor, because a cursor is only honoured against the filters and the order it was issued under.

**The list reloads on the *place*, not on the scope.** It writes what is selected back into `IWorkspace.Scope`, so a
list keyed on the whole scope would read the folder again on every click. `MessagePlace` is the scope without what is
selected inside it, and that is the whole reason the type exists.

**Selection is the workspace's rather than the control's.** The modifiers, the range and the drag stay the platform's
through `SelectionMode="Extended"`, and a touch head reaches the same state by holding a row, which checks a control
that is visible and can be left. What comes out of it is `IWorkspace.Scope`, which is what stage 3's *select and ask*
reads.

**A row is drawn from the page that carried it and from nothing else**, so fifty rows are one request.
`MessageListShape` composes it — the correspondent, which is the recipients where the place is mail this owner sent;
the date, as a time today and a date before that; and the one sentence a screen reader is given instead of six
unlabelled controls — and is a pure reduction, so all of it is reachable by an ordinary unit test.

**Four rendered states rather than one blank list**: the page under way, the read that failed, a place holding no mail,
and a place whose mail this list is keeping out. The last two are told apart in words, and the empty-state wording
points at the mailbox pane for how current the copy is, because that is where freshness is said per folder and a
spinner would claim something is arriving.

## Contract

`400` now becomes `DeploymentFailureReason.RequestRefused` rather than an unusable answer. It is the client's own
request being refused, so the caller that composed it can compose another: a cursor issued for a list somebody has
since re-sorted is a position to give up, not an error to show, so the list drops it and opens at the leading end.

No public surface breaks. The MCP tool contract, the configuration schema, the database schema and the deployment
contract are untouched, and the client endpoint is called rather than changed.

## Privacy

Nothing about mail reaches a log or telemetry. What outlives the run is a cursor, a folder alias, an account
identifier and a role — mail metadata, kept in the store the platform gives this application on this person's own
device, and never a row.

## Tests

61 new tests across the wire records, the query string, the window, the shape, the run's bounded map, the two halves
of the persisted arrangement, the list itself, and the Mail model. `frontend/tests/Client.UnitTests` is 513 passing.

## What this deliberately does not do

- **The XAML is exercised by no test and was not run.** This session was not dispatched with the Uno App MCP, so the
  virtualization, the touch selection mode and the four rendered states are reasoned from the markup rather than seen.
  `frontend/tests/AGENTS.md` is what says such a case is named in the pull request rather than asserted indirectly.
- **Opening a message goes nowhere yet.** Keyboard navigation moves through the list and the row it lands on becomes
  the scope the reading surface is drawn from, which is how a list with a companion column works — but that surface is
  #1163 and the thread is #1162, so there is nothing to navigate to. No open gesture was invented for a destination
  that does not exist.
- **The position is remembered to the page rather than to the pixel.** A page is the unit a cursor names, so reopening
  puts somebody back among the mail they were reading and the list opens at the top of that page.
- **A sent folder opened by its alias draws senders.** Recipients are answered from the role, because a message does
  not know which of its addresses the reader is, and a folder chosen by alias reaches this client without a role.

https://claude.ai/code/session_01TP1VXtGoyUNFmkFnzz7Lz6
