### PR TITLE
[#1323] Resolve the client's whole service graph without a window to launch it in

### DIFF
--- a/frontend/src/Client/App.xaml.cs
+++ b/frontend/src/Client/App.xaml.cs
@@ -3,15 +3,11 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Diagnostics.CodeAnalysis;
-using MailFathom.Client.Backend;
 using MailFathom.Client.Deployment;
-using MailFathom.Client.Presentation.Mailboxes;
-using MailFathom.Client.Presentation.Messages;
 using MailFathom.Client.Presentation.Settings;
 using MailFathom.Client.Presentation.Spaces;
 using MailFathom.Client.Presentation.Spaces.Mail;
 using MailFathom.Client.Presentation.Workspace;
-using MailFathom.Client.Session;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace MailFathom.Client;
@@ -82,42 +78,11 @@ public partial class App : Application
                 // point at which it takes effect, because applying a culture is what Uno does on the next launch
                 // rather than to a visual tree already built. The screen offering it says so.
                 .UseLocalization()
+                // Everything this application registers, which is written beside this file rather than in it: a graph
+                // composed only inside OnLaunched is one nothing can resolve without a window, and it is what
+                // ClientCompositionTests builds and resolves in full.
                 .ConfigureServices((context, services) =>
-                {
-                    this.ComposeDeployment(services, context.Configuration);
-
-                    // What the three spaces share, so that moving between them keeps the question somebody was
-                    // composing and what it would be asked against. One for the run rather than one per model: a
-                    // model is discarded as its view is navigated away from, and so would be anything it held.
-                    services.AddSingleton<IWorkspace, SharedWorkspace>();
-
-                    // The tree those spaces are scoped by, on the same terms and for the same reason: a tree held per
-                    // model would forget what was open the moment somebody moved between spaces, and would ask the
-                    // deployment for the same folders again while doing it. Where it was left outlives the run, which
-                    // is what makes starting the client again opening it rather than finding one's way back.
-                    services.AddSingleton<IMailboxTreeMemory, LocalSettingsMailboxTreeMemory>();
-                    services.AddSingleton<IMailboxTree, DeploymentMailboxTree>();
-
-                    // The mail that tree is narrowed to, on the same terms and for the same reason: a list held per
-                    // model would read the folder's first page again every time somebody moved between spaces, and
-                    // would forget how far they had scrolled while doing it. Where it was left outlives the run for
-                    // the place the tree reopens on, and outlives only the run for every other place it visited.
-                    services.AddSingleton<IMessageListMemory, LocalSettingsMessageListMemory>();
-                    services.AddSingleton<IMessageList, DeploymentMessageList>();
-
-                    // What the deployment allows this caller, for the same reason and on the same terms. It is the
-                    // one place that answers whether something may be offered, so every screen reads one answer
-                    // instead of deriving its own from a request the deployment refused — and it keeps itself
-                    // current by listening where the two things that invalidate it happen.
-                    services.AddSingleton<IClientSession, DeploymentClientSession>();
-
-                    // How many times a client that has lost its deployment asks again before it stops and offers the
-                    // ask as a button, and what the wait between attempts is measured against. Both are registered
-                    // rather than written into the session, because what they decide is a policy this composition
-                    // states and a test states differently.
-                    services.AddSingleton(DeploymentConnectionRetry.Standard);
-                    services.AddSingleton(TimeProvider.System);
-                })
+                    ClientComposition.Compose(services, context.Configuration, this.deploymentAddress))
                 // Light, dark, and follow-the-system, with the choice written to the platform's own settings store so
                 // the application starts the way it was left. Nothing here decides which one: AppTheme.System is the
                 // default the service reads back when nothing was ever chosen.
@@ -152,44 +117,6 @@ public partial class App : Application
                     this,
                     pointed ? ClientRoutes.Workspace : ClientRoutes.Connect);
             });
-    }
-
-    /// <summary>Registers everything that decides which deployment this head reaches, and how it is reached.</summary>
-    /// <remarks>
-    /// <para>
-    /// The composition root's whole part in it. Nothing here names a deployment and <c>Client.Backend</c> has no
-    /// default address and composes none from a literal, so a client that reached the wrong one would have been sent
-    /// there by something readable — a file somebody wrote, a build somebody ran, or an address somebody typed.
-    /// </para>
-    /// <para>
-    /// What each of the three registrations is for: the settings are what an installation stated, the source is what
-    /// this head knows for itself, and the store is where a person's own choice outlives a restart.
-    /// <see cref="DeploymentChoice" /> is where they meet, and it is asked once, after the host is built and before
-    /// anything is navigated to.
-    /// </para>
-    /// <para>
-    /// The stated values are read by name rather than bound onto the record. Binding is reflection over properties, and
-    /// the browser head is trimmed — the same reason this stack source-generates every serializer it uses — so a bound
-    /// section is one the trimmer can quietly empty. Two keys are not worth a source-generated binder either, and
-    /// reading them is the shape that cannot be trimmed away.
-    /// </para>
-    /// </remarks>
-    private void ComposeDeployment(IServiceCollection services, IConfiguration configuration)
-    {
-        var stated = configuration.GetSection(DeploymentSettings.SectionName);
-
-        var settings = new DeploymentSettings
-        {
-            Address = stated[nameof(DeploymentSettings.Address)] ?? string.Empty,
-            ClientId = stated[nameof(DeploymentSettings.ClientId)] ?? string.Empty,
-        };
-
-        services
-            .AddSingleton(settings)
-            .AddSingleton<IDeploymentAddressSource>(this.deploymentAddress)
-            .AddSingleton<IDeploymentChoiceStore, LocalSettingsDeploymentChoiceStore>()
-            .AddSingleton<DeploymentChoice>()
-            .AddMailFathomDeployment(new DeploymentOptions(settings.ClientId));
     }
 
     /// <summary>

--- a/frontend/src/Client/ClientComposition.cs
+++ b/frontend/src/Client/ClientComposition.cs
@@ -1,0 +1,125 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Backend;
+using MailFathom.Client.Deployment;
+using MailFathom.Client.Presentation.Mailboxes;
+using MailFathom.Client.Presentation.Messages;
+using MailFathom.Client.Presentation.Workspace;
+using MailFathom.Client.Session;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MailFathom.Client;
+
+/// <summary>Everything the client registers, in one place a test can call without starting a head.</summary>
+/// <remarks>
+/// <para>
+/// It is the whole of what <see cref="App" /> hands the host builder's <c>ConfigureServices</c>, moved out of the
+/// launch path rather than duplicated beside it: <see cref="App.OnLaunched" /> needs a window, an application object,
+/// and a XAML runtime, none of which a unit-test host has, so a graph composed only inside it is a graph first
+/// resolved on somebody's machine. Everything else a head is built from — configuration, localization, logging, theme
+/// switching, and navigation — stays where it is, because each of those is a call on the builder rather than a
+/// registration this application writes.
+/// </para>
+/// <para>
+/// What this does not register is what the builder contributes around it: <c>IStringLocalizer</c>,
+/// <c>ILocalizationService</c>, <c>IThemeService</c>, and <c>INavigator</c> come from the <c>Use*</c> calls in
+/// <see cref="App.OnLaunched" />, and a screen reaching one of them is reaching the framework rather than this
+/// composition.
+/// </para>
+/// </remarks>
+internal static class ClientComposition
+{
+    /// <summary>Registers everything the client resolves, for a head that has already said how it finds its deployment.</summary>
+    /// <param name="services">The collection the head's host is being built from.</param>
+    /// <param name="configuration">What the installation states, which is where the deployment settings are read from.</param>
+    /// <param name="deploymentAddress">How this head learns where its deployment is, already wrapped in whatever the build stated.</param>
+    /// <returns>The same collection, so registration composes.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    internal static IServiceCollection Compose(
+        IServiceCollection services,
+        IConfiguration configuration,
+        IDeploymentAddressSource deploymentAddress)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(deploymentAddress);
+
+        ComposeDeployment(services, configuration, deploymentAddress);
+
+        // What the three spaces share, so that moving between them keeps the question somebody was composing and what
+        // it would be asked against. One for the run rather than one per model: a model is discarded as its view is
+        // navigated away from, and so would be anything it held.
+        services.AddSingleton<IWorkspace, SharedWorkspace>();
+
+        // The tree those spaces are scoped by, on the same terms and for the same reason: a tree held per model would
+        // forget what was open the moment somebody moved between spaces, and would ask the deployment for the same
+        // folders again while doing it. Where it was left outlives the run, which is what makes starting the client
+        // again opening it rather than finding one's way back.
+        services.AddSingleton<IMailboxTreeMemory, LocalSettingsMailboxTreeMemory>();
+        services.AddSingleton<IMailboxTree, DeploymentMailboxTree>();
+
+        // The mail that tree is narrowed to, on the same terms and for the same reason: a list held per model would
+        // read the folder's first page again every time somebody moved between spaces, and would forget how far they
+        // had scrolled while doing it. Where it was left outlives the run for the place the tree reopens on, and
+        // outlives only the run for every other place it visited.
+        services.AddSingleton<IMessageListMemory, LocalSettingsMessageListMemory>();
+        services.AddSingleton<IMessageList, DeploymentMessageList>();
+
+        // What the deployment allows this caller, for the same reason and on the same terms. It is the one place that
+        // answers whether something may be offered, so every screen reads one answer instead of deriving its own from
+        // a request the deployment refused — and it keeps itself current by listening where the two things that
+        // invalidate it happen.
+        services.AddSingleton<IClientSession, DeploymentClientSession>();
+
+        // How many times a client that has lost its deployment asks again before it stops and offers the ask as a
+        // button, and what the wait between attempts is measured against. Both are registered rather than written into
+        // the session, because what they decide is a policy this composition states and a test states differently.
+        services.AddSingleton(DeploymentConnectionRetry.Standard);
+        services.AddSingleton(TimeProvider.System);
+
+        return services;
+    }
+
+    /// <summary>Registers everything that decides which deployment this head reaches, and how it is reached.</summary>
+    /// <remarks>
+    /// <para>
+    /// The composition root's whole part in it. Nothing here names a deployment and <c>Client.Backend</c> has no
+    /// default address and composes none from a literal, so a client that reached the wrong one would have been sent
+    /// there by something readable — a file somebody wrote, a build somebody ran, or an address somebody typed.
+    /// </para>
+    /// <para>
+    /// What each of the three registrations is for: the settings are what an installation stated, the source is what
+    /// this head knows for itself, and the store is where a person's own choice outlives a restart.
+    /// <see cref="DeploymentChoice" /> is where they meet, and it is asked once, after the host is built and before
+    /// anything is navigated to.
+    /// </para>
+    /// <para>
+    /// The stated values are read by name rather than bound onto the record. Binding is reflection over properties, and
+    /// the browser head is trimmed — the same reason this stack source-generates every serializer it uses — so a bound
+    /// section is one the trimmer can quietly empty. Two keys are not worth a source-generated binder either, and
+    /// reading them is the shape that cannot be trimmed away.
+    /// </para>
+    /// </remarks>
+    private static void ComposeDeployment(
+        IServiceCollection services,
+        IConfiguration configuration,
+        IDeploymentAddressSource deploymentAddress)
+    {
+        var stated = configuration.GetSection(DeploymentSettings.SectionName);
+
+        var settings = new DeploymentSettings
+        {
+            Address = stated[nameof(DeploymentSettings.Address)] ?? string.Empty,
+            ClientId = stated[nameof(DeploymentSettings.ClientId)] ?? string.Empty,
+        };
+
+        services
+            .AddSingleton(settings)
+            .AddSingleton(deploymentAddress)
+            .AddSingleton<IDeploymentChoiceStore, LocalSettingsDeploymentChoiceStore>()
+            .AddSingleton<DeploymentChoice>()
+            .AddMailFathomDeployment(new DeploymentOptions(settings.ClientId));
+    }
+}

--- a/frontend/src/README.md
+++ b/frontend/src/README.md
@@ -17,6 +17,7 @@ What is inside the two projects:
 | Path | What it holds |
 |---|---|
 | `Client/App.xaml`, `App.xaml.cs` | The composition root: the host every head starts through, logging, and the route registry |
+| `Client/ClientComposition.cs` | Every service the application registers, beside the launch path rather than inside it, so the graph can be composed and resolved without a window |
 | `Client/Presentation/` | The shell, the frame the three spaces are shown inside, the spaces themselves, and the MVUX models behind them |
 | `Client/Styles/` | The Material palette every brush resolves from — the one place a colour value is written |
 | `Client/Platforms/` | What belongs to one head only: the two entry points, the browser head's web manifest, linker configuration, and font stylesheet, and its half of the sign-in redirect |

--- a/frontend/tests/Client.UnitTests/Client.UnitTests.csproj
+++ b/frontend/tests/Client.UnitTests/Client.UnitTests.csproj
@@ -30,6 +30,15 @@
           TargetPath="Build/Client.csproj"
           CopyToOutputDirectory="PreserveNewest" />
 
+    <!-- The configuration the application ships, on the same terms and for the same reason: it travels into the bundle
+         embedded, so a value edited out of it composes a head that fails while starting and no build reports it. What
+         the suite does with it is compose the real service graph against it, which is the one reading that says the
+         file every head is launched from still holds what the composition reads. -->
+    <None Include="..\..\src\Client\appsettings.json"
+          Link="Configuration/appsettings.json"
+          TargetPath="Configuration/appsettings.json"
+          CopyToOutputDirectory="PreserveNewest" />
+
     <!-- The string tables, on the same terms and for the same reason: they are compiled into a resource map a running
          head resolves and this host has none, so the suite reads the authored files instead. What it asserts of them
          is which languages are authored at all and whether every table says the same things, neither of which a build

--- a/frontend/tests/Client.UnitTests/ClientCompositionTests.cs
+++ b/frontend/tests/Client.UnitTests/ClientCompositionTests.cs
@@ -1,0 +1,511 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using MailFathom.Client.Backend;
+using MailFathom.Client.Backend.Authorization;
+using MailFathom.Client.Backend.Authorization.Redirect;
+using MailFathom.Client.Deployment;
+using MailFathom.Client.Presentation.Mailboxes;
+using MailFathom.Client.Presentation.Messages;
+using MailFathom.Client.Presentation.Workspace;
+using MailFathom.Client.Session;
+using MailFathom.Client.UnitTests.TestDoubles;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Localization;
+
+namespace MailFathom.Client.UnitTests;
+
+/// <summary>Composes the real client graph and resolves it, without a window to launch it in.</summary>
+/// <remarks>
+/// <para>
+/// A container resolves a factory-registered service the first time something asks for it, so a dependency nobody
+/// registered is not a failure the composition reports: it is an exception out of whichever screen asked first, after
+/// the application has already drawn itself. <c>ValidateOnBuild</c> answers half of that and no more — it inspects the
+/// constructors the container can see — so every registration this application owns is resolved here rather than
+/// validated, and every model a screen is drawn from is constructed beside them, because navigation builds a model
+/// from the same provider and a model is the one consumer of most of what is registered.
+/// </para>
+/// <para>
+/// What the tests supply around the composition is what the host builder supplies in a running head: the string table,
+/// the navigator, the theme service, and the localization service all come from the <c>Use*</c> calls in
+/// <see cref="App.OnLaunched" /> rather than from <see cref="ClientComposition" />, and they are stood in for here for
+/// the same reason a unit host stands in for a window. The three readers of the platform's own settings store are
+/// stood in for as well, because <c>ApplicationData.Current</c> belongs to a running application — which of them the
+/// composition registered is asserted on its own instead. Everything else is the application's own.
+/// </para>
+/// <para>
+/// Nothing here reaches a deployment. The graph is built from the service collection directly, so no transport is
+/// created until a test asks for one and no request is ever made: a transport is constructed from an address without
+/// dialling it.
+/// </para>
+/// </remarks>
+public sealed class ClientCompositionTests
+{
+    /// <summary>Where the configuration the application ships is read from beside the test assembly.</summary>
+    private static readonly string ShippedConfiguration =
+        Path.Combine(AppContext.BaseDirectory, "Configuration", "appsettings.json");
+
+    /// <summary>What an installation states, in the shape the application reads it in.</summary>
+    private static readonly KeyValuePair<string, string?>[] StatedDeployment =
+    [
+        new($"{DeploymentSettings.SectionName}:{nameof(DeploymentSettings.Address)}", "https://mail.example/"),
+        new($"{DeploymentSettings.SectionName}:{nameof(DeploymentSettings.ClientId)}", "mailfathom-client"),
+    ];
+
+    /// <summary>
+    /// What every space shares for the length of a run, and would silently stop sharing if one of these were ever
+    /// registered per model.
+    /// </summary>
+    /// <remarks>
+    /// Stated as a list rather than asserted by resolving twice, because the defect this guards against is a lifetime
+    /// written wrongly rather than a container behaving unexpectedly: a transient registration resolves perfectly and
+    /// hands the next screen a tree that has forgotten where somebody was.
+    /// </remarks>
+    private static readonly Type[] SharedForTheRun =
+    [
+        typeof(IWorkspace),
+        typeof(IMailboxTreeMemory),
+        typeof(IMailboxTree),
+        typeof(IMessageListMemory),
+        typeof(IMessageList),
+        typeof(IClientSession),
+        typeof(DeploymentChoice),
+        typeof(DeploymentAddress),
+        typeof(AccessTokenStore),
+    ];
+
+    /// <summary>The assertion this class exists for.</summary>
+    [Fact]
+    public void Compose_ResolvesEveryServiceItRegistered()
+    {
+        // Arrange
+        var services = ComposeServices();
+
+        // Act
+        var unbuildable = ReportEveryRegistrationItCannotBuild(services);
+
+        // Assert
+        // Reported together rather than through Assert.Empty, which abbreviates a collection: one missing registration
+        // usually leaves several services unbuildable, and the reader needs the one that is actually absent.
+        if (unbuildable.Length > 0)
+        {
+            Assert.Fail(
+                $"The client registered services it cannot build:{Environment.NewLine}  "
+                + string.Join($"{Environment.NewLine}  ", unbuildable));
+        }
+    }
+
+    /// <summary>
+    /// The same pass over the configuration every head actually reads, rather than over keys a test invented.
+    /// </summary>
+    /// <remarks>
+    /// The application's own <c>appsettings.json</c> travels into the bundle and is the one source a browser head can
+    /// read, so a value edited out of it composes a head that fails while starting — which no other test here would
+    /// notice, each of them stating its own configuration. The file is read from beside the test assembly rather than
+    /// embedded, for the reason every other file this suite reads is: one file rather than two that have to agree.
+    /// </remarks>
+    [Fact]
+    public void Compose_WithTheConfigurationTheApplicationShips_ResolvesEveryServiceItRegistered()
+    {
+        // Arrange
+        var services = ComposeServices(
+            new ConfigurationBuilder().AddJsonFile(ShippedConfiguration).Build());
+
+        // Act
+        var unbuildable = ReportEveryRegistrationItCannotBuild(services);
+
+        // Assert
+        if (unbuildable.Length > 0)
+        {
+            Assert.Fail(
+                $"The configuration the application ships composes services it cannot build:{Environment.NewLine}  "
+                + string.Join($"{Environment.NewLine}  ", unbuildable));
+        }
+    }
+
+    /// <summary>
+    /// The other half of what the composition is for: every screen is drawn from a model, navigation builds each one
+    /// from this provider, and a model asking for something nobody registered fails when its screen is opened rather
+    /// than when the application starts.
+    /// </summary>
+    /// <remarks>
+    /// The models are discovered rather than listed, so a screen added without its dependencies registered fails here
+    /// instead of on the first navigation to it. A model is a record — MVUX requires one — and the bindable proxy the
+    /// generator emits beside it is not, which is what separates the two without naming either.
+    /// </remarks>
+    [Fact]
+    public void Compose_ConstructsEveryModelAScreenIsDrawnFrom()
+    {
+        // Arrange
+        var services = ComposeServices();
+
+        using var provider = BuiltProvider(services);
+
+        var models = PresentationModels();
+
+        // Act
+        string[] unbuildable =
+        [
+            .. models
+                .Select(model => ReportConstructing(provider, model))
+                .OfType<string>(),
+        ];
+
+        // Assert
+        // The count is asserted as well as the failures, because a discovery that found nothing would otherwise report
+        // a graph in which every screen composes as one in which none was looked at.
+        Assert.NotEmpty(models);
+
+        if (unbuildable.Length > 0)
+        {
+            Assert.Fail(
+                $"The client cannot build every model a screen is drawn from:{Environment.NewLine}  "
+                + string.Join($"{Environment.NewLine}  ", unbuildable));
+        }
+    }
+
+    /// <summary>What the run shares is registered once and shared, which no resolution of a working graph would notice.</summary>
+    [Fact]
+    public void Compose_RegistersWhatEverySpaceSharesOncePerRun()
+    {
+        // Arrange
+        var services = ComposeServices();
+
+        // Act
+        var registered = SharedForTheRun.ToDictionary(
+            static shared => shared,
+            shared => services.Where(descriptor => descriptor.ServiceType == shared).ToArray());
+
+        // Assert
+        Assert.All(
+            registered,
+            shared =>
+            {
+                var descriptor = Assert.Single(shared.Value);
+
+                Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+            });
+    }
+
+    /// <summary>
+    /// What outlives a run is read from the platform's own settings store, which is the one part of the graph the
+    /// tests stand in for.
+    /// </summary>
+    /// <remarks>
+    /// Asserted from the registrations rather than by resolving them, because resolving is what a unit host cannot do
+    /// here: each of the three reaches <c>ApplicationData.Current</c>, which belongs to a running application. So this
+    /// is the reading that says the composition still names them — without it, the stand-ins the other tests put in
+    /// their place would hide a head composed with something else entirely.
+    /// </remarks>
+    [Fact]
+    public void Compose_ReadsWhatOutlivesARunFromThePlatformsOwnSettingsStore()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        ClientComposition.Compose(
+            services,
+            StatedConfiguration(StatedDeployment),
+            new StubDeploymentAddressSource(null));
+
+        // Assert
+        Assert.Equal(
+            typeof(LocalSettingsMailboxTreeMemory),
+            Assert.Single(services, static descriptor => descriptor.ServiceType == typeof(IMailboxTreeMemory))
+                .ImplementationType);
+
+        Assert.Equal(
+            typeof(LocalSettingsMessageListMemory),
+            Assert.Single(services, static descriptor => descriptor.ServiceType == typeof(IMessageListMemory))
+                .ImplementationType);
+
+        Assert.Equal(
+            typeof(LocalSettingsDeploymentChoiceStore),
+            Assert.Single(services, static descriptor => descriptor.ServiceType == typeof(IDeploymentChoiceStore))
+                .ImplementationType);
+    }
+
+    /// <summary>What the installation stated reaches the type that holds it, by name rather than through a binder.</summary>
+    [Fact]
+    public void Compose_ReadsTheStatedDeploymentByName()
+    {
+        // Arrange
+        var services = ComposeServices();
+
+        // Act
+        using var provider = BuiltProvider(services);
+
+        var settings = provider.GetRequiredService<DeploymentSettings>();
+
+        // Assert
+        Assert.Equal("https://mail.example/", settings.Address);
+        Assert.Equal("mailfathom-client", settings.ClientId);
+    }
+
+    /// <summary>
+    /// A section stating no address composes, because a head nobody has pointed anywhere asks on its first screen
+    /// rather than failing to start.
+    /// </summary>
+    [Fact]
+    public void Compose_WithNoAddressStated_ComposesAHeadThatAsksForOne()
+    {
+        // Arrange
+        var services = ComposeServices(StatedConfiguration(
+        [
+            new($"{DeploymentSettings.SectionName}:{nameof(DeploymentSettings.ClientId)}", "mailfathom-client"),
+        ]));
+
+        // Act
+        using var provider = BuiltProvider(services);
+
+        // Assert
+        Assert.Empty(provider.GetRequiredService<DeploymentSettings>().Address);
+        Assert.Null(provider.GetRequiredService<DeploymentAddress>().Current);
+    }
+
+    /// <summary>
+    /// A section stating no client identifier refuses while the application is starting, which is where that has to
+    /// happen.
+    /// </summary>
+    /// <remarks>
+    /// The identifier is what every grant this public client makes is registered under, so a head composed without one
+    /// could sign nobody in — and a setting that was quietly ignored is worse than one that was refused. The refusal
+    /// names the argument, which is what an operator reading a startup failure has to go on.
+    /// </remarks>
+    [Fact]
+    public void Compose_WithNoClientIdStated_RefusesToCompose()
+    {
+        // Arrange
+        var configuration = StatedConfiguration(
+        [
+            new($"{DeploymentSettings.SectionName}:{nameof(DeploymentSettings.Address)}", "https://mail.example/"),
+        ]);
+
+        // Act
+        var refusal = Assert.Throws<ArgumentException>(
+            () => ClientComposition.Compose(
+                new ServiceCollection(),
+                configuration,
+                new StubDeploymentAddressSource(null)));
+
+        // Assert
+        Assert.Equal("clientId", refusal.ParamName);
+    }
+
+    /// <summary>
+    /// The three transports are the three the client is entitled to, each configured on the terms its own callers are
+    /// held to.
+    /// </summary>
+    /// <remarks>
+    /// Asserted from the transports rather than from the registrations, because what a caller gets is an
+    /// <see cref="HttpClient" /> the factory built: the address the deployment's transport carries is read as it is
+    /// created, and the two aimed at machines nobody has vouched for carry none at all.
+    /// </remarks>
+    [Fact]
+    public void Compose_ConfiguresOneTransportPerKindOfMachineItReaches()
+    {
+        // Arrange
+        var services = ComposeServices();
+
+        using var provider = BuiltProvider(services);
+
+        provider.GetRequiredService<DeploymentAddress>().PointAt(new Uri("https://mail.example/"));
+
+        var transports = provider.GetRequiredService<IHttpClientFactory>();
+
+        // Act
+        using var deployment = transports.CreateClient(DeploymentHttpClients.Deployment);
+        using var authorizationServer = transports.CreateClient(DeploymentHttpClients.AuthorizationServer);
+        using var probe = transports.CreateClient(DeploymentHttpClients.DeploymentProbe);
+
+        // Assert
+        Assert.Equal(new Uri("https://mail.example/"), deployment.BaseAddress);
+        Assert.Null(authorizationServer.BaseAddress);
+        Assert.Null(probe.BaseAddress);
+
+        Assert.All(
+            new[] { deployment, authorizationServer, probe },
+            transport => Assert.Equal(DeploymentOptions.DefaultTimeout, transport.Timeout));
+
+        Assert.Equal(DeploymentExchange.MaxMailBodyBytes, deployment.MaxResponseContentBufferSize);
+        Assert.Equal(DeploymentExchange.MaxDocumentBytes, authorizationServer.MaxResponseContentBufferSize);
+        Assert.Equal(DeploymentExchange.MaxDocumentBytes, probe.MaxResponseContentBufferSize);
+    }
+
+    /// <summary>The head that catches its redirect differently keeps its own listener, which is what the browser head does.</summary>
+    [Fact]
+    public void Compose_WithAHeadThatCatchesItsOwnRedirect_KeepsThatListener()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        using var listener = new StubSignInRedirectListener(static _ => new SignInRedirect(null, null, null));
+
+        services.AddSingleton<ISignInRedirectListenerFactory>(listener);
+
+        // Act
+        ClientComposition.Compose(
+            services,
+            StatedConfiguration(StatedDeployment),
+            new StubDeploymentAddressSource(null));
+
+        // Assert
+        var registered = Assert.Single(
+            services,
+            static descriptor => descriptor.ServiceType == typeof(ISignInRedirectListenerFactory));
+
+        Assert.Same(listener, registered.ImplementationInstance);
+    }
+
+    /// <summary>A head that catches none is given the loopback listener an installed head signs in through.</summary>
+    [Fact]
+    public void Compose_WithAHeadThatCatchesNoRedirect_RegistersTheLoopbackListener()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        ClientComposition.Compose(
+            services,
+            StatedConfiguration(StatedDeployment),
+            new StubDeploymentAddressSource(null));
+
+        // Assert
+        var registered = Assert.Single(
+            services,
+            static descriptor => descriptor.ServiceType == typeof(ISignInRedirectListenerFactory));
+
+        Assert.Equal(typeof(LoopbackSignInRedirectListenerFactory), registered.ImplementationType);
+    }
+
+    /// <summary>Composes the client with one configuration, and with the services a running head's builder contributes.</summary>
+    private static ServiceCollection ComposeServices(IConfiguration? configuration = null)
+    {
+        var services = new ServiceCollection();
+
+        ClientComposition.Compose(
+            services,
+            configuration ?? StatedConfiguration(StatedDeployment),
+            new StubDeploymentAddressSource(null));
+
+        // What the Use* calls in App.OnLaunched put in beside the composition. Every one of them is the framework's,
+        // and a screen reaching one of them is reaching a running head rather than anything registered here.
+        services.AddSingleton<IStringLocalizer>(new StubStringLocalizer(new Dictionary<string, string>()));
+        services.AddSingleton<INavigator, StubNavigator>();
+        services.AddSingleton<IThemeService, StubThemeService>();
+        services.AddSingleton<ILocalizationService>(new StubLocalizationService("en", "en", "pl"));
+
+        // The three readers of the platform's own settings store, which is the one part of this graph a unit host
+        // genuinely has none of: ApplicationData.Current belongs to a running application, and each of these reaches
+        // it as it is read. They are stood in for so the rest of the graph can be resolved around them, and which
+        // implementation the composition registered is asserted separately — see
+        // Compose_ReadsWhatOutlivesARunFromThePlatformsOwnSettingsStore.
+        services.Replace(ServiceDescriptor.Singleton<IMailboxTreeMemory>(new StubMailboxTreeMemory()));
+        services.Replace(ServiceDescriptor.Singleton<IMessageListMemory>(new StubMessageListMemory()));
+        services.Replace(ServiceDescriptor.Singleton<IDeploymentChoiceStore>(new StubDeploymentChoiceStore()));
+
+        return services;
+    }
+
+    /// <summary>Builds the configuration one shape states, and nothing this machine holds.</summary>
+    private static IConfiguration StatedConfiguration(IReadOnlyList<KeyValuePair<string, string?>> stated) =>
+        new ConfigurationBuilder().AddInMemoryCollection(stated).Build();
+
+    /// <summary>Builds the graph with both validations on, so a captured scope and an unconstructable type are reported here.</summary>
+    private static ServiceProvider BuiltProvider(IServiceCollection services) =>
+        services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true,
+        });
+
+    /// <summary>Resolves every registration this repository owns, reporting each one the graph could not build.</summary>
+    private static string[] ReportEveryRegistrationItCannotBuild(IServiceCollection services)
+    {
+        using var provider = BuiltProvider(services);
+
+        return
+        [
+            .. services
+                .Where(static descriptor => IsOwned(descriptor.ServiceType)
+                    || (descriptor.ImplementationType is { } implementation && IsOwned(implementation)))
+                .Where(static descriptor => !descriptor.ServiceType.IsGenericTypeDefinition)
+
+                // One resolution per service type rather than per descriptor, because resolving a service type builds
+                // every implementation registered against it.
+                .DistinctBy(static descriptor => descriptor.ServiceType)
+                .Select(descriptor => ReportResolving(provider, descriptor.ServiceType))
+                .OfType<string>(),
+        ];
+    }
+
+    /// <summary>Every model a screen is drawn from, discovered rather than listed.</summary>
+    private static Type[] PresentationModels() =>
+        [.. typeof(App).Assembly
+            .GetTypes()
+            .Where(static candidate => candidate.Namespace?.StartsWith(
+                "MailFathom.Client.Presentation",
+                StringComparison.Ordinal) is true)
+            .Where(static candidate => candidate.Name.EndsWith("Model", StringComparison.Ordinal))
+            .Where(static candidate => candidate is { IsClass: true, IsAbstract: false, IsGenericTypeDefinition: false })
+            .Where(IsRecord)];
+
+    /// <summary>Whether a type is a record, which every MVUX model is and no generated proxy beside one is.</summary>
+    private static bool IsRecord(Type candidate) =>
+        candidate.GetMethod(
+            "<Clone>$",
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic) is not null;
+
+    /// <summary>Resolves one registration, reporting what it could not build rather than ending the pass at the first one.</summary>
+    /// <returns>The failure, or <see langword="null" /> where every implementation of the service resolved.</returns>
+    [SuppressMessage(
+        "Design",
+        "CA1031:Do not catch general exception types",
+        Justification = "A registration that cannot be built is what this pass reports, and a factory throws whatever it throws — narrowing the catch would end the pass on the first failure and hide every registration behind it, which is the opposite of what a report of a broken graph is for.")]
+    private static string? ReportResolving(IServiceProvider provider, Type service)
+    {
+        try
+        {
+            // Materialized rather than left as a query, because the resolution is what this asks for and a deferred
+            // sequence would report every registration as sound without building one of them.
+            _ = provider.GetServices(service).ToArray();
+
+            return null;
+        }
+        catch (Exception failure)
+        {
+            return $"{service.FullName}: {failure.Message}";
+        }
+    }
+
+    /// <summary>Builds one model the way navigation builds it, reporting what it could not resolve.</summary>
+    /// <returns>The failure, or <see langword="null" /> where the model was constructed.</returns>
+    [SuppressMessage(
+        "Design",
+        "CA1031:Do not catch general exception types",
+        Justification = "A model that cannot be built is what this pass reports, and a constructor throws whatever it throws — the reasoning is the one ReportResolving carries.")]
+    private static string? ReportConstructing(IServiceProvider provider, Type model)
+    {
+        try
+        {
+            _ = ActivatorUtilities.CreateInstance(provider, model);
+
+            return null;
+        }
+        catch (Exception failure)
+        {
+            return $"{model.FullName}: {failure.Message}";
+        }
+    }
+
+    /// <summary>Whether a type is one of this repository's, including one named only as a generic argument.</summary>
+    private static bool IsOwned(Type type) =>
+        type.Assembly.GetName().Name?.StartsWith("MailFathom.", StringComparison.Ordinal) is true
+        || (type.IsGenericType && type.GetGenericArguments().Any(IsOwned));
+}

--- a/frontend/tests/README.md
+++ b/frontend/tests/README.md
@@ -21,6 +21,8 @@ What it asserts today is what a scaffold has to say for itself — that the clie
 build declares, that the MVUX model behind the only screen yields it, and that the languages the model offers are the
 ones the embedded configuration names, and that those cultures are exactly the ones a table under `src/Client/Strings/`
 is authored for and that every table holds the same keys —
+that the service graph the application composes resolves in full and builds every model a screen is drawn from,
+against the configuration the bundle actually ships as well as against one a test states —
 and the whole of what `Client.Backend` does
 against a stubbed transport: the wire contract, the four ways an exchange can fail, and the sign-in end to end with the
 one head-specific step stubbed at its port. `AGENTS.md` beside this file states what belongs here, how a feed is


### PR DESCRIPTION
Closes #1323

## What this changes

The client registered its services inside `App.OnLaunched`, which needs a window, an application object, and a XAML
runtime — so nothing could compose the graph without starting a head. A dependency nobody registered was therefore not
a failure the composition reported: it was an exception out of whichever screen asked first, after the application had
already drawn itself. The backend has answered the same question since `HostCompositionTests`, and the client had no
equivalent.

- `frontend/src/Client/ClientComposition.cs` holds the registrations, moved out of the launch path unchanged and with
  their reasoning. `OnLaunched` hands the host builder one call. Everything the builder contributes rather than this
  application — configuration, localization, logging, theme switching, navigation — stays where it is.
- `frontend/tests/Client.UnitTests/ClientCompositionTests.cs` composes that graph with `ValidateOnBuild` and
  `ValidateScopes` on and resolves every registration the repository owns.

## What the suite now asserts

- **Every registration resolves**, twice: against a configuration a test states, and against the `appsettings.json` the
  bundle actually ships. The second is the reading that says a value edited out of that file would compose a head that
  fails while starting — the project file links it into the test output the way it already links the palette, the
  application's own project file, the string tables, and every authored view.
- **Every model a screen is drawn from is constructed** the way navigation constructs one. The models are discovered
  rather than listed — a record under `Presentation` whose name ends in `Model` — so a screen added without its
  dependencies registered fails here instead of on the first navigation to it. Six are found today.
- **What the run shares is registered once and shared.** A transient registration resolves perfectly and hands the next
  screen a tree that has forgotten where somebody was, which no resolution of a working graph would notice.
- **One transport per kind of machine the client reaches**, each with the base address, timeout, and body ceiling its
  own callers are held to — asserted from the transports the factory builds rather than from the registrations.
- **The redirect listener's `TryAdd` contract**, from both sides: a head that catches its own redirect keeps its
  listener, and a head that catches none is given the loopback one.
- **What the composition reads from the platform's settings store.** `ApplicationData.Current` belongs to a running
  application, so the three readers of it are stood in for while the rest of the graph is resolved around them — and
  which implementation the composition registered is asserted on its own, so the stand-ins hide nothing.

## Verification

- `scripts/verify-full.sh` — green, 261/261 contract assertions, client suite 610/610.
- The composition test was mutation-checked: removing the `IClientSession` registration turns 7 of the 11 new
  assertions red, including both resolve passes and the model pass.

## Noticed beside this change, not fixed here

`BrowserSignInRedirectListenerFactory` is registered nowhere. `DeploymentRegistration`'s own remark says a head that
catches its redirect differently "registers its own before calling this" and names the browser head as that head, but
no head does — so a browser head would today be given the loopback factory, which cannot bind a local socket in a
browser. Nothing reaches it yet: `DeploymentSignIn` is registered and no screen resolves it, so the path is dormant.
Left out of this change deliberately, since wiring it needs a decision about how a head contributes to the composition
and the client's sign-in surface is being reworked separately. Raised as #1333.

## Breaking changes

None. No configuration key, database column, MCP tool argument, or deployment contract moves.
