### PR TITLE
[#1368] Honour the drawing terminal and run AppHost http without TLS

### DIFF
--- a/backend/src/AppHost/Properties/launchSettings.json
+++ b/backend/src/AppHost/Properties/launchSettings.json
@@ -6,7 +6,9 @@
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "environmentVariables": {
-        "DOTNET_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
     }
   }

--- a/backend/src/Cli/Output/CliRenderer.cs
+++ b/backend/src/Cli/Output/CliRenderer.cs
@@ -46,9 +46,12 @@ internal sealed class CliRenderer
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
     /// <remarks>
     /// The console is built over the writer it was given rather than over the process's own, so what is drawn is
-    /// assertable: a test hands it a string writer and reads back the bytes an operator would have seen. Interaction is
-    /// off because nothing here prompts — a question is asked by <see cref="ICliConsole.Confirm" />, which reads the
-    /// answer as a line and needs no cursor.
+    /// assertable: a test hands it a string writer and reads back the bytes an operator would have seen. ANSI support
+    /// follows <paramref name="terminal" /> rather than Spectre.Console's detector, because
+    /// <see cref="CliTerminal.Decide" /> has already honoured <c>NO_COLOR</c> and a redirected stream: detecting again
+    /// would let the process environment veto a drawing a test constructed as coloured. Interaction is off because
+    /// nothing here prompts — a question is asked by <see cref="ICliConsole.Confirm" />, which reads the answer as a
+    /// line and needs no cursor.
     /// </remarks>
     internal CliRenderer(TextWriter writer, CliTerminal terminal)
     {
@@ -57,8 +60,8 @@ internal sealed class CliRenderer
 
         this.console = AnsiConsole.Create(new AnsiConsoleSettings
         {
-            Ansi = terminal.PermitsColour ? AnsiSupport.Detect : AnsiSupport.No,
-            ColorSystem = terminal.PermitsColour ? ColorSystemSupport.Detect : ColorSystemSupport.NoColors,
+            Ansi = terminal.PermitsColour ? AnsiSupport.Yes : AnsiSupport.No,
+            ColorSystem = terminal.PermitsColour ? ColorSystemSupport.TrueColor : ColorSystemSupport.NoColors,
             Interactive = InteractionSupport.No,
             Out = new AnsiConsoleOutput(new TrimmedLineWriter(writer)),
         });

--- a/backend/tests/AppHost.UnitTests/AppHost.UnitTests.csproj
+++ b/backend/tests/AppHost.UnitTests/AppHost.UnitTests.csproj
@@ -13,5 +13,6 @@
     <Compile Include="..\..\src\AppHost\OrchestrationContract.cs" Link="OrchestrationContract.cs" />
     <Compile Include="..\..\src\AppHost\DevelopmentCredentialProvisioner.cs" Link="DevelopmentCredentialProvisioner.cs" />
     <None Include="..\..\src\AppHost\Program.cs" CopyToOutputDirectory="PreserveNewest" Link="Build\Program.cs" />
+    <None Include="..\..\src\AppHost\Properties\launchSettings.json" CopyToOutputDirectory="PreserveNewest" Link="Build\launchSettings.json" />
   </ItemGroup>
 </Project>

--- a/backend/tests/AppHost.UnitTests/AppHostHttpLaunchProfileTests.cs
+++ b/backend/tests/AppHost.UnitTests/AppHostHttpLaunchProfileTests.cs
@@ -1,0 +1,39 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text.Json;
+using Xunit;
+
+namespace MailFathom.AppHost.UnitTests;
+
+/// <summary>Covers the launch profile the AppHost actually starts under locally.</summary>
+public sealed class AppHostHttpLaunchProfileTests
+{
+    /// <summary>
+    /// The documentation says there is no local TLS listener. Aspire still allocates an HTTPS dashboard unless the
+    /// profile that is named <c>http</c> says it may run unsecured, and a machine whose development certificate is
+    /// present but untrusted then fails while allocating <c>aspire-dashboard-https</c>.
+    /// </summary>
+    [Fact]
+    public void HttpProfile_AllowsUnsecuredTransportAndNamesNoHttpsDashboard()
+    {
+        // Arrange
+        using var document = JsonDocument.Parse(
+            File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Build", "launchSettings.json")));
+        var http = document.RootElement.GetProperty("profiles").GetProperty("http");
+        var environment = http.GetProperty("environmentVariables");
+
+        // Act
+        var allowsUnsecured = environment.GetProperty("ASPIRE_ALLOW_UNSECURED_TRANSPORT").GetString();
+        var applicationUrl = http.TryGetProperty("applicationUrl", out var url) ? url.GetString() : null;
+
+        // Assert
+        Assert.Equal("true", allowsUnsecured, StringComparer.Ordinal);
+        Assert.Equal("Development", environment.GetProperty("DOTNET_ENVIRONMENT").GetString(), StringComparer.Ordinal);
+        if (applicationUrl is not null)
+        {
+            Assert.DoesNotContain("https://", applicationUrl, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/backend/tests/Cli.UnitTests/Output/CliRendererTests.cs
+++ b/backend/tests/Cli.UnitTests/Output/CliRendererTests.cs
@@ -99,6 +99,10 @@ public sealed class CliRendererTests
         Assert.DoesNotContain(EscapeSequence, writer.ToString(), StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// Colour follows the terminal the renderer was given, not a second look at <c>NO_COLOR</c>. Detecting again would
+    /// let a harness that exports that variable strip the marks a test constructed as coloured.
+    /// </summary>
     [Fact]
     public void WriteLine_FailureOnAStreamThatPermitsColour_MarksTheLine()
     {

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -222,6 +222,14 @@ daemon:
 dotnet run --project backend/src/AppHost/AppHost.csproj
 ```
 
+The AppHost's only launch profile is named `http` and sets `ASPIRE_ALLOW_UNSECURED_TRANSPORT`, because there is no
+local TLS listener and Aspire otherwise allocates `aspire-dashboard-https` against the ASP.NET development certificate.
+That certificate can be present in the user store and still untrusted by the OS; the profile must not require it.
+
+A browser head driven from a script uses `scripts/chromium-headless.sh`. Snap Chromium's `/usr/bin/chromium` wrapper
+calls `snap-confine`, which cannot change AppArmor profile from an unconfined process; the script starts the chrome
+binary on the snap mount instead, with `--headless` and a writable `--user-data-dir`.
+
 Before any resource starts, Aspire asks for any of three parameters it has not already stored:
 `mail-account-host`, `mail-account-username`, and the secret `mail-account-password`. They configure one local account
 named `local`, over implicit TLS on port 993, with its inbox as the default folder. Aspire offers to keep the values in

--- a/scripts/chromium-headless.sh
+++ b/scripts/chromium-headless.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Copyright © 2026 Krzysztof Kasprowicz
+# Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+# Project repository: https://github.com/Krzysztof318/MailFathom
+
+set -euo pipefail
+
+# Snap's /usr/bin/chromium is a wrapper that calls snap-confine, which cannot change AppArmor
+# profile from unconfined. The chrome binary on the snap mount does not go through that wrapper.
+
+find_chrome() {
+  local candidate
+
+  if [[ -x /snap/chromium/current/usr/lib/chromium-browser/chrome ]]; then
+    printf '%s\n' /snap/chromium/current/usr/lib/chromium-browser/chrome
+    return 0
+  fi
+
+  for candidate in google-chrome-stable google-chrome chromium-browser chromium; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      candidate="$(command -v "$candidate")"
+      if is_snap_wrapper "$candidate"; then
+        continue
+      fi
+
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  echo "chromium-headless: no Chromium binary found that snap-confine is not required to launch." >&2
+  echo "Install Chromium outside Snap, or keep the snap package so /snap/chromium/current/usr/lib/chromium-browser/chrome exists." >&2
+  return 1
+}
+
+is_snap_wrapper() {
+  local resolved="$1"
+
+  if resolved="$(readlink -f "$1" 2>/dev/null)"; then
+    [[ "$resolved" == /snap/* ]] && return 0
+  fi
+
+  head -c 256 "$1" 2>/dev/null | grep -q snap-confine
+}
+
+chrome="$(find_chrome)"
+user_data="$(mktemp -d "${TMPDIR:-/tmp}/chromium-headless-XXXXXX")"
+trap 'rm -rf "$user_data"' EXIT
+mkdir -p "$user_data/crashes"
+
+# HOME is pointed at the same directory so Chrome does not write crashpad state into the
+# operator's real home. --headless (not --headless=new): dump-dom against the snap binary
+# returned no bytes under the new mode. --no-sandbox is required when the process is not confined.
+# Not exec: the trap has to remove the user-data directory after Chrome exits.
+export HOME="$user_data"
+"$chrome" \
+  --headless \
+  --disable-gpu \
+  --no-sandbox \
+  --disable-dev-shm-usage \
+  --disable-crash-reporter \
+  --disable-breakpad \
+  --crash-dumps-dir="$user_data/crashes" \
+  --user-data-dir="$user_data" \
+  "$@"


### PR DESCRIPTION
Closes #1368

## What changes

- `CliRenderer` follows the `CliTerminal` it was given (`AnsiSupport.Yes` / `No`) instead of asking Spectre.Console to detect again. `NO_COLOR` is already applied in `CliTerminal.Decide`; detecting a second time made the suite fail in an agent harness that exports it.
- The AppHost `http` launch profile sets `ASPIRE_ALLOW_UNSECURED_TRANSPORT=true`. Aspire was allocating `aspire-dashboard-https` against a development certificate that is present but untrusted, which is the opposite of “there is no local TLS listener”.
- `scripts/chromium-headless.sh` starts Chromium from the snap mount binary (or a non-snap Chrome), with `--headless` and a writable `--user-data-dir`, because `/usr/bin/chromium` goes through `snap-confine` and cannot change AppArmor profile from unconfined.

## How it was verified

- `bash scripts/verify-full.sh` passed on this branch, based on current `origin/main`.
- `Cli.UnitTests` passed with `NO_COLOR=1`, `TERM=dumb`, and the other colour-refusal variables the harness exports.
- `scripts/chromium-headless.sh --dump-dom 'data:text/html,<html><body>probe-ok</body></html>'` printed the DOM.

Machine facts that stay out of this change, and need a command on the host, are listed on the pull request comment trail only if asked: trusting the ASP.NET development certificate, AppArmor for the Chromium snap wrapper, and `~/.cache/gh` ownership.

## Checklist

- [x] `bash scripts/verify-full.sh` passes on this branch, rebased onto current `main`.
- [x] Behavior changes are covered by unit tests, and the coverage gate passes.
- [x] Affected documentation is updated in this change set.
- [x] `bash scripts/review-obligations.sh` was run, and every row it reported is answered — by a test, by a page, or by why nothing is owed there.
- [x] `CHANGELOG.md` is untouched — it is written by the release pull request alone.
- [x] Every new C# file carries the repository's standard header, applied by `scripts/verify-fast.sh` rather than typed, and no file gained a second copyright line, an author tag, a name, or a contact detail.
- [x] Nothing here is under terms MailFathom could not distribute under Apache-2.0. A new dependency, service, container image, or externally sourced sample has its row in `THIRD_PARTY_LICENSES.md` in this change set.
- [x] No credential, token, private key, real mailbox data, or personal information is in the diff.