### PR TITLE
[#1362] Draw mail lists from FeedView Data so a successful answer is shown

### DIFF
--- a/frontend/src/Client/Presentation/Messages/DeploymentMessageList.cs
+++ b/frontend/src/Client/Presentation/Messages/DeploymentMessageList.cs
@@ -107,7 +107,7 @@ internal sealed class DeploymentMessageList : IMessageList
             Feed.Combine(standing, place, this.asked).SelectAsync(this.OpenAsync));
 
         this.Chosen = State<IImmutableList<MessageRow>>.Empty(this);
-        this.Rows = this.loaded.Select(this.Draw).AsListFeed().Selection(this.Chosen);
+        this.Rows = this.loaded.Select(this.Draw).AsListFeed();
         this.Arrangement = this.arranged;
         this.HasMoreAfter = this.loaded.Select(static window => window.HasMoreAfter);
         this.HasMoreBefore = this.loaded.Select(static window => window.HasMoreBefore);

--- a/frontend/src/Client/Presentation/Messages/IMessageList.cs
+++ b/frontend/src/Client/Presentation/Messages/IMessageList.cs
@@ -30,9 +30,11 @@ public interface IMessageList
 
     /// <summary>What is selected in the list, which the workspace scope is written from.</summary>
     /// <remarks>
-    /// Held as a state the selector writes rather than as something composed from clicks, because a multi-selection is
-    /// the platform's own gesture — the modifiers, the range, the drag, and the touch selection mode all belong to the
-    /// control, and a list that reimplemented them would feel like neither platform.
+    /// Held as a state the list control writes rather than as something composed from clicks, because a multi-selection
+    /// is the platform's own gesture — the modifiers, the range, the drag, and the touch selection mode all belong to
+    /// the control, and a list that reimplemented them would feel like neither platform. The write is the view's, not
+    /// MVUX's <c>Selection</c> operator: that operator keeps a list feed transient until a selector attaches, and the
+    /// selector lives inside the <c>FeedView</c> that is waiting for the feed to leave progress.
     /// </remarks>
     IState<IImmutableList<MessageRow>> Chosen { get; }
 

--- a/frontend/src/Client/Presentation/Search/MailSearchView.xaml
+++ b/frontend/src/Client/Presentation/Search/MailSearchView.xaml
@@ -4,6 +4,7 @@ Licensed under the Apache License, Version 2.0. See LICENSE in the project root 
 Project repository: https://github.com/Krzysztof318/MailFathom
 -->
 <UserControl x:Class="MailFathom.Client.Presentation.Search.MailSearchView"
+             x:Name="SearchViewRoot"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:messages="using:MailFathom.Client.Presentation.Messages"
@@ -179,28 +180,26 @@ Project repository: https://github.com/Krzysztof318/MailFathom
                Severity="Warning" />
     </StackPanel>
 
-    <Grid Grid.Row="4">
-      <ListView x:Uid="MailSearchView.List.Results"
-                ItemsSource="{Binding SearchResults}"
-                SelectionMode="Single"
-                IsItemClickEnabled="True"
-                utu:CommandExtensions.Command="{Binding OpenSearchResult}"
-                Padding="4,0,4,12">
-        <ListView.ItemTemplate>
-          <DataTemplate x:DataType="messages:MessageRow">
-            <messages:MessageRowView Row="{x:Bind}" />
-          </DataTemplate>
-        </ListView.ItemTemplate>
-      </ListView>
+    <mvux:FeedView Grid.Row="4"
+                   Source="{Binding SearchResults}">
+      <mvux:FeedView.ValueTemplate>
+        <DataTemplate>
+          <ListView x:Uid="MailSearchView.List.Results"
+                    ItemsSource="{Binding Data}"
+                    SelectionMode="Single"
+                    IsItemClickEnabled="True"
+                    utu:CommandExtensions.Command="{Binding DataContext.OpenSearchResult, ElementName=SearchViewRoot}"
+                    Padding="4,0,4,12">
+            <ListView.ItemTemplate>
+              <DataTemplate x:DataType="messages:MessageRow">
+                <messages:MessageRowView Row="{x:Bind}" />
+              </DataTemplate>
+            </ListView.ItemTemplate>
+          </ListView>
+        </DataTemplate>
+      </mvux:FeedView.ValueTemplate>
 
-      <mvux:FeedView Source="{Binding SearchResults}">
-        <mvux:FeedView.ValueTemplate>
-          <DataTemplate>
-            <Border Height="0" />
-          </DataTemplate>
-        </mvux:FeedView.ValueTemplate>
-
-        <mvux:FeedView.ProgressTemplate>
+      <mvux:FeedView.ProgressTemplate>
           <DataTemplate>
             <ProgressBar IsIndeterminate="True"
                          VerticalAlignment="Top"
@@ -247,7 +246,6 @@ Project repository: https://github.com/Krzysztof318/MailFathom
           </DataTemplate>
         </mvux:FeedView.ErrorTemplate>
       </mvux:FeedView>
-    </Grid>
 
     <StackPanel Grid.Row="5"
                 Padding="12,4,12,8"

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailModel.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailModel.cs
@@ -133,6 +133,23 @@ public partial record MailModel
     /// <summary>What is selected in the list, which is what the rest of the client reads as the scope of a question.</summary>
     public IState<IImmutableList<MessageRow>> Chosen => this.messages.Chosen;
 
+    /// <summary>Makes the rows selected in the list the application's selection, which is what every other space reads as the scope of a question.</summary>
+    /// <param name="chosen">The rows selected in the list, or none.</param>
+    /// <param name="cancellationToken">Abandons the change.</param>
+    /// <returns>A task completing once the selection has been written.</returns>
+    /// <remarks>
+    /// Written from the list control rather than through MVUX's <c>Selection</c> operator, because that operator keeps
+    /// the list feed transient until a selector attaches, and the list is drawn through a <c>FeedView</c> whose value
+    /// template is the selector — a feed that stayed transient would never leave progress, which is a blank Mail space
+    /// after the deployment has already answered.
+    /// </remarks>
+    public ValueTask ChooseAsync(IImmutableList<MessageRow> chosen, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(chosen);
+
+        return this.Chosen.UpdateAsync(_ => chosen, cancellationToken);
+    }
+
     /// <summary>Whether there is more mail after what is loaded.</summary>
     public IFeed<bool> HasMoreAfter => this.messages.HasMoreAfter;
 

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailPage.xaml
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailPage.xaml
@@ -4,6 +4,7 @@ Licensed under the Apache License, Version 2.0. See LICENSE in the project root 
 Project repository: https://github.com/Krzysztof318/MailFathom
 -->
 <Page x:Class="MailFathom.Client.Presentation.Spaces.Mail.MailPage"
+      x:Name="MailRoot"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:mvux="using:Uno.Extensions.Reactive.UI"
@@ -24,7 +25,7 @@ Project repository: https://github.com/Krzysztof318/MailFathom
             <AdaptiveTrigger MinWindowWidth="{StaticResource WorkspaceWideWindowWidth}" />
           </VisualState.StateTriggers>
           <VisualState.Setters>
-            <Setter Target="MessageRows.(uen:Navigation.Request)" Value="" />
+            <Setter Target="MailRoot.ThreadNavigationRequest" Value="" />
           </VisualState.Setters>
         </VisualState>
       </VisualStateGroup>
@@ -133,43 +134,33 @@ Project repository: https://github.com/Krzysztof318/MailFathom
                   Style="{StaticResource TextBlockButtonStyle}"
                   Visibility="{Binding HasMoreBefore, Converter={StaticResource AffirmedVisibility}}" />
 
-          <Grid Grid.Row="2">
-            <!-- One virtualized list over a bounded window. The panel realizes the rows on screen rather than the rows
-                 loaded, and the window bounds what is loaded rather than what has been scrolled past, so message forty
-                 thousand of a folder costs what message one costs. Every row carries its own key, so a page arriving
-                 updates the rows it changed and leaves the containers of the rest — and what was selected stays
-                 selected.
+          <mvux:FeedView Grid.Row="2"
+                         Source="{Binding Messages}">
+            <!-- The list is drawn from the feed's value the way the mailbox tree is: a ListView bound to the feed
+                 itself sits empty on the browser head after the deployment has already answered, because that head
+                 does not expose an IListFeed as an items source the way a FeedView's Data does. -->
+            <mvux:FeedView.ValueTemplate>
+              <DataTemplate>
+                <ListView x:Uid="MailPage.List.Messages"
+                          ItemsSource="{Binding Data}"
+                          uen:Navigation.Request="{Binding ThreadNavigationRequest, ElementName=MailRoot}"
+                          SelectionMode="Extended"
+                          IsItemClickEnabled="False"
+                          Loaded="OnMessageRowsLoaded"
+                          Unloaded="OnMessageRowsUnloaded"
+                          SelectionChanged="OnMessageRowsSelectionChanged"
+                          Holding="OnRowHeld"
+                          Padding="4,0,4,12">
+                  <ListView.ItemTemplate>
+                    <DataTemplate x:DataType="messages:MessageRow">
+                      <messages:MessageRowView Row="{x:Bind}" />
+                    </DataTemplate>
+                  </ListView.ItemTemplate>
+                </ListView>
+              </DataTemplate>
+            </mvux:FeedView.ValueTemplate>
 
-                 Extended is the selection a pointer expects: the modifiers, the range, the drag, and the keyboard all
-                 belong to the control rather than to anything written here, and a touch head reaches a multiple
-                 selection through the long press below. What comes out of it is the workspace scope, which is what
-                 makes selecting four messages the scope of the next question rather than a highlight. -->
-            <ListView x:Name="MessageRows"
-                      x:Uid="MailPage.List.Messages"
-                      ItemsSource="{Binding Messages}"
-                      uen:Navigation.Request="MailThread"
-                      SelectionMode="Extended"
-                      IsItemClickEnabled="False"
-                      Holding="OnRowHeld"
-                      Padding="4,0,4,12">
-              <ListView.ItemTemplate>
-                <DataTemplate x:DataType="messages:MessageRow">
-                  <messages:MessageRowView Row="{x:Bind}" />
-                </DataTemplate>
-              </ListView.ItemTemplate>
-            </ListView>
-
-            <!-- The three states the list genuinely has, rendered by the feed rather than remembered by this page. Its
-                 value template draws nothing, because the list above is what draws a list that arrived — the same
-                 arrangement the frame uses for the session it is composed over. -->
-            <mvux:FeedView Source="{Binding Messages}">
-              <mvux:FeedView.ValueTemplate>
-                <DataTemplate>
-                  <Border Height="0" />
-                </DataTemplate>
-              </mvux:FeedView.ValueTemplate>
-
-              <mvux:FeedView.ProgressTemplate>
+            <mvux:FeedView.ProgressTemplate>
                 <DataTemplate>
                   <ProgressBar IsIndeterminate="True"
                                VerticalAlignment="Top"
@@ -219,7 +210,6 @@ Project repository: https://github.com/Krzysztof318/MailFathom
                 </DataTemplate>
               </mvux:FeedView.ErrorTemplate>
             </mvux:FeedView>
-          </Grid>
 
           <StackPanel Grid.Row="3"
                       Padding="12,4,12,8"

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailPage.xaml.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailPage.xaml.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Collections.Immutable;
+using MailFathom.Client.Presentation.Messages;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml.Input;
 
@@ -12,14 +14,30 @@ namespace MailFathom.Client.Presentation.Spaces.Mail;
 /// The handlers below are the list controls' own behaviour rather than the space's: which selection mode a selector is
 /// in is a fact about this window and this input device, and where a list is scrolled to is a fact about a viewport.
 /// Neither is about the mail somebody is reading. What comes <em>out</em> of a selection is the model's, and it goes
-/// into the workspace scope — so nothing here reads or writes what is selected.
+/// into the workspace scope — so nothing here reads the selection, it only writes it.
 /// </remarks>
 public sealed partial class MailPage : Page
 {
+    /// <summary>Identifies <see cref="ThreadNavigationRequest"/>.</summary>
+    public static readonly DependencyProperty ThreadNavigationRequestProperty = DependencyProperty.Register(
+        nameof(ThreadNavigationRequest),
+        typeof(string),
+        typeof(MailPage),
+        new PropertyMetadata("MailThread"));
+
+    private ListView? messageRows;
+
     /// <summary>Initializes the space.</summary>
     public MailPage()
     {
         this.InitializeComponent();
+    }
+
+    /// <summary>The route a selected row opens, or empty where the wide companion already holds the conversation.</summary>
+    public string ThreadNavigationRequest
+    {
+        get => (string)this.GetValue(ThreadNavigationRequestProperty);
+        set => this.SetValue(ThreadNavigationRequestProperty, value);
     }
 
     /// <summary>Puts the list into the selection a touch head reaches by pressing and holding a row.</summary>
@@ -39,8 +57,13 @@ public sealed partial class MailPage : Page
     }
 
     /// <summary>Offers the selection several rows at a time, which is what a tap does in this mode.</summary>
-    private void OnSelectingMany(object sender, RoutedEventArgs args) =>
-        this.MessageRows.SelectionMode = ListViewSelectionMode.Multiple;
+    private void OnSelectingMany(object sender, RoutedEventArgs args)
+    {
+        if (this.messageRows is { } list)
+        {
+            list.SelectionMode = ListViewSelectionMode.Multiple;
+        }
+    }
 
     /// <summary>Returns the list to the selection a pointer expects, keeping nothing that was chosen in the other one.</summary>
     /// <remarks>
@@ -50,7 +73,35 @@ public sealed partial class MailPage : Page
     /// </remarks>
     private void OnSelectingOne(object sender, RoutedEventArgs args)
     {
-        this.MessageRows.SelectedItems.Clear();
-        this.MessageRows.SelectionMode = ListViewSelectionMode.Extended;
+        if (this.messageRows is not { } list)
+        {
+            return;
+        }
+
+        list.SelectedItems.Clear();
+        list.SelectionMode = ListViewSelectionMode.Extended;
+    }
+
+    private void OnMessageRowsLoaded(object sender, RoutedEventArgs args) =>
+        this.messageRows = (ListView)sender;
+
+    private void OnMessageRowsUnloaded(object sender, RoutedEventArgs args)
+    {
+        if (ReferenceEquals(this.messageRows, sender))
+        {
+            this.messageRows = null;
+        }
+    }
+
+    private async void OnMessageRowsSelectionChanged(object sender, SelectionChangedEventArgs args)
+    {
+        if (sender is not ListView list || this.DataContext is not MailViewModel model)
+        {
+            return;
+        }
+
+        IImmutableList<MessageRow> chosen = [.. list.SelectedItems.OfType<MessageRow>()];
+
+        await model.Model.ChooseAsync(chosen, CancellationToken.None);
     }
 }

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailThreadView.xaml
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailThreadView.xaml
@@ -81,15 +81,17 @@ Project repository: https://github.com/Krzysztof318/MailFathom
                Severity="Informational" />
     </StackPanel>
 
-    <Grid Grid.Row="1">
-      <ListView x:Name="ThreadMessageRows"
-                x:Uid="MailPage.List.ThreadMessages"
-                ItemsSource="{Binding ThreadMessages}"
-                SelectionMode="Single"
-                IsItemClickEnabled="False"
-                Loaded="OnThreadLoaded"
-                Unloaded="OnThreadUnloaded"
-                Padding="4,0,4,12">
+    <mvux:FeedView Grid.Row="1"
+                   Source="{Binding ThreadMessages}">
+      <mvux:FeedView.ValueTemplate>
+        <DataTemplate>
+          <ListView x:Uid="MailPage.List.ThreadMessages"
+                    ItemsSource="{Binding Data}"
+                    SelectionMode="Single"
+                    IsItemClickEnabled="False"
+                    Loaded="OnThreadLoaded"
+                    Unloaded="OnThreadUnloaded"
+                    Padding="4,0,4,12">
         <ListView.ItemTemplate>
           <DataTemplate x:DataType="threads:ThreadMessageRow">
             <StackPanel Spacing="4">
@@ -97,7 +99,7 @@ Project repository: https://github.com/Krzysztof318/MailFathom
                             HorizontalAlignment="Stretch"
                             HorizontalContentAlignment="Stretch"
                             IsChecked="{x:Bind IsExpanded, Mode=OneWay}"
-                            Command="{utu:ItemsControlBinding Path=DataContext.ToggleThreadMessage}"
+                            Command="{Binding DataContext.ToggleThreadMessage, ElementName=ThreadViewRoot}"
                             CommandParameter="{x:Bind Key}"
                             uen:Navigation.Request="{Binding MessageRoute, ElementName=ThreadViewRoot}"
                             uen:Navigation.Data="{Binding}"
@@ -199,7 +201,7 @@ Project repository: https://github.com/Krzysztof318/MailFathom
                 <Button x:Uid="MailPage.Button.ShowWholeMessage"
                         HorizontalAlignment="Left"
                         Style="{StaticResource TextBlockButtonStyle}"
-                        Command="{utu:ItemsControlBinding Path=DataContext.ShowWholeThreadMessage}"
+                        Command="{Binding DataContext.ShowWholeThreadMessage, ElementName=ThreadViewRoot}"
                         CommandParameter="{x:Bind Key}"
                         Visibility="{x:Bind OffersWholeMessage, Converter={StaticResource AffirmedVisibility}}" />
 
@@ -213,7 +215,7 @@ Project repository: https://github.com/Krzysztof318/MailFathom
                          Severity="Warning">
                   <InfoBar.ActionButton>
                     <Button x:Uid="MailPage.Button.RetryWholeMessage"
-                            Command="{utu:ItemsControlBinding Path=DataContext.ShowWholeThreadMessage}"
+                            Command="{Binding DataContext.ShowWholeThreadMessage, ElementName=ThreadViewRoot}"
                             CommandParameter="{x:Bind Key}" />
                   </InfoBar.ActionButton>
                 </InfoBar>
@@ -222,23 +224,18 @@ Project repository: https://github.com/Krzysztof318/MailFathom
                                          Reading="{x:Bind Message, Mode=OneWay}"
                                          Body="{x:Bind WholeMessage, Mode=OneWay}"
                                          Visibility="{x:Bind ShowsMessage, Converter={StaticResource AffirmedVisibility}}"
-                                         ShowRemoteContentCommand="{utu:ItemsControlBinding Path=DataContext.ShowThreadRemoteContent}"
+                                         ShowRemoteContentCommand="{Binding DataContext.ShowThreadRemoteContent, ElementName=ThreadViewRoot}"
                                          ShowRemoteContentCommandParameter="{x:Bind Key}"
-                                         SaveAttachmentCommand="{utu:ItemsControlBinding Path=DataContext.SaveAttachment}"
-                                         CancelAttachmentCommand="{utu:ItemsControlBinding Path=DataContext.CancelAttachment}"
-                                         UseSelectionCommand="{utu:ItemsControlBinding Path=DataContext.UseBodySelection}" />
+                                         SaveAttachmentCommand="{Binding DataContext.SaveAttachment, ElementName=ThreadViewRoot}"
+                                         CancelAttachmentCommand="{Binding DataContext.CancelAttachment, ElementName=ThreadViewRoot}"
+                                         UseSelectionCommand="{Binding DataContext.UseBodySelection, ElementName=ThreadViewRoot}" />
               </StackPanel>
             </StackPanel>
           </DataTemplate>
         </ListView.ItemTemplate>
-      </ListView>
-
-      <mvux:FeedView Source="{Binding ThreadMessages}">
-        <mvux:FeedView.ValueTemplate>
-          <DataTemplate>
-            <Border Height="0" />
-          </DataTemplate>
-        </mvux:FeedView.ValueTemplate>
+          </ListView>
+        </DataTemplate>
+      </mvux:FeedView.ValueTemplate>
 
         <mvux:FeedView.ProgressTemplate>
           <DataTemplate>
@@ -279,8 +276,7 @@ Project repository: https://github.com/Krzysztof318/MailFathom
             </InfoBar>
           </DataTemplate>
         </mvux:FeedView.ErrorTemplate>
-      </mvux:FeedView>
-    </Grid>
+    </mvux:FeedView>
 
     <StackPanel Grid.Row="2"
                 Padding="12,4,12,8"

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailThreadView.xaml.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailThreadView.xaml.cs
@@ -18,6 +18,7 @@ public sealed partial class MailThreadView : UserControl
         new PropertyMetadata(string.Empty));
 
     private string scrolledTo = string.Empty;
+    private ListView? threadMessageRows;
 
     /// <summary>Initializes the conversation.</summary>
     public MailThreadView() => this.InitializeComponent();
@@ -31,7 +32,9 @@ public sealed partial class MailThreadView : UserControl
 
     private void OnThreadLoaded(object sender, RoutedEventArgs args)
     {
-        if (this.ThreadMessageRows.ItemsSource is INotifyCollectionChanged watchable)
+        this.threadMessageRows = (ListView)sender;
+
+        if (this.threadMessageRows.ItemsSource is INotifyCollectionChanged watchable)
         {
             watchable.CollectionChanged += this.OnThreadMessagesChanged;
         }
@@ -41,10 +44,12 @@ public sealed partial class MailThreadView : UserControl
 
     private void OnThreadUnloaded(object sender, RoutedEventArgs args)
     {
-        if (this.ThreadMessageRows.ItemsSource is INotifyCollectionChanged watchable)
+        if (this.threadMessageRows is { } list && list.ItemsSource is INotifyCollectionChanged watchable)
         {
             watchable.CollectionChanged -= this.OnThreadMessagesChanged;
         }
+
+        this.threadMessageRows = null;
     }
 
     private void OnThreadMessagesChanged(object? sender, NotifyCollectionChangedEventArgs args) =>
@@ -52,7 +57,7 @@ public sealed partial class MailThreadView : UserControl
 
     private void BringOpenedMessageIntoView()
     {
-        if (this.ThreadMessageRows.ItemsSource is not IEnumerable<object> rows)
+        if (this.threadMessageRows?.ItemsSource is not IEnumerable<object> rows)
         {
             return;
         }
@@ -72,6 +77,6 @@ public sealed partial class MailThreadView : UserControl
         }
 
         this.scrolledTo = opened.Key;
-        this.ThreadMessageRows.ScrollIntoView(opened);
+        this.threadMessageRows.ScrollIntoView(opened);
     }
 }

--- a/frontend/src/README.md
+++ b/frontend/src/README.md
@@ -132,7 +132,9 @@ when the message selection changes, and is never written to the mailbox memory. 
 ordinary extended selection with its modifiers and its drag, and on a touch head a press and hold puts the list into a
 selecting mode that is visible and can be left. Loading, a read that failed, a folder holding no mail,
 and a folder whose mail this list is keeping out are four rendered states rather than one blank list — the last two are
-told apart in words, and how current the copy is stays the tree's to say.
+told apart in words, and how current the copy is stays the tree's to say. Those states are a `FeedView` whose value
+template is the list itself, bound to `Data`, the way the mailbox tree is: a `ListView` bound to the feed as its items
+source draws nothing on the browser head after the deployment has already answered.
 
 **Search is the other list in Mail, and it is the run's own as well.** It starts at the account and folder the mailbox
 tree put in force, then keeps every constraint in front of the reader: account, folder, sender, recipient, both ends of

--- a/frontend/tests/Client.UnitTests/Presentation/Messages/DeploymentMessageListTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Messages/DeploymentMessageListTests.cs
@@ -44,6 +44,47 @@ public sealed class DeploymentMessageListTests
         Assert.DoesNotContain("cursor=", asked.Query, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// A place holding no mail is an answer rather than a wait: the list leaves progress so the empty-folder state can
+    /// be drawn instead of looking like a request that never came back.
+    /// </summary>
+    [Fact]
+    public async Task Rows_ADeploymentAnsweringWithNoMail_LeavesProgressAndDrawsNothing()
+    {
+        // Arrange
+        using var over = await ListOver.CreateAsync(
+            _ => Answer(Page(1, 0, next: null, previous: null)),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Act
+        var rows = await over.List.Rows;
+
+        // Assert
+        Assert.NotNull(rows);
+        Assert.Empty(rows);
+        Assert.Single(over.Harness.Deployment.Requests);
+    }
+
+    /// <summary>
+    /// A leading page that did not arrive is the list's own failure, so a retryable error can be drawn instead of
+    /// waiting on an answer that will not come.
+    /// </summary>
+    [Fact]
+    public async Task Rows_ALeadingPageThatDidNotArrive_IsTheListsOwnFailure()
+    {
+        // Arrange
+        using var over = await ListOver.CreateAsync(
+            _ => StubTransport.JsonResponse("{}", HttpStatusCode.InternalServerError),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Act
+        var failure = await Assert.ThrowsAsync<DeploymentFailure>(async () => await over.List.Rows);
+
+        // Assert
+        Assert.Equal(DeploymentFailureReason.Unusable, failure.Reason);
+        Assert.Single(over.Harness.Deployment.Requests);
+    }
+
     /// <summary>The place somebody narrowed to is what the deployment is asked about, rather than every mailbox.</summary>
     [Fact]
     public async Task Rows_AScopeNarrowedToAFolder_AsksTheDeploymentAboutThatFolder()

--- a/frontend/tests/Client.UnitTests/Presentation/Spaces/Mail/MailModelTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Spaces/Mail/MailModelTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Collections.Immutable;
 using MailFathom.Client.Backend;
 using MailFathom.Client.Backend.Search;
 using MailFathom.Client.Backend.Timeline;
@@ -72,6 +73,32 @@ public sealed class MailModelTests
         Assert.Equal([MailMessages.Key(1), MailMessages.Key(2)], rows!.Select(row => row.Key));
         Assert.Same(list.Chosen, model.Chosen);
         Assert.Same(list.PagingFailed, model.PagingFailed);
+    }
+
+    /// <summary>
+    /// Selecting in the list is the application's selection rather than the control's, so a question asked next is
+    /// asked about the rows somebody picked.
+    /// </summary>
+    [Fact]
+    public async Task ChooseAsync_RowsSomebodySelected_ReachTheListAsWhatIsChosen()
+    {
+        // Arrange
+        using var session = SessionOffering("mailfathom.mail.read");
+        var list = new StubMessageList(Row(1), Row(2));
+        await using var model = new MailModel(
+            session,
+            list,
+            new StubMailThread(),
+            new StubWorkspace(),
+            new StubMailSearch());
+        var rows = await model.Messages;
+
+        // Act
+        await model.ChooseAsync(ImmutableList.Create(rows![0]), TestContext.Current.CancellationToken);
+
+        // Assert
+        var chosen = await model.Chosen;
+        Assert.Equal([MailMessages.Key(1)], chosen!.Select(row => row.Key));
     }
 
     /// <summary>
@@ -467,6 +494,24 @@ public sealed class MailModelTests
             () => new MailModel(session, new StubMessageList(), new StubMailThread(), null!, new StubMailSearch()));
         Assert.Throws<ArgumentNullException>(
             () => new MailModel(session, new StubMessageList(), new StubMailThread(), new StubWorkspace(), null!));
+    }
+
+    /// <summary>A selection nobody named is a caller's mistake rather than a list with nothing chosen.</summary>
+    [Fact]
+    public async Task ChooseAsync_AMissingSelection_IsRefused()
+    {
+        // Arrange
+        using var session = SessionOffering("mailfathom.mail.read");
+        await using var model = new MailModel(
+            session,
+            new StubMessageList(),
+            new StubMailThread(),
+            new StubWorkspace(),
+            new StubMailSearch());
+
+        // Act, Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => model.ChooseAsync(null!, TestContext.Current.CancellationToken).AsTask());
     }
 
     private static MessageRow Row(int number) => new(


### PR DESCRIPTION
Closes #1362

## What changes

The Aspire browser topology was already answering: login, session, folders, and the timeline route all succeed. Mail still drew nothing because the list, search results, and conversation bound a `ListView` to the `IListFeed` itself beside a `FeedView` whose value template was an empty border.

The mailbox tree — the one list that does show after sign-in — already draws its rows from the `FeedView` value template bound to `Data`. Mail, search, and thread now do the same. Selection is written from the list control into `MailModel.ChooseAsync` rather than through MVUX's `Selection` operator, which keeps a list feed transient until a selector attaches, and the selector now lives inside the template that was waiting for that feed to leave progress.

Desktop startup route selection is already covered by the default-route test from #1363. This change is the remaining half of #1362: a successful timeline, an empty one, and a failed one all leave progress.

## How it was verified

- `bash scripts/verify-full.sh` passed on this branch, based on current `origin/main`.
- Added `DeploymentMessageListTests` for an empty leading page and a refused leading page, and `MailModelTests` for `ChooseAsync`.
- 742 client unit tests passed.
- Could not exercise the Aspire browser head end to end in this session; the binding is the same shape the mailbox tree already uses on that head.

## Checklist

- [x] `bash scripts/verify-full.sh` passes on this branch, rebased onto current `main`.
- [x] Behavior changes are covered by unit tests, and the coverage gate passes.
- [x] Affected documentation is updated in this change set.
- [x] `bash scripts/review-obligations.sh` was run, and every row it reported is answered — by a test, by a page, or by why nothing is owed there.
- [x] `CHANGELOG.md` is untouched — it is written by the release pull request alone.
- [x] Every new C# file carries the repository's standard header, applied by `scripts/verify-fast.sh` rather than typed, and no file gained a second copyright line, an author tag, a name, or a contact detail.
- [x] Nothing here is under terms MailFathom could not distribute under Apache-2.0. A new dependency, service, container image, or externally sourced sample has its row in `THIRD_PARTY_LICENSES.md` in this change set.
- [x] No credential, token, private key, real mailbox data, or personal information is in the diff.