### PR TITLE
[#1371] Ask for the mail timeline before updating sibling feeds

### DIFF
--- a/frontend/src/Client/Presentation/Messages/DeploymentMessageList.cs
+++ b/frontend/src/Client/Presentation/Messages/DeploymentMessageList.cs
@@ -48,12 +48,13 @@ internal sealed class DeploymentMessageList : IMessageList
     private readonly IMessageListMemory memory;
     private readonly TimeProvider clock;
     private readonly IStringLocalizer words;
-    private readonly IState<MessageListArrangement> arranged;
     private readonly IState<int> asked;
     private readonly IState<bool> pagingFailed;
     private readonly IState<MessageWindow> loaded;
 
     private MessagePlace? openedPlace;
+    private MessageListArrangement currentArrangement = MessageListArrangement.Default;
+    private MessageWindow? pagingFailedFor;
 
     /// <summary>Initializes the list over what serves it, where it is drawn from, and where it was left.</summary>
     /// <param name="deployment">Where a page of the owner's mail is asked for.</param>
@@ -93,7 +94,6 @@ internal sealed class DeploymentMessageList : IMessageList
         // The place rather than the scope, so a row being clicked is not a folder being opened again.
         var place = workspace.Scope.Select(MessagePlace.Of);
 
-        this.arranged = State.Value(this, () => MessageListArrangement.Default);
         this.pagingFailed = State.Value(this, () => false);
 
         // Why a counter beside the two triggers above: a session that answers a second time with the same grant is one
@@ -108,10 +108,15 @@ internal sealed class DeploymentMessageList : IMessageList
 
         this.Chosen = State<IImmutableList<MessageRow>>.Empty(this);
         this.Rows = this.loaded.Select(this.Draw).AsListFeed();
-        this.Arrangement = this.arranged;
+        this.Arrangement = this.loaded.Select(static window => window.Arrangement);
         this.HasMoreAfter = this.loaded.Select(static window => window.HasMoreAfter);
         this.HasMoreBefore = this.loaded.Select(static window => window.HasMoreBefore);
-        this.PagingFailed = this.pagingFailed;
+
+        // True only for a paging failure of the window that is still loaded. A sibling state written from OpenAsync
+        // never runs while a FeedView is waiting on that production — the view holds the dispatcher the write needs —
+        // so a folder change clears the indicator by producing a window the failure is not of, rather than by writing
+        // the state from inside the read.
+        this.PagingFailed = Feed.Combine(this.loaded, this.pagingFailed).Select(this.IsPagingFailureOfLoaded);
 
         // What makes the selection the application's rather than the control's. MVUX owns the subscription's lifetime,
         // so it ends with this instance.
@@ -151,7 +156,7 @@ internal sealed class DeploymentMessageList : IMessageList
     {
         ArgumentNullException.ThrowIfNull(arrangement);
 
-        await this.arranged.UpdateAsync(_ => arrangement, cancellationToken).ConfigureAwait(false);
+        this.currentArrangement = arrangement;
 
         await this.asked.UpdateAsync(static asked => asked + 1, cancellationToken).ConfigureAwait(false);
     }
@@ -178,15 +183,14 @@ internal sealed class DeploymentMessageList : IMessageList
         var arriving = !place.Equals(this.openedPlace);
         var remembered = this.memory.Read(place.RememberedAs);
 
-        var arrangement = arriving
-            ? remembered.Arrangement
-            : await this.arranged.Value(cancellationToken).ConfigureAwait(false) ?? MessageListArrangement.Default;
+        var arrangement = arriving ? remembered.Arrangement : this.currentArrangement;
 
         this.openedPlace = place;
+        this.currentArrangement = arrangement;
 
-        await this.arranged.UpdateAsync(_ => arrangement, cancellationToken).ConfigureAwait(false);
-        await this.pagingFailed.UpdateAsync(static _ => false, cancellationToken).ConfigureAwait(false);
-
+        // The page is the whole of this production. A FeedView waiting on it holds the dispatcher a sibling state
+        // write needs, so an arrangement or paging update from here never ran and left Mail on progress without a
+        // request leaving the process. The tree's folder read is the same shape: HTTP, then the value, nothing else.
         var page = await this.ReopeningAsync(
             place,
             arrangement,
@@ -302,6 +306,8 @@ internal sealed class DeploymentMessageList : IMessageList
         {
             if (await this.StillLoadedAsync(window, cancellationToken).ConfigureAwait(false) is not null)
             {
+                this.pagingFailedFor = window;
+
                 await this.pagingFailed.UpdateAsync(static _ => true, cancellationToken).ConfigureAwait(false);
             }
 
@@ -317,10 +323,16 @@ internal sealed class DeploymentMessageList : IMessageList
             return;
         }
 
+        this.pagingFailedFor = null;
+
         await this.pagingFailed.UpdateAsync(static _ => false, cancellationToken).ConfigureAwait(false);
 
         this.Remember(extended);
     }
+
+    /// <summary>Whether the paging indicator names a failure of the window that is still on the screen.</summary>
+    private bool IsPagingFailureOfLoaded((MessageWindow Window, bool Failed) pair) =>
+        pair.Failed && this.pagingFailedFor is { } failed && pair.Window.IsOf(failed);
 
     /// <summary>Reads the loaded window back, where it is still of the list a read was started for.</summary>
     /// <param name="window">The window that read was started from.</param>

--- a/frontend/src/Client/Presentation/Search/MailSearchView.xaml
+++ b/frontend/src/Client/Presentation/Search/MailSearchView.xaml
@@ -11,7 +11,7 @@ Project repository: https://github.com/Krzysztof318/MailFathom
              xmlns:mvux="using:Uno.Extensions.Reactive.UI"
              xmlns:search="using:MailFathom.Client.Presentation.Search"
              xmlns:utu="using:Uno.Toolkit.UI">
-  <Grid>
+  <Grid Background="{ThemeResource BackgroundBrush}">
     <Grid.RowDefinitions>
       <RowDefinition Height="Auto" />
       <RowDefinition Height="Auto" />

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailModel.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailModel.cs
@@ -10,6 +10,7 @@ using MailFathom.Client.Presentation.Spaces.Mail.Reading;
 using MailFathom.Client.Presentation.Threads;
 using MailFathom.Client.Presentation.Workspace;
 using MailFathom.Client.Session;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace MailFathom.Client.Presentation.Spaces.Mail;
 
@@ -50,6 +51,7 @@ public partial record MailModel
     /// <param name="workspace">The scope a selected passage narrows for the intent field.</param>
     /// <param name="search">The run's own ranked list, which opens the same conversation without replacing itself.</param>
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    [ActivatorUtilitiesConstructor]
     public MailModel(
         IClientSession session,
         IMessageList messages,

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailPage.xaml
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailPage.xaml
@@ -40,7 +40,10 @@ Project repository: https://github.com/Krzysztof318/MailFathom
     <workspace:WorkspaceColumns>
       <workspace:WorkspaceColumns.Primary>
         <Grid>
-          <Grid Visibility="{Binding ShowsTimeline, Converter={StaticResource AffirmedVisibility}}">
+          <!-- Collapsed would unload the FeedView and cancel the list's read, so a search overlay that opened as
+               this space did left Mail on progress without a request leaving the process. The overlay covers the
+               list; this grid only stops taking input while search is in front. -->
+          <Grid IsHitTestVisible="{Binding ShowsTimeline}">
           <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />

--- a/frontend/src/Client/Presentation/Threads/DeploymentMailThread.cs
+++ b/frontend/src/Client/Presentation/Threads/DeploymentMailThread.cs
@@ -343,8 +343,8 @@ internal sealed class DeploymentMailThread : IMailThread
             return ThreadWindow.Nothing;
         }
 
-        await this.pagingFailed.UpdateAsync(static _ => false, cancellationToken).ConfigureAwait(false);
-
+        // The page is the whole of this production, for the same reason the message list's is: a FeedView waiting on
+        // it holds the dispatcher a sibling paging write needs, so clearing the indicator from here never ran.
         var page = await this.deployment
             .ReadMailThreadAsync(conversation, PageSize, cursor: null, cancellationToken)
             .ConfigureAwait(false);

--- a/frontend/tests/Client.UnitTests/Presentation/Messages/DeploymentMessageListTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Messages/DeploymentMessageListTests.cs
@@ -66,6 +66,54 @@ public sealed class DeploymentMessageListTests
     }
 
     /// <summary>
+    /// Opening Mail is the first time the list is composed, and the workspace has already read the session by then. A
+    /// list that waited on a sibling state — the arrangement, a paging flag — before asking for the page sat on
+    /// progress without a request leaving, because the FeedView waiting on that production holds the dispatcher those
+    /// writes need. The page is asked for first, the same way the mailbox tree reads folders.
+    /// </summary>
+    [Fact]
+    public async Task Rows_ASessionTheWorkspaceAlreadyRead_StillAsksForTheLeadingPage()
+    {
+        // Arrange
+        using var harness = await DeploymentHarness.CreateAsync(
+            _ => Answer(Page(1, 1, next: null, previous: null)),
+            cancellationToken: TestContext.Current.CancellationToken);
+        using var session = Session();
+        var workspace = new SharedWorkspace(new StubMailboxTreeMemory());
+
+        Assert.NotNull(await session.Standing);
+
+        var list = new DeploymentMessageList(
+            harness.Client,
+            session,
+            workspace,
+            new StubMessageListMemory(),
+            new StubClock(Now),
+            Words());
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        timeout.CancelAfter(Patience);
+
+        // Act
+        IImmutableList<MessageRow>? rows;
+        try
+        {
+            rows = await list.Rows.AsFeed().Value(timeout.Token);
+        }
+        catch (OperationCanceledException) when (!TestContext.Current.CancellationToken.IsCancellationRequested)
+        {
+            Assert.Fail(
+                "The list did not ask the deployment for the leading page after the workspace had already read the session.");
+            return;
+        }
+
+        // Assert
+        Assert.NotNull(rows);
+        Assert.Equal(MailMessages.Key(1), Assert.Single(rows).Key);
+        Assert.Equal("/api/client/emails", Assert.Single(harness.Deployment.Requests).RequestUri.AbsolutePath);
+    }
+
+    /// <summary>
     /// A leading page that did not arrive is the list's own failure, so a retryable error can be drawn instead of
     /// waiting on an answer that will not come.
     /// </summary>


### PR DESCRIPTION
## Summary

Opening Mail after sign-in left the space on progress and never asked the deployment for `/api/client/emails`. A `FeedView` waiting on `OpenAsync` holds the UI dispatcher; writing the arrangement and paging states from inside that production never completed, so the request never left the process. The mailbox tree already avoids that shape: it asks HTTP, then returns the value.

This change:

- Asks for the leading page before any sibling `UpdateAsync`, and projects arrangement and paging failure from the loaded window instead of writing them from inside the read.
- Stops collapsing the timeline `FeedView` while search is in front, because `Visibility=Collapsed` unloads the feed and cancels the same read.
- Pins `MailModel`'s DI constructor so the workspace route does not take the phone constructor that needs a `ThreadMessageRow`.

Closes #1371

## Test plan

- [x] `DeploymentMessageListTests` including `Rows_ASessionTheWorkspaceAlreadyRead_StillAsksForTheLeadingPage`
- [x] `scripts/verify-full.sh` (frontend stack, 769 tests)
- [ ] After merge: sign in on WASM (Aspire) and desktop pointed at the client endpoint, open Mail, confirm `/api/client/emails` reaches the host and the empty-folder or list state is drawn instead of indefinite progress