### PR TITLE
[#1165] Compose mail for phone and wide layouts

### DIFF
--- a/frontend/src/Client/App.xaml.cs
+++ b/frontend/src/Client/App.xaml.cs
@@ -8,6 +8,7 @@ using MailFathom.Client.Deployment;
 using MailFathom.Client.Presentation.Settings;
 using MailFathom.Client.Presentation.Spaces;
 using MailFathom.Client.Presentation.Spaces.Mail;
+using MailFathom.Client.Presentation.Threads;
 using MailFathom.Client.Presentation.Workspace;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -167,6 +168,8 @@ public partial class App : Application
             new ViewMap<WorkspacePage, WorkspaceModel>(),
             new ViewMap<DiscoverPage>(),
             new ViewMap<MailPage, MailModel>(),
+            new ViewMap<MailThreadPage, MailModel>(),
+            new DataViewMap<MailMessagePage, MailModel, ThreadMessageRow>(),
             new ViewMap<CasesPage>(),
             new ViewMap<SettingsPage, SettingsModel>(),
             new ViewMap<ConnectPage, ConnectModel>(),
@@ -188,9 +191,11 @@ public partial class App : Application
                         Nested:
                         [
                             new RouteMap(ClientRoutes.Discover, View: views.FindByView<DiscoverPage>(), IsDefault: true),
-                            new RouteMap(ClientRoutes.Mail, View: views.FindByViewModel<MailModel>()),
+                            new RouteMap(ClientRoutes.Mail, View: views.FindByView<MailPage>()),
                             new RouteMap(ClientRoutes.Cases, View: views.FindByView<CasesPage>()),
                         ]),
+                    new RouteMap(ClientRoutes.MailThread, View: views.FindByView<MailThreadPage>()),
+                    new RouteMap(ClientRoutes.MailMessage, View: views.FindByView<MailMessagePage>()),
                     new RouteMap(ClientRoutes.Settings, View: views.FindByViewModel<SettingsModel>()),
                     new RouteMap(ClientRoutes.Connect, View: views.FindByViewModel<ConnectModel>()),
                     new RouteMap(ClientRoutes.SignIn, View: views.FindByViewModel<SignInModel>()),

--- a/frontend/src/Client/Presentation/ClientRoutes.cs
+++ b/frontend/src/Client/Presentation/ClientRoutes.cs
@@ -22,6 +22,12 @@ internal static class ClientRoutes
     /// <summary>The space correspondence is read in.</summary>
     internal const string Mail = "Mail";
 
+    /// <summary>The phone-width screen that follows the selected message's conversation.</summary>
+    internal const string MailThread = "MailThread";
+
+    /// <summary>The phone-width screen that reads one message of the open conversation.</summary>
+    internal const string MailMessage = "MailMessage";
+
     /// <summary>The space a thread being worked through is followed in.</summary>
     internal const string Cases = "Cases";
 

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailMessagePage.xaml
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailMessagePage.xaml
@@ -1,0 +1,140 @@
+<!--
+Copyright © 2026 Krzysztof Kasprowicz
+Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+Project repository: https://github.com/Krzysztof318/MailFathom
+-->
+<Page x:Class="MailFathom.Client.Presentation.Spaces.Mail.MailMessagePage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mvux="using:Uno.Extensions.Reactive.UI"
+      xmlns:uen="using:Uno.Extensions.Navigation.UI"
+      xmlns:utu="using:Uno.Toolkit.UI"
+      xmlns:reading="using:MailFathom.Client.Presentation.Spaces.Mail.Reading"
+      xmlns:spaces="using:MailFathom.Client.Presentation.Spaces"
+      xmlns:threads="using:MailFathom.Client.Presentation.Threads"
+      Background="{ThemeResource BackgroundBrush}">
+
+  <Grid x:Name="MessagePageRoot"
+        utu:SafeArea.Insets="VisibleBounds">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition />
+    </Grid.RowDefinitions>
+
+    <Button x:Uid="MailMessagePage.Button.Back"
+            Margin="16,12"
+            HorizontalAlignment="Left"
+            uen:Navigation.Request="-"
+            Style="{StaticResource TextBlockButtonStyle}">
+      <SymbolIcon Symbol="Back" />
+    </Button>
+
+    <mvux:FeedView Grid.Row="1"
+                   Source="{Binding OpenedThreadMessage}">
+      <mvux:FeedView.ValueTemplate>
+        <DataTemplate x:DataType="threads:ThreadMessageRow">
+          <Grid>
+            <spaces:SpacePlaceholder x:Uid="MailPage.Message"
+                                     Visibility="{x:Bind IsClosed, Converter={StaticResource AffirmedVisibility}}" />
+
+            <ScrollViewer IsTabStop="True"
+                          Visibility="{x:Bind IsOpen, Converter={StaticResource AffirmedVisibility}}">
+              <StackPanel Padding="16"
+                          Spacing="12">
+              <TextBlock Text="{x:Bind Subject}"
+                         TextWrapping="Wrap"
+                         Style="{StaticResource TitleLargeTextBlockStyle}"
+                         Foreground="{ThemeResource OnSurfaceBrush}" />
+
+              <Grid ColumnSpacing="12">
+                <Grid.ColumnDefinitions>
+                  <ColumnDefinition />
+                  <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <TextBlock Text="{x:Bind Author}"
+                           Style="{StaticResource BodyStrongTextBlockStyle}"
+                           Foreground="{ThemeResource OnSurfaceBrush}"
+                           TextTrimming="CharacterEllipsis" />
+
+                <TextBlock Grid.Column="1"
+                           Text="{x:Bind Written}"
+                           Style="{StaticResource CaptionTextBlockStyle}"
+                           Foreground="{ThemeResource OnSurfaceVariantBrush}" />
+              </Grid>
+
+              <TextBlock Text="{x:Bind Recipients}"
+                         TextWrapping="Wrap"
+                         Style="{StaticResource CaptionTextBlockStyle}"
+                         Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                         Visibility="{x:Bind HasRecipients, Converter={StaticResource AffirmedVisibility}}" />
+
+              <TextBlock Text="{x:Bind Contribution}"
+                         TextWrapping="Wrap"
+                         IsTextSelectionEnabled="True"
+                         Style="{StaticResource BodyTextBlockStyle}"
+                         Foreground="{ThemeResource OnSurfaceBrush}"
+                         Visibility="{x:Bind HasContribution, Converter={StaticResource AffirmedVisibility}}" />
+
+              <Button x:Uid="MailPage.Button.ShowWholeMessage"
+                      HorizontalAlignment="Left"
+                      Style="{StaticResource TextBlockButtonStyle}"
+                      Command="{Binding DataContext.ShowWholeThreadMessage, ElementName=MessagePageRoot}"
+                      CommandParameter="{x:Bind Key}"
+                      Visibility="{x:Bind OffersStandaloneWholeMessage, Converter={StaticResource AffirmedVisibility}}" />
+
+              <ProgressBar IsIndeterminate="True"
+                           HorizontalAlignment="Stretch"
+                           Visibility="{x:Bind IsReadingWholeMessage, Converter={StaticResource AffirmedVisibility}}" />
+
+              <InfoBar x:Uid="MailPage.InfoBar.WholeMessageUnavailable"
+                       IsOpen="{x:Bind WholeMessageFailed, Mode=OneWay}"
+                       IsClosable="False"
+                       Severity="Warning">
+                <InfoBar.ActionButton>
+                  <Button x:Uid="MailPage.Button.RetryWholeMessage"
+                          Command="{Binding DataContext.ShowWholeThreadMessage, ElementName=MessagePageRoot}"
+                          CommandParameter="{x:Bind Key}" />
+                </InfoBar.ActionButton>
+              </InfoBar>
+
+              <reading:MailMessageView Reading="{x:Bind Message, Mode=OneWay}"
+                                       Body="{x:Bind WholeMessage, Mode=OneWay}"
+                                       Visibility="{x:Bind ShowsMessage, Converter={StaticResource AffirmedVisibility}}"
+                                       ShowRemoteContentCommand="{Binding DataContext.ShowThreadRemoteContent, ElementName=MessagePageRoot}"
+                                       ShowRemoteContentCommandParameter="{x:Bind Key}"
+                                       SaveAttachmentCommand="{Binding DataContext.SaveAttachment, ElementName=MessagePageRoot}"
+                                       CancelAttachmentCommand="{Binding DataContext.CancelAttachment, ElementName=MessagePageRoot}"
+                                       UseSelectionCommand="{Binding DataContext.UseBodySelection, ElementName=MessagePageRoot}" />
+              </StackPanel>
+            </ScrollViewer>
+          </Grid>
+        </DataTemplate>
+      </mvux:FeedView.ValueTemplate>
+
+      <mvux:FeedView.ProgressTemplate>
+        <DataTemplate>
+          <ProgressBar IsIndeterminate="True"
+                       VerticalAlignment="Top"
+                       HorizontalAlignment="Stretch" />
+        </DataTemplate>
+      </mvux:FeedView.ProgressTemplate>
+
+      <mvux:FeedView.ErrorTemplate>
+        <DataTemplate>
+          <InfoBar x:Uid="MailPage.InfoBar.ThreadUnavailable"
+                   Margin="16"
+                   VerticalAlignment="Top"
+                   IsOpen="True"
+                   IsClosable="False"
+                   Severity="Error">
+            <InfoBar.ActionButton>
+              <Button x:Uid="MailPage.Button.RetryThread"
+                      Command="{Binding Parent.RetryThread}" />
+            </InfoBar.ActionButton>
+          </InfoBar>
+        </DataTemplate>
+      </mvux:FeedView.ErrorTemplate>
+    </mvux:FeedView>
+  </Grid>
+</Page>

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailMessagePage.xaml.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailMessagePage.xaml.cs
@@ -1,0 +1,12 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Presentation.Spaces.Mail;
+
+/// <summary>The phone-width route that reads one message of the open conversation.</summary>
+public sealed partial class MailMessagePage : Page
+{
+    /// <summary>Initializes the route.</summary>
+    public MailMessagePage() => this.InitializeComponent();
+}

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailModel.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailModel.cs
@@ -56,6 +56,36 @@ public partial record MailModel
         IMailThread thread,
         IWorkspace workspace,
         IMailSearch search)
+        : this(session, messages, thread, workspace, search, openedMessageKey: null)
+    {
+    }
+
+    /// <summary>Initializes the same mail model for the phone route that draws one message from the open conversation.</summary>
+    /// <param name="openedMessage">The conversation row the route opened.</param>
+    /// <param name="session">What the deployment allows this caller.</param>
+    /// <param name="messages">The run's own message list, drawn from wherever the mailbox tree says somebody is.</param>
+    /// <param name="thread">The run's own conversation, which is whatever the list has one message selected in.</param>
+    /// <param name="workspace">The scope a selected passage narrows for the intent field.</param>
+    /// <param name="search">The run's own ranked list, which opens the same conversation without replacing itself.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    public MailModel(
+        ThreadMessageRow openedMessage,
+        IClientSession session,
+        IMessageList messages,
+        IMailThread thread,
+        IWorkspace workspace,
+        IMailSearch search)
+        : this(session, messages, thread, workspace, search, KeyOf(openedMessage))
+    {
+    }
+
+    private MailModel(
+        IClientSession session,
+        IMessageList messages,
+        IMailThread thread,
+        IWorkspace workspace,
+        IMailSearch search,
+        string? openedMessageKey)
     {
         ArgumentNullException.ThrowIfNull(session);
         ArgumentNullException.ThrowIfNull(messages);
@@ -81,6 +111,11 @@ public partial record MailModel
         this.KeepsEverything =
             messages.Arrangement.Select(static arrangement => !arrangement.KeepsLessThanEverything);
         this.ShowsTimeline = search.IsOpen.Select(static isOpen => !isOpen);
+        this.OpenedThreadMessage = thread.Messages.AsFeed().Select(
+            rows => openedMessageKey is null
+                ? ThreadMessageRow.Nothing
+                : rows.FirstOrDefault(row => string.Equals(row.Key, openedMessageKey, StringComparison.Ordinal))
+                    ?? ThreadMessageRow.Nothing);
     }
 
     /// <summary>Whether this session keeps the space correspondence is read in from being put in front of this caller.</summary>
@@ -195,6 +230,10 @@ public partial record MailModel
 
     /// <summary>Whether the last attempt to read more of the conversation did not arrive.</summary>
     public IFeed<bool> ThreadPagingFailed => this.thread.PagingFailed;
+
+    /// <summary>The live conversation row named by the phone's message route.</summary>
+    /// <remarks>Projected from the run-wide conversation rather than copied from navigation data, so a body read or attachment update reaches both compositions.</remarks>
+    public IFeed<ThreadMessageRow> OpenedThreadMessage { get; }
 
     /// <summary>Shows what one message of the conversation added, or collapses it back to a line.</summary>
     /// <param name="key">The message, as its row names itself.</param>
@@ -383,5 +422,12 @@ public partial record MailModel
         var arrangement = await this.messages.Arrangement ?? MessageListArrangement.Default;
 
         await this.messages.ArrangeAsync(change(arrangement), cancellationToken).ConfigureAwait(false);
+    }
+
+    private static string KeyOf(ThreadMessageRow message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        return message.Key;
     }
 }

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailPage.xaml
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailPage.xaml
@@ -7,16 +7,29 @@ Project repository: https://github.com/Krzysztof318/MailFathom
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:mvux="using:Uno.Extensions.Reactive.UI"
+      xmlns:uen="using:Uno.Extensions.Navigation.UI"
       xmlns:utu="using:Uno.Toolkit.UI"
+      xmlns:mail="using:MailFathom.Client.Presentation.Spaces.Mail"
       xmlns:messages="using:MailFathom.Client.Presentation.Messages"
-      xmlns:reading="using:MailFathom.Client.Presentation.Spaces.Mail.Reading"
       xmlns:search="using:MailFathom.Client.Presentation.Search"
       xmlns:spaces="using:MailFathom.Client.Presentation.Spaces"
-      xmlns:threads="using:MailFathom.Client.Presentation.Threads"
       xmlns:workspace="using:MailFathom.Client.Presentation.Workspace"
       NavigationCacheMode="Required">
 
   <Grid>
+    <VisualStateManager.VisualStateGroups>
+      <VisualStateGroup>
+        <VisualState x:Name="WideMail">
+          <VisualState.StateTriggers>
+            <AdaptiveTrigger MinWindowWidth="{StaticResource WorkspaceWideWindowWidth}" />
+          </VisualState.StateTriggers>
+          <VisualState.Setters>
+            <Setter Target="MessageRows.(uen:Navigation.Request)" Value="" />
+          </VisualState.Setters>
+        </VisualState>
+      </VisualStateGroup>
+    </VisualStateManager.VisualStateGroups>
+
     <!-- The list beside what is open on a wide window, and the list alone on a narrow one, where opening something is
          a screen rather than a second column. What the companion column holds is the conversation the selected
          message is in.
@@ -134,6 +147,7 @@ Project repository: https://github.com/Krzysztof318/MailFathom
             <ListView x:Name="MessageRows"
                       x:Uid="MailPage.List.Messages"
                       ItemsSource="{Binding Messages}"
+                      uen:Navigation.Request="MailThread"
                       SelectionMode="Extended"
                       IsItemClickEnabled="False"
                       Holding="OnRowHeld"
@@ -240,328 +254,7 @@ Project repository: https://github.com/Krzysztof318/MailFathom
         </Grid>
       </workspace:WorkspaceColumns.Primary>
       <workspace:WorkspaceColumns.Companion>
-        <!-- The conversation the selected message is in. It is not scoped to the folder the list is drawn from and
-             cannot be: the question is in the inbox, the answer is in the sent folder, and a forwarded copy is
-             somewhere else again — so what is drawn here spans every folder of every account, in the conversation's
-             own order. -->
-        <Grid>
-          <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition />
-            <RowDefinition Height="Auto" />
-          </Grid.RowDefinitions>
-
-          <!-- Who is in the conversation and how large it is, answered by the deployment about the whole of it rather
-               than derived from the messages in hand: a header walked out of the page would name whoever happened to
-               be on it and would change as the rest arrived. -->
-          <StackPanel Grid.Row="0"
-                      Padding="16,12"
-                      Spacing="6"
-                      AutomationProperties.Name="{Binding Thread.Announcement}"
-                      Visibility="{Binding Thread.IsOpen, Converter={StaticResource AffirmedVisibility}}">
-            <TextBlock Text="{Binding Thread.Subject}"
-                       TextWrapping="Wrap"
-                       Style="{StaticResource SubtitleTextBlockStyle}"
-                       Foreground="{ThemeResource OnSurfaceBrush}" />
-
-            <TextBlock Text="{Binding Thread.MessageCount}"
-                       Style="{StaticResource CaptionTextBlockStyle}"
-                       Foreground="{ThemeResource OnSurfaceVariantBrush}"
-                       AutomationProperties.AccessibilityView="Raw" />
-
-            <ScrollViewer HorizontalScrollBarVisibility="Auto"
-                          VerticalScrollBarVisibility="Disabled"
-                          HorizontalScrollMode="Auto"
-                          VerticalScrollMode="Disabled">
-              <ItemsControl ItemsSource="{Binding Thread.Participants}">
-                <ItemsControl.ItemsPanel>
-                  <ItemsPanelTemplate>
-                    <StackPanel Orientation="Horizontal"
-                                Spacing="12" />
-                  </ItemsPanelTemplate>
-                </ItemsControl.ItemsPanel>
-                <ItemsControl.ItemTemplate>
-                  <DataTemplate x:DataType="threads:ThreadParticipantRow">
-                    <StackPanel Orientation="Horizontal"
-                                Spacing="4"
-                                AutomationProperties.Name="{x:Bind Announcement}">
-                      <TextBlock Text="{x:Bind Author}"
-                                 Style="{StaticResource CaptionTextBlockStyle}"
-                                 Foreground="{ThemeResource OnSurfaceBrush}"
-                                 AutomationProperties.AccessibilityView="Raw"
-                                 TextTrimming="CharacterEllipsis" />
-                      <TextBlock Text="{x:Bind MessageCount}"
-                                 Style="{StaticResource CaptionTextBlockStyle}"
-                                 Foreground="{ThemeResource OnSurfaceVariantBrush}"
-                                 AutomationProperties.AccessibilityView="Raw" />
-                    </StackPanel>
-                  </DataTemplate>
-                </ItemsControl.ItemTemplate>
-              </ItemsControl>
-            </ScrollViewer>
-
-            <TextBlock x:Uid="MailPage.TextBlock.MoreParticipants"
-                       Style="{StaticResource CaptionTextBlockStyle}"
-                       Foreground="{ThemeResource OnSurfaceVariantBrush}"
-                       TextWrapping="Wrap"
-                       Visibility="{Binding Thread.HasUnnamedParticipants, Converter={StaticResource AffirmedVisibility}}" />
-
-            <!-- A conversation larger than one read assembles says so rather than showing what it did assemble as
-                 though that were the whole of it. -->
-            <InfoBar x:Uid="MailPage.InfoBar.ThreadRunsPast"
-                     IsOpen="{Binding Thread.RunsPastAssembly}"
-                     IsClosable="False"
-                     Severity="Informational" />
-          </StackPanel>
-
-          <Grid Grid.Row="1">
-            <!-- Every message of the conversation, each collapsed to one line and each opened by the control on that
-                 line. The list is what a screen reader announces the structure from and what the arrow keys move
-                 between; the control on each line is what opens one without a pointer. -->
-            <ListView x:Name="ThreadMessageRows"
-                      x:Uid="MailPage.List.ThreadMessages"
-                      ItemsSource="{Binding ThreadMessages}"
-                      SelectionMode="Single"
-                      IsItemClickEnabled="False"
-                      Loaded="OnThreadLoaded"
-                      Unloaded="OnThreadUnloaded"
-                      Padding="4,0,4,12">
-              <ListView.ItemTemplate>
-                <DataTemplate x:DataType="threads:ThreadMessageRow">
-                  <StackPanel Spacing="4">
-                    <ToggleButton x:Uid="MailPage.Toggle.ThreadMessage"
-                                  HorizontalAlignment="Stretch"
-                                  HorizontalContentAlignment="Stretch"
-                                  IsChecked="{x:Bind IsExpanded, Mode=OneWay}"
-                                  Command="{utu:ItemsControlBinding Path=DataContext.ToggleThreadMessage}"
-                                  CommandParameter="{x:Bind Key}"
-                                  AutomationProperties.Name="{x:Bind Announcement}">
-                      <!-- The line states itself once for a screen reader and draws itself in parts for everybody
-                           else, exactly as a row of the list beside it does. -->
-                      <Grid ColumnSpacing="8">
-                        <Grid.ColumnDefinitions>
-                          <ColumnDefinition Width="Auto" />
-                          <ColumnDefinition />
-                          <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-
-                        <Border Width="8"
-                                Height="8"
-                                CornerRadius="4"
-                                VerticalAlignment="Top"
-                                Margin="0,6,0,0"
-                                AutomationProperties.AccessibilityView="Raw"
-                                Background="{ThemeResource PrimaryBrush}"
-                                Visibility="{x:Bind IsUnread, Converter={StaticResource AffirmedVisibility}}" />
-
-                        <StackPanel Grid.Column="1"
-                                    Spacing="2">
-                          <TextBlock Text="{x:Bind Author}"
-                                     Style="{StaticResource BodyStrongTextBlockStyle}"
-                                     Foreground="{ThemeResource OnSurfaceBrush}"
-                                     AutomationProperties.AccessibilityView="Raw"
-                                     TextTrimming="CharacterEllipsis" />
-
-                          <!-- What the message added, in the one line it collapses to. It arrived with the
-                               conversation, so a thread of thirty messages costs one request to draw. -->
-                          <TextBlock Text="{x:Bind Contribution}"
-                                     Style="{StaticResource CaptionTextBlockStyle}"
-                                     Foreground="{ThemeResource OnSurfaceVariantBrush}"
-                                     AutomationProperties.AccessibilityView="Raw"
-                                     TextTrimming="CharacterEllipsis"
-                                     Visibility="{x:Bind HasContribution, Converter={StaticResource AffirmedVisibility}}" />
-                        </StackPanel>
-
-                        <StackPanel Grid.Column="2"
-                                    Spacing="2"
-                                    HorizontalAlignment="Right">
-                          <TextBlock Text="{x:Bind Written}"
-                                     HorizontalAlignment="Right"
-                                     Style="{StaticResource CaptionTextBlockStyle}"
-                                     Foreground="{ThemeResource OnSurfaceVariantBrush}"
-                                     AutomationProperties.AccessibilityView="Raw" />
-
-                          <StackPanel Orientation="Horizontal"
-                                      HorizontalAlignment="Right"
-                                      Spacing="4">
-                            <FontIcon Glyph="&#xE172;"
-                                      FontSize="12"
-                                      AutomationProperties.AccessibilityView="Raw"
-                                      Foreground="{ThemeResource OnSurfaceVariantBrush}"
-                                      Visibility="{x:Bind IsAnswered, Converter={StaticResource AffirmedVisibility}}" />
-
-                            <FontIcon Glyph="&#xE7C1;"
-                                      FontSize="12"
-                                      AutomationProperties.AccessibilityView="Raw"
-                                      Foreground="{ThemeResource TertiaryBrush}"
-                                      Visibility="{x:Bind IsFlagged, Converter={StaticResource AffirmedVisibility}}" />
-
-                            <FontIcon Glyph="&#xE723;"
-                                      FontSize="12"
-                                      AutomationProperties.AccessibilityView="Raw"
-                                      Foreground="{ThemeResource OnSurfaceVariantBrush}"
-                                      Visibility="{x:Bind HasAttachments, Converter={StaticResource AffirmedVisibility}}" />
-
-                            <TextBlock Text="{x:Bind AttachmentCountText}"
-                                       Style="{StaticResource CaptionTextBlockStyle}"
-                                       AutomationProperties.AccessibilityView="Raw"
-                                       Foreground="{ThemeResource OnSurfaceVariantBrush}"
-                                       Visibility="{x:Bind ShowsAttachmentCount, Converter={StaticResource AffirmedVisibility}}" />
-                          </StackPanel>
-                        </StackPanel>
-                      </Grid>
-                    </ToggleButton>
-
-                    <!-- What the message added, in full, once it is open — and never the quoted history under it,
-                         which is the read below rather than eight copies of the first message down the page. -->
-                    <StackPanel Margin="16,0,8,8"
-                                Spacing="8"
-                                Visibility="{x:Bind IsExpanded, Converter={StaticResource AffirmedVisibility}}">
-                      <TextBlock Text="{x:Bind Recipients}"
-                                 TextWrapping="Wrap"
-                                 Style="{StaticResource CaptionTextBlockStyle}"
-                                 Foreground="{ThemeResource OnSurfaceVariantBrush}"
-                                 Visibility="{x:Bind HasRecipients, Converter={StaticResource AffirmedVisibility}}" />
-
-                      <TextBlock Text="{x:Bind Contribution}"
-                                 TextWrapping="Wrap"
-                                 IsTextSelectionEnabled="True"
-                                 Style="{StaticResource BodyTextBlockStyle}"
-                                 Foreground="{ThemeResource OnSurfaceBrush}"
-                                 Visibility="{x:Bind HasContribution, Converter={StaticResource AffirmedVisibility}}" />
-
-                      <!-- A message this deployment holds but has not extracted yet says so, rather than reading as a
-                           message somebody sent with nothing in it. -->
-                      <TextBlock x:Uid="MailPage.TextBlock.NoContribution"
-                                 TextWrapping="Wrap"
-                                 Style="{StaticResource CaptionTextBlockStyle}"
-                                 Foreground="{ThemeResource OnSurfaceVariantBrush}"
-                                 Visibility="{x:Bind AwaitsContribution, Converter={StaticResource AffirmedVisibility}}" />
-
-                      <!-- The one gesture on this screen that costs a request. The command carries the message it acts
-                           on, so it runs per message and its progress belongs to that message rather than to the
-                           conversation — which is why the wait below is drawn here and not by a LoadingView. -->
-                      <Button x:Uid="MailPage.Button.ShowWholeMessage"
-                              HorizontalAlignment="Left"
-                              Style="{StaticResource TextBlockButtonStyle}"
-                              Command="{utu:ItemsControlBinding Path=DataContext.ShowWholeThreadMessage}"
-                              CommandParameter="{x:Bind Key}"
-                              Visibility="{x:Bind OffersWholeMessage, Converter={StaticResource AffirmedVisibility}}" />
-
-                      <ProgressBar IsIndeterminate="True"
-                                   HorizontalAlignment="Stretch"
-                                   Visibility="{x:Bind AwaitsWholeMessage, Converter={StaticResource AffirmedVisibility}}" />
-
-                      <InfoBar x:Uid="MailPage.InfoBar.WholeMessageUnavailable"
-                               IsOpen="{x:Bind ShowsWholeMessageFailure, Mode=OneWay}"
-                               IsClosable="False"
-                               Severity="Warning">
-                        <InfoBar.ActionButton>
-                          <Button x:Uid="MailPage.Button.RetryWholeMessage"
-                                  Command="{utu:ItemsControlBinding Path=DataContext.ShowWholeThreadMessage}"
-                                  CommandParameter="{x:Bind Key}" />
-                        </InfoBar.ActionButton>
-                      </InfoBar>
-
-                      <!-- The whole message, quoted history and all, drawn by the pane that already knows how to draw
-                           one and how to ask before anything in it leaves the application. Its height is bounded so a
-                           long message stays one message of the conversation rather than the whole column. -->
-                      <reading:MailMessageView MaxHeight="640"
-                                               Reading="{x:Bind Message, Mode=OneWay}"
-                                               Body="{x:Bind WholeMessage, Mode=OneWay}"
-                                               Visibility="{x:Bind ShowsMessage, Converter={StaticResource AffirmedVisibility}}"
-                                               ShowRemoteContentCommand="{utu:ItemsControlBinding Path=DataContext.ShowThreadRemoteContent}"
-                                               ShowRemoteContentCommandParameter="{x:Bind Key}"
-                                               SaveAttachmentCommand="{utu:ItemsControlBinding Path=DataContext.SaveAttachment}"
-                                               CancelAttachmentCommand="{utu:ItemsControlBinding Path=DataContext.CancelAttachment}"
-                                               UseSelectionCommand="{utu:ItemsControlBinding Path=DataContext.UseBodySelection}" />
-                    </StackPanel>
-                  </StackPanel>
-                </DataTemplate>
-              </ListView.ItemTemplate>
-            </ListView>
-
-            <!-- The three states the conversation genuinely has, rendered by the feed rather than remembered by this
-                 page, on the same arrangement the list beside it uses. -->
-            <mvux:FeedView Source="{Binding ThreadMessages}">
-              <mvux:FeedView.ValueTemplate>
-                <DataTemplate>
-                  <Border Height="0" />
-                </DataTemplate>
-              </mvux:FeedView.ValueTemplate>
-
-              <mvux:FeedView.ProgressTemplate>
-                <DataTemplate>
-                  <ProgressBar IsIndeterminate="True"
-                               VerticalAlignment="Top"
-                               HorizontalAlignment="Stretch" />
-                </DataTemplate>
-              </mvux:FeedView.ProgressTemplate>
-
-              <!-- Two states rather than one, because they lead to different acts: nothing selected is a message to
-                   choose, and an open conversation holding nothing is mail this deployment has not taken in yet. Each
-                   is shown on its own affirmative, so neither is announced while the read that decides it is still
-                   running. -->
-              <mvux:FeedView.NoneTemplate>
-                <DataTemplate>
-                  <Grid>
-                    <spaces:SpacePlaceholder x:Uid="MailPage.Thread"
-                                             Visibility="{Binding Parent.Thread.IsClosed, Converter={StaticResource AffirmedVisibility}}" />
-
-                    <InfoBar x:Uid="MailPage.InfoBar.NoThreadMessages"
-                             Margin="16"
-                             VerticalAlignment="Top"
-                             IsOpen="{Binding Parent.Thread.IsOpen}"
-                             IsClosable="False"
-                             Severity="Informational" />
-                  </Grid>
-                </DataTemplate>
-              </mvux:FeedView.NoneTemplate>
-
-              <mvux:FeedView.ErrorTemplate>
-                <DataTemplate>
-                  <InfoBar x:Uid="MailPage.InfoBar.ThreadUnavailable"
-                           Margin="16"
-                           VerticalAlignment="Top"
-                           IsOpen="True"
-                           IsClosable="False"
-                           Severity="Error">
-                    <InfoBar.ActionButton>
-                      <Button x:Uid="MailPage.Button.RetryThread"
-                              Command="{Binding Parent.RetryThread}" />
-                    </InfoBar.ActionButton>
-                  </InfoBar>
-                </DataTemplate>
-              </mvux:FeedView.ErrorTemplate>
-            </mvux:FeedView>
-          </Grid>
-
-          <StackPanel Grid.Row="2"
-                      Padding="12,4,12,8"
-                      Spacing="4">
-            <!-- A page that did not arrive is said beside the conversation rather than instead of it, because what is
-                 already drawn is still true. -->
-            <InfoBar x:Uid="MailPage.InfoBar.ThreadPageUnavailable"
-                     IsOpen="{Binding ThreadPagingFailed}"
-                     IsClosable="False"
-                     Severity="Warning" />
-
-            <utu:LoadingView Source="{Binding ShowMoreThreadMessages}"
-                             Visibility="{Binding HasMoreThreadMessages, Converter={StaticResource AffirmedVisibility}}">
-              <utu:LoadingView.Content>
-                <Button x:Uid="MailPage.Button.ShowMoreThreadMessages"
-                        HorizontalAlignment="Stretch"
-                        Command="{Binding ShowMoreThreadMessages}"
-                        Style="{StaticResource TextBlockButtonStyle}" />
-              </utu:LoadingView.Content>
-
-              <utu:LoadingView.LoadingContent>
-                <ProgressBar IsIndeterminate="True"
-                             HorizontalAlignment="Stretch" />
-              </utu:LoadingView.LoadingContent>
-            </utu:LoadingView>
-          </StackPanel>
-        </Grid>
+        <mail:MailThreadView />
       </workspace:WorkspaceColumns.Companion>
     </workspace:WorkspaceColumns>
 

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailPage.xaml.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailPage.xaml.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Collections.Specialized;
-using MailFathom.Client.Presentation.Threads;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml.Input;
 
@@ -18,78 +16,10 @@ namespace MailFathom.Client.Presentation.Spaces.Mail;
 /// </remarks>
 public sealed partial class MailPage : Page
 {
-    private string scrolledTo = string.Empty;
-
     /// <summary>Initializes the space.</summary>
     public MailPage()
     {
         this.InitializeComponent();
-    }
-
-    /// <summary>Brings the message a conversation was opened at into view, once the conversation has arrived.</summary>
-    /// <param name="sender">The conversation's list.</param>
-    /// <param name="args">The load, which is where the collection behind the list becomes watchable.</param>
-    /// <remarks>
-    /// Scrolling is the one part of opening a conversation at a message that a model cannot do: which message is opened
-    /// is the model's answer and is asserted as one, and where a viewport sits is the control's. The collection is
-    /// watched rather than the items bound once, because the rows are rebuilt whenever anything is expanded and the
-    /// conversation itself arrives after the list is loaded.
-    /// </remarks>
-    private void OnThreadLoaded(object sender, RoutedEventArgs args)
-    {
-        if (this.ThreadMessageRows.ItemsSource is INotifyCollectionChanged watchable)
-        {
-            watchable.CollectionChanged += this.OnThreadMessagesChanged;
-        }
-
-        this.BringOpenedMessageIntoView();
-    }
-
-    /// <summary>Stops watching the conversation's rows when the space goes away.</summary>
-    private void OnThreadUnloaded(object sender, RoutedEventArgs args)
-    {
-        if (this.ThreadMessageRows.ItemsSource is INotifyCollectionChanged watchable)
-        {
-            watchable.CollectionChanged -= this.OnThreadMessagesChanged;
-        }
-    }
-
-    private void OnThreadMessagesChanged(object? sender, NotifyCollectionChangedEventArgs args) =>
-        this.BringOpenedMessageIntoView();
-
-    /// <summary>Scrolls to the opened message, and only the first time each one becomes the opened one.</summary>
-    /// <remarks>
-    /// Which message was last scrolled to is kept here rather than answered by the model, because the model's answer
-    /// stays true for as long as the conversation is open: expanding another message rebuilds the rows without changing
-    /// which one was arrived at, and scrolling again on each of those would drag the viewport away from whatever the
-    /// reader had just pressed.
-    /// </remarks>
-    private void BringOpenedMessageIntoView()
-    {
-        if (this.ThreadMessageRows.ItemsSource is not IEnumerable<object> rows)
-        {
-            return;
-        }
-
-        var opened = rows.OfType<ThreadMessageRow>().FirstOrDefault(static row => row.IsOpenedAt);
-
-        if (opened is null)
-        {
-            // A conversation nobody has open was scrolled to nothing, and this page outlives the conversations opened
-            // in it: without this, arriving at the same message a second time would find the guard already naming it
-            // and would leave the viewport wherever the last reading left it.
-            this.scrolledTo = string.Empty;
-
-            return;
-        }
-
-        if (string.Equals(opened.Key, this.scrolledTo, StringComparison.Ordinal))
-        {
-            return;
-        }
-
-        this.scrolledTo = opened.Key;
-        this.ThreadMessageRows.ScrollIntoView(opened);
     }
 
     /// <summary>Puts the list into the selection a touch head reaches by pressing and holding a row.</summary>

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailThreadPage.xaml
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailThreadPage.xaml
@@ -1,0 +1,32 @@
+<!--
+Copyright © 2026 Krzysztof Kasprowicz
+Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+Project repository: https://github.com/Krzysztof318/MailFathom
+-->
+<Page x:Class="MailFathom.Client.Presentation.Spaces.Mail.MailThreadPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mail="using:MailFathom.Client.Presentation.Spaces.Mail"
+      xmlns:uen="using:Uno.Extensions.Navigation.UI"
+      xmlns:utu="using:Uno.Toolkit.UI"
+      NavigationCacheMode="Required"
+      Background="{ThemeResource BackgroundBrush}">
+
+  <Grid utu:SafeArea.Insets="VisibleBounds">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition />
+    </Grid.RowDefinitions>
+
+    <Button x:Uid="MailThreadPage.Button.Back"
+            Margin="16,12"
+            HorizontalAlignment="Left"
+            uen:Navigation.Request="-"
+            Style="{StaticResource TextBlockButtonStyle}">
+      <SymbolIcon Symbol="Back" />
+    </Button>
+
+    <mail:MailThreadView Grid.Row="1"
+                         MessageRoute="MailMessage" />
+  </Grid>
+</Page>

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailThreadPage.xaml.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailThreadPage.xaml.cs
@@ -1,0 +1,12 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Client.Presentation.Spaces.Mail;
+
+/// <summary>The phone-width route that follows the selected message's conversation.</summary>
+public sealed partial class MailThreadPage : Page
+{
+    /// <summary>Initializes the route.</summary>
+    public MailThreadPage() => this.InitializeComponent();
+}

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailThreadView.xaml
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailThreadView.xaml
@@ -1,0 +1,309 @@
+<!--
+Copyright © 2026 Krzysztof Kasprowicz
+Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+Project repository: https://github.com/Krzysztof318/MailFathom
+-->
+<UserControl x:Class="MailFathom.Client.Presentation.Spaces.Mail.MailThreadView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mvux="using:Uno.Extensions.Reactive.UI"
+             xmlns:uen="using:Uno.Extensions.Navigation.UI"
+             xmlns:utu="using:Uno.Toolkit.UI"
+             xmlns:reading="using:MailFathom.Client.Presentation.Spaces.Mail.Reading"
+             xmlns:spaces="using:MailFathom.Client.Presentation.Spaces"
+             xmlns:threads="using:MailFathom.Client.Presentation.Threads"
+             x:Name="ThreadViewRoot">
+
+  <!-- The conversation the selected message is in. It is shared by the wide companion column and the phone route,
+       so both read the same run-wide model and neither copies the thread or its current message. -->
+  <Grid>
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition />
+      <RowDefinition Height="Auto" />
+    </Grid.RowDefinitions>
+
+    <StackPanel Grid.Row="0"
+                Padding="16,12"
+                Spacing="6"
+                AutomationProperties.Name="{Binding Thread.Announcement}"
+                Visibility="{Binding Thread.IsOpen, Converter={StaticResource AffirmedVisibility}}">
+      <TextBlock Text="{Binding Thread.Subject}"
+                 TextWrapping="Wrap"
+                 Style="{StaticResource SubtitleTextBlockStyle}"
+                 Foreground="{ThemeResource OnSurfaceBrush}" />
+
+      <TextBlock Text="{Binding Thread.MessageCount}"
+                 Style="{StaticResource CaptionTextBlockStyle}"
+                 Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                 AutomationProperties.AccessibilityView="Raw" />
+
+      <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                    VerticalScrollBarVisibility="Disabled"
+                    HorizontalScrollMode="Auto"
+                    VerticalScrollMode="Disabled">
+        <ItemsControl ItemsSource="{Binding Thread.Participants}">
+          <ItemsControl.ItemsPanel>
+            <ItemsPanelTemplate>
+              <StackPanel Orientation="Horizontal"
+                          Spacing="12" />
+            </ItemsPanelTemplate>
+          </ItemsControl.ItemsPanel>
+          <ItemsControl.ItemTemplate>
+            <DataTemplate x:DataType="threads:ThreadParticipantRow">
+              <StackPanel Orientation="Horizontal"
+                          Spacing="4"
+                          AutomationProperties.Name="{x:Bind Announcement}">
+                <TextBlock Text="{x:Bind Author}"
+                           Style="{StaticResource CaptionTextBlockStyle}"
+                           Foreground="{ThemeResource OnSurfaceBrush}"
+                           AutomationProperties.AccessibilityView="Raw"
+                           TextTrimming="CharacterEllipsis" />
+                <TextBlock Text="{x:Bind MessageCount}"
+                           Style="{StaticResource CaptionTextBlockStyle}"
+                           Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                           AutomationProperties.AccessibilityView="Raw" />
+              </StackPanel>
+            </DataTemplate>
+          </ItemsControl.ItemTemplate>
+        </ItemsControl>
+      </ScrollViewer>
+
+      <TextBlock x:Uid="MailPage.TextBlock.MoreParticipants"
+                 Style="{StaticResource CaptionTextBlockStyle}"
+                 Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                 TextWrapping="Wrap"
+                 Visibility="{Binding Thread.HasUnnamedParticipants, Converter={StaticResource AffirmedVisibility}}" />
+
+      <InfoBar x:Uid="MailPage.InfoBar.ThreadRunsPast"
+               IsOpen="{Binding Thread.RunsPastAssembly}"
+               IsClosable="False"
+               Severity="Informational" />
+    </StackPanel>
+
+    <Grid Grid.Row="1">
+      <ListView x:Name="ThreadMessageRows"
+                x:Uid="MailPage.List.ThreadMessages"
+                ItemsSource="{Binding ThreadMessages}"
+                SelectionMode="Single"
+                IsItemClickEnabled="False"
+                Loaded="OnThreadLoaded"
+                Unloaded="OnThreadUnloaded"
+                Padding="4,0,4,12">
+        <ListView.ItemTemplate>
+          <DataTemplate x:DataType="threads:ThreadMessageRow">
+            <StackPanel Spacing="4">
+              <ToggleButton x:Uid="MailPage.Toggle.ThreadMessage"
+                            HorizontalAlignment="Stretch"
+                            HorizontalContentAlignment="Stretch"
+                            IsChecked="{x:Bind IsExpanded, Mode=OneWay}"
+                            Command="{utu:ItemsControlBinding Path=DataContext.ToggleThreadMessage}"
+                            CommandParameter="{x:Bind Key}"
+                            uen:Navigation.Request="{Binding MessageRoute, ElementName=ThreadViewRoot}"
+                            uen:Navigation.Data="{Binding}"
+                            AutomationProperties.Name="{x:Bind Announcement}">
+                <Grid ColumnSpacing="8">
+                  <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition />
+                    <ColumnDefinition Width="Auto" />
+                  </Grid.ColumnDefinitions>
+
+                  <Border Width="8"
+                          Height="8"
+                          CornerRadius="4"
+                          VerticalAlignment="Top"
+                          Margin="0,6,0,0"
+                          AutomationProperties.AccessibilityView="Raw"
+                          Background="{ThemeResource PrimaryBrush}"
+                          Visibility="{x:Bind IsUnread, Converter={StaticResource AffirmedVisibility}}" />
+
+                  <StackPanel Grid.Column="1"
+                              Spacing="2">
+                    <TextBlock Text="{x:Bind Author}"
+                               Style="{StaticResource BodyStrongTextBlockStyle}"
+                               Foreground="{ThemeResource OnSurfaceBrush}"
+                               AutomationProperties.AccessibilityView="Raw"
+                               TextTrimming="CharacterEllipsis" />
+
+                    <TextBlock Text="{x:Bind Contribution}"
+                               Style="{StaticResource CaptionTextBlockStyle}"
+                               Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                               AutomationProperties.AccessibilityView="Raw"
+                               TextTrimming="CharacterEllipsis"
+                               Visibility="{x:Bind HasContribution, Converter={StaticResource AffirmedVisibility}}" />
+                  </StackPanel>
+
+                  <StackPanel Grid.Column="2"
+                              Spacing="2"
+                              HorizontalAlignment="Right">
+                    <TextBlock Text="{x:Bind Written}"
+                               HorizontalAlignment="Right"
+                               Style="{StaticResource CaptionTextBlockStyle}"
+                               Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                               AutomationProperties.AccessibilityView="Raw" />
+
+                    <StackPanel Orientation="Horizontal"
+                                HorizontalAlignment="Right"
+                                Spacing="4">
+                      <FontIcon Glyph="&#xE172;"
+                                FontSize="12"
+                                AutomationProperties.AccessibilityView="Raw"
+                                Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                                Visibility="{x:Bind IsAnswered, Converter={StaticResource AffirmedVisibility}}" />
+
+                      <FontIcon Glyph="&#xE7C1;"
+                                FontSize="12"
+                                AutomationProperties.AccessibilityView="Raw"
+                                Foreground="{ThemeResource TertiaryBrush}"
+                                Visibility="{x:Bind IsFlagged, Converter={StaticResource AffirmedVisibility}}" />
+
+                      <FontIcon Glyph="&#xE723;"
+                                FontSize="12"
+                                AutomationProperties.AccessibilityView="Raw"
+                                Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                                Visibility="{x:Bind HasAttachments, Converter={StaticResource AffirmedVisibility}}" />
+
+                      <TextBlock Text="{x:Bind AttachmentCountText}"
+                                 Style="{StaticResource CaptionTextBlockStyle}"
+                                 AutomationProperties.AccessibilityView="Raw"
+                                 Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                                 Visibility="{x:Bind ShowsAttachmentCount, Converter={StaticResource AffirmedVisibility}}" />
+                    </StackPanel>
+                  </StackPanel>
+                </Grid>
+              </ToggleButton>
+
+              <StackPanel Margin="16,0,8,8"
+                          Spacing="8"
+                          Visibility="{x:Bind IsExpanded, Converter={StaticResource AffirmedVisibility}}">
+                <TextBlock Text="{x:Bind Recipients}"
+                           TextWrapping="Wrap"
+                           Style="{StaticResource CaptionTextBlockStyle}"
+                           Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                           Visibility="{x:Bind HasRecipients, Converter={StaticResource AffirmedVisibility}}" />
+
+                <TextBlock Text="{x:Bind Contribution}"
+                           TextWrapping="Wrap"
+                           IsTextSelectionEnabled="True"
+                           Style="{StaticResource BodyTextBlockStyle}"
+                           Foreground="{ThemeResource OnSurfaceBrush}"
+                           Visibility="{x:Bind HasContribution, Converter={StaticResource AffirmedVisibility}}" />
+
+                <TextBlock x:Uid="MailPage.TextBlock.NoContribution"
+                           TextWrapping="Wrap"
+                           Style="{StaticResource CaptionTextBlockStyle}"
+                           Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                           Visibility="{x:Bind AwaitsContribution, Converter={StaticResource AffirmedVisibility}}" />
+
+                <Button x:Uid="MailPage.Button.ShowWholeMessage"
+                        HorizontalAlignment="Left"
+                        Style="{StaticResource TextBlockButtonStyle}"
+                        Command="{utu:ItemsControlBinding Path=DataContext.ShowWholeThreadMessage}"
+                        CommandParameter="{x:Bind Key}"
+                        Visibility="{x:Bind OffersWholeMessage, Converter={StaticResource AffirmedVisibility}}" />
+
+                <ProgressBar IsIndeterminate="True"
+                             HorizontalAlignment="Stretch"
+                             Visibility="{x:Bind AwaitsWholeMessage, Converter={StaticResource AffirmedVisibility}}" />
+
+                <InfoBar x:Uid="MailPage.InfoBar.WholeMessageUnavailable"
+                         IsOpen="{x:Bind ShowsWholeMessageFailure, Mode=OneWay}"
+                         IsClosable="False"
+                         Severity="Warning">
+                  <InfoBar.ActionButton>
+                    <Button x:Uid="MailPage.Button.RetryWholeMessage"
+                            Command="{utu:ItemsControlBinding Path=DataContext.ShowWholeThreadMessage}"
+                            CommandParameter="{x:Bind Key}" />
+                  </InfoBar.ActionButton>
+                </InfoBar>
+
+                <reading:MailMessageView MaxHeight="640"
+                                         Reading="{x:Bind Message, Mode=OneWay}"
+                                         Body="{x:Bind WholeMessage, Mode=OneWay}"
+                                         Visibility="{x:Bind ShowsMessage, Converter={StaticResource AffirmedVisibility}}"
+                                         ShowRemoteContentCommand="{utu:ItemsControlBinding Path=DataContext.ShowThreadRemoteContent}"
+                                         ShowRemoteContentCommandParameter="{x:Bind Key}"
+                                         SaveAttachmentCommand="{utu:ItemsControlBinding Path=DataContext.SaveAttachment}"
+                                         CancelAttachmentCommand="{utu:ItemsControlBinding Path=DataContext.CancelAttachment}"
+                                         UseSelectionCommand="{utu:ItemsControlBinding Path=DataContext.UseBodySelection}" />
+              </StackPanel>
+            </StackPanel>
+          </DataTemplate>
+        </ListView.ItemTemplate>
+      </ListView>
+
+      <mvux:FeedView Source="{Binding ThreadMessages}">
+        <mvux:FeedView.ValueTemplate>
+          <DataTemplate>
+            <Border Height="0" />
+          </DataTemplate>
+        </mvux:FeedView.ValueTemplate>
+
+        <mvux:FeedView.ProgressTemplate>
+          <DataTemplate>
+            <ProgressBar IsIndeterminate="True"
+                         VerticalAlignment="Top"
+                         HorizontalAlignment="Stretch" />
+          </DataTemplate>
+        </mvux:FeedView.ProgressTemplate>
+
+        <mvux:FeedView.NoneTemplate>
+          <DataTemplate>
+            <Grid>
+              <spaces:SpacePlaceholder x:Uid="MailPage.Thread"
+                                       Visibility="{Binding Parent.Thread.IsClosed, Converter={StaticResource AffirmedVisibility}}" />
+
+              <InfoBar x:Uid="MailPage.InfoBar.NoThreadMessages"
+                       Margin="16"
+                       VerticalAlignment="Top"
+                       IsOpen="{Binding Parent.Thread.IsOpen}"
+                       IsClosable="False"
+                       Severity="Informational" />
+            </Grid>
+          </DataTemplate>
+        </mvux:FeedView.NoneTemplate>
+
+        <mvux:FeedView.ErrorTemplate>
+          <DataTemplate>
+            <InfoBar x:Uid="MailPage.InfoBar.ThreadUnavailable"
+                     Margin="16"
+                     VerticalAlignment="Top"
+                     IsOpen="True"
+                     IsClosable="False"
+                     Severity="Error">
+              <InfoBar.ActionButton>
+                <Button x:Uid="MailPage.Button.RetryThread"
+                        Command="{Binding Parent.RetryThread}" />
+              </InfoBar.ActionButton>
+            </InfoBar>
+          </DataTemplate>
+        </mvux:FeedView.ErrorTemplate>
+      </mvux:FeedView>
+    </Grid>
+
+    <StackPanel Grid.Row="2"
+                Padding="12,4,12,8"
+                Spacing="4">
+      <InfoBar x:Uid="MailPage.InfoBar.ThreadPageUnavailable"
+               IsOpen="{Binding ThreadPagingFailed}"
+               IsClosable="False"
+               Severity="Warning" />
+
+      <utu:LoadingView Source="{Binding ShowMoreThreadMessages}"
+                       Visibility="{Binding HasMoreThreadMessages, Converter={StaticResource AffirmedVisibility}}">
+        <utu:LoadingView.Content>
+          <Button x:Uid="MailPage.Button.ShowMoreThreadMessages"
+                  HorizontalAlignment="Stretch"
+                  Command="{Binding ShowMoreThreadMessages}"
+                  Style="{StaticResource TextBlockButtonStyle}" />
+        </utu:LoadingView.Content>
+
+        <utu:LoadingView.LoadingContent>
+          <ProgressBar IsIndeterminate="True"
+                       HorizontalAlignment="Stretch" />
+        </utu:LoadingView.LoadingContent>
+      </utu:LoadingView>
+    </StackPanel>
+  </Grid>
+</UserControl>

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailThreadView.xaml.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailThreadView.xaml.cs
@@ -1,0 +1,77 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Specialized;
+using MailFathom.Client.Presentation.Threads;
+
+namespace MailFathom.Client.Presentation.Spaces.Mail;
+
+/// <summary>The conversation shared by the wide companion column and the phone route.</summary>
+public sealed partial class MailThreadView : UserControl
+{
+    /// <summary>Identifies the route opened when the conversation's selection changes.</summary>
+    public static readonly DependencyProperty MessageRouteProperty = DependencyProperty.Register(
+        nameof(MessageRoute),
+        typeof(string),
+        typeof(MailThreadView),
+        new PropertyMetadata(string.Empty));
+
+    private string scrolledTo = string.Empty;
+
+    /// <summary>Initializes the conversation.</summary>
+    public MailThreadView() => this.InitializeComponent();
+
+    /// <summary>The route one selected message opens, or empty where the conversation remains the wide companion.</summary>
+    public string MessageRoute
+    {
+        get => (string)this.GetValue(MessageRouteProperty);
+        set => this.SetValue(MessageRouteProperty, value);
+    }
+
+    private void OnThreadLoaded(object sender, RoutedEventArgs args)
+    {
+        if (this.ThreadMessageRows.ItemsSource is INotifyCollectionChanged watchable)
+        {
+            watchable.CollectionChanged += this.OnThreadMessagesChanged;
+        }
+
+        this.BringOpenedMessageIntoView();
+    }
+
+    private void OnThreadUnloaded(object sender, RoutedEventArgs args)
+    {
+        if (this.ThreadMessageRows.ItemsSource is INotifyCollectionChanged watchable)
+        {
+            watchable.CollectionChanged -= this.OnThreadMessagesChanged;
+        }
+    }
+
+    private void OnThreadMessagesChanged(object? sender, NotifyCollectionChangedEventArgs args) =>
+        this.BringOpenedMessageIntoView();
+
+    private void BringOpenedMessageIntoView()
+    {
+        if (this.ThreadMessageRows.ItemsSource is not IEnumerable<object> rows)
+        {
+            return;
+        }
+
+        var opened = rows.OfType<ThreadMessageRow>().FirstOrDefault(static row => row.IsOpenedAt);
+
+        if (opened is null)
+        {
+            this.scrolledTo = string.Empty;
+
+            return;
+        }
+
+        if (string.Equals(opened.Key, this.scrolledTo, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        this.scrolledTo = opened.Key;
+        this.ThreadMessageRows.ScrollIntoView(opened);
+    }
+}

--- a/frontend/src/Client/Presentation/Threads/ThreadMessageRow.cs
+++ b/frontend/src/Client/Presentation/Threads/ThreadMessageRow.cs
@@ -63,6 +63,33 @@ public sealed partial record ThreadMessageRow(
     bool IsReadingWholeMessage,
     bool WholeMessageFailed)
 {
+    /// <summary>An undrawn row used while no message route is open.</summary>
+    internal static ThreadMessageRow Nothing { get; } = new(
+        string.Empty,
+        string.Empty,
+        string.Empty,
+        string.Empty,
+        string.Empty,
+        string.Empty,
+        string.Empty,
+        IsExpanded: false,
+        IsOpenedAt: false,
+        IsUnread: false,
+        IsFlagged: false,
+        IsAnswered: false,
+        HasAttachments: false,
+        AttachmentCount: 0,
+        Message: null,
+        WholeMessage: null,
+        IsReadingWholeMessage: false,
+        WholeMessageFailed: false);
+
+    /// <summary>Gets whether this is a message the route can draw.</summary>
+    public bool IsOpen => this.Key.Length > 0;
+
+    /// <summary>Gets whether the route has no message to draw.</summary>
+    public bool IsClosed => this.Key.Length is 0;
+
     /// <summary>Gets whether there is anything of what the message added to draw.</summary>
     /// <remarks>
     /// A message this deployment holds but has not extracted yet has none, which is an ordinary state of a mailbox
@@ -96,6 +123,10 @@ public sealed partial record ThreadMessageRow(
     /// </remarks>
     public bool OffersWholeMessage =>
         this.IsExpanded && this.WholeMessage is null && !this.IsReadingWholeMessage && !this.WholeMessageFailed;
+
+    /// <summary>Gets whether the phone's message screen may ask for the whole message.</summary>
+    public bool OffersStandaloneWholeMessage =>
+        this.WholeMessage is null && !this.IsReadingWholeMessage && !this.WholeMessageFailed;
 
     /// <summary>Gets whether the whole message is on its way, which is what the message says while it waits.</summary>
     public bool AwaitsWholeMessage => this.IsExpanded && this.IsReadingWholeMessage;

--- a/frontend/src/Client/Strings/en/Resources.resw
+++ b/frontend/src/Client/Strings/en/Resources.resw
@@ -441,6 +441,14 @@
     <value>Select a message to read the conversation it is part of.</value>
     <comment>Says what to do rather than that something is missing: nothing being open is the ordinary state of this column.</comment>
   </data>
+  <data name="MailPage.Message.Heading" xml:space="preserve">
+    <value>No message open</value>
+    <comment>Heads the phone-width message route while its conversation no longer names a message.</comment>
+  </data>
+  <data name="MailPage.Message.Detail" xml:space="preserve">
+    <value>Go back and choose a message from the conversation.</value>
+    <comment>Says how to leave an empty message route.</comment>
+  </data>
   <data name="MailPage.List.ThreadMessages.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Messages in this conversation</value>
     <comment>Names the list itself, so a screen reader announces what the messages belong to before it reads one.</comment>
@@ -552,6 +560,14 @@
   <data name="SettingsPage.Button.Back.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Back</value>
     <comment>Names the button that returns to the workspace, which carries an icon rather than words.</comment>
+  </data>
+  <data name="MailThreadPage.Button.Back.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Back to mail</value>
+    <comment>Names the icon button that returns from a conversation to the phone-width mail list.</comment>
+  </data>
+  <data name="MailMessagePage.Button.Back.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Back to conversation</value>
+    <comment>Names the icon button that returns from one message to its phone-width conversation.</comment>
   </data>
   <data name="SettingsPage.TextBlock.Title.Text" xml:space="preserve">
     <value>Settings</value>

--- a/frontend/src/Client/Strings/pl/Resources.resw
+++ b/frontend/src/Client/Strings/pl/Resources.resw
@@ -441,6 +441,14 @@
     <value>Wybierz wiadomość, aby przeczytać rozmowę, której jest częścią.</value>
     <comment>Says what to do rather than that something is missing: nothing being open is the ordinary state of this column.</comment>
   </data>
+  <data name="MailPage.Message.Heading" xml:space="preserve">
+    <value>Żadna wiadomość nie jest otwarta</value>
+    <comment>Heads the phone-width message route while its conversation no longer names a message.</comment>
+  </data>
+  <data name="MailPage.Message.Detail" xml:space="preserve">
+    <value>Wróć i wybierz wiadomość z rozmowy.</value>
+    <comment>Says how to leave an empty message route.</comment>
+  </data>
   <data name="MailPage.List.ThreadMessages.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Wiadomości w tej rozmowie</value>
     <comment>Names the list itself, so a screen reader announces what the messages belong to before it reads one.</comment>
@@ -552,6 +560,14 @@
   <data name="SettingsPage.Button.Back.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Wstecz</value>
     <comment>Names the button that returns to the workspace, which carries an icon rather than words.</comment>
+  </data>
+  <data name="MailThreadPage.Button.Back.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Wróć do poczty</value>
+    <comment>Names the icon button that returns from a conversation to the phone-width mail list.</comment>
+  </data>
+  <data name="MailMessagePage.Button.Back.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Wróć do rozmowy</value>
+    <comment>Names the icon button that returns from one message to its phone-width conversation.</comment>
   </data>
   <data name="SettingsPage.TextBlock.Title.Text" xml:space="preserve">
     <value>Ustawienia</value>

--- a/frontend/src/README.md
+++ b/frontend/src/README.md
@@ -44,13 +44,14 @@ message list described below, and Discover's and Cases' say they are empty until
 own page in.
 
 **Each space is a route, and so is everything else on screen.** `App.RegisterRoutes` nests `Discover`, `Mail`, and
-`Cases` inside the frame and registers `Settings` and `Connect` beside it, every one of them named once in
-`ClientRoutes`, so each is reachable and reloadable by its route — the
+`Cases` inside the frame and registers `MailThread`, `MailMessage`, `Settings`, and the two entry screens beside it,
+every one of them named once in `ClientRoutes`, so each is reachable and reloadable by its route — the
 browser opened at `/Workspace/Cases` lands on Cases with that space named on the bar. Because Uno's navigation is what
 moved there, the Android system back gesture and back key and the browser's back button all move back through the
-client's own screens rather than out of the application: going to settings and back returns to the space somebody left,
-not to the first one. A screen reached by swapping content by hand would be a screen neither of them knows about, which
-is why nothing here does that.
+client's own screens rather than out of the application: on a phone-width window a selected row opens its conversation,
+a selected conversation row opens its message, and each back returns one step; going to settings and back returns to
+the space somebody left, not to the first one. A screen reached by swapping content by hand would be a screen neither
+of them knows about, which is why nothing here does that.
 
 **Where a route is registered decides whether it can be returned from**, which is why settings is a level up rather
 than a fourth name beside the three. The spaces share one content area and are switched between, so moving among them
@@ -60,14 +61,16 @@ what puts the workspace behind it.
 **The composition follows the width of the window and never the platform.** Below 700 pixels the spaces are named on a
 bar along the bottom and the workspace is one column; at 700 that bar is replaced by a navigation rail beside the
 workspace; at 1000 the workspace itself opens a companion column, so what a space shows beside its main content stands
-next to it instead of being reached as a separate screen. The two widths are `WorkspaceRailWindowWidth` and
+next to it instead of being reached as a separate screen. Mail disables its row navigation at that second breakpoint:
+below it the list, conversation, and message are the route stack above; at and above it the list and the same
+`MailThreadView` share the workspace. The two widths are `WorkspaceRailWindowWidth` and
 `WorkspaceWideWindowWidth` in `App.xaml`, read by every adaptive trigger that acts on them, and the switch is
 `VisualStateManager` throughout: no code asks which platform is running, so a resized desktop window and a phone are
 the same case. `WorkspaceColumns` is the control that gives a space that workspace, so all three read the same at the
 same width. Content stays clear of a notch, a rounded corner, and a system bar through `utu:SafeArea.Insets`, stated at
-the root of the frame and again on the settings screen, which takes the whole surface rather than opening inside it.
-The soft keyboard is the one mask the toolkit supports on a `SafeArea` or a `ScrollViewer` alone, so it is stated as a
-control around the field this frame takes typing in.
+the root of the frame and again on every screen that takes the whole surface, including the conversation and message
+routes. The soft keyboard is the one mask the toolkit supports on a `SafeArea` or a `ScrollViewer` alone, so it is
+stated as a control around the field this frame takes typing in.
 
 **What travels with somebody between spaces is `IWorkspace`**, registered once for the run. It holds the question being
 composed and the scope that question would be asked against — an account, a folder within it or a special-use role
@@ -151,6 +154,13 @@ a forwarded copy is somewhere else again — so what is drawn is every folder of
 order. Where somebody arrived at a particular message, that message is the one opened and scrolled to; where they
 arrived at the conversation itself, the newest is.
 
+The view over that state is one `MailThreadView`, placed in the companion column on a wide window and on the
+`MailThread` route below the wide breakpoint. The latter gives its message list the `MailMessage` navigation request;
+the former gives it none, so choosing a conversation row expands it in place rather than leaving the multi-column
+workspace. Both route models resolve the same singleton list, conversation, workspace, and search, so filters,
+selection, position, account, and folder survive the change in composition instead of being reconstructed from a
+navigation payload.
+
 **What each message added arrived with the conversation, and the whole of one is a request somebody made.** A message
 collapses to a line and opens to what it contributed, which the deployment publishes with the quoted history and the
 signature trimmed off — so an exchange of thirty replies is one request to draw and the eighth reply does not redraw the
@@ -162,6 +172,11 @@ message, which is what keeps the question asked before a link is followed one pi
 that message drops the whole of it along with the answer about its remote pictures,
 so no allowance outlives the reason it was given. A page of the conversation that did not arrive, and a whole message
 that did not, are each said beside what is already drawn rather than instead of it.
+
+On the phone route the selected `ThreadMessageRow` is navigation data only long enough to name the row. `MailModel`
+projects that key back over the live `IMailThread.Messages` feed, so reading the whole body, revealing remote content,
+and attachment progress update the message route and the wide companion from one source rather than leaving a copied
+row behind.
 
 **Settings is reached from the frame rather than named among the spaces**, because it is not one. It is the screen that
 says which build is running and which deployment this client is pointed at, carries the two choices below and the way to

--- a/frontend/tests/Client.UnitTests/Presentation/Spaces/Mail/MailModelTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Spaces/Mail/MailModelTests.cs
@@ -9,6 +9,7 @@ using MailFathom.Client.Presentation.Messages;
 using MailFathom.Client.Presentation.Search;
 using MailFathom.Client.Presentation.Spaces.Mail;
 using MailFathom.Client.Presentation.Spaces.Mail.Reading;
+using MailFathom.Client.Presentation.Threads;
 using MailFathom.Client.Presentation.Workspace;
 using MailFathom.Client.Session;
 using MailFathom.Client.UnitTests.TestDoubles;
@@ -95,6 +96,55 @@ public sealed class MailModelTests
         Assert.Same(thread.Messages, model.ThreadMessages);
         Assert.Same(thread.HasMoreMessages, model.HasMoreThreadMessages);
         Assert.Same(thread.PagingFailed, model.ThreadPagingFailed);
+    }
+
+    /// <summary>The phone's message route reads the selected conversation row from the same run-wide thread as the wide composition.</summary>
+    [Fact]
+    public async Task OpenedThreadMessage_ANavigationRow_ReadsTheLiveRowFromTheRunsOwnConversation()
+    {
+        // Arrange
+        using var session = SessionOffering("mailfathom.mail.read");
+        var first = ThreadRow(1);
+        var navigation = ThreadRow(2);
+        var opened = navigation with { Contribution = "Updated after navigation" };
+        var thread = new StubMailThread(first, opened);
+        await using var model = new MailModel(
+            navigation,
+            session,
+            new StubMessageList(),
+            thread,
+            new StubWorkspace(),
+            new StubMailSearch());
+
+        // Act
+        var message = await model.OpenedThreadMessage;
+
+        // Assert
+        Assert.Same(opened, message);
+    }
+
+    /// <summary>The phone route can offer the whole-message read before the conversation row is expanded inline.</summary>
+    [Fact]
+    public void OffersStandaloneWholeMessage_ACollapsedConversationRow_OffersTheRead()
+    {
+        // Arrange
+        var message = ThreadRow(1);
+
+        // Act, Assert
+        Assert.True(message.OffersStandaloneWholeMessage);
+    }
+
+    /// <summary>The message route can distinguish a live row from the sentinel shown while none is open.</summary>
+    [Fact]
+    public void IsClosed_ARowWithoutAnIdentity_ReportsTheRouteAsClosed()
+    {
+        // Arrange
+        var opened = ThreadRow(1);
+        var closed = opened with { Key = string.Empty };
+
+        // Act, Assert
+        Assert.False(opened.IsClosed);
+        Assert.True(closed.IsClosed);
     }
 
     /// <summary>
@@ -432,6 +482,26 @@ public sealed class MailModelTests
         IsAnswered: false,
         HasAttachments: false,
         AttachmentCount: 0);
+
+    private static ThreadMessageRow ThreadRow(int number) => new(
+        MailMessages.Key(number),
+        "Someone",
+        "Quarterly review",
+        "Owner",
+        "What this one added",
+        "09:41",
+        "Someone, Quarterly review, 09:41",
+        IsExpanded: false,
+        IsOpenedAt: false,
+        IsUnread: false,
+        IsFlagged: false,
+        IsAnswered: false,
+        HasAttachments: false,
+        AttachmentCount: 0,
+        Message: null,
+        WholeMessage: null,
+        IsReadingWholeMessage: false,
+        WholeMessageFailed: false);
 
     private static StubClientSession SessionOffering(params string[] permissions) =>
         new(SessionStanding.Of(new DeploymentSession("MailFathom", "0.8.0", permissions)));


### PR DESCRIPTION
## Summary

- Reuse the same mail model and singleton workspace state for the wide three-column workspace and the narrow list-to-thread-to-message route stack.
- Extract the conversation into a shared view, add routed thread and message pages with back navigation and safe-area handling, and keep wide selection inline at the responsive breakpoint.
- Project routed message selection from the live conversation, localize the new navigation states, and document the responsive composition.

## Verification

- `scripts/verify-fast.sh` — 737 tests passed.
- `scripts/verify-full.sh` — build succeeded with 0 warnings, 737 tests passed, formatting changed 0 files, and 264 workflow contract checks passed.
- The desktop head started under an isolated Xvfb display and the browser head served from an ephemeral port. Runtime screenshots and visual-tree evidence could not be captured because the Uno App MCP was attached to another session's shared DevServer; restarting that foreign server would violate the repository's parallel-session isolation rule.

Closes #1165
