### PR TITLE
[#1357] Make the normal Aspire launch locally usable

### DIFF
--- a/backend/src/AppHost/AppHost.csproj
+++ b/backend/src/AppHost/AppHost.csproj
@@ -22,4 +22,10 @@
          migration resource names this project by path rather than as something to start. -->
     <ProjectReference Include="..\Infrastructure\Infrastructure.csproj" IsAspireProjectResource="false" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(RepositoryRoot)deploy/openssl/legacy-mail-server.cnf.example"
+          Link="legacy-mail-server.cnf"
+          CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>

--- a/backend/src/AppHost/DevelopmentCredentialProvisioner.cs
+++ b/backend/src/AppHost/DevelopmentCredentialProvisioner.cs
@@ -1,0 +1,144 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace MailFathom.AppHost;
+
+internal sealed class DevelopmentCredentialProvisioner(HttpClient client, TimeProvider timeProvider)
+{
+    private static readonly TimeSpan ReadinessRetryDelay = TimeSpan.FromMilliseconds(250);
+    private static readonly TimeSpan ReadinessTimeout = TimeSpan.FromMinutes(2);
+
+    internal async Task<bool> EnsureAsync(
+        Uri startedEndpoint,
+        Uri adminEndpoint,
+        string username,
+        string password,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(startedEndpoint);
+        ArgumentNullException.ThrowIfNull(adminEndpoint);
+        ArgumentException.ThrowIfNullOrWhiteSpace(username);
+        ArgumentException.ThrowIfNullOrWhiteSpace(password);
+
+        await this.WaitForStartedAsync(startedEndpoint, cancellationToken);
+
+        var owner = await this.ReadSoleServedOwnerAsync(adminEndpoint, cancellationToken);
+        if (await this.CredentialExistsAsync(adminEndpoint, owner, username, cancellationToken))
+        {
+            return false;
+        }
+
+        var requestBody = new JsonObject
+        {
+            ["method"] = "password",
+            ["username"] = username,
+            ["password"] = password,
+            ["permissions"] = null,
+        };
+        using var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            new Uri(adminEndpoint, $"api/admin/owners/{owner:D}/credentials"))
+        {
+            Content = new StringContent(requestBody.ToJsonString(), Encoding.UTF8, "application/json"),
+        };
+        using var response = await client.SendAsync(
+            request,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken);
+
+        response.EnsureSuccessStatusCode();
+
+        return true;
+    }
+
+    private async Task WaitForStartedAsync(Uri startedEndpoint, CancellationToken cancellationToken)
+    {
+        var deadline = timeProvider.GetUtcNow() + ReadinessTimeout;
+
+        while (true)
+        {
+            try
+            {
+                using var response = await client.GetAsync(
+                    startedEndpoint,
+                    HttpCompletionOption.ResponseHeadersRead,
+                    cancellationToken);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    return;
+                }
+
+                if (response.StatusCode != HttpStatusCode.ServiceUnavailable)
+                {
+                    response.EnsureSuccessStatusCode();
+                }
+            }
+            catch (HttpRequestException) when (!cancellationToken.IsCancellationRequested)
+            {
+            }
+            catch (TaskCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+            }
+
+            if (timeProvider.GetUtcNow() >= deadline)
+            {
+                throw new TimeoutException("The local MailFathom host did not report startup readiness within two minutes.");
+            }
+
+            await Task.Delay(ReadinessRetryDelay, timeProvider, cancellationToken);
+        }
+    }
+
+    private async Task<Guid> ReadSoleServedOwnerAsync(Uri adminEndpoint, CancellationToken cancellationToken)
+    {
+        using var response = await client.GetAsync(
+            new Uri(adminEndpoint, "api/admin/owners"),
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        await using var content = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using var document = await JsonDocument.ParseAsync(content, cancellationToken: cancellationToken);
+        var owners = document.RootElement
+            .GetProperty("owners")
+            .EnumerateArray()
+            .Where(static owner => owner.GetProperty("served").GetBoolean())
+            .Select(static owner => owner.GetProperty("id").GetGuid())
+            .ToArray();
+
+        return owners.Length == 1
+            ? owners[0]
+            : throw new InvalidOperationException(
+                $"The normal Aspire launch expected one served owner but found {owners.Length.ToString(System.Globalization.CultureInfo.InvariantCulture)}.");
+    }
+
+    private async Task<bool> CredentialExistsAsync(
+        Uri adminEndpoint,
+        Guid owner,
+        string username,
+        CancellationToken cancellationToken)
+    {
+        using var response = await client.GetAsync(
+            new Uri(adminEndpoint, $"api/admin/owners/{owner:D}/credentials"),
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        await using var content = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using var document = await JsonDocument.ParseAsync(content, cancellationToken: cancellationToken);
+
+        return document.RootElement
+            .GetProperty("credentials")
+            .EnumerateArray()
+            .Any(credential =>
+                string.Equals(credential.GetProperty("method").GetString(), "password", StringComparison.Ordinal)
+                && string.Equals(credential.GetProperty("lookup").GetString(), username, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/backend/src/AppHost/DevelopmentCredentialProvisioningWorker.cs
+++ b/backend/src/AppHost/DevelopmentCredentialProvisioningWorker.cs
@@ -1,0 +1,71 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MailFathom.AppHost;
+
+/// <summary>Provisions the synthetic Basic credential after the normal local host is ready.</summary>
+/// <remarks>
+/// The write goes through the existing administrative API rather than through persistence, so the same password policy,
+/// hashing, audit, and ownership rules apply here as to an operator provisioning the credential. An existing credential
+/// is left alone, which preserves a local rotation across restarts of the persistent database.
+/// </remarks>
+internal sealed partial class DevelopmentCredentialProvisioningWorker(
+    ResourceNotificationService resourceNotifications,
+    IHttpClientFactory httpClientFactory,
+    EndpointReference healthEndpoint,
+    EndpointReference adminEndpoint,
+    TimeProvider timeProvider,
+    ILogger<DevelopmentCredentialProvisioningWorker> logger) : BackgroundService
+{
+    internal const string HttpClientName = "mailfathom-development-provisioning";
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await resourceNotifications.WaitForResourceHealthyAsync(
+            OrchestrationContract.HostResourceName,
+            WaitBehavior.StopOnResourceUnavailable,
+            stoppingToken);
+
+        var healthAddress = await ResolveHttpAddressAsync(healthEndpoint, stoppingToken);
+        var adminAddress = await ResolveHttpAddressAsync(adminEndpoint, stoppingToken);
+        using var client = httpClientFactory.CreateClient(HttpClientName);
+        var provisioner = new DevelopmentCredentialProvisioner(client, timeProvider);
+
+        var created = await provisioner.EnsureAsync(
+            new Uri(healthAddress, "started"),
+            adminAddress,
+            OrchestrationContract.DevelopmentBasicUsername,
+            OrchestrationContract.DevelopmentBasicPassword,
+            stoppingToken);
+
+        if (created)
+        {
+            CredentialProvisioned(logger, OrchestrationContract.DevelopmentBasicUsername);
+        }
+        else
+        {
+            CredentialAlreadyExists(logger, OrchestrationContract.DevelopmentBasicUsername);
+        }
+    }
+
+    private static async Task<Uri> ResolveHttpAddressAsync(
+        EndpointReference endpoint,
+        CancellationToken cancellationToken)
+    {
+        var resolvedAddress = await endpoint.GetValueAsync(cancellationToken)
+            ?? throw new InvalidOperationException($"The {endpoint.EndpointName} endpoint was not allocated.");
+        var allocatedAddress = new Uri(resolvedAddress, UriKind.Absolute);
+
+        return new UriBuilder(allocatedAddress) { Scheme = Uri.UriSchemeHttp }.Uri;
+    }
+
+    [LoggerMessage(1, LogLevel.Information, "Provisioned the local Basic credential named {Username}.")]
+    private static partial void CredentialProvisioned(ILogger logger, string username);
+
+    [LoggerMessage(2, LogLevel.Information, "The local Basic credential named {Username} already exists and was left unchanged.")]
+    private static partial void CredentialAlreadyExists(ILogger logger, string username);
+}

--- a/backend/src/AppHost/OrchestrationContract.cs
+++ b/backend/src/AppHost/OrchestrationContract.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Collections.Frozen;
 using System.Globalization;
 using System.Net;
 using System.Net.Sockets;
@@ -230,8 +231,9 @@ public static class OrchestrationContract
     /// <summary>The endpoint the MailFathom host serves its administrative surface on.</summary>
     /// <remarks>
     /// <para>
-    /// Present only under <see cref="IntegrationTestingArgument" />. A developer's orchestration administers nothing
-    /// over the network, and an endpoint enabled for them would be a socket nobody asked for.
+    /// Present in both topologies. The normal local run binds it to loopback and authenticates nobody so its own
+    /// credential provisioner can use the published API; the integration topology protects it with an API key and uses
+    /// the same name so the suite resolves the endpoint the app model declared.
     /// </para>
     /// <para>
     /// Declared with the <c>tcp</c> scheme rather than <c>http</c>, for the reason every endpoint on this resource is:
@@ -708,6 +710,34 @@ public static class OrchestrationContract
     /// </remarks>
     public const string ClientEnabledKey = "Client:Enabled";
 
+    /// <summary>The fixed configuration a normal local run supplies beside its interactive mailbox values.</summary>
+    /// <remarks>
+    /// Every listener is restricted to loopback because the MCP and administrative surfaces deliberately authenticate
+    /// nobody in this topology. The client surface accepts the password credential the app host provisions after the
+    /// service starts.
+    /// </remarks>
+    public static IReadOnlyDictionary<string, string> DevelopmentHostEnvironment { get; } =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["MailSynchronization__Enabled"] = "true",
+            ["MailSynchronization__Accounts__0__AccountId"] = "local",
+            ["MailSynchronization__Accounts__0__DisplayName"] = "Local mailbox",
+            ["MailSynchronization__Accounts__0__Secrets__Password__Name"] = "local-mail-password",
+            ["McpEndpoint__Enabled"] = "true",
+            ["McpEndpoint__BindAddress"] = DeveloperLoopbackAddress,
+            ["AdminEndpoint__Enabled"] = "true",
+            ["AdminEndpoint__BindAddress"] = DeveloperLoopbackAddress,
+            ["ClientEndpoint__Enabled"] = "true",
+            ["ClientEndpoint__Authentication__0__Method"] = "password",
+        }.ToFrozenDictionary(StringComparer.Ordinal);
+
+    /// <summary>The username the normal local run provisions for the browser client.</summary>
+    public const string DevelopmentBasicUsername = "test";
+
+    /// <summary>The password the normal local run provisions for the browser client.</summary>
+    /// <remarks>Long enough to satisfy the product password policy, and synthetic because the local endpoint is restricted to loopback.</remarks>
+    public const string DevelopmentBasicPassword = "test-password";
+
     /// <summary>The lowest number a pinned port may state.</summary>
     private const int MinimumPortNumber = 1;
 
@@ -747,6 +777,16 @@ public static class OrchestrationContract
         }
 
         return $"{EphemeralResourceNamePrefix}-{statedIdentifier}";
+    }
+
+    /// <summary>Reports whether the argument list selects the integration-test topology.</summary>
+    /// <param name="arguments">The app host arguments exactly as its caller supplied them.</param>
+    /// <returns><see langword="true" /> only when the explicit integration-test switch is present.</returns>
+    public static bool RunsIntegrationTests(IReadOnlyList<string> arguments)
+    {
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        return arguments.Contains(IntegrationTestingArgument, StringComparer.Ordinal);
     }
 
     /// <summary>Reads the port a developer pinned under <paramref name="configurationKey" />.</summary>

--- a/backend/src/AppHost/OrchestrationContract.cs
+++ b/backend/src/AppHost/OrchestrationContract.cs
@@ -625,17 +625,18 @@ public static class OrchestrationContract
     /// <summary>The environment variable OpenSSL reads the path of its configuration file from.</summary>
     /// <remarks>
     /// <para>
-    /// A variable this app model passes through rather than one it publishes a value for. It exists here because a
-    /// developer whose mailbox is served by a mail server the platform's own TLS policy refuses sets it before starting
-    /// the orchestration, and a resource Aspire starts inherits nothing of the kind on its own.
+    /// The normal topology supplies the repository's supported security-level-1 policy so legacy mail servers remain
+    /// reachable on a first run. A developer may override that file by exporting this variable before starting Aspire.
     /// </para>
     /// <para>
-    /// The distinction is deliberate: deciding that a weaker TLS policy applies is an operator's act, taken once, in
-    /// the environment they start MailFathom from. An app model that named a file of its own would take that decision
-    /// for every developer who ever runs it.
+    /// The integration-test topology receives neither value, so its TLS behavior does not depend on the machine that
+    /// started it.
     /// </para>
     /// </remarks>
     public const string OpenSslConfigurationVariable = "OPENSSL_CONF";
+
+    /// <summary>The supported OpenSSL policy copied beside the normal AppHost output.</summary>
+    public const string DevelopmentOpenSslConfigurationFileName = "legacy-mail-server.cnf";
 
     /// <summary>The environment variable a caller states this run's ephemeral resource identifier in.</summary>
     /// <remarks>
@@ -787,6 +788,31 @@ public static class OrchestrationContract
         ArgumentNullException.ThrowIfNull(arguments);
 
         return arguments.Contains(IntegrationTestingArgument, StringComparer.Ordinal);
+    }
+
+    /// <summary>Resolves the OpenSSL policy the MailFathom host receives from this topology.</summary>
+    /// <param name="runsIntegrationTests">Whether the integration-test topology is selected.</param>
+    /// <param name="explicitlyConfiguredPath">The path exported by the developer, or <see langword="null" /> when none was exported.</param>
+    /// <param name="appHostBaseDirectory">The directory containing the shipped development policy.</param>
+    /// <returns>The explicit or shipped policy path for a normal run, and <see langword="null" /> for an integration-test run.</returns>
+    public static string? ResolveOpenSslConfigurationPath(
+        bool runsIntegrationTests,
+        string? explicitlyConfiguredPath,
+        string appHostBaseDirectory)
+    {
+        if (runsIntegrationTests)
+        {
+            return null;
+        }
+
+        if (!string.IsNullOrWhiteSpace(explicitlyConfiguredPath))
+        {
+            return explicitlyConfiguredPath;
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(appHostBaseDirectory);
+
+        return Path.Combine(appHostBaseDirectory, DevelopmentOpenSslConfigurationFileName);
     }
 
     /// <summary>Reads the port a developer pinned under <paramref name="configurationKey" />.</summary>

--- a/backend/src/AppHost/Program.cs
+++ b/backend/src/AppHost/Program.cs
@@ -256,17 +256,14 @@ var mailFathomHost = builder.AddProject<Projects.Host>(OrchestrationContract.Hos
         "DataEncryption__Keys__0__Material__SecretReference",
         $"plaintext:{OrchestrationContract.DataEncryptionKeyMaterial}");
 
-// Passed through from this process's own environment rather than set here, and only when a developer set it. OpenSSL
-// reads it while it initializes, so it is the one way to reach a mail server whose cipher suite or key size the
-// platform's TLS policy refuses — and it relaxes that policy for every connection the host makes, the database
-// included. Which is exactly why the app model must not be the thing that decides it applies: it carries the value an
-// operator chose, or nothing at all.
-//
-// Never under the integration-test topology. That suite proves what MailFathom does against servers it starts itself,
-// and a policy inherited from whichever machine ran it would make the handshakes it exercises depend on that machine.
-var openSslConfigurationPath = Environment.GetEnvironmentVariable(OrchestrationContract.OpenSslConfigurationVariable);
+// The normal local topology favors compatibility with older mail servers through the repository's supported
+// security-level-1 policy. It still accepts an explicit path for calibration, while integration tests inherit neither.
+var openSslConfigurationPath = OrchestrationContract.ResolveOpenSslConfigurationPath(
+    runsIntegrationTests,
+    Environment.GetEnvironmentVariable(OrchestrationContract.OpenSslConfigurationVariable),
+    AppContext.BaseDirectory);
 
-if (!runsIntegrationTests && !string.IsNullOrWhiteSpace(openSslConfigurationPath))
+if (openSslConfigurationPath is not null)
 {
     mailFathomHost.WithEnvironment(OrchestrationContract.OpenSslConfigurationVariable, openSslConfigurationPath);
 }

--- a/backend/src/AppHost/Program.cs
+++ b/backend/src/AppHost/Program.cs
@@ -15,7 +15,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 // Read from the argument list rather than from builder.Configuration, which also binds environment variables. An
 // IntegrationTesting variable left in a shell or a CI environment would otherwise put an ordinary run on the fixed-name
 // ephemeral database and leave its volume under the prefix the test script deletes.
-var runsIntegrationTests = args.Contains(OrchestrationContract.IntegrationTestingArgument, StringComparer.Ordinal);
+var runsIntegrationTests = OrchestrationContract.RunsIntegrationTests(args);
 
 // The port this checkout pinned for a socket, or null where it pinned none — which is what leaves the number to be
 // found per run and lets a second checkout start while the first is running. Read from the app host's own
@@ -458,22 +458,43 @@ if (runsIntegrationTests)
 }
 else
 {
-    // The two sockets a developer's run serves, each stated by the section that owns it, and each on a free port this
-    // run found unless this checkout pinned one. Found here rather than left to the orchestrator, which allocates a
-    // port for the proxy it would put in front of a resource and refuses an endpoint that declares none while asking
-    // for no proxy — and no proxy is what keeps the socket a client reaches the socket Kestrel opened.
+    // The four host sockets and the browser client's socket, each stated by the section that owns it and each on a free
+    // port this run found unless this checkout pinned one. Found here rather than left to the orchestrator, which
+    // allocates a port for the proxy it would put in front of a resource and refuses an endpoint that declares none
+    // while asking for no proxy — and no proxy is what keeps the socket a client reaches the socket Kestrel opened.
     //
-    // All four are found in one call whether or not any is pinned, because that is what makes them different from each
+    // All five are found in one call whether or not any is pinned, because that is what makes them different from each
     // other; a pinned value then replaces the one it was found for and the others stay where they were put. The last
     // one belongs to the client below, and is found here rather than beside it for that reason: a second call would
     // release these before choosing, and two sockets handed one number is a run that fails on whichever binds second.
-    var foundPorts = OrchestrationContract.FindFreePorts(4);
+    var foundPorts = OrchestrationContract.FindFreePorts(5);
     var mcpEndpointPort = PinnedPort(OrchestrationContract.PinnedMcpEndpointPortKey) ?? foundPorts[0];
     var healthEndpointsPort = PinnedPort(OrchestrationContract.PinnedHealthEndpointsPortKey) ?? foundPorts[1];
-    var clientEndpointPort = PinnedPort(OrchestrationContract.PinnedClientEndpointPortKey) ?? foundPorts[2];
-    var clientPort = PinnedPort(OrchestrationContract.PinnedClientPortKey) ?? foundPorts[3];
+    var adminEndpointPort = foundPorts[2];
+    var clientEndpointPort = PinnedPort(OrchestrationContract.PinnedClientEndpointPortKey) ?? foundPorts[3];
+    var clientPort = PinnedPort(OrchestrationContract.PinnedClientPortKey) ?? foundPorts[4];
+
+    var mailAccountHost = builder
+        .AddParameter("mail-account-host")
+        .WithDescription("The IMAP server host name for the mailbox MailFathom synchronizes.");
+    var mailAccountUserName = builder
+        .AddParameter("mail-account-username")
+        .WithDescription("The IMAP username for the mailbox MailFathom synchronizes.");
+    var mailAccountPassword = builder
+        .AddParameter("mail-account-password", secret: true)
+        .WithDescription("The IMAP password or app password for the mailbox MailFathom synchronizes.");
+
+    foreach (var setting in OrchestrationContract.DevelopmentHostEnvironment)
+    {
+        mailFathomHost.WithEnvironment(setting.Key, setting.Value);
+    }
 
     mailFathomHost
+        .WithEnvironment("MailSynchronization__Accounts__0__Host", mailAccountHost)
+        .WithEnvironment("MailSynchronization__Accounts__0__UserName", mailAccountUserName)
+        .WithEnvironment(
+            "MailSynchronization__Accounts__0__Secrets__Password__SecretReference",
+            ReferenceExpression.Create($"plaintext:{mailAccountPassword}"))
         // The MCP endpoint's own socket, stated to the app model and injected into the host's own configuration key, so
         // the number is written once rather than declared here and configured again beside it. Its scheme is tcp rather
         // than http, for the reason the probe endpoint's is: Aspire builds ASPNETCORE_URLS from the http and https
@@ -521,11 +542,16 @@ else
             targetPort: healthEndpointsPort,
             isProxied: false,
             env: "HealthEndpoints__Port")
-        // The client surface's socket, declared exactly as the MCP endpoint's is and bound exactly as little: both
-        // sections ship disabled, so this run publishes a number and the host binds nothing under it until this
-        // checkout says otherwise. Enabling a surface that reads the mailbox stays a developer's own act here, the way
-        // McpEndpoint:Enabled is — and it is stated in the host's user secrets rather than by this app model, so the
-        // credential that guards it is decided in the same place and at the same time.
+        .WithEndpoint(
+            name: OrchestrationContract.HostAdminEndpointName,
+            scheme: "tcp",
+            port: adminEndpointPort,
+            targetPort: adminEndpointPort,
+            isProxied: false,
+            env: "AdminEndpoint__Port")
+        // The client surface's socket, declared exactly as the MCP endpoint's is. The normal app model enables it and
+        // admits the password method so the browser head has a usable service on its first run; the credential itself
+        // is provisioned through the administrative API after the host reports startup readiness.
         //
         // A socket of its own rather than the MCP endpoint's, though every surface's default port would have shared
         // one. What cannot be shared is the bind address: a wildcard beside a specific address on one port is two
@@ -540,6 +566,18 @@ else
             targetPort: clientEndpointPort,
             isProxied: false,
             env: "ClientEndpoint__Port");
+
+    builder.Services
+        .AddHttpClient(DevelopmentCredentialProvisioningWorker.HttpClientName, client =>
+            client.Timeout = TimeSpan.FromSeconds(10))
+        .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler { AllowAutoRedirect = false });
+    builder.Services.AddHostedService(provider => new DevelopmentCredentialProvisioningWorker(
+        provider.GetRequiredService<ResourceNotificationService>(),
+        provider.GetRequiredService<IHttpClientFactory>(),
+        mailFathomHost.GetEndpoint("health"),
+        mailFathomHost.GetEndpoint(OrchestrationContract.HostAdminEndpointName),
+        TimeProvider.System,
+        provider.GetRequiredService<ILogger<DevelopmentCredentialProvisioningWorker>>()));
 
     // The client, in the one topology it belongs to. What the app model reaches into the other stack with is a
     // directory and a command: no project under frontend/ enters backend/MailFathom.slnx, no backend project references
@@ -596,11 +634,9 @@ else
         // The service's half of the same wiring, and the whole of it: the head's own origin as the one browser origin
         // the client surface answers, rather than the every-origin posture an unstated list means. A local run is the
         // one place the exact origin is known, so narrowing it costs nothing and answers in advance the preflight a
-        // deployment will also have to answer — which is what leaves turning the surface on a single key rather than a
-        // key and a puzzle about why the first call was refused.
+        // deployment will also have to answer, so the first call is not refused on a preflight.
         //
-        // Written only where a head exists to make the request. Turning the surface on is not written here at all, for
-        // the reason stated where its socket is declared.
+        // Written only where a head exists to make the request.
         mailFathomHost.WithEnvironment("ClientEndpoint__Cors__AllowedOrigins__0", clientOrigin);
     }
 }

--- a/backend/tests/AppHost.UnitTests/AppHost.UnitTests.csproj
+++ b/backend/tests/AppHost.UnitTests/AppHost.UnitTests.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>
 
@@ -10,5 +11,6 @@
          IntegrationTests are the two that do not. The file this names depends on nothing but the base class library,
          so compiling it here exercises the same code the app model runs. -->
     <Compile Include="..\..\src\AppHost\OrchestrationContract.cs" Link="OrchestrationContract.cs" />
+    <Compile Include="..\..\src\AppHost\DevelopmentCredentialProvisioner.cs" Link="DevelopmentCredentialProvisioner.cs" />
   </ItemGroup>
 </Project>

--- a/backend/tests/AppHost.UnitTests/DevelopmentCredentialProvisionerTests.cs
+++ b/backend/tests/AppHost.UnitTests/DevelopmentCredentialProvisionerTests.cs
@@ -1,0 +1,111 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Net;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailFathom.AppHost.UnitTests;
+
+public sealed class DevelopmentCredentialProvisionerTests
+{
+    private static readonly Uri StartedEndpoint = new("http://127.0.0.1:5100/started");
+    private static readonly Uri AdminEndpoint = new("http://127.0.0.1:5200/");
+    private static readonly Guid OwnerId = Guid.Parse("b107de3d-4331-4755-8b17-3270dbe53b59");
+
+    [Fact]
+    public async Task EnsureAsync_CredentialDoesNotExist_ProvisionsItAfterTheHostStarts()
+    {
+        // Arrange
+        using var responses = new RecordingHandler(
+            Response(HttpStatusCode.ServiceUnavailable),
+            Response(HttpStatusCode.OK),
+            JsonResponse($$"""{"owners":[{"id":"{{OwnerId}}","served":true}]}"""),
+            JsonResponse($$"""{"owner":"{{OwnerId}}","credentials":[]}"""),
+            JsonResponse("{}"));
+        using var client = new HttpClient(responses);
+        var timeProvider = new FakeTimeProvider();
+        var provisioner = new DevelopmentCredentialProvisioner(client, timeProvider);
+
+        // Act
+        var provisioning = provisioner.EnsureAsync(
+            StartedEndpoint,
+            AdminEndpoint,
+            "test",
+            "test-password",
+            TestContext.Current.CancellationToken);
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        var credentialCreated = await provisioning;
+
+        // Assert
+        Assert.True(credentialCreated);
+        Assert.Equal(
+            [
+                $"GET {StartedEndpoint}",
+                $"GET {StartedEndpoint}",
+                "GET http://127.0.0.1:5200/api/admin/owners",
+                $"GET http://127.0.0.1:5200/api/admin/owners/{OwnerId:D}/credentials",
+                $"POST http://127.0.0.1:5200/api/admin/owners/{OwnerId:D}/credentials",
+            ],
+            responses.Requests.Select(static request => $"{request.Method} {request.Address}"));
+        Assert.Equal(
+            "{\"method\":\"password\",\"username\":\"test\",\"password\":\"test-password\",\"permissions\":null}",
+            responses.Requests[^1].Body);
+    }
+
+    [Fact]
+    public async Task EnsureAsync_CredentialAlreadyExists_LeavesItUnchanged()
+    {
+        // Arrange
+        using var responses = new RecordingHandler(
+            Response(HttpStatusCode.OK),
+            JsonResponse($$"""{"owners":[{"id":"{{OwnerId}}","served":true}]}"""),
+            JsonResponse(
+                $$"""{"owner":"{{OwnerId}}","credentials":[{"method":"password","lookup":"test","enabled":true}]}"""));
+        using var client = new HttpClient(responses);
+        var provisioner = new DevelopmentCredentialProvisioner(client, TimeProvider.System);
+
+        // Act
+        var credentialCreated = await provisioner.EnsureAsync(
+            StartedEndpoint,
+            AdminEndpoint,
+            "test",
+            "test-password",
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(credentialCreated);
+        Assert.Equal(3, responses.Requests.Count);
+    }
+
+    private static HttpResponseMessage Response(HttpStatusCode statusCode) => new(statusCode);
+
+    private static HttpResponseMessage JsonResponse(string json) => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json"),
+    };
+
+    private sealed class RecordingHandler(params HttpResponseMessage[] responses) : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> responses = new(responses);
+
+        internal List<RecordedRequest> Requests { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            this.Requests.Add(new RecordedRequest(
+                request.Method,
+                request.RequestUri!,
+                request.Content is null
+                    ? null
+                    : await request.Content.ReadAsStringAsync(cancellationToken)));
+
+            return this.responses.Dequeue();
+        }
+    }
+
+    private sealed record RecordedRequest(HttpMethod Method, Uri Address, string? Body);
+}

--- a/backend/tests/AppHost.UnitTests/OrchestrationContractTests.cs
+++ b/backend/tests/AppHost.UnitTests/OrchestrationContractTests.cs
@@ -314,6 +314,55 @@ public sealed class OrchestrationContractTests
         Assert.Contains(OrchestrationContract.ClientEnabledKey, failure.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void RunsIntegrationTests_IntegrationArgumentIsPresent_SelectsTheEphemeralTopology()
+    {
+        // Act
+        var runsIntegrationTests = OrchestrationContract.RunsIntegrationTests(
+            ["unrelated=value", OrchestrationContract.IntegrationTestingArgument]);
+
+        // Assert
+        Assert.True(runsIntegrationTests);
+    }
+
+    [Fact]
+    public void RunsIntegrationTests_IntegrationArgumentIsAbsent_SelectsTheDevelopmentTopology()
+    {
+        // Act
+        var runsIntegrationTests = OrchestrationContract.RunsIntegrationTests(["IntegrationTesting=false"]);
+
+        // Assert
+        Assert.False(runsIntegrationTests);
+    }
+
+    [Fact]
+    public void DevelopmentHostEnvironment_NormalTopology_EnablesTheLocalSurfacesAndMailbox()
+    {
+        // Act
+        var environment = OrchestrationContract.DevelopmentHostEnvironment;
+
+        // Assert
+        Assert.Equal(10, environment.Count);
+        Assert.Equal("true", environment["MailSynchronization__Enabled"]);
+        Assert.Equal("local", environment["MailSynchronization__Accounts__0__AccountId"]);
+        Assert.Equal("Local mailbox", environment["MailSynchronization__Accounts__0__DisplayName"]);
+        Assert.Equal("local-mail-password", environment["MailSynchronization__Accounts__0__Secrets__Password__Name"]);
+        Assert.Equal("true", environment["McpEndpoint__Enabled"]);
+        Assert.Equal(OrchestrationContract.DeveloperLoopbackAddress, environment["McpEndpoint__BindAddress"]);
+        Assert.Equal("true", environment["AdminEndpoint__Enabled"]);
+        Assert.Equal(OrchestrationContract.DeveloperLoopbackAddress, environment["AdminEndpoint__BindAddress"]);
+        Assert.Equal("true", environment["ClientEndpoint__Enabled"]);
+        Assert.Equal("password", environment["ClientEndpoint__Authentication__0__Method"]);
+    }
+
+    [Fact]
+    public void DevelopmentBasicCredential_NormalTopology_UsesTheDocumentedSyntheticValues()
+    {
+        // Assert
+        Assert.Equal("test", OrchestrationContract.DevelopmentBasicUsername);
+        Assert.Equal("test-password", OrchestrationContract.DevelopmentBasicPassword);
+    }
+
     /// <summary>The address the client and the service are wired together on is one nothing outside this machine reaches.</summary>
     /// <remarks>
     /// The one property of that constant the compiler cannot state. Three things are built from it — the socket the

--- a/backend/tests/AppHost.UnitTests/OrchestrationContractTests.cs
+++ b/backend/tests/AppHost.UnitTests/OrchestrationContractTests.cs
@@ -336,6 +336,56 @@ public sealed class OrchestrationContractTests
     }
 
     [Fact]
+    public void ResolveOpenSslConfigurationPath_NormalTopologyWithNoOverride_UsesTheShippedDevelopmentPolicy()
+    {
+        // Arrange
+        var appHostBaseDirectory = Path.Combine("apphost", "output");
+
+        // Act
+        var configurationPath = OrchestrationContract.ResolveOpenSslConfigurationPath(
+            runsIntegrationTests: false,
+            explicitlyConfiguredPath: null,
+            appHostBaseDirectory);
+
+        // Assert
+        Assert.Equal(
+            Path.Combine(appHostBaseDirectory, OrchestrationContract.DevelopmentOpenSslConfigurationFileName),
+            configurationPath);
+    }
+
+    [Fact]
+    public void ResolveOpenSslConfigurationPath_NormalTopologyWithOverride_UsesTheExplicitPath()
+    {
+        // Arrange
+        const string explicitlyConfiguredPath = "/etc/mailfathom/custom-openssl.cnf";
+
+        // Act
+        var configurationPath = OrchestrationContract.ResolveOpenSslConfigurationPath(
+            runsIntegrationTests: false,
+            explicitlyConfiguredPath,
+            appHostBaseDirectory: "unused");
+
+        // Assert
+        Assert.Equal(explicitlyConfiguredPath, configurationPath);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("/etc/mailfathom/custom-openssl.cnf")]
+    public void ResolveOpenSslConfigurationPath_IntegrationTopology_LeavesOpenSslUnconfigured(
+        string? explicitlyConfiguredPath)
+    {
+        // Act
+        var configurationPath = OrchestrationContract.ResolveOpenSslConfigurationPath(
+            runsIntegrationTests: true,
+            explicitlyConfiguredPath,
+            appHostBaseDirectory: "unused");
+
+        // Assert
+        Assert.Null(configurationPath);
+    }
+
+    [Fact]
     public void DevelopmentHostEnvironment_NormalTopology_EnablesTheLocalSurfacesAndMailbox()
     {
         // Act

--- a/backend/tests/AppHost.UnitTests/packages.lock.json
+++ b/backend/tests/AppHost.UnitTests/packages.lock.json
@@ -26,6 +26,12 @@
         "resolved": "10.0.302",
         "contentHash": "mbJSf5EOYkgnPQ0jO0qo4AByQYDGbBZDs0+23xdkK2ckuvYJGlPT1nPR0WCSnzwXdiVypOTZ4ArcT4H/X/f1mQ=="
       },
+      "Microsoft.Extensions.TimeProvider.Testing": {
+        "type": "Direct",
+        "requested": "[10.8.0, )",
+        "resolved": "10.8.0",
+        "contentHash": "xXcxGfXSO/8o7IfYK36r3eZTl9RMKAl5K6x3x6o/QQBolI0t8vsLIGmhc3HJBTd11u1uPLHz61VnOTSTmY7ZVA=="
+      },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Direct",
         "requested": "[17.14.15, )",

--- a/deploy/openssl/legacy-mail-server.cnf.example
+++ b/deploy/openssl/legacy-mail-server.cnf.example
@@ -7,9 +7,9 @@
 #
 # Read docs/operations/platform-tls-policy.md before you do: this relaxes the TLS policy of the whole process, not of
 # one account, so every connection it makes — the database included — may accept a weaker parameter afterwards.
-# scripts/quick-start-compose.sh is the one thing that applies it without being asked, because a first run meeting a
-# handshake error that names nothing is a first run that ends there; --no-legacy-tls prepares the same deployment
-# under the platform default. Every other deployment copies this file deliberately or holds no copy of it at all.
+# scripts/quick-start-compose.sh and the normal local Aspire topology apply it without being asked, because a first run
+# meeting a handshake error that names nothing is a first run that ends there. The quick start's --no-legacy-tls option
+# prepares the same deployment under the platform default; Aspire accepts an explicitly exported OPENSSL_CONF instead.
 #
 # OPENSSL_CONF replaces the distribution's own configuration rather than adding to it, which is why the whole
 # openssl_conf -> ssl_conf -> system_default chain is stated here: on Ubuntu the security level is compiled in, so

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -222,6 +222,12 @@ daemon:
 dotnet run --project backend/src/AppHost/AppHost.csproj
 ```
 
+Before any resource starts, Aspire asks for any of three parameters it has not already stored:
+`mail-account-host`, `mail-account-username`, and the secret `mail-account-password`. They configure one local account
+named `local`, over implicit TLS on port 993, with its inbox as the default folder. Aspire offers to keep the values in
+the AppHost's user secrets; leaving any of them unanswered leaves the application waiting rather than starting a host
+with no mailbox.
+
 Four resources come up, three of them in dependency order. The `postgres` container starts first and has to report
 healthy; the `mailfathom-migrations` resource then applies every pending migration to it; and `mailfathom-host` waits
 for that run
@@ -231,27 +237,30 @@ looks. The fourth is `mailfathom-client`, which serves the browser head and wait
 server has nothing to wait for; it is [described below](#the-client-resource).
 Because the host runs in `Development`, it also publishes [the HTTP API document and the explorer](http-api-documentation.md)
 at `/openapi/v1.json` and `/scalar` on every port this run actually binds. Neither exists in any other environment, and
-neither is on a port of its own. Which ports those are follows the shipped defaults rather than the two sockets the app
-model declares: the probes are on, so their loopback socket answers both addresses from the first run, and the MCP
-socket answers them once `McpEndpoint:Enabled` is turned on the way [development secrets](#development-secrets) below
-shows. What the document *carries* is a second question with the same shape — the administrative and client endpoints
-are both off by default and this orchestration turns neither on, so the explorer opens on an empty catalogue until a
-configuration enables one, which [the endpoint configuration](configuration-endpoints.md) page describes.
-The host runs in the `Development` environment on two sockets, the MCP endpoint's on `localhost` and the probes'
-on `127.0.0.1`, each on a free port the run takes unless this checkout [pinned one](#pinning-a-port); the
-dashboard reports the numbers it took. There is no local TLS listener: MailFathom
+neither is on a port of its own. The normal orchestration enables the MCP, administrative, and client surfaces, so the
+document carries both HTTP APIs from the first run. The host runs in the `Development` environment on four loopback
+sockets — MCP, probes, administration, and the client surface — each on a free port the run takes unless the setting
+has a documented pin; the dashboard reports the numbers it took. MCP and administration authenticate nobody in this
+local topology. The client surface accepts HTTP Basic and the AppHost provisions `test` / `test-password` for the sole
+owner once the host reports startup readiness. A credential already present under that username is left unchanged, so
+a local rotation survives the persistent database and every later orchestration restart.
+
+There is no local TLS listener: MailFathom
 never serves one out of an ASP.NET Core development certificate, so a developer who wants TLS configures
-`McpEndpoint:Https` the way a deployment does, which is also the shape they will ship. Neither socket is proxied: the
+`McpEndpoint:Https` the way a deployment does, which is also the shape they will ship. None of these sockets is proxied: the
 socket a client connects to is the socket Kestrel opened, which is what keeps a TLS handshake — and a client
 certificate — a conversation with the host itself. The probe listener is pinned to loopback deliberately, because the
-probes answer without a credential and nothing on a local network has any business asking them — which is also why it is a socket of
-its own here rather than the MCP endpoint's. A shared socket is one socket, so the probes would answer wherever the MCP
-endpoint does. The integration topology shares one deliberately, and [what that couples](configuration-endpoints.md#which-settings-a-shared-socket-couples)
+probes answer without a credential and nothing on a local network has any business asking them. The other three are
+also loopback because two deliberately authenticate nobody and the remaining one sends a reusable password over plain
+HTTP; none is a surface for another machine. The probes keep a socket of their own rather than sharing the MCP
+endpoint's. A shared socket is one socket, so the probes would answer wherever the MCP endpoint does. The integration
+topology shares one deliberately, and [what that couples](configuration-endpoints.md#which-settings-a-shared-socket-couples)
 is the same list a deployment reads.
 
-Both ports are stated by the app model the same way: a TCP endpoint that injects itself into the host's own setting —
-`McpEndpoint:Port` and `HealthEndpoints:Port` — so each number is declared once rather than declared and then configured
-again beside it. The scheme is what makes that possible. Aspire builds `ASPNETCORE_URLS` from HTTP and HTTPS endpoints,
+The four ports are stated by the app model the same way: a TCP endpoint that injects itself into the owning setting —
+`McpEndpoint:Port`, `HealthEndpoints:Port`, `AdminEndpoint:Port`, and `ClientEndpoint:Port` — so each number is declared
+once rather than declared and then configured again beside it. The scheme is what makes that possible. Aspire builds
+`ASPNETCORE_URLS` from HTTP and HTTPS endpoints,
 and MailFathom refuses that variable outright, because each surface states where it is served in its own section; a TCP
 endpoint is published without ever reaching it. That is also why the resource carries no `WithHttpHealthCheck`, which
 derives its address from an HTTP endpoint this app model declares none of.
@@ -319,19 +328,12 @@ machine, and that is also why it is a socket rather than a share of the MCP endp
 specific one on a single port is two sockets the operating system grants only one of, so sharing would have published
 the client surface wherever the MCP endpoint is published.
 
-**The surface itself is off until you turn it on**, exactly as `McpEndpoint` is, and for the same reason: enabling a
-listener that reads the mailbox is a developer's own act rather than something starting a head does for them. What the
-orchestration configures is everything else — the port, the loopback bind, and the head's own origin as the one browser
-origin `ClientEndpoint:Cors:AllowedOrigins` answers — so turning it on is one key beside whichever credential you want
-guarding it, and the first cross-origin call is served rather than refused on a preflight:
-
-```bash
-dotnet user-secrets --project backend/src/Host/Host.csproj set "ClientEndpoint:Enabled" "true"
-```
-
-Leave it off and the head still starts, still knows where the service is, and is refused by a socket nothing is
-listening on — which is the same answer a locally started MCP client gets before `McpEndpoint:Enabled` is set. A run
-started with `Client:Enabled` false configures no origin either, because no head exists to make the request.
+**The surface is enabled by the normal orchestration.** The app model supplies its port and loopback bind, enables the
+password method, and gives it the head's own origin as the one browser origin
+`ClientEndpoint:Cors:AllowedOrigins` answers. The AppHost then provisions the credential above through the ordinary
+administrative API, so password policy, hashing, ownership, and audit behavior are the same as for a credential an
+operator created. A run started with `Client:Enabled` false starts no head and configures no origin, but the client API
+surface and its Basic credential remain available for a desktop head or a direct request.
 
 A **desktop** head takes the same property and reads the same key, so an orchestration could point one the same way.
 Started by hand it is given none, and reads `Deployment:Address` out of
@@ -395,16 +397,10 @@ because Aspire injects `OTEL_EXPORTER_OTLP_ENDPOINT` into the resources it start
 only place telemetry export is configured at all — a deployment exports nothing until an operator sets the variable
 themselves. [Telemetry](telemetry.md) records what the host emits and where it goes.
 
-A freshly started host synchronizes nothing and serves neither the MCP endpoint nor the client surface, because every
-one of those defaults is the shipped one. Configure a development mailbox through user secrets as
-[development secrets](#development-secrets) below shows, and enable the endpoint the same way when a tool call is what
-is being tested — in Development the `ReferenceOrInline` interpretation keeps the credential a one-liner:
-
-```bash
-dotnet user-secrets --project backend/src/Host/Host.csproj set "McpEndpoint:Enabled" "true"
-dotnet user-secrets --project backend/src/Host/Host.csproj set "McpEndpoint:Authentication:0:ApiKey:Name" "dev"
-dotnet user-secrets --project backend/src/Host/Host.csproj set "McpEndpoint:Authentication:0:ApiKey:SecretReference" "plaintext:dev-key"
-```
+A freshly started normal orchestration synchronizes the mailbox supplied through its required parameters. Its MCP and
+administrative endpoints accept unauthenticated local requests, and the client endpoint accepts the synthetic Basic
+credential above. These are AppHost development choices rather than changed product defaults: starting `Host.csproj`
+directly or running a deployment still reads the shipped disabled endpoint defaults.
 
 A development mailbox served by a mail server whose TLS parameters the platform refuses needs one more thing, and the
 symptom sends most people the wrong way: the handshake fails, but reads as an authentication failure. Export
@@ -414,8 +410,9 @@ what it costs, and how to confirm the handshake is what failed. The AppHost pass
 sets one, so a checkout that exports nothing runs under the platform default; the integration-test topology receives it
 under no circumstances, because a suite whose handshakes depended on the machine that ran it would prove nothing.
 
-An MCP client then connects to `http://localhost:<the port the MCP endpoint took>/mcp` with
-`Authorization: Bearer dev-key`. Stopping the orchestration with `Ctrl+C` — or
+An MCP client connects to `http://127.0.0.1:<the port the MCP endpoint took>/mcp` without a credential. An
+administrative client uses the dashboard's `admin` address the same way, while the browser client signs in as `test`
+with `test-password`. Stopping the orchestration with `Ctrl+C` — or
 `aspire stop --apphost backend/src/AppHost/AppHost.csproj --non-interactive` — leaves the synchronized mail in place, because
 the database volume outlives the container and the container outlives the run. The container is stopped rather than
 left running, so the next start is a restart of the server that was there.
@@ -501,7 +498,8 @@ generated per clone, so every checkout reads the same store and the commands bel
 store is loaded by the framework in the `Development` environment only, which is the environment the orchestration and
 both launch profiles run the host in.
 
-Configure a development account in `appsettings.Development.json` or, better, in user secrets:
+When the host is started directly rather than through Aspire, configure a development account in
+`appsettings.Development.json` or, better, in user secrets:
 
 ```bash
 dotnet user-secrets --project backend/src/Host/Host.csproj set \

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -402,13 +402,11 @@ administrative endpoints accept unauthenticated local requests, and the client e
 credential above. These are AppHost development choices rather than changed product defaults: starting `Host.csproj`
 directly or running a deployment still reads the shipped disabled endpoint defaults.
 
-A development mailbox served by a mail server whose TLS parameters the platform refuses needs one more thing, and the
-symptom sends most people the wrong way: the handshake fails, but reads as an authentication failure. Export
-`OPENSSL_CONF` in the shell the orchestration starts from and the AppHost passes it through to `mailfathom-host`, which
-then reports at startup that it is running under it. [The platform TLS policy](platform-tls-policy.md) covers the file,
-what it costs, and how to confirm the handshake is what failed. The AppHost passes an exported value through and never
-sets one, so a checkout that exports nothing runs under the platform default; the integration-test topology receives it
-under no circumstances, because a suite whose handshakes depended on the machine that ran it would prove nothing.
+The normal AppHost topology starts `mailfathom-host` under the repository's supported OpenSSL security-level-1 sample,
+so an older mail server is less likely to fail its TLS handshake under the misleading name of an authentication failure.
+[The platform TLS policy](platform-tls-policy.md) covers exactly what the file admits and what it leaves unchanged. An
+explicitly exported `OPENSSL_CONF` takes precedence when a developer needs another policy; the integration-test topology
+receives neither value, because a suite whose handshakes depended on the machine that ran it would prove nothing.
 
 An MCP client connects to `http://127.0.0.1:<the port the MCP endpoint took>/mcp` without a credential. An
 administrative client uses the dashboard's `admin` address the same way, while the browser client signs in as `test`

--- a/docs/operations/platform-tls-policy.md
+++ b/docs/operations/platform-tls-policy.md
@@ -174,13 +174,13 @@ therefore the same act written for a different launcher, and each is equally sup
   There is currently no chart hook for an arbitrary file, so the file has to reach the container another way — an image
   built on top of the published one is the straightforward path.
 
-- **Through Aspire, locally.** The AppHost starts the host as a child resource, which inherits nothing of the kind on
-  its own, so it passes the variable through from the shell the orchestration was started in. It passes a value through
-  rather than setting one, so a checkout that exports nothing runs under the platform default; the integration-test
-  topology never receives it at all.
+- **Through Aspire, locally.** The normal AppHost topology copies this repository's sample beside its output and points
+  the host at it by default, so a first run can reach an older mail server without diagnosing a misleading
+  authentication failure first. An explicitly exported value takes precedence when a developer needs another policy;
+  the integration-test topology never receives either value.
 
   ```bash
-  export OPENSSL_CONF=/etc/mailfathom/openssl-legacy.cnf
+  export OPENSSL_CONF=/etc/mailfathom/custom-openssl.cnf
   dotnet run --project backend/src/AppHost/AppHost.csproj
   ```
 


### PR DESCRIPTION
## Summary

- require the normal Aspire topology to collect the IMAP host, username, and password before starting resources
- enable the local MCP and administrative endpoints without authentication, and enable the client endpoint with HTTP Basic
- provision the synthetic `test` / `test-password` owner credential idempotently through the existing administrative API
- apply the shipped `DEFAULT@SECLEVEL=1` OpenSSL policy by default in the normal Aspire topology while preserving an explicit `OPENSSL_CONF` override
- keep every listener on loopback and leave the integration-test topology unchanged
- update local-development guidance and cover the topology contract and credential provisioning behavior

## Security

The permissive endpoints, synthetic credential, and relaxed OpenSSL policy exist only in the normal local AppHost topology. All four Host listeners bind to loopback, the product configuration defaults remain unchanged, and credential provisioning still passes through the existing password policy, hashing, ownership, and audit boundaries. The OpenSSL sample lowers only the security level to 1; it does not lower the protocol floor or disable certificate validation. An explicitly exported `OPENSSL_CONF` remains the operator override, and the integration-test topology receives neither value.

## Verification

- `env -u NO_COLOR TERM=xterm-256color scripts/verify-full.sh`
- 13,046 tests passed
- aggregate line coverage: 95.28%
- 264 workflow contract checks passed

Closes #1357
