### PR TITLE
Read messages in the client

### DIFF
--- a/frontend/src/Client.Backend/DeploymentClient.cs
+++ b/frontend/src/Client.Backend/DeploymentClient.cs
@@ -146,6 +146,16 @@ public sealed class DeploymentClient
             DeploymentJsonContext.Default.DeploymentMailThreadPage,
             cancellationToken);
 
+    /// <summary>Asks the deployment for everything a reading pane draws around one message.</summary>
+    public Task<DeploymentMailMessageDetail> ReadMailMessageAsync(
+        Guid storedEmailId,
+        CancellationToken cancellationToken = default) =>
+        DeploymentExchange.ReadAsync(
+            this.Transport(),
+            new HttpRequestMessage(HttpMethod.Get, DeploymentRoutes.MailMessagePath(storedEmailId)),
+            DeploymentJsonContext.Default.DeploymentMailMessageDetail,
+            cancellationToken);
+
     /// <summary>Asks the deployment for one message's body, in both the renderings a reading pane draws it from.</summary>
     /// <param name="storedEmailId">The message to read, as a list row or a conversation published it.</param>
     /// <param name="remoteImages">Whether the reader has asked for this message's remote pictures, having been told what that reveals.</param>
@@ -169,6 +179,31 @@ public sealed class DeploymentClient
             DeploymentJsonContext.Default.DeploymentMailBody,
             cancellationToken,
             DeploymentExchange.MaxMailBodyBytes);
+
+    /// <summary>Streams one attachment into the destination a reader chose.</summary>
+    public Task DownloadMailAttachmentAsync(
+        Guid storedEmailId,
+        int position,
+        long expectedSizeOctets,
+        Stream destination,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(position);
+        ArgumentOutOfRangeException.ThrowIfNegative(expectedSizeOctets);
+        ArgumentNullException.ThrowIfNull(destination);
+
+        if (!destination.CanWrite)
+        {
+            throw new ArgumentException("The attachment destination must be writable.", nameof(destination));
+        }
+
+        return DeploymentExchange.CopyAsync(
+            this.Transport(),
+            new HttpRequestMessage(HttpMethod.Get, DeploymentRoutes.MailAttachmentPath(storedEmailId, position)),
+            expectedSizeOctets,
+            destination,
+            cancellationToken);
+    }
 
     /// <summary>Takes a transport aimed at wherever the client is pointed right now.</summary>
     /// <remarks>

--- a/frontend/src/Client.Backend/DeploymentExchange.cs
+++ b/frontend/src/Client.Backend/DeploymentExchange.cs
@@ -46,6 +46,14 @@ internal static class DeploymentExchange
     /// </remarks>
     internal const int MaxMailBodyBytes = 8 * 1024 * 1024;
 
+    /// <summary>The largest attachment this client will write, independently of what a deployment declares.</summary>
+    /// <remarks>
+    /// One attachment cannot exceed the largest raw message the service admits, whose public configuration contract
+    /// tops out at 100 MiB. Stating the same ceiling here means a compromised deployment cannot turn its own claimed
+    /// length into an unbounded write on the reader's device.
+    /// </remarks>
+    internal const long MaxMailAttachmentBytes = 100L * 1024 * 1024;
+
     /// <summary>Sends one request and reads the document it answers with.</summary>
     /// <typeparam name="TDocument">The contract the body is read against.</typeparam>
     /// <param name="transport">The client the request is sent on.</param>
@@ -128,16 +136,20 @@ internal static class DeploymentExchange
         CancellationToken cancellationToken)
     {
         using (request)
-        using (var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
         {
-            timeout.CancelAfter(transport.Timeout);
+            if (expectedSizeOctets > MaxMailAttachmentBytes)
+            {
+                throw new DeploymentFailure(
+                    DeploymentFailureReason.Unusable,
+                    "MailFathom described a file larger than this client will save, so it was not requested.");
+            }
 
             try
             {
                 using var response = await SendAsync(
                     transport,
                     request,
-                    timeout.Token,
+                    cancellationToken,
                     HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
 
                 RefuseUnusableStatus(response);
@@ -149,8 +161,9 @@ internal static class DeploymentExchange
                         "MailFathom answered with a file whose size differs from its description, so it was not used.");
                 }
 
-                var source = await response.Content.ReadAsStreamAsync(timeout.Token).ConfigureAwait(false);
+                var source = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
                 await using var sourceLifetime = source.ConfigureAwait(false);
+                using var inactivity = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 var buffer = ArrayPool<byte>.Shared.Rent(81920);
 
                 try
@@ -158,16 +171,27 @@ internal static class DeploymentExchange
                     long written = 0;
                     int read;
 
-                    while ((read = await source.ReadAsync(buffer.AsMemory(), timeout.Token).ConfigureAwait(false)) > 0)
+                    while (true)
                     {
-                        if (written + read > expectedSizeOctets)
+                        inactivity.CancelAfter(transport.Timeout);
+                        read = await source.ReadAsync(buffer.AsMemory(), inactivity.Token).ConfigureAwait(false);
+                        inactivity.CancelAfter(Timeout.InfiniteTimeSpan);
+
+                        if (read is 0)
+                        {
+                            break;
+                        }
+
+                        if (read > expectedSizeOctets - written)
                         {
                             throw new DeploymentFailure(
                                 DeploymentFailureReason.Unusable,
                                 "MailFathom sent more of a file than its description promised, so it was not used.");
                         }
 
-                        await destination.WriteAsync(buffer.AsMemory(0, read), timeout.Token).ConfigureAwait(false);
+                        inactivity.CancelAfter(transport.Timeout);
+                        await destination.WriteAsync(buffer.AsMemory(0, read), inactivity.Token).ConfigureAwait(false);
+                        inactivity.CancelAfter(Timeout.InfiniteTimeSpan);
                         written += read;
                     }
 

--- a/frontend/src/Client.Backend/DeploymentExchange.cs
+++ b/frontend/src/Client.Backend/DeploymentExchange.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Buffers;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
@@ -76,16 +77,18 @@ internal static class DeploymentExchange
     /// <param name="transport">The client the request is sent on.</param>
     /// <param name="request">The request.</param>
     /// <param name="cancellationToken">Cancels the request.</param>
+    /// <param name="completion">Whether the send completes after the headers or after the body has been buffered.</param>
     /// <returns>The answer, whatever its status.</returns>
     /// <exception cref="DeploymentFailure">Thrown when nothing answered.</exception>
     internal static async Task<HttpResponseMessage> SendAsync(
         HttpClient transport,
         HttpRequestMessage request,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        HttpCompletionOption completion = HttpCompletionOption.ResponseContentRead)
     {
         try
         {
-            return await transport.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            return await transport.SendAsync(request, completion, cancellationToken).ConfigureAwait(false);
         }
         catch (TaskCanceledException failure) when (!cancellationToken.IsCancellationRequested)
         {
@@ -113,6 +116,80 @@ internal static class DeploymentExchange
                 DeploymentFailureReason.Unreachable,
                 "MailFathom could not be reached. Check that the address is right and that this device is online.",
                 failure);
+        }
+    }
+
+    /// <summary>Streams an answer into a destination, accepting exactly the number of octets its description promised.</summary>
+    internal static async Task CopyAsync(
+        HttpClient transport,
+        HttpRequestMessage request,
+        long expectedSizeOctets,
+        Stream destination,
+        CancellationToken cancellationToken)
+    {
+        using (request)
+        using (var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
+        {
+            timeout.CancelAfter(transport.Timeout);
+
+            try
+            {
+                using var response = await SendAsync(
+                    transport,
+                    request,
+                    timeout.Token,
+                    HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+
+                RefuseUnusableStatus(response);
+
+                if (response.Content.Headers.ContentLength != expectedSizeOctets)
+                {
+                    throw new DeploymentFailure(
+                        DeploymentFailureReason.Unusable,
+                        "MailFathom answered with a file whose size differs from its description, so it was not used.");
+                }
+
+                var source = await response.Content.ReadAsStreamAsync(timeout.Token).ConfigureAwait(false);
+                await using var sourceLifetime = source.ConfigureAwait(false);
+                var buffer = ArrayPool<byte>.Shared.Rent(81920);
+
+                try
+                {
+                    long written = 0;
+                    int read;
+
+                    while ((read = await source.ReadAsync(buffer.AsMemory(), timeout.Token).ConfigureAwait(false)) > 0)
+                    {
+                        if (written + read > expectedSizeOctets)
+                        {
+                            throw new DeploymentFailure(
+                                DeploymentFailureReason.Unusable,
+                                "MailFathom sent more of a file than its description promised, so it was not used.");
+                        }
+
+                        await destination.WriteAsync(buffer.AsMemory(0, read), timeout.Token).ConfigureAwait(false);
+                        written += read;
+                    }
+
+                    if (written != expectedSizeOctets)
+                    {
+                        throw new DeploymentFailure(
+                            DeploymentFailureReason.Unusable,
+                            "MailFathom sent less of a file than its description promised, so it was not used.");
+                    }
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(buffer);
+                }
+            }
+            catch (OperationCanceledException failure) when (!cancellationToken.IsCancellationRequested)
+            {
+                throw new DeploymentFailure(
+                    DeploymentFailureReason.TimedOut,
+                    "MailFathom did not finish sending the file in time.",
+                    failure);
+            }
         }
     }
 

--- a/frontend/src/Client.Backend/DeploymentJsonContext.cs
+++ b/frontend/src/Client.Backend/DeploymentJsonContext.cs
@@ -31,6 +31,7 @@ namespace MailFathom.Client.Backend;
 [JsonSerializable(typeof(DeploymentMailFolders))]
 [JsonSerializable(typeof(DeploymentMailTimelinePage))]
 [JsonSerializable(typeof(DeploymentMailThreadPage))]
+[JsonSerializable(typeof(DeploymentMailMessageDetail))]
 [JsonSerializable(typeof(DeploymentMailBody))]
 // One entry per block the reduction publishes, because the reader that dispatches on a block's identity resolves each
 // of them by its own generated type info rather than by reflection over the hierarchy.

--- a/frontend/src/Client.Backend/DeploymentRoutes.cs
+++ b/frontend/src/Client.Backend/DeploymentRoutes.cs
@@ -80,6 +80,10 @@ internal static class DeploymentRoutes
         return string.Create(CultureInfo.InvariantCulture, $"{Prefix}/threads/{threadId:D}{query}");
     }
 
+    /// <summary>Where a deployment describes everything a pane draws around one message.</summary>
+    internal static string MailMessagePath(Guid storedEmailId) =>
+        string.Create(CultureInfo.InvariantCulture, $"{Prefix}/messages/{storedEmailId:D}");
+
     /// <summary>Where a deployment serves one message's body, as the two renderings a reading pane draws it from.</summary>
     /// <param name="storedEmailId">The message, as a list row or a conversation published it.</param>
     /// <param name="remoteImages">Whether the reader has asked for this message's remote pictures.</param>
@@ -92,4 +96,8 @@ internal static class DeploymentRoutes
     internal static string MailBodyPath(Guid storedEmailId, bool remoteImages) => string.Create(
         CultureInfo.InvariantCulture,
         $"{Prefix}/messages/{storedEmailId:D}/body{(remoteImages ? "?remoteImages=true" : string.Empty)}");
+
+    /// <summary>Where a deployment streams one attachment of one message.</summary>
+    internal static string MailAttachmentPath(Guid storedEmailId, int position) =>
+        string.Create(CultureInfo.InvariantCulture, $"{Prefix}/messages/{storedEmailId:D}/attachments/{position}");
 }

--- a/frontend/src/Client.Backend/Mail/DeploymentMailMessageDetail.cs
+++ b/frontend/src/Client.Backend/Mail/DeploymentMailMessageDetail.cs
@@ -1,0 +1,70 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Backend.Mail;
+
+/// <summary>Everything a reading pane draws around one message, with none of its body or attachment octets.</summary>
+/// <param name="StoredEmailId">The message.</param>
+/// <param name="Account">The account the message belongs to.</param>
+/// <param name="Folder">The folder the message belongs to.</param>
+/// <param name="ThreadId">The conversation the message belongs to, or <see langword="null" /> where none is known.</param>
+/// <param name="SizeOctets">The size the mail server reported for the whole message.</param>
+/// <param name="Headers">What the message displays above its body.</param>
+/// <param name="Body">Whether the body can be read and which forms the sender wrote.</param>
+/// <param name="Sender">What the deployment established about the displayed author.</param>
+/// <param name="Attachments">The files the message carries, described without their octets.</param>
+/// <param name="Carried">The counts for the message's non-body parts, or <see langword="null" /> where none were parsed.</param>
+/// <param name="Unread">Whether the mail server last reported the message as unseen.</param>
+/// <param name="Flagged">Whether the mail server last reported the message as flagged.</param>
+/// <param name="Answered">Whether the mail server last reported the message as answered.</param>
+public sealed record DeploymentMailMessageDetail(
+    Guid StoredEmailId,
+    string Account,
+    string Folder,
+    Guid? ThreadId,
+    long SizeOctets,
+    DeploymentMailHeaders Headers,
+    DeploymentMailBodyForms Body,
+    DeploymentMailSenderVerdict Sender,
+    IReadOnlyList<DeploymentMailAttachment> Attachments,
+    DeploymentMailCarriedParts? Carried,
+    bool Unread,
+    bool Flagged,
+    bool Answered);
+
+/// <summary>The headers one message displays above its body.</summary>
+public sealed record DeploymentMailHeaders(
+    string? Subject,
+    DateTimeOffset? SentAt,
+    DateTimeOffset? ReceivedAt,
+    IReadOnlyList<DeploymentMailParticipant> Participants,
+    string? MessageId,
+    string? InReplyTo,
+    IReadOnlyList<string> References);
+
+/// <summary>One address a message wrote, and the header it appeared in.</summary>
+public sealed record DeploymentMailParticipant(string Role, string Address, string? DisplayName);
+
+/// <summary>Whether a message's body can be read and which forms the sender wrote.</summary>
+public sealed record DeploymentMailBodyForms(string Availability, bool PlainText, bool Html);
+
+/// <summary>What the deployment established about the displayed author.</summary>
+public sealed record DeploymentMailSenderVerdict(string AuthorAuthentication, string DeploymentTrust);
+
+/// <summary>One file a message carries, described without its octets.</summary>
+public sealed record DeploymentMailAttachment(
+    int Position,
+    string? FileName,
+    bool WasFileNameNormalized,
+    string MediaType,
+    long SizeOctets);
+
+/// <summary>The counts for everything one message carries besides its body.</summary>
+public sealed record DeploymentMailCarriedParts(
+    int AttachmentCount,
+    long TotalSizeOctets,
+    int InlineResourceCount,
+    bool Encrypted,
+    bool UnverifiedSignature,
+    bool UnexpandedTnefPart);

--- a/frontend/src/Client/ClientComposition.cs
+++ b/frontend/src/Client/ClientComposition.cs
@@ -7,6 +7,7 @@ using MailFathom.Client.Backend.Authorization;
 using MailFathom.Client.Deployment;
 using MailFathom.Client.Presentation.Mailboxes;
 using MailFathom.Client.Presentation.Messages;
+using MailFathom.Client.Presentation.Spaces.Mail.Reading;
 using MailFathom.Client.Presentation.Threads;
 using MailFathom.Client.Presentation.Workspace;
 using MailFathom.Client.Session;
@@ -76,6 +77,7 @@ internal static class ClientComposition
         // its own: a conversation is reached by naming one message inside it, which a search result and a citation both
         // do, so a conversation held per model would be one screen for the mail space and another for everywhere else.
         services.AddSingleton<IMailThread, DeploymentMailThread>();
+        services.AddSingleton<IMailAttachmentSaver, PickedMailAttachmentSaver>();
 
         // What the deployment allows this caller, for the same reason and on the same terms. It is the one place that
         // answers whether something may be offered, so every screen reads one answer instead of deriving its own from

--- a/frontend/src/Client/Presentation/Mailboxes/DeploymentMailboxTree.cs
+++ b/frontend/src/Client/Presentation/Mailboxes/DeploymentMailboxTree.cs
@@ -176,6 +176,12 @@ internal sealed class DeploymentMailboxTree : IMailboxTree
         var scope = await this.workspace.Scope.Value(cancellationToken).ConfigureAwait(false)
             ?? WorkspaceScope.Everything;
 
-        this.memory.Write(new RememberedMailboxes(scope with { Selection = ImmutableArray<string>.Empty }, shown));
+        this.memory.Write(new RememberedMailboxes(
+            scope with
+            {
+                Selection = ImmutableArray<string>.Empty,
+                BodySelection = string.Empty,
+            },
+            shown));
     }
 }

--- a/frontend/src/Client/Presentation/Messages/DeploymentMessageList.cs
+++ b/frontend/src/Client/Presentation/Messages/DeploymentMessageList.cs
@@ -347,7 +347,11 @@ internal sealed class DeploymentMessageList : IMessageList
         IImmutableList<string> selected = [.. (chosen ?? []).Select(static row => row.Key)];
 
         await this.workspace.Scope.UpdateAsync(
-            scope => (scope ?? WorkspaceScope.Everything) with { Selection = selected },
+            scope => (scope ?? WorkspaceScope.Everything) with
+            {
+                Selection = selected,
+                BodySelection = string.Empty,
+            },
             cancellationToken).ConfigureAwait(false);
     }
 

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailModel.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailModel.cs
@@ -5,7 +5,9 @@
 using System.Collections.Immutable;
 using MailFathom.Client.Backend.Timeline;
 using MailFathom.Client.Presentation.Messages;
+using MailFathom.Client.Presentation.Spaces.Mail.Reading;
 using MailFathom.Client.Presentation.Threads;
+using MailFathom.Client.Presentation.Workspace;
 using MailFathom.Client.Session;
 
 namespace MailFathom.Client.Presentation.Spaces.Mail;
@@ -37,20 +39,24 @@ public partial record MailModel
 {
     private readonly IMessageList messages;
     private readonly IMailThread thread;
+    private readonly IWorkspace workspace;
 
     /// <summary>Initializes the space over what decides whether it may be offered, and the list and conversation it is read through.</summary>
     /// <param name="session">What the deployment allows this caller.</param>
     /// <param name="messages">The run's own message list, drawn from wherever the mailbox tree says somebody is.</param>
     /// <param name="thread">The run's own conversation, which is whatever the list has one message selected in.</param>
+    /// <param name="workspace">The scope a selected passage narrows for the intent field.</param>
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
-    public MailModel(IClientSession session, IMessageList messages, IMailThread thread)
+    public MailModel(IClientSession session, IMessageList messages, IMailThread thread, IWorkspace workspace)
     {
         ArgumentNullException.ThrowIfNull(session);
         ArgumentNullException.ThrowIfNull(messages);
         ArgumentNullException.ThrowIfNull(thread);
+        ArgumentNullException.ThrowIfNull(workspace);
 
         this.messages = messages;
         this.thread = thread;
+        this.workspace = workspace;
 
         this.WithholdsMail = session.Standing.Select(standing => standing.Withholds(ClientCapability.Mail));
 
@@ -152,6 +158,25 @@ public partial record MailModel
     /// <returns>A task completing once the second read has been asked for.</returns>
     public ValueTask ShowThreadRemoteContent(string key, CancellationToken cancellationToken) =>
         this.thread.ShowRemoteContentAsync(key, cancellationToken);
+
+    /// <summary>Streams one attachment into the destination the reader chooses.</summary>
+    public ValueTask SaveAttachment(
+        MailAttachmentRequest request,
+        CancellationToken cancellationToken) =>
+        this.thread.SaveAttachmentAsync(request, cancellationToken);
+
+    /// <summary>Stops streaming one attachment.</summary>
+    public void CancelAttachment(MailAttachmentRequest request) => this.thread.CancelAttachment(request);
+
+    /// <summary>Makes a passage selected in the body the narrowest part of the shared scope.</summary>
+    public ValueTask UseBodySelection(string selection, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(selection);
+
+        return this.workspace.Scope.UpdateAsync(
+            scope => (scope ?? WorkspaceScope.Everything) with { BodySelection = selection },
+            cancellationToken);
+    }
 
     /// <summary>Takes the next page of the conversation onto the end of what has been read.</summary>
     /// <param name="cancellationToken">Abandons the page.</param>

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailPage.xaml
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailPage.xaml
@@ -541,11 +541,15 @@ Project repository: https://github.com/Krzysztof318/MailFathom
                       <!-- The whole message, quoted history and all, drawn by the pane that already knows how to draw
                            one and how to ask before anything in it leaves the application. Its height is bounded so a
                            long message stays one message of the conversation rather than the whole column. -->
-                      <reading:MailBodyView MaxHeight="640"
-                                            Reading="{x:Bind WholeMessage, Mode=OneWay}"
-                                            Visibility="{x:Bind ShowsWholeMessage, Converter={StaticResource AffirmedVisibility}}"
-                                            ShowRemoteContentCommand="{utu:ItemsControlBinding Path=DataContext.ShowThreadRemoteContent}"
-                                            ShowRemoteContentCommandParameter="{x:Bind Key}" />
+                      <reading:MailMessageView MaxHeight="640"
+                                               Reading="{x:Bind Message, Mode=OneWay}"
+                                               Body="{x:Bind WholeMessage, Mode=OneWay}"
+                                               Visibility="{x:Bind ShowsMessage, Converter={StaticResource AffirmedVisibility}}"
+                                               ShowRemoteContentCommand="{utu:ItemsControlBinding Path=DataContext.ShowThreadRemoteContent}"
+                                               ShowRemoteContentCommandParameter="{x:Bind Key}"
+                                               SaveAttachmentCommand="{utu:ItemsControlBinding Path=DataContext.SaveAttachment}"
+                                               CancelAttachmentCommand="{utu:ItemsControlBinding Path=DataContext.CancelAttachment}"
+                                               UseSelectionCommand="{utu:ItemsControlBinding Path=DataContext.UseBodySelection}" />
                     </StackPanel>
                   </StackPanel>
                 </DataTemplate>

--- a/frontend/src/Client/Presentation/Spaces/Mail/Reading/IMailAttachmentSaver.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/Reading/IMailAttachmentSaver.cs
@@ -1,0 +1,21 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Backend.Mail;
+
+namespace MailFathom.Client.Presentation.Spaces.Mail.Reading;
+
+/// <summary>Lets a person choose where one attachment is written, without putting a storage type in a model.</summary>
+public interface IMailAttachmentSaver
+{
+    /// <summary>Chooses a destination and writes the attachment there.</summary>
+    /// <param name="attachment">The safe name and type suggested to the platform picker.</param>
+    /// <param name="write">Streams the file into the destination.</param>
+    /// <param name="cancellationToken">Cancels the choice or the write.</param>
+    /// <returns><see langword="true" /> where the file was saved, or <see langword="false" /> where the picker was cancelled.</returns>
+    ValueTask<bool> SaveAsync(
+        DeploymentMailAttachment attachment,
+        Func<Stream, CancellationToken, Task> write,
+        CancellationToken cancellationToken);
+}

--- a/frontend/src/Client/Presentation/Spaces/Mail/Reading/MailBodyDrawing.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/Reading/MailBodyDrawing.cs
@@ -73,6 +73,7 @@ internal sealed class MailBodyDrawing
 
     private readonly MailBodyWords words;
     private readonly Action<MailBodyLink, string> follow;
+    private readonly Action<string>? selected;
     private readonly List<PendingPicture> pictures = [];
 
     /// <summary>What the words being drawn actually sit on, where a cell painted something other than the surface.</summary>
@@ -87,14 +88,19 @@ internal sealed class MailBodyDrawing
     /// <summary>Initializes a drawing over the sentences it composes and what it hands a followed link to.</summary>
     /// <param name="words">The sentences the drawing itself needs.</param>
     /// <param name="follow">What a link and the words the message put on it are handed to when it is chosen.</param>
+    /// <param name="selected">What receives a passage selected in one of the drawing's text blocks.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="words" /> or <paramref name="follow" /> is <see langword="null" />.</exception>
-    internal MailBodyDrawing(MailBodyWords words, Action<MailBodyLink, string> follow)
+    internal MailBodyDrawing(
+        MailBodyWords words,
+        Action<MailBodyLink, string> follow,
+        Action<string>? selected = null)
     {
         ArgumentNullException.ThrowIfNull(words);
         ArgumentNullException.ThrowIfNull(follow);
 
         this.words = words;
         this.follow = follow;
+        this.selected = selected;
     }
 
     /// <summary>Draws the blocks, leaving each picture a place to arrive in.</summary>
@@ -398,7 +404,7 @@ internal sealed class MailBodyDrawing
         MailBodyQuoteBlock quote => this.Quote(quote, depth),
         MailBodyTableBlock table => this.Table(table, depth),
         MailBodyImageBlock picture => this.Picture(picture),
-        MailBodyPreformattedBlock preformatted => Preformatted(preformatted),
+        MailBodyPreformattedBlock preformatted => this.Preformatted(preformatted),
         MailBodySeparatorBlock => Separator(),
         _ => this.Unsupported(),
     };
@@ -428,6 +434,7 @@ internal sealed class MailBodyDrawing
     private TextBlock Text(IReadOnlyList<MailBodyRun> content)
     {
         var text = new TextBlock { TextWrapping = TextWrapping.Wrap, IsTextSelectionEnabled = true };
+        this.WatchSelection(text);
 
         foreach (var run in content)
         {
@@ -671,7 +678,7 @@ internal sealed class MailBodyDrawing
         return text;
     }
 
-    private static ScrollViewer Preformatted(MailBodyPreformattedBlock preformatted)
+    private ScrollViewer Preformatted(MailBodyPreformattedBlock preformatted)
     {
         var text = new TextBlock
         {
@@ -679,6 +686,7 @@ internal sealed class MailBodyDrawing
             TextWrapping = TextWrapping.NoWrap,
             IsTextSelectionEnabled = true,
         };
+        this.WatchSelection(text);
         Apply(text, PreformattedStyleKey);
 
         // Scrolled rather than wrapped: re-wrapping a code sample or a diff would change what the message says, which
@@ -692,6 +700,21 @@ internal sealed class MailBodyDrawing
             VerticalScrollMode = ScrollMode.Disabled,
         };
     }
+
+    private void WatchSelection(TextBlock text)
+    {
+        if (this.selected is null)
+        {
+            return;
+        }
+
+        text.PointerReleased += (_, _) => this.ReportSelection(text);
+        text.KeyUp += (_, _) => this.ReportSelection(text);
+    }
+
+#pragma warning disable Uno0001 // Implemented by the pinned Uno Skia renderer used by both published heads.
+    private void ReportSelection(TextBlock text) => this.selected!(text.SelectedText);
+#pragma warning restore Uno0001
 
     private static Border Separator()
     {

--- a/frontend/src/Client/Presentation/Spaces/Mail/Reading/MailBodyView.xaml
+++ b/frontend/src/Client/Presentation/Spaces/Mail/Reading/MailBodyView.xaml
@@ -78,11 +78,21 @@ Project repository: https://github.com/Krzysztof318/MailFathom
 
         <!-- The message as words, which is a rendering in its own right rather than a broken one. -->
         <TextBlock x:Uid="MailBody.Words"
+                   x:Name="PlainText"
                    Text="{x:Bind Reading.PlainText, Mode=OneWay}"
                    TextWrapping="Wrap"
                    IsTextSelectionEnabled="True"
+                   PointerReleased="OnPlainTextSelectionFinished"
+                   KeyUp="OnPlainTextSelectionFinished"
                    Style="{StaticResource MailBodyParagraphStyle}"
                    Visibility="{x:Bind Reading.ShowsPlainText, Mode=OneWay, Converter={StaticResource AffirmedVisibility}}" />
+
+        <Button x:Uid="MailBody.Button.UseSelection"
+                HorizontalAlignment="Left"
+                Command="{x:Bind UseSelectionCommand, Mode=OneWay}"
+                CommandParameter="{x:Bind SelectedText, Mode=OneWay}"
+                Style="{StaticResource TextBlockButtonStyle}"
+                Visibility="{x:Bind HasSelection, Mode=OneWay, Converter={StaticResource AffirmedVisibility}}" />
 
       </StackPanel>
     </ScrollViewer>

--- a/frontend/src/Client/Presentation/Spaces/Mail/Reading/MailBodyView.xaml.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/Reading/MailBodyView.xaml.cs
@@ -45,6 +45,27 @@ public sealed partial class MailBodyView : UserControl
             typeof(MailBodyView),
             new PropertyMetadata(null));
 
+    /// <summary>Identifies the <see cref="UseSelectionCommand"/> property.</summary>
+    public static readonly DependencyProperty UseSelectionCommandProperty = DependencyProperty.Register(
+        nameof(UseSelectionCommand),
+        typeof(ICommand),
+        typeof(MailBodyView),
+        new PropertyMetadata(null));
+
+    /// <summary>Identifies the <see cref="SelectedText"/> property.</summary>
+    public static readonly DependencyProperty SelectedTextProperty = DependencyProperty.Register(
+        nameof(SelectedText),
+        typeof(string),
+        typeof(MailBodyView),
+        new PropertyMetadata(string.Empty, OnSelectedTextChanged));
+
+    /// <summary>Identifies the <see cref="HasSelection"/> property.</summary>
+    public static readonly DependencyProperty HasSelectionProperty = DependencyProperty.Register(
+        nameof(HasSelection),
+        typeof(bool),
+        typeof(MailBodyView),
+        new PropertyMetadata(false));
+
     /// <summary>Identifies the <see cref="Nothing"/> property.</summary>
     public static readonly DependencyProperty NothingProperty = DependencyProperty.Register(
         nameof(Nothing),
@@ -90,6 +111,27 @@ public sealed partial class MailBodyView : UserControl
         set => this.SetValue(ShowRemoteContentCommandParameterProperty, value);
     }
 
+    /// <summary>Gets or sets what makes the selected passage the workspace scope.</summary>
+    public ICommand? UseSelectionCommand
+    {
+        get => (ICommand?)this.GetValue(UseSelectionCommandProperty);
+        set => this.SetValue(UseSelectionCommandProperty, value);
+    }
+
+    /// <summary>Gets or sets the passage selected in the body.</summary>
+    public string SelectedText
+    {
+        get => (string)this.GetValue(SelectedTextProperty);
+        set => this.SetValue(SelectedTextProperty, value);
+    }
+
+    /// <summary>Gets or sets whether a selected passage can be made the scope.</summary>
+    public bool HasSelection
+    {
+        get => (bool)this.GetValue(HasSelectionProperty);
+        set => this.SetValue(HasSelectionProperty, value);
+    }
+
     /// <summary>Gets or sets whether the pane has nothing open in it.</summary>
     /// <remarks>
     /// Stated as its own affirmative rather than read as the absence of a reading, so the state a binding carries
@@ -104,9 +146,13 @@ public sealed partial class MailBodyView : UserControl
     private static void OnReadingChanged(DependencyObject subject, DependencyPropertyChangedEventArgs change) =>
         ((MailBodyView)subject).Redraw();
 
+    private static void OnSelectedTextChanged(DependencyObject subject, DependencyPropertyChangedEventArgs change) =>
+        ((MailBodyView)subject).HasSelection = change.NewValue is string { Length: > 0 };
+
     private void Redraw()
     {
         this.Nothing = this.Reading is not { IsOpen: true };
+        this.SelectedText = string.Empty;
         this.Document.Child = null;
 
         if (this.Reading is { DrawsDocument: true } reading)
@@ -125,7 +171,8 @@ public sealed partial class MailBodyView : UserControl
     {
         var drawing = new MailBodyDrawing(
             reading.Words,
-            (link, displayed) => _ = this.AskAsync(link, displayed, reading.Words));
+            (link, displayed) => _ = this.AskAsync(link, displayed, reading.Words),
+            selected => this.SelectedText = selected);
 
         // The tree is attached before a picture is resolved, so the message is on the screen while its pictures are
         // being decided. A remote one the reader consented to is a request to somebody else's server, and waiting for
@@ -136,6 +183,16 @@ public sealed partial class MailBodyView : UserControl
         // so nothing can have arrived by this line, and the pictures are awaited one at a time — which is the stretch a
         // reader can leave the message in.
         await drawing.FillPicturesAsync(() => ReferenceEquals(this.Reading, reading));
+    }
+
+    private void OnPlainTextSelectionFinished(object sender, RoutedEventArgs args)
+    {
+        if (sender is TextBlock text)
+        {
+#pragma warning disable Uno0001 // Implemented by the pinned Uno Skia renderer used by both published heads.
+            this.SelectedText = text.SelectedText;
+#pragma warning restore Uno0001
+        }
     }
 
     /// <summary>Shows where a link actually goes, and opens it only if the reader says so.</summary>

--- a/frontend/src/Client/Presentation/Spaces/Mail/Reading/MailMessageReading.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/Reading/MailMessageReading.cs
@@ -1,0 +1,188 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Globalization;
+using MailFathom.Client.Backend.Mail;
+using MailFathom.Client.Presentation.Messages;
+using Microsoft.Extensions.Localization;
+
+namespace MailFathom.Client.Presentation.Spaces.Mail.Reading;
+
+/// <summary>One message as the reading pane draws everything around its body.</summary>
+public sealed record MailMessageReading(
+    string Subject,
+    IReadOnlyList<MailMessageHeaderRow> Headers,
+    bool ShowsSenderNotice,
+    bool WarnsAboutSender,
+    string SenderNotice,
+    IReadOnlyList<MailAttachmentRow> Attachments)
+{
+    /// <summary>Whether the sender notice is the positive statement that this deployment trusts the authenticated author.</summary>
+    public bool ShowsTrustedSender => this.ShowsSenderNotice && !this.WarnsAboutSender;
+
+    /// <summary>Whether the sender notice is a warning.</summary>
+    public bool ShowsSenderWarning => this.ShowsSenderNotice && this.WarnsAboutSender;
+
+    /// <summary>Whether the message carries attachments to list.</summary>
+    public bool HasAttachments => this.Attachments.Count > 0;
+
+    internal static MailMessageReading Of(
+        DeploymentMailMessageDetail message,
+        IReadOnlyDictionary<int, MailAttachmentStanding> downloads,
+        IStringLocalizer words)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        ArgumentNullException.ThrowIfNull(downloads);
+        ArgumentNullException.ThrowIfNull(words);
+
+        var headers = message.Headers.Participants
+            .Select(participant => new MailMessageHeaderRow(
+                words[MailMessageWords.HeaderRoleKey(participant.Role)],
+                AddressOf(participant)))
+            .ToList();
+
+        Add(headers, "SentAt", message.Headers.SentAt?.ToString("f", CultureInfo.CurrentCulture), words);
+        Add(headers, "ReceivedAt", message.Headers.ReceivedAt?.ToString("f", CultureInfo.CurrentCulture), words);
+        Add(headers, "MessageId", message.Headers.MessageId, words);
+        Add(headers, "InReplyTo", message.Headers.InReplyTo, words);
+        Add(
+            headers,
+            "References",
+            message.Headers.References.Count is 0 ? null : string.Join(", ", message.Headers.References),
+            words);
+
+        var from = message.Headers.Participants.FirstOrDefault(
+            static participant => string.Equals(participant.Role, "From", StringComparison.OrdinalIgnoreCase));
+
+        var sender = SenderNoticeOf(message.Sender, from?.Address, words);
+
+        return new MailMessageReading(
+            message.Headers.Subject ?? words[MessageWords.NoSubjectKey],
+            headers,
+            sender.Show,
+            sender.Warn,
+            sender.Text,
+            [.. message.Attachments.Select(attachment => MailAttachmentRow.Of(
+                message.StoredEmailId,
+                attachment,
+                downloads.GetValueOrDefault(attachment.Position),
+                words))]);
+    }
+
+    private static void Add(
+        List<MailMessageHeaderRow> headers,
+        string role,
+        string? value,
+        IStringLocalizer words)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            headers.Add(new MailMessageHeaderRow(words[MailMessageWords.HeaderRoleKey(role)], value));
+        }
+    }
+
+    private static string AddressOf(DeploymentMailParticipant participant) =>
+        string.IsNullOrWhiteSpace(participant.DisplayName)
+            ? participant.Address
+            : $"{participant.DisplayName} <{participant.Address}>";
+
+    private static (bool Show, bool Warn, string Text) SenderNoticeOf(
+        DeploymentMailSenderVerdict sender,
+        string? displayedAuthor,
+        IStringLocalizer words)
+    {
+        if (string.Equals(sender.AuthorAuthentication, "Authenticated", StringComparison.Ordinal)
+            && string.Equals(sender.DeploymentTrust, "Unknown", StringComparison.Ordinal))
+        {
+            return (false, false, string.Empty);
+        }
+
+        if (AuthenticatedAuthorOf(displayedAuthor) is { } authenticatedAuthor
+            && string.Equals(sender.AuthorAuthentication, "Authenticated", StringComparison.Ordinal)
+            && string.Equals(sender.DeploymentTrust, "Trusted", StringComparison.Ordinal))
+        {
+            return (true, false, words[MailMessageWords.TrustedSenderKey, authenticatedAuthor]);
+        }
+
+        if (!string.IsNullOrWhiteSpace(displayedAuthor)
+            && string.Equals(sender.AuthorAuthentication, "Failed", StringComparison.Ordinal))
+        {
+            return (true, true, words[MailMessageWords.FailedSenderKey, displayedAuthor]);
+        }
+
+        if (string.Equals(sender.AuthorAuthentication, "NotEstablished", StringComparison.Ordinal)
+            && string.Equals(sender.DeploymentTrust, "Unknown", StringComparison.Ordinal))
+        {
+            return (false, false, string.Empty);
+        }
+
+        return (true, true, words[MailMessageWords.UnrecognizedSenderKey]);
+    }
+
+    private static string? AuthenticatedAuthorOf(string? displayedAddress)
+    {
+        var separator = displayedAddress?.LastIndexOf('@') ?? -1;
+
+        return separator >= 0 && separator < displayedAddress!.Length - 1
+            ? displayedAddress[(separator + 1)..]
+            : null;
+    }
+}
+
+/// <summary>One header line, already labelled in the language the application is being read in.</summary>
+public sealed record MailMessageHeaderRow(string Role, string Value);
+
+/// <summary>The identity passed to attachment commands.</summary>
+public sealed record MailAttachmentRequest(Guid Message, int Position);
+
+/// <summary>One attachment as the pane draws it before, during, and after a download.</summary>
+public sealed record MailAttachmentRow(
+    MailAttachmentRequest Request,
+    string FileName,
+    string MediaType,
+    string Size,
+    bool WasFileNameNormalized,
+    string NormalizedFileNameNotice,
+    bool CanDownload,
+    bool CanCancel,
+    bool DownloadFailed,
+    bool Downloaded)
+{
+    internal static MailAttachmentRow Of(
+        Guid message,
+        DeploymentMailAttachment attachment,
+        MailAttachmentStanding standing,
+        IStringLocalizer words) => new(
+        new MailAttachmentRequest(message, attachment.Position),
+        attachment.FileName ?? words[MailMessageWords.AttachmentFallbackKey, attachment.Position + 1],
+        attachment.MediaType,
+        MailSize.Format(attachment.SizeOctets),
+        attachment.WasFileNameNormalized,
+        words[MailMessageWords.NormalizedFileNameKey],
+        standing is MailAttachmentStanding.None,
+        standing is MailAttachmentStanding.Downloading,
+        standing is MailAttachmentStanding.Failed,
+        standing is MailAttachmentStanding.Downloaded);
+}
+
+/// <summary>What the latest attempt to save one attachment is doing.</summary>
+internal enum MailAttachmentStanding
+{
+    None = 0,
+    Downloading = 1,
+    Failed = 2,
+    Downloaded = 3,
+}
+
+/// <summary>Writes an octet count at the scale a person deciding whether to download it needs.</summary>
+internal static class MailSize
+{
+    internal static string Format(long octets) => octets switch
+    {
+        < 1024 => string.Create(CultureInfo.CurrentCulture, $"{octets:N0} B"),
+        < 1024 * 1024 => string.Create(CultureInfo.CurrentCulture, $"{octets / 1024d:N1} KB"),
+        < 1024L * 1024 * 1024 => string.Create(CultureInfo.CurrentCulture, $"{octets / (1024d * 1024):N1} MB"),
+        _ => string.Create(CultureInfo.CurrentCulture, $"{octets / (1024d * 1024 * 1024):N1} GB"),
+    };
+}

--- a/frontend/src/Client/Presentation/Spaces/Mail/Reading/MailMessageView.xaml
+++ b/frontend/src/Client/Presentation/Spaces/Mail/Reading/MailMessageView.xaml
@@ -1,0 +1,116 @@
+<!--
+Copyright © 2026 Krzysztof Kasprowicz
+Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+Project repository: https://github.com/Krzysztof318/MailFathom
+-->
+<UserControl x:Class="MailFathom.Client.Presentation.Spaces.Mail.Reading.MailMessageView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:utu="using:Uno.Toolkit.UI"
+             xmlns:reading="using:MailFathom.Client.Presentation.Spaces.Mail.Reading">
+  <StackPanel Spacing="12">
+    <TextBlock Text="{x:Bind Reading.Subject, Mode=OneWay}"
+               TextWrapping="Wrap"
+               Style="{StaticResource SubtitleTextBlockStyle}" />
+
+    <InfoBar x:Uid="MailMessage.InfoBar.TrustedSender"
+             IsOpen="{x:Bind Reading.ShowsTrustedSender, Mode=OneWay}"
+             IsClosable="False"
+             Severity="Success"
+             Message="{x:Bind Reading.SenderNotice, Mode=OneWay}" />
+
+    <InfoBar x:Uid="MailMessage.InfoBar.SenderWarning"
+             IsOpen="{x:Bind Reading.ShowsSenderWarning, Mode=OneWay}"
+             IsClosable="False"
+             Severity="Warning"
+             Message="{x:Bind Reading.SenderNotice, Mode=OneWay}" />
+
+    <ItemsControl ItemsSource="{x:Bind Reading.Headers, Mode=OneWay}">
+      <ItemsControl.ItemTemplate>
+        <DataTemplate x:DataType="reading:MailMessageHeaderRow">
+          <Grid ColumnSpacing="8">
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="Auto" />
+              <ColumnDefinition />
+            </Grid.ColumnDefinitions>
+            <TextBlock Text="{x:Bind Role}"
+                       Style="{StaticResource CaptionTextBlockStyle}"
+                       Foreground="{ThemeResource OnSurfaceVariantBrush}" />
+            <TextBlock Grid.Column="1"
+                       Text="{x:Bind Value}"
+                       TextWrapping="Wrap"
+                       IsTextSelectionEnabled="True"
+                       Style="{StaticResource BodyTextBlockStyle}" />
+          </Grid>
+        </DataTemplate>
+      </ItemsControl.ItemTemplate>
+    </ItemsControl>
+
+    <StackPanel Spacing="8"
+                Visibility="{x:Bind Reading.HasAttachments, Mode=OneWay, Converter={StaticResource AffirmedVisibility}}">
+      <TextBlock x:Uid="MailMessage.TextBlock.Attachments"
+                 Style="{StaticResource BodyStrongTextBlockStyle}" />
+
+      <ItemsControl ItemsSource="{x:Bind Reading.Attachments, Mode=OneWay}">
+        <ItemsControl.ItemTemplate>
+          <DataTemplate x:DataType="reading:MailAttachmentRow">
+            <Border Padding="12"
+                    BorderThickness="1"
+                    BorderBrush="{ThemeResource OutlineVariantBrush}"
+                    CornerRadius="8">
+              <StackPanel Spacing="6">
+                <TextBlock Text="{x:Bind FileName}"
+                           TextWrapping="Wrap"
+                           Style="{StaticResource BodyStrongTextBlockStyle}" />
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                  <TextBlock Text="{x:Bind MediaType}"
+                             Style="{StaticResource CaptionTextBlockStyle}"
+                             Foreground="{ThemeResource OnSurfaceVariantBrush}" />
+                  <TextBlock Text="{x:Bind Size}"
+                             Style="{StaticResource CaptionTextBlockStyle}"
+                             Foreground="{ThemeResource OnSurfaceVariantBrush}" />
+                </StackPanel>
+                <InfoBar IsOpen="{x:Bind WasFileNameNormalized}"
+                         IsClosable="False"
+                         Severity="Informational"
+                         Message="{x:Bind NormalizedFileNameNotice}" />
+                <Button x:Uid="MailMessage.Button.DownloadAttachment"
+                        HorizontalAlignment="Left"
+                        Command="{utu:AncestorBinding AncestorType=UserControl, Path=SaveAttachmentCommand}"
+                        CommandParameter="{x:Bind Request}"
+                        Visibility="{x:Bind CanDownload, Converter={StaticResource AffirmedVisibility}}" />
+                <StackPanel Orientation="Horizontal"
+                            Spacing="8"
+                            Visibility="{x:Bind CanCancel, Converter={StaticResource AffirmedVisibility}}">
+                  <ProgressRing IsActive="True" />
+                  <Button x:Uid="MailMessage.Button.CancelAttachment"
+                          Command="{utu:AncestorBinding AncestorType=UserControl, Path=CancelAttachmentCommand}"
+                          CommandParameter="{x:Bind Request}" />
+                </StackPanel>
+                <InfoBar x:Uid="MailMessage.InfoBar.AttachmentUnavailable"
+                         IsOpen="{x:Bind DownloadFailed}"
+                         IsClosable="False"
+                         Severity="Error">
+                  <InfoBar.ActionButton>
+                    <Button x:Uid="MailMessage.Button.RetryAttachment"
+                            Command="{utu:AncestorBinding AncestorType=UserControl, Path=SaveAttachmentCommand}"
+                            CommandParameter="{x:Bind Request}" />
+                  </InfoBar.ActionButton>
+                </InfoBar>
+                <InfoBar x:Uid="MailMessage.InfoBar.AttachmentSaved"
+                         IsOpen="{x:Bind Downloaded}"
+                         IsClosable="False"
+                         Severity="Success" />
+              </StackPanel>
+            </Border>
+          </DataTemplate>
+        </ItemsControl.ItemTemplate>
+      </ItemsControl>
+    </StackPanel>
+
+    <reading:MailBodyView Reading="{x:Bind Body, Mode=OneWay}"
+                          ShowRemoteContentCommand="{x:Bind ShowRemoteContentCommand, Mode=OneWay}"
+                          ShowRemoteContentCommandParameter="{x:Bind ShowRemoteContentCommandParameter, Mode=OneWay}"
+                          UseSelectionCommand="{x:Bind UseSelectionCommand, Mode=OneWay}" />
+  </StackPanel>
+</UserControl>

--- a/frontend/src/Client/Presentation/Spaces/Mail/Reading/MailMessageView.xaml.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/Reading/MailMessageView.xaml.cs
@@ -1,0 +1,104 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Presentation.Spaces.Mail.Reading;
+
+/// <summary>Composes one message's headers, sender verdict, attachments, and body.</summary>
+public sealed partial class MailMessageView : UserControl
+{
+    /// <summary>Identifies <see cref="Reading"/>.</summary>
+    public static readonly DependencyProperty ReadingProperty = DependencyProperty.Register(
+        nameof(Reading),
+        typeof(MailMessageReading),
+        typeof(MailMessageView),
+        new PropertyMetadata(null));
+    /// <summary>Identifies <see cref="Body"/>.</summary>
+    public static readonly DependencyProperty BodyProperty = DependencyProperty.Register(
+        nameof(Body),
+        typeof(MailBodyReading),
+        typeof(MailMessageView),
+        new PropertyMetadata(null));
+    /// <summary>Identifies <see cref="ShowRemoteContentCommand"/>.</summary>
+    public static readonly DependencyProperty ShowRemoteContentCommandProperty = DependencyProperty.Register(
+        nameof(ShowRemoteContentCommand),
+        typeof(ICommand),
+        typeof(MailMessageView),
+        new PropertyMetadata(null));
+    /// <summary>Identifies <see cref="ShowRemoteContentCommandParameter"/>.</summary>
+    public static readonly DependencyProperty ShowRemoteContentCommandParameterProperty = DependencyProperty.Register(
+        nameof(ShowRemoteContentCommandParameter),
+        typeof(object),
+        typeof(MailMessageView),
+        new PropertyMetadata(null));
+    /// <summary>Identifies <see cref="SaveAttachmentCommand"/>.</summary>
+    public static readonly DependencyProperty SaveAttachmentCommandProperty = DependencyProperty.Register(
+        nameof(SaveAttachmentCommand),
+        typeof(ICommand),
+        typeof(MailMessageView),
+        new PropertyMetadata(null));
+    /// <summary>Identifies <see cref="CancelAttachmentCommand"/>.</summary>
+    public static readonly DependencyProperty CancelAttachmentCommandProperty = DependencyProperty.Register(
+        nameof(CancelAttachmentCommand),
+        typeof(ICommand),
+        typeof(MailMessageView),
+        new PropertyMetadata(null));
+    /// <summary>Identifies <see cref="UseSelectionCommand"/>.</summary>
+    public static readonly DependencyProperty UseSelectionCommandProperty = DependencyProperty.Register(
+        nameof(UseSelectionCommand),
+        typeof(ICommand),
+        typeof(MailMessageView),
+        new PropertyMetadata(null));
+
+    /// <summary>Initializes the pane.</summary>
+    public MailMessageView() => this.InitializeComponent();
+
+    /// <summary>Gets or sets everything drawn around the body.</summary>
+    public MailMessageReading? Reading
+    {
+        get => (MailMessageReading?)this.GetValue(ReadingProperty);
+        set => this.SetValue(ReadingProperty, value);
+    }
+
+    /// <summary>Gets or sets the body drawn inside the message.</summary>
+    public MailBodyReading? Body
+    {
+        get => (MailBodyReading?)this.GetValue(BodyProperty);
+        set => this.SetValue(BodyProperty, value);
+    }
+
+    /// <summary>Gets or sets the command that re-reads the body with remote pictures.</summary>
+    public ICommand? ShowRemoteContentCommand
+    {
+        get => (ICommand?)this.GetValue(ShowRemoteContentCommandProperty);
+        set => this.SetValue(ShowRemoteContentCommandProperty, value);
+    }
+
+    /// <summary>Gets or sets the message passed to the remote-content command.</summary>
+    public object? ShowRemoteContentCommandParameter
+    {
+        get => this.GetValue(ShowRemoteContentCommandParameterProperty);
+        set => this.SetValue(ShowRemoteContentCommandParameterProperty, value);
+    }
+
+    /// <summary>Gets or sets the command that saves an attachment.</summary>
+    public ICommand? SaveAttachmentCommand
+    {
+        get => (ICommand?)this.GetValue(SaveAttachmentCommandProperty);
+        set => this.SetValue(SaveAttachmentCommandProperty, value);
+    }
+
+    /// <summary>Gets or sets the command that cancels an attachment save.</summary>
+    public ICommand? CancelAttachmentCommand
+    {
+        get => (ICommand?)this.GetValue(CancelAttachmentCommandProperty);
+        set => this.SetValue(CancelAttachmentCommandProperty, value);
+    }
+
+    /// <summary>Gets or sets the command that makes a selected body passage the workspace scope.</summary>
+    public ICommand? UseSelectionCommand
+    {
+        get => (ICommand?)this.GetValue(UseSelectionCommandProperty);
+        set => this.SetValue(UseSelectionCommandProperty, value);
+    }
+}

--- a/frontend/src/Client/Presentation/Spaces/Mail/Reading/MailMessageWords.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/Reading/MailMessageWords.cs
@@ -1,0 +1,37 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Presentation.Spaces.Mail.Reading;
+
+/// <summary>The entries used to compose message details that no control authors on its own.</summary>
+internal static class MailMessageWords
+{
+    internal const string TrustedSenderKey = "MailMessage.Sender.Trusted";
+    internal const string FailedSenderKey = "MailMessage.Sender.Failed";
+    internal const string UnrecognizedSenderKey = "MailMessage.Sender.Unrecognized";
+    internal const string AttachmentFallbackKey = "MailMessage.Attachment.Fallback";
+    internal const string NormalizedFileNameKey = "MailMessage.Attachment.Normalized";
+    internal const string AttachmentFileTypeKey = "MailMessage.Attachment.FileType";
+
+    internal static IReadOnlyList<string> ResourceKeys { get; } =
+    [
+        TrustedSenderKey,
+        FailedSenderKey,
+        UnrecognizedSenderKey,
+        AttachmentFallbackKey,
+        NormalizedFileNameKey,
+        AttachmentFileTypeKey,
+        HeaderRoleKey("From"),
+        HeaderRoleKey("To"),
+        HeaderRoleKey("Cc"),
+        HeaderRoleKey("Bcc"),
+        HeaderRoleKey("SentAt"),
+        HeaderRoleKey("ReceivedAt"),
+        HeaderRoleKey("MessageId"),
+        HeaderRoleKey("InReplyTo"),
+        HeaderRoleKey("References"),
+    ];
+
+    internal static string HeaderRoleKey(string role) => $"MailMessage.Header.{role}";
+}

--- a/frontend/src/Client/Presentation/Spaces/Mail/Reading/PickedMailAttachmentSaver.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/Reading/PickedMailAttachmentSaver.cs
@@ -1,0 +1,81 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Backend.Mail;
+using Microsoft.Extensions.Localization;
+using Windows.Storage.Pickers;
+using Windows.Storage.Provider;
+
+namespace MailFathom.Client.Presentation.Spaces.Mail.Reading;
+
+/// <summary>Saves an attachment through the platform picker, staging it before replacing the chosen file.</summary>
+internal sealed class PickedMailAttachmentSaver : IMailAttachmentSaver
+{
+    private readonly IStringLocalizer words;
+
+    public PickedMailAttachmentSaver(IStringLocalizer words)
+    {
+        ArgumentNullException.ThrowIfNull(words);
+
+        this.words = words;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<bool> SaveAsync(
+        DeploymentMailAttachment attachment,
+        Func<Stream, CancellationToken, Task> write,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(attachment);
+        ArgumentNullException.ThrowIfNull(write);
+
+        var name = attachment.FileName
+            ?? this.words[MailMessageWords.AttachmentFallbackKey, attachment.Position + 1].Value;
+        var extension = Path.GetExtension(name);
+        extension = string.IsNullOrWhiteSpace(extension) ? ".bin" : extension;
+
+        var picker = new FileSavePicker
+        {
+            SuggestedStartLocation = PickerLocationId.Downloads,
+            SuggestedFileName = name,
+        };
+
+        picker.FileTypeChoices.Add(
+            this.words[MailMessageWords.AttachmentFileTypeKey],
+            [extension]);
+
+        var chosen = await picker.PickSaveFileAsync();
+
+        if (chosen is null)
+        {
+            return false;
+        }
+
+        var temporary = await ApplicationData.Current.TemporaryFolder.CreateFileAsync(
+            $"mailfathom-{Guid.NewGuid():N}",
+            CreationCollisionOption.GenerateUniqueName);
+
+        try
+        {
+            await using (var destination = await temporary.OpenStreamForWriteAsync().ConfigureAwait(false))
+            {
+                await write(destination, cancellationToken).ConfigureAwait(false);
+            }
+
+            CachedFileManager.DeferUpdates(chosen);
+            await temporary.CopyAndReplaceAsync(chosen);
+
+            if (await CachedFileManager.CompleteUpdatesAsync(chosen) is not FileUpdateStatus.Complete)
+            {
+                throw new IOException("The platform did not complete the attachment save.");
+            }
+
+            return true;
+        }
+        finally
+        {
+            await temporary.DeleteAsync();
+        }
+    }
+}

--- a/frontend/src/Client/Presentation/Spaces/Mail/Reading/PickedMailAttachmentSaver.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/Reading/PickedMailAttachmentSaver.cs
@@ -45,16 +45,19 @@ internal sealed class PickedMailAttachmentSaver : IMailAttachmentSaver
             this.words[MailMessageWords.AttachmentFileTypeKey],
             [extension]);
 
-        var chosen = await picker.PickSaveFileAsync();
+        var chosen = await picker.PickSaveFileAsync().AsTask(cancellationToken).ConfigureAwait(false);
 
         if (chosen is null)
         {
             return false;
         }
 
-        var temporary = await ApplicationData.Current.TemporaryFolder.CreateFileAsync(
-            $"mailfathom-{Guid.NewGuid():N}",
-            CreationCollisionOption.GenerateUniqueName);
+        var temporary = await ApplicationData.Current.TemporaryFolder
+            .CreateFileAsync(
+                $"mailfathom-{Guid.NewGuid():N}",
+                CreationCollisionOption.GenerateUniqueName)
+            .AsTask(cancellationToken)
+            .ConfigureAwait(false);
 
         try
         {
@@ -64,9 +67,11 @@ internal sealed class PickedMailAttachmentSaver : IMailAttachmentSaver
             }
 
             CachedFileManager.DeferUpdates(chosen);
-            await temporary.CopyAndReplaceAsync(chosen);
+            await temporary.CopyAndReplaceAsync(chosen).AsTask(cancellationToken).ConfigureAwait(false);
 
-            if (await CachedFileManager.CompleteUpdatesAsync(chosen) is not FileUpdateStatus.Complete)
+            if (await CachedFileManager.CompleteUpdatesAsync(chosen)
+                    .AsTask(cancellationToken)
+                    .ConfigureAwait(false) is not FileUpdateStatus.Complete)
             {
                 throw new IOException("The platform did not complete the attachment save.");
             }
@@ -75,7 +80,7 @@ internal sealed class PickedMailAttachmentSaver : IMailAttachmentSaver
         }
         finally
         {
-            await temporary.DeleteAsync();
+            await temporary.DeleteAsync().AsTask().ConfigureAwait(false);
         }
     }
 }

--- a/frontend/src/Client/Presentation/Threads/DeploymentMailThread.cs
+++ b/frontend/src/Client/Presentation/Threads/DeploymentMailThread.cs
@@ -2,8 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.Globalization;
 using MailFathom.Client.Backend;
+using MailFathom.Client.Backend.Mail;
 using MailFathom.Client.Backend.Threads;
 using MailFathom.Client.Presentation.Messages;
 using MailFathom.Client.Presentation.Spaces.Mail.Reading;
@@ -44,32 +47,38 @@ internal sealed class DeploymentMailThread : IMailThread
 
     private readonly DeploymentClient deployment;
     private readonly IClientSession session;
+    private readonly IMailAttachmentSaver attachmentSaver;
     private readonly IStringLocalizer words;
     private readonly IState<ThreadOpening> opened;
     private readonly IState<int> asked;
     private readonly IState<bool> pagingFailed;
     private readonly IState<IImmutableDictionary<string, ThreadMessageDetail>> disclosed;
     private readonly IState<ThreadWindow> loaded;
+    private readonly ConcurrentDictionary<MailAttachmentRequest, CancellationTokenSource> attachmentDownloads = [];
 
     /// <summary>Initializes the conversation over what serves it, what decides it may be read, and what opens one.</summary>
     /// <param name="deployment">Where a page of a conversation is asked for.</param>
     /// <param name="session">What the deployment allows this caller, and whether it can be reached at all.</param>
     /// <param name="messages">The list whose selection is how a conversation is reached in the mail space.</param>
+    /// <param name="attachmentSaver">Lets the reader choose where one requested attachment is written.</param>
     /// <param name="words">Where the sentences a conversation is composed from come from.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     public DeploymentMailThread(
         DeploymentClient deployment,
         IClientSession session,
         IMessageList messages,
+        IMailAttachmentSaver attachmentSaver,
         IStringLocalizer words)
     {
         ArgumentNullException.ThrowIfNull(deployment);
         ArgumentNullException.ThrowIfNull(session);
         ArgumentNullException.ThrowIfNull(messages);
+        ArgumentNullException.ThrowIfNull(attachmentSaver);
         ArgumentNullException.ThrowIfNull(words);
 
         this.deployment = deployment;
         this.session = session;
+        this.attachmentSaver = attachmentSaver;
         this.words = words;
 
         // Held as a state rather than read as the session's own feed, for the reason every other reader of it holds
@@ -152,6 +161,94 @@ internal sealed class DeploymentMailThread : IMailThread
     /// <inheritdoc />
     public ValueTask ShowRemoteContentAsync(string key, CancellationToken cancellationToken) =>
         this.ReadWholeAsync(key, remoteImages: true, cancellationToken);
+
+    /// <inheritdoc />
+    public async ValueTask SaveAttachmentAsync(
+        MailAttachmentRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var key = request.Message.ToString("D", CultureInfo.InvariantCulture);
+
+        if (await this.DetailOfAsync(key, cancellationToken).ConfigureAwait(false) is not
+            { Expanded: true, Message: { } message } detail)
+        {
+            return;
+        }
+
+        var attachment = message.Attachments.FirstOrDefault(held => held.Position == request.Position);
+
+        if (attachment is null)
+        {
+            return;
+        }
+
+        using var download = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        if (!this.attachmentDownloads.TryAdd(request, download))
+        {
+            return;
+        }
+
+        await this.WriteAttachmentStandingAsync(
+            key,
+            detail,
+            request.Position,
+            MailAttachmentStanding.Downloading,
+            cancellationToken).ConfigureAwait(false);
+
+        var standing = MailAttachmentStanding.None;
+
+        try
+        {
+            var saved = await this.attachmentSaver.SaveAsync(
+                attachment,
+                (destination, token) => this.deployment.DownloadMailAttachmentAsync(
+                    request.Message,
+                    request.Position,
+                    attachment.SizeOctets,
+                    destination,
+                    token),
+                download.Token).ConfigureAwait(false);
+
+            standing = saved ? MailAttachmentStanding.Downloaded : MailAttachmentStanding.None;
+        }
+        catch (OperationCanceledException) when (download.IsCancellationRequested)
+        {
+            standing = MailAttachmentStanding.None;
+        }
+        catch (Exception failure) when (failure is DeploymentFailure or IOException or UnauthorizedAccessException)
+        {
+            standing = MailAttachmentStanding.Failed;
+        }
+        finally
+        {
+            this.attachmentDownloads.TryRemove(request, out _);
+        }
+
+        if (await this.DetailOfAsync(key, CancellationToken.None).ConfigureAwait(false) is
+            { Expanded: true, Message: not null } current)
+        {
+            await this.WriteAttachmentStandingAsync(
+                key,
+                current,
+                request.Position,
+                standing,
+                CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
+    public void CancelAttachment(MailAttachmentRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (this.attachmentDownloads.TryGetValue(request, out var download))
+        {
+            download.Cancel();
+        }
+    }
 
     /// <inheritdoc />
     public async ValueTask ShowMoreAsync(CancellationToken cancellationToken)
@@ -291,6 +388,32 @@ internal sealed class DeploymentMailThread : IMailThread
             },
             cancellationToken).ConfigureAwait(false);
 
+        if (detail.Message is null)
+        {
+            DeploymentMailMessageDetail messageDetail;
+
+            try
+            {
+                messageDetail = await this.deployment
+                    .ReadMailMessageAsync(message, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (DeploymentFailure)
+            {
+                await this.FailWholeReadAsync(key, window, remoteImages, cancellationToken).ConfigureAwait(false);
+
+                return;
+            }
+
+            if (await this.StillLoadedAsync(window, cancellationToken).ConfigureAwait(false) is null
+                || await this.DetailOfAsync(key, cancellationToken).ConfigureAwait(false) is not { Expanded: true } described)
+            {
+                return;
+            }
+
+            await this.WriteAsync(key, described with { Message = messageDetail }, cancellationToken).ConfigureAwait(false);
+        }
+
         MailBodyReading? whole;
 
         try
@@ -331,6 +454,29 @@ internal sealed class DeploymentMailThread : IMailThread
             cancellationToken).ConfigureAwait(false);
     }
 
+    private async ValueTask FailWholeReadAsync(
+        string key,
+        ThreadWindow window,
+        bool remoteImages,
+        CancellationToken cancellationToken)
+    {
+        if (await this.StillLoadedAsync(window, cancellationToken).ConfigureAwait(false) is null
+            || await this.DetailOfAsync(key, cancellationToken).ConfigureAwait(false) is not { Expanded: true } current)
+        {
+            return;
+        }
+
+        await this.WriteAsync(
+            key,
+            current with
+            {
+                IsReadingWholeMessage = false,
+                WholeMessageFailed = true,
+                RemoteImages = remoteImages,
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
     /// <summary>Reads how much of one message is shown, or nothing where the conversation does not hold it.</summary>
     private async ValueTask<ThreadMessageDetail?> DetailOfAsync(string key, CancellationToken cancellationToken)
     {
@@ -354,6 +500,17 @@ internal sealed class DeploymentMailThread : IMailThread
 
     private ValueTask WriteAsync(string key, ThreadMessageDetail detail, CancellationToken cancellationToken) =>
         this.disclosed.UpdateAsync(held => (held ?? Nothing).SetItem(key, detail), cancellationToken);
+
+    private ValueTask WriteAttachmentStandingAsync(
+        string key,
+        ThreadMessageDetail detail,
+        int position,
+        MailAttachmentStanding standing,
+        CancellationToken cancellationToken) =>
+        this.WriteAsync(
+            key,
+            detail with { Attachments = detail.Attachments.SetItem(position, standing) },
+            cancellationToken);
 
     /// <summary>Reads the loaded conversation back, where it is still the one a read was started for.</summary>
     private async ValueTask<ThreadWindow?> StillLoadedAsync(

--- a/frontend/src/Client/Presentation/Threads/DeploymentMailThread.cs
+++ b/frontend/src/Client/Presentation/Threads/DeploymentMailThread.cs
@@ -218,7 +218,9 @@ internal sealed class DeploymentMailThread : IMailThread
         {
             standing = MailAttachmentStanding.None;
         }
-        catch (Exception failure) when (failure is DeploymentFailure or IOException or UnauthorizedAccessException)
+#pragma warning disable CA1031 // Every platform adapter failure must leave this per-item command in a rendered state.
+        catch (Exception)
+#pragma warning restore CA1031
         {
             standing = MailAttachmentStanding.Failed;
         }

--- a/frontend/src/Client/Presentation/Threads/DeploymentMailThread.cs
+++ b/frontend/src/Client/Presentation/Threads/DeploymentMailThread.cs
@@ -197,7 +197,6 @@ internal sealed class DeploymentMailThread : IMailThread
         {
             await this.WriteAttachmentStandingAsync(
                 key,
-                detail,
                 request.Position,
                 MailAttachmentStanding.Downloading,
                 cancellationToken).ConfigureAwait(false);
@@ -230,11 +229,10 @@ internal sealed class DeploymentMailThread : IMailThread
         }
 
         if (await this.DetailOfAsync(key, CancellationToken.None).ConfigureAwait(false) is
-            { Expanded: true, Message: not null } current)
+            { Expanded: true, Message: not null })
         {
             await this.WriteAttachmentStandingAsync(
                 key,
-                current,
                 request.Position,
                 standing,
                 CancellationToken.None).ConfigureAwait(false);
@@ -505,13 +503,21 @@ internal sealed class DeploymentMailThread : IMailThread
 
     private ValueTask WriteAttachmentStandingAsync(
         string key,
-        ThreadMessageDetail detail,
         int position,
         MailAttachmentStanding standing,
         CancellationToken cancellationToken) =>
-        this.WriteAsync(
-            key,
-            detail with { Attachments = detail.Attachments.SetItem(position, standing) },
+        this.disclosed.UpdateAsync(
+            held =>
+            {
+                var details = held ?? Nothing;
+
+                return details.TryGetValue(key, out var current)
+                    && current is { Expanded: true, Message: not null }
+                        ? details.SetItem(
+                            key,
+                            current with { Attachments = current.Attachments.SetItem(position, standing) })
+                        : details;
+            },
             cancellationToken);
 
     /// <summary>Reads the loaded conversation back, where it is still the one a read was started for.</summary>

--- a/frontend/src/Client/Presentation/Threads/DeploymentMailThread.cs
+++ b/frontend/src/Client/Presentation/Threads/DeploymentMailThread.cs
@@ -191,17 +191,17 @@ internal sealed class DeploymentMailThread : IMailThread
             return;
         }
 
-        await this.WriteAttachmentStandingAsync(
-            key,
-            detail,
-            request.Position,
-            MailAttachmentStanding.Downloading,
-            cancellationToken).ConfigureAwait(false);
-
         var standing = MailAttachmentStanding.None;
 
         try
         {
+            await this.WriteAttachmentStandingAsync(
+                key,
+                detail,
+                request.Position,
+                MailAttachmentStanding.Downloading,
+                cancellationToken).ConfigureAwait(false);
+
             var saved = await this.attachmentSaver.SaveAsync(
                 attachment,
                 (destination, token) => this.deployment.DownloadMailAttachmentAsync(

--- a/frontend/src/Client/Presentation/Threads/IMailThread.cs
+++ b/frontend/src/Client/Presentation/Threads/IMailThread.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Client.Presentation.Spaces.Mail.Reading;
+
 namespace MailFathom.Client.Presentation.Threads;
 
 /// <summary>The one conversation a run has open, wherever it was opened from.</summary>
@@ -76,6 +78,12 @@ public interface IMailThread
     /// not written down, not carried to the next message, and not carried to this one the next time it is opened.
     /// </remarks>
     ValueTask ShowRemoteContentAsync(string key, CancellationToken cancellationToken);
+
+    /// <summary>Lets the reader choose where one attachment is streamed.</summary>
+    ValueTask SaveAttachmentAsync(MailAttachmentRequest request, CancellationToken cancellationToken);
+
+    /// <summary>Cancels the attachment currently being saved.</summary>
+    void CancelAttachment(MailAttachmentRequest request);
 
     /// <summary>Takes the next page of the conversation onto the end of what has been read.</summary>
     /// <param name="cancellationToken">Abandons the page.</param>

--- a/frontend/src/Client/Presentation/Threads/ThreadMessageDetail.cs
+++ b/frontend/src/Client/Presentation/Threads/ThreadMessageDetail.cs
@@ -2,16 +2,20 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Collections.Immutable;
+using MailFathom.Client.Backend.Mail;
 using MailFathom.Client.Presentation.Spaces.Mail.Reading;
 
 namespace MailFathom.Client.Presentation.Threads;
 
 /// <summary>How much of one message of the conversation the reader has asked to see.</summary>
 /// <param name="Expanded">Whether the message shows what it added rather than the one line it collapses to.</param>
-/// <param name="WholeMessage">The whole message, quoted history included, or <see langword="null" /> where nobody has asked for it.</param>
+/// <param name="Message">Everything drawn around the body, or <see langword="null" /> where nobody has asked for it.</param>
+/// <param name="WholeMessage">The whole body, quoted history included, or <see langword="null" /> where nobody has asked for it.</param>
 /// <param name="IsReadingWholeMessage">Whether the whole message is on its way.</param>
 /// <param name="WholeMessageFailed">Whether the last attempt to read the whole message did not arrive.</param>
 /// <param name="RemoteImages">Whether this reading of the whole message asked for its remote pictures.</param>
+/// <param name="Attachments">What the latest save attempt for each attachment is doing.</param>
 /// <remarks>
 /// <para>
 /// Two gestures rather than one, and the split is the point of the screen: expanding shows what the message added,
@@ -27,18 +31,22 @@ namespace MailFathom.Client.Presentation.Threads;
 /// </remarks>
 internal sealed record ThreadMessageDetail(
     bool Expanded,
+    DeploymentMailMessageDetail? Message,
     MailBodyReading? WholeMessage,
     bool IsReadingWholeMessage,
     bool WholeMessageFailed,
-    bool RemoteImages)
+    bool RemoteImages,
+    IImmutableDictionary<int, MailAttachmentStanding> Attachments)
 {
     /// <summary>A message showing the one line it collapses to.</summary>
     internal static ThreadMessageDetail Collapsed { get; } = new(
         Expanded: false,
+        Message: null,
         WholeMessage: null,
         IsReadingWholeMessage: false,
         WholeMessageFailed: false,
-        RemoteImages: false);
+        RemoteImages: false,
+        Attachments: ImmutableDictionary<int, MailAttachmentStanding>.Empty);
 
     /// <summary>A message showing what it added, with nothing yet asked of the whole of it.</summary>
     internal static ThreadMessageDetail Opened { get; } = Collapsed with { Expanded = true };

--- a/frontend/src/Client/Presentation/Threads/ThreadMessageRow.cs
+++ b/frontend/src/Client/Presentation/Threads/ThreadMessageRow.cs
@@ -22,6 +22,7 @@ namespace MailFathom.Client.Presentation.Threads;
 /// <param name="IsAnswered">Whether it last reported it with <c>\Answered</c>.</param>
 /// <param name="HasAttachments">Whether the message carries anything besides its body and its inline resources.</param>
 /// <param name="AttachmentCount">How many of those there are.</param>
+/// <param name="Message">Everything the pane draws around the whole message, or <see langword="null" /> where nobody has asked for it.</param>
 /// <param name="WholeMessage">The whole message as a reading pane draws it, or <see langword="null" /> where nobody has asked for it.</param>
 /// <param name="IsReadingWholeMessage">Whether the whole message is on its way.</param>
 /// <param name="WholeMessageFailed">Whether the last attempt to read the whole message did not arrive.</param>
@@ -57,6 +58,7 @@ public sealed partial record ThreadMessageRow(
     bool IsAnswered,
     bool HasAttachments,
     int AttachmentCount,
+    MailMessageReading? Message,
     MailBodyReading? WholeMessage,
     bool IsReadingWholeMessage,
     bool WholeMessageFailed)
@@ -78,6 +80,9 @@ public sealed partial record ThreadMessageRow(
     /// which is what a row of a list already does with a preview nothing has extracted.
     /// </remarks>
     public bool HasRecipients => this.Recipients.Length > 0;
+
+    /// <summary>Gets whether the message's headers and attachments are drawn.</summary>
+    public bool ShowsMessage => this.IsExpanded && this.Message is not null;
 
     /// <summary>Gets whether the whole message is drawn under what it added.</summary>
     public bool ShowsWholeMessage => this.IsExpanded && this.WholeMessage is not null;

--- a/frontend/src/Client/Presentation/Threads/ThreadShape.cs
+++ b/frontend/src/Client/Presentation/Threads/ThreadShape.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using MailFathom.Client.Backend.Threads;
 using MailFathom.Client.Backend.Timeline;
 using MailFathom.Client.Presentation.Messages;
+using MailFathom.Client.Presentation.Spaces.Mail.Reading;
 using Microsoft.Extensions.Localization;
 
 namespace MailFathom.Client.Presentation.Threads;
@@ -207,6 +208,9 @@ internal static class ThreadShape
             email.Answered,
             email.HasAttachments,
             email.AttachmentCount,
+            detail.Message is { } describedMessage
+                ? MailMessageReading.Of(describedMessage, detail.Attachments, words)
+                : null,
             detail.WholeMessage,
             detail.IsReadingWholeMessage,
             detail.WholeMessageFailed);

--- a/frontend/src/Client/Presentation/Workspace/WorkspaceModel.cs
+++ b/frontend/src/Client/Presentation/Workspace/WorkspaceModel.cs
@@ -26,6 +26,7 @@ public partial record WorkspaceModel
     private const string AccountFolderKey = "WorkspaceScope.AccountFolder";
     private const string RoleKey = "WorkspaceScope.Role";
     private const string SelectedKey = "WorkspaceScope.Selected";
+    private const string BodySelectionKey = "WorkspaceScope.BodySelection";
     private const string ConnectionAttemptKey = "Workspace.Connection.Attempt";
 
     private readonly IWorkspace workspace;
@@ -197,7 +198,7 @@ public partial record WorkspaceModel
     /// a sentence. The unit suite holds every authored table to naming all four.
     /// </remarks>
     internal static IReadOnlyList<string> ScopeResourceKeys { get; } =
-        [EverythingKey, AccountFolderKey, RoleKey, SelectedKey];
+        [EverythingKey, AccountFolderKey, RoleKey, SelectedKey, BodySelectionKey];
 
     /// <summary>The keys the connection notice's own words are resolved by, on the same terms as the scope's.</summary>
     internal static IReadOnlyList<string> ConnectionResourceKeys { get; } = [ConnectionAttemptKey];
@@ -261,8 +262,11 @@ public partial record WorkspaceModel
             _ => this.localizer[EverythingKey].Value,
         };
 
-        return scope.Selection.Count is 0
-            ? where
-            : this.localizer[SelectedKey, where, scope.Selection.Count].Value;
+        if (scope.BodySelection.Length > 0)
+        {
+            return this.localizer[BodySelectionKey, where].Value;
+        }
+
+        return scope.Selection.Count is 0 ? where : this.localizer[SelectedKey, where, scope.Selection.Count].Value;
     }
 }

--- a/frontend/src/Client/Presentation/Workspace/WorkspaceModel.cs
+++ b/frontend/src/Client/Presentation/Workspace/WorkspaceModel.cs
@@ -195,7 +195,7 @@ public partial record WorkspaceModel
     /// <remarks>
     /// A scope is described by composing words rather than by a <c>x:Uid</c> on a control, so these keys are asked
     /// for from code — which makes a typo in one of them the single way a reader would meet the key itself instead of
-    /// a sentence. The unit suite holds every authored table to naming all four.
+    /// a sentence. The unit suite holds every authored table to naming all five.
     /// </remarks>
     internal static IReadOnlyList<string> ScopeResourceKeys { get; } =
         [EverythingKey, AccountFolderKey, RoleKey, SelectedKey, BodySelectionKey];

--- a/frontend/src/Client/Presentation/Workspace/WorkspaceScope.cs
+++ b/frontend/src/Client/Presentation/Workspace/WorkspaceScope.cs
@@ -51,7 +51,7 @@ public sealed record WorkspaceScope
 
     /// <summary>Whether this scope narrows to anything at all.</summary>
     /// <remarks>
-    /// Each of the four is asked about rather than only the account, because nothing here refuses a folder named
+    /// Each of the five is asked about rather than only the account, because nothing here refuses a folder named
     /// without one: the properties above say what a well-formed scope looks like, and a reader that assumed the type
     /// enforced it would answer <see langword="false" /> for a scope that plainly narrows.
     /// </remarks>

--- a/frontend/src/Client/Presentation/Workspace/WorkspaceScope.cs
+++ b/frontend/src/Client/Presentation/Workspace/WorkspaceScope.cs
@@ -8,7 +8,7 @@ namespace MailFathom.Client.Presentation.Workspace;
 
 /// <summary>
 /// What the next question would be asked against: an account, a folder within it or a role across all of them, and
-/// whatever is selected there.
+/// whatever is selected there, down to a passage somebody selected in one message.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -17,9 +17,9 @@ namespace MailFathom.Client.Presentation.Workspace;
 /// asking about, and a scope each space kept for itself would say they had.
 /// </para>
 /// <para>
-/// Nothing here identifies a person or carries mail content. An account, a folder, and a role are names the deployment
-/// already told this client, and a selection is a list of the identifiers it handed over with them — the classification
-/// the root instructions put on mail metadata follows all four, so none of them is put in a log or in telemetry.
+/// A body selection is mail content and every other member is sensitive mail metadata. They live only in this run's
+/// state, are never persisted, logged, or recorded in telemetry, and leave the process only when a later act explicitly
+/// asks something against this scope.
 /// </para>
 /// </remarks>
 public sealed record WorkspaceScope
@@ -46,6 +46,9 @@ public sealed record WorkspaceScope
     /// <summary>What is selected within the scope above, in the order it was selected.</summary>
     public IImmutableList<string> Selection { get; init; } = ImmutableArray<string>.Empty;
 
+    /// <summary>The passage selected inside the one message in scope, or empty where none is selected.</summary>
+    public string BodySelection { get; init; } = string.Empty;
+
     /// <summary>Whether this scope narrows to anything at all.</summary>
     /// <remarks>
     /// Each of the four is asked about rather than only the account, because nothing here refuses a folder named
@@ -53,7 +56,11 @@ public sealed record WorkspaceScope
     /// enforced it would answer <see langword="false" /> for a scope that plainly narrows.
     /// </remarks>
     public bool NarrowsAnything =>
-        this.Account is not null || this.Folder is not null || this.Role is not null || this.Selection.Count > 0;
+        this.Account is not null
+        || this.Folder is not null
+        || this.Role is not null
+        || this.Selection.Count > 0
+        || this.BodySelection.Length > 0;
 
     /// <summary>Whether this scope and another name the same place, whatever either has selected inside it.</summary>
     /// <param name="other">The scope to compare against.</param>
@@ -81,9 +88,10 @@ public sealed record WorkspaceScope
     /// </remarks>
     public bool Equals(WorkspaceScope? other) =>
         this.NamesSamePlaceAs(other)
-        && this.Selection.SequenceEqual(other!.Selection, StringComparer.Ordinal);
+        && this.Selection.SequenceEqual(other!.Selection, StringComparer.Ordinal)
+        && string.Equals(this.BodySelection, other.BodySelection, StringComparison.Ordinal);
 
     /// <inheritdoc />
     public override int GetHashCode() =>
-        HashCode.Combine(this.Account, this.Folder, this.Role, this.Selection.Count);
+        HashCode.Combine(this.Account, this.Folder, this.Role, this.Selection.Count, this.BodySelection);
 }

--- a/frontend/src/Client/Strings/en/Resources.resw
+++ b/frontend/src/Client/Strings/en/Resources.resw
@@ -337,6 +337,10 @@
     <value>{0} · {1} selected</value>
     <comment>What is in scope, and how many things are selected within it. {0} is the scope as the two entries above phrase it and {1} is a count.</comment>
   </data>
+  <data name="WorkspaceScope.BodySelection" xml:space="preserve">
+    <value>{0} · selected passage</value>
+    <comment>Says that the scope is one passage selected inside the one message in {0}, without repeating mail content in the frame.</comment>
+  </data>
   <data name="DiscoverPage.Answer.Heading" xml:space="preserve">
     <value>Discover</value>
     <comment>Names the primary column of the Discover space while that space is being built.</comment>
@@ -937,4 +941,33 @@
     <value>Message body as text</value>
     <comment>What a screen reader announces the message as where it is read as words rather than drawn.</comment>
   </data>
+  <data name="MailBody.Button.UseSelection.Content" xml:space="preserve">
+    <value>Use selection as scope</value>
+    <comment>Makes the passage the reader selected the narrowest part of the scope beside the intent field.</comment>
+  </data>
+  <data name="MailMessage.Sender.Trusted" xml:space="preserve"><value>Authenticated author {0} is trusted by this deployment.</value><comment>Shown only for an author both authenticated and named by the deployment. {0} is the authenticated author domain, not the raw From value.</comment></data>
+  <data name="MailMessage.Sender.Failed" xml:space="preserve"><value>The displayed sender {0} did not authenticate.</value><comment>Warns about the displayed author the receiving server checked and rejected. {0} is explicitly the displayed claim, not an authenticated identity.</comment></data>
+  <data name="MailMessage.Sender.Unrecognized" xml:space="preserve"><value>This deployment reported a sender verdict this version of MailFathom does not understand.</value><comment>Safe reading of a verdict added after this client, rather than treating an unknown value as ordinary.</comment></data>
+  <data name="MailMessage.Attachment.Fallback" xml:space="preserve"><value>Attachment {0}</value><comment>Names an attachment whose MIME part carried no usable file name. {0} is its one-based position.</comment></data>
+  <data name="MailMessage.Attachment.Normalized" xml:space="preserve"><value>The sender's file name was made safe before it was shown.</value><comment>States that a sender-written path or control character was removed from the displayed and suggested file name.</comment></data>
+  <data name="MailMessage.Attachment.FileType" xml:space="preserve"><value>Attachment</value><comment>Describes the file type choice handed to the platform save picker.</comment></data>
+  <data name="MailMessage.Header.From" xml:space="preserve"><value>From</value><comment>Labels the From participant of an opened message.</comment></data>
+  <data name="MailMessage.Header.To" xml:space="preserve"><value>To</value><comment>Labels a To participant of an opened message.</comment></data>
+  <data name="MailMessage.Header.Cc" xml:space="preserve"><value>Cc</value><comment>Labels a Cc participant of an opened message.</comment></data>
+  <data name="MailMessage.Header.Bcc" xml:space="preserve"><value>Bcc</value><comment>Labels a Bcc participant of an opened message.</comment></data>
+  <data name="MailMessage.Header.SentAt" xml:space="preserve"><value>Sent</value><comment>Labels when the sender dated an opened message.</comment></data>
+  <data name="MailMessage.Header.ReceivedAt" xml:space="preserve"><value>Received</value><comment>Labels when the receiving hop dated an opened message.</comment></data>
+  <data name="MailMessage.Header.MessageId" xml:space="preserve"><value>Message ID</value><comment>Labels the message's own threading identifier.</comment></data>
+  <data name="MailMessage.Header.InReplyTo" xml:space="preserve"><value>In reply to</value><comment>Labels the identifier this message says it answers.</comment></data>
+  <data name="MailMessage.Header.References" xml:space="preserve"><value>References</value><comment>Labels the message identifiers placing this message in a conversation.</comment></data>
+  <data name="MailMessage.InfoBar.TrustedSender.Title" xml:space="preserve"><value>Trusted sender</value><comment>Heads the uncommon positive sender verdict.</comment></data>
+  <data name="MailMessage.InfoBar.SenderWarning.Title" xml:space="preserve"><value>Check who sent this</value><comment>Heads a sender verdict that is not safe to treat as ordinary.</comment></data>
+  <data name="MailMessage.TextBlock.Attachments.Text" xml:space="preserve"><value>Attachments</value><comment>Heads the files listed before any is fetched.</comment></data>
+  <data name="MailMessage.Button.DownloadAttachment.Content" xml:space="preserve"><value>Download</value><comment>Opens the platform picker and streams this attachment.</comment></data>
+  <data name="MailMessage.Button.CancelAttachment.Content" xml:space="preserve"><value>Cancel</value><comment>Stops the attachment currently being streamed.</comment></data>
+  <data name="MailMessage.InfoBar.AttachmentUnavailable.Title" xml:space="preserve"><value>Download failed</value><comment>Heads the failure of one attachment while leaving the message readable.</comment></data>
+  <data name="MailMessage.InfoBar.AttachmentUnavailable.Message" xml:space="preserve"><value>This attachment could not be saved.</value><comment>States the bounded outcome without repeating server or file content.</comment></data>
+  <data name="MailMessage.Button.RetryAttachment.Content" xml:space="preserve"><value>Try again</value><comment>Repeats the save choice and stream for one attachment.</comment></data>
+  <data name="MailMessage.InfoBar.AttachmentSaved.Title" xml:space="preserve"><value>Saved</value><comment>Heads the completed save of one attachment.</comment></data>
+  <data name="MailMessage.InfoBar.AttachmentSaved.Message" xml:space="preserve"><value>The attachment was saved.</value><comment>Confirms the platform completed the chosen file update.</comment></data>
 </root>

--- a/frontend/src/Client/Strings/pl/Resources.resw
+++ b/frontend/src/Client/Strings/pl/Resources.resw
@@ -337,6 +337,10 @@
     <value>{0} · zaznaczono: {1}</value>
     <comment>What is in scope, and how many things are selected within it. {0} is the scope as the two entries above phrase it and {1} is a count; the Polish wording avoids a plural form the count would have to agree with.</comment>
   </data>
+  <data name="WorkspaceScope.BodySelection" xml:space="preserve">
+    <value>{0} · zaznaczony fragment</value>
+    <comment>Says that the scope is one passage selected inside the one message in {0}, without repeating mail content in the frame.</comment>
+  </data>
   <data name="DiscoverPage.Answer.Heading" xml:space="preserve">
     <value>Odkrywanie</value>
     <comment>Names the primary column of the Discover space while that space is being built.</comment>
@@ -937,4 +941,33 @@
     <value>Treść wiadomości jako tekst</value>
     <comment>What a screen reader announces the message as where it is read as words rather than drawn.</comment>
   </data>
+  <data name="MailBody.Button.UseSelection.Content" xml:space="preserve">
+    <value>Użyj zaznaczenia jako zakresu</value>
+    <comment>Makes the passage the reader selected the narrowest part of the scope beside the intent field.</comment>
+  </data>
+  <data name="MailMessage.Sender.Trusted" xml:space="preserve"><value>Uwierzytelniony autor {0} jest zaufany w tym wdrożeniu.</value><comment>Shown only for an author both authenticated and named by the deployment. {0} is the authenticated author domain, not the raw From value.</comment></data>
+  <data name="MailMessage.Sender.Failed" xml:space="preserve"><value>Wyświetlony nadawca {0} nie został uwierzytelniony.</value><comment>Warns about the displayed author the receiving server checked and rejected. {0} is explicitly the displayed claim, not an authenticated identity.</comment></data>
+  <data name="MailMessage.Sender.Unrecognized" xml:space="preserve"><value>Wdrożenie zwróciło werdykt nadawcy, którego ta wersja MailFathom nie rozumie.</value><comment>Safe reading of a verdict added after this client, rather than treating an unknown value as ordinary.</comment></data>
+  <data name="MailMessage.Attachment.Fallback" xml:space="preserve"><value>Załącznik {0}</value><comment>Names an attachment whose MIME part carried no usable file name. {0} is its one-based position.</comment></data>
+  <data name="MailMessage.Attachment.Normalized" xml:space="preserve"><value>Nazwa pliku od nadawcy została zabezpieczona przed wyświetleniem.</value><comment>States that a sender-written path or control character was removed from the displayed and suggested file name.</comment></data>
+  <data name="MailMessage.Attachment.FileType" xml:space="preserve"><value>Załącznik</value><comment>Describes the file type choice handed to the platform save picker.</comment></data>
+  <data name="MailMessage.Header.From" xml:space="preserve"><value>Od</value><comment>Labels the From participant of an opened message.</comment></data>
+  <data name="MailMessage.Header.To" xml:space="preserve"><value>Do</value><comment>Labels a To participant of an opened message.</comment></data>
+  <data name="MailMessage.Header.Cc" xml:space="preserve"><value>DW</value><comment>Labels a Cc participant of an opened message.</comment></data>
+  <data name="MailMessage.Header.Bcc" xml:space="preserve"><value>UDW</value><comment>Labels a Bcc participant of an opened message.</comment></data>
+  <data name="MailMessage.Header.SentAt" xml:space="preserve"><value>Wysłano</value><comment>Labels when the sender dated an opened message.</comment></data>
+  <data name="MailMessage.Header.ReceivedAt" xml:space="preserve"><value>Odebrano</value><comment>Labels when the receiving hop dated an opened message.</comment></data>
+  <data name="MailMessage.Header.MessageId" xml:space="preserve"><value>Identyfikator wiadomości</value><comment>Labels the message's own threading identifier.</comment></data>
+  <data name="MailMessage.Header.InReplyTo" xml:space="preserve"><value>W odpowiedzi na</value><comment>Labels the identifier this message says it answers.</comment></data>
+  <data name="MailMessage.Header.References" xml:space="preserve"><value>Odwołania</value><comment>Labels the message identifiers placing this message in a conversation.</comment></data>
+  <data name="MailMessage.InfoBar.TrustedSender.Title" xml:space="preserve"><value>Zaufany nadawca</value><comment>Heads the uncommon positive sender verdict.</comment></data>
+  <data name="MailMessage.InfoBar.SenderWarning.Title" xml:space="preserve"><value>Sprawdź, kto to wysłał</value><comment>Heads a sender verdict that is not safe to treat as ordinary.</comment></data>
+  <data name="MailMessage.TextBlock.Attachments.Text" xml:space="preserve"><value>Załączniki</value><comment>Heads the files listed before any is fetched.</comment></data>
+  <data name="MailMessage.Button.DownloadAttachment.Content" xml:space="preserve"><value>Pobierz</value><comment>Opens the platform picker and streams this attachment.</comment></data>
+  <data name="MailMessage.Button.CancelAttachment.Content" xml:space="preserve"><value>Anuluj</value><comment>Stops the attachment currently being streamed.</comment></data>
+  <data name="MailMessage.InfoBar.AttachmentUnavailable.Title" xml:space="preserve"><value>Pobieranie nie powiodło się</value><comment>Heads the failure of one attachment while leaving the message readable.</comment></data>
+  <data name="MailMessage.InfoBar.AttachmentUnavailable.Message" xml:space="preserve"><value>Nie udało się zapisać tego załącznika.</value><comment>States the bounded outcome without repeating server or file content.</comment></data>
+  <data name="MailMessage.Button.RetryAttachment.Content" xml:space="preserve"><value>Spróbuj ponownie</value><comment>Repeats the save choice and stream for one attachment.</comment></data>
+  <data name="MailMessage.InfoBar.AttachmentSaved.Title" xml:space="preserve"><value>Zapisano</value><comment>Heads the completed save of one attachment.</comment></data>
+  <data name="MailMessage.InfoBar.AttachmentSaved.Message" xml:space="preserve"><value>Załącznik został zapisany.</value><comment>Confirms the platform completed the chosen file update.</comment></data>
 </root>

--- a/frontend/src/README.md
+++ b/frontend/src/README.md
@@ -123,9 +123,11 @@ and is remembered with the place, because a cursor is only honoured against the 
 under.
 
 **What is selected is the application's rather than the control's.** The list mirrors its selection into
-`IWorkspace.Scope`, which is what lets a question in Discover be asked about mail somebody picked in Mail; on a pointer
-head that is the ordinary extended selection with its modifiers and its drag, and on a touch head a press and hold puts
-the list into a selecting mode that is visible and can be left. Loading, a read that failed, a folder holding no mail,
+`IWorkspace.Scope`, which is what lets a question in Discover be asked about mail somebody picked in Mail. Selecting a
+passage inside one opened message can narrow that same scope once more; the passage stays in the run's state, is cleared
+when the message selection changes, and is never written to the mailbox memory. On a pointer head the list itself uses
+ordinary extended selection with its modifiers and its drag, and on a touch head a press and hold puts the list into a
+selecting mode that is visible and can be left. Loading, a read that failed, a folder holding no mail,
 and a folder whose mail this list is keeping out are four rendered states rather than one blank list — the last two are
 told apart in words, and how current the copy is stays the tree's to say.
 
@@ -142,9 +144,12 @@ arrived at the conversation itself, the newest is.
 **What each message added arrived with the conversation, and the whole of one is a request somebody made.** A message
 collapses to a line and opens to what it contributed, which the deployment publishes with the quoted history and the
 signature trimmed off — so an exchange of thirty replies is one request to draw and the eighth reply does not redraw the
-seven above it. The whole message, quoted history and all, is read only for the message somebody asked it of and drawn
-by the same pane a single message is read in, which is what keeps the question asked before a link is followed one piece
-of code rather than two. Collapsing that message drops the whole of it along with the answer about its remote pictures,
+seven above it. The whole message, quoted history and all, is read only for the message somebody asked it of. Its pane
+draws the parsed headers, the deployment's sender verdict, and each attachment's safe name, declared type, and decoded
+size before it draws the body. A file is streamed only after the reader chooses a destination, through a cancellable
+per-attachment action, and the chosen file is replaced only after the stream completes. The same pane draws a single
+message, which is what keeps the question asked before a link is followed one piece of code rather than two. Collapsing
+that message drops the whole of it along with the answer about its remote pictures,
 so no allowance outlives the reason it was given. A page of the conversation that did not arrive, and a whole message
 that did not, are each said beside what is already drawn rather than instead of it.
 

--- a/frontend/tests/Client.UnitTests/Backend/DeploymentClientTests.cs
+++ b/frontend/tests/Client.UnitTests/Backend/DeploymentClientTests.cs
@@ -402,6 +402,84 @@ public sealed class DeploymentClientTests
         Assert.Empty(destination.ToArray());
     }
 
+    [Fact]
+    public async Task DownloadMailAttachmentAsync_AFileAboveTheClientCeiling_RefusesItWithoutARequest()
+    {
+        // Arrange
+        using var harness = await DeploymentHarness.CreateAsync(
+            _ => throw new InvalidOperationException("No request should be sent."),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await using var destination = new MemoryStream();
+
+        // Act
+        var failure = await Assert.ThrowsAsync<DeploymentFailure>(
+            () => harness.Client.DownloadMailAttachmentAsync(
+                Guid.Parse("8f14e45f-ceea-467a-9f3e-1c3ecdf1e9a1"),
+                position: 0,
+                expectedSizeOctets: DeploymentExchange.MaxMailAttachmentBytes + 1,
+                destination,
+                TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(DeploymentFailureReason.Unusable, failure.Reason);
+        Assert.Empty(harness.Deployment.Requests);
+        Assert.Empty(destination.ToArray());
+    }
+
+    [Fact]
+    public async Task DownloadMailAttachmentAsync_AStreamLongerThanItsMatchingHeader_RefusesItBeforeWritingTheOverrun()
+    {
+        // Arrange
+        using var harness = await DeploymentHarness.CreateAsync(
+            _ => AttachmentResponse([1, 2, 3, 4], declaredLength: 3),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await using var destination = new MemoryStream();
+
+        // Act
+        var failure = await Assert.ThrowsAsync<DeploymentFailure>(
+            () => harness.Client.DownloadMailAttachmentAsync(
+                Guid.Parse("8f14e45f-ceea-467a-9f3e-1c3ecdf1e9a1"),
+                position: 0,
+                expectedSizeOctets: 3,
+                destination,
+                TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(DeploymentFailureReason.Unusable, failure.Reason);
+        Assert.Empty(destination.ToArray());
+    }
+
+    [Fact]
+    public async Task DownloadMailAttachmentAsync_AStreamShorterThanItsMatchingHeader_RefusesItAfterTheStagingWrite()
+    {
+        // Arrange
+        using var harness = await DeploymentHarness.CreateAsync(
+            _ => AttachmentResponse([1, 2, 3], declaredLength: 4),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await using var destination = new MemoryStream();
+
+        // Act
+        var failure = await Assert.ThrowsAsync<DeploymentFailure>(
+            () => harness.Client.DownloadMailAttachmentAsync(
+                Guid.Parse("8f14e45f-ceea-467a-9f3e-1c3ecdf1e9a1"),
+                position: 0,
+                expectedSizeOctets: 4,
+                destination,
+                TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(DeploymentFailureReason.Unusable, failure.Reason);
+        Assert.Equal([1, 2, 3], destination.ToArray());
+    }
+
+    private static HttpResponseMessage AttachmentResponse(byte[] octets, long declaredLength)
+    {
+        var content = new StreamContent(new MemoryStream(octets));
+        content.Headers.ContentLength = declaredLength;
+
+        return new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+    }
+
     private static string ABodyWhosePlainTextIs(string text) =>
         $$"""
         {

--- a/frontend/tests/Client.UnitTests/Backend/DeploymentClientTests.cs
+++ b/frontend/tests/Client.UnitTests/Backend/DeploymentClientTests.cs
@@ -286,6 +286,122 @@ public sealed class DeploymentClientTests
         Assert.Equal(DeploymentFailureReason.Unusable, failure.Reason);
     }
 
+    [Fact]
+    public async Task ReadMailMessageAsync_AStoredMessage_ReadsEverythingThePaneDrawsAroundItsBody()
+    {
+        // Arrange
+        using var harness = await DeploymentHarness.CreateAsync(
+            _ => StubTransport.JsonResponse(
+                """
+                {
+                  "storedEmailId": "8f14e45f-ceea-467a-9f3e-1c3ecdf1e9a1",
+                  "account": "personal",
+                  "folder": "INBOX",
+                  "threadId": "5de1bfc2-e8ca-4388-8e7f-1f304b07d671",
+                  "sizeOctets": 2416381,
+                  "headers": {
+                    "subject": "Release 0.8.0",
+                    "sentAt": "2026-08-27T09:14:00+00:00",
+                    "receivedAt": "2026-08-27T09:14:06+00:00",
+                    "participants": [
+                      { "role": "From", "address": "release@example.test", "displayName": "Release notices" },
+                      { "role": "To", "address": "reader@example.test", "displayName": null }
+                    ],
+                    "messageId": "release-0-8-0@example.test",
+                    "inReplyTo": null,
+                    "references": ["earlier@example.test"]
+                  },
+                  "body": { "availability": "Readable", "plainText": true, "html": true },
+                  "sender": { "authorAuthentication": "Authenticated", "deploymentTrust": "Trusted" },
+                  "attachments": [
+                    {
+                      "position": 0,
+                      "fileName": "release-notes.pdf",
+                      "wasFileNameNormalized": false,
+                      "mediaType": "application/pdf",
+                      "sizeOctets": 2401337
+                    }
+                  ],
+                  "carried": {
+                    "attachmentCount": 1,
+                    "totalSizeOctets": 2401337,
+                    "inlineResourceCount": 2,
+                    "encrypted": false,
+                    "unverifiedSignature": true,
+                    "unexpandedTnefPart": false
+                  },
+                  "unread": true,
+                  "flagged": false,
+                  "answered": true
+                }
+                """),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Act
+        var message = await harness.Client.ReadMailMessageAsync(
+            Guid.Parse("8f14e45f-ceea-467a-9f3e-1c3ecdf1e9a1"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("Release 0.8.0", message.Headers.Subject);
+        Assert.Equal("release@example.test", message.Headers.Participants[0].Address);
+        Assert.Equal("Authenticated", message.Sender.AuthorAuthentication);
+        Assert.Equal("Trusted", message.Sender.DeploymentTrust);
+        Assert.Equal("release-notes.pdf", Assert.Single(message.Attachments).FileName);
+        Assert.Equal(2, message.Carried!.InlineResourceCount);
+        Assert.True(message.Carried.UnverifiedSignature);
+        Assert.True(message.Unread);
+        Assert.True(message.Answered);
+    }
+
+    [Fact]
+    public async Task DownloadMailAttachmentAsync_AFileSomebodyRequested_StreamsItToTheChosenDestination()
+    {
+        // Arrange
+        byte[] octets = [4, 8, 15, 16, 23, 42];
+        using var harness = await DeploymentHarness.CreateAsync(
+            _ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(octets) },
+            cancellationToken: TestContext.Current.CancellationToken);
+        await using var destination = new MemoryStream();
+
+        // Act
+        await harness.Client.DownloadMailAttachmentAsync(
+            Guid.Parse("8f14e45f-ceea-467a-9f3e-1c3ecdf1e9a1"),
+            position: 3,
+            expectedSizeOctets: octets.Length,
+            destination,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(octets, destination.ToArray());
+        Assert.Equal(
+            new Uri("https://mail.example/api/client/messages/8f14e45f-ceea-467a-9f3e-1c3ecdf1e9a1/attachments/3"),
+            Assert.Single(harness.Deployment.Requests).RequestUri);
+    }
+
+    [Fact]
+    public async Task DownloadMailAttachmentAsync_AResponseWhoseLengthChanged_RefusesItBeforeWriting()
+    {
+        // Arrange
+        using var harness = await DeploymentHarness.CreateAsync(
+            _ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent([1, 2, 3]) },
+            cancellationToken: TestContext.Current.CancellationToken);
+        await using var destination = new MemoryStream();
+
+        // Act
+        var failure = await Assert.ThrowsAsync<DeploymentFailure>(
+            () => harness.Client.DownloadMailAttachmentAsync(
+                Guid.Parse("8f14e45f-ceea-467a-9f3e-1c3ecdf1e9a1"),
+                position: 0,
+                expectedSizeOctets: 4,
+                destination,
+                TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(DeploymentFailureReason.Unusable, failure.Reason);
+        Assert.Empty(destination.ToArray());
+    }
+
     private static string ABodyWhosePlainTextIs(string text) =>
         $$"""
         {

--- a/frontend/tests/Client.UnitTests/Presentation/Mailboxes/DeploymentMailboxTreeTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Mailboxes/DeploymentMailboxTreeTests.cs
@@ -247,7 +247,11 @@ public sealed class DeploymentMailboxTreeTests
         await over.Tree.SelectAsync(mailbox, TestContext.Current.CancellationToken);
 
         await over.Workspace.Scope.UpdateAsync(
-            scope => scope! with { Selection = ImmutableArray.Create("117") },
+            scope => scope! with
+            {
+                Selection = ImmutableArray.Create("117"),
+                BodySelection = "the selected passage",
+            },
             TestContext.Current.CancellationToken);
 
         // Act
@@ -255,6 +259,7 @@ public sealed class DeploymentMailboxTreeTests
 
         // Assert
         Assert.Empty(over.Memory.Remembered.Scope.Selection);
+        Assert.Empty(over.Memory.Remembered.Scope.BodySelection);
         Assert.Equal("work", over.Memory.Remembered.Scope.Account);
     }
 

--- a/frontend/tests/Client.UnitTests/Presentation/Spaces/Mail/MailModelTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Spaces/Mail/MailModelTests.cs
@@ -6,6 +6,8 @@ using MailFathom.Client.Backend;
 using MailFathom.Client.Backend.Timeline;
 using MailFathom.Client.Presentation.Messages;
 using MailFathom.Client.Presentation.Spaces.Mail;
+using MailFathom.Client.Presentation.Spaces.Mail.Reading;
+using MailFathom.Client.Presentation.Workspace;
 using MailFathom.Client.Session;
 using MailFathom.Client.UnitTests.TestDoubles;
 
@@ -23,10 +25,10 @@ public sealed class MailModelTests
     {
         // Arrange
         using var withheld = SessionOffering("mailfathom.mail.ask");
-        await using var withheldModel = new MailModel(withheld, new StubMessageList(), new StubMailThread());
+        await using var withheldModel = new MailModel(withheld, new StubMessageList(), new StubMailThread(), new StubWorkspace());
 
         using var offered = SessionOffering("mailfathom.mail.read");
-        await using var offeredModel = new MailModel(offered, new StubMessageList(), new StubMailThread());
+        await using var offeredModel = new MailModel(offered, new StubMessageList(), new StubMailThread(), new StubWorkspace());
 
         // Act, Assert
         Assert.True(await withheldModel.WithholdsMail);
@@ -43,7 +45,7 @@ public sealed class MailModelTests
         // Arrange
         using var session = SessionOffering("mailfathom.mail.read");
         var list = new StubMessageList(Row(1), Row(2));
-        await using var model = new MailModel(session, list, new StubMailThread());
+        await using var model = new MailModel(session, list, new StubMailThread(), new StubWorkspace());
 
         // Act
         var rows = await model.Messages;
@@ -64,7 +66,7 @@ public sealed class MailModelTests
         // Arrange
         using var session = SessionOffering("mailfathom.mail.read");
         var thread = new StubMailThread();
-        await using var model = new MailModel(session, new StubMessageList(), thread);
+        await using var model = new MailModel(session, new StubMessageList(), thread, new StubWorkspace());
 
         // Act, Assert
         Assert.Same(thread.Reading, model.Thread);
@@ -84,12 +86,16 @@ public sealed class MailModelTests
         // Arrange
         using var session = SessionOffering("mailfathom.mail.read");
         var thread = new StubMailThread();
-        await using var model = new MailModel(session, new StubMessageList(), thread);
+        await using var model = new MailModel(session, new StubMessageList(), thread, new StubWorkspace());
+
+        var attachment = new MailAttachmentRequest(MailMessages.Identity(4), Position: 2);
 
         // Act
         await model.ToggleThreadMessage(MailMessages.Key(1), TestContext.Current.CancellationToken);
         await model.ShowWholeThreadMessage(MailMessages.Key(2), TestContext.Current.CancellationToken);
         await model.ShowThreadRemoteContent(MailMessages.Key(3), TestContext.Current.CancellationToken);
+        await model.SaveAttachment(attachment, TestContext.Current.CancellationToken);
+        model.CancelAttachment(attachment);
         await model.ShowMoreThreadMessages(TestContext.Current.CancellationToken);
         await model.RetryThread(TestContext.Current.CancellationToken);
 
@@ -97,6 +103,8 @@ public sealed class MailModelTests
         Assert.Equal([MailMessages.Key(1)], thread.Toggled);
         Assert.Equal([MailMessages.Key(2)], thread.Whole);
         Assert.Equal([MailMessages.Key(3)], thread.Remote);
+        Assert.Equal([attachment], thread.Saved);
+        Assert.Equal([attachment], thread.Cancelled);
         Assert.Equal(1, thread.Pages);
         Assert.Equal(1, thread.Asks);
     }
@@ -108,7 +116,7 @@ public sealed class MailModelTests
         // Arrange
         using var session = SessionOffering("mailfathom.mail.read");
         var list = new StubMessageList(Row(1)) { More = true, Earlier = false };
-        await using var model = new MailModel(session, list, new StubMailThread());
+        await using var model = new MailModel(session, list, new StubMailThread(), new StubWorkspace());
 
         // Act, Assert
         Assert.True(await model.HasMoreAfter);
@@ -122,7 +130,7 @@ public sealed class MailModelTests
         // Arrange
         using var session = SessionOffering("mailfathom.mail.read");
         var list = new StubMessageList();
-        await using var model = new MailModel(session, list, new StubMailThread());
+        await using var model = new MailModel(session, list, new StubMailThread(), new StubWorkspace());
 
         await list.ArrangeAsync(
             new MessageListArrangement
@@ -154,7 +162,7 @@ public sealed class MailModelTests
     {
         // Arrange
         using var session = SessionOffering("mailfathom.mail.read");
-        await using var model = new MailModel(session, new StubMessageList(), new StubMailThread());
+        await using var model = new MailModel(session, new StubMessageList(), new StubMailThread(), new StubWorkspace());
 
         // Act, Assert
         Assert.True(await model.KeepsEverything);
@@ -168,7 +176,7 @@ public sealed class MailModelTests
         // Arrange
         using var session = SessionOffering("mailfathom.mail.read");
         var list = new StubMessageList();
-        await using var model = new MailModel(session, list, new StubMailThread());
+        await using var model = new MailModel(session, list, new StubMailThread(), new StubWorkspace());
 
         // Act
         await model.ShowMore(TestContext.Current.CancellationToken);
@@ -188,7 +196,7 @@ public sealed class MailModelTests
         // Arrange
         using var session = SessionOffering("mailfathom.mail.read");
         var list = new StubMessageList();
-        await using var model = new MailModel(session, list, new StubMailThread());
+        await using var model = new MailModel(session, list, new StubMailThread(), new StubWorkspace());
 
         // Act
         await model.ReverseOrder(TestContext.Current.CancellationToken);
@@ -210,7 +218,7 @@ public sealed class MailModelTests
         // Arrange
         using var session = SessionOffering("mailfathom.mail.read");
         var list = new StubMessageList();
-        await using var model = new MailModel(session, list, new StubMailThread());
+        await using var model = new MailModel(session, list, new StubMailThread(), new StubWorkspace());
 
         // Act
         await model.ToggleUnreadOnly(TestContext.Current.CancellationToken);
@@ -237,7 +245,7 @@ public sealed class MailModelTests
         // Arrange
         using var session = SessionOffering("mailfathom.mail.read");
         var list = new StubMessageList();
-        await using var model = new MailModel(session, list, new StubMailThread());
+        await using var model = new MailModel(session, list, new StubMailThread(), new StubWorkspace());
 
         // Act
         await model.ToggleUnreadOnly(TestContext.Current.CancellationToken);
@@ -245,6 +253,24 @@ public sealed class MailModelTests
 
         // Assert
         Assert.Equal([true, false], list.Arranged.Select(arrangement => arrangement.UnreadOnly));
+    }
+
+    [Fact]
+    public async Task UseBodySelection_AFragmentSomebodyChose_PutsItIntoTheSharedScopeWithoutLosingTheMessage()
+    {
+        // Arrange
+        using var session = SessionOffering("mailfathom.mail.read");
+        var workspace = new StubWorkspace(
+            WorkspaceScope.Everything with { Selection = [MailMessages.Key(1)] });
+        await using var model = new MailModel(session, new StubMessageList(), new StubMailThread(), workspace);
+
+        // Act
+        await model.UseBodySelection("the selected passage", TestContext.Current.CancellationToken);
+
+        // Assert
+        var scope = await workspace.Scope;
+        Assert.Equal([MailMessages.Key(1)], scope!.Selection);
+        Assert.Equal("the selected passage", scope.BodySelection);
     }
 
     /// <summary>A space that could be built without either of these would be one that can say neither what it shows nor whether it may.</summary>
@@ -256,10 +282,11 @@ public sealed class MailModelTests
 
         // Act, Assert
         Assert.Throws<ArgumentNullException>(
-            () => new MailModel(null!, new StubMessageList(), new StubMailThread()));
+            () => new MailModel(null!, new StubMessageList(), new StubMailThread(), new StubWorkspace()));
 
-        Assert.Throws<ArgumentNullException>(() => new MailModel(session, null!, new StubMailThread()));
-        Assert.Throws<ArgumentNullException>(() => new MailModel(session, new StubMessageList(), null!));
+        Assert.Throws<ArgumentNullException>(() => new MailModel(session, null!, new StubMailThread(), new StubWorkspace()));
+        Assert.Throws<ArgumentNullException>(() => new MailModel(session, new StubMessageList(), null!, new StubWorkspace()));
+        Assert.Throws<ArgumentNullException>(() => new MailModel(session, new StubMessageList(), new StubMailThread(), null!));
     }
 
     private static MessageRow Row(int number) => new(

--- a/frontend/tests/Client.UnitTests/Presentation/Spaces/Mail/Reading/MailMessageReadingTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Spaces/Mail/Reading/MailMessageReadingTests.cs
@@ -114,6 +114,35 @@ public sealed class MailMessageReadingTests
         Assert.False(attachment.CanCancel);
     }
 
+    [Fact]
+    public void Of_AnAttachmentBeingDownloaded_OffersCancellationAlone()
+    {
+        // Arrange
+        var message = Message(
+            authorAuthentication: "Authenticated",
+            deploymentTrust: "Unknown",
+            attachments:
+            [
+                new DeploymentMailAttachment(
+                    Position: 2,
+                    FileName: "release-notes.pdf",
+                    WasFileNameNormalized: false,
+                    MediaType: "application/pdf",
+                    SizeOctets: 2_401_337),
+            ]);
+        IReadOnlyDictionary<int, MailAttachmentStanding> downloads =
+            new Dictionary<int, MailAttachmentStanding> { [2] = MailAttachmentStanding.Downloading };
+
+        // Act
+        var attachment = Assert.Single(MailMessageReading.Of(message, downloads, Words()).Attachments);
+
+        // Assert
+        Assert.True(attachment.CanCancel);
+        Assert.False(attachment.CanDownload);
+        Assert.False(attachment.DownloadFailed);
+        Assert.False(attachment.Downloaded);
+    }
+
     private static DeploymentMailMessageDetail Message(
         string authorAuthentication,
         string deploymentTrust,

--- a/frontend/tests/Client.UnitTests/Presentation/Spaces/Mail/Reading/MailMessageReadingTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Spaces/Mail/Reading/MailMessageReadingTests.cs
@@ -1,0 +1,146 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Globalization;
+using MailFathom.Client.Backend.Mail;
+using MailFathom.Client.Presentation.Spaces.Mail.Reading;
+using MailFathom.Client.UnitTests.TestDoubles;
+
+namespace MailFathom.Client.UnitTests.Presentation.Spaces.Mail.Reading;
+
+/// <summary>How the message contract becomes the honest, quiet reading a pane draws.</summary>
+public sealed class MailMessageReadingTests
+{
+    [Fact]
+    public void Of_AnAuthenticatedAuthorNobodyNamed_LeavesTheOrdinaryCaseQuiet()
+    {
+        // Arrange
+        var message = Message(authorAuthentication: "Authenticated", deploymentTrust: "Unknown");
+
+        // Act
+        var reading = MailMessageReading.Of(message, NoDownloads, Words());
+
+        // Assert
+        Assert.False(reading.ShowsSenderNotice);
+        Assert.False(reading.WarnsAboutSender);
+    }
+
+    [Fact]
+    public void Of_AnAuthenticatedAuthorTheDeploymentTrusts_NamesTheAuthenticatedDomain()
+    {
+        // Arrange
+        var message = Message(authorAuthentication: "Authenticated", deploymentTrust: "Trusted");
+
+        // Act
+        var reading = MailMessageReading.Of(message, NoDownloads, Words());
+
+        // Assert
+        Assert.True(reading.ShowsSenderNotice);
+        Assert.False(reading.WarnsAboutSender);
+        Assert.Equal("Trusted example.test", reading.SenderNotice);
+    }
+
+    [Fact]
+    public void Of_ADisplayedAuthorWhoseAuthenticationFailed_WarnsWithoutCallingTheClaimAuthenticated()
+    {
+        // Arrange
+        var message = Message(authorAuthentication: "Failed", deploymentTrust: "Unknown");
+
+        // Act
+        var reading = MailMessageReading.Of(message, NoDownloads, Words());
+
+        // Assert
+        Assert.True(reading.ShowsSenderNotice);
+        Assert.True(reading.WarnsAboutSender);
+        Assert.Equal("Failed release@example.test", reading.SenderNotice);
+    }
+
+    [Fact]
+    public void Of_AVerdictThisBuildDoesNotKnow_WarnsRatherThanReadingItAsOrdinary()
+    {
+        // Arrange
+        var message = Message(authorAuthentication: "FutureOutcome", deploymentTrust: "Unknown");
+
+        // Act
+        var reading = MailMessageReading.Of(message, NoDownloads, Words());
+
+        // Assert
+        Assert.True(reading.WarnsAboutSender);
+        Assert.Equal("Unrecognized", reading.SenderNotice);
+    }
+
+    [Fact]
+    public void Of_AnAttachment_StatesItsSafeNameTypeAndSizeBeforeItIsFetched()
+    {
+        // Arrange
+        var message = Message(
+            authorAuthentication: "Authenticated",
+            deploymentTrust: "Unknown",
+            attachments:
+            [
+                new DeploymentMailAttachment(
+                    Position: 2,
+                    FileName: "release-notes.pdf",
+                    WasFileNameNormalized: true,
+                    MediaType: "application/pdf",
+                    SizeOctets: 2_401_337),
+            ]);
+
+        // Act
+        var reading = MailMessageReading.Of(message, NoDownloads, Words());
+
+        // Assert
+        var attachment = Assert.Single(reading.Attachments);
+        Assert.Equal("release-notes.pdf", attachment.FileName);
+        Assert.Equal("application/pdf", attachment.MediaType);
+        Assert.Equal("2.3 MB", attachment.Size);
+        Assert.True(attachment.WasFileNameNormalized);
+        Assert.True(attachment.CanDownload);
+        Assert.False(attachment.CanCancel);
+    }
+
+    private static DeploymentMailMessageDetail Message(
+        string authorAuthentication,
+        string deploymentTrust,
+        IReadOnlyList<DeploymentMailAttachment>? attachments = null) => new(
+        StoredEmailId: Guid.Parse("8f14e45f-ceea-467a-9f3e-1c3ecdf1e9a1"),
+        Account: "personal",
+        Folder: "INBOX",
+        ThreadId: Guid.Parse("5de1bfc2-e8ca-4388-8e7f-1f304b07d671"),
+        SizeOctets: 2_416_381,
+        Headers: new DeploymentMailHeaders(
+            Subject: "Release 0.8.0",
+            SentAt: DateTimeOffset.Parse("2026-08-27T09:14:00+00:00", CultureInfo.InvariantCulture),
+            ReceivedAt: DateTimeOffset.Parse("2026-08-27T09:14:06+00:00", CultureInfo.InvariantCulture),
+            Participants:
+            [
+                new DeploymentMailParticipant("From", "release@example.test", "Release notices"),
+                new DeploymentMailParticipant("To", "reader@example.test", null),
+            ],
+            MessageId: "release-0-8-0@example.test",
+            InReplyTo: null,
+            References: []),
+        Body: new DeploymentMailBodyForms("Readable", PlainText: true, Html: true),
+        Sender: new DeploymentMailSenderVerdict(authorAuthentication, deploymentTrust),
+        Attachments: attachments ?? [],
+        Carried: null,
+        Unread: true,
+        Flagged: false,
+        Answered: false);
+
+    private static IReadOnlyDictionary<int, MailAttachmentStanding> NoDownloads { get; } =
+        new Dictionary<int, MailAttachmentStanding>();
+
+    private static StubStringLocalizer Words() => new(
+        new Dictionary<string, string>
+        {
+            [MailMessageWords.TrustedSenderKey] = "Trusted {0}",
+            [MailMessageWords.FailedSenderKey] = "Failed {0}",
+            [MailMessageWords.UnrecognizedSenderKey] = "Unrecognized",
+            [MailMessageWords.AttachmentFallbackKey] = "Attachment {0}",
+            [MailMessageWords.NormalizedFileNameKey] = "The sender's file name was made safe.",
+            [MailMessageWords.HeaderRoleKey("From")] = "From",
+            [MailMessageWords.HeaderRoleKey("To")] = "To",
+        });
+}

--- a/frontend/tests/Client.UnitTests/Presentation/Spaces/Mail/Reading/MailMessageReadingTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Spaces/Mail/Reading/MailMessageReadingTests.cs
@@ -27,6 +27,20 @@ public sealed class MailMessageReadingTests
     }
 
     [Fact]
+    public void Of_AnAuthorWhoseAuthenticationWasNotEstablished_LeavesTheOrdinaryCaseQuiet()
+    {
+        // Arrange
+        var message = Message(authorAuthentication: "NotEstablished", deploymentTrust: "Unknown");
+
+        // Act
+        var reading = MailMessageReading.Of(message, NoDownloads, Words());
+
+        // Assert
+        Assert.False(reading.ShowsSenderNotice);
+        Assert.False(reading.WarnsAboutSender);
+    }
+
+    [Fact]
     public void Of_AnAuthenticatedAuthorTheDeploymentTrusts_NamesTheAuthenticatedDomain()
     {
         // Arrange

--- a/frontend/tests/Client.UnitTests/Presentation/Threads/DeploymentMailThreadTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Threads/DeploymentMailThreadTests.cs
@@ -530,13 +530,14 @@ public sealed class DeploymentMailThreadTests
 
     /// <summary>Answers the conversation, a message's details, and its whole body from their own documents.</summary>
     private static Func<HttpRequestMessage, HttpResponseMessage> Answering(string conversation) =>
-        request => IsBody(request)
-            ? Answer(WholeMessage)
-            : IsAttachment(request)
-                ? new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent([1, 2, 3]) }
-            : IsMessage(request)
-                ? Answer(MessageDetail)
-                : Answer(conversation);
+        request => request switch
+        {
+            _ when IsBody(request) => Answer(WholeMessage),
+            _ when IsAttachment(request) =>
+                new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent([1, 2, 3]) },
+            _ when IsMessage(request) => Answer(MessageDetail),
+            _ => Answer(conversation),
+        };
 
     private static HttpResponseMessage Answer(string document, HttpStatusCode status = HttpStatusCode.OK) =>
         StubTransport.JsonResponse(document, status);

--- a/frontend/tests/Client.UnitTests/Presentation/Threads/DeploymentMailThreadTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Threads/DeploymentMailThreadTests.cs
@@ -5,7 +5,9 @@
 using System.Collections.Immutable;
 using System.Net;
 using MailFathom.Client.Backend;
+using MailFathom.Client.Backend.Mail;
 using MailFathom.Client.Presentation.Messages;
+using MailFathom.Client.Presentation.Spaces.Mail.Reading;
 using MailFathom.Client.Presentation.Threads;
 using MailFathom.Client.Session;
 using MailFathom.Client.UnitTests.TestDoubles;
@@ -28,6 +30,43 @@ public sealed class DeploymentMailThreadTests
                          "originalCharacterCount": 45, "truncation": "None" },
           "document": null,
           "remoteImagesRequested": false
+        }
+        """;
+
+    private const string MessageDetail =
+        """
+        {
+          "storedEmailId": "00000000-0000-0000-0000-000000000001",
+          "account": "personal",
+          "folder": "INBOX",
+          "threadId": "10000000-0000-0000-0000-000000000000",
+          "sizeOctets": 1024,
+          "headers": {
+            "subject": "Quarterly review",
+            "sentAt": "2026-08-27T09:14:00+00:00",
+            "receivedAt": "2026-08-27T09:14:06+00:00",
+            "participants": [
+              { "role": "From", "address": "someone@example.test", "displayName": "Someone" }
+            ],
+            "messageId": "one@example.test",
+            "inReplyTo": null,
+            "references": []
+          },
+          "body": { "availability": "Readable", "plainText": true, "html": false },
+          "sender": { "authorAuthentication": "Authenticated", "deploymentTrust": "Unknown" },
+          "attachments": [
+            {
+              "position": 0,
+              "fileName": "quarterly-review.pdf",
+              "wasFileNameNormalized": false,
+              "mediaType": "application/pdf",
+              "sizeOctets": 3
+            }
+          ],
+          "carried": null,
+          "unread": false,
+          "flagged": false,
+          "answered": false
         }
         """;
 
@@ -208,12 +247,17 @@ public sealed class DeploymentMailThreadTests
         // Assert
         var messages = await over.Thread.Messages;
         Assert.True(messages![0].ShowsWholeMessage);
+        Assert.Equal("Quarterly review", messages[0].Message!.Subject);
         Assert.False(messages[1].ShowsWholeMessage);
         Assert.False(messages[2].ShowsWholeMessage);
 
         Assert.Equal(
             $"/api/client/messages/{MailMessages.Identity(1):D}/body",
             over.Harness.Deployment.Requests[^1].RequestUri.AbsolutePath);
+        Assert.Contains(
+            over.Harness.Deployment.Requests,
+            request => request.RequestUri.AbsolutePath
+                == $"/api/client/messages/{MailMessages.Identity(1):D}");
     }
 
     /// <summary>Asking for remote pictures is a second read of that one message, in the terms the reader allowed.</summary>
@@ -236,6 +280,51 @@ public sealed class DeploymentMailThreadTests
         Assert.Contains("remoteImages=true", asked.Query, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task SaveAttachmentAsync_OneFileSomebodySelected_StreamsOnlyThatFileAndMarksItDownloaded()
+    {
+        // Arrange
+        using var over = await ThreadOver.CreateAsync(Answering(MailThreads.Document(2)),
+            TestContext.Current.CancellationToken);
+        await over.Opened();
+        await over.Thread.ShowWholeMessageAsync(MailMessages.Key(1), TestContext.Current.CancellationToken);
+        var request = Assert.Single((await over.Thread.Messages)![0].Message!.Attachments).Request;
+
+        // Act
+        await over.Thread.SaveAttachmentAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal([1, 2, 3], over.Saver.Saved);
+        Assert.True(Assert.Single((await over.Thread.Messages)![0].Message!.Attachments).Downloaded);
+        Assert.Equal(
+            $"/api/client/messages/{MailMessages.Identity(1):D}/attachments/0",
+            over.Harness.Deployment.Requests[^1].RequestUri.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task CancelAttachment_AFileBeingSaved_CancelsItWithoutReportingAFailure()
+    {
+        // Arrange
+        using var over = await ThreadOver.CreateAsync(Answering(MailThreads.Document(2)),
+            TestContext.Current.CancellationToken);
+        await over.Opened();
+        await over.Thread.ShowWholeMessageAsync(MailMessages.Key(1), TestContext.Current.CancellationToken);
+        var request = Assert.Single((await over.Thread.Messages)![0].Message!.Attachments).Request;
+        over.Saver.Hold = true;
+
+        var saving = over.Thread.SaveAttachmentAsync(request, TestContext.Current.CancellationToken).AsTask();
+        Assert.True(over.Saver.Started.Wait(Patience, TestContext.Current.CancellationToken));
+
+        // Act
+        over.Thread.CancelAttachment(request);
+        await saving;
+
+        // Assert
+        var attachment = Assert.Single((await over.Thread.Messages)![0].Message!.Attachments);
+        Assert.True(attachment.CanDownload);
+        Assert.False(attachment.DownloadFailed);
+    }
+
     /// <summary>
     /// A whole message that did not arrive is said on that message, because the conversation and what the message
     /// added are still on the screen and still true.
@@ -244,9 +333,12 @@ public sealed class DeploymentMailThreadTests
     public async Task ShowWholeMessageAsync_AReadThatFailed_SaysSoOnTheMessageAndLeavesTheConversationDrawn()
     {
         // Arrange
-        using var over = await ThreadOver.CreateAsync(request => IsBody(request)
-            ? Answer("{}", HttpStatusCode.BadGateway)
-            : Answer(MailThreads.Document(2)),
+        using var over = await ThreadOver.CreateAsync(request => request.RequestUri!.AbsolutePath switch
+        {
+            var path when path.EndsWith("/body", StringComparison.Ordinal) => Answer("{}", HttpStatusCode.BadGateway),
+            var path when path.Contains("/messages/", StringComparison.Ordinal) => Answer(MessageDetail),
+            _ => Answer(MailThreads.Document(2)),
+        },
             TestContext.Current.CancellationToken);
 
         await over.Opened();
@@ -279,9 +371,14 @@ public sealed class DeploymentMailThreadTests
 
         using var over = await ThreadOver.CreateAsync(request =>
         {
-            if (!IsBody(request))
+            if (IsThread(request))
             {
                 return Answer(MailThreads.Document(2));
+            }
+
+            if (IsMessage(request))
+            {
+                return Answer(MessageDetail);
             }
 
             reached.Set();
@@ -413,15 +510,32 @@ public sealed class DeploymentMailThreadTests
         Assert.Equal([false, true, false], messages!.Select(message => message.IsExpanded));
     }
 
-    /// <summary>Answers the conversation from one document, and every message's whole body from the same one.</summary>
+    /// <summary>Answers the conversation, a message's details, and its whole body from their own documents.</summary>
     private static Func<HttpRequestMessage, HttpResponseMessage> Answering(string conversation) =>
-        request => IsBody(request) ? Answer(WholeMessage) : Answer(conversation);
+        request => IsBody(request)
+            ? Answer(WholeMessage)
+            : IsAttachment(request)
+                ? new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent([1, 2, 3]) }
+            : IsMessage(request)
+                ? Answer(MessageDetail)
+                : Answer(conversation);
 
     private static HttpResponseMessage Answer(string document, HttpStatusCode status = HttpStatusCode.OK) =>
         StubTransport.JsonResponse(document, status);
 
     private static bool IsBody(HttpRequestMessage request) =>
         request.RequestUri?.AbsolutePath.EndsWith("/body", StringComparison.Ordinal) is true;
+
+    private static bool IsMessage(HttpRequestMessage request) =>
+        request.RequestUri?.AbsolutePath.Contains("/messages/", StringComparison.Ordinal) is true
+        && !IsBody(request)
+        && !IsAttachment(request);
+
+    private static bool IsAttachment(HttpRequestMessage request) =>
+        request.RequestUri?.AbsolutePath.Contains("/attachments/", StringComparison.Ordinal) is true;
+
+    private static bool IsThread(HttpRequestMessage request) =>
+        request.RequestUri?.AbsolutePath.Contains("/threads/", StringComparison.Ordinal) is true;
 
     /// <summary>Reads the cursor a request carried, which is what tells one page of a script apart from the next.</summary>
     private static string? Cursor(HttpRequestMessage request) =>
@@ -460,7 +574,8 @@ public sealed class DeploymentMailThreadTests
 
             this.List = new StubMessageList();
 
-            this.Thread = new DeploymentMailThread(this.Harness.Client, this.Session, this.List, Words());
+            this.Saver = new StubMailAttachmentSaver();
+            this.Thread = new DeploymentMailThread(this.Harness.Client, this.Session, this.List, this.Saver, Words());
         }
 
         /// <summary>Builds the conversation over a scripted deployment the client is already pointed at.</summary>
@@ -477,6 +592,8 @@ public sealed class DeploymentMailThreadTests
         internal StubClientSession Session { get; }
 
         internal StubMessageList List { get; }
+
+        internal StubMailAttachmentSaver Saver { get; }
 
         internal DeploymentMailThread Thread { get; }
 
@@ -537,6 +654,43 @@ public sealed class DeploymentMailThreadTests
             [ThreadWords.RecipientsKey] = "To {0}",
             [ThreadWords.ParticipantMessagesKey] = "({0})",
             [ThreadWords.ParticipantAnnouncementKey] = "{0} wrote {1}",
+            [MailMessageWords.TrustedSenderKey] = "Trusted {0}",
+            [MailMessageWords.FailedSenderKey] = "Failed {0}",
+            [MailMessageWords.UnrecognizedSenderKey] = "Unrecognized",
+            [MailMessageWords.AttachmentFallbackKey] = "Attachment {0}",
+            [MailMessageWords.NormalizedFileNameKey] = "The sender's file name was made safe.",
+            [MailMessageWords.HeaderRoleKey("From")] = "From",
+            [MailMessageWords.HeaderRoleKey("SentAt")] = "Sent",
+            [MailMessageWords.HeaderRoleKey("ReceivedAt")] = "Received",
+            [MailMessageWords.HeaderRoleKey("MessageId")] = "Message ID",
         });
+    }
+
+    private sealed class StubMailAttachmentSaver : IMailAttachmentSaver
+    {
+        internal ManualResetEventSlim Started { get; } = new(false);
+
+        internal bool Hold { get; set; }
+
+        internal byte[] Saved { get; private set; } = [];
+
+        public async ValueTask<bool> SaveAsync(
+            DeploymentMailAttachment attachment,
+            Func<Stream, CancellationToken, Task> write,
+            CancellationToken cancellationToken)
+        {
+            this.Started.Set();
+
+            if (this.Hold)
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            }
+
+            await using var destination = new MemoryStream();
+            await write(destination, cancellationToken);
+            this.Saved = destination.ToArray();
+
+            return true;
+        }
     }
 }

--- a/frontend/tests/Client.UnitTests/Presentation/Threads/DeploymentMailThreadTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Threads/DeploymentMailThreadTests.cs
@@ -61,6 +61,13 @@ public sealed class DeploymentMailThreadTests
               "wasFileNameNormalized": false,
               "mediaType": "application/pdf",
               "sizeOctets": 3
+            },
+            {
+              "position": 1,
+              "fileName": "review-data.csv",
+              "wasFileNameNormalized": false,
+              "mediaType": "text/csv",
+              "sizeOctets": 3
             }
           ],
           "carried": null,
@@ -288,14 +295,14 @@ public sealed class DeploymentMailThreadTests
             TestContext.Current.CancellationToken);
         await over.Opened();
         await over.Thread.ShowWholeMessageAsync(MailMessages.Key(1), TestContext.Current.CancellationToken);
-        var request = Assert.Single((await over.Thread.Messages)![0].Message!.Attachments).Request;
+        var request = (await over.Thread.Messages)![0].Message!.Attachments[0].Request;
 
         // Act
         await over.Thread.SaveAttachmentAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal([1, 2, 3], over.Saver.Saved);
-        Assert.True(Assert.Single((await over.Thread.Messages)![0].Message!.Attachments).Downloaded);
+        Assert.True((await over.Thread.Messages)![0].Message!.Attachments[0].Downloaded);
         Assert.Equal(
             $"/api/client/messages/{MailMessages.Identity(1):D}/attachments/0",
             over.Harness.Deployment.Requests[^1].RequestUri.AbsolutePath);
@@ -309,7 +316,7 @@ public sealed class DeploymentMailThreadTests
             TestContext.Current.CancellationToken);
         await over.Opened();
         await over.Thread.ShowWholeMessageAsync(MailMessages.Key(1), TestContext.Current.CancellationToken);
-        var request = Assert.Single((await over.Thread.Messages)![0].Message!.Attachments).Request;
+        var request = (await over.Thread.Messages)![0].Message!.Attachments[0].Request;
         over.Saver.Hold = true;
 
         var saving = over.Thread.SaveAttachmentAsync(request, TestContext.Current.CancellationToken).AsTask();
@@ -320,9 +327,40 @@ public sealed class DeploymentMailThreadTests
         await saving;
 
         // Assert
-        var attachment = Assert.Single((await over.Thread.Messages)![0].Message!.Attachments);
+        var attachment = (await over.Thread.Messages)![0].Message!.Attachments[0];
         Assert.True(attachment.CanDownload);
         Assert.False(attachment.DownloadFailed);
+    }
+
+    [Fact]
+    public async Task SaveAttachmentAsync_TwoFilesOfOneMessage_KeepIndependentStandings()
+    {
+        // Arrange
+        using var over = await ThreadOver.CreateAsync(Answering(MailThreads.Document(2)),
+            TestContext.Current.CancellationToken);
+        await over.Opened();
+        await over.Thread.ShowWholeMessageAsync(MailMessages.Key(1), TestContext.Current.CancellationToken);
+        var requests = (await over.Thread.Messages)![0].Message!.Attachments
+            .Select(attachment => attachment.Request)
+            .ToArray();
+        over.Saver.Hold = true;
+
+        // Act
+        var savings = requests
+            .Select(request => over.Thread.SaveAttachmentAsync(request, TestContext.Current.CancellationToken).AsTask())
+            .ToArray();
+        await over.Until(async () => (await over.Thread.Messages)![0].Message!.Attachments.All(row => row.CanCancel));
+
+        // Assert
+        Assert.All((await over.Thread.Messages)![0].Message!.Attachments, row => Assert.True(row.CanCancel));
+
+        foreach (var request in requests)
+        {
+            over.Thread.CancelAttachment(request);
+        }
+
+        await Task.WhenAll(savings);
+        Assert.All((await over.Thread.Messages)![0].Message!.Attachments, row => Assert.True(row.CanDownload));
     }
 
     [Fact]
@@ -333,14 +371,14 @@ public sealed class DeploymentMailThreadTests
             TestContext.Current.CancellationToken);
         await over.Opened();
         await over.Thread.ShowWholeMessageAsync(MailMessages.Key(1), TestContext.Current.CancellationToken);
-        var request = Assert.Single((await over.Thread.Messages)![0].Message!.Attachments).Request;
+        var request = (await over.Thread.Messages)![0].Message!.Attachments[0].Request;
         over.Saver.Failure = new InvalidOperationException("The platform save surface failed.");
 
         // Act
         await over.Thread.SaveAttachmentAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
-        Assert.True(Assert.Single((await over.Thread.Messages)![0].Message!.Attachments).DownloadFailed);
+        Assert.True((await over.Thread.Messages)![0].Message!.Attachments[0].DownloadFailed);
     }
 
     /// <summary>

--- a/frontend/tests/Client.UnitTests/Presentation/Threads/DeploymentMailThreadTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Threads/DeploymentMailThreadTests.cs
@@ -325,6 +325,24 @@ public sealed class DeploymentMailThreadTests
         Assert.False(attachment.DownloadFailed);
     }
 
+    [Fact]
+    public async Task SaveAttachmentAsync_APlatformFailure_MarksTheAttachmentAsFailed()
+    {
+        // Arrange
+        using var over = await ThreadOver.CreateAsync(Answering(MailThreads.Document(2)),
+            TestContext.Current.CancellationToken);
+        await over.Opened();
+        await over.Thread.ShowWholeMessageAsync(MailMessages.Key(1), TestContext.Current.CancellationToken);
+        var request = Assert.Single((await over.Thread.Messages)![0].Message!.Attachments).Request;
+        over.Saver.Failure = new InvalidOperationException("The platform save surface failed.");
+
+        // Act
+        await over.Thread.SaveAttachmentAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(Assert.Single((await over.Thread.Messages)![0].Message!.Attachments).DownloadFailed);
+    }
+
     /// <summary>
     /// A whole message that did not arrive is said on that message, because the conversation and what the message
     /// added are still on the screen and still true.
@@ -672,6 +690,8 @@ public sealed class DeploymentMailThreadTests
 
         internal bool Hold { get; set; }
 
+        internal Exception? Failure { get; set; }
+
         internal byte[] Saved { get; private set; } = [];
 
         public async ValueTask<bool> SaveAsync(
@@ -680,6 +700,11 @@ public sealed class DeploymentMailThreadTests
             CancellationToken cancellationToken)
         {
             this.Started.Set();
+
+            if (this.Failure is { } failure)
+            {
+                throw failure;
+            }
 
             if (this.Hold)
             {

--- a/frontend/tests/Client.UnitTests/Presentation/Workspace/WorkspaceModelTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Workspace/WorkspaceModelTests.cs
@@ -134,6 +134,28 @@ public sealed class WorkspaceModelTests : IDisposable
         Assert.Equal("work@example.test · Inbox · 2 selected", await model.ScopeDescription);
     }
 
+    [Fact]
+    public async Task ScopeDescription_APassageWithinOneMessage_SaysTheScopeIsTheSelectedPassage()
+    {
+        // Arrange
+        var workspace = new SharedWorkspace(new StubMailboxTreeMemory());
+        await using var model = this.ModelOver(workspace);
+
+        // Act
+        await workspace.Scope.UpdateAsync(
+            _ => new WorkspaceScope
+            {
+                Account = "work@example.test",
+                Folder = "Inbox",
+                Selection = ImmutableArray.Create("117"),
+                BodySelection = "the selected passage",
+            },
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("work@example.test · Inbox · selected passage", await model.ScopeDescription);
+    }
+
     /// <summary>
     /// A frame built again over the same workspace — which is what a reload of the client's route is — reads the scope
     /// a space narrowed to rather than starting over at everything.
@@ -462,6 +484,7 @@ public sealed class WorkspaceModelTests : IDisposable
         ["WorkspaceScope.AccountFolder"] = "{0} · {1}",
         ["WorkspaceScope.Role"] = "{0}, every mailbox",
         ["WorkspaceScope.Selected"] = "{0} · {1} selected",
+        ["WorkspaceScope.BodySelection"] = "{0} · selected passage",
         ["Mailboxes.Role.Sent"] = "Sent",
         ["Workspace.Connection.Attempt"] = "Attempt {0} of {1}",
     });

--- a/frontend/tests/Client.UnitTests/Presentation/Workspace/WorkspaceScopeTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Workspace/WorkspaceScopeTests.cs
@@ -25,6 +25,7 @@ public sealed class WorkspaceScopeTests
         Assert.Null(scope.Folder);
         Assert.Null(scope.Role);
         Assert.Empty(scope.Selection);
+        Assert.Equal(string.Empty, scope.BodySelection);
         Assert.False(scope.NarrowsAnything);
     }
 
@@ -41,12 +42,14 @@ public sealed class WorkspaceScopeTests
         var folder = WorkspaceScope.Everything with { Folder = "Inbox" };
         var role = WorkspaceScope.Everything with { Role = "Sent" };
         var selection = WorkspaceScope.Everything with { Selection = ImmutableArray.Create("1") };
+        var bodySelection = WorkspaceScope.Everything with { BodySelection = "the selected passage" };
 
         // Assert
         Assert.True(account.NarrowsAnything);
         Assert.True(folder.NarrowsAnything);
         Assert.True(role.NarrowsAnything);
         Assert.True(selection.NarrowsAnything);
+        Assert.True(bodySelection.NarrowsAnything);
     }
 
     /// <summary>
@@ -78,6 +81,17 @@ public sealed class WorkspaceScopeTests
         // Assert
         Assert.NotEqual(one, reordered);
         Assert.NotEqual(one, shorter);
+    }
+
+    [Fact]
+    public void Equals_TwoDifferentBodySelections_AreDifferentScopes()
+    {
+        // Arrange
+        var one = WorkspaceScope.Everything with { BodySelection = "first passage" };
+        var other = WorkspaceScope.Everything with { BodySelection = "second passage" };
+
+        // Assert
+        Assert.NotEqual(one, other);
     }
 
     /// <summary>A folder is read within its account, so the same folder name under another account is another scope.</summary>

--- a/frontend/tests/Client.UnitTests/TestDoubles/StubMailThread.cs
+++ b/frontend/tests/Client.UnitTests/TestDoubles/StubMailThread.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Collections.Immutable;
+using MailFathom.Client.Presentation.Spaces.Mail.Reading;
 using MailFathom.Client.Presentation.Threads;
 
 namespace MailFathom.Client.UnitTests.TestDoubles;
@@ -41,6 +42,12 @@ internal sealed class StubMailThread : IMailThread
 
     /// <summary>Gets every message the stub was asked to read again with its remote pictures, in order.</summary>
     internal List<string> Remote { get; } = [];
+
+    /// <summary>Gets every attachment the stub was asked to save, in order.</summary>
+    internal List<MailAttachmentRequest> Saved { get; } = [];
+
+    /// <summary>Gets every attachment the stub was asked to stop saving, in order.</summary>
+    internal List<MailAttachmentRequest> Cancelled { get; } = [];
 
     /// <summary>Gets how many times the stub was asked for another page of the conversation.</summary>
     internal int Pages { get; private set; }
@@ -91,6 +98,17 @@ internal sealed class StubMailThread : IMailThread
 
         return ValueTask.CompletedTask;
     }
+
+    /// <inheritdoc />
+    public ValueTask SaveAttachmentAsync(MailAttachmentRequest request, CancellationToken cancellationToken)
+    {
+        this.Saved.Add(request);
+
+        return ValueTask.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public void CancelAttachment(MailAttachmentRequest request) => this.Cancelled.Add(request);
 
     /// <inheritdoc />
     public ValueTask ShowMoreAsync(CancellationToken cancellationToken)

--- a/frontend/tests/Client.UnitTests/TestDoubles/StubWorkspace.cs
+++ b/frontend/tests/Client.UnitTests/TestDoubles/StubWorkspace.cs
@@ -1,0 +1,21 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Client.Presentation.Workspace;
+
+namespace MailFathom.Client.UnitTests.TestDoubles;
+
+/// <summary>A run's shared question and scope, initialized to what a test names.</summary>
+internal sealed class StubWorkspace : IWorkspace
+{
+    internal StubWorkspace(WorkspaceScope? scope = null)
+    {
+        this.Intent = State.Value(this, () => string.Empty);
+        this.Scope = State.Value(this, () => scope ?? WorkspaceScope.Everything);
+    }
+
+    public IState<string> Intent { get; }
+
+    public IState<WorkspaceScope> Scope { get; }
+}


### PR DESCRIPTION
## Summary

- compose the message headers, sender verdict, attachments, and existing safe body renderer in the mail reading pane
- stream an attachment only after the reader chooses a destination, with per-file progress, cancellation, exact-length validation, and atomic replacement
- carry a selected body passage in the in-memory workspace scope and clear it when the message selection changes
- keep stage 1 read-only: opening a message sends no flag mutation; mutation route #1208 remains stage-7 work

## Verification

- `scripts/verify-full.sh`
- Release build: `net10.0`, `net10.0-desktop`, and `net10.0-browserwasm`, 0 warnings and 0 errors
- Client unit tests: 710 passed, 0 failed
- Workflow and documentation contracts: 264 passed, 0 failed

## UI validation

The source passed the Uno design review for theme resources, bounded collections, rendered async states, standard keyboard-focusable controls, and localized copy. Runtime light/dark and narrow/wide screenshots plus keyboard traversal were not captured because this session had no running application connected to mail data.

Closes #1163
