### PR TITLE
[#1347] Keep a comment out of the review's concurrency group

### DIFF
--- a/.github/workflows/fathom-review.yml
+++ b/.github/workflows/fathom-review.yml
@@ -9,9 +9,10 @@ name: Fathom review
 # `main` ruleset: it advises, and nothing waits on it.
 #
 # Every trigger here runs the workflow file from the default branch, never from the branch under
-# review. `pull_request_target` and `issue_comment` both do that by definition, and there is
-# deliberately no `workflow_dispatch`, because a dispatch takes a ref and would let a branch supply
-# the job that receives the Claude credential.
+# review. `pull_request_target` and `issue_comment` both do that by definition, and so does
+# `repository_dispatch`, which GitHub runs from the default branch and which takes no ref to run it
+# from in the first place. There is deliberately no `workflow_dispatch`, because that one *does*
+# take a ref and would let a branch supply the job that receives the Claude credential.
 #
 # The branch under review is never checked out and nothing from it is executed. The workspace holds
 # the base commit, which is code that already merged; the change itself arrives as data through the
@@ -82,9 +83,30 @@ on:
       - closed
     branches:
       - main
+
+  # The escape hatch that reviews a draft and a fork, and the half of it that decides. A run this
+  # event creates never reviews: it asks whether the comment requested one and, when it did, asks
+  # for the review through `repository_dispatch` below.
+  #
+  # That split is a property of the trigger rather than of the gate. `issue_comment` fires for every
+  # comment on every pull request, and the run has already joined a concurrency group before
+  # anything can tell a request from a passing remark — so what the group must not contain is every
+  # comment, which is a decision only the group expression can take. The commentary under it is the
+  # whole argument.
   issue_comment:
     types:
       - created
+
+  # The review a comment asked for, as a run of its own, carrying the pull request's number and the
+  # model the comment chose. It is the only event here that always reviews.
+  #
+  # `repository_dispatch` rather than `workflow_dispatch` for the reason the header gives: this one
+  # takes no ref, so nothing about it lets a branch supply the job that holds the Claude credential.
+  # Creating one needs write access to the repository, which is the bar the comment gate already
+  # applies to a comment's author, so it reaches nothing a comment did not reach before.
+  repository_dispatch:
+    types:
+      - fathom-review-requested
 
 concurrency:
   # One run per pull request, so two reviews never post to the same change at once. What decides
@@ -98,11 +120,10 @@ concurrency:
   # worth the saved usage, because the review is one POST at the end of the job — a run stopped
   # before it posts nothing at all, and a run stopped after it has already finished.
   #
-  # **Every other event asks for a review rather than invalidating one, so it waits.** A comment, a
-  # label, and a pull request marked ready all leave the head alone: what is running is still
-  # reading the code that will merge, and its verdict is still worth having. They queue on this
-  # group instead, which costs a pending run and produces two verdicts in order rather than one
-  # verdict thrown away.
+  # **Every other event asks for a review rather than invalidating one, so it waits.** A label and a
+  # pull request marked ready leave the head alone: what is running is still reading the code that
+  # will merge, and its verdict is still worth having. They queue on this group instead, which costs
+  # a pending run and produces two verdicts in order rather than one verdict thrown away.
   #
   # That distinction is the whole reason `cancel-in-progress` is an expression. `issue_comment`
   # fires for *any* comment on a pull request, including one written by a bot with no interest in
@@ -111,7 +132,46 @@ concurrency:
   # the run enters this group before the gate can speak, so an unconditional `true` here means a
   # comment cancels a review in flight several minutes in and then declines to start one, which is
   # the entire cost of a review spent to publish nothing.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  #
+  # **`cancel-in-progress` governs a running run and nothing else, and a group cancels a *pending*
+  # run whatever it says.** GitHub holds at most one pending run per group: when a run joins the
+  # group, whatever run was already pending there is cancelled outright, unconditionally. So the
+  # expression above never reaches the case that costs the most — a review created and not yet
+  # started, which is where every review is for its first seconds. Measured on pull request #1335 on
+  # 2026-08-28: run `33163573560`, the review of freshly pushed head `ce165647`, was created at
+  # 10:29:54 and cancelled at 10:30:05 having started no job at all, by an ordinary round-summary
+  # comment that created its own run one second earlier. That head carried no verdict until a
+  # maintainer asked for one four hours later.
+  #
+  # Which is why membership of this group is decided here rather than by the gate. A run that can
+  # neither review nor cancel is given a group of its own, keyed by its run id and therefore shared
+  # with nothing, so it never displaces a review waiting to start. Two classes of event are in that
+  # position, and both arrive on a pull request repeatedly while it is being worked on:
+  #
+  # - **A comment.** After #1347 an `issue_comment` run reviews nothing at all — it asks for the
+  #   review through `repository_dispatch`, and *that* run joins this group. So the trigger whose
+  #   verdict cannot be known in time is also the one that no longer needs to be known: a comment
+  #   never belongs here, whatever it says.
+  # - **A label that is not `fathom-review`.** `Apply pull request rules` writes labels, and the one
+  #   label that asks for a review is the only `labeled` event the gate admits.
+  #
+  # Everything else joins the group and must. `synchronize` and `closed` because cancelling is what
+  # they are here for; `repository_dispatch` and `labeled` with `fathom-review` because they review;
+  # and `opened`, `reopened`, and `ready_for_review` because each reviews unless the pull request is
+  # a draft, a fork's, or the updater's. Those three can decline, and are kept here anyway: a pull
+  # request just opened or reopened has no review of its own to displace, and `ready_for_review`
+  # would have to land in the seconds a requested review of the same draft sat pending. That is the
+  # residue this arrangement accepts, and it is bounded by an event a hand performs once.
+  #
+  # The clauses below are folded into one line, so each of them is a whole condition rather than a
+  # continuation: a run keyed apart, the two events that are keyed apart, the key that is shared
+  # with nothing, and the pull request's own key that everything else joins.
+  group: >-
+    ${{ github.workflow }}-${{
+    (github.event_name == 'issue_comment'
+    || (github.event.action == 'labeled' && github.event.label.name != 'fathom-review'))
+    && format('request-{0}', github.run_id)
+    || format('pull-request-{0}', github.event.pull_request.number || github.event.client_payload.pull_request_number) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request_target' && (github.event.action == 'synchronize' || github.event.action == 'closed') }}
 
 permissions:
@@ -160,6 +220,10 @@ jobs:
       actions: read
     outputs:
       review: ${{ steps.gate.outputs.review }}
+      # Whether this run is the deciding half of the comment path: it reviews nothing and asks for a
+      # review of its own instead. `request` below is the job that asks, and it is the only consumer.
+      # The two are never both true — a run either reviews or asks for one.
+      dispatch: ${{ steps.gate.outputs.dispatch }}
       pull_request_number: ${{ steps.gate.outputs.pull_request_number }}
       # Whether somebody asked for this review rather than a push starting it. The submission step is
       # what records it on the review it publishes, and the gate of a later run is what reads it back.
@@ -199,7 +263,12 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action }}
           REPOSITORY: ${{ github.repository }}
-          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || github.event.client_payload.pull_request_number }}
+          # The model the comment asked for, decided by the gate of the run that dispatched this one
+          # and carried here rather than parsed twice. It is data from an API call rather than from
+          # this workflow, so the branch that reads it checks it against the identifiers this file
+          # names instead of passing it to the action.
+          REQUESTED_MODEL: ${{ github.event.client_payload.model }}
           PULL_REQUEST_DRAFT: ${{ github.event.pull_request.draft }}
           PULL_REQUEST_AUTHOR: ${{ github.event.pull_request.user.login }}
           HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
@@ -228,6 +297,10 @@ jobs:
           set -euo pipefail
 
           review='false'
+          # Whether this run's answer is to ask for a review rather than to perform one. Only the
+          # comment path sets it, because only a comment arrives in a run that must stay out of the
+          # pull request's concurrency group — the commentary on that group is why.
+          dispatch='false'
           # Whether somebody asked for this run in so many words. A label or a comment is a person
           # with write access deciding the pass is worth its cost; every other path is the workflow
           # deciding for them, and only that one is bounded below.
@@ -328,12 +401,37 @@ jobs:
               elif [[ "$COMMENT_ASSOCIATION" != 'OWNER' && "$COMMENT_ASSOCIATION" != 'MEMBER' && "$COMMENT_ASSOCIATION" != 'COLLABORATOR' ]]; then
                 reason="the comment author is ${COMMENT_ASSOCIATION} and cannot spend review usage"
               else
-                review='true'
-                explicit='true'
-                reason='a maintainer asked for fathom-review in a comment'
+                # The decision is the same one this branch always took; what changed is that the
+                # run holding it cannot be the run that reviews. `request` below turns this into a
+                # `repository_dispatch`, and the review happens in the run that event creates.
+                dispatch='true'
+                reason='a maintainer asked for fathom-review in a comment; asking for a run of its own'
                 # The escape hatch to the more expensive model, for a change where the default
                 # reviewer's verdict is worth a second, costlier opinion.
                 if [[ "${COMMENT_BODY,,}" == *opus* ]]; then
+                  model='claude-opus-5'
+                fi
+              fi
+              ;;
+            repository_dispatch)
+              # The comment path's second half. Nothing is re-decided here: this event exists only
+              # because the gate above said yes in the run that dispatched it, and creating one by
+              # hand needs the write access that gate demands of a comment's author, so the two ways
+              # to reach this branch are bounded by the same permission.
+              if [[ -z "$PULL_REQUEST_NUMBER" ]]; then
+                # The payload arrives over the API, so it is checked rather than assumed. Refusing
+                # here costs one short job; letting it through would fail the collection step
+                # several minutes later with an error about a pull request nobody named.
+                reason='the dispatch names no pull request'
+              else
+                review='true'
+                explicit='true'
+                reason='a maintainer asked for fathom-review in a comment'
+
+                # Checked against the identifier this file names rather than passed through. A
+                # payload carrying anything else reviews with the default model, which is the same
+                # answer a comment that named no model gets.
+                if [[ "$REQUESTED_MODEL" == 'claude-opus-5' ]]; then
                   model='claude-opus-5'
                 fi
               fi
@@ -448,6 +546,7 @@ jobs:
 
           {
             echo "review=${review}"
+            echo "dispatch=${dispatch}"
             echo "pull_request_number=${PULL_REQUEST_NUMBER}"
             echo "model=${model}"
             echo "explicit=${explicit}"
@@ -455,7 +554,7 @@ jobs:
             echo "posture=${posture}"
           } >> "$GITHUB_OUTPUT"
 
-          echo "Review: ${review} (${reason}); posture: ${posture} after ${automatic_reviews} automatic passes."
+          echo "Review: ${review}, dispatch: ${dispatch} (${reason}); posture: ${posture} after ${automatic_reviews} automatic passes."
 
       # `security` says this change needs a security review before it merges. It is written on the
       # issue — `docs/operations/issue-tracking.md` § "Labels" — and `Apply pull request rules`
@@ -582,6 +681,55 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
           echo "Security review: ${security_review}, model: ${model} (${reason})."
+
+  # The other half of the comment path. A comment cannot start a review in the run it creates — the
+  # concurrency commentary above is the whole argument — so the comment's run ends here, by asking
+  # for the review as an event of its own. What that costs is one short job and a second entry in
+  # the run list; what it buys is a comment that cannot cancel anything, whatever it says and
+  # whoever wrote it.
+  #
+  # A failed ask fails this job rather than retrying. `call-github-api.sh` is for reads and for a
+  # mutation that writes a value it already knows, and this call creates a record: asking twice
+  # would review twice. A red run on a review somebody asked for is the signal a maintainer can act
+  # on, which is what the request path has and the automatic one does not.
+  request:
+    name: Ask for the review the comment asked for
+    needs:
+      - decide
+    if: needs.decide.outputs.dispatch == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      # `POST /repos/{owner}/{repo}/dispatches` is a write to the repository, and `contents: write`
+      # is the narrowest permission that reaches it. It is the only write in this file not minted
+      # from the App's private key, and this job alone holds it: it checks nothing out, runs no
+      # model, and its whole body is one API call built from values the gate decided. The `main`
+      # ruleset is what stands between that token and the default branch.
+      contents: write
+    steps:
+      - name: Ask for a review of this pull request
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PULL_REQUEST_NUMBER: ${{ needs.decide.outputs.pull_request_number }}
+          MODEL: ${{ needs.decide.outputs.model }}
+          # The `repository_dispatch` type this workflow listens for, spelled here and in the `on:`
+          # block above. `scripts/test-agent-workflow.sh` fails when the two disagree, because a
+          # mismatch drops every requested review while this job stays green saying it asked.
+          EVENT_TYPE: fathom-review-requested
+        run: |
+          set -euo pipefail
+
+          # Built with `jq` rather than interpolated, so the number and the model reach the payload
+          # as JSON values whatever they contain.
+          jq -n \
+            --arg event_type "$EVENT_TYPE" \
+            --arg pull_request_number "$PULL_REQUEST_NUMBER" \
+            --arg model "$MODEL" \
+            '{event_type: $event_type, client_payload: {pull_request_number: $pull_request_number, model: $model}}' \
+            | gh api "repos/${REPOSITORY}/dispatches" --input -
+
+          echo "Asked for a review of #${PULL_REQUEST_NUMBER} with ${MODEL}."
 
   # The board says a review is running, from the moment it starts rather than when it concludes. A
   # review takes minutes, and until this job existed the column said whatever the last event left

--- a/docs/operations/agent-workflow.md
+++ b/docs/operations/agent-workflow.md
@@ -904,6 +904,14 @@ Two things ask for a review anyway, whichever skip refused it:
   Adding `opus` to that comment buys a second, costlier opinion;
   `claude-sonnet-5` is the default.
 
+  A comment reaches the reviewer as two runs rather than one. The run the comment
+  itself creates only decides, and when the answer is yes it asks for the review
+  through a `repository_dispatch` the workflow listens for; the review happens in
+  the run that event creates. Nothing about the phrase or who may type it changes
+  — the split is about concurrency, and
+  [When a review is cancelled](#when-a-review-is-cancelled) is the whole reason
+  for it.
+
   Three things about that phrase are deliberate. It is not `@claude`, which
   collides with GitHub Copilot's own trigger. It has to lead a line rather than
   appear anywhere in the body, because `fathom-review` names this pipeline and is
@@ -955,6 +963,8 @@ A review published before this arrangement carries no marker and counts as
 nothing, which resets the budget of any pull request open at the time and is
 worth a sentence rather than a migration.
 
+### When a review is cancelled
+
 A run also ends before it finishes when the pull request it is reading closes. A
 merge — the owner's ruleset bypass included — and a close both arrive as
 `closed`, and the gate refuses that event outright: it is a trigger only so that
@@ -971,16 +981,52 @@ Those two events are the whole of what may cancel, and the rule they share is
 worth stating in the other direction: **a comment never ends a review already
 running.** A push replaces the head and a close removes it, so in both cases what
 is running has stopped describing the code that will merge. Everything else —
-a comment, a label, a pull request marked ready — asks for a review without
-invalidating one, and queues on the same group instead. `cancel-in-progress` is
-therefore an expression naming those two events rather than the literal `true`,
-because `issue_comment` fires for *any* comment on a pull request, a bot's
-included, and the gate that tells a request apart from a passing remark runs
-inside the run — after the run has entered the group. Left unconditional, a
-notice posted by another workflow ends a review several minutes in and then
-declines to start one, which spends the entire cost of a review to publish
-nothing. `a_comment_never_cancels_a_review_in_flight` in
+a label, a pull request marked ready — asks for a review without invalidating
+one, and queues on the same group instead. `cancel-in-progress` is therefore an
+expression naming those two events rather than the literal `true`, because
+`issue_comment` fires for *any* comment on a pull request, a bot's included, and
+the gate that tells a request apart from a passing remark runs inside the run —
+after the run has entered the group. Left unconditional, a notice posted by
+another workflow ends a review several minutes in and then declines to start one,
+which spends the entire cost of a review to publish nothing.
+`a_comment_never_cancels_a_review_in_flight` in
 `scripts/test-agent-workflow.sh` is what keeps it from quietly reverting.
+
+That expression governs a run that is **running**, and it is only half the
+answer, because a concurrency group also cancels a run that is **pending** — and
+that cancellation is unconditional. GitHub holds one pending run per group: when
+a run joins, whichever run was waiting there is ended outright, whatever
+`cancel-in-progress` says. Every review is pending for its first seconds, so any
+comment arriving in them ended it and then declined to start one, leaving the
+head with no verdict at all. Measured on pull request #1335 on 2026-08-28: the
+review of freshly pushed head `ce165647` was created at 10:29:54 and cancelled at
+10:30:05 having started no job, by an ordinary round-summary comment that created
+its own run a second earlier; that head carried no verdict until a maintainer
+asked for one four hours later.
+
+So what decides the outcome is **membership of the group** rather than the
+cancellation rule, and the group expression is where it is decided rather than
+in the gate — which is inside the run and therefore always too late. A run that
+can neither review nor cancel is keyed by its own run id and shares a group with
+nothing. Two events are in that position, and both arrive on a pull request
+repeatedly while it is being worked on: a comment, which after this arrangement
+reviews nothing at all and asks for the review through a `repository_dispatch`
+whose run joins the group in its place, and a `labeled` event for a label that is
+not `fathom-review`, since `Apply pull request rules` writes labels and only that
+one asks for a review.
+
+Everything else joins the group and must: `synchronize` and `closed` because
+cancelling is what they are there for, `repository_dispatch` and `fathom-review`
+labelling because they review, and `opened`, `reopened`, and `ready_for_review`
+because each of them reviews unless the pull request is a draft, a fork's, or the
+updater's. Those three can decline and are kept in the group anyway — a pull
+request just opened or reopened has no review of its own to displace, and
+`ready_for_review` would have to land in the seconds a requested review of the
+same draft sat pending. That residue is bounded by an event a hand performs once,
+which is why it is stated rather than engineered away.
+`a_comment_never_cancels_a_queued_review` is the assertion, and
+`the_reviewer_listens_for_the_dispatch_it_sends` is what keeps the two halves of
+the comment path naming one event type.
 
 The workflow reports no status check and is not in the `main` ruleset. It
 advises; nothing waits on it.
@@ -1067,8 +1113,12 @@ tells Claude to report such an instruction as a P1 finding rather than obey it,
 but the guarantee is structural rather than textual.
 
 Every trigger runs the workflow file from the default branch.
-`pull_request_target` and `issue_comment` both do, by definition, and the next
-section is why that trigger is allowed here when no other workflow may use it.
+`pull_request_target` and `issue_comment` both do, by definition, and so does
+`repository_dispatch`, which takes no ref to run from at all — which is why the
+comment path asks for its review that way rather than through a
+`workflow_dispatch`, whose ref a branch could aim at the job holding the Claude
+credential. The next section is why `pull_request_target` is allowed here when no
+other workflow may use it.
 
 The paths under `$RUNNER_TEMP` are declared on each step that uses them rather
 than once for the job, because `runner` is not among the contexts a job-level
@@ -1263,10 +1313,11 @@ with them. `Fathom review` uses it anyway, as the first of two recorded
 exceptions rather than as a rule the repository quietly breaks.
 
 The exception holds because the trigger is what the workflow needs and the danger
-is not what it does. `issue_comment` and a label event carry no head ref to run,
-and reviewing a fork at a maintainer's request is the whole reason the workflow
-reaches one at all; `pull_request` would give the run neither the secrets it needs
-to publish under the App nor a trigger a maintainer can aim. What makes that safe
+is not what it does. `issue_comment`, `repository_dispatch`, and a label event
+carry no head ref to run, and reviewing a fork at a maintainer's request is the
+whole reason the workflow reaches one at all; `pull_request` would give the run
+neither the secrets it needs to publish under the App nor a trigger a maintainer
+can aim. What makes that safe
 is structural rather than procedural: every job holds `base.sha` and never the
 branch, nothing from the contribution is executed, and every session — each reader
 and the judge — runs with `Read`, `Grep`, and `Glob` and no shell, writer, network
@@ -1930,6 +1981,15 @@ now minted per run, scoped to this repository, expiring with the job, and held b
 the single step that makes no model call. The App itself needs exactly one
 permission, `Pull requests: Read and write`, which covers submitting a review and
 commenting on a pull request alike.
+
+One write in the file is not the App's, and it is worth naming because it is the
+exception: the job that turns a review request into a `repository_dispatch` holds
+`contents: write`, which is the narrowest permission that reaches
+`POST /repos/{owner}/{repo}/dispatches`. That job checks nothing out, runs no
+model, and its whole body is one API call built from values the gate decided;
+`main`'s ruleset is what stands between the token and the default branch. It is
+the only workflow-token write in the file; every other write a run performs is
+the App's, minted per run and held by the step that publishes.
 
 A missing or invalid App credential fails the run at its first step, before the
 change is collected and before any subscription usage is spent.

--- a/docs/operations/agent-workflow.md
+++ b/docs/operations/agent-workflow.md
@@ -1358,8 +1358,12 @@ grow:
 - `concurrency` with a conditional `cancel-in-progress` means a superseded head
   never finishes a review, so a rapid series of pushes costs one run rather than
   one per push, and a merge or a close ends the run reading a pull request that
-  has stopped being worth a verdict — while a comment, which cannot supersede
-  anything, queues rather than throwing a finished review away;
+  has stopped being worth a verdict. A comment supersedes nothing and no longer
+  joins that group at all: its run only decides, and the `repository_dispatch` it
+  may send is what queues there instead, so a review already running is neither
+  cancelled nor thrown away.
+  [When a review is cancelled](#when-a-review-is-cancelled) carries the whole of
+  it;
 - a fork's own pushes never start a review; a maintainer's label does;
 - the comment trigger requires an `OWNER`, `MEMBER`, or `COLLABORATOR` author, so
   nobody outside the project can spend the subscription by typing;

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -1331,7 +1331,7 @@ job of `repository-contracts.yml` and again locally in `scripts/verify-full.sh`,
 | `only_the_recorded_workflows_use_pull_request_target` | A third `pull_request_target` trigger beside the two `fathom-review.yml` and `contributor-licence.yml` hold, and a licence workflow that checks anything out, reaches an action beyond the token mint, or runs a command fetching the contribution directly |
 | `the_reviewer_resolves_one_claude_credential_everywhere` | A step in `fathom-review.yml` reaching a Claude credential without the `CLAUDE_CODE_PROFILE` selector, or a fifth step holding one, either of which leaves a leak check comparing a review against a token no run spent |
 
-Every write scope in the repository but one belongs to publishing something: `packages: write` with
+Every write scope in the repository but two belongs to publishing something: `packages: write` with
 `id-token: write` and `attestations: write` in `nightly.yml`, `publish-container-image.yml`, and
 `publish-helm-chart.yml`, plus `packages: write` on the nightly prune job and `contents: write` on
 the job that writes the release announcement. `publish-documentation.yml` holds `pages: write` with
@@ -1346,12 +1346,22 @@ its own announcing job holds. The jobs that build the schema artifact and the co
 nothing beyond a read, because neither publishes anything: they upload an artifact the announcing job
 attaches.
 
-The exception is `security-events: write` in `codeql.yml`, and it is the only write scope held by a
-job that runs for a pull request. It is what the analysis is for: the scope writes code-scanning
-alerts and nothing else — not repository contents, not a package, not a release — and an analysis
-that cannot record an alert produces a log line instead of a check. The contract above is what keeps
-the list honest, so adding a second such scope is an edit somebody argues rather than a line nobody
-notices.
+The first exception is `security-events: write` in `codeql.yml`. It is what the analysis is for: the
+scope writes code-scanning alerts and nothing else — not repository contents, not a package, not a
+release — and an analysis that cannot record an alert produces a log line instead of a check.
+
+The second is `contents: write` in `fathom-review.yml`, on the one job that turns a review somebody
+asked for in a comment into the `repository_dispatch` that performs it. That is the narrowest
+permission `POST /repos/{owner}/{repo}/dispatches` reaches, and it is the widest of the two
+exceptions, so what contains it is where it is held rather than how it is scoped: the job checks
+nothing out, runs no model, holds no Claude credential, and its whole body is one API call built from
+values the gate already decided. `main`'s ruleset is what stands between that token and the default
+branch. [When a review is cancelled](agent-workflow.md#when-a-review-is-cancelled) is why the comment
+path is two runs at all.
+
+Both are held by jobs reached from a pull request rather than from a publication — one from the
+change itself and one from a comment on it — and the contract above is what keeps the list honest, so
+adding a third such scope is an edit somebody argues rather than a line nobody notices.
 
 **What lives in the repository settings**, which no check here can read:
 

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -679,7 +679,7 @@ scanner's finding does. The seed is what reproduces a value; the message is wher
 
 The default mode writes every word from word lists in the repository. `--ai` is the opt-in mode in which the
 *content* — subject and body, greeting and signature — is written by a model instead, and OpenAI is the only provider
-the implementation reaches: the same single client construction [ADR 0011](../decisions/0011-reaching-a-provider-outside-the-openai-wire-protocol.md)
+the implementation reaches: the same single client construction [ADR 0011](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0011-reaching-a-provider-outside-the-openai-wire-protocol.md)
 records for the service — the OpenAI wire protocol, a base address, and a key — built by the tool directly, because a
 development tool composes from its own files rather than from the service's dependency injection.
 

--- a/scripts/test-agent-workflow.sh
+++ b/scripts/test-agent-workflow.sh
@@ -6756,6 +6756,12 @@ every_workflow_job_declares_its_permissions() {
 # to the rule the rest of this list describes. It writes code-scanning alerts and nothing else, and an
 # analysis that cannot record one is a log line rather than a check.
 #
+# A second scope belongs to no publishing job either: `fathom-review.yml` holds `contents: write` on
+# the one job that turns a review request into a `repository_dispatch`, because that is the narrowest
+# permission `POST /repos/{owner}/{repo}/dispatches` reaches. It is the only write in that file not
+# minted from the App's private key, it is held by a job that checks nothing out and runs no model,
+# and `main`'s ruleset is what stands between the token and the default branch.
+#
 # `publish-documentation.yml` publishes too, and what it publishes is a GitHub Pages deployment rather
 # than a package: `pages: write` creates the deployment and `id-token: write` is what the deployment is
 # claimed with. Both sit on the deploying job alone, and neither reaches the repository — the site is
@@ -6769,6 +6775,7 @@ every_write_scope_is_one_the_policy_records() {
     printf '%s\n' \
       'apply-pull-request-rules.yml pull-requests: write' \
       'codeql.yml security-events: write' \
+      'fathom-review.yml contents: write' \
       'nightly.yml attestations: write' \
       'nightly.yml id-token: write' \
       'nightly.yml packages: write' \
@@ -7226,6 +7233,72 @@ a_comment_never_cancels_a_review_in_flight() {
       return 1
     fi
   done
+}
+
+# The other half of the same hole, and the half `cancel-in-progress` cannot reach. That expression
+# governs a run that is *running*; a concurrency group also cancels a run that is *pending*, and it
+# does so unconditionally — GitHub holds one pending run per group, and a run joining the group ends
+# whichever was waiting there. A review is pending for its first seconds, so any comment arriving in
+# them ended it and then declined to start one, leaving the head with no verdict at all.
+#
+# What answers it is membership rather than cancellation: a run that can neither review nor cancel
+# is keyed by its own run id, so it shares a group with nothing. Two events are in that position and
+# both arrive on a pull request repeatedly — a comment, and a label that is not `fathom-review`.
+#
+# The commentary is stripped before the expression is read, because this file's prose names every
+# term below while arguing for it, and an assertion satisfied by the argument for a rule rather than
+# by the rule would pass whatever the expression said.
+a_comment_never_cancels_a_queued_review() {
+  local reviewer_workflow="$source_repository_root/.github/workflows/fathom-review.yml"
+  local concurrency
+  local failures=''
+  local required_term
+
+  concurrency="$(sed -n '/^concurrency:/,/^permissions:/p' "$reviewer_workflow" | grep -v '^[[:space:]]*#')"
+
+  for required_term in \
+    "github.event_name == 'issue_comment'" \
+    "github.event.action == 'labeled'" \
+    "github.event.label.name != 'fathom-review'" \
+    'github.run_id'; do
+    if [[ "$concurrency" != *"$required_term"* ]]; then
+      failures+="fathom-review.yml's concurrency group does not name ${required_term}, so a run that reviews nothing shares the pull request's group and cancels a review still queued there. "
+    fi
+  done
+
+  if [[ "$concurrency" != *'github.event.client_payload.pull_request_number'* ]]; then
+    failures+="fathom-review.yml's concurrency group does not key a requested review by the pull request it reviews, so two reviews can post to one pull request at once. "
+  fi
+
+  if [[ -n "$failures" ]]; then
+    printf '%s\n' "$failures" >&2
+    return 1
+  fi
+}
+
+# The comment path is two runs joined by one `repository_dispatch` type: `request` names it when it
+# asks for the review, and the `on:` block names it when it listens for one. A mismatch loses every
+# requested review while the job that asked reports success, which is the one failure here that
+# nothing else would report — so the two spellings are held together rather than trusted to agree.
+the_reviewer_listens_for_the_dispatch_it_sends() {
+  local reviewer_workflow="$source_repository_root/.github/workflows/fathom-review.yml"
+  local declared_type
+  local sent_type
+
+  declared_type="$(sed -n '/^  repository_dispatch:/,/^[a-z]/p' "$reviewer_workflow" |
+    sed -nE 's/^      - (.+)$/\1/p')"
+  sent_type="$(sed -nE 's/^          EVENT_TYPE: (.+)$/\1/p' "$reviewer_workflow")"
+
+  if [[ -z "$declared_type" ]]; then
+    printf 'fathom-review.yml declares no repository_dispatch type, so a comment asking for a review reaches nothing\n' >&2
+    return 1
+  fi
+
+  if [[ "$declared_type" != "$sent_type" ]]; then
+    printf "fathom-review.yml listens for repository_dispatch '%s' but asks for one as '%s'\n" \
+      "$declared_type" "$sent_type" >&2
+    return 1
+  fi
 }
 
 # The reviewer's subscription credential is named in five places: the workflow-level `env` that
@@ -8285,6 +8358,8 @@ run_test the_mutation_score_is_reported_and_never_gated
 run_test a_paid_provider_run_is_never_the_default
 run_test only_the_recorded_workflows_use_pull_request_target
 run_test a_comment_never_cancels_a_review_in_flight
+run_test a_comment_never_cancels_a_queued_review
+run_test the_reviewer_listens_for_the_dispatch_it_sends
 run_test the_reviewer_resolves_one_claude_credential_everywhere
 run_test the_development_tooling_never_reaches_a_published_artifact
 run_test the_required_check_aggregates_every_job_in_ci

--- a/scripts/test-agent-workflow.sh
+++ b/scripts/test-agent-workflow.sh
@@ -1829,17 +1829,24 @@ run_fathom_review_gate() {
   (
     export PATH="$fathom_review_bin_directory:$PATH"
     export FAKE_REVIEWS_FILE="$reviews_file"
-    export EVENT_NAME='pull_request_target'
+    # The trigger the run arrived as. Every contract but the comment path's is about a
+    # `pull_request_target` action, so that stays the default and a test names the event only when it
+    # is about a different one. The five below travel with it: a comment carries a body and an
+    # association, and a dispatch carries the number and the model the comment's own run decided.
+    # `PULL_REQUEST_NUMBER` takes the `-` form rather than `:-` so a contract can set it empty, which
+    # is the malformed payload the dispatch branch refuses.
+    export EVENT_NAME="${GATE_EVENT_NAME:-pull_request_target}"
     export EVENT_ACTION="$event_action"
     export REPOSITORY='Krzysztof318/MailFathom'
-    export PULL_REQUEST_NUMBER='1'
+    export PULL_REQUEST_NUMBER="${GATE_PULL_REQUEST_NUMBER-1}"
     export PULL_REQUEST_DRAFT='false'
     export PULL_REQUEST_AUTHOR="$pull_request_author"
     export HEAD_REPOSITORY='Krzysztof318/MailFathom'
     export ADDED_LABEL="$added_label"
-    export IS_PULL_REQUEST_COMMENT='false'
-    export COMMENT_BODY=''
-    export COMMENT_ASSOCIATION=''
+    export IS_PULL_REQUEST_COMMENT="${GATE_IS_PULL_REQUEST_COMMENT:-false}"
+    export COMMENT_BODY="${GATE_COMMENT_BODY:-}"
+    export COMMENT_ASSOCIATION="${GATE_COMMENT_ASSOCIATION:-}"
+    export REQUESTED_MODEL="${GATE_REQUESTED_MODEL:-}"
     export GH_TOKEN='fake-token'
     export REVIEWER_LOGIN='fathom-reviewer[bot]'
     export UPDATER_LOGIN='dependabot[bot]'
@@ -2053,6 +2060,128 @@ fathom_review_reviews_an_updater_pull_request_the_maintainer_labelled() {
 
   assert_contains 'review=true' "$step_output_file"
   assert_contains 'a maintainer applied the fathom-review label' "$output_file"
+}
+
+# The comment path is two runs, and these six contracts hold the gate's half of both. A comment's own
+# run decides and asks; the dispatch it asks with is what reviews. The concurrency contracts above
+# assert that the two runs are keyed apart — what is asserted here is that the gate actually routes
+# them that way, since a branch that set `review` where it means `dispatch` would review inside the
+# very run that must not, and every YAML assertion in this file would still pass.
+run_fathom_review_comment_gate() {
+  local comment_body="$1"
+  local output_file="$2"
+  local step_output_file="$3"
+  # Write access is what the comment path checks instead of the draft and fork checks it skips, so
+  # the ordinary case is an author who has it and a contract names one who does not.
+  local comment_association="${4:-OWNER}"
+
+  (
+    export GATE_EVENT_NAME='issue_comment'
+    export GATE_IS_PULL_REQUEST_COMMENT='true'
+    export GATE_COMMENT_BODY="$comment_body"
+    export GATE_COMMENT_ASSOCIATION="$comment_association"
+    run_fathom_review_gate 'created' "$output_file" "$step_output_file"
+  )
+}
+
+# A `repository_dispatch` carries no action, which is why the harness is given an empty one: the
+# group expression reads `github.event.action` and finds nothing there, and so does the gate.
+run_fathom_review_dispatch_gate() {
+  local requested_model="$1"
+  local output_file="$2"
+  local step_output_file="$3"
+  local pull_request_number="${4-1}"
+
+  (
+    export GATE_EVENT_NAME='repository_dispatch'
+    export GATE_REQUESTED_MODEL="$requested_model"
+    export GATE_PULL_REQUEST_NUMBER="$pull_request_number"
+    run_fathom_review_gate '' "$output_file" "$step_output_file"
+  )
+}
+
+fathom_review_asks_for_a_run_of_its_own_when_a_comment_requests_a_review() {
+  local output_file="$test_directory/fathom-review-comment-output"
+  local step_output_file="$test_directory/fathom-review-comment-step-output"
+
+  run_fathom_review_comment_gate 'fathom-review' "$output_file" "$step_output_file"
+
+  assert_contains 'dispatch=true' "$step_output_file"
+  # The run that read the comment must not be the run that reviews, because it joined a group of its
+  # own to avoid cancelling anything and would then review outside the one review is serialized in.
+  assert_contains 'review=false' "$step_output_file"
+  assert_contains 'asking for a run of its own' "$output_file"
+}
+
+fathom_review_carries_the_model_a_comment_named_into_the_request() {
+  local output_file="$test_directory/fathom-review-comment-opus-output"
+  local step_output_file="$test_directory/fathom-review-comment-opus-step-output"
+
+  run_fathom_review_comment_gate 'fathom-review opus' "$output_file" "$step_output_file"
+
+  assert_contains 'dispatch=true' "$step_output_file"
+  # The `request` job reads this output into the payload, so a model decided here and dropped there
+  # would review with the default while the comment said otherwise and nothing said so.
+  assert_contains 'model=claude-opus-5' "$step_output_file"
+}
+
+fathom_review_neither_reviews_nor_asks_for_a_comment_that_only_mentions_the_phrase() {
+  local output_file="$test_directory/fathom-review-comment-prose-output"
+  local step_output_file="$test_directory/fathom-review-comment-prose-step-output"
+
+  run_fathom_review_comment_gate 'I will rerun the fathom-review workflow tomorrow.' \
+    "$output_file" "$step_output_file"
+
+  assert_contains 'dispatch=false' "$step_output_file"
+  assert_contains 'review=false' "$step_output_file"
+  assert_contains 'does not ask for fathom-review' "$output_file"
+}
+
+fathom_review_refuses_a_comment_from_an_author_without_write_access() {
+  local output_file="$test_directory/fathom-review-comment-outsider-output"
+  local step_output_file="$test_directory/fathom-review-comment-outsider-step-output"
+
+  run_fathom_review_comment_gate 'fathom-review' "$output_file" "$step_output_file" 'CONTRIBUTOR'
+
+  # The dispatch is what spends the subscription now, so the association check has to refuse before
+  # it rather than before a review this run no longer performs.
+  assert_contains 'dispatch=false' "$step_output_file"
+  assert_contains 'cannot spend review usage' "$output_file"
+}
+
+fathom_review_reviews_the_pull_request_a_dispatch_names() {
+  local output_file="$test_directory/fathom-review-dispatch-output"
+  local step_output_file="$test_directory/fathom-review-dispatch-step-output"
+
+  run_fathom_review_dispatch_gate 'claude-opus-5' "$output_file" "$step_output_file"
+
+  assert_contains 'review=true' "$step_output_file"
+  # Somebody asked for this pass, so the ceiling neither refuses it nor counts it and the bar stays
+  # full — the same three consequences a label carries, reached through the comment path instead.
+  assert_contains 'explicit=true' "$step_output_file"
+  assert_contains 'model=claude-opus-5' "$step_output_file"
+}
+
+fathom_review_reviews_with_the_default_model_when_a_dispatch_names_an_unknown_one() {
+  local output_file="$test_directory/fathom-review-dispatch-model-output"
+  local step_output_file="$test_directory/fathom-review-dispatch-model-step-output"
+
+  run_fathom_review_dispatch_gate 'gpt-4' "$output_file" "$step_output_file"
+
+  assert_contains 'review=true' "$step_output_file"
+  # The payload arrives over the API rather than from this file, so a model is checked against the
+  # identifiers the workflow names instead of being handed to the action.
+  assert_contains 'model=claude-sonnet-5' "$step_output_file"
+}
+
+fathom_review_refuses_a_dispatch_that_names_no_pull_request() {
+  local output_file="$test_directory/fathom-review-dispatch-empty-output"
+  local step_output_file="$test_directory/fathom-review-dispatch-empty-step-output"
+
+  run_fathom_review_dispatch_gate 'claude-sonnet-5' "$output_file" "$step_output_file" ''
+
+  assert_contains 'review=false' "$step_output_file"
+  assert_contains 'names no pull request' "$output_file"
 }
 
 # The settle step waits for the pull request's conversation to stop moving before the snapshot is
@@ -8186,6 +8315,13 @@ run_test fathom_review_answers_a_request_past_the_automatic_ceiling
 run_test fathom_review_refuses_a_closed_pull_request
 run_test fathom_review_refuses_a_pull_request_the_updater_opened
 run_test fathom_review_reviews_an_updater_pull_request_the_maintainer_labelled
+run_test fathom_review_asks_for_a_run_of_its_own_when_a_comment_requests_a_review
+run_test fathom_review_carries_the_model_a_comment_named_into_the_request
+run_test fathom_review_neither_reviews_nor_asks_for_a_comment_that_only_mentions_the_phrase
+run_test fathom_review_refuses_a_comment_from_an_author_without_write_access
+run_test fathom_review_reviews_the_pull_request_a_dispatch_names
+run_test fathom_review_reviews_with_the_default_model_when_a_dispatch_names_an_unknown_one
+run_test fathom_review_refuses_a_dispatch_that_names_no_pull_request
 run_test fathom_review_collects_at_once_when_nobody_has_commented
 run_test fathom_review_waits_before_freezing_a_quiet_conversation
 run_test fathom_review_stops_waiting_at_the_ceiling


### PR DESCRIPTION
Closes #1347

## What was wrong

`Fathom review` declares one workflow-level concurrency group per pull request and cancels on an expression naming `synchronize` and `closed`. That expression governs a run that is **running**. A concurrency group also cancels a run that is **pending**, and that cancellation is unconditional — GitHub holds one pending run per group, and a run joining it ends whichever was waiting there whatever `cancel-in-progress` says.

Every review is pending for its first seconds, so any comment arriving in them ended it and then declined to start one. Measured on #1335 on 2026-08-28: run `33163573560`, the review of freshly pushed head `ce165647`, was created at 10:29:54 and cancelled at 10:30:05 having started no job, by an ordinary round-summary comment that created its own run a second earlier. That head carried no verdict until the owner asked for one four hours later.

## The shape taken

Decide **membership of the group** rather than the cancellation rule — the gate cannot, because it runs inside a run that has already joined. A run that can neither review nor cancel is keyed by its own run id and shares a group with nothing:

- **A comment.** An `issue_comment` run now reviews nothing at all. It runs the same gate it always did and, when the comment asked for a review, asks for one through a `repository_dispatch` the workflow listens for; *that* run joins the group. So the trigger whose verdict cannot be known in time is the one that no longer needs to be known — a comment never belongs in the group, whatever it says.
- **A `labeled` event for a label that is not `fathom-review`**, which `Apply pull request rules` produces routinely.

Everything else joins the group and must: `synchronize` and `closed` because cancelling is what they are there for, `repository_dispatch` and `fathom-review` labelling because they review, and `opened`, `reopened`, and `ready_for_review` because each reviews unless the pull request is a draft, a fork's, or the updater's.

`repository_dispatch` rather than `workflow_dispatch`: the file's header refuses a dispatch that takes a ref, because a ref would let a branch supply the job holding the Claude credential. `repository_dispatch` takes none — GitHub always runs it from the default branch — and GitHub documents it as one of the two events a `GITHUB_TOKEN` may still trigger a run with. `anthropics/claude-code-action` handles the event explicitly in its context parser, so the reader and judge jobs are unaffected.

### The residue, stated rather than engineered away

`opened`, `reopened`, and `ready_for_review` can decline (draft, fork, `dependabot[bot]`) and are kept in the group anyway: a pull request just opened or reopened has no review of its own to displace, and `ready_for_review` would have to land in the seconds a requested review of the same draft sat pending. Keeping those out would mean restating the gate's draft, fork, and author checks in the group expression — a second implementation that can disagree with the first.

A comment that *does* ask for a review still replaces a queued review with its own, which is the dedupe the group exists for; the pull request is never left without a verdict.

## Permissions

One new write: `contents: write` on the `request` job, the narrowest permission `POST /repos/{owner}/{repo}/dispatches` reaches. It is the only workflow-token write in the file — every other write is the App's. That job checks nothing out, runs no model, holds no Claude credential, and its whole body is one API call built from values the gate decided; `main`'s ruleset stands between the token and the default branch. `every_write_scope_is_one_the_policy_records` refused it until it was named in the policy list, which is that contract working as intended.

## Tests

**The concurrency group, over the YAML.**

- `a_comment_never_cancels_a_queued_review` asserts the group expression keys the two declining event classes apart and keys a dispatched review by the pull request it reviews. It reads the block with commentary stripped, so the argument for a rule cannot satisfy an assertion about the rule. **It fails against `main` today**: none of the five terms it requires appears there.
- `the_reviewer_listens_for_the_dispatch_it_sends` holds the `on:` block and the `request` job to one event type — a mismatch would drop every requested review while the job that asked stayed green.
- `a_comment_never_cancels_a_review_in_flight` is unchanged and still passes; it covers the other half.

**The gate branch that routes them, executed.** The contracts above assert that the two runs are keyed apart; a gate setting `review` where it means `dispatch` would review inside the very run that must not, and every assertion over the YAML would still pass. `run_fathom_review_gate` now takes the event and the comment's own fields from the environment, defaulting to the `pull_request_target` every other contract is about, so its twelve existing call sites are unchanged.

- `fathom_review_asks_for_a_run_of_its_own_when_a_comment_requests_a_review` — `dispatch=true` and `review=false`.
- `fathom_review_carries_the_model_a_comment_named_into_the_request` — `opus` reaches the output the `request` job reads into the payload.
- `fathom_review_neither_reviews_nor_asks_for_a_comment_that_only_mentions_the_phrase` — the line-start rule, which had no executable test before either.
- `fathom_review_refuses_a_comment_from_an_author_without_write_access` — the association guard, now in front of a dispatch rather than a review.
- `fathom_review_reviews_the_pull_request_a_dispatch_names` — `review=true`, `explicit=true`, model carried.
- `fathom_review_reviews_with_the_default_model_when_a_dispatch_names_an_unknown_one` — an unknown model falls back instead of reaching the action.
- `fathom_review_refuses_a_dispatch_that_names_no_pull_request` — the `-z "$PULL_REQUEST_NUMBER"` guard.

273 contracts pass.

## Breaking changes

None to the MCP tool contract, the configuration schema, the database schema, or the deployment contract. The comment trigger's phrase, its author bar, and the `opus` escape hatch are all unchanged; what changed is that a comment reaches the reviewer as two runs instead of one.

## Documentation

`docs/operations/agent-workflow.md` gains a `When a review is cancelled` section stating what governs a queued run beside what governs a running one, and records the two-run comment path, the trigger list, and the new write. `docs/operations/local-development.md`'s write-scope enumeration said "but one" and now names both exceptions.