### PR TITLE
[#1162] Show a thread as what each message added, openable at any message in it

### DIFF
--- a/docs/architecture/solution-structure.md
+++ b/docs/architecture/solution-structure.md
@@ -202,10 +202,13 @@ project here and neither build reads the other's files.
 - `src/Client/Presentation/` holds every screen. The shell, the screen that asks which deployment this client reaches,
   and `ClientRoutes` — where each route is named once — sit directly under it, while `Workspace/`, `Spaces/`, and
   `Settings/` hold the frame the product's three spaces are shown inside, those spaces, and the settings screen.
-  Two directories sit beside them and are not screens. `Mailboxes/` is the tree of accounts and folders the frame shows
-  in its pane, which is what narrows the scope every space then reads; `Messages/` is the message list of whatever place
-  that scope names — a bounded window over the deployment's keyset-paged timeline, registered once for the run, whose
-  selection is written back into that same scope for every other space to read. Every screen carries an MVUX model
+  Three directories sit beside them and are not screens. `Mailboxes/` is the tree of accounts and folders the frame
+  shows in its pane, which is what narrows the scope every space then reads; `Messages/` is the message list of whatever
+  place that scope names — a bounded window over the deployment's keyset-paged timeline, registered once for the run,
+  whose selection is written back into that same scope for every other space to read; `Threads/` is the conversation
+  that selection is in, registered once for the run as well, because a conversation is reached by naming one message
+  inside it — which a search result and a citation do as readily as a row of the list does — rather than only from the
+  list. Every screen carries an MVUX model
   except the Discover and Cases pages, which have none yet because each is filled in by the parent that owns it. Every
   screen is a route rather than content something swaps by hand, which is what makes the system back
   gesture and the browser's history move through the client's own screens;

--- a/frontend/src/AGENTS.md
+++ b/frontend/src/AGENTS.md
@@ -420,14 +420,16 @@ above is what keeps that from being a rule somebody has to enforce by reading.
   process does not own, and a screen that repeated it would be putting an attacker's words in MailFathom's voice.
 - **The surface it reaches is `/api/client`**, the backend's third transport surface, served only where a deployment
   enabled `ClientEndpoint`. It is not the MCP endpoint and not the administrative one: a credential admitted by either
-  of those authenticates nothing here. This client calls four of its routes today — `GET /api/client/session`,
+  of those authenticates nothing here. This client calls six of its routes today — `GET /api/client/session`,
   reporting the running version and the grant the caller's credential carries and nothing that identifies that
   credential; `GET /api/client/accounts`, reporting the signed-in owner's own mailboxes and how current the copy of
   each one is; `GET /api/client/folders`, reporting the folder hierarchy beneath each of those mailboxes with the
   role the service gave each folder and how much mail it holds; `GET /api/client/emails`, serving one page of the
-  message list by cursor, which is the route the mail screen then spends its time in; and
-  `GET /api/client/messages/{storedEmailId}/body`, reporting one message as the closed document tree a reading pane
-  draws and as the words it falls back to, carrying no remote reference unless that one read asked for them. The
+  message list by cursor, which is the route the mail screen then spends its time in;
+  `GET /api/client/threads/{threadId}`, serving one page of a conversation with what each of its messages added
+  already on the message, which is what makes opening an exchange of thirty replies one request rather than thirty;
+  and `GET /api/client/messages/{storedEmailId}/body`, reporting one message as the closed document tree a reading
+  pane draws and as the words it falls back to, carrying no remote reference unless that one read asked for them. The
   surface publishes more than the client has reached yet, so
   [the client endpoint](../../docs/operations/client-endpoint.md) rather than this file is what says what is there. No
   route reaches a mail server, so no screen here can wait on IMAP or set the remote `\Seen` flag.

--- a/frontend/src/Client.Backend/DeploymentClient.cs
+++ b/frontend/src/Client.Backend/DeploymentClient.cs
@@ -5,6 +5,7 @@
 using MailFathom.Client.Backend.Accounts;
 using MailFathom.Client.Backend.Folders;
 using MailFathom.Client.Backend.Mail;
+using MailFathom.Client.Backend.Threads;
 using MailFathom.Client.Backend.Timeline;
 
 namespace MailFathom.Client.Backend;
@@ -19,11 +20,12 @@ namespace MailFathom.Client.Backend;
 /// keeps a route from being written without one by accident.
 /// </para>
 /// <para>
-/// Three of the four routes it carries are the ones a client reads before it draws anything: what the deployment made
-/// of the caller, which mailboxes that caller has beside a statement of how current each copy is, and the folders those
-/// mailboxes hold. The fourth is the one a mail screen then spends its time in — one page of the message list, asked
-/// for by cursor. None of them reaches a mail server, so no screen here can wait on IMAP or set the remote
-/// <c>\Seen</c> flag.
+/// Three of the routes it carries are the ones a client reads before it draws anything: what the deployment made of the
+/// caller, which mailboxes that caller has beside a statement of how current each copy is, and the folders those
+/// mailboxes hold. The rest are the mail itself — one page of the message list asked for by cursor, which is where a
+/// mail screen spends its time; one conversation across every folder and account it spans; and one message's body in
+/// the two renderings a reading pane draws it from. None of them reaches a mail server, so no screen here can wait on
+/// IMAP or set the remote <c>\Seen</c> flag.
 /// </para>
 /// </remarks>
 public sealed class DeploymentClient
@@ -117,6 +119,32 @@ public sealed class DeploymentClient
             DeploymentJsonContext.Default.DeploymentMailTimelinePage,
             cancellationToken);
     }
+
+    /// <summary>Asks the deployment for one page of one of the owner's conversations.</summary>
+    /// <param name="threadId">The conversation to read, as a message row published it.</param>
+    /// <param name="pageSize">How many messages the page may hold, or <see langword="null" /> for the deployment's own default.</param>
+    /// <param name="cursor">The cursor a previous page returned, or <see langword="null" /> for the beginning of the conversation.</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
+    /// <returns>The page, the whole conversation's participants and counts beside it, and the cursor continuing it where one exists.</returns>
+    /// <exception cref="DeploymentFailure">Thrown when the deployment refused, was unreachable, did not answer in time, or answered with something else.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when nothing has pointed this client at a deployment yet.</exception>
+    /// <remarks>
+    /// A cursor the deployment will not honour — one it never issued, one issued for another conversation, and one
+    /// naming a message the conversation no longer shows — arrives as
+    /// <see cref="DeploymentFailureReason.RequestRefused" />, because it is a value this client sent and can therefore
+    /// stop sending. A conversation this owner does not hold and one no deployment ever held are answered identically
+    /// by the deployment, so nothing here separates the two either.
+    /// </remarks>
+    public Task<DeploymentMailThreadPage> ReadMailThreadAsync(
+        Guid threadId,
+        int? pageSize = null,
+        string? cursor = null,
+        CancellationToken cancellationToken = default) =>
+        DeploymentExchange.ReadAsync(
+            this.Transport(),
+            new HttpRequestMessage(HttpMethod.Get, DeploymentRoutes.MailThreadPath(threadId, pageSize, cursor)),
+            DeploymentJsonContext.Default.DeploymentMailThreadPage,
+            cancellationToken);
 
     /// <summary>Asks the deployment for one message's body, in both the renderings a reading pane draws it from.</summary>
     /// <param name="storedEmailId">The message to read, as a list row or a conversation published it.</param>

--- a/frontend/src/Client.Backend/DeploymentJsonContext.cs
+++ b/frontend/src/Client.Backend/DeploymentJsonContext.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Serialization;
 using MailFathom.Client.Backend.Accounts;
 using MailFathom.Client.Backend.Folders;
 using MailFathom.Client.Backend.Mail;
+using MailFathom.Client.Backend.Threads;
 using MailFathom.Client.Backend.Timeline;
 
 namespace MailFathom.Client.Backend;
@@ -29,6 +30,7 @@ namespace MailFathom.Client.Backend;
 [JsonSerializable(typeof(DeploymentMailAccounts))]
 [JsonSerializable(typeof(DeploymentMailFolders))]
 [JsonSerializable(typeof(DeploymentMailTimelinePage))]
+[JsonSerializable(typeof(DeploymentMailThreadPage))]
 [JsonSerializable(typeof(DeploymentMailBody))]
 // One entry per block the reduction publishes, because the reader that dispatches on a block's identity resolves each
 // of them by its own generated type info rather than by reflection over the hierarchy.

--- a/frontend/src/Client.Backend/DeploymentRoutes.cs
+++ b/frontend/src/Client.Backend/DeploymentRoutes.cs
@@ -48,6 +48,38 @@ internal static class DeploymentRoutes
     /// </remarks>
     internal const string MailTimelinePath = $"{Prefix}/emails";
 
+    /// <summary>Where a deployment serves one page of one conversation, across every folder and account it spans.</summary>
+    /// <param name="threadId">The conversation, as a message row published it.</param>
+    /// <param name="pageSize">How many messages the page may hold, or <see langword="null" /> for the deployment's own default.</param>
+    /// <param name="cursor">The cursor a previous page returned, or <see langword="null" /> for the beginning of the conversation.</param>
+    /// <returns>The path, relative to the address the composing host supplied.</returns>
+    /// <remarks>
+    /// The conversation is the one thing named in the path, because it is the resource; how much of it is served and
+    /// where the serving continues from are the query. Nothing narrows it to a folder or an account — a reply that
+    /// landed in another mailbox's junk folder is still part of the exchange somebody is reading, and the route is what
+    /// says so by taking neither.
+    /// </remarks>
+    internal static string MailThreadPath(Guid threadId, int? pageSize, string? cursor)
+    {
+        var stated = new List<string>(2);
+
+        if (pageSize is { } wanted)
+        {
+            stated.Add($"pageSize={wanted.ToString(CultureInfo.InvariantCulture)}");
+        }
+
+        // Escaped rather than written raw: a cursor is a value this client received rather than composed, whatever it
+        // happens to look like today.
+        if (!string.IsNullOrEmpty(cursor))
+        {
+            stated.Add($"cursor={Uri.EscapeDataString(cursor)}");
+        }
+
+        var query = stated.Count is 0 ? string.Empty : $"?{string.Join('&', stated)}";
+
+        return string.Create(CultureInfo.InvariantCulture, $"{Prefix}/threads/{threadId:D}{query}");
+    }
+
     /// <summary>Where a deployment serves one message's body, as the two renderings a reading pane draws it from.</summary>
     /// <param name="storedEmailId">The message, as a list row or a conversation published it.</param>
     /// <param name="remoteImages">Whether the reader has asked for this message's remote pictures.</param>

--- a/frontend/src/Client.Backend/Threads/DeploymentMailThreadPage.cs
+++ b/frontend/src/Client.Backend/Threads/DeploymentMailThreadPage.cs
@@ -1,0 +1,52 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Backend.Threads;
+
+/// <summary>One conversation as a deployment serves it, and one page of the messages in it.</summary>
+/// <param name="ThreadId">The conversation, as the request named it.</param>
+/// <param name="Messages">The page's messages, in the conversation's own order.</param>
+/// <param name="Participants">Everybody who wrote in the conversation, in the order they first wrote in it.</param>
+/// <param name="MessageCount">How many messages the conversation holds of those this caller may see.</param>
+/// <param name="MoreMessagesNotAssembled">Whether the conversation runs past what one read assembles at all.</param>
+/// <param name="MoreParticipantsNotNamed">Whether the conversation has authors <paramref name="Participants" /> does not name.</param>
+/// <param name="NextCursor">The cursor the following page is asked with, or <see langword="null" /> at the end of the conversation.</param>
+/// <param name="PageSize">How many messages the read ran under, which is what the request asked for or the default it took.</param>
+/// <remarks>
+/// <para>
+/// Everything outside the messages describes the whole conversation rather than the page, which is what lets a header be
+/// drawn from the first page and stay accurate without the rest being held: the participants, the count, and both bounds
+/// are answers about the conversation.
+/// </para>
+/// <para>
+/// A conversation is not scoped to a folder and this record carries none. The question is in the inbox, the answer is in
+/// the sent folder, and a forwarded copy is somewhere else again, so what is served spans every folder of every account
+/// the signed-in owner owns.
+/// </para>
+/// <para>
+/// All of it is that owner's own correspondence and carries the classification the root instructions put on mail: it is
+/// put in front of that owner alone and reaches no log, no telemetry, and no local store.
+/// </para>
+/// </remarks>
+public sealed record DeploymentMailThreadPage(
+    Guid ThreadId,
+    IReadOnlyList<DeploymentThreadMessage> Messages,
+    IReadOnlyList<DeploymentThreadParticipant> Participants,
+    int MessageCount,
+    bool MoreMessagesNotAssembled,
+    bool MoreParticipantsNotNamed,
+    string? NextCursor,
+    int PageSize)
+{
+    /// <summary>Gets the messages, reading a document that named none as a page that holds nothing.</summary>
+    /// <remarks>
+    /// A missing member deserializes to <see langword="null" /> rather than to an empty list, and every reader wants the
+    /// same answer for the two. Said once here rather than at each reader, as the list and folders documents already
+    /// say it.
+    /// </remarks>
+    public IReadOnlyList<DeploymentThreadMessage> Written => this.Messages ?? [];
+
+    /// <summary>Gets the authors, reading a document that named none as a conversation nobody is named in.</summary>
+    public IReadOnlyList<DeploymentThreadParticipant> Authors => this.Participants ?? [];
+}

--- a/frontend/src/Client.Backend/Threads/DeploymentThreadMessage.cs
+++ b/frontend/src/Client.Backend/Threads/DeploymentThreadMessage.cs
@@ -9,7 +9,7 @@ namespace MailFathom.Client.Backend.Threads;
 /// <summary>One message of a conversation, and where it sits in that conversation.</summary>
 /// <param name="Position">The zero-based place the message holds in the conversation's own order, which continues across pages.</param>
 /// <param name="AnsweredId">The message this one answers among the ones served, or <see langword="null" /> where it is a root of what is served.</param>
-/// <param name="Email">The message itself, in the same shape a list row carries.</param>
+/// <param name="Email">The message itself, in the same shape a list row carries, or <see langword="null" /> where the answer placed a message in the conversation without describing one.</param>
 /// <remarks>
 /// <para>
 /// The message is the list route's own row rather than a second shape, so this client parses one message across the

--- a/frontend/src/Client.Backend/Threads/DeploymentThreadMessage.cs
+++ b/frontend/src/Client.Backend/Threads/DeploymentThreadMessage.cs
@@ -1,0 +1,28 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Backend.Timeline;
+
+namespace MailFathom.Client.Backend.Threads;
+
+/// <summary>One message of a conversation, and where it sits in that conversation.</summary>
+/// <param name="Position">The zero-based place the message holds in the conversation's own order, which continues across pages.</param>
+/// <param name="AnsweredId">The message this one answers among the ones served, or <see langword="null" /> where it is a root of what is served.</param>
+/// <param name="Email">The message itself, in the same shape a list row carries.</param>
+/// <remarks>
+/// <para>
+/// The message is the list route's own row rather than a second shape, so this client parses one message across the
+/// whole surface and the two routes cannot come to disagree about one of them. Its preview is what this message added
+/// with the quoted history and the signature block trimmed off, which is what keeps the eighth reply from redrawing the
+/// seven above it, and its identity is what the whole message is reached by.
+/// </para>
+/// <para>
+/// A message whose parent sits in a folder an operator withheld is served as a root naming nothing, so the gap the
+/// withheld message would leave discloses nothing about it.
+/// </para>
+/// </remarks>
+public sealed record DeploymentThreadMessage(
+    int Position,
+    Guid? AnsweredId,
+    DeploymentMailMessage? Email);

--- a/frontend/src/Client.Backend/Threads/DeploymentThreadParticipant.cs
+++ b/frontend/src/Client.Backend/Threads/DeploymentThreadParticipant.cs
@@ -1,0 +1,16 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Backend.Threads;
+
+/// <summary>Somebody who has written in the conversation, and how much of it is theirs.</summary>
+/// <param name="Address">The address they wrote from, as their messages wrote it.</param>
+/// <param name="DisplayName">The name their most recent message wrote, or <see langword="null" /> where none of them carried one.</param>
+/// <param name="MessageCount">How many of the conversation's messages they sent.</param>
+/// <remarks>
+/// An author rather than an addressee, and drawn from the whole conversation rather than from the page in hand — which
+/// is the point of the deployment publishing it at all: a header derived here would be this client paging a
+/// conversation in order to name who is in it.
+/// </remarks>
+public sealed record DeploymentThreadParticipant(string? Address, string? DisplayName, int MessageCount);

--- a/frontend/src/Client/ClientComposition.cs
+++ b/frontend/src/Client/ClientComposition.cs
@@ -7,6 +7,7 @@ using MailFathom.Client.Backend.Authorization;
 using MailFathom.Client.Deployment;
 using MailFathom.Client.Presentation.Mailboxes;
 using MailFathom.Client.Presentation.Messages;
+using MailFathom.Client.Presentation.Threads;
 using MailFathom.Client.Presentation.Workspace;
 using MailFathom.Client.Session;
 using Microsoft.Extensions.DependencyInjection;
@@ -70,6 +71,11 @@ internal static class ClientComposition
         // outlives only the run for every other place it visited.
         services.AddSingleton<IMessageListMemory, LocalSettingsMessageListMemory>();
         services.AddSingleton<IMessageList, DeploymentMessageList>();
+
+        // The conversation a message in that list is read in, on the same terms and for the same reason — with one of
+        // its own: a conversation is reached by naming one message inside it, which a search result and a citation both
+        // do, so a conversation held per model would be one screen for the mail space and another for everywhere else.
+        services.AddSingleton<IMailThread, DeploymentMailThread>();
 
         // What the deployment allows this caller, for the same reason and on the same terms. It is the one place that
         // answers whether something may be offered, so every screen reads one answer instead of deriving its own from

--- a/frontend/src/Client/Presentation/Messages/MessageListShape.cs
+++ b/frontend/src/Client/Presentation/Messages/MessageListShape.cs
@@ -54,6 +54,7 @@ internal static class MessageListShape
 
         return new MessageRow(
             message.Id.ToString("D", CultureInfo.InvariantCulture),
+            message.ThreadId,
             correspondent,
             subject,
             message.Preview ?? string.Empty,

--- a/frontend/src/Client/Presentation/Messages/MessageRow.cs
+++ b/frontend/src/Client/Presentation/Messages/MessageRow.cs
@@ -8,6 +8,7 @@ namespace MailFathom.Client.Presentation.Messages;
 
 /// <summary>One line of the message list, with everything the view draws it from and nothing else.</summary>
 /// <param name="Key">The message's own identity, which is what this row is matched by across a redraw and what the scope names it by.</param>
+/// <param name="ThreadId">The conversation the message belongs to, or <see langword="null" /> where nothing has placed it in one.</param>
 /// <param name="Correspondent">Who the message is with — its sender, or its recipients where the place is mail this owner sent.</param>
 /// <param name="Subject">What the message is about, or the words standing in for a message that carried no subject.</param>
 /// <param name="Preview">The opening of the message's own text, and empty where nothing has extracted it yet.</param>
@@ -30,6 +31,12 @@ namespace MailFathom.Client.Presentation.Messages;
 /// that had to be redrawn on every click.
 /// </para>
 /// <para>
+/// The conversation is the one member here nothing draws. It is carried because selecting a row is how a conversation
+/// is opened, and the identity that opens one is published on the message rather than derivable from anything else the
+/// row holds — a screen that had to ask the deployment which conversation a selected message is in would be a request
+/// per click.
+/// </para>
+/// <para>
 /// It is <c>partial</c> because <paramref name="Key" /> makes it eligible for MVUX's key-equality generation, which is
 /// what carries a row's identity across a redraw: a page taken onto the window updates the rows it changed and leaves
 /// the containers of the rest alone, and what was selected stays selected. The generator refuses to run on a sealed
@@ -42,6 +49,7 @@ namespace MailFathom.Client.Presentation.Messages;
 /// </remarks>
 public sealed partial record MessageRow(
     string Key,
+    Guid? ThreadId,
     string Correspondent,
     string Subject,
     string Preview,

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailModel.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailModel.cs
@@ -5,6 +5,7 @@
 using System.Collections.Immutable;
 using MailFathom.Client.Backend.Timeline;
 using MailFathom.Client.Presentation.Messages;
+using MailFathom.Client.Presentation.Threads;
 using MailFathom.Client.Session;
 
 namespace MailFathom.Client.Presentation.Spaces.Mail;
@@ -23,6 +24,11 @@ namespace MailFathom.Client.Presentation.Spaces.Mail;
 /// coming back is finding the list where it was rather than reading its first page again.
 /// </para>
 /// <para>
+/// The conversation the list opens is the run's own on the same terms, and it is read through here rather than held:
+/// selecting a message is how one is reached in this space, and a search result or a citation reaches the same
+/// conversation by naming a message in it, so a conversation this model owned would be one of two.
+/// </para>
+/// <para>
 /// Beside that is the space's own reading of the session: whether correspondence may be put in front of this caller at
 /// all, read here rather than derived from a request the deployment refused.
 /// </para>
@@ -30,17 +36,21 @@ namespace MailFathom.Client.Presentation.Spaces.Mail;
 public partial record MailModel
 {
     private readonly IMessageList messages;
+    private readonly IMailThread thread;
 
-    /// <summary>Initializes the space over what decides whether it may be offered, and the list it is read through.</summary>
+    /// <summary>Initializes the space over what decides whether it may be offered, and the list and conversation it is read through.</summary>
     /// <param name="session">What the deployment allows this caller.</param>
     /// <param name="messages">The run's own message list, drawn from wherever the mailbox tree says somebody is.</param>
+    /// <param name="thread">The run's own conversation, which is whatever the list has one message selected in.</param>
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
-    public MailModel(IClientSession session, IMessageList messages)
+    public MailModel(IClientSession session, IMessageList messages, IMailThread thread)
     {
         ArgumentNullException.ThrowIfNull(session);
         ArgumentNullException.ThrowIfNull(messages);
+        ArgumentNullException.ThrowIfNull(thread);
 
         this.messages = messages;
+        this.thread = thread;
 
         this.WithholdsMail = session.Standing.Select(standing => standing.Withholds(ClientCapability.Mail));
 
@@ -107,6 +117,53 @@ public partial record MailModel
     /// and neither may be announced while the answer is still on its way.
     /// </remarks>
     public IFeed<bool> KeepsEverything { get; }
+
+    /// <summary>The conversation the selected message is in, as its header is drawn.</summary>
+    /// <remarks>The run's own conversation read through this model, so a citation that opened one and a row that opened one are the same screen rather than two.</remarks>
+    public IFeed<ThreadReading> Thread => this.thread.Reading;
+
+    /// <summary>The messages of that conversation, in the conversation's own order.</summary>
+    public IListFeed<ThreadMessageRow> ThreadMessages => this.thread.Messages;
+
+    /// <summary>Whether there is more of the conversation after what has been read.</summary>
+    public IFeed<bool> HasMoreThreadMessages => this.thread.HasMoreMessages;
+
+    /// <summary>Whether the last attempt to read more of the conversation did not arrive.</summary>
+    public IFeed<bool> ThreadPagingFailed => this.thread.PagingFailed;
+
+    /// <summary>Shows what one message of the conversation added, or collapses it back to a line.</summary>
+    /// <param name="key">The message, as its row names itself.</param>
+    /// <param name="cancellationToken">Abandons the change.</param>
+    /// <returns>A task completing once the message has been opened or closed.</returns>
+    /// <remarks>It carries the message it acts on, so the command generated from it runs per message and reports its progress on the message rather than over the conversation.</remarks>
+    public ValueTask ToggleThreadMessage(string key, CancellationToken cancellationToken) =>
+        this.thread.ToggleAsync(key, cancellationToken);
+
+    /// <summary>Reads the whole of one message, which is what its quoted history is reached by.</summary>
+    /// <param name="key">The message, as its row names itself.</param>
+    /// <param name="cancellationToken">Abandons the read.</param>
+    /// <returns>A task completing once the whole message has arrived or the attempt has been reported.</returns>
+    public ValueTask ShowWholeThreadMessage(string key, CancellationToken cancellationToken) =>
+        this.thread.ShowWholeMessageAsync(key, cancellationToken);
+
+    /// <summary>Reads one whole message again, this time fetching what it asks for from somebody else's server.</summary>
+    /// <param name="key">The message, as its row names itself.</param>
+    /// <param name="cancellationToken">Abandons the read.</param>
+    /// <returns>A task completing once the second read has been asked for.</returns>
+    public ValueTask ShowThreadRemoteContent(string key, CancellationToken cancellationToken) =>
+        this.thread.ShowRemoteContentAsync(key, cancellationToken);
+
+    /// <summary>Takes the next page of the conversation onto the end of what has been read.</summary>
+    /// <param name="cancellationToken">Abandons the page.</param>
+    /// <returns>A task completing once the page has arrived or the attempt has been reported.</returns>
+    public ValueTask ShowMoreThreadMessages(CancellationToken cancellationToken) =>
+        this.thread.ShowMoreAsync(cancellationToken);
+
+    /// <summary>Asks the deployment for the conversation again, which is what a person presses when it did not arrive.</summary>
+    /// <param name="cancellationToken">Abandons the ask.</param>
+    /// <returns>A task completing once the ask has been made.</returns>
+    public ValueTask RetryThread(CancellationToken cancellationToken) =>
+        this.thread.AskAgainAsync(cancellationToken);
 
     /// <summary>Takes the next page onto the end of the list.</summary>
     /// <param name="cancellationToken">Abandons the page.</param>

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailPage.xaml
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailPage.xaml
@@ -459,6 +459,12 @@ Project repository: https://github.com/Krzysztof318/MailFathom
                           <StackPanel Orientation="Horizontal"
                                       HorizontalAlignment="Right"
                                       Spacing="4">
+                            <FontIcon Glyph="&#xE172;"
+                                      FontSize="12"
+                                      AutomationProperties.AccessibilityView="Raw"
+                                      Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                                      Visibility="{x:Bind IsAnswered, Converter={StaticResource AffirmedVisibility}}" />
+
                             <FontIcon Glyph="&#xE7C1;"
                                       FontSize="12"
                                       AutomationProperties.AccessibilityView="Raw"

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailPage.xaml
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailPage.xaml
@@ -9,13 +9,16 @@ Project repository: https://github.com/Krzysztof318/MailFathom
       xmlns:mvux="using:Uno.Extensions.Reactive.UI"
       xmlns:utu="using:Uno.Toolkit.UI"
       xmlns:messages="using:MailFathom.Client.Presentation.Messages"
+      xmlns:reading="using:MailFathom.Client.Presentation.Spaces.Mail.Reading"
       xmlns:spaces="using:MailFathom.Client.Presentation.Spaces"
+      xmlns:threads="using:MailFathom.Client.Presentation.Threads"
       xmlns:workspace="using:MailFathom.Client.Presentation.Workspace"
       NavigationCacheMode="Required">
 
   <Grid>
     <!-- The list beside what is open on a wide window, and the list alone on a narrow one, where opening something is
-         a screen rather than a second column. What the companion column holds is #1159's to decide.
+         a screen rather than a second column. What the companion column holds is the conversation the selected
+         message is in.
 
          Which mailbox and which folder the list is of is not asked here: the tree in the frame is the client's scope
          selector, and this space reads the scope it wrote. -->
@@ -312,7 +315,318 @@ Project repository: https://github.com/Krzysztof318/MailFathom
         </Grid>
       </workspace:WorkspaceColumns.Primary>
       <workspace:WorkspaceColumns.Companion>
-        <spaces:SpacePlaceholder x:Uid="MailPage.Reading" />
+        <!-- The conversation the selected message is in. It is not scoped to the folder the list is drawn from and
+             cannot be: the question is in the inbox, the answer is in the sent folder, and a forwarded copy is
+             somewhere else again — so what is drawn here spans every folder of every account, in the conversation's
+             own order. -->
+        <Grid>
+          <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition />
+            <RowDefinition Height="Auto" />
+          </Grid.RowDefinitions>
+
+          <!-- Who is in the conversation and how large it is, answered by the deployment about the whole of it rather
+               than derived from the messages in hand: a header walked out of the page would name whoever happened to
+               be on it and would change as the rest arrived. -->
+          <StackPanel Grid.Row="0"
+                      Padding="16,12"
+                      Spacing="6"
+                      AutomationProperties.Name="{Binding Thread.Announcement}"
+                      Visibility="{Binding Thread.IsOpen, Converter={StaticResource AffirmedVisibility}}">
+            <TextBlock Text="{Binding Thread.Subject}"
+                       TextWrapping="Wrap"
+                       Style="{StaticResource SubtitleTextBlockStyle}"
+                       Foreground="{ThemeResource OnSurfaceBrush}" />
+
+            <TextBlock Text="{Binding Thread.MessageCount}"
+                       Style="{StaticResource CaptionTextBlockStyle}"
+                       Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                       AutomationProperties.AccessibilityView="Raw" />
+
+            <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                          VerticalScrollBarVisibility="Disabled"
+                          HorizontalScrollMode="Auto"
+                          VerticalScrollMode="Disabled">
+              <ItemsControl ItemsSource="{Binding Thread.Participants}">
+                <ItemsControl.ItemsPanel>
+                  <ItemsPanelTemplate>
+                    <StackPanel Orientation="Horizontal"
+                                Spacing="12" />
+                  </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                  <DataTemplate x:DataType="threads:ThreadParticipantRow">
+                    <StackPanel Orientation="Horizontal"
+                                Spacing="4"
+                                AutomationProperties.Name="{x:Bind Announcement}">
+                      <TextBlock Text="{x:Bind Author}"
+                                 Style="{StaticResource CaptionTextBlockStyle}"
+                                 Foreground="{ThemeResource OnSurfaceBrush}"
+                                 AutomationProperties.AccessibilityView="Raw"
+                                 TextTrimming="CharacterEllipsis" />
+                      <TextBlock Text="{x:Bind MessageCount}"
+                                 Style="{StaticResource CaptionTextBlockStyle}"
+                                 Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                                 AutomationProperties.AccessibilityView="Raw" />
+                    </StackPanel>
+                  </DataTemplate>
+                </ItemsControl.ItemTemplate>
+              </ItemsControl>
+            </ScrollViewer>
+
+            <TextBlock x:Uid="MailPage.TextBlock.MoreParticipants"
+                       Style="{StaticResource CaptionTextBlockStyle}"
+                       Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                       TextWrapping="Wrap"
+                       Visibility="{Binding Thread.HasUnnamedParticipants, Converter={StaticResource AffirmedVisibility}}" />
+
+            <!-- A conversation larger than one read assembles says so rather than showing what it did assemble as
+                 though that were the whole of it. -->
+            <InfoBar x:Uid="MailPage.InfoBar.ThreadRunsPast"
+                     IsOpen="{Binding Thread.RunsPastAssembly}"
+                     IsClosable="False"
+                     Severity="Informational" />
+          </StackPanel>
+
+          <Grid Grid.Row="1">
+            <!-- Every message of the conversation, each collapsed to one line and each opened by the control on that
+                 line. The list is what a screen reader announces the structure from and what the arrow keys move
+                 between; the control on each line is what opens one without a pointer. -->
+            <ListView x:Name="ThreadMessageRows"
+                      x:Uid="MailPage.List.ThreadMessages"
+                      ItemsSource="{Binding ThreadMessages}"
+                      SelectionMode="Single"
+                      IsItemClickEnabled="False"
+                      Loaded="OnThreadLoaded"
+                      Unloaded="OnThreadUnloaded"
+                      Padding="4,0,4,12">
+              <ListView.ItemTemplate>
+                <DataTemplate x:DataType="threads:ThreadMessageRow">
+                  <StackPanel Spacing="4">
+                    <ToggleButton x:Uid="MailPage.Toggle.ThreadMessage"
+                                  HorizontalAlignment="Stretch"
+                                  HorizontalContentAlignment="Stretch"
+                                  IsChecked="{x:Bind IsExpanded, Mode=OneWay}"
+                                  Command="{utu:ItemsControlBinding Path=DataContext.ToggleThreadMessage}"
+                                  CommandParameter="{x:Bind Key}"
+                                  AutomationProperties.Name="{x:Bind Announcement}">
+                      <!-- The line states itself once for a screen reader and draws itself in parts for everybody
+                           else, exactly as a row of the list beside it does. -->
+                      <Grid ColumnSpacing="8">
+                        <Grid.ColumnDefinitions>
+                          <ColumnDefinition Width="Auto" />
+                          <ColumnDefinition />
+                          <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+
+                        <Border Width="8"
+                                Height="8"
+                                CornerRadius="4"
+                                VerticalAlignment="Top"
+                                Margin="0,6,0,0"
+                                AutomationProperties.AccessibilityView="Raw"
+                                Background="{ThemeResource PrimaryBrush}"
+                                Visibility="{x:Bind IsUnread, Converter={StaticResource AffirmedVisibility}}" />
+
+                        <StackPanel Grid.Column="1"
+                                    Spacing="2">
+                          <TextBlock Text="{x:Bind Author}"
+                                     Style="{StaticResource BodyStrongTextBlockStyle}"
+                                     Foreground="{ThemeResource OnSurfaceBrush}"
+                                     AutomationProperties.AccessibilityView="Raw"
+                                     TextTrimming="CharacterEllipsis" />
+
+                          <!-- What the message added, in the one line it collapses to. It arrived with the
+                               conversation, so a thread of thirty messages costs one request to draw. -->
+                          <TextBlock Text="{x:Bind Contribution}"
+                                     Style="{StaticResource CaptionTextBlockStyle}"
+                                     Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                                     AutomationProperties.AccessibilityView="Raw"
+                                     TextTrimming="CharacterEllipsis"
+                                     Visibility="{x:Bind HasContribution, Converter={StaticResource AffirmedVisibility}}" />
+                        </StackPanel>
+
+                        <StackPanel Grid.Column="2"
+                                    Spacing="2"
+                                    HorizontalAlignment="Right">
+                          <TextBlock Text="{x:Bind Written}"
+                                     HorizontalAlignment="Right"
+                                     Style="{StaticResource CaptionTextBlockStyle}"
+                                     Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                                     AutomationProperties.AccessibilityView="Raw" />
+
+                          <StackPanel Orientation="Horizontal"
+                                      HorizontalAlignment="Right"
+                                      Spacing="4">
+                            <FontIcon Glyph="&#xE7C1;"
+                                      FontSize="12"
+                                      AutomationProperties.AccessibilityView="Raw"
+                                      Foreground="{ThemeResource TertiaryBrush}"
+                                      Visibility="{x:Bind IsFlagged, Converter={StaticResource AffirmedVisibility}}" />
+
+                            <FontIcon Glyph="&#xE723;"
+                                      FontSize="12"
+                                      AutomationProperties.AccessibilityView="Raw"
+                                      Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                                      Visibility="{x:Bind HasAttachments, Converter={StaticResource AffirmedVisibility}}" />
+
+                            <TextBlock Text="{x:Bind AttachmentCountText}"
+                                       Style="{StaticResource CaptionTextBlockStyle}"
+                                       AutomationProperties.AccessibilityView="Raw"
+                                       Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                                       Visibility="{x:Bind ShowsAttachmentCount, Converter={StaticResource AffirmedVisibility}}" />
+                          </StackPanel>
+                        </StackPanel>
+                      </Grid>
+                    </ToggleButton>
+
+                    <!-- What the message added, in full, once it is open — and never the quoted history under it,
+                         which is the read below rather than eight copies of the first message down the page. -->
+                    <StackPanel Margin="16,0,8,8"
+                                Spacing="8"
+                                Visibility="{x:Bind IsExpanded, Converter={StaticResource AffirmedVisibility}}">
+                      <TextBlock Text="{x:Bind Recipients}"
+                                 TextWrapping="Wrap"
+                                 Style="{StaticResource CaptionTextBlockStyle}"
+                                 Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                                 Visibility="{x:Bind HasRecipients, Converter={StaticResource AffirmedVisibility}}" />
+
+                      <TextBlock Text="{x:Bind Contribution}"
+                                 TextWrapping="Wrap"
+                                 IsTextSelectionEnabled="True"
+                                 Style="{StaticResource BodyTextBlockStyle}"
+                                 Foreground="{ThemeResource OnSurfaceBrush}"
+                                 Visibility="{x:Bind HasContribution, Converter={StaticResource AffirmedVisibility}}" />
+
+                      <!-- A message this deployment holds but has not extracted yet says so, rather than reading as a
+                           message somebody sent with nothing in it. -->
+                      <TextBlock x:Uid="MailPage.TextBlock.NoContribution"
+                                 TextWrapping="Wrap"
+                                 Style="{StaticResource CaptionTextBlockStyle}"
+                                 Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                                 Visibility="{x:Bind AwaitsContribution, Converter={StaticResource AffirmedVisibility}}" />
+
+                      <!-- The one gesture on this screen that costs a request. The command carries the message it acts
+                           on, so it runs per message and its progress belongs to that message rather than to the
+                           conversation — which is why the wait below is drawn here and not by a LoadingView. -->
+                      <Button x:Uid="MailPage.Button.ShowWholeMessage"
+                              HorizontalAlignment="Left"
+                              Style="{StaticResource TextBlockButtonStyle}"
+                              Command="{utu:ItemsControlBinding Path=DataContext.ShowWholeThreadMessage}"
+                              CommandParameter="{x:Bind Key}"
+                              Visibility="{x:Bind OffersWholeMessage, Converter={StaticResource AffirmedVisibility}}" />
+
+                      <ProgressBar IsIndeterminate="True"
+                                   HorizontalAlignment="Stretch"
+                                   Visibility="{x:Bind AwaitsWholeMessage, Converter={StaticResource AffirmedVisibility}}" />
+
+                      <InfoBar x:Uid="MailPage.InfoBar.WholeMessageUnavailable"
+                               IsOpen="{x:Bind ShowsWholeMessageFailure, Mode=OneWay}"
+                               IsClosable="False"
+                               Severity="Warning">
+                        <InfoBar.ActionButton>
+                          <Button x:Uid="MailPage.Button.RetryWholeMessage"
+                                  Command="{utu:ItemsControlBinding Path=DataContext.ShowWholeThreadMessage}"
+                                  CommandParameter="{x:Bind Key}" />
+                        </InfoBar.ActionButton>
+                      </InfoBar>
+
+                      <!-- The whole message, quoted history and all, drawn by the pane that already knows how to draw
+                           one and how to ask before anything in it leaves the application. Its height is bounded so a
+                           long message stays one message of the conversation rather than the whole column. -->
+                      <reading:MailBodyView MaxHeight="640"
+                                            Reading="{x:Bind WholeMessage, Mode=OneWay}"
+                                            Visibility="{x:Bind ShowsWholeMessage, Converter={StaticResource AffirmedVisibility}}"
+                                            ShowRemoteContentCommand="{utu:ItemsControlBinding Path=DataContext.ShowThreadRemoteContent}"
+                                            ShowRemoteContentCommandParameter="{x:Bind Key}" />
+                    </StackPanel>
+                  </StackPanel>
+                </DataTemplate>
+              </ListView.ItemTemplate>
+            </ListView>
+
+            <!-- The three states the conversation genuinely has, rendered by the feed rather than remembered by this
+                 page, on the same arrangement the list beside it uses. -->
+            <mvux:FeedView Source="{Binding ThreadMessages}">
+              <mvux:FeedView.ValueTemplate>
+                <DataTemplate>
+                  <Border Height="0" />
+                </DataTemplate>
+              </mvux:FeedView.ValueTemplate>
+
+              <mvux:FeedView.ProgressTemplate>
+                <DataTemplate>
+                  <ProgressBar IsIndeterminate="True"
+                               VerticalAlignment="Top"
+                               HorizontalAlignment="Stretch" />
+                </DataTemplate>
+              </mvux:FeedView.ProgressTemplate>
+
+              <!-- Two states rather than one, because they lead to different acts: nothing selected is a message to
+                   choose, and an open conversation holding nothing is mail this deployment has not taken in yet. Each
+                   is shown on its own affirmative, so neither is announced while the read that decides it is still
+                   running. -->
+              <mvux:FeedView.NoneTemplate>
+                <DataTemplate>
+                  <Grid>
+                    <spaces:SpacePlaceholder x:Uid="MailPage.Thread"
+                                             Visibility="{Binding Parent.Thread.IsClosed, Converter={StaticResource AffirmedVisibility}}" />
+
+                    <InfoBar x:Uid="MailPage.InfoBar.NoThreadMessages"
+                             Margin="16"
+                             VerticalAlignment="Top"
+                             IsOpen="{Binding Parent.Thread.IsOpen}"
+                             IsClosable="False"
+                             Severity="Informational" />
+                  </Grid>
+                </DataTemplate>
+              </mvux:FeedView.NoneTemplate>
+
+              <mvux:FeedView.ErrorTemplate>
+                <DataTemplate>
+                  <InfoBar x:Uid="MailPage.InfoBar.ThreadUnavailable"
+                           Margin="16"
+                           VerticalAlignment="Top"
+                           IsOpen="True"
+                           IsClosable="False"
+                           Severity="Error">
+                    <InfoBar.ActionButton>
+                      <Button x:Uid="MailPage.Button.RetryThread"
+                              Command="{Binding Parent.RetryThread}" />
+                    </InfoBar.ActionButton>
+                  </InfoBar>
+                </DataTemplate>
+              </mvux:FeedView.ErrorTemplate>
+            </mvux:FeedView>
+          </Grid>
+
+          <StackPanel Grid.Row="2"
+                      Padding="12,4,12,8"
+                      Spacing="4">
+            <!-- A page that did not arrive is said beside the conversation rather than instead of it, because what is
+                 already drawn is still true. -->
+            <InfoBar x:Uid="MailPage.InfoBar.ThreadPageUnavailable"
+                     IsOpen="{Binding ThreadPagingFailed}"
+                     IsClosable="False"
+                     Severity="Warning" />
+
+            <utu:LoadingView Source="{Binding ShowMoreThreadMessages}"
+                             Visibility="{Binding HasMoreThreadMessages, Converter={StaticResource AffirmedVisibility}}">
+              <utu:LoadingView.Content>
+                <Button x:Uid="MailPage.Button.ShowMoreThreadMessages"
+                        HorizontalAlignment="Stretch"
+                        Command="{Binding ShowMoreThreadMessages}"
+                        Style="{StaticResource TextBlockButtonStyle}" />
+              </utu:LoadingView.Content>
+
+              <utu:LoadingView.LoadingContent>
+                <ProgressBar IsIndeterminate="True"
+                             HorizontalAlignment="Stretch" />
+              </utu:LoadingView.LoadingContent>
+            </utu:LoadingView>
+          </StackPanel>
+        </Grid>
       </workspace:WorkspaceColumns.Companion>
     </workspace:WorkspaceColumns>
 

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailPage.xaml.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailPage.xaml.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Collections.Specialized;
+using MailFathom.Client.Presentation.Threads;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml.Input;
 
@@ -9,17 +11,75 @@ namespace MailFathom.Client.Presentation.Spaces.Mail;
 
 /// <summary>Mail: the mailbox itself, read the way a mail client is read.</summary>
 /// <remarks>
-/// The handlers below are the list control's own behaviour rather than the space's: which selection mode a selector is
-/// in is a fact about this window and this input device, not about the mail somebody is reading. What comes <em>out</em>
-/// of a selection is the model's, and it goes into the workspace scope — so nothing here reads or writes what is
-/// selected.
+/// The handlers below are the list controls' own behaviour rather than the space's: which selection mode a selector is
+/// in is a fact about this window and this input device, and where a list is scrolled to is a fact about a viewport.
+/// Neither is about the mail somebody is reading. What comes <em>out</em> of a selection is the model's, and it goes
+/// into the workspace scope — so nothing here reads or writes what is selected.
 /// </remarks>
 public sealed partial class MailPage : Page
 {
+    private string scrolledTo = string.Empty;
+
     /// <summary>Initializes the space.</summary>
     public MailPage()
     {
         this.InitializeComponent();
+    }
+
+    /// <summary>Brings the message a conversation was opened at into view, once the conversation has arrived.</summary>
+    /// <param name="sender">The conversation's list.</param>
+    /// <param name="args">The load, which is where the collection behind the list becomes watchable.</param>
+    /// <remarks>
+    /// Scrolling is the one part of opening a conversation at a message that a model cannot do: which message is opened
+    /// is the model's answer and is asserted as one, and where a viewport sits is the control's. The collection is
+    /// watched rather than the items bound once, because the rows are rebuilt whenever anything is expanded and the
+    /// conversation itself arrives after the list is loaded.
+    /// </remarks>
+    private void OnThreadLoaded(object sender, RoutedEventArgs args)
+    {
+        if (this.ThreadMessageRows.ItemsSource is INotifyCollectionChanged watchable)
+        {
+            watchable.CollectionChanged += this.OnThreadMessagesChanged;
+        }
+
+        this.BringOpenedMessageIntoView();
+    }
+
+    /// <summary>Stops watching the conversation's rows when the space goes away.</summary>
+    private void OnThreadUnloaded(object sender, RoutedEventArgs args)
+    {
+        if (this.ThreadMessageRows.ItemsSource is INotifyCollectionChanged watchable)
+        {
+            watchable.CollectionChanged -= this.OnThreadMessagesChanged;
+        }
+    }
+
+    private void OnThreadMessagesChanged(object? sender, NotifyCollectionChangedEventArgs args) =>
+        this.BringOpenedMessageIntoView();
+
+    /// <summary>Scrolls to the opened message, and only the first time each one becomes the opened one.</summary>
+    /// <remarks>
+    /// Which message was last scrolled to is kept here rather than answered by the model, because the model's answer
+    /// stays true for as long as the conversation is open: expanding another message rebuilds the rows without changing
+    /// which one was arrived at, and scrolling again on each of those would drag the viewport away from whatever the
+    /// reader had just pressed.
+    /// </remarks>
+    private void BringOpenedMessageIntoView()
+    {
+        if (this.ThreadMessageRows.ItemsSource is not IEnumerable<object> rows)
+        {
+            return;
+        }
+
+        var opened = rows.OfType<ThreadMessageRow>().FirstOrDefault(static row => row.IsOpenedAt);
+
+        if (opened is null || string.Equals(opened.Key, this.scrolledTo, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        this.scrolledTo = opened.Key;
+        this.ThreadMessageRows.ScrollIntoView(opened);
     }
 
     /// <summary>Puts the list into the selection a touch head reaches by pressing and holding a row.</summary>

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailPage.xaml.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailPage.xaml.cs
@@ -73,7 +73,17 @@ public sealed partial class MailPage : Page
 
         var opened = rows.OfType<ThreadMessageRow>().FirstOrDefault(static row => row.IsOpenedAt);
 
-        if (opened is null || string.Equals(opened.Key, this.scrolledTo, StringComparison.Ordinal))
+        if (opened is null)
+        {
+            // A conversation nobody has open was scrolled to nothing, and this page outlives the conversations opened
+            // in it: without this, arriving at the same message a second time would find the guard already naming it
+            // and would leave the viewport wherever the last reading left it.
+            this.scrolledTo = string.Empty;
+
+            return;
+        }
+
+        if (string.Equals(opened.Key, this.scrolledTo, StringComparison.Ordinal))
         {
             return;
         }

--- a/frontend/src/Client/Presentation/Spaces/Mail/Reading/MailBodyView.xaml
+++ b/frontend/src/Client/Presentation/Spaces/Mail/Reading/MailBodyView.xaml
@@ -30,7 +30,8 @@ Project repository: https://github.com/Krzysztof318/MailFathom
                  Message="{x:Bind Reading.WithheldRemoteContent, Mode=OneWay}">
           <InfoBar.ActionButton>
             <Button x:Uid="MailBody.Button.ShowRemoteContent"
-                    Command="{x:Bind ShowRemoteContentCommand, Mode=OneWay}" />
+                    Command="{x:Bind ShowRemoteContentCommand, Mode=OneWay}"
+                    CommandParameter="{x:Bind ShowRemoteContentCommandParameter, Mode=OneWay}" />
           </InfoBar.ActionButton>
         </InfoBar>
 

--- a/frontend/src/Client/Presentation/Spaces/Mail/Reading/MailBodyView.xaml.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/Reading/MailBodyView.xaml.cs
@@ -37,6 +37,14 @@ public sealed partial class MailBodyView : UserControl
         typeof(MailBodyView),
         new PropertyMetadata(null));
 
+    /// <summary>Identifies the <see cref="ShowRemoteContentCommandParameter"/> property.</summary>
+    public static readonly DependencyProperty ShowRemoteContentCommandParameterProperty =
+        DependencyProperty.Register(
+            nameof(ShowRemoteContentCommandParameter),
+            typeof(object),
+            typeof(MailBodyView),
+            new PropertyMetadata(null));
+
     /// <summary>Identifies the <see cref="Nothing"/> property.</summary>
     public static readonly DependencyProperty NothingProperty = DependencyProperty.Register(
         nameof(Nothing),
@@ -68,6 +76,18 @@ public sealed partial class MailBodyView : UserControl
     {
         get => (ICommand?)this.GetValue(ShowRemoteContentCommandProperty);
         set => this.SetValue(ShowRemoteContentCommandProperty, value);
+    }
+
+    /// <summary>Gets or sets what the command re-reading the message is told to act on, where it acts on one thing among several.</summary>
+    /// <remarks>
+    /// A pane composed over one open message needs none of this and leaves it unset. One composed inside a conversation
+    /// does: the same command re-reads whichever message the reader asked it of, and a command that runs per item is
+    /// told which item by its parameter rather than by the pane it happens to be drawn in.
+    /// </remarks>
+    public object? ShowRemoteContentCommandParameter
+    {
+        get => this.GetValue(ShowRemoteContentCommandParameterProperty);
+        set => this.SetValue(ShowRemoteContentCommandParameterProperty, value);
     }
 
     /// <summary>Gets or sets whether the pane has nothing open in it.</summary>

--- a/frontend/src/Client/Presentation/Threads/DeploymentMailThread.cs
+++ b/frontend/src/Client/Presentation/Threads/DeploymentMailThread.cs
@@ -1,0 +1,371 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Immutable;
+using MailFathom.Client.Backend;
+using MailFathom.Client.Backend.Threads;
+using MailFathom.Client.Presentation.Messages;
+using MailFathom.Client.Presentation.Spaces.Mail.Reading;
+using MailFathom.Client.Session;
+using Microsoft.Extensions.Localization;
+
+namespace MailFathom.Client.Presentation.Threads;
+
+/// <summary>The conversation as one deployment pages it, and as one person has opened it.</summary>
+/// <remarks>
+/// <para>
+/// It is read off the session and off what the message list has selected, which is one subscription and one act for the
+/// person: selecting a message in the mail space is how a conversation is reached there, and the session already asks
+/// the deployment again when the signed-in identity changes, when the client is pointed somewhere else, and when a lost
+/// connection comes back. Nothing here retries on top of that — the root instructions refuse nested retry storms.
+/// </para>
+/// <para>
+/// Everything else that reaches a conversation names one instead. A search result and a citation both arrive at one
+/// message inside an exchange, so <see cref="OpenAsync" /> takes the message beside the conversation and the screen
+/// opens there rather than at the beginning.
+/// </para>
+/// <para>
+/// What each message added arrived with the conversation, so a thread of thirty messages is one request. The whole of a
+/// message — its quoted history with it — is a read of its own, made only for the message somebody asked it of, which
+/// is what keeps opening a conversation from being thirty requests and keeps the eighth reply from redrawing the seven
+/// above it.
+/// </para>
+/// </remarks>
+internal sealed class DeploymentMailThread : IMailThread
+{
+    /// <summary>How many messages one page of a conversation holds.</summary>
+    /// <remarks>
+    /// Stated rather than left to the deployment's default, because the default is a tool's page size and this is a
+    /// screen's: a conversation is read from its beginning and most of them end inside one page, so a page a screenful
+    /// short of the whole exchange would be a request per scroll. It is within what the surface accepts.
+    /// </remarks>
+    internal const int PageSize = 50;
+
+    private readonly DeploymentClient deployment;
+    private readonly IClientSession session;
+    private readonly IStringLocalizer words;
+    private readonly IState<ThreadOpening> opened;
+    private readonly IState<int> asked;
+    private readonly IState<bool> pagingFailed;
+    private readonly IState<IImmutableDictionary<string, ThreadMessageDetail>> disclosed;
+    private readonly IState<ThreadWindow> loaded;
+
+    /// <summary>Initializes the conversation over what serves it, what decides it may be read, and what opens one.</summary>
+    /// <param name="deployment">Where a page of a conversation is asked for.</param>
+    /// <param name="session">What the deployment allows this caller, and whether it can be reached at all.</param>
+    /// <param name="messages">The list whose selection is how a conversation is reached in the mail space.</param>
+    /// <param name="words">Where the sentences a conversation is composed from come from.</param>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    public DeploymentMailThread(
+        DeploymentClient deployment,
+        IClientSession session,
+        IMessageList messages,
+        IStringLocalizer words)
+    {
+        ArgumentNullException.ThrowIfNull(deployment);
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(messages);
+        ArgumentNullException.ThrowIfNull(words);
+
+        this.deployment = deployment;
+        this.session = session;
+        this.words = words;
+
+        // Held as a state rather than read as the session's own feed, for the reason every other reader of it holds
+        // one: a feed is read from the start by whoever subscribes, and each projection below would otherwise be a
+        // reader of its own.
+        var standing = State.FromFeed(this, session.Standing);
+
+        this.opened = State.Value(this, () => ThreadOpening.Nothing);
+        this.asked = State.Value(this, () => 0);
+        this.pagingFailed = State.Value(this, () => false);
+        this.disclosed = State.Value(
+            this,
+            () => (IImmutableDictionary<string, ThreadMessageDetail>)ImmutableDictionary<string, ThreadMessageDetail>
+                .Empty
+                .WithComparers(StringComparer.Ordinal));
+
+        this.loaded = State.FromFeed(
+            this,
+            Feed.Combine(standing, this.opened, this.asked).SelectAsync(this.ReadAsync));
+
+        this.Reading = this.loaded.Select(window => ThreadShape.Header(window, this.words));
+        this.Messages = Feed.Combine(this.loaded, this.disclosed).Select(this.Draw).AsListFeed();
+        this.HasMoreMessages = this.loaded.Select(static window => window.HasMore);
+        this.PagingFailed = this.pagingFailed;
+
+        // What makes selecting a message in the list opening its conversation. MVUX owns the subscription's lifetime,
+        // so it ends with this instance.
+        messages.Chosen.ForEach(this.FollowAsync);
+    }
+
+    /// <inheritdoc />
+    public IFeed<ThreadReading> Reading { get; }
+
+    /// <inheritdoc />
+    public IListFeed<ThreadMessageRow> Messages { get; }
+
+    /// <inheritdoc />
+    public IFeed<bool> HasMoreMessages { get; }
+
+    /// <inheritdoc />
+    public IFeed<bool> PagingFailed { get; }
+
+    /// <inheritdoc />
+    public async ValueTask OpenAsync(Guid? threadId, Guid? atMessage, CancellationToken cancellationToken)
+    {
+        var opening = threadId is { } conversation
+            ? new ThreadOpening(conversation, atMessage)
+            : ThreadOpening.Nothing;
+
+        // Written before the opening rather than after it, so the conversation that arrives is drawn with nothing the
+        // one before it had opened. Both are states, so a value equal to what is held reaches nobody as a change.
+        await this.disclosed.UpdateAsync(_ => Nothing, cancellationToken).ConfigureAwait(false);
+
+        await this.opened.UpdateAsync(_ => opening, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask ToggleAsync(string key, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        if (await this.DetailOfAsync(key, cancellationToken).ConfigureAwait(false) is not { } detail)
+        {
+            return;
+        }
+
+        // Collapsing drops the whole message with the answer about its remote pictures, so an allowance never outlives
+        // the expansion it was given during.
+        var toggled = detail.Expanded ? ThreadMessageDetail.Collapsed : detail with { Expanded = true };
+
+        await this.disclosed
+            .UpdateAsync(held => (held ?? Nothing).SetItem(key, toggled), cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public ValueTask ShowWholeMessageAsync(string key, CancellationToken cancellationToken) =>
+        this.ReadWholeAsync(key, remoteImages: false, cancellationToken);
+
+    /// <inheritdoc />
+    public ValueTask ShowRemoteContentAsync(string key, CancellationToken cancellationToken) =>
+        this.ReadWholeAsync(key, remoteImages: true, cancellationToken);
+
+    /// <inheritdoc />
+    public async ValueTask ShowMoreAsync(CancellationToken cancellationToken)
+    {
+        if (await this.loaded.Value(cancellationToken).ConfigureAwait(false) is not { } window)
+        {
+            return;
+        }
+
+        if (window.ThreadId is not { } conversation || window.NextCursor is not { } cursor)
+        {
+            return;
+        }
+
+        DeploymentMailThreadPage page;
+
+        try
+        {
+            page = await this.deployment
+                .ReadMailThreadAsync(conversation, PageSize, cursor, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (DeploymentFailure)
+        {
+            if (await this.StillLoadedAsync(window, cancellationToken).ConfigureAwait(false) is not null)
+            {
+                await this.pagingFailed.UpdateAsync(static _ => true, cancellationToken).ConfigureAwait(false);
+            }
+
+            return;
+        }
+
+        // Everything the read says afterwards is said about the conversation it was started for, so it is written only
+        // while that conversation is still the one open: a page in flight when somebody opens another exchange is
+        // answered by a screen that has already moved, and splicing it on would put one conversation's messages under
+        // another's header.
+        await this.loaded
+            .UpdateAsync(held => held?.IsOf(window) is true ? held.Extended(page) : held, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (await this.StillLoadedAsync(window, cancellationToken).ConfigureAwait(false) is null)
+        {
+            return;
+        }
+
+        await this.pagingFailed.UpdateAsync(static _ => false, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask AskAgainAsync(CancellationToken cancellationToken)
+    {
+        this.session.Refresh();
+
+        await this.asked.UpdateAsync(static asked => asked + 1, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>An empty set of disclosures, which is a conversation nobody has opened anything inside.</summary>
+    private static IImmutableDictionary<string, ThreadMessageDetail> Nothing { get; } =
+        ImmutableDictionary<string, ThreadMessageDetail>.Empty.WithComparers(StringComparer.Ordinal);
+
+    /// <summary>Opens the conversation of the one message the list has selected, and closes it for anything else.</summary>
+    /// <remarks>
+    /// One message names one conversation; several name none, because a question asked about four messages is not a
+    /// conversation to read. A message nothing has placed in a conversation names none either, which is an ordinary
+    /// state of mail this deployment has stored and not yet threaded.
+    /// </remarks>
+    private async ValueTask FollowAsync(IImmutableList<MessageRow>? chosen, CancellationToken cancellationToken)
+    {
+        var row = chosen is [var only] ? only : null;
+
+        // The row writes its own identity as the invariant form of the message's, which is the same identity the
+        // conversation names its messages by.
+        var message = row is not null && Guid.TryParseExact(row.Key, "D", out var parsed) ? parsed : (Guid?)null;
+
+        await this.OpenAsync(row?.ThreadId, message, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Reads the first page of whatever conversation is open, once the session that decides it may be has arrived.</summary>
+    /// <remarks>
+    /// Neither the standing nor the counter is read: what they are here for is when this runs rather than what it asks
+    /// for. A conversation nobody has opened is not a read at all, which is the state the screen starts in and the one
+    /// selecting several messages returns it to.
+    /// </remarks>
+    private async ValueTask<ThreadWindow> ReadAsync(
+        (SessionStanding Standing, ThreadOpening Opening, int Asked) trigger,
+        CancellationToken cancellationToken)
+    {
+        var opening = trigger.Opening;
+
+        if (opening.ThreadId is not { } conversation)
+        {
+            return ThreadWindow.Nothing;
+        }
+
+        await this.pagingFailed.UpdateAsync(static _ => false, cancellationToken).ConfigureAwait(false);
+
+        var page = await this.deployment
+            .ReadMailThreadAsync(conversation, PageSize, cursor: null, cancellationToken)
+            .ConfigureAwait(false);
+
+        return ThreadWindow.Opening(opening, page);
+    }
+
+    /// <summary>Reads the whole of one message, in the terms the reader asked for it.</summary>
+    /// <remarks>
+    /// The read is held against the conversation it was started under exactly as a page is: a message opened while one
+    /// exchange was on the screen and answered after another has been belongs to neither, and drawing it would put one
+    /// message's body under another conversation's messages.
+    /// </remarks>
+    private async ValueTask ReadWholeAsync(string key, bool remoteImages, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        if (!Guid.TryParseExact(key, "D", out var message))
+        {
+            return;
+        }
+
+        if (await this.loaded.Value(cancellationToken).ConfigureAwait(false) is not { IsOpen: true } window)
+        {
+            return;
+        }
+
+        if (await this.DetailOfAsync(key, cancellationToken).ConfigureAwait(false) is not { } detail)
+        {
+            return;
+        }
+
+        await this.WriteAsync(
+            key,
+            detail with
+            {
+                Expanded = true,
+                IsReadingWholeMessage = true,
+                WholeMessageFailed = false,
+                RemoteImages = remoteImages,
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        MailBodyReading? whole;
+
+        try
+        {
+            var body = await this.deployment
+                .ReadMailBodyAsync(message, remoteImages, cancellationToken)
+                .ConfigureAwait(false);
+
+            whole = MailBodyReading.Of(body, this.words);
+        }
+        catch (DeploymentFailure)
+        {
+            whole = null;
+        }
+
+        if (await this.StillLoadedAsync(window, cancellationToken).ConfigureAwait(false) is null)
+        {
+            return;
+        }
+
+        // Read again rather than written onto what was held when the read began: collapsing a message drops the whole
+        // of it, and a reader who closed the message while it was on its way would otherwise have it opened back up by
+        // an answer to a question they had already withdrawn.
+        if (await this.DetailOfAsync(key, cancellationToken).ConfigureAwait(false) is not { Expanded: true } current)
+        {
+            return;
+        }
+
+        await this.WriteAsync(
+            key,
+            current with
+            {
+                WholeMessage = whole,
+                IsReadingWholeMessage = false,
+                WholeMessageFailed = whole is null,
+                RemoteImages = remoteImages,
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Reads how much of one message is shown, or nothing where the conversation does not hold it.</summary>
+    private async ValueTask<ThreadMessageDetail?> DetailOfAsync(string key, CancellationToken cancellationToken)
+    {
+        if (await this.loaded.Value(cancellationToken).ConfigureAwait(false) is not { } window)
+        {
+            return null;
+        }
+
+        var message = window.Messages.FirstOrDefault(
+            held => string.Equals(ThreadShape.KeyOf(held), key, StringComparison.Ordinal));
+
+        if (message is null)
+        {
+            return null;
+        }
+
+        var held = await this.disclosed.Value(cancellationToken).ConfigureAwait(false) ?? Nothing;
+
+        return ThreadShape.DetailOf(message, held, ThreadShape.OpenedKey(window));
+    }
+
+    private ValueTask WriteAsync(string key, ThreadMessageDetail detail, CancellationToken cancellationToken) =>
+        this.disclosed.UpdateAsync(held => (held ?? Nothing).SetItem(key, detail), cancellationToken);
+
+    /// <summary>Reads the loaded conversation back, where it is still the one a read was started for.</summary>
+    private async ValueTask<ThreadWindow?> StillLoadedAsync(
+        ThreadWindow window,
+        CancellationToken cancellationToken)
+    {
+        var current = await this.loaded.Value(cancellationToken).ConfigureAwait(false);
+
+        return current?.IsOf(window) is true ? current : null;
+    }
+
+    private IImmutableList<ThreadMessageRow> Draw(
+        (ThreadWindow Window, IImmutableDictionary<string, ThreadMessageDetail> Disclosed) drawn) =>
+        ThreadShape.Messages(drawn.Window ?? ThreadWindow.Nothing, drawn.Disclosed ?? Nothing, this.words);
+}

--- a/frontend/src/Client/Presentation/Threads/IMailThread.cs
+++ b/frontend/src/Client/Presentation/Threads/IMailThread.cs
@@ -1,0 +1,89 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Presentation.Threads;
+
+/// <summary>The one conversation a run has open, wherever it was opened from.</summary>
+/// <remarks>
+/// <para>
+/// One for the run rather than one per screen, for the reason the mailbox tree and the message list are: a model is
+/// built and discarded as its view is navigated to and away from, so a conversation each screen kept would be read
+/// again every time somebody moved between spaces — and would lose which of its messages they had opened while doing
+/// it.
+/// </para>
+/// <para>
+/// It is opened at a message as readily as at a conversation, and that is not a convenience: a search result and a
+/// citation both reach mail by naming one message inside an exchange, so a screen that could only open a conversation
+/// at its start would lose the context somebody arrived with. The message named is scrolled to and shown, and the rest
+/// of the conversation collapses to a line each.
+/// </para>
+/// </remarks>
+public interface IMailThread
+{
+    /// <summary>The conversation's header, answered about the whole of it rather than about what has been read.</summary>
+    IFeed<ThreadReading> Reading { get; }
+
+    /// <summary>The messages read so far, in the conversation's own order.</summary>
+    /// <remarks>
+    /// A list feed rather than a feed of a list, so the three states this genuinely has are the framework's rather than
+    /// each one remembered by a view: the read under way, the read that failed, and no conversation open to draw.
+    /// </remarks>
+    IListFeed<ThreadMessageRow> Messages { get; }
+
+    /// <summary>Whether there is more of the conversation after what has been read.</summary>
+    IFeed<bool> HasMoreMessages { get; }
+
+    /// <summary>Whether the last attempt to read more of the conversation did not arrive.</summary>
+    /// <remarks>
+    /// Its own answer rather than the conversation's error state, because a page that failed leaves what is already
+    /// drawn on the screen: putting the whole conversation into an error would take an exchange somebody is reading
+    /// away over one request.
+    /// </remarks>
+    IFeed<bool> PagingFailed { get; }
+
+    /// <summary>Opens a conversation, at the message somebody arrived at where they arrived at one.</summary>
+    /// <param name="threadId">The conversation to open, or <see langword="null" /> to leave the screen with nothing in it.</param>
+    /// <param name="atMessage">The message to show and scroll to, or <see langword="null" /> to open at the newest.</param>
+    /// <param name="cancellationToken">Abandons the change.</param>
+    /// <returns>A task completing once the conversation is being read.</returns>
+    ValueTask OpenAsync(Guid? threadId, Guid? atMessage, CancellationToken cancellationToken);
+
+    /// <summary>Shows what one message added, or collapses it back to the line it stands for.</summary>
+    /// <param name="key">The message, as a row names itself.</param>
+    /// <param name="cancellationToken">Abandons the change.</param>
+    /// <returns>A task completing once the message has been opened or closed.</returns>
+    /// <remarks>Collapsing a message drops the whole of it with the answer about its remote pictures, so nothing an expansion asked for outlives it.</remarks>
+    ValueTask ToggleAsync(string key, CancellationToken cancellationToken);
+
+    /// <summary>Reads the whole of one message, which is what the quoted history under it is reached by.</summary>
+    /// <param name="key">The message, as a row names itself.</param>
+    /// <param name="cancellationToken">Abandons the read.</param>
+    /// <returns>A task completing once the whole message has arrived or the attempt has been reported.</returns>
+    /// <remarks>
+    /// The read every other message of the conversation does not make. What each message added arrived with the
+    /// conversation, so this is the one gesture that costs a request — which is why it is a gesture rather than
+    /// something the screen does on everybody's behalf.
+    /// </remarks>
+    ValueTask ShowWholeMessageAsync(string key, CancellationToken cancellationToken);
+
+    /// <summary>Reads one whole message again, this time fetching what it asks for from somebody else's server.</summary>
+    /// <param name="key">The message, as a row names itself.</param>
+    /// <param name="cancellationToken">Abandons the read.</param>
+    /// <returns>A task completing once the second read has been asked for.</returns>
+    /// <remarks>
+    /// The reader's act taken for the message in front of them, on the terms the reading pane already takes it: it is
+    /// not written down, not carried to the next message, and not carried to this one the next time it is opened.
+    /// </remarks>
+    ValueTask ShowRemoteContentAsync(string key, CancellationToken cancellationToken);
+
+    /// <summary>Takes the next page of the conversation onto the end of what has been read.</summary>
+    /// <param name="cancellationToken">Abandons the page.</param>
+    /// <returns>A task completing once the page has arrived or the attempt has been reported.</returns>
+    ValueTask ShowMoreAsync(CancellationToken cancellationToken);
+
+    /// <summary>Asks the deployment again, which is what a person presses when the conversation did not arrive.</summary>
+    /// <param name="cancellationToken">Abandons the ask.</param>
+    /// <returns>A task completing once the ask has been made.</returns>
+    ValueTask AskAgainAsync(CancellationToken cancellationToken);
+}

--- a/frontend/src/Client/Presentation/Threads/ThreadMessageDetail.cs
+++ b/frontend/src/Client/Presentation/Threads/ThreadMessageDetail.cs
@@ -1,0 +1,45 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Presentation.Spaces.Mail.Reading;
+
+namespace MailFathom.Client.Presentation.Threads;
+
+/// <summary>How much of one message of the conversation the reader has asked to see.</summary>
+/// <param name="Expanded">Whether the message shows what it added rather than the one line it collapses to.</param>
+/// <param name="WholeMessage">The whole message, quoted history included, or <see langword="null" /> where nobody has asked for it.</param>
+/// <param name="IsReadingWholeMessage">Whether the whole message is on its way.</param>
+/// <param name="WholeMessageFailed">Whether the last attempt to read the whole message did not arrive.</param>
+/// <param name="RemoteImages">Whether this reading of the whole message asked for its remote pictures.</param>
+/// <remarks>
+/// <para>
+/// Two gestures rather than one, and the split is the point of the screen: expanding shows what the message added,
+/// which the conversation already carried and which therefore costs nothing, and the whole message — the quoted history
+/// with it — is a read of its own that only happens because somebody asked. A thread that fetched every body would be
+/// thirty requests to draw one exchange, and one that drew the quoted history inline would be the same paragraph eight
+/// times.
+/// </para>
+/// <para>
+/// The answer about remote pictures travels with the message it was given for, exactly as it does in the reading pane:
+/// collapsing a message drops the whole of this, so no allowance outlives the reason it was given.
+/// </para>
+/// </remarks>
+internal sealed record ThreadMessageDetail(
+    bool Expanded,
+    MailBodyReading? WholeMessage,
+    bool IsReadingWholeMessage,
+    bool WholeMessageFailed,
+    bool RemoteImages)
+{
+    /// <summary>A message showing the one line it collapses to.</summary>
+    internal static ThreadMessageDetail Collapsed { get; } = new(
+        Expanded: false,
+        WholeMessage: null,
+        IsReadingWholeMessage: false,
+        WholeMessageFailed: false,
+        RemoteImages: false);
+
+    /// <summary>A message showing what it added, with nothing yet asked of the whole of it.</summary>
+    internal static ThreadMessageDetail Opened { get; } = Collapsed with { Expanded = true };
+}

--- a/frontend/src/Client/Presentation/Threads/ThreadMessageRow.cs
+++ b/frontend/src/Client/Presentation/Threads/ThreadMessageRow.cs
@@ -1,0 +1,106 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Globalization;
+using MailFathom.Client.Presentation.Spaces.Mail.Reading;
+
+namespace MailFathom.Client.Presentation.Threads;
+
+/// <summary>One message of the conversation, with everything the screen draws it from and nothing else.</summary>
+/// <param name="Key">The message's own identity, which is what this row is matched by across a redraw and what the whole of the message is read by.</param>
+/// <param name="Author">Who wrote the message — the name they wrote under, or the address they wrote from.</param>
+/// <param name="Subject">What the message is about, or the words standing in for a message that carried no subject.</param>
+/// <param name="Recipients">Who it went to, already written as the line the expanded message shows.</param>
+/// <param name="Contribution">What this message added, with its quoted history and signature already trimmed off by the deployment.</param>
+/// <param name="Written">When the message was written, in full rather than in the bands a list shows, because a conversation spans years.</param>
+/// <param name="Announcement">The whole line as one sentence, which is what a screen reader is given instead of six controls.</param>
+/// <param name="IsExpanded">Whether the message shows what it added rather than the one line it collapses to.</param>
+/// <param name="IsOpenedAt">Whether this is the message the conversation was opened at, which is the one the screen scrolls to.</param>
+/// <param name="IsUnread">Whether the mail server last reported the message without <c>\Seen</c>.</param>
+/// <param name="IsFlagged">Whether it last reported it with <c>\Flagged</c>.</param>
+/// <param name="IsAnswered">Whether it last reported it with <c>\Answered</c>.</param>
+/// <param name="HasAttachments">Whether the message carries anything besides its body and its inline resources.</param>
+/// <param name="AttachmentCount">How many of those there are.</param>
+/// <param name="WholeMessage">The whole message as a reading pane draws it, or <see langword="null" /> where nobody has asked for it.</param>
+/// <param name="IsReadingWholeMessage">Whether the whole message is on its way.</param>
+/// <param name="WholeMessageFailed">Whether the last attempt to read the whole message did not arrive.</param>
+/// <remarks>
+/// <para>
+/// Everything down to the contribution came out of the page that carried the conversation, so a thread of thirty
+/// messages is one request until somebody asks for the whole of one. That asymmetry is the screen: what each message
+/// added is what a conversation is read as, and the quoted history under it is one gesture away rather than eight
+/// copies of the first message down the page.
+/// </para>
+/// <para>
+/// It is <c>partial</c> because <paramref name="Key" /> makes it eligible for MVUX's key-equality generation, which is
+/// what carries a message's identity across a redraw: expanding one message rebuilds the rows and leaves the containers
+/// of the others alone, so nothing that was scrolled to moves and nothing that was drawn is drawn again.
+/// </para>
+/// <para>
+/// Every word on it is this owner's own correspondence. It is put in front of that owner alone and reaches no log, no
+/// telemetry, and no local store.
+/// </para>
+/// </remarks>
+public sealed partial record ThreadMessageRow(
+    string Key,
+    string Author,
+    string Subject,
+    string Recipients,
+    string Contribution,
+    string Written,
+    string Announcement,
+    bool IsExpanded,
+    bool IsOpenedAt,
+    bool IsUnread,
+    bool IsFlagged,
+    bool IsAnswered,
+    bool HasAttachments,
+    int AttachmentCount,
+    MailBodyReading? WholeMessage,
+    bool IsReadingWholeMessage,
+    bool WholeMessageFailed)
+{
+    /// <summary>Gets whether there is anything of what the message added to draw.</summary>
+    /// <remarks>
+    /// A message this deployment holds but has not extracted yet has none, which is an ordinary state of a mailbox
+    /// still being taken in rather than a message with nothing in it. The expanded message says so rather than showing
+    /// a blank.
+    /// </remarks>
+    public bool HasContribution => this.Contribution.Length > 0;
+
+    /// <summary>Gets whether the message is expanded and nothing has been extracted of what it added.</summary>
+    public bool AwaitsContribution => this.IsExpanded && !this.HasContribution;
+
+    /// <summary>Gets whether there is anybody the message went to worth drawing.</summary>
+    /// <remarks>
+    /// A message whose recipients no header carried draws one line less rather than a label with nothing after it,
+    /// which is what a row of a list already does with a preview nothing has extracted.
+    /// </remarks>
+    public bool HasRecipients => this.Recipients.Length > 0;
+
+    /// <summary>Gets whether the whole message is drawn under what it added.</summary>
+    public bool ShowsWholeMessage => this.IsExpanded && this.WholeMessage is not null;
+
+    /// <summary>Gets whether the reader may still ask for the whole message, quoted history and all.</summary>
+    /// <remarks>
+    /// Stated as its own affirmative rather than read as the absence of a reading, so the offer is on the screen only
+    /// once the message is open and only while there is something to ask for. A read that did not arrive is the one
+    /// case where there is something to ask for and this is still false: the notice below carries the ask itself, and
+    /// two controls offering the same thing would read as two different ones.
+    /// </remarks>
+    public bool OffersWholeMessage =>
+        this.IsExpanded && this.WholeMessage is null && !this.IsReadingWholeMessage && !this.WholeMessageFailed;
+
+    /// <summary>Gets whether the whole message is on its way, which is what the message says while it waits.</summary>
+    public bool AwaitsWholeMessage => this.IsExpanded && this.IsReadingWholeMessage;
+
+    /// <summary>Gets whether the last attempt at the whole message did not arrive, which is what the retry is offered on.</summary>
+    public bool ShowsWholeMessageFailure => this.IsExpanded && this.WholeMessageFailed;
+
+    /// <summary>Gets whether the number of attachments is worth drawing beside the mark saying there are any.</summary>
+    public bool ShowsAttachmentCount => this.AttachmentCount > 1;
+
+    /// <summary>Gets how many attachments there are, as the reader's own language writes a number.</summary>
+    public string AttachmentCountText => this.AttachmentCount.ToString("N0", CultureInfo.CurrentCulture);
+}

--- a/frontend/src/Client/Presentation/Threads/ThreadOpening.cs
+++ b/frontend/src/Client/Presentation/Threads/ThreadOpening.cs
@@ -1,0 +1,29 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Presentation.Threads;
+
+/// <summary>Which conversation is open, and which message in it somebody arrived at.</summary>
+/// <param name="ThreadId">The conversation, or <see langword="null" /> where none is open.</param>
+/// <param name="AtMessage">The message somebody arrived at, or <see langword="null" /> where they arrived at the conversation itself.</param>
+/// <remarks>
+/// <para>
+/// One value rather than two states, because the two are decided together and never separately: arriving at a
+/// conversation from a search result, from a citation, or from a row of the list is one act, and a message named
+/// without the conversation it is in is not something this screen can open.
+/// </para>
+/// <para>
+/// Where nobody arrived at a particular message the newest is the one opened, which is what somebody catching up on a
+/// conversation came for. That is decided where the conversation is read rather than here, because it is a fact about
+/// what the deployment answered rather than about what was asked.
+/// </para>
+/// </remarks>
+internal sealed record ThreadOpening(Guid? ThreadId, Guid? AtMessage)
+{
+    /// <summary>Nothing open, which is what the screen starts at and what selecting nothing returns it to.</summary>
+    internal static ThreadOpening Nothing { get; } = new(ThreadId: null, AtMessage: null);
+
+    /// <summary>Gets whether a conversation is open at all.</summary>
+    internal bool IsOpen => this.ThreadId is not null;
+}

--- a/frontend/src/Client/Presentation/Threads/ThreadParticipantRow.cs
+++ b/frontend/src/Client/Presentation/Threads/ThreadParticipantRow.cs
@@ -10,9 +10,17 @@ namespace MailFathom.Client.Presentation.Threads;
 /// <param name="MessageCount">How many of the conversation's messages are theirs, as the reader's own language writes a number.</param>
 /// <param name="Announcement">The entry as one sentence, which is what a screen reader is given instead of two labels.</param>
 /// <remarks>
+/// <para>
 /// Drawn from what the deployment said about the whole conversation rather than from the messages in hand, which is the
 /// point of it being published at all: a header derived by walking the messages would name whoever happened to be on
 /// the first page and would change as more of the conversation arrived.
+/// </para>
+/// <para>
+/// It is <c>partial</c> because <paramref name="Key" /> makes it eligible for MVUX's key-equality generation, which is
+/// what carries an author across a redraw: a page taken onto the conversation updates the entries whose counts changed
+/// and leaves the containers of the rest alone. The generator refuses to run on a sealed record that is not partial and
+/// says so as <c>KE0001</c>.
+/// </para>
 /// </remarks>
 public sealed partial record ThreadParticipantRow(
     string Key,

--- a/frontend/src/Client/Presentation/Threads/ThreadParticipantRow.cs
+++ b/frontend/src/Client/Presentation/Threads/ThreadParticipantRow.cs
@@ -1,0 +1,21 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Presentation.Threads;
+
+/// <summary>One author of the conversation, as the header names them.</summary>
+/// <param name="Key">The address they wrote from, which is what this entry is matched by across a redraw.</param>
+/// <param name="Author">The name they wrote under, or the address they wrote from where no message carried one.</param>
+/// <param name="MessageCount">How many of the conversation's messages are theirs, as the reader's own language writes a number.</param>
+/// <param name="Announcement">The entry as one sentence, which is what a screen reader is given instead of two labels.</param>
+/// <remarks>
+/// Drawn from what the deployment said about the whole conversation rather than from the messages in hand, which is the
+/// point of it being published at all: a header derived by walking the messages would name whoever happened to be on
+/// the first page and would change as more of the conversation arrived.
+/// </remarks>
+public sealed partial record ThreadParticipantRow(
+    string Key,
+    string Author,
+    string MessageCount,
+    string Announcement);

--- a/frontend/src/Client/Presentation/Threads/ThreadReading.cs
+++ b/frontend/src/Client/Presentation/Threads/ThreadReading.cs
@@ -1,0 +1,103 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Immutable;
+
+namespace MailFathom.Client.Presentation.Threads;
+
+/// <summary>The conversation as its header is drawn, with every sentence about it already in words.</summary>
+/// <remarks>
+/// <para>
+/// The header is answered about the whole conversation rather than about the messages that have arrived, which is what
+/// the deployment publishes the participants and the count for: everything here stays true while the conversation is
+/// paged, and a screen that derived it would be reading a thread in order to say who is in it.
+/// </para>
+/// <para>
+/// Everything it carries is mail, so none of it is logged, written to local storage, or put in a telemetry event.
+/// </para>
+/// </remarks>
+public sealed record ThreadReading
+{
+    private ThreadReading()
+    {
+        this.IsClosed = true;
+        this.Subject = string.Empty;
+        this.MessageCount = string.Empty;
+        this.Announcement = string.Empty;
+        this.Participants = [];
+    }
+
+    /// <summary>No conversation open, which is what the screen shows before a message is selected.</summary>
+    public static ThreadReading Nothing { get; } = new();
+
+    /// <summary>Gets whether a conversation is open at all, as against a screen nothing has been opened in.</summary>
+    public bool IsOpen { get; private init; }
+
+    /// <summary>Gets whether nothing is open, which is what the screen shows before a message is selected.</summary>
+    /// <remarks>
+    /// Stated as its own affirmative rather than read as the absence of the one above, because both sides of the
+    /// decision are drawn and neither may be drawn before the answer arrives: a header carrying no value yet reaches a
+    /// binding as nothing at all, and a screen that showed <em>nothing is open</em> on that would announce an empty
+    /// conversation while the one somebody asked for was still on its way.
+    /// </remarks>
+    public bool IsClosed { get; private init; }
+
+    /// <summary>Gets what the conversation is about, taken from the message that began it.</summary>
+    public string Subject { get; private init; }
+
+    /// <summary>Gets how many messages the conversation holds, as the reader's own language writes a sentence about it.</summary>
+    public string MessageCount { get; private init; }
+
+    /// <summary>Gets the conversation stated once, which is what a screen reader is given for the header.</summary>
+    public string Announcement { get; private init; }
+
+    /// <summary>Gets everybody the deployment named as having written in the conversation.</summary>
+    public IImmutableList<ThreadParticipantRow> Participants { get; private init; }
+
+    /// <summary>Gets whether the conversation has authors the header does not name.</summary>
+    public bool HasUnnamedParticipants { get; private init; }
+
+    /// <summary>Gets whether the conversation runs past what one read of it assembles at all.</summary>
+    /// <remarks>
+    /// Said rather than hidden, and said as its own sentence rather than folded into the count: a conversation that
+    /// large is a mailing list's archive rather than correspondence somebody is following, and a screen that silently
+    /// showed the first five hundred of it would be claiming to show the whole.
+    /// </remarks>
+    public bool RunsPastAssembly { get; private init; }
+
+    /// <summary>Reads a conversation into the header the screen draws.</summary>
+    /// <param name="subject">What the conversation is about.</param>
+    /// <param name="messageCount">How many messages it holds, already in words.</param>
+    /// <param name="announcement">The whole header as one sentence.</param>
+    /// <param name="participants">Everybody the deployment named as having written in it.</param>
+    /// <param name="hasUnnamedParticipants">Whether it has authors the participants do not name.</param>
+    /// <param name="runsPastAssembly">Whether it runs past what one read assembles.</param>
+    /// <returns>The header.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    public static ThreadReading Of(
+        string subject,
+        string messageCount,
+        string announcement,
+        IImmutableList<ThreadParticipantRow> participants,
+        bool hasUnnamedParticipants,
+        bool runsPastAssembly)
+    {
+        ArgumentNullException.ThrowIfNull(subject);
+        ArgumentNullException.ThrowIfNull(messageCount);
+        ArgumentNullException.ThrowIfNull(announcement);
+        ArgumentNullException.ThrowIfNull(participants);
+
+        return new ThreadReading
+        {
+            IsOpen = true,
+            IsClosed = false,
+            Subject = subject,
+            MessageCount = messageCount,
+            Announcement = announcement,
+            Participants = participants,
+            HasUnnamedParticipants = hasUnnamedParticipants,
+            RunsPastAssembly = runsPastAssembly,
+        };
+    }
+}

--- a/frontend/src/Client/Presentation/Threads/ThreadShape.cs
+++ b/frontend/src/Client/Presentation/Threads/ThreadShape.cs
@@ -1,0 +1,286 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Immutable;
+using System.Globalization;
+using MailFathom.Client.Backend.Threads;
+using MailFathom.Client.Backend.Timeline;
+using MailFathom.Client.Presentation.Messages;
+using Microsoft.Extensions.Localization;
+
+namespace MailFathom.Client.Presentation.Threads;
+
+/// <summary>Reduces a read conversation to the header and the messages the screen draws.</summary>
+/// <remarks>
+/// <para>
+/// A pure reduction of what the deployment answered and what the reader has opened, so the whole of what a conversation
+/// says is reachable by an ordinary unit test rather than only by looking at a running head — which is the same reason
+/// the message list is shaped outside its view.
+/// </para>
+/// <para>
+/// It composes rather than formats in the view because a binding cannot stand a sentence in for a subject nobody wrote,
+/// cannot write a date in the reader's own culture, and cannot compose the one line a screen reader is given instead of
+/// the several controls a sighted reader sees.
+/// </para>
+/// </remarks>
+internal static class ThreadShape
+{
+    /// <summary>Draws the conversation's header, which is answered about the whole of it rather than about the page.</summary>
+    /// <param name="window">What has been read of the conversation.</param>
+    /// <param name="words">Where the sentences the header is composed from come from.</param>
+    /// <returns>The header, or the empty one where no conversation is open.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    internal static ThreadReading Header(ThreadWindow window, IStringLocalizer words)
+    {
+        ArgumentNullException.ThrowIfNull(window);
+        ArgumentNullException.ThrowIfNull(words);
+
+        if (!window.IsOpen)
+        {
+            return ThreadReading.Nothing;
+        }
+
+        var subject = Subject(window, words);
+        var count = words[ThreadWords.MessageCountKey, window.MessageCount].Value;
+
+        return ThreadReading.Of(
+            subject,
+            count,
+            words[ThreadWords.AnnouncementKey, subject, count].Value,
+            [.. window.Participants.Select(participant => Draw(participant, words)).OfType<ThreadParticipantRow>()],
+            window.MoreParticipantsNotNamed,
+            window.MoreMessagesNotAssembled);
+    }
+
+    /// <summary>Draws what has been read of the conversation as the messages the screen shows.</summary>
+    /// <param name="window">What has been read, in the conversation's own order.</param>
+    /// <param name="opened">How much of each message the reader has asked to see, by the message's own identity, for the messages they have asked anything of.</param>
+    /// <param name="words">Where the sentences a message is composed from come from.</param>
+    /// <returns>The messages, in the conversation's own order.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    internal static IImmutableList<ThreadMessageRow> Messages(
+        ThreadWindow window,
+        IImmutableDictionary<string, ThreadMessageDetail> opened,
+        IStringLocalizer words)
+    {
+        ArgumentNullException.ThrowIfNull(window);
+        ArgumentNullException.ThrowIfNull(opened);
+        ArgumentNullException.ThrowIfNull(words);
+
+        var openedAt = OpenedKey(window);
+
+        return [.. window.Messages.Select(message => Draw(message, DetailOf(message, opened, openedAt), openedAt, words))];
+    }
+
+    /// <summary>Says how much of one message is shown, for a message the reader has said nothing about.</summary>
+    /// <remarks>
+    /// The message a conversation opened at is expanded without anything having been written down, which is what keeps
+    /// opening one from being a write: a conversation opened and left alone has an empty set of disclosures, and the
+    /// same conversation reopened at another message opens there rather than where the last one did. Collapsing the
+    /// opened message writes an entry, and that entry then decides — so the reader's own act always wins over the
+    /// default.
+    /// </remarks>
+    internal static ThreadMessageDetail DetailOf(
+        DeploymentThreadMessage message,
+        IImmutableDictionary<string, ThreadMessageDetail> opened,
+        string openedAt)
+    {
+        ArgumentNullException.ThrowIfNull(opened);
+
+        var key = KeyOf(message);
+
+        if (opened.TryGetValue(key, out var detail))
+        {
+            return detail;
+        }
+
+        return string.Equals(key, openedAt, StringComparison.Ordinal)
+            ? ThreadMessageDetail.Opened
+            : ThreadMessageDetail.Collapsed;
+    }
+
+    /// <summary>Names the message a conversation opens showing, which is the one somebody arrived at or the newest.</summary>
+    /// <param name="window">What has been read of the conversation.</param>
+    /// <returns>The message's identity, or an empty string where the conversation holds none.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="window" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// Arriving at a particular message is not an edge case — it is how a search result and a citation reach mail at
+    /// all — so the message named is the one opened whether or not it is the newest. Where nobody named one, the newest
+    /// is what somebody catching up on the conversation came for, and the order is the conversation's own, so the
+    /// newest is the last of it that has been read. A message the conversation no longer shows names nothing, which
+    /// leaves the newest opened rather than the conversation opened at nothing.
+    /// </remarks>
+    internal static string OpenedKey(ThreadWindow window)
+    {
+        ArgumentNullException.ThrowIfNull(window);
+
+        if (window.Messages.Count is 0)
+        {
+            return string.Empty;
+        }
+
+        if (window.OpenedAt is { } arrivedAt)
+        {
+            var named = Written(arrivedAt);
+
+            if (window.Messages.Any(message => string.Equals(KeyOf(message), named, StringComparison.Ordinal)))
+            {
+                return named;
+            }
+        }
+
+        return KeyOf(window.Messages[^1]);
+    }
+
+    /// <summary>Names one message of the conversation as every other part of the client names it.</summary>
+    internal static string KeyOf(DeploymentThreadMessage message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        return message.Email is { } email ? Written(email.Id) : string.Empty;
+    }
+
+    private static string Written(Guid identity) => identity.ToString("D", CultureInfo.InvariantCulture);
+
+    /// <summary>Takes what the conversation is about from the message that began it.</summary>
+    /// <remarks>
+    /// The first message rather than the newest, because a subject rewritten halfway down a thread describes a reply
+    /// rather than the exchange, and because paging forward would otherwise rewrite the header somebody is reading
+    /// under.
+    /// </remarks>
+    private static string Subject(ThreadWindow window, IStringLocalizer words)
+    {
+        var opening = window.Messages.Count is 0 ? null : window.Messages[0].Email?.Subject;
+
+        return string.IsNullOrWhiteSpace(opening) ? words[MessageWords.NoSubjectKey].Value : opening;
+    }
+
+    /// <summary>Draws one author of the conversation, or nothing where the answer named neither a name nor an address.</summary>
+    private static ThreadParticipantRow? Draw(DeploymentThreadParticipant participant, IStringLocalizer words)
+    {
+        var author = Named(participant.DisplayName, participant.Address);
+
+        if (author is null)
+        {
+            return null;
+        }
+
+        return new ThreadParticipantRow(
+            string.IsNullOrWhiteSpace(participant.Address) ? author : participant.Address,
+            author,
+            words[ThreadWords.ParticipantMessagesKey, participant.MessageCount].Value,
+
+            // The count rather than what is drawn beside the name: the two entries are written for different readers,
+            // and a sentence composed from a bracketed number would be read out as one.
+            words[ThreadWords.ParticipantAnnouncementKey, author, participant.MessageCount].Value);
+    }
+
+    /// <summary>Draws one message of the conversation as the screen shows it.</summary>
+    private static ThreadMessageRow Draw(
+        DeploymentThreadMessage message,
+        ThreadMessageDetail detail,
+        string openedAt,
+        IStringLocalizer words)
+    {
+        var email = message.Email!;
+        var key = Written(email.Id);
+        var author = Named(email.SenderDisplayName, email.SenderAddress) ?? words[MessageWords.NoSenderKey].Value;
+        var subject = string.IsNullOrWhiteSpace(email.Subject)
+            ? words[MessageWords.NoSubjectKey].Value
+            : email.Subject;
+        var written = Written(email, words);
+
+        return new ThreadMessageRow(
+            key,
+            author,
+            subject,
+            Recipients(email, words),
+            email.Preview ?? string.Empty,
+            written,
+            Announced(author, subject, written, email, words),
+            detail.Expanded,
+            string.Equals(key, openedAt, StringComparison.Ordinal),
+            email.Unread,
+            email.Flagged,
+            email.Answered,
+            email.HasAttachments,
+            email.AttachmentCount,
+            detail.WholeMessage,
+            detail.IsReadingWholeMessage,
+            detail.WholeMessageFailed);
+    }
+
+    /// <summary>Writes who a message went to, or nothing where it named nobody this screen can draw.</summary>
+    private static string Recipients(DeploymentMailMessage email, IStringLocalizer words) => email.Recipients switch
+    {
+        [] => string.Empty,
+        [var only] => words[ThreadWords.RecipientsKey, only].Value,
+        [var first, ..] => words[
+            ThreadWords.RecipientsKey,
+            words[MessageWords.MoreRecipientsKey, first, email.Recipients.Count - 1].Value].Value,
+    };
+
+    /// <summary>Takes the display name where the header carried one and the address otherwise.</summary>
+    private static string? Named(string? displayName, string? address) =>
+        string.IsNullOrWhiteSpace(displayName)
+            ? (string.IsNullOrWhiteSpace(address) ? null : address)
+            : displayName;
+
+    /// <summary>
+    /// Writes when a message was written, with its date and its time and in the reader's own culture.
+    /// </summary>
+    /// <remarks>
+    /// In full rather than in the three bands the message list writes. A list is read down one folder's recent mail, so
+    /// a time is enough for today and a day is enough for this year; a conversation is read across whatever span it
+    /// covers, and two replies a year apart written as <c>14:02</c> and <c>3 Aug</c> would place neither.
+    /// </remarks>
+    private static string Written(DeploymentMailMessage email, IStringLocalizer words)
+    {
+        var written = email.SentAt ?? email.ReceivedAt;
+
+        return written is { } instant
+            ? instant.ToLocalTime().ToString("g", CultureInfo.CurrentCulture)
+            : words[MessageWords.NoDateKey].Value;
+    }
+
+    /// <summary>Composes the one sentence a screen reader is given for a message.</summary>
+    /// <remarks>
+    /// The same shape a list row is announced with, and through the same entries: a conversation's messages and a
+    /// folder's rows stand for the same thing, and announcing them differently would make one exchange read as two
+    /// kinds of mail. The marks are appended rather than folded in, because each is absent from most messages.
+    /// </remarks>
+    private static string Announced(
+        string author,
+        string subject,
+        string written,
+        DeploymentMailMessage email,
+        IStringLocalizer words)
+    {
+        var announced = words[MessageWords.AnnouncementKey, author, subject, written].Value;
+
+        var marks = new List<string>(4);
+
+        if (email.Unread)
+        {
+            marks.Add(words[MessageWords.UnreadKey].Value);
+        }
+
+        if (email.Flagged)
+        {
+            marks.Add(words[MessageWords.FlaggedKey].Value);
+        }
+
+        if (email.Answered)
+        {
+            marks.Add(words[MessageWords.AnsweredKey].Value);
+        }
+
+        if (email.HasAttachments)
+        {
+            marks.Add(words[MessageWords.AttachmentsKey].Value);
+        }
+
+        return marks.Count is 0 ? announced : $"{announced} {string.Join(' ', marks)}";
+    }
+}

--- a/frontend/src/Client/Presentation/Threads/ThreadShape.cs
+++ b/frontend/src/Client/Presentation/Threads/ThreadShape.cs
@@ -122,7 +122,7 @@ internal static class ThreadShape
 
         if (window.OpenedAt is { } arrivedAt)
         {
-            var named = Written(arrivedAt);
+            var named = KeyOf(arrivedAt);
 
             if (window.Messages.Any(message => string.Equals(KeyOf(message), named, StringComparison.Ordinal)))
             {
@@ -138,10 +138,11 @@ internal static class ThreadShape
     {
         ArgumentNullException.ThrowIfNull(message);
 
-        return message.Email is { } email ? Written(email.Id) : string.Empty;
+        return message.Email is { } email ? KeyOf(email.Id) : string.Empty;
     }
 
-    private static string Written(Guid identity) => identity.ToString("D", CultureInfo.InvariantCulture);
+    /// <summary>Names one message as every other part of the client names it, from the identity alone.</summary>
+    private static string KeyOf(Guid identity) => identity.ToString("D", CultureInfo.InvariantCulture);
 
     /// <summary>Takes what the conversation is about from the message that began it.</summary>
     /// <remarks>
@@ -184,7 +185,7 @@ internal static class ThreadShape
         IStringLocalizer words)
     {
         var email = message.Email!;
-        var key = Written(email.Id);
+        var key = KeyOf(email.Id);
         var author = Named(email.SenderDisplayName, email.SenderAddress) ?? words[MessageWords.NoSenderKey].Value;
         var subject = string.IsNullOrWhiteSpace(email.Subject)
             ? words[MessageWords.NoSubjectKey].Value

--- a/frontend/src/Client/Presentation/Threads/ThreadWindow.cs
+++ b/frontend/src/Client/Presentation/Threads/ThreadWindow.cs
@@ -1,0 +1,125 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Immutable;
+using MailFathom.Client.Backend.Threads;
+
+namespace MailFathom.Client.Presentation.Threads;
+
+/// <summary>What of one conversation has been read, and where reading it continues from.</summary>
+/// <param name="ThreadId">The conversation, or <see langword="null" /> where none is open.</param>
+/// <param name="Messages">The messages read so far, in the conversation's own order.</param>
+/// <param name="Participants">Everybody the deployment named as having written in the conversation.</param>
+/// <param name="MessageCount">How many messages the whole conversation holds of those this caller may see.</param>
+/// <param name="MoreMessagesNotAssembled">Whether the conversation runs past what one read assembles at all.</param>
+/// <param name="MoreParticipantsNotNamed">Whether the conversation has authors the participants do not name.</param>
+/// <param name="NextCursor">The cursor the following page is asked with, or <see langword="null" /> where the conversation ends here.</param>
+/// <param name="OpenedAt">The message somebody arrived at, or <see langword="null" /> where the newest is the one opened.</param>
+/// <remarks>
+/// <para>
+/// A conversation grows forwards and never backwards, which is what makes this an accumulation rather than the bounded
+/// window the message list holds: a thread is read from its beginning and the bound on it is the deployment's own, so
+/// there is no far end to drop and nothing to ask for a second time.
+/// </para>
+/// <para>
+/// Everything outside the messages is answered about the whole conversation rather than about the page, so a header
+/// drawn from the first page stays true as later pages arrive — and a later page that answered nothing about them
+/// leaves what the first one said standing rather than emptying it.
+/// </para>
+/// <para>
+/// The messages are this owner's own correspondence and carry the classification of everything else about mail: they
+/// are held for as long as the conversation is open and are written nowhere.
+/// </para>
+/// </remarks>
+internal sealed record ThreadWindow(
+    Guid? ThreadId,
+    IImmutableList<DeploymentThreadMessage> Messages,
+    IImmutableList<DeploymentThreadParticipant> Participants,
+    int MessageCount,
+    bool MoreMessagesNotAssembled,
+    bool MoreParticipantsNotNamed,
+    string? NextCursor,
+    Guid? OpenedAt)
+{
+    /// <summary>No conversation open, which is what the screen holds before one is.</summary>
+    internal static ThreadWindow Nothing { get; } = new(
+        ThreadId: null,
+        [],
+        [],
+        MessageCount: 0,
+        MoreMessagesNotAssembled: false,
+        MoreParticipantsNotNamed: false,
+        NextCursor: null,
+        OpenedAt: null);
+
+    /// <summary>Gets whether a conversation is open at all, as against a screen nothing has been opened in.</summary>
+    internal bool IsOpen => this.ThreadId is not null;
+
+    /// <summary>Gets whether there is more of the conversation to read.</summary>
+    internal bool HasMore => this.NextCursor is not null;
+
+    /// <summary>Reads the first page of a conversation somebody has just opened.</summary>
+    /// <param name="opening">Which conversation was opened, and at which message.</param>
+    /// <param name="page">What the deployment answered.</param>
+    /// <returns>The window that first page establishes.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    internal static ThreadWindow Opening(ThreadOpening opening, DeploymentMailThreadPage page)
+    {
+        ArgumentNullException.ThrowIfNull(opening);
+        ArgumentNullException.ThrowIfNull(page);
+
+        return new ThreadWindow(
+            opening.ThreadId,
+            [.. Readable(page)],
+            [.. page.Authors],
+            page.MessageCount,
+            page.MoreMessagesNotAssembled,
+            page.MoreParticipantsNotNamed,
+            page.NextCursor,
+            opening.AtMessage);
+    }
+
+    /// <summary>Takes the following page onto the end of what has been read.</summary>
+    /// <param name="page">What the deployment answered.</param>
+    /// <returns>The window the page extends.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="page" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The counts and the participants are taken from the newer answer, because each of them describes the whole
+    /// conversation as the deployment reads it now rather than as it read it when the first page was asked for.
+    /// </remarks>
+    internal ThreadWindow Extended(DeploymentMailThreadPage page)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        return this with
+        {
+            Messages = [.. this.Messages, .. Readable(page)],
+            Participants = [.. page.Authors],
+            MessageCount = page.MessageCount,
+            MoreMessagesNotAssembled = page.MoreMessagesNotAssembled,
+            MoreParticipantsNotNamed = page.MoreParticipantsNotNamed,
+            NextCursor = page.NextCursor,
+        };
+    }
+
+    /// <summary>Gets whether this window is of the same reading of the same conversation as another.</summary>
+    /// <param name="other">The window a read was started from.</param>
+    /// <returns><see langword="true" /> when both hold the same conversation opened at the same message.</returns>
+    /// <remarks>
+    /// What a page arriving late is held against. A read started while one conversation was open and answered after
+    /// another has been is a page of neither, and splicing it on would put one exchange's messages under another's
+    /// header.
+    /// </remarks>
+    internal bool IsOf(ThreadWindow other) =>
+        other is not null && this.ThreadId == other.ThreadId && this.OpenedAt == other.OpenedAt;
+
+    /// <summary>Keeps the messages a screen can draw, which is those the deployment described at all.</summary>
+    /// <remarks>
+    /// A message the answer named without a body of its own is a document this build cannot draw a line from, so it is
+    /// left out rather than drawn as a row with nothing in it. It stays counted, because the count is the deployment's
+    /// statement about the conversation rather than about what arrived here.
+    /// </remarks>
+    private static IEnumerable<DeploymentThreadMessage> Readable(DeploymentMailThreadPage page) =>
+        page.Written.Where(static message => message.Email is not null);
+}

--- a/frontend/src/Client/Presentation/Threads/ThreadWords.cs
+++ b/frontend/src/Client/Presentation/Threads/ThreadWords.cs
@@ -1,0 +1,53 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Presentation.Threads;
+
+/// <summary>The words a conversation is written in that no control authors, and the one place their entries are named.</summary>
+/// <remarks>
+/// <para>
+/// Only what is composed from what a deployment answered is here. Everything a control states about itself — the button
+/// that asks for the whole message, the notice that a conversation runs past what is assembled — is named by a
+/// <c>x:Uid</c> on that control instead, which is where a reader of the page looks for it.
+/// </para>
+/// <para>
+/// What a message row shares with the message list is asked for through <see cref="Messages.MessageWords" /> rather
+/// than named again here. A conversation's rows and a folder's rows stand in for the same absences — a message nobody
+/// dated, a sender no header carried, a subject nobody wrote — and two tables saying so would be one sentence
+/// translated twice.
+/// </para>
+/// </remarks>
+internal static class ThreadWords
+{
+    /// <summary>The entry saying how many messages the conversation holds, which takes the count.</summary>
+    internal const string MessageCountKey = "Thread.MessageCount";
+
+    /// <summary>The entry naming who a message went to, which takes the recipients already written as a line.</summary>
+    internal const string RecipientsKey = "Thread.Recipients";
+
+    /// <summary>The entry saying how many of the conversation's messages one author wrote, which takes the count.</summary>
+    internal const string ParticipantMessagesKey = "Thread.Participant.Messages";
+
+    /// <summary>The entry a participant's whole announcement is composed through, which takes the author and the count.</summary>
+    internal const string ParticipantAnnouncementKey = "Thread.Participant.Announcement";
+
+    /// <summary>The entry the header's whole announcement is composed through, which takes the subject and the count.</summary>
+    internal const string AnnouncementKey = "Thread.Announcement";
+
+    /// <summary>
+    /// Every entry a conversation asks the tables for, which is what the suite holds each authored table to answering.
+    /// </summary>
+    /// <remarks>
+    /// Named as one list rather than asserted key by key, so an entry added to the header or to a message and nowhere
+    /// else is reported by the suite rather than met by a reader as the key itself.
+    /// </remarks>
+    internal static IReadOnlyList<string> ResourceKeys { get; } =
+    [
+        MessageCountKey,
+        RecipientsKey,
+        ParticipantMessagesKey,
+        ParticipantAnnouncementKey,
+        AnnouncementKey,
+    ];
+}

--- a/frontend/src/Client/Strings/en/Resources.resw
+++ b/frontend/src/Client/Strings/en/Resources.resw
@@ -429,13 +429,105 @@
     <value>What is already shown is still current. Ask for the page again.</value>
     <comment>Says that nothing was lost, because a warning over a list that is still correct otherwise reads as the list being wrong.</comment>
   </data>
-  <data name="MailPage.Reading.Heading" xml:space="preserve">
-    <value>Reading</value>
+  <data name="MailPage.Thread.Heading" xml:space="preserve">
+    <value>Conversation</value>
     <comment>Names the companion column of the Mail space, which a wide window shows beside the list.</comment>
   </data>
-  <data name="MailPage.Reading.Detail" xml:space="preserve">
-    <value>This column is still being built.</value>
-    <comment>The companion column's counterpart to the sentence above.</comment>
+  <data name="MailPage.Thread.Detail" xml:space="preserve">
+    <value>Select a message to read the conversation it is part of.</value>
+    <comment>Says what to do rather than that something is missing: nothing being open is the ordinary state of this column.</comment>
+  </data>
+  <data name="MailPage.List.ThreadMessages.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Messages in this conversation</value>
+    <comment>Names the list itself, so a screen reader announces what the messages belong to before it reads one.</comment>
+  </data>
+  <data name="MailPage.Toggle.ThreadMessage.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Show what this message added</value>
+    <comment>Names the control that opens one message of the conversation. The control announces whether it is on, so the name says only what it does.</comment>
+  </data>
+  <data name="MailPage.TextBlock.MoreParticipants.Text" xml:space="preserve">
+    <value>Others wrote in this conversation too.</value>
+    <comment>Says that the header names some of the authors rather than all of them, so a long conversation is not read as having had fewer people in it.</comment>
+  </data>
+  <data name="MailPage.TextBlock.NoContribution.Text" xml:space="preserve">
+    <value>MailFathom has not read this message yet, so there is nothing to show of what it added.</value>
+    <comment>Names the ordinary state of a mailbox still being taken in, so a message with nothing under it is not read as one somebody sent empty.</comment>
+  </data>
+  <data name="MailPage.Button.ShowWholeMessage.Content" xml:space="preserve">
+    <value>Show the whole message</value>
+    <comment>Asks for the message itself, quoted history and all, which is the one gesture in this column that costs a request.</comment>
+  </data>
+  <data name="MailPage.InfoBar.WholeMessageUnavailable.Title" xml:space="preserve">
+    <value>That message did not arrive</value>
+    <comment>Heads a failed read of one whole message, which leaves the conversation and what the message added on the screen.</comment>
+  </data>
+  <data name="MailPage.InfoBar.WholeMessageUnavailable.Message" xml:space="preserve">
+    <value>What this message added is still shown above. Ask for the whole of it again.</value>
+    <comment>Says that nothing was lost, because a warning over a message that is still readable otherwise reads as the message being wrong.</comment>
+  </data>
+  <data name="MailPage.Button.RetryWholeMessage.Content" xml:space="preserve">
+    <value>Try again</value>
+    <comment>Asks the deployment for the whole message again, which is what a person presses when it did not arrive.</comment>
+  </data>
+  <data name="MailPage.InfoBar.ThreadRunsPast.Title" xml:space="preserve">
+    <value>This conversation is longer than it is shown</value>
+    <comment>Heads a conversation too large to assemble in one read, which is a mailing list's archive rather than correspondence somebody is following.</comment>
+  </data>
+  <data name="MailPage.InfoBar.ThreadRunsPast.Message" xml:space="preserve">
+    <value>MailFathom assembles a conversation up to a bound, and this one runs past it. What is shown is the beginning of it rather than the whole.</value>
+    <comment>Says which part is shown, because a screen that showed part of a conversation silently would be claiming to show all of it.</comment>
+  </data>
+  <data name="MailPage.InfoBar.NoThreadMessages.Title" xml:space="preserve">
+    <value>Nothing to show</value>
+    <comment>Heads an open conversation with no message this client can draw, which is a state rather than a failure.</comment>
+  </data>
+  <data name="MailPage.InfoBar.NoThreadMessages.Message" xml:space="preserve">
+    <value>This conversation holds no message MailFathom has taken in yet. The mailbox pane says how current this copy is.</value>
+    <comment>Points at where how current a copy is, is actually said, which is per folder in the tree rather than repeated here.</comment>
+  </data>
+  <data name="MailPage.InfoBar.ThreadUnavailable.Title" xml:space="preserve">
+    <value>This conversation could not be read</value>
+    <comment>Heads the state a failed read of the conversation is shown.</comment>
+  </data>
+  <data name="MailPage.InfoBar.ThreadUnavailable.Message" xml:space="preserve">
+    <value>MailFathom did not answer with this conversation. Try again, and look at the mailbox pane if it keeps failing.</value>
+    <comment>Says what to try in this application's own words rather than repeating a message written for a log.</comment>
+  </data>
+  <data name="MailPage.Button.RetryThread.Content" xml:space="preserve">
+    <value>Try again</value>
+    <comment>Asks the deployment for the conversation again, which is what a person presses when it did not arrive.</comment>
+  </data>
+  <data name="MailPage.InfoBar.ThreadPageUnavailable.Title" xml:space="preserve">
+    <value>That page did not arrive</value>
+    <comment>Heads a page of the conversation that failed, which leaves the messages already drawn on the screen.</comment>
+  </data>
+  <data name="MailPage.InfoBar.ThreadPageUnavailable.Message" xml:space="preserve">
+    <value>What is already shown is still current. Ask for the page again.</value>
+    <comment>Says that nothing was lost, because a warning over a conversation that is still correct otherwise reads as the conversation being wrong.</comment>
+  </data>
+  <data name="MailPage.Button.ShowMoreThreadMessages.Content" xml:space="preserve">
+    <value>Show more of this conversation</value>
+    <comment>Asks for the next page of the conversation, which runs forward from where the last one ended.</comment>
+  </data>
+  <data name="Thread.MessageCount" xml:space="preserve">
+    <value>Messages: {0}</value>
+    <comment>Says how large the whole conversation is, as the deployment answered it rather than as what has been read. Written as a label and a number so one message and many read correctly under one entry.</comment>
+  </data>
+  <data name="Thread.Announcement" xml:space="preserve">
+    <value>Conversation: {0}. {1}</value>
+    <comment>Composes the header as the one sentence a screen reader is given instead of a subject, a count, and a row of authors. Takes the subject and the count already in words.</comment>
+  </data>
+  <data name="Thread.Recipients" xml:space="preserve">
+    <value>To {0}</value>
+    <comment>Names who an opened message went to. Takes the recipients already written as a line, so the entry says only what the line is for.</comment>
+  </data>
+  <data name="Thread.Participant.Messages" xml:space="preserve">
+    <value>({0})</value>
+    <comment>How many of the conversation's messages one author wrote, drawn beside their name. A number in its own right rather than a sentence, because the name it sits beside is the sentence.</comment>
+  </data>
+  <data name="Thread.Participant.Announcement" xml:space="preserve">
+    <value>{0}, messages written: {1}</value>
+    <comment>Composes one author as the sentence a screen reader is given instead of a name and a number. Written as a label and a number so one message and many read correctly under one entry.</comment>
   </data>
   <data name="CasesPage.Cases.Heading" xml:space="preserve">
     <value>Cases</value>

--- a/frontend/src/Client/Strings/pl/Resources.resw
+++ b/frontend/src/Client/Strings/pl/Resources.resw
@@ -429,13 +429,105 @@
     <value>To, co już widać, jest nadal aktualne. Poproś o tę stronę jeszcze raz.</value>
     <comment>Says that nothing was lost, because a warning over a list that is still correct otherwise reads as the list being wrong.</comment>
   </data>
-  <data name="MailPage.Reading.Heading" xml:space="preserve">
-    <value>Czytanie</value>
+  <data name="MailPage.Thread.Heading" xml:space="preserve">
+    <value>Rozmowa</value>
     <comment>Names the companion column of the Mail space, which a wide window shows beside the list.</comment>
   </data>
-  <data name="MailPage.Reading.Detail" xml:space="preserve">
-    <value>Ta kolumna jest wciąż budowana.</value>
-    <comment>The companion column's counterpart to the sentence above.</comment>
+  <data name="MailPage.Thread.Detail" xml:space="preserve">
+    <value>Wybierz wiadomość, aby przeczytać rozmowę, której jest częścią.</value>
+    <comment>Says what to do rather than that something is missing: nothing being open is the ordinary state of this column.</comment>
+  </data>
+  <data name="MailPage.List.ThreadMessages.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Wiadomości w tej rozmowie</value>
+    <comment>Names the list itself, so a screen reader announces what the messages belong to before it reads one.</comment>
+  </data>
+  <data name="MailPage.Toggle.ThreadMessage.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Pokaż, co wnosi ta wiadomość</value>
+    <comment>Names the control that opens one message of the conversation. The control announces whether it is on, so the name says only what it does.</comment>
+  </data>
+  <data name="MailPage.TextBlock.MoreParticipants.Text" xml:space="preserve">
+    <value>W tej rozmowie pisały też inne osoby.</value>
+    <comment>Says that the header names some of the authors rather than all of them, so a long conversation is not read as having had fewer people in it.</comment>
+  </data>
+  <data name="MailPage.TextBlock.NoContribution.Text" xml:space="preserve">
+    <value>MailFathom nie przeczytał jeszcze tej wiadomości, więc nie ma czego pokazać z tego, co wnosi.</value>
+    <comment>Names the ordinary state of a mailbox still being taken in, so a message with nothing under it is not read as one somebody sent empty.</comment>
+  </data>
+  <data name="MailPage.Button.ShowWholeMessage.Content" xml:space="preserve">
+    <value>Pokaż całą wiadomość</value>
+    <comment>Asks for the message itself, quoted history and all, which is the one gesture in this column that costs a request.</comment>
+  </data>
+  <data name="MailPage.InfoBar.WholeMessageUnavailable.Title" xml:space="preserve">
+    <value>Ta wiadomość nie dotarła</value>
+    <comment>Heads a failed read of one whole message, which leaves the conversation and what the message added on the screen.</comment>
+  </data>
+  <data name="MailPage.InfoBar.WholeMessageUnavailable.Message" xml:space="preserve">
+    <value>To, co wnosi ta wiadomość, jest nadal widoczne powyżej. Poproś o całość jeszcze raz.</value>
+    <comment>Says that nothing was lost, because a warning over a message that is still readable otherwise reads as the message being wrong.</comment>
+  </data>
+  <data name="MailPage.Button.RetryWholeMessage.Content" xml:space="preserve">
+    <value>Spróbuj ponownie</value>
+    <comment>Asks the deployment for the whole message again, which is what a person presses when it did not arrive.</comment>
+  </data>
+  <data name="MailPage.InfoBar.ThreadRunsPast.Title" xml:space="preserve">
+    <value>Ta rozmowa jest dłuższa, niż tu widać</value>
+    <comment>Heads a conversation too large to assemble in one read, which is a mailing list's archive rather than correspondence somebody is following.</comment>
+  </data>
+  <data name="MailPage.InfoBar.ThreadRunsPast.Message" xml:space="preserve">
+    <value>MailFathom składa rozmowę do pewnej granicy, a ta ją przekracza. Widoczny jest jej początek, a nie całość.</value>
+    <comment>Says which part is shown, because a screen that showed part of a conversation silently would be claiming to show all of it.</comment>
+  </data>
+  <data name="MailPage.InfoBar.NoThreadMessages.Title" xml:space="preserve">
+    <value>Nie ma czego pokazać</value>
+    <comment>Heads an open conversation with no message this client can draw, which is a state rather than a failure.</comment>
+  </data>
+  <data name="MailPage.InfoBar.NoThreadMessages.Message" xml:space="preserve">
+    <value>Ta rozmowa nie zawiera żadnej wiadomości, którą MailFathom już pobrał. Panel skrzynek mówi, jak aktualna jest ta kopia.</value>
+    <comment>Points at where how current a copy is, is actually said, which is per folder in the tree rather than repeated here.</comment>
+  </data>
+  <data name="MailPage.InfoBar.ThreadUnavailable.Title" xml:space="preserve">
+    <value>Nie udało się odczytać tej rozmowy</value>
+    <comment>Heads the state a failed read of the conversation is shown.</comment>
+  </data>
+  <data name="MailPage.InfoBar.ThreadUnavailable.Message" xml:space="preserve">
+    <value>MailFathom nie odpowiedział tą rozmową. Spróbuj ponownie, a jeśli błąd się powtarza, zajrzyj do panelu skrzynek.</value>
+    <comment>Says what to try in this application's own words rather than repeating a message written for a log.</comment>
+  </data>
+  <data name="MailPage.Button.RetryThread.Content" xml:space="preserve">
+    <value>Spróbuj ponownie</value>
+    <comment>Asks the deployment for the conversation again, which is what a person presses when it did not arrive.</comment>
+  </data>
+  <data name="MailPage.InfoBar.ThreadPageUnavailable.Title" xml:space="preserve">
+    <value>Ta strona nie dotarła</value>
+    <comment>Heads a page of the conversation that failed, which leaves the messages already drawn on the screen.</comment>
+  </data>
+  <data name="MailPage.InfoBar.ThreadPageUnavailable.Message" xml:space="preserve">
+    <value>To, co już widać, jest nadal aktualne. Poproś o tę stronę jeszcze raz.</value>
+    <comment>Says that nothing was lost, because a warning over a conversation that is still correct otherwise reads as the conversation being wrong.</comment>
+  </data>
+  <data name="MailPage.Button.ShowMoreThreadMessages.Content" xml:space="preserve">
+    <value>Pokaż dalszą część rozmowy</value>
+    <comment>Asks for the next page of the conversation, which runs forward from where the last one ended.</comment>
+  </data>
+  <data name="Thread.MessageCount" xml:space="preserve">
+    <value>Wiadomości: {0}</value>
+    <comment>Says how large the whole conversation is, as the deployment answered it rather than as what has been read. Written as a label and a number so one message and many read correctly under one entry.</comment>
+  </data>
+  <data name="Thread.Announcement" xml:space="preserve">
+    <value>Rozmowa: {0}. {1}</value>
+    <comment>Composes the header as the one sentence a screen reader is given instead of a subject, a count, and a row of authors. Takes the subject and the count already in words.</comment>
+  </data>
+  <data name="Thread.Recipients" xml:space="preserve">
+    <value>Do {0}</value>
+    <comment>Names who an opened message went to. Takes the recipients already written as a line, so the entry says only what the line is for.</comment>
+  </data>
+  <data name="Thread.Participant.Messages" xml:space="preserve">
+    <value>({0})</value>
+    <comment>How many of the conversation's messages one author wrote, drawn beside their name. A number in its own right rather than a sentence, because the name it sits beside is the sentence.</comment>
+  </data>
+  <data name="Thread.Participant.Announcement" xml:space="preserve">
+    <value>{0}, liczba napisanych wiadomości: {1}</value>
+    <comment>Composes one author as the sentence a screen reader is given instead of a name and a number. Written as a label and a number so one message and many read correctly under one entry.</comment>
   </data>
   <data name="CasesPage.Cases.Heading" xml:space="preserve">
     <value>Sprawy</value>

--- a/frontend/src/README.md
+++ b/frontend/src/README.md
@@ -129,6 +129,25 @@ the list into a selecting mode that is visible and can be left. Loading, a read 
 and a folder whose mail this list is keeping out are four rendered states rather than one blank list — the last two are
 told apart in words, and how current the copy is stays the tree's to say.
 
+**The conversation that selection is in is the other half of the space.** `Client/Presentation/Threads/` holds it, and
+`IMailThread` is registered once for the run beside the list — not because a screen keeps it, but because a conversation
+is reached by naming one message inside it, which a search result and a citation do as readily as a row of the list
+does, so a conversation each screen owned would be two. Selecting one message opens the exchange it belongs to, and
+selecting several closes it, because a question asked about four messages is not an exchange to read. It is not scoped
+to the folder the list is drawn from and cannot be: the question is in the inbox, the answer is in the sent folder, and
+a forwarded copy is somewhere else again — so what is drawn is every folder of every account, in the conversation's own
+order. Where somebody arrived at a particular message, that message is the one opened and scrolled to; where they
+arrived at the conversation itself, the newest is.
+
+**What each message added arrived with the conversation, and the whole of one is a request somebody made.** A message
+collapses to a line and opens to what it contributed, which the deployment publishes with the quoted history and the
+signature trimmed off — so an exchange of thirty replies is one request to draw and the eighth reply does not redraw the
+seven above it. The whole message, quoted history and all, is read only for the message somebody asked it of and drawn
+by the same pane a single message is read in, which is what keeps the question asked before a link is followed one piece
+of code rather than two. Collapsing that message drops the whole of it along with the answer about its remote pictures,
+so no allowance outlives the reason it was given. A page of the conversation that did not arrive, and a whole message
+that did not, are each said beside what is already drawn rather than instead of it.
+
 **Settings is reached from the frame rather than named among the spaces**, because it is not one. It is the screen that
 says which build is running and which deployment this client is pointed at, carries the two choices below and the way to
 point it at another deployment, and carries the way back out as a navigation request rather than as a handler — the same

--- a/frontend/tests/Client.UnitTests/Backend/Threads/DeploymentMailThreadPageTests.cs
+++ b/frontend/tests/Client.UnitTests/Backend/Threads/DeploymentMailThreadPageTests.cs
@@ -1,0 +1,139 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Net;
+using MailFathom.Client.Backend;
+using MailFathom.Client.UnitTests.TestDoubles;
+
+namespace MailFathom.Client.UnitTests.Backend.Threads;
+
+/// <summary>What the client makes of the conversation a deployment serves, and of the route it asks for one on.</summary>
+public sealed class DeploymentMailThreadPageTests
+{
+    /// <summary>The conversation is a resource of its own, named in the path and narrowed by nothing.</summary>
+    [Fact]
+    public async Task ReadMailThreadAsync_AnyRequest_NamesTheConversationInThePathAndScopesItByNothing()
+    {
+        // Arrange
+        using var harness = new DeploymentHarness(_ => StubTransport.JsonResponse(MailThreads.Document(2)));
+
+        // Act
+        await harness.Client.ReadMailThreadAsync(
+            MailThreads.Identity,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var asked = Assert.Single(harness.Deployment.Requests).RequestUri;
+        Assert.Equal($"/api/client/threads/{MailThreads.Identity:D}", asked.AbsolutePath);
+        Assert.Empty(asked.Query);
+    }
+
+    /// <summary>How much is served and where the serving continues from are the query, and are written only when stated.</summary>
+    [Fact]
+    public async Task ReadMailThreadAsync_APageSizeAndACursor_WritesBothIntoTheQuery()
+    {
+        // Arrange
+        using var harness = new DeploymentHarness(_ => StubTransport.JsonResponse(MailThreads.Document(1)));
+
+        // Act
+        await harness.Client.ReadMailThreadAsync(
+            MailThreads.Identity,
+            pageSize: 25,
+            cursor: "after 3",
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var asked = Assert.Single(harness.Deployment.Requests).RequestUri;
+        Assert.Contains("pageSize=25", asked.Query, StringComparison.Ordinal);
+        Assert.Contains("cursor=after%203", asked.Query, StringComparison.Ordinal);
+    }
+
+    /// <summary>Every field of the contract is read, because a header drawn from half of it would be wrong about the rest.</summary>
+    [Fact]
+    public async Task ReadMailThreadAsync_ADeploymentAnswering_ReadsEveryFieldOfTheContract()
+    {
+        // Arrange
+        using var harness = new DeploymentHarness(_ => StubTransport.JsonResponse(MailThreads.Document(2, "after-2")));
+
+        // Act
+        var page = await harness.Client.ReadMailThreadAsync(
+            MailThreads.Identity,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(MailThreads.Identity, page.ThreadId);
+        Assert.Equal(2, page.MessageCount);
+        Assert.Equal("after-2", page.NextCursor);
+        Assert.Equal(50, page.PageSize);
+        Assert.False(page.MoreMessagesNotAssembled);
+        Assert.False(page.MoreParticipantsNotNamed);
+
+        Assert.Equal([0, 1], page.Written.Select(static message => message.Position));
+        Assert.Equal(MailMessages.Identity(1), page.Written[0].Email!.Id);
+        Assert.Equal("What this one added", page.Written[0].Email!.Preview);
+
+        var participant = Assert.Single(page.Authors);
+        Assert.Equal("someone@example.test", participant.Address);
+        Assert.Equal("Someone", participant.DisplayName);
+        Assert.Equal(2, participant.MessageCount);
+    }
+
+    /// <summary>
+    /// A document naming neither messages nor participants is a conversation holding none rather than a null every
+    /// reader would have to answer for itself.
+    /// </summary>
+    [Fact]
+    public async Task ReadMailThreadAsync_ADocumentNamingNeitherList_ReadsBothAsEmptyRatherThanAsNothing()
+    {
+        // Arrange
+        using var harness = new DeploymentHarness(_ => StubTransport.JsonResponse(
+            $$"""{"threadId":"{{MailThreads.Identity}}","messageCount":0,"pageSize":50}"""));
+
+        // Act
+        var page = await harness.Client.ReadMailThreadAsync(
+            MailThreads.Identity,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(page.Written);
+        Assert.Empty(page.Authors);
+    }
+
+    /// <summary>A cursor the deployment will not honour is this client's own value to stop sending rather than a defect.</summary>
+    [Fact]
+    public async Task ReadMailThreadAsync_ACursorTheDeploymentRefuses_ReportsTheCaseTheClientCanActOn()
+    {
+        // Arrange
+        using var harness = new DeploymentHarness(
+            _ => StubTransport.JsonResponse("{}", HttpStatusCode.BadRequest));
+
+        // Act
+        var failure = await Assert.ThrowsAsync<DeploymentFailure>(
+            () => harness.Client.ReadMailThreadAsync(
+                MailThreads.Identity,
+                cursor: "stale",
+                cancellationToken: TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(DeploymentFailureReason.RequestRefused, failure.Reason);
+    }
+
+    /// <summary>A caller whose grant does not carry reading mail is refused rather than answered with nothing.</summary>
+    [Fact]
+    public async Task ReadMailThreadAsync_ARefusedCredential_ReportsTheOneCaseThePersonCanActOn()
+    {
+        // Arrange
+        using var harness = new DeploymentHarness(
+            _ => StubTransport.JsonResponse("{}", HttpStatusCode.Forbidden));
+
+        // Act
+        var failure = await Assert.ThrowsAsync<DeploymentFailure>(
+            () => harness.Client.ReadMailThreadAsync(
+                MailThreads.Identity,
+                cancellationToken: TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(DeploymentFailureReason.CredentialRefused, failure.Reason);
+    }
+}

--- a/frontend/tests/Client.UnitTests/Backend/Threads/DeploymentMailThreadPageTests.cs
+++ b/frontend/tests/Client.UnitTests/Backend/Threads/DeploymentMailThreadPageTests.cs
@@ -16,7 +16,9 @@ public sealed class DeploymentMailThreadPageTests
     public async Task ReadMailThreadAsync_AnyRequest_NamesTheConversationInThePathAndScopesItByNothing()
     {
         // Arrange
-        using var harness = new DeploymentHarness(_ => StubTransport.JsonResponse(MailThreads.Document(2)));
+        using var harness = await DeploymentHarness.CreateAsync(
+            _ => StubTransport.JsonResponse(MailThreads.Document(2)),
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // Act
         await harness.Client.ReadMailThreadAsync(
@@ -34,7 +36,9 @@ public sealed class DeploymentMailThreadPageTests
     public async Task ReadMailThreadAsync_APageSizeAndACursor_WritesBothIntoTheQuery()
     {
         // Arrange
-        using var harness = new DeploymentHarness(_ => StubTransport.JsonResponse(MailThreads.Document(1)));
+        using var harness = await DeploymentHarness.CreateAsync(
+            _ => StubTransport.JsonResponse(MailThreads.Document(1)),
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // Act
         await harness.Client.ReadMailThreadAsync(
@@ -54,7 +58,9 @@ public sealed class DeploymentMailThreadPageTests
     public async Task ReadMailThreadAsync_ADeploymentAnswering_ReadsEveryFieldOfTheContract()
     {
         // Arrange
-        using var harness = new DeploymentHarness(_ => StubTransport.JsonResponse(MailThreads.Document(2, "after-2")));
+        using var harness = await DeploymentHarness.CreateAsync(
+            _ => StubTransport.JsonResponse(MailThreads.Document(2, "after-2")),
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // Act
         var page = await harness.Client.ReadMailThreadAsync(
@@ -87,8 +93,10 @@ public sealed class DeploymentMailThreadPageTests
     public async Task ReadMailThreadAsync_ADocumentNamingNeitherList_ReadsBothAsEmptyRatherThanAsNothing()
     {
         // Arrange
-        using var harness = new DeploymentHarness(_ => StubTransport.JsonResponse(
-            $$"""{"threadId":"{{MailThreads.Identity}}","messageCount":0,"pageSize":50}"""));
+        using var harness = await DeploymentHarness.CreateAsync(
+            _ => StubTransport.JsonResponse(
+                $$"""{"threadId":"{{MailThreads.Identity}}","messageCount":0,"pageSize":50}"""),
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // Act
         var page = await harness.Client.ReadMailThreadAsync(
@@ -105,8 +113,9 @@ public sealed class DeploymentMailThreadPageTests
     public async Task ReadMailThreadAsync_ACursorTheDeploymentRefuses_ReportsTheCaseTheClientCanActOn()
     {
         // Arrange
-        using var harness = new DeploymentHarness(
-            _ => StubTransport.JsonResponse("{}", HttpStatusCode.BadRequest));
+        using var harness = await DeploymentHarness.CreateAsync(
+            _ => StubTransport.JsonResponse("{}", HttpStatusCode.BadRequest),
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // Act
         var failure = await Assert.ThrowsAsync<DeploymentFailure>(
@@ -124,8 +133,9 @@ public sealed class DeploymentMailThreadPageTests
     public async Task ReadMailThreadAsync_ARefusedCredential_ReportsTheOneCaseThePersonCanActOn()
     {
         // Arrange
-        using var harness = new DeploymentHarness(
-            _ => StubTransport.JsonResponse("{}", HttpStatusCode.Forbidden));
+        using var harness = await DeploymentHarness.CreateAsync(
+            _ => StubTransport.JsonResponse("{}", HttpStatusCode.Forbidden),
+            cancellationToken: TestContext.Current.CancellationToken);
 
         // Act
         var failure = await Assert.ThrowsAsync<DeploymentFailure>(

--- a/frontend/tests/Client.UnitTests/ClientCompositionTests.cs
+++ b/frontend/tests/Client.UnitTests/ClientCompositionTests.cs
@@ -9,6 +9,7 @@ using MailFathom.Client.Backend.Authorization;
 using MailFathom.Client.Deployment;
 using MailFathom.Client.Presentation.Mailboxes;
 using MailFathom.Client.Presentation.Messages;
+using MailFathom.Client.Presentation.Threads;
 using MailFathom.Client.Presentation.Workspace;
 using MailFathom.Client.Session;
 using MailFathom.Client.UnitTests.TestDoubles;
@@ -71,6 +72,7 @@ public sealed class ClientCompositionTests
         typeof(IMailboxTree),
         typeof(IMessageListMemory),
         typeof(IMessageList),
+        typeof(IMailThread),
         typeof(IClientSession),
         typeof(DeploymentChoice),
         typeof(DeploymentAddress),

--- a/frontend/tests/Client.UnitTests/Presentation/Spaces/Mail/MailModelTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Spaces/Mail/MailModelTests.cs
@@ -23,10 +23,10 @@ public sealed class MailModelTests
     {
         // Arrange
         using var withheld = SessionOffering("mailfathom.mail.ask");
-        await using var withheldModel = new MailModel(withheld, new StubMessageList());
+        await using var withheldModel = new MailModel(withheld, new StubMessageList(), new StubMailThread());
 
         using var offered = SessionOffering("mailfathom.mail.read");
-        await using var offeredModel = new MailModel(offered, new StubMessageList());
+        await using var offeredModel = new MailModel(offered, new StubMessageList(), new StubMailThread());
 
         // Act, Assert
         Assert.True(await withheldModel.WithholdsMail);
@@ -43,7 +43,7 @@ public sealed class MailModelTests
         // Arrange
         using var session = SessionOffering("mailfathom.mail.read");
         var list = new StubMessageList(Row(1), Row(2));
-        await using var model = new MailModel(session, list);
+        await using var model = new MailModel(session, list, new StubMailThread());
 
         // Act
         var rows = await model.Messages;
@@ -61,7 +61,7 @@ public sealed class MailModelTests
         // Arrange
         using var session = SessionOffering("mailfathom.mail.read");
         var list = new StubMessageList(Row(1)) { More = true, Earlier = false };
-        await using var model = new MailModel(session, list);
+        await using var model = new MailModel(session, list, new StubMailThread());
 
         // Act, Assert
         Assert.True(await model.HasMoreAfter);
@@ -75,7 +75,7 @@ public sealed class MailModelTests
         // Arrange
         using var session = SessionOffering("mailfathom.mail.read");
         var list = new StubMessageList();
-        await using var model = new MailModel(session, list);
+        await using var model = new MailModel(session, list, new StubMailThread());
 
         await list.ArrangeAsync(
             new MessageListArrangement
@@ -107,7 +107,7 @@ public sealed class MailModelTests
     {
         // Arrange
         using var session = SessionOffering("mailfathom.mail.read");
-        await using var model = new MailModel(session, new StubMessageList());
+        await using var model = new MailModel(session, new StubMessageList(), new StubMailThread());
 
         // Act, Assert
         Assert.True(await model.KeepsEverything);
@@ -121,7 +121,7 @@ public sealed class MailModelTests
         // Arrange
         using var session = SessionOffering("mailfathom.mail.read");
         var list = new StubMessageList();
-        await using var model = new MailModel(session, list);
+        await using var model = new MailModel(session, list, new StubMailThread());
 
         // Act
         await model.ShowMore(TestContext.Current.CancellationToken);
@@ -141,7 +141,7 @@ public sealed class MailModelTests
         // Arrange
         using var session = SessionOffering("mailfathom.mail.read");
         var list = new StubMessageList();
-        await using var model = new MailModel(session, list);
+        await using var model = new MailModel(session, list, new StubMailThread());
 
         // Act
         await model.ReverseOrder(TestContext.Current.CancellationToken);
@@ -163,7 +163,7 @@ public sealed class MailModelTests
         // Arrange
         using var session = SessionOffering("mailfathom.mail.read");
         var list = new StubMessageList();
-        await using var model = new MailModel(session, list);
+        await using var model = new MailModel(session, list, new StubMailThread());
 
         // Act
         await model.ToggleUnreadOnly(TestContext.Current.CancellationToken);
@@ -190,7 +190,7 @@ public sealed class MailModelTests
         // Arrange
         using var session = SessionOffering("mailfathom.mail.read");
         var list = new StubMessageList();
-        await using var model = new MailModel(session, list);
+        await using var model = new MailModel(session, list, new StubMailThread());
 
         // Act
         await model.ToggleUnreadOnly(TestContext.Current.CancellationToken);
@@ -208,12 +208,16 @@ public sealed class MailModelTests
         using var session = SessionOffering("mailfathom.mail.read");
 
         // Act, Assert
-        Assert.Throws<ArgumentNullException>(() => new MailModel(null!, new StubMessageList()));
-        Assert.Throws<ArgumentNullException>(() => new MailModel(session, null!));
+        Assert.Throws<ArgumentNullException>(
+            () => new MailModel(null!, new StubMessageList(), new StubMailThread()));
+
+        Assert.Throws<ArgumentNullException>(() => new MailModel(session, null!, new StubMailThread()));
+        Assert.Throws<ArgumentNullException>(() => new MailModel(session, new StubMessageList(), null!));
     }
 
     private static MessageRow Row(int number) => new(
         MailMessages.Key(number),
+        MailThreads.Identity,
         "Someone",
         "Quarterly review",
         Preview: string.Empty,

--- a/frontend/tests/Client.UnitTests/Presentation/Spaces/Mail/MailModelTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Spaces/Mail/MailModelTests.cs
@@ -54,6 +54,53 @@ public sealed class MailModelTests
         Assert.Same(list.PagingFailed, model.PagingFailed);
     }
 
+    /// <summary>
+    /// The conversation is the run's own read through this space as well, so a citation that opened one and a row that
+    /// opened one are the same screen rather than two.
+    /// </summary>
+    [Fact]
+    public async Task Thread_TheRunsOwnConversation_IsReadThroughRatherThanCopied()
+    {
+        // Arrange
+        using var session = SessionOffering("mailfathom.mail.read");
+        var thread = new StubMailThread();
+        await using var model = new MailModel(session, new StubMessageList(), thread);
+
+        // Act, Assert
+        Assert.Same(thread.Reading, model.Thread);
+        Assert.Same(thread.Messages, model.ThreadMessages);
+        Assert.Same(thread.HasMoreMessages, model.HasMoreThreadMessages);
+        Assert.Same(thread.PagingFailed, model.ThreadPagingFailed);
+    }
+
+    /// <summary>
+    /// Every gesture the conversation column offers reaches the conversation the run holds, and reaches the member that
+    /// gesture means: expanding a message and reading the whole of it are two different requests of the deployment, and
+    /// one wired to the other would compile.
+    /// </summary>
+    [Fact]
+    public async Task ToggleThreadMessage_EveryGestureTheColumnOffers_ReachesTheConversationTheRunHolds()
+    {
+        // Arrange
+        using var session = SessionOffering("mailfathom.mail.read");
+        var thread = new StubMailThread();
+        await using var model = new MailModel(session, new StubMessageList(), thread);
+
+        // Act
+        await model.ToggleThreadMessage(MailMessages.Key(1), TestContext.Current.CancellationToken);
+        await model.ShowWholeThreadMessage(MailMessages.Key(2), TestContext.Current.CancellationToken);
+        await model.ShowThreadRemoteContent(MailMessages.Key(3), TestContext.Current.CancellationToken);
+        await model.ShowMoreThreadMessages(TestContext.Current.CancellationToken);
+        await model.RetryThread(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal([MailMessages.Key(1)], thread.Toggled);
+        Assert.Equal([MailMessages.Key(2)], thread.Whole);
+        Assert.Equal([MailMessages.Key(3)], thread.Remote);
+        Assert.Equal(1, thread.Pages);
+        Assert.Equal(1, thread.Asks);
+    }
+
     /// <summary>Both ends of the loaded window are reported, because each is a control of its own on the screen.</summary>
     [Fact]
     public async Task HasMoreAfter_AWindowWithMailEitherSideOfIt_ReportsEachEndSeparately()

--- a/frontend/tests/Client.UnitTests/Presentation/Threads/DeploymentMailThreadTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Threads/DeploymentMailThreadTests.cs
@@ -1,0 +1,517 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Immutable;
+using System.Net;
+using MailFathom.Client.Backend;
+using MailFathom.Client.Presentation.Messages;
+using MailFathom.Client.Presentation.Threads;
+using MailFathom.Client.Session;
+using MailFathom.Client.UnitTests.TestDoubles;
+
+namespace MailFathom.Client.UnitTests.Presentation.Threads;
+
+/// <summary>The conversation over one deployment: what opens it, what it reads, and what one gesture costs.</summary>
+public sealed class DeploymentMailThreadTests
+{
+    /// <summary>How long a test waits on a request it is holding open before it gives up rather than hanging the run.</summary>
+    private static readonly TimeSpan Patience = TimeSpan.FromSeconds(30);
+
+    /// <summary>One message's body, answered for the one gesture that reads one.</summary>
+    private const string WholeMessage =
+        """
+        {
+          "storedEmailId": "00000000-0000-0000-0000-000000000001",
+          "availability": "Readable",
+          "plainText": { "text": "What this one added, and everything it quoted.",
+                         "originalCharacterCount": 45, "truncation": "None" },
+          "document": null,
+          "remoteImagesRequested": false
+        }
+        """;
+
+    /// <summary>Nothing is read until a conversation is opened, because a screen nothing is open in is not a request.</summary>
+    [Fact]
+    public async Task Messages_NothingOpened_AsksTheDeploymentForNothing()
+    {
+        // Arrange
+        using var over = new ThreadOver(_ => Answer(MailThreads.Document(2)));
+
+        // Act
+        var messages = await over.Thread.Messages;
+
+        // Assert
+        Assert.Equal(0, messages?.Count ?? 0);
+        Assert.Empty(over.Harness.Deployment.Requests);
+    }
+
+    /// <summary>Opening a conversation reads it from its beginning, in one request for the whole exchange.</summary>
+    [Fact]
+    public async Task OpenAsync_AConversation_ReadsItFromItsBeginningInOneRequest()
+    {
+        // Arrange
+        using var over = new ThreadOver(_ => Answer(MailThreads.Document(3)));
+
+        // Act
+        await over.Thread.OpenAsync(MailThreads.Identity, null, TestContext.Current.CancellationToken);
+        await over.Until(async () => (await over.Thread.Messages)?.Count is 3);
+
+        // Assert
+        var asked = Assert.Single(over.Harness.Deployment.Requests).RequestUri;
+        Assert.Equal($"/api/client/threads/{MailThreads.Identity:D}", asked.AbsolutePath);
+        Assert.Contains($"pageSize={DeploymentMailThread.PageSize}", asked.Query, StringComparison.Ordinal);
+        Assert.DoesNotContain("cursor=", asked.Query, StringComparison.Ordinal);
+    }
+
+    /// <summary>The header is drawn from what the deployment said about the whole conversation.</summary>
+    [Fact]
+    public async Task Reading_AConversationOpened_DrawsTheHeaderTheDeploymentAnswered()
+    {
+        // Arrange
+        using var over = new ThreadOver(_ => Answer(MailThreads.Document(2)));
+
+        // Act
+        await over.Thread.OpenAsync(MailThreads.Identity, null, TestContext.Current.CancellationToken);
+        await over.Until(async () => (await over.Thread.Reading)?.IsOpen is true);
+
+        // Assert
+        var header = await over.Thread.Reading;
+        Assert.Equal("2 messages", header!.MessageCount);
+        Assert.Equal(["Someone"], header.Participants.Select(person => person.Author));
+    }
+
+    /// <summary>Selecting one message in the list is how a conversation is reached in the mail space.</summary>
+    [Fact]
+    public async Task Chosen_OneMessageSelectedInTheList_OpensTheConversationItIsIn()
+    {
+        // Arrange
+        using var over = new ThreadOver(_ => Answer(MailThreads.Document(2)));
+
+        // Act
+        await over.List.Chosen.UpdateAsync(
+            _ => ImmutableList.Create(Row(1)),
+            TestContext.Current.CancellationToken);
+
+        await over.Until(async () => (await over.Thread.Messages)?.Count is 2);
+
+        // Assert
+        var asked = Assert.Single(over.Harness.Deployment.Requests).RequestUri;
+        Assert.Equal($"/api/client/threads/{MailThreads.Identity:D}", asked.AbsolutePath);
+    }
+
+    /// <summary>
+    /// Several messages selected name no conversation, because a question asked about four messages is not an exchange
+    /// to read.
+    /// </summary>
+    [Fact]
+    public async Task Chosen_SeveralMessagesSelected_LeavesTheScreenWithNothingOpen()
+    {
+        // Arrange
+        using var over = new ThreadOver(_ => Answer(MailThreads.Document(2)));
+
+        await over.List.Chosen.UpdateAsync(
+            _ => ImmutableList.Create(Row(1)),
+            TestContext.Current.CancellationToken);
+
+        await over.Until(async () => (await over.Thread.Messages)?.Count is 2);
+
+        // Act
+        await over.List.Chosen.UpdateAsync(
+            _ => ImmutableList.Create(Row(1), Row(2)),
+            TestContext.Current.CancellationToken);
+
+        await over.Until(async () => (await over.Thread.Reading)?.IsClosed is true);
+
+        // Assert
+        Assert.Equal(0, (await over.Thread.Messages)?.Count ?? 0);
+    }
+
+    /// <summary>A message nothing has placed in a conversation names none, which is an ordinary state of stored mail.</summary>
+    [Fact]
+    public async Task Chosen_AMessageInNoConversation_AsksTheDeploymentForNothing()
+    {
+        // Arrange
+        using var over = new ThreadOver(_ => Answer(MailThreads.Document(2)));
+
+        // Act
+        await over.List.Chosen.UpdateAsync(
+            _ => ImmutableList.Create(Unthreaded(1)),
+            TestContext.Current.CancellationToken);
+
+        await over.Until(async () => (await over.Thread.Reading)?.IsClosed is true);
+
+        // Assert
+        Assert.Empty(over.Harness.Deployment.Requests);
+    }
+
+    /// <summary>What each message added arrived with the conversation, so opening one costs no request.</summary>
+    [Fact]
+    public async Task ToggleAsync_AMessageOfTheConversation_ShowsWhatItAddedWithoutAskingTheDeployment()
+    {
+        // Arrange
+        using var over = new ThreadOver(_ => Answer(MailThreads.Document(3)));
+        await over.Opened();
+
+        // Act
+        await over.Thread.ToggleAsync(MailMessages.Key(1), TestContext.Current.CancellationToken);
+
+        // Assert
+        var messages = await over.Thread.Messages;
+        Assert.True(messages![0].IsExpanded);
+        Assert.Single(over.Harness.Deployment.Requests);
+    }
+
+    /// <summary>Collapsing a message drops the whole of it, so nothing an expansion asked for outlives it.</summary>
+    [Fact]
+    public async Task ToggleAsync_AnOpenMessageWhoseWholeWasRead_DropsTheWholeMessageWithTheExpansion()
+    {
+        // Arrange
+        using var over = new ThreadOver(Answering(MailThreads.Document(2)));
+
+        await over.Opened();
+        await over.Thread.ShowWholeMessageAsync(MailMessages.Key(2), TestContext.Current.CancellationToken);
+
+        Assert.True((await over.Thread.Messages)![1].ShowsWholeMessage);
+
+        // Act
+        await over.Thread.ToggleAsync(MailMessages.Key(2), TestContext.Current.CancellationToken);
+        await over.Thread.ToggleAsync(MailMessages.Key(2), TestContext.Current.CancellationToken);
+
+        // Assert
+        var messages = await over.Thread.Messages;
+        Assert.True(messages![1].IsExpanded);
+        Assert.False(messages[1].ShowsWholeMessage);
+        Assert.True(messages[1].OffersWholeMessage);
+    }
+
+    /// <summary>The whole message is the one gesture that costs a request, and it is made for one message alone.</summary>
+    [Fact]
+    public async Task ShowWholeMessageAsync_AMessageSomebodyAskedFor_ReadsThatMessageAndNoOther()
+    {
+        // Arrange
+        using var over = new ThreadOver(Answering(MailThreads.Document(3)));
+        await over.Opened();
+
+        // Act
+        await over.Thread.ShowWholeMessageAsync(MailMessages.Key(1), TestContext.Current.CancellationToken);
+
+        // Assert
+        var messages = await over.Thread.Messages;
+        Assert.True(messages![0].ShowsWholeMessage);
+        Assert.False(messages[1].ShowsWholeMessage);
+        Assert.False(messages[2].ShowsWholeMessage);
+
+        Assert.Equal(
+            $"/api/client/messages/{MailMessages.Identity(1):D}/body",
+            over.Harness.Deployment.Requests[^1].RequestUri.AbsolutePath);
+    }
+
+    /// <summary>Asking for remote pictures is a second read of that one message, in the terms the reader allowed.</summary>
+    [Fact]
+    public async Task ShowRemoteContentAsync_AMessageTheReaderAllowed_ReadsThatMessageAgainWithThemAsked()
+    {
+        // Arrange
+        using var over = new ThreadOver(Answering(MailThreads.Document(2)));
+
+        await over.Opened();
+        await over.Thread.ShowWholeMessageAsync(MailMessages.Key(1), TestContext.Current.CancellationToken);
+
+        // Act
+        await over.Thread.ShowRemoteContentAsync(MailMessages.Key(1), TestContext.Current.CancellationToken);
+
+        // Assert
+        var asked = over.Harness.Deployment.Requests[^1].RequestUri;
+        Assert.Equal($"/api/client/messages/{MailMessages.Identity(1):D}/body", asked.AbsolutePath);
+        Assert.Contains("remoteImages=true", asked.Query, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A whole message that did not arrive is said on that message, because the conversation and what the message
+    /// added are still on the screen and still true.
+    /// </summary>
+    [Fact]
+    public async Task ShowWholeMessageAsync_AReadThatFailed_SaysSoOnTheMessageAndLeavesTheConversationDrawn()
+    {
+        // Arrange
+        using var over = new ThreadOver(request => IsBody(request)
+            ? Answer("{}", HttpStatusCode.BadGateway)
+            : Answer(MailThreads.Document(2)));
+
+        await over.Opened();
+
+        // Act
+        await over.Thread.ShowWholeMessageAsync(MailMessages.Key(1), TestContext.Current.CancellationToken);
+
+        // Assert
+        var messages = await over.Thread.Messages;
+        Assert.Equal(2, messages!.Count);
+        Assert.True(messages[0].ShowsWholeMessageFailure);
+        Assert.False(messages[0].AwaitsWholeMessage);
+
+        // The ask lives on the notice rather than beside it, so the button that offers the whole message is gone.
+        Assert.False(messages[0].OffersWholeMessage);
+    }
+
+    /// <summary>
+    /// A message closed while its whole was on its way keeps nothing of what arrived, because closing one is what
+    /// drops the whole of it and an answer to a withdrawn question may not reopen it.
+    /// </summary>
+    [Fact]
+    public async Task ShowWholeMessageAsync_AMessageClosedWhileTheReadWasOnItsWay_KeepsNothingOfWhatArrived()
+    {
+        // Arrange
+        var cancellation = TestContext.Current.CancellationToken;
+
+        using var reached = new ManualResetEventSlim(false);
+        using var released = new ManualResetEventSlim(false);
+
+        using var over = new ThreadOver(request =>
+        {
+            if (!IsBody(request))
+            {
+                return Answer(MailThreads.Document(2));
+            }
+
+            reached.Set();
+            released.Wait(Patience, cancellation);
+
+            return Answer(WholeMessage);
+        });
+
+        await over.Opened();
+
+        // The read is started on a thread of its own because the scripted deployment holds the request open on the one
+        // that made it, which is how a test states that a message's whole is still in flight.
+        var reading = Task.Run(
+            async () => await over.Thread.ShowWholeMessageAsync(MailMessages.Key(1), cancellation),
+            cancellation);
+
+        Assert.True(reached.Wait(Patience, cancellation));
+
+        // Act
+        await over.Thread.ToggleAsync(MailMessages.Key(1), cancellation);
+
+        released.Set();
+        await reading;
+
+        // Assert
+        var messages = await over.Thread.Messages;
+        Assert.False(messages![0].IsExpanded);
+        Assert.False(messages[0].ShowsWholeMessage);
+
+        await over.Thread.ToggleAsync(MailMessages.Key(1), cancellation);
+
+        messages = await over.Thread.Messages;
+        Assert.False(messages![0].ShowsWholeMessage);
+        Assert.True(messages[0].OffersWholeMessage);
+    }
+
+    /// <summary>A conversation longer than one page continues from the cursor the last page answered with.</summary>
+    [Fact]
+    public async Task ShowMoreAsync_MoreOfTheConversation_TakesThePageOntoTheEndOfWhatWasRead()
+    {
+        // Arrange
+        using var over = new ThreadOver(request => Answer(
+            Cursor(request) is null
+                ? MailThreads.Document(2, nextCursor: "after-2")
+                : MailThreads.Document(2, from: 3)));
+
+        await over.Opened();
+
+        // Act
+        await over.Thread.ShowMoreAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var messages = await over.Thread.Messages;
+        Assert.Equal(
+            [MailMessages.Key(1), MailMessages.Key(2), MailMessages.Key(3), MailMessages.Key(4)],
+            messages!.Select(message => message.Key));
+
+        Assert.False(await over.Thread.HasMoreMessages);
+        Assert.Contains(
+            "cursor=after-2",
+            over.Harness.Deployment.Requests[^1].RequestUri.Query,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>A page of the conversation that did not arrive is said beside it rather than instead of it.</summary>
+    [Fact]
+    public async Task ShowMoreAsync_APageThatFailed_KeepsWhatIsDrawnAndSaysThePageDidNotArrive()
+    {
+        // Arrange
+        using var over = new ThreadOver(request => Cursor(request) is null
+            ? Answer(MailThreads.Document(2, nextCursor: "after-2"))
+            : Answer("{}", HttpStatusCode.ServiceUnavailable));
+
+        await over.Opened();
+
+        // Act
+        await over.Thread.ShowMoreAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(2, (await over.Thread.Messages)!.Count);
+        Assert.True(await over.Thread.PagingFailed);
+    }
+
+    /// <summary>Asking again reaches the session as well, because a lost connection is what usually broke the read.</summary>
+    [Fact]
+    public async Task AskAgainAsync_AConversationThatDidNotArrive_AsksTheSessionAndTheDeploymentAgain()
+    {
+        // Arrange
+        using var over = new ThreadOver(_ => Answer(MailThreads.Document(1)));
+        await over.Opened();
+
+        // Act
+        await over.Thread.AskAgainAsync(TestContext.Current.CancellationToken);
+        await over.Until(() => ValueTask.FromResult(over.Harness.Deployment.Requests.Count > 1));
+
+        // Assert
+        Assert.Equal(1, over.Session.Refreshes);
+    }
+
+    /// <summary>Reopening a conversation at another message opens there rather than where the last reading did.</summary>
+    [Fact]
+    public async Task OpenAsync_TheSameConversationAtAnotherMessage_OpensAtTheMessageNamed()
+    {
+        // Arrange
+        using var over = new ThreadOver(_ => Answer(MailThreads.Document(3)));
+
+        await over.Thread.OpenAsync(
+            MailThreads.Identity,
+            MailMessages.Identity(1),
+            TestContext.Current.CancellationToken);
+
+        await over.Until(async () => (await over.Thread.Messages)?[0].IsOpenedAt is true);
+
+        // Act
+        await over.Thread.OpenAsync(
+            MailThreads.Identity,
+            MailMessages.Identity(2),
+            TestContext.Current.CancellationToken);
+
+        await over.Until(async () => (await over.Thread.Messages)?[1].IsOpenedAt is true);
+
+        // Assert
+        var messages = await over.Thread.Messages;
+        Assert.Equal([false, true, false], messages!.Select(message => message.IsExpanded));
+    }
+
+    /// <summary>Answers the conversation from one document, and every message's whole body from the same one.</summary>
+    private static Func<HttpRequestMessage, HttpResponseMessage> Answering(string conversation) =>
+        request => IsBody(request) ? Answer(WholeMessage) : Answer(conversation);
+
+    private static HttpResponseMessage Answer(string document, HttpStatusCode status = HttpStatusCode.OK) =>
+        StubTransport.JsonResponse(document, status);
+
+    private static bool IsBody(HttpRequestMessage request) =>
+        request.RequestUri?.AbsolutePath.EndsWith("/body", StringComparison.Ordinal) is true;
+
+    /// <summary>Reads the cursor a request carried, which is what tells one page of a script apart from the next.</summary>
+    private static string? Cursor(HttpRequestMessage request) =>
+        (request.RequestUri?.Query ?? string.Empty)
+            .TrimStart('?')
+            .Split('&')
+            .FirstOrDefault(stated => stated.StartsWith("cursor=", StringComparison.Ordinal))?["cursor=".Length..];
+
+    /// <summary>A row of the message list, in the conversation every arrangement here is of.</summary>
+    private static MessageRow Row(int number) => Drawn(number, MailThreads.Identity);
+
+    /// <summary>A row of the message list that nothing has placed in a conversation.</summary>
+    private static MessageRow Unthreaded(int number) => Drawn(number, null);
+
+    private static MessageRow Drawn(int number, Guid? threadId) => new(
+        MailMessages.Key(number),
+        threadId,
+        "Someone",
+        "Quarterly review",
+        "What this one added",
+        "14:02",
+        "Someone, Quarterly review, 14:02",
+        IsUnread: false,
+        IsFlagged: false,
+        IsAnswered: false,
+        HasAttachments: false,
+        AttachmentCount: 0);
+
+    private sealed class ThreadOver : IDisposable
+    {
+        internal ThreadOver(Func<HttpRequestMessage, HttpResponseMessage> deployment)
+        {
+            this.Harness = new DeploymentHarness(deployment);
+            this.Session = new StubClientSession(
+                SessionStanding.Of(new DeploymentSession("MailFathom", "0.8.0", ["mailfathom.mail.read"])));
+
+            this.List = new StubMessageList();
+
+            this.Thread = new DeploymentMailThread(this.Harness.Client, this.Session, this.List, Words());
+        }
+
+        internal DeploymentHarness Harness { get; }
+
+        internal StubClientSession Session { get; }
+
+        internal StubMessageList List { get; }
+
+        internal DeploymentMailThread Thread { get; }
+
+        /// <summary>Opens the conversation every test but the first begins from, and waits for it to arrive.</summary>
+        /// <returns>The wait.</returns>
+        internal async Task Opened()
+        {
+            await this.Thread.OpenAsync(MailThreads.Identity, null, TestContext.Current.CancellationToken);
+
+            await this.Until(async () => (await this.Thread.Messages)?.Count > 0);
+        }
+
+        /// <summary>Waits until a consequence of a feed re-evaluating has happened, or fails the test.</summary>
+        /// <param name="settled">What is being waited for.</param>
+        /// <returns>The wait.</returns>
+        /// <remarks>
+        /// Only what reaches the conversation through a feed rather than through a call is waited on: opening one, and
+        /// the list's selection reaching it. Each of those is finished by MVUX re-evaluating a feed on a thread of its
+        /// own, and no await a test holds is the one that finishes it. Everything the conversation does inside an
+        /// awaited method is asserted straight after that await instead. Polling rather than a recorded feed, for the
+        /// reason <c>frontend/tests/AGENTS.md</c> gives about the package that records one.
+        /// </remarks>
+        internal async Task Until(Func<ValueTask<bool>> settled)
+        {
+            for (var attempt = 0; attempt < 400; attempt++)
+            {
+                if (await settled())
+                {
+                    return;
+                }
+
+                await Task.Delay(10, TestContext.Current.CancellationToken);
+            }
+
+            Assert.Fail("The conversation did not settle on what the test was waiting for.");
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            this.Session.Dispose();
+            this.Harness.Dispose();
+        }
+
+        private static StubStringLocalizer Words() => new(new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [MessageWords.NoSenderKey] = "Unknown sender",
+            [MessageWords.NoSubjectKey] = "No subject",
+            [MessageWords.NoDateKey] = "No date",
+            [MessageWords.MoreRecipientsKey] = "{0} and {1} more",
+            [MessageWords.AnnouncementKey] = "{0}, {1}, {2}",
+            [MessageWords.UnreadKey] = "unread",
+            [MessageWords.FlaggedKey] = "flagged",
+            [MessageWords.AnsweredKey] = "answered",
+            [MessageWords.AttachmentsKey] = "attachment",
+            [ThreadWords.MessageCountKey] = "{0} messages",
+            [ThreadWords.AnnouncementKey] = "Conversation {0}. {1}",
+            [ThreadWords.RecipientsKey] = "To {0}",
+            [ThreadWords.ParticipantMessagesKey] = "({0})",
+            [ThreadWords.ParticipantAnnouncementKey] = "{0} wrote {1}",
+        });
+    }
+}

--- a/frontend/tests/Client.UnitTests/Presentation/Threads/DeploymentMailThreadTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Threads/DeploymentMailThreadTests.cs
@@ -36,7 +36,8 @@ public sealed class DeploymentMailThreadTests
     public async Task Messages_NothingOpened_AsksTheDeploymentForNothing()
     {
         // Arrange
-        using var over = new ThreadOver(_ => Answer(MailThreads.Document(2)));
+        using var over = await ThreadOver.CreateAsync(_ => Answer(MailThreads.Document(2)),
+            TestContext.Current.CancellationToken);
 
         // Act
         var messages = await over.Thread.Messages;
@@ -51,7 +52,8 @@ public sealed class DeploymentMailThreadTests
     public async Task OpenAsync_AConversation_ReadsItFromItsBeginningInOneRequest()
     {
         // Arrange
-        using var over = new ThreadOver(_ => Answer(MailThreads.Document(3)));
+        using var over = await ThreadOver.CreateAsync(_ => Answer(MailThreads.Document(3)),
+            TestContext.Current.CancellationToken);
 
         // Act
         await over.Thread.OpenAsync(MailThreads.Identity, null, TestContext.Current.CancellationToken);
@@ -69,7 +71,8 @@ public sealed class DeploymentMailThreadTests
     public async Task Reading_AConversationOpened_DrawsTheHeaderTheDeploymentAnswered()
     {
         // Arrange
-        using var over = new ThreadOver(_ => Answer(MailThreads.Document(2)));
+        using var over = await ThreadOver.CreateAsync(_ => Answer(MailThreads.Document(2)),
+            TestContext.Current.CancellationToken);
 
         // Act
         await over.Thread.OpenAsync(MailThreads.Identity, null, TestContext.Current.CancellationToken);
@@ -86,7 +89,8 @@ public sealed class DeploymentMailThreadTests
     public async Task Chosen_OneMessageSelectedInTheList_OpensTheConversationItIsIn()
     {
         // Arrange
-        using var over = new ThreadOver(_ => Answer(MailThreads.Document(2)));
+        using var over = await ThreadOver.CreateAsync(_ => Answer(MailThreads.Document(2)),
+            TestContext.Current.CancellationToken);
 
         // Act
         await over.List.Chosen.UpdateAsync(
@@ -108,7 +112,8 @@ public sealed class DeploymentMailThreadTests
     public async Task Chosen_SeveralMessagesSelected_LeavesTheScreenWithNothingOpen()
     {
         // Arrange
-        using var over = new ThreadOver(_ => Answer(MailThreads.Document(2)));
+        using var over = await ThreadOver.CreateAsync(_ => Answer(MailThreads.Document(2)),
+            TestContext.Current.CancellationToken);
 
         await over.List.Chosen.UpdateAsync(
             _ => ImmutableList.Create(Row(1)),
@@ -132,7 +137,8 @@ public sealed class DeploymentMailThreadTests
     public async Task Chosen_AMessageInNoConversation_AsksTheDeploymentForNothing()
     {
         // Arrange
-        using var over = new ThreadOver(_ => Answer(MailThreads.Document(2)));
+        using var over = await ThreadOver.CreateAsync(_ => Answer(MailThreads.Document(2)),
+            TestContext.Current.CancellationToken);
 
         // Act
         await over.List.Chosen.UpdateAsync(
@@ -150,7 +156,8 @@ public sealed class DeploymentMailThreadTests
     public async Task ToggleAsync_AMessageOfTheConversation_ShowsWhatItAddedWithoutAskingTheDeployment()
     {
         // Arrange
-        using var over = new ThreadOver(_ => Answer(MailThreads.Document(3)));
+        using var over = await ThreadOver.CreateAsync(_ => Answer(MailThreads.Document(3)),
+            TestContext.Current.CancellationToken);
         await over.Opened();
 
         // Act
@@ -167,7 +174,8 @@ public sealed class DeploymentMailThreadTests
     public async Task ToggleAsync_AnOpenMessageWhoseWholeWasRead_DropsTheWholeMessageWithTheExpansion()
     {
         // Arrange
-        using var over = new ThreadOver(Answering(MailThreads.Document(2)));
+        using var over = await ThreadOver.CreateAsync(Answering(MailThreads.Document(2)),
+            TestContext.Current.CancellationToken);
 
         await over.Opened();
         await over.Thread.ShowWholeMessageAsync(MailMessages.Key(2), TestContext.Current.CancellationToken);
@@ -190,7 +198,8 @@ public sealed class DeploymentMailThreadTests
     public async Task ShowWholeMessageAsync_AMessageSomebodyAskedFor_ReadsThatMessageAndNoOther()
     {
         // Arrange
-        using var over = new ThreadOver(Answering(MailThreads.Document(3)));
+        using var over = await ThreadOver.CreateAsync(Answering(MailThreads.Document(3)),
+            TestContext.Current.CancellationToken);
         await over.Opened();
 
         // Act
@@ -212,7 +221,8 @@ public sealed class DeploymentMailThreadTests
     public async Task ShowRemoteContentAsync_AMessageTheReaderAllowed_ReadsThatMessageAgainWithThemAsked()
     {
         // Arrange
-        using var over = new ThreadOver(Answering(MailThreads.Document(2)));
+        using var over = await ThreadOver.CreateAsync(Answering(MailThreads.Document(2)),
+            TestContext.Current.CancellationToken);
 
         await over.Opened();
         await over.Thread.ShowWholeMessageAsync(MailMessages.Key(1), TestContext.Current.CancellationToken);
@@ -234,9 +244,10 @@ public sealed class DeploymentMailThreadTests
     public async Task ShowWholeMessageAsync_AReadThatFailed_SaysSoOnTheMessageAndLeavesTheConversationDrawn()
     {
         // Arrange
-        using var over = new ThreadOver(request => IsBody(request)
+        using var over = await ThreadOver.CreateAsync(request => IsBody(request)
             ? Answer("{}", HttpStatusCode.BadGateway)
-            : Answer(MailThreads.Document(2)));
+            : Answer(MailThreads.Document(2)),
+            TestContext.Current.CancellationToken);
 
         await over.Opened();
 
@@ -266,7 +277,7 @@ public sealed class DeploymentMailThreadTests
         using var reached = new ManualResetEventSlim(false);
         using var released = new ManualResetEventSlim(false);
 
-        using var over = new ThreadOver(request =>
+        using var over = await ThreadOver.CreateAsync(request =>
         {
             if (!IsBody(request))
             {
@@ -277,7 +288,8 @@ public sealed class DeploymentMailThreadTests
             released.Wait(Patience, cancellation);
 
             return Answer(WholeMessage);
-        });
+        },
+            TestContext.Current.CancellationToken);
 
         await over.Opened();
 
@@ -312,10 +324,11 @@ public sealed class DeploymentMailThreadTests
     public async Task ShowMoreAsync_MoreOfTheConversation_TakesThePageOntoTheEndOfWhatWasRead()
     {
         // Arrange
-        using var over = new ThreadOver(request => Answer(
+        using var over = await ThreadOver.CreateAsync(request => Answer(
             Cursor(request) is null
                 ? MailThreads.Document(2, nextCursor: "after-2")
-                : MailThreads.Document(2, from: 3)));
+                : MailThreads.Document(2, from: 3)),
+            TestContext.Current.CancellationToken);
 
         await over.Opened();
 
@@ -340,9 +353,10 @@ public sealed class DeploymentMailThreadTests
     public async Task ShowMoreAsync_APageThatFailed_KeepsWhatIsDrawnAndSaysThePageDidNotArrive()
     {
         // Arrange
-        using var over = new ThreadOver(request => Cursor(request) is null
+        using var over = await ThreadOver.CreateAsync(request => Cursor(request) is null
             ? Answer(MailThreads.Document(2, nextCursor: "after-2"))
-            : Answer("{}", HttpStatusCode.ServiceUnavailable));
+            : Answer("{}", HttpStatusCode.ServiceUnavailable),
+            TestContext.Current.CancellationToken);
 
         await over.Opened();
 
@@ -359,7 +373,8 @@ public sealed class DeploymentMailThreadTests
     public async Task AskAgainAsync_AConversationThatDidNotArrive_AsksTheSessionAndTheDeploymentAgain()
     {
         // Arrange
-        using var over = new ThreadOver(_ => Answer(MailThreads.Document(1)));
+        using var over = await ThreadOver.CreateAsync(_ => Answer(MailThreads.Document(1)),
+            TestContext.Current.CancellationToken);
         await over.Opened();
 
         // Act
@@ -375,7 +390,8 @@ public sealed class DeploymentMailThreadTests
     public async Task OpenAsync_TheSameConversationAtAnotherMessage_OpensAtTheMessageNamed()
     {
         // Arrange
-        using var over = new ThreadOver(_ => Answer(MailThreads.Document(3)));
+        using var over = await ThreadOver.CreateAsync(_ => Answer(MailThreads.Document(3)),
+            TestContext.Current.CancellationToken);
 
         await over.Thread.OpenAsync(
             MailThreads.Identity,
@@ -436,9 +452,9 @@ public sealed class DeploymentMailThreadTests
 
     private sealed class ThreadOver : IDisposable
     {
-        internal ThreadOver(Func<HttpRequestMessage, HttpResponseMessage> deployment)
+        private ThreadOver(DeploymentHarness harness)
         {
-            this.Harness = new DeploymentHarness(deployment);
+            this.Harness = harness;
             this.Session = new StubClientSession(
                 SessionStanding.Of(new DeploymentSession("MailFathom", "0.8.0", ["mailfathom.mail.read"])));
 
@@ -446,6 +462,15 @@ public sealed class DeploymentMailThreadTests
 
             this.Thread = new DeploymentMailThread(this.Harness.Client, this.Session, this.List, Words());
         }
+
+        /// <summary>Builds the conversation over a scripted deployment the client is already pointed at.</summary>
+        /// <param name="deployment">How the deployment answers.</param>
+        /// <param name="cancellationToken">Abandons the pointing.</param>
+        /// <returns>The arrangement the test owns.</returns>
+        internal static async ValueTask<ThreadOver> CreateAsync(
+            Func<HttpRequestMessage, HttpResponseMessage> deployment,
+            CancellationToken cancellationToken = default) =>
+            new(await DeploymentHarness.CreateAsync(deployment, cancellationToken: cancellationToken));
 
         internal DeploymentHarness Harness { get; }
 

--- a/frontend/tests/Client.UnitTests/Presentation/Threads/ThreadShapeTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Threads/ThreadShapeTests.cs
@@ -1,0 +1,370 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Immutable;
+using System.Globalization;
+using MailFathom.Client.Backend.Threads;
+using MailFathom.Client.Presentation.Messages;
+using MailFathom.Client.Presentation.Threads;
+using MailFathom.Client.UnitTests.TestDoubles;
+
+namespace MailFathom.Client.UnitTests.Presentation.Threads;
+
+/// <summary>What a conversation reads as: its header, its messages, and which of them a reading opens at.</summary>
+public sealed class ThreadShapeTests
+{
+    private static readonly DateTimeOffset Written = new(2026, 3, 14, 9, 15, 0, TimeSpan.Zero);
+
+    /// <summary>The header is answered about the whole conversation rather than about the messages in hand.</summary>
+    [Fact]
+    public void Header_AConversationLargerThanItsPage_SaysWhatTheDeploymentSaidAboutTheWholeOfIt()
+    {
+        // Arrange
+        var window = Opened(
+            MailThreads.Page(
+                [MailThreads.Message(1)],
+                [new DeploymentThreadParticipant("first@example.test", "First", 4),
+                 new DeploymentThreadParticipant("second@example.test", null, 2)],
+                messageCount: 6,
+                moreMessagesNotAssembled: true,
+                moreParticipantsNotNamed: true));
+
+        // Act
+        var header = ThreadShape.Header(window, Words());
+
+        // Assert
+        Assert.True(header.IsOpen);
+        Assert.False(header.IsClosed);
+        Assert.Equal("Quarterly review", header.Subject);
+        Assert.Equal("6 messages", header.MessageCount);
+        Assert.Equal("Conversation Quarterly review. 6 messages", header.Announcement);
+        Assert.True(header.HasUnnamedParticipants);
+        Assert.True(header.RunsPastAssembly);
+
+        Assert.Equal(["First", "second@example.test"], header.Participants.Select(person => person.Author));
+        Assert.Equal(["(4)", "(2)"], header.Participants.Select(person => person.MessageCount));
+        Assert.Equal("First wrote 4", header.Participants[0].Announcement);
+    }
+
+    /// <summary>
+    /// What the conversation is about comes from the message that began it, so paging forward does not rewrite the
+    /// header somebody is reading under.
+    /// </summary>
+    [Fact]
+    public void Header_AReplyThatRewroteTheSubject_TakesTheSubjectOfTheMessageThatBeganIt()
+    {
+        // Arrange
+        var window = Opened(MailThreads.Page(
+        [
+            MailThreads.Message(1, subject: "Quarterly review"),
+            MailThreads.Message(2, subject: "Re: something else entirely"),
+        ]));
+
+        // Act
+        var header = ThreadShape.Header(window, Words());
+
+        // Assert
+        Assert.Equal("Quarterly review", header.Subject);
+    }
+
+    /// <summary>An author the answer named with neither a name nor an address names nobody rather than a blank.</summary>
+    [Fact]
+    public void Header_AnAuthorNamedByNeitherANameNorAnAddress_IsLeftOutOfTheHeader()
+    {
+        // Arrange
+        var window = Opened(MailThreads.Page(
+            [MailThreads.Message(1)],
+            [new DeploymentThreadParticipant(null, null, 1),
+             new DeploymentThreadParticipant("first@example.test", "First", 1)]));
+
+        // Act
+        var header = ThreadShape.Header(window, Words());
+
+        // Assert
+        Assert.Equal(["First"], header.Participants.Select(person => person.Author));
+    }
+
+    /// <summary>A screen nothing has been opened in draws the empty header rather than one about nothing.</summary>
+    [Fact]
+    public void Header_NoConversationOpened_IsTheEmptyOne()
+    {
+        // Act
+        var header = ThreadShape.Header(ThreadWindow.Nothing, Words());
+
+        // Assert
+        Assert.False(header.IsOpen);
+        Assert.True(header.IsClosed);
+        Assert.Empty(header.Participants);
+    }
+
+    /// <summary>
+    /// A conversation opens showing the newest message, which is what somebody catching up on one came for, with the
+    /// rest collapsed to a line each.
+    /// </summary>
+    [Fact]
+    public void Messages_AConversationNobodyArrivedAtAMessageIn_OpensTheNewestAndCollapsesTheRest()
+    {
+        // Arrange
+        var window = Opened(MailThreads.Page(
+            [MailThreads.Message(1), MailThreads.Message(2), MailThreads.Message(3)]));
+
+        // Act
+        var messages = ThreadShape.Messages(window, Nothing, Words());
+
+        // Assert
+        Assert.Equal([false, false, true], messages.Select(message => message.IsExpanded));
+        Assert.Equal([false, false, true], messages.Select(message => message.IsOpenedAt));
+    }
+
+    /// <summary>
+    /// Arriving at a message is how a search result and a citation reach mail, so the message named is the one opened
+    /// whether or not it is the newest.
+    /// </summary>
+    [Fact]
+    public void Messages_AConversationArrivedAtAMessageIn_OpensThatMessageRatherThanTheNewest()
+    {
+        // Arrange
+        var window = ThreadWindow.Opening(
+            new ThreadOpening(MailThreads.Identity, MailMessages.Identity(1)),
+            MailThreads.Page([MailThreads.Message(1), MailThreads.Message(2)]));
+
+        // Act
+        var messages = ThreadShape.Messages(window, Nothing, Words());
+
+        // Assert
+        Assert.Equal([true, false], messages.Select(message => message.IsExpanded));
+        Assert.Equal([true, false], messages.Select(message => message.IsOpenedAt));
+    }
+
+    /// <summary>
+    /// A message the conversation no longer shows names nothing, which leaves the newest opened rather than the
+    /// conversation opened at nothing.
+    /// </summary>
+    [Fact]
+    public void Messages_AnArrivalAtAMessageTheConversationNoLongerShows_FallsBackToTheNewest()
+    {
+        // Arrange
+        var window = ThreadWindow.Opening(
+            new ThreadOpening(MailThreads.Identity, MailMessages.Identity(9)),
+            MailThreads.Page([MailThreads.Message(1), MailThreads.Message(2)]));
+
+        // Act
+        var messages = ThreadShape.Messages(window, Nothing, Words());
+
+        // Assert
+        Assert.Equal([false, true], messages.Select(message => message.IsExpanded));
+    }
+
+    /// <summary>The reader's own act wins over the message a conversation opened at.</summary>
+    [Fact]
+    public void Messages_TheOpenedMessageCollapsedByTheReader_IsDrawnCollapsed()
+    {
+        // Arrange
+        var window = Opened(MailThreads.Page([MailThreads.Message(1), MailThreads.Message(2)]));
+
+        var closed = Nothing.SetItem(MailMessages.Key(2), ThreadMessageDetail.Collapsed);
+
+        // Act
+        var messages = ThreadShape.Messages(window, closed, Words());
+
+        // Assert
+        Assert.Equal([false, false], messages.Select(message => message.IsExpanded));
+        Assert.True(messages[1].IsOpenedAt);
+    }
+
+    /// <summary>Everything a message draws comes out of the conversation, so drawing thirty of them costs one request.</summary>
+    [Fact]
+    public void Messages_AMessageTheDeploymentDescribed_DrawsItFromTheConversationAlone()
+    {
+        // Arrange
+        var window = Opened(MailThreads.Page(
+        [
+            MailThreads.Message(
+                1,
+                contribution: "Numbers are attached.",
+                sentAt: Written,
+                senderDisplayName: "First",
+                recipients: ["owner@example.test", "second@example.test"],
+                unread: true),
+        ]));
+
+        // Act
+        var message = Assert.Single(ThreadShape.Messages(window, Nothing, Words()));
+
+        // Assert
+        Assert.Equal(MailMessages.Key(1), message.Key);
+        Assert.Equal("First", message.Author);
+        Assert.Equal("Quarterly review", message.Subject);
+        Assert.Equal("Numbers are attached.", message.Contribution);
+        Assert.True(message.HasContribution);
+        Assert.False(message.AwaitsContribution);
+        Assert.Equal("To owner@example.test and 1 more", message.Recipients);
+        Assert.True(message.HasRecipients);
+        Assert.True(message.IsUnread);
+        Assert.Equal(
+            Written.ToLocalTime().ToString("g", CultureInfo.CurrentCulture),
+            message.Written);
+    }
+
+    /// <summary>
+    /// A message this deployment holds but has not extracted yet has nothing to show of what it added, which is a state
+    /// of a mailbox still being taken in rather than a message somebody sent empty.
+    /// </summary>
+    [Fact]
+    public void Messages_AMessageNothingHasExtracted_SaysSoRatherThanDrawingABlank()
+    {
+        // Arrange
+        var window = Opened(MailThreads.Page([MailThreads.Message(1, contribution: null)]));
+
+        // Act
+        var message = Assert.Single(ThreadShape.Messages(window, Nothing, Words()));
+
+        // Assert
+        Assert.Empty(message.Contribution);
+        Assert.False(message.HasContribution);
+        Assert.True(message.AwaitsContribution);
+    }
+
+    /// <summary>A message no header dated is written under a sentence rather than under a blank.</summary>
+    [Fact]
+    public void Messages_AMessageNoHeaderDated_IsWrittenUnderASentence()
+    {
+        // Arrange
+        var window = Opened(MailThreads.Page([MailThreads.Message(1, sentAt: null)]));
+
+        // Act
+        var message = Assert.Single(ThreadShape.Messages(window, Nothing, Words()));
+
+        // Assert
+        Assert.Equal("No date", message.Written);
+    }
+
+    /// <summary>A message the header carried no sender for is drawn under a sentence rather than under a blank.</summary>
+    [Fact]
+    public void Messages_AMessageWithNoUsableSender_IsDrawnUnderASentence()
+    {
+        // Arrange
+        var window = Opened(MailThreads.Page(
+            [MailThreads.Message(1, senderDisplayName: null, senderAddress: null)]));
+
+        // Act
+        var message = Assert.Single(ThreadShape.Messages(window, Nothing, Words()));
+
+        // Assert
+        Assert.Equal("Unknown sender", message.Author);
+    }
+
+    /// <summary>A message naming nobody it went to draws one line less rather than a label with nothing after it.</summary>
+    [Fact]
+    public void Messages_AMessageNamingNobodyItWentTo_DrawsNoRecipientLine()
+    {
+        // Arrange
+        var window = Opened(MailThreads.Page([MailThreads.Message(1, recipients: [])]));
+
+        // Act
+        var message = Assert.Single(ThreadShape.Messages(window, Nothing, Words()));
+
+        // Assert
+        Assert.Empty(message.Recipients);
+        Assert.False(message.HasRecipients);
+    }
+
+    /// <summary>
+    /// A message states itself once for a screen reader, through the same entries a list row does: a conversation's
+    /// messages and a folder's rows stand for the same thing.
+    /// </summary>
+    [Fact]
+    public void Messages_AMessageCarryingMarks_StatesItselfOnceWithThemAppended()
+    {
+        // Arrange
+        var window = Opened(MailThreads.Page([MailThreads.Message(1, sentAt: Written, unread: true)]));
+
+        // Act
+        var message = Assert.Single(ThreadShape.Messages(window, Nothing, Words()));
+
+        // Assert
+        Assert.Equal(
+            $"Someone, Quarterly review, {message.Written} unread",
+            message.Announcement);
+    }
+
+    /// <summary>What the reader has asked of one message travels with that message and with nothing else.</summary>
+    [Fact]
+    public void Messages_AMessageWhoseWholeReadFailed_SaysSoOnThatMessageAlone()
+    {
+        // Arrange
+        var window = Opened(MailThreads.Page([MailThreads.Message(1), MailThreads.Message(2)]));
+
+        var failed = Nothing.SetItem(
+            MailMessages.Key(1),
+            ThreadMessageDetail.Opened with { WholeMessageFailed = true });
+
+        // Act
+        var messages = ThreadShape.Messages(window, failed, Words());
+
+        // Assert
+        Assert.True(messages[0].ShowsWholeMessageFailure);
+        Assert.False(messages[0].OffersWholeMessage);
+        Assert.False(messages[1].ShowsWholeMessageFailure);
+    }
+
+    /// <summary>The whole message is offered only while a message is open and only while there is something to ask for.</summary>
+    [Fact]
+    public void Messages_AMessageBeingRead_OffersNothingWhileTheReadIsOnItsWay()
+    {
+        // Arrange
+        var window = Opened(MailThreads.Page([MailThreads.Message(1)]));
+
+        var reading = Nothing.SetItem(
+            MailMessages.Key(1),
+            ThreadMessageDetail.Opened with { IsReadingWholeMessage = true });
+
+        // Act
+        var message = Assert.Single(ThreadShape.Messages(window, reading, Words()));
+
+        // Assert
+        Assert.True(message.AwaitsWholeMessage);
+        Assert.False(message.OffersWholeMessage);
+        Assert.False(message.ShowsWholeMessage);
+    }
+
+    /// <summary>A collapsed message offers nothing of the whole of it, because the offer is made on an open one.</summary>
+    [Fact]
+    public void Messages_ACollapsedMessage_OffersNothingOfTheWholeOfIt()
+    {
+        // Arrange
+        var window = Opened(MailThreads.Page([MailThreads.Message(1), MailThreads.Message(2)]));
+
+        // Act
+        var messages = ThreadShape.Messages(window, Nothing, Words());
+
+        // Assert
+        Assert.False(messages[0].OffersWholeMessage);
+        Assert.True(messages[1].OffersWholeMessage);
+    }
+
+    private static IImmutableDictionary<string, ThreadMessageDetail> Nothing { get; } =
+        ImmutableDictionary<string, ThreadMessageDetail>.Empty.WithComparers(StringComparer.Ordinal);
+
+    private static ThreadWindow Opened(DeploymentMailThreadPage page) =>
+        ThreadWindow.Opening(new ThreadOpening(MailThreads.Identity, AtMessage: null), page);
+
+    private static StubStringLocalizer Words() => new(new Dictionary<string, string>(StringComparer.Ordinal)
+    {
+        [MessageWords.NoSenderKey] = "Unknown sender",
+        [MessageWords.NoSubjectKey] = "No subject",
+        [MessageWords.NoDateKey] = "No date",
+        [MessageWords.MoreRecipientsKey] = "{0} and {1} more",
+        [MessageWords.AnnouncementKey] = "{0}, {1}, {2}",
+        [MessageWords.UnreadKey] = "unread",
+        [MessageWords.FlaggedKey] = "flagged",
+        [MessageWords.AnsweredKey] = "answered",
+        [MessageWords.AttachmentsKey] = "attachment",
+        [ThreadWords.MessageCountKey] = "{0} messages",
+        [ThreadWords.AnnouncementKey] = "Conversation {0}. {1}",
+        [ThreadWords.RecipientsKey] = "To {0}",
+        [ThreadWords.ParticipantMessagesKey] = "({0})",
+        [ThreadWords.ParticipantAnnouncementKey] = "{0} wrote {1}",
+    });
+}

--- a/frontend/tests/Client.UnitTests/Presentation/Threads/ThreadWindowTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Threads/ThreadWindowTests.cs
@@ -1,0 +1,130 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Backend.Threads;
+using MailFathom.Client.Presentation.Threads;
+using MailFathom.Client.UnitTests.TestDoubles;
+
+namespace MailFathom.Client.UnitTests.Presentation.Threads;
+
+/// <summary>What one conversation accumulates as it is paged, and what a page arriving late is held against.</summary>
+public sealed class ThreadWindowTests
+{
+    /// <summary>Opening a conversation establishes what the deployment said about the whole of it, not about the page.</summary>
+    [Fact]
+    public void Opening_APageADeploymentServed_KeepsWhatItSaidAboutTheWholeConversation()
+    {
+        // Arrange
+        var page = MailThreads.Page(
+            [MailThreads.Message(1), MailThreads.Message(2)],
+            messageCount: 9,
+            moreMessagesNotAssembled: true,
+            moreParticipantsNotNamed: true,
+            nextCursor: "after-2");
+
+        // Act
+        var window = ThreadWindow.Opening(new ThreadOpening(MailThreads.Identity, MailMessages.Identity(2)), page);
+
+        // Assert
+        Assert.True(window.IsOpen);
+        Assert.Equal(MailThreads.Identity, window.ThreadId);
+        Assert.Equal(MailMessages.Identity(2), window.OpenedAt);
+        Assert.Equal(9, window.MessageCount);
+        Assert.True(window.MoreMessagesNotAssembled);
+        Assert.True(window.MoreParticipantsNotNamed);
+        Assert.True(window.HasMore);
+        Assert.Equal(2, window.Messages.Count);
+    }
+
+    /// <summary>A conversation grows forwards, so a page is taken onto the end of what has been read.</summary>
+    [Fact]
+    public void Extended_AFollowingPage_TakesItOntoTheEndOfWhatWasRead()
+    {
+        // Arrange
+        var window = ThreadWindow.Opening(
+            new ThreadOpening(MailThreads.Identity, AtMessage: null),
+            MailThreads.Page([MailThreads.Message(1)], nextCursor: "after-1"));
+
+        // Act
+        var extended = window.Extended(MailThreads.Page([MailThreads.Message(2)], messageCount: 2));
+
+        // Assert
+        Assert.Equal(
+            [MailMessages.Identity(1), MailMessages.Identity(2)],
+            extended.Messages.Select(message => message.Email!.Id));
+
+        Assert.False(extended.HasMore);
+    }
+
+    /// <summary>
+    /// The counts come from the newer answer, because each of them describes the conversation as the deployment reads
+    /// it now rather than as it read it when the first page was asked for.
+    /// </summary>
+    [Fact]
+    public void Extended_ADeploymentThatHasSinceCountedDifferently_TakesTheNewerCount()
+    {
+        // Arrange
+        var window = ThreadWindow.Opening(
+            new ThreadOpening(MailThreads.Identity, AtMessage: null),
+            MailThreads.Page([MailThreads.Message(1)], messageCount: 2, nextCursor: "after-1"));
+
+        // Act
+        var extended = window.Extended(MailThreads.Page([MailThreads.Message(2)], messageCount: 3));
+
+        // Assert
+        Assert.Equal(3, extended.MessageCount);
+    }
+
+    /// <summary>
+    /// A message the answer described with no message of its own is left out rather than drawn as a line with nothing
+    /// on it, and stays counted, because the count is the deployment's statement about the conversation.
+    /// </summary>
+    [Fact]
+    public void Opening_AMessageTheAnswerDescribedWithNothing_LeavesItOutAndKeepsTheCount()
+    {
+        // Arrange
+        var page = MailThreads.Page(
+            [MailThreads.Message(1), new DeploymentThreadMessage(1, AnsweredId: null, Email: null)],
+            messageCount: 2);
+
+        // Act
+        var window = ThreadWindow.Opening(new ThreadOpening(MailThreads.Identity, AtMessage: null), page);
+
+        // Assert
+        Assert.Single(window.Messages);
+        Assert.Equal(2, window.MessageCount);
+    }
+
+    /// <summary>
+    /// A page in flight when another conversation is opened belongs to neither, which is what holding it against the
+    /// reading it was started under decides.
+    /// </summary>
+    [Fact]
+    public void IsOf_AWindowOfAnotherConversationOrAnotherArrival_IsNotTheSameReading()
+    {
+        // Arrange
+        var page = MailThreads.Page([MailThreads.Message(1)]);
+        var window = ThreadWindow.Opening(new ThreadOpening(MailThreads.Identity, AtMessage: null), page);
+
+        var elsewhere = ThreadWindow.Opening(new ThreadOpening(Guid.NewGuid(), AtMessage: null), page);
+        var arrivedAt = ThreadWindow.Opening(
+            new ThreadOpening(MailThreads.Identity, MailMessages.Identity(1)),
+            page);
+
+        // Act, Assert
+        Assert.True(window.IsOf(window));
+        Assert.False(window.IsOf(elsewhere));
+        Assert.False(window.IsOf(arrivedAt));
+    }
+
+    /// <summary>A screen nothing has been opened in is a state of its own rather than an empty conversation.</summary>
+    [Fact]
+    public void Nothing_NoConversationOpened_IsNeitherOpenNorPageable()
+    {
+        // Act, Assert
+        Assert.False(ThreadWindow.Nothing.IsOpen);
+        Assert.False(ThreadWindow.Nothing.HasMore);
+        Assert.Empty(ThreadWindow.Nothing.Messages);
+    }
+}

--- a/frontend/tests/Client.UnitTests/Strings/ResourceTableTests.cs
+++ b/frontend/tests/Client.UnitTests/Strings/ResourceTableTests.cs
@@ -10,6 +10,7 @@ using MailFathom.Client.Presentation;
 using MailFathom.Client.Presentation.Mailboxes;
 using MailFathom.Client.Presentation.Messages;
 using MailFathom.Client.Presentation.Spaces.Mail.Reading;
+using MailFathom.Client.Presentation.Threads;
 using MailFathom.Client.Presentation.Workspace;
 using MailFathom.Client.Session;
 
@@ -252,6 +253,24 @@ public sealed class ResourceTableTests
     {
         // Arrange
         var expected = MessageWords.ResourceKeys;
+
+        // Act
+        var table = DeclaredLanguages.TableOf(culture);
+
+        // Assert
+        Assert.All(expected, key => Assert.True(table.ContainsKey(key), key));
+    }
+
+    /// <summary>
+    /// A conversation's header and the line each of its messages collapses to are composed from what a deployment
+    /// answered rather than authored against a control, so their keys are asserted here with the rest.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Languages))]
+    public void Tables_TheWordsAConversationIsComposedFrom_AreNamedInEveryLanguage(string culture)
+    {
+        // Arrange
+        var expected = ThreadWords.ResourceKeys;
 
         // Act
         var table = DeclaredLanguages.TableOf(culture);

--- a/frontend/tests/Client.UnitTests/TestDoubles/MailMessages.cs
+++ b/frontend/tests/Client.UnitTests/TestDoubles/MailMessages.cs
@@ -27,6 +27,7 @@ internal static class MailMessages
     /// <param name="answered">Whether it last reported it with <c>\Answered</c>.</param>
     /// <param name="attachmentCount">How many attachments it carries.</param>
     /// <param name="preview">The opening of its own text, or <see langword="null" /> where nothing has extracted it.</param>
+    /// <param name="threadId">The conversation it belongs to, or <see langword="null" /> where nothing has placed it in one.</param>
     /// <returns>The message.</returns>
     internal static DeploymentMailMessage Message(
         int number,
@@ -39,12 +40,13 @@ internal static class MailMessages
         bool flagged = false,
         bool answered = false,
         int attachmentCount = 0,
-        string? preview = null) =>
+        string? preview = null,
+        Guid? threadId = null) =>
         new(
             Identity(number),
             "work",
             "INBOX",
-            ThreadId: null,
+            threadId,
             subject,
             receivedAt,
             receivedAt,

--- a/frontend/tests/Client.UnitTests/TestDoubles/MailThreads.cs
+++ b/frontend/tests/Client.UnitTests/TestDoubles/MailThreads.cs
@@ -1,0 +1,143 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Globalization;
+using MailFathom.Client.Backend.Threads;
+
+namespace MailFathom.Client.UnitTests.TestDoubles;
+
+/// <summary>The conversations a test arranges a thread out of, composed once rather than at each arrangement.</summary>
+/// <remarks>
+/// A conversation carries eight fields around a list of messages that carry seventeen each, and a test is usually about
+/// one of them. Everything here is invented: no address, subject, or contribution below belongs to anybody.
+/// </remarks>
+internal static class MailThreads
+{
+    /// <summary>The conversation every arrangement here is of.</summary>
+    internal static Guid Identity { get; } = Guid.ParseExact("00000000000000000000000000000099", "N");
+
+    /// <summary>Composes one page of a conversation, defaulting everything a test is not about.</summary>
+    /// <param name="messages">The messages the page carries, in the conversation's own order.</param>
+    /// <param name="participants">Everybody the deployment names as having written in it.</param>
+    /// <param name="messageCount">How many messages the whole conversation holds, which defaults to what the page carries.</param>
+    /// <param name="moreMessagesNotAssembled">Whether it runs past what one read assembles.</param>
+    /// <param name="moreParticipantsNotNamed">Whether it has authors the participants do not name.</param>
+    /// <param name="nextCursor">The cursor continuing it, or <see langword="null" /> where it ends there.</param>
+    /// <returns>The page.</returns>
+    internal static DeploymentMailThreadPage Page(
+        IReadOnlyList<DeploymentThreadMessage> messages,
+        IReadOnlyList<DeploymentThreadParticipant>? participants = null,
+        int? messageCount = null,
+        bool moreMessagesNotAssembled = false,
+        bool moreParticipantsNotNamed = false,
+        string? nextCursor = null) =>
+        new(
+            Identity,
+            messages,
+            participants ?? [new DeploymentThreadParticipant("someone@example.test", "Someone", messages.Count)],
+            messageCount ?? messages.Count,
+            moreMessagesNotAssembled,
+            moreParticipantsNotNamed,
+            nextCursor,
+            PageSize: 50);
+
+    /// <summary>Composes one message of a conversation around the message the list would draw for it.</summary>
+    /// <param name="number">What makes this message's identity its own.</param>
+    /// <param name="position">Where it sits in the conversation's order, which defaults to its number.</param>
+    /// <param name="answered">The message it answers, or <see langword="null" /> where it is a root of what is shown.</param>
+    /// <param name="contribution">What it added, or <see langword="null" /> where nothing has extracted it.</param>
+    /// <param name="sentAt">When it was written, or <see langword="null" /> where no header dated it.</param>
+    /// <param name="senderDisplayName">The name the sender wrote, or <see langword="null" /> where the header carried none.</param>
+    /// <param name="senderAddress">The address the sender wrote, or <see langword="null" /> where none was found.</param>
+    /// <param name="recipients">Who it went to.</param>
+    /// <param name="unread">Whether the mail server last reported it without <c>\Seen</c>.</param>
+    /// <param name="subject">What it is about, or <see langword="null" /> where it carried no subject.</param>
+    /// <returns>The message.</returns>
+    internal static DeploymentThreadMessage Message(
+        int number,
+        int? position = null,
+        Guid? answered = null,
+        string? contribution = "What this one added",
+        DateTimeOffset? sentAt = null,
+        string? senderDisplayName = "Someone",
+        string? senderAddress = "someone@example.test",
+        IReadOnlyList<string>? recipients = null,
+        bool unread = false,
+        string? subject = "Quarterly review") =>
+        new(
+            position ?? number,
+            answered,
+            MailMessages.Message(
+                number,
+                sentAt,
+                subject,
+                senderDisplayName,
+                senderAddress,
+                recipients,
+                unread,
+                preview: contribution,
+                threadId: Identity));
+
+    /// <summary>Writes one page of a conversation as the deployment writes it on the wire.</summary>
+    /// <param name="messages">How many messages the page carries, numbered from one.</param>
+    /// <param name="nextCursor">The cursor continuing it, or <see langword="null" /> where it ends there.</param>
+    /// <param name="from">The number the page's first message carries, so a second page follows the first.</param>
+    /// <returns>The document.</returns>
+    /// <remarks>
+    /// Written as text rather than serialized from the record above, because what a test of the client's own reader is
+    /// about is the wire format: a document composed through this client's serializer could not fail the way an answer
+    /// naming a member differently would.
+    /// </remarks>
+    internal static string Document(int messages, string? nextCursor = null, int from = 1)
+    {
+        var written = Enumerable
+            .Range(from, messages)
+            .Select(number => string.Create(
+                CultureInfo.InvariantCulture,
+                $$"""
+                  {
+                    "position": {{number - 1}},
+                    "answeredId": null,
+                    "email": {
+                      "id": "{{MailMessages.Identity(number)}}",
+                      "account": "work",
+                      "folder": "INBOX",
+                      "threadId": "{{Identity}}",
+                      "subject": "Quarterly review",
+                      "receivedAt": "2026-08-15T09:58:00+00:00",
+                      "sentAt": "2026-08-15T09:57:12+00:00",
+                      "senderAddress": "someone@example.test",
+                      "senderDisplayName": "Someone",
+                      "toAddresses": [ "owner@example.test" ],
+                      "unread": false,
+                      "flagged": false,
+                      "answered": false,
+                      "hasAttachments": false,
+                      "attachmentCount": 0,
+                      "sizeOctets": 1024,
+                      "preview": "What this one added"
+                    }
+                  }
+                  """));
+
+        var cursor = nextCursor is null ? "null" : $"\"{nextCursor}\"";
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $$"""
+              {
+                "threadId": "{{Identity}}",
+                "messages": [ {{string.Join(',', written)}} ],
+                "participants": [
+                  { "address": "someone@example.test", "displayName": "Someone", "messageCount": {{messages}} }
+                ],
+                "messageCount": {{messages}},
+                "moreMessagesNotAssembled": false,
+                "moreParticipantsNotNamed": false,
+                "nextCursor": {{cursor}},
+                "pageSize": 50
+              }
+              """);
+    }
+}

--- a/frontend/tests/Client.UnitTests/TestDoubles/StubMailThread.cs
+++ b/frontend/tests/Client.UnitTests/TestDoubles/StubMailThread.cs
@@ -1,0 +1,110 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Immutable;
+using MailFathom.Client.Presentation.Threads;
+
+namespace MailFathom.Client.UnitTests.TestDoubles;
+
+/// <summary>A conversation that answers with what a test handed it and records what was asked of it.</summary>
+/// <remarks>
+/// The Mail space hands every one of these on rather than deciding any of them, so what its tests need is a
+/// conversation that says whether it was reached and with what — the behaviour of a real one is asserted where it is
+/// built.
+/// </remarks>
+internal sealed class StubMailThread : IMailThread
+{
+    /// <summary>Builds a conversation drawing the messages a test states.</summary>
+    /// <param name="messages">What the conversation answers with.</param>
+    internal StubMailThread(params ThreadMessageRow[] messages)
+    {
+        IImmutableList<ThreadMessageRow> drawn = [.. messages];
+
+        this.Reading = Feed.Async(_ => ValueTask.FromResult(ThreadReading.Nothing));
+        this.Messages = Feed.Async(_ => ValueTask.FromResult(drawn)).AsListFeed();
+        this.HasMoreMessages = Feed.Async(_ => ValueTask.FromResult(this.More));
+        this.PagingFailed = Feed.Async(_ => ValueTask.FromResult(false));
+    }
+
+    /// <summary>Gets or sets whether the stub reports more of the conversation after what has been read.</summary>
+    internal bool More { get; set; }
+
+    /// <summary>Gets every conversation the stub was asked to open, in order.</summary>
+    internal List<(Guid? ThreadId, Guid? AtMessage)> Opened { get; } = [];
+
+    /// <summary>Gets every message the stub was asked to expand or collapse, in order.</summary>
+    internal List<string> Toggled { get; } = [];
+
+    /// <summary>Gets every message the stub was asked for the whole of, in order.</summary>
+    internal List<string> Whole { get; } = [];
+
+    /// <summary>Gets every message the stub was asked to read again with its remote pictures, in order.</summary>
+    internal List<string> Remote { get; } = [];
+
+    /// <summary>Gets how many times the stub was asked for another page of the conversation.</summary>
+    internal int Pages { get; private set; }
+
+    /// <summary>Gets how many times the stub was asked to read the deployment again.</summary>
+    internal int Asks { get; private set; }
+
+    /// <inheritdoc />
+    public IFeed<ThreadReading> Reading { get; }
+
+    /// <inheritdoc />
+    public IListFeed<ThreadMessageRow> Messages { get; }
+
+    /// <inheritdoc />
+    public IFeed<bool> HasMoreMessages { get; }
+
+    /// <inheritdoc />
+    public IFeed<bool> PagingFailed { get; }
+
+    /// <inheritdoc />
+    public ValueTask OpenAsync(Guid? threadId, Guid? atMessage, CancellationToken cancellationToken)
+    {
+        this.Opened.Add((threadId, atMessage));
+
+        return ValueTask.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public ValueTask ToggleAsync(string key, CancellationToken cancellationToken)
+    {
+        this.Toggled.Add(key);
+
+        return ValueTask.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public ValueTask ShowWholeMessageAsync(string key, CancellationToken cancellationToken)
+    {
+        this.Whole.Add(key);
+
+        return ValueTask.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public ValueTask ShowRemoteContentAsync(string key, CancellationToken cancellationToken)
+    {
+        this.Remote.Add(key);
+
+        return ValueTask.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public ValueTask ShowMoreAsync(CancellationToken cancellationToken)
+    {
+        this.Pages++;
+
+        return ValueTask.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public ValueTask AskAgainAsync(CancellationToken cancellationToken)
+    {
+        this.Asks++;
+
+        return ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
Closes #1162

The Mail space's companion column was a placeholder. It now draws the conversation the selected
message belongs to.

## What the screen does

- **The header is answered about the whole exchange** — the subject the first message set, how many
  messages the conversation holds, and everybody the deployment named as having written in it — so a
  header drawn from the first page stays true as later pages arrive rather than naming whoever
  happened to be on it.
- **Every message collapses to one line and opens to what it added.** The deployment publishes that
  contribution with the quoted history and the signature trimmed off, and it arrives *with* the
  conversation — so an exchange of thirty replies is one request to draw, and the eighth reply does
  not redraw the seven above it.
- **The whole of a message, quoted history and all, is a request somebody made.** It is read only for
  the message it was asked of and drawn by `MailBodyView`, the pane a single message is already read
  in — which keeps the question asked before a link is followed one piece of code rather than two.
  Collapsing that message drops the whole of it along with the answer about its remote pictures, so
  no allowance outlives the reason it was given.
- **A conversation opens at the message somebody arrived at.** A search result and a citation both
  reach mail by naming one message inside an exchange, so that message is expanded and scrolled to;
  where nobody named one, the newest is.
- **Nothing is scoped to the folder the list is drawn from**, and it cannot be: the question is in the
  inbox, the answer is in the sent folder, and a forwarded copy is somewhere else again.
- **Each failure is said where it belongs.** A conversation that did not arrive is the feed's error
  state with an ask; a page that did not arrive, and a whole message that did not, are each said
  beside what is already drawn rather than instead of it.

## How it is put together

- `Client.Backend/Threads/` states the wire contract for `GET /api/client/threads/{threadId}` and
  reads it through the source-generated context, `DeploymentRoutes` writes the route, and
  `DeploymentClient.ReadMailThreadAsync` is the one call.
- `Client/Presentation/Threads/` holds the conversation. `IMailThread` is registered once for the run
  beside the message list and the mailbox tree, because a conversation is reached by naming a message
  inside it rather than only from the list — one held per model would be one screen for Mail and
  another for everywhere else. It follows `IMessageList.Chosen`: one message selected opens the
  exchange it is in, several close it.
- `ThreadShape` is a pure reduction of what the deployment answered plus what the reader has opened,
  so the whole of what the screen says is reachable by an ordinary unit test — the same arrangement
  `MessageListShape` has.
- `MessageRow` gains `ThreadId`, the one member nothing draws: it is what opens the conversation
  without a request per click.
- `MailBodyView` gains a `ShowRemoteContentCommandParameter` dependency property, because inside a
  conversation one command re-reads whichever message the reader asked it of.

## Not in this change

A reading pane over a single message (#1163) and the responsive composition of the two columns
(#1165) are their own issues. This change reuses `MailBodyView` and the body route rather than
building either.

## Incidental repair

`frontend/tests/Client.UnitTests/Client.UnitTests.csproj` is unparseable on `main`: the
`manifest.webmanifest` item lost its `CopyToOutputDirectory` attribute and its closing tag in #1334,
so MSBuild fails with `MSB4025` and nothing under `frontend/` builds. One line restores it. It is
carried here because the branch could not be built or verified without it.

## Contract

No break. `GET /api/client/threads/{threadId}` is a route the client endpoint already published and
`docs/operations/client-endpoint.md` already documents; this change is the first client of it. No
configuration key, database column, MCP tool argument, or deployment contract moves.

## Verification

- `scripts/verify-full.sh` — pass, 659 client unit tests, 261 contract assertions.
- `scripts/review-obligations.sh` — two rows, both answered: ADR 0019 is unaffected by a new
  dependency property on `MailBodyView`, and `docs/architecture/solution-structure.md` is updated in
  this change for the third non-screen directory under `Presentation/`.
- `$check-docs-licenses` — Docs pass, Changelog n/a, Licenses n/a (no dependency moves).
