### PR TITLE
[#1359] Align the Aspire client endpoint origin

### DIFF
--- a/backend/src/AppHost/OrchestrationContract.cs
+++ b/backend/src/AppHost/OrchestrationContract.cs
@@ -335,11 +335,11 @@ public static class OrchestrationContract
     /// <summary>The address a developer's own machine serves the client on and reaches the service at.</summary>
     /// <remarks>
     /// Loopback, because a WebAssembly bundle built in Debug against somebody's own machine is not something anything
-    /// on a local network has any business loading. Stated once rather than beside each of the three things built from
-    /// it, which have to agree with one another: the address the client's development server binds, the browser origin
-    /// the service is configured to answer, and the address the head is built to call. A page served under one
-    /// spelling and permitted under another is a first call refused on a preflight, which reads as a broken client
-    /// rather than as two spellings of one machine.
+    /// on a local network has any business loading. Stated once rather than beside each of the four things built from
+    /// it, which have to agree with one another: the address the client's development server binds, the endpoint Aspire
+    /// publishes, the browser origin the service is configured to answer, and the address the head is built to call. A
+    /// page served under one spelling and permitted under another is a first call refused on a preflight, which reads
+    /// as a broken client rather than as two spellings of one machine.
     /// </remarks>
     public const string DeveloperLoopbackAddress = "127.0.0.1";
 
@@ -813,6 +813,21 @@ public static class OrchestrationContract
         ArgumentException.ThrowIfNullOrWhiteSpace(appHostBaseDirectory);
 
         return Path.Combine(appHostBaseDirectory, DevelopmentOpenSslConfigurationFileName);
+    }
+
+    /// <summary>Resolves the addresses and published host that join the browser client to the service in development.</summary>
+    /// <param name="clientPort">The port serving the browser head.</param>
+    /// <param name="clientEndpointPort">The port serving the client API.</param>
+    /// <returns>The browser origin, service address, and Aspire endpoint host, all under the development loopback address.</returns>
+    public static (string ClientOrigin, string ServiceAddress, string PublishedClientHost)
+        ResolveDevelopmentClientNetwork(int clientPort, int clientEndpointPort)
+    {
+        var clientOrigin =
+            $"http://{DeveloperLoopbackAddress}:{clientPort.ToString(CultureInfo.InvariantCulture)}";
+        var serviceAddress =
+            $"http://{DeveloperLoopbackAddress}:{clientEndpointPort.ToString(CultureInfo.InvariantCulture)}/";
+
+        return (clientOrigin, serviceAddress, DeveloperLoopbackAddress);
     }
 
     /// <summary>Reads the port a developer pinned under <paramref name="configurationKey" />.</summary>

--- a/backend/src/AppHost/Program.cs
+++ b/backend/src/AppHost/Program.cs
@@ -593,13 +593,10 @@ else
     // an orchestration that already publishes the address as an endpoint does not need to do for the developer.
     if (OrchestrationContract.ResolveClientEnabled(builder.Configuration[OrchestrationContract.ClientEnabledKey]))
     {
-        // The two origins this pair is wired from, each composed once because both sides read the same one. The
-        // client's is what its development server binds and what the service is told to answer as a browser origin;
-        // the service's is the client surface's own socket, declared above, which is what the head is built to call.
-        var clientOrigin =
-            $"http://{OrchestrationContract.DeveloperLoopbackAddress}:{clientPort.ToString(CultureInfo.InvariantCulture)}";
-        var serviceAddress =
-            $"http://{OrchestrationContract.DeveloperLoopbackAddress}:{clientEndpointPort.ToString(CultureInfo.InvariantCulture)}/";
+        // The browser origin, the service address, and the host Aspire publishes are resolved together because a page
+        // served under one loopback spelling and admitted under another is a first call refused by CORS.
+        var clientNetwork =
+            OrchestrationContract.ResolveDevelopmentClientNetwork(clientPort, clientEndpointPort);
 
         builder
             .AddExecutable(
@@ -614,19 +611,23 @@ else
                 // and reads none of this process's environment, so the one channel that reaches it is the bundle the
                 // build produces: the client's project file writes this property into the runtime host configuration,
                 // and the WebAssembly SDK carries that into the boot configuration the page fetches.
-                $"--property:{OrchestrationContract.ClientDeploymentAddressProperty}={serviceAddress}")
+                $"--property:{OrchestrationContract.ClientDeploymentAddressProperty}={clientNetwork.ServiceAddress}")
             // The address the development server binds, stated to it and published to the app model as one number, so
             // the endpoint the dashboard links is the endpoint the browser head is served on. Unproxied for the reason
             // the host's sockets are: what the app model publishes is then what a browser connects to.
             //
             // On loopback, because a WebAssembly bundle built in Debug against a developer's own machine is not
             // something anything on a local network has any business loading.
-            .WithEnvironment(OrchestrationContract.ClientServerUrlsVariable, clientOrigin)
+            .WithEnvironment(OrchestrationContract.ClientServerUrlsVariable, clientNetwork.ClientOrigin)
             .WithHttpEndpoint(
                 name: OrchestrationContract.ClientHttpEndpointName,
                 port: clientPort,
                 targetPort: clientPort,
-                isProxied: false);
+                isProxied: false)
+            .WithEndpoint(
+                OrchestrationContract.ClientHttpEndpointName,
+                endpoint => endpoint.TargetHost = clientNetwork.PublishedClientHost,
+                createIfNotExists: false);
 
         // The service's half of the same wiring, and the whole of it: the head's own origin as the one browser origin
         // the client surface answers, rather than the every-origin posture an unstated list means. A local run is the
@@ -634,7 +635,7 @@ else
         // deployment will also have to answer, so the first call is not refused on a preflight.
         //
         // Written only where a head exists to make the request.
-        mailFathomHost.WithEnvironment("ClientEndpoint__Cors__AllowedOrigins__0", clientOrigin);
+        mailFathomHost.WithEnvironment("ClientEndpoint__Cors__AllowedOrigins__0", clientNetwork.ClientOrigin);
     }
 }
 

--- a/backend/tests/AppHost.UnitTests/OrchestrationContractTests.cs
+++ b/backend/tests/AppHost.UnitTests/OrchestrationContractTests.cs
@@ -415,10 +415,10 @@ public sealed class OrchestrationContractTests
 
     /// <summary>The address the client and the service are wired together on is one nothing outside this machine reaches.</summary>
     /// <remarks>
-    /// The one property of that constant the compiler cannot state. Three things are built from it — the socket the
-    /// client's development server binds, the browser origin the service is configured to answer, and the address the
-    /// head is built to call — so a value that stopped being loopback would publish a Debug WebAssembly bundle to
-    /// every interface of a developer's machine without any of the three disagreeing about it.
+    /// The one property of that constant the compiler cannot state. Four things are built from it — the socket the
+    /// client's development server binds, the endpoint Aspire publishes, the browser origin the service is configured
+    /// to answer, and the address the head is built to call — so a value that stopped being loopback would publish a
+    /// Debug WebAssembly bundle to every interface of a developer's machine without any of the four disagreeing about it.
     /// </remarks>
     [Fact]
     public void DeveloperLoopbackAddress_IsAnAddressOnlyThisMachineReaches()
@@ -429,6 +429,23 @@ public sealed class OrchestrationContractTests
         // Assert
         Assert.True(parsed);
         Assert.True(IPAddress.IsLoopback(address!));
+    }
+
+    /// <summary>The browser origin Aspire publishes has to be the one the service admits, or the first API call is refused by CORS.</summary>
+    [Fact]
+    public void ResolveDevelopmentClientNetwork_NormalTopology_UsesOneLoopbackHostAcrossTheBrowserAndService()
+    {
+        // Arrange
+        const int clientPort = 5000;
+        const int clientEndpointPort = 8082;
+
+        // Act
+        var network = OrchestrationContract.ResolveDevelopmentClientNetwork(clientPort, clientEndpointPort);
+
+        // Assert
+        Assert.Equal("http://127.0.0.1:5000", network.ClientOrigin);
+        Assert.Equal("http://127.0.0.1:8082/", network.ServiceAddress);
+        Assert.Equal("127.0.0.1", network.PublishedClientHost);
     }
 
     /// <summary>The name the deployment address travels into the client's build under has to be one MSBuild will carry.</summary>

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -1,6 +1,6 @@
 # The client endpoint
 
-<!-- describes: backend/src/Host/Configuration/Endpoints/ClientEndpointOptions.cs, backend/src/Host/Configuration/Endpoints/ClientApplicationOptions.cs, backend/src/Host/Api/ClientApiEndpoints.cs, backend/src/Host/Api/ClientMailAccountsEndpoint.cs, backend/src/Host/Api/ClientMailFoldersEndpoint.cs, backend/src/Host/Api/ClientMailTimelineEndpoint.cs, backend/src/Host/Api/ClientMailThreadEndpoint.cs, backend/src/Host/Api/ClientMailMessageEndpoint.cs, backend/src/Host/Api/ClientMailBodyEndpoint.cs, backend/src/Host/Api/ClientMailAttachmentEndpoint.cs, backend/src/Host/Api/AttachmentContentResponse.cs, backend/src/Host/Api/ProtectedResourceMetadataEndpoint.cs, backend/src/Host/Security/Endpoints/ClientTransportSecurityExtensions.cs, backend/src/Host/Hosting/ClientApplicationFiles.cs, backend/src/Host/Hosting/Warnings/ClientTransportSecurityWarning.cs, backend/src/Host/Hosting/Warnings/PasswordClearTextTransportWarning.cs, backend/src/Host/Api/ClientOwnerRecordEndpoint.cs -->
+<!-- describes: backend/src/AppHost/Program.cs, backend/src/AppHost/OrchestrationContract.cs, backend/src/Host/Configuration/Endpoints/ClientEndpointOptions.cs, backend/src/Host/Configuration/Endpoints/ClientApplicationOptions.cs, backend/src/Host/Api/ClientApiEndpoints.cs, backend/src/Host/Api/ClientMailAccountsEndpoint.cs, backend/src/Host/Api/ClientMailFoldersEndpoint.cs, backend/src/Host/Api/ClientMailTimelineEndpoint.cs, backend/src/Host/Api/ClientMailThreadEndpoint.cs, backend/src/Host/Api/ClientMailMessageEndpoint.cs, backend/src/Host/Api/ClientMailBodyEndpoint.cs, backend/src/Host/Api/ClientMailAttachmentEndpoint.cs, backend/src/Host/Api/AttachmentContentResponse.cs, backend/src/Host/Api/ProtectedResourceMetadataEndpoint.cs, backend/src/Host/Security/Endpoints/ClientTransportSecurityExtensions.cs, backend/src/Host/Hosting/ClientApplicationFiles.cs, backend/src/Host/Hosting/Warnings/ClientTransportSecurityWarning.cs, backend/src/Host/Hosting/Warnings/PasswordClearTextTransportWarning.cs, backend/src/Host/Api/ClientOwnerRecordEndpoint.cs -->
 
 Where the MailFathom client reaches the service, what a deployment has to enable before it answers, and what a person's
 mail client presents to get in.
@@ -50,11 +50,10 @@ what stays each surface's own.
 Every key this section takes is in
 [endpoint configuration](configuration-endpoints.md#clientendpoint), with its default and its constraint.
 
-**A local `aspire run` configures everything but this key**: a loopback socket of its own and the browser head's own
-origin as the one origin it answers, because that run starts a head that has to reach something. It does not turn the
-surface on — that stays a developer's act here as much as anywhere else.
-[The client resource](local-development.md#the-client-resource) is what to state locally, and what is already stated
-for you.
+**A normal local `aspire run` is the development exception to that default.** It enables the surface on a loopback
+socket of its own, admits the password method, and permits only the browser head's own origin, because that run starts
+a head that has to reach something. The AppHost provisions its synthetic credential after the service reports ready;
+[the client resource](local-development.md#the-client-resource) records the complete local topology and credential.
 
 ## What it serves
 

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -271,6 +271,11 @@ derives its address from an HTTP endpoint this app model declares none of.
 dashboard lists like any other endpoint. It is what makes `aspire run` bring up a MailFathom with a face on it rather
 than a service and a second terminal.
 
+The dashboard publishes that endpoint under `127.0.0.1`, the same loopback spelling the development server binds and
+the client surface admits through CORS. Aspire's default endpoint host is `localhost`; leaving that default in place
+would serve the page under a different browser origin even though both names reach the same machine, and the first
+client API request would be refused.
+
 It is an **executable** resource rather than a project one, and the reason is the client's target frameworks rather
 than its directory. Aspire starts a project resource by running `dotnet run --project <path> --configuration Debug
 --no-launch-profile`, and that argument list carries no framework — `ProjectResourceOptions` exposes a launch profile


### PR DESCRIPTION
Closes #1359

## What changes

- Resolve the development browser origin, client API address, and Aspire-published client host as one AppHost contract.
- Publish `mailfathom-client` under `127.0.0.1`, matching the development server bind and the origin admitted by the client API CORS policy.
- Cover the shared network contract with an AppHost unit test and correct both operational pages, including the documentation marker that allowed the Aspire behavior to drift unnoticed.

## How it was verified

- TDD red: `AppHost.UnitTests` failed with CS0117 before `ResolveDevelopmentClientNetwork` existed.
- Focused green: `AppHost.UnitTests` passed 63/63 and the AppHost Debug build completed with zero warnings.
- `scripts/review-obligations.sh` was reviewed; the AppHost contract test and both affected operational pages answer the relevant rows.
- `env -u NO_COLOR TERM=xterm-256color COLORTERM=truecolor scripts/verify-full.sh` passed after the commit on current `origin/main`: 13,047 tests, 0 failures, 95.28% aggregate line coverage, 0 formatted files, and 264 workflow contract checks.
- The container-backed Aspire topology was not started because this change does not invoke the manually requested integration suite or occupy its shared PostgreSQL resources.

## Checklist

- [x] `bash scripts/verify-full.sh` passes on this branch, rebased onto current `main`.
- [x] Behavior changes are covered by unit tests, and the coverage gate passes.
- [x] Affected documentation is updated in this change set.
- [x] `bash scripts/review-obligations.sh` was run, and every row it reported is answered — by a test, by a page, or by why nothing is owed there.
- [x] `CHANGELOG.md` is untouched — it is written by the release pull request alone.
- [x] Every new C# file carries the repository's standard header, applied by `scripts/verify-fast.sh` rather than typed, and no file gained a second copyright line, an author tag, a name, or a contact detail.
- [x] Nothing here is under terms MailFathom could not distribute under Apache-2.0. A new dependency, service, container image, or externally sourced sample has its row in `THIRD_PARTY_LICENSES.md` in this change set.
- [x] No credential, token, private key, real mailbox data, or personal information is in the diff.
