### PR TITLE
[#1371] Publish one constructor on the mail model so its screen gets a data context

### DIFF
--- a/frontend/src/AGENTS.md
+++ b/frontend/src/AGENTS.md
@@ -64,6 +64,17 @@ framework beside it.
   what makes a loading state and an error state the default rather than something each screen remembers to add.
 - **Awaiting a feed inside a model is normal** (`var value = await SomeState;`); awaiting one inside a view is a sign
   the work belongs in the model.
+- **A model a route names publishes exactly one public constructor.** Navigation builds a routed screen's data context
+  by reflection over the bindable type the generator emits beside the model: it takes the first of `GetConstructors()`
+  — an order the runtime does not define — and fills every parameter from the container and from nowhere else. Publish
+  two and which one a screen is built through is decided by reflection ordering; the route that loses is handed `null`
+  for what it carried no data for, its own guard throws, and Uno swallows that and leaves the page with no data context
+  at all. Nothing reports it, because every binding then keeps its target's default: a `FeedView` bound to nothing
+  renders as loading for good, an overlay whose visibility never arrives stays over what it covers, a command that is
+  null is inert, and no request the screen exists to make is ever sent. A screen opened both with and without route
+  data is therefore one constructor with an optional parameter rather than two — a route's data reaches the container
+  as a registration that yields `null` when the navigation carried none, so the one constructor is asked for it either
+  way. `ClientNavigationTests` asserts this over the real route tree, because it is not visible in any one file.
 
 ## Nothing waits in silence, and nothing waits without a way out
 

--- a/frontend/src/Client/Presentation/Spaces/Mail/MailModel.cs
+++ b/frontend/src/Client/Presentation/Spaces/Mail/MailModel.cs
@@ -10,7 +10,6 @@ using MailFathom.Client.Presentation.Spaces.Mail.Reading;
 using MailFathom.Client.Presentation.Threads;
 using MailFathom.Client.Presentation.Workspace;
 using MailFathom.Client.Session;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace MailFathom.Client.Presentation.Spaces.Mail;
 
@@ -50,44 +49,34 @@ public partial record MailModel
     /// <param name="thread">The run's own conversation, which is whatever the list has one message selected in.</param>
     /// <param name="workspace">The scope a selected passage narrows for the intent field.</param>
     /// <param name="search">The run's own ranked list, which opens the same conversation without replacing itself.</param>
-    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
-    [ActivatorUtilitiesConstructor]
+    /// <param name="openedMessage">
+    /// The conversation row the phone route opened, or <see langword="null" /> where the route named none — which is
+    /// every route into this space but that one.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument other than <paramref name="openedMessage" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// <para>
+    /// One public constructor, and that is a constraint the navigation framework imposes rather than a preference.
+    /// Uno builds the bindable type the generator emits beside this record by taking
+    /// <see cref="Type.GetConstructors()" /> and using the first — an order the runtime does not define — and it fills
+    /// every parameter from the container alone. So a model reachable through a route may publish exactly one
+    /// constructor: publish two and which of them a screen is built through is decided by reflection ordering, and the
+    /// page whose turn it is to lose gets no data context at all rather than an error anybody sees.
+    /// </para>
+    /// <para>
+    /// That is also why <paramref name="openedMessage" /> is optional rather than a constructor of its own. A route's
+    /// data reaches the container as a registration that yields <see langword="null" /> when the navigation carried
+    /// none, so the one constructor is asked for it on every route into this space and answers for both: the row on
+    /// the phone route that named one, and nothing on the routes that open the space at large.
+    /// </para>
+    /// </remarks>
     public MailModel(
-        IClientSession session,
-        IMessageList messages,
-        IMailThread thread,
-        IWorkspace workspace,
-        IMailSearch search)
-        : this(session, messages, thread, workspace, search, openedMessageKey: null)
-    {
-    }
-
-    /// <summary>Initializes the same mail model for the phone route that draws one message from the open conversation.</summary>
-    /// <param name="openedMessage">The conversation row the route opened.</param>
-    /// <param name="session">What the deployment allows this caller.</param>
-    /// <param name="messages">The run's own message list, drawn from wherever the mailbox tree says somebody is.</param>
-    /// <param name="thread">The run's own conversation, which is whatever the list has one message selected in.</param>
-    /// <param name="workspace">The scope a selected passage narrows for the intent field.</param>
-    /// <param name="search">The run's own ranked list, which opens the same conversation without replacing itself.</param>
-    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
-    public MailModel(
-        ThreadMessageRow openedMessage,
-        IClientSession session,
-        IMessageList messages,
-        IMailThread thread,
-        IWorkspace workspace,
-        IMailSearch search)
-        : this(session, messages, thread, workspace, search, KeyOf(openedMessage))
-    {
-    }
-
-    private MailModel(
         IClientSession session,
         IMessageList messages,
         IMailThread thread,
         IWorkspace workspace,
         IMailSearch search,
-        string? openedMessageKey)
+        ThreadMessageRow? openedMessage = null)
     {
         ArgumentNullException.ThrowIfNull(session);
         ArgumentNullException.ThrowIfNull(messages);
@@ -99,6 +88,10 @@ public partial record MailModel
         this.thread = thread;
         this.workspace = workspace;
         this.search = search;
+
+        // The key rather than the row, so the model outlives the navigation without holding one message's content for
+        // as long as the space is open. Which row carries that key is whatever the run's own conversation holds now.
+        var openedMessageKey = openedMessage?.Key;
 
         this.WithholdsMail = session.Standing.Select(standing => standing.Withholds(ClientCapability.Mail));
 
@@ -441,12 +434,5 @@ public partial record MailModel
         var arrangement = await this.messages.Arrangement ?? MessageListArrangement.Default;
 
         await this.messages.ArrangeAsync(change(arrangement), cancellationToken).ConfigureAwait(false);
-    }
-
-    private static string KeyOf(ThreadMessageRow message)
-    {
-        ArgumentNullException.ThrowIfNull(message);
-
-        return message.Key;
     }
 }

--- a/frontend/tests/Client.UnitTests/ClientNavigationTests.cs
+++ b/frontend/tests/Client.UnitTests/ClientNavigationTests.cs
@@ -71,6 +71,64 @@ public sealed class ClientNavigationTests
         Assert.Equal(ClientRoutes.Discover, defaultSpace.Path);
     }
 
+    /// <summary>
+    /// Every model a route names publishes one public constructor, which is what lets navigation build the screen it
+    /// belongs to.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Uno builds a routed screen's data context by reflection: it takes the bindable type the MVUX generator emits
+    /// beside the model, calls <see cref="Type.GetConstructors()" />, uses the <em>first</em> one — an order the
+    /// runtime does not define — and fills each of its parameters from the container and from nowhere else. The
+    /// generator mirrors the model's public constructors onto that type, so a model with two of them leaves the choice
+    /// to reflection ordering.
+    /// </para>
+    /// <para>
+    /// What the losing side costs is why this is asserted rather than left to review. A constructor chosen for the
+    /// wrong route is handed <see langword="null" /> for the parameters that route carried no data for, the guard
+    /// inside it throws, and Uno swallows that and leaves the page with no data context at all. Every binding on the
+    /// page then keeps its target's default — a feed bound to nothing renders as loading for good, an overlay whose
+    /// visibility never arrives stays over what it covers, and a command that is null is inert — so the screen hangs
+    /// with no error in any log, no failed request to find, and no request made at all. That is
+    /// <see href="https://github.com/Krzysztof318/MailFathom/issues/1371">issue 1371</see>, and it reached a released
+    /// client because nothing here read the constructors.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void RegisterRoutes_EveryRoutedModel_PublishesOneConstructorForNavigationToBuildItThrough()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var views = new ViewRegistry(services);
+        var routes = new RouteRegistry(services);
+
+        // Act
+        App.RegisterRoutes(views, routes);
+
+        string[] ambiguous =
+        [
+            .. views.Items
+                .Select(static map => map.ViewModel)
+                .OfType<Type>()
+                .Distinct()
+                .Where(static model => model.GetConstructors().Length != 1)
+                .Select(static model =>
+                    $"{model.FullName}: {model.GetConstructors().Length} public constructors"),
+        ];
+
+        // Assert
+        // The registry is read for emptiness as well, because a registration that named no model would otherwise
+        // report a route tree in which every model is unambiguous as one in which none was looked at.
+        Assert.NotEmpty(views.Items);
+
+        if (ambiguous.Length > 0)
+        {
+            Assert.Fail(
+                $"Navigation cannot decide which constructor to build these models through:{Environment.NewLine}  "
+                + string.Join($"{Environment.NewLine}  ", ambiguous));
+        }
+    }
+
     private static IEnumerable<RouteMap> Flatten(IEnumerable<RouteMap> routes)
     {
         foreach (var route in routes)

--- a/frontend/tests/Client.UnitTests/Presentation/Spaces/Mail/MailModelTests.cs
+++ b/frontend/tests/Client.UnitTests/Presentation/Spaces/Mail/MailModelTests.cs
@@ -136,12 +136,12 @@ public sealed class MailModelTests
         var opened = navigation with { Contribution = "Updated after navigation" };
         var thread = new StubMailThread(first, opened);
         await using var model = new MailModel(
-            navigation,
             session,
             new StubMessageList(),
             thread,
             new StubWorkspace(),
-            new StubMailSearch());
+            new StubMailSearch(),
+            navigation);
 
         // Act
         var message = await model.OpenedThreadMessage;


### PR DESCRIPTION
Mail hung on loading after sign-in because `MailPage` had **no data context at all**, not because a request failed or a response was mishandled. With nothing bound, the timeline `FeedView`'s source stayed null and rendered progress for good, the search overlay's `Visibility` binding produced no value so it kept its default and covered the list, every command was inert, and **no request the screen exists to make ever left the process**.

## The failing hop

Uno builds a routed screen's data context by reflection over the bindable type the MVUX generator emits beside the model. `TypeExtensions.GetNavigationConstructor` takes `type.GetConstructors().FirstOrDefault()` — the *first* public constructor, in an order the runtime does not define — and fills every parameter from the container and from nowhere else.

`MailModel` published two public constructors, so the generator mirrored two onto `MailViewModel` and the choice fell to reflection ordering:

- the constructor taking a `ThreadMessageRow` won on the `Mail` route, which carries no such data;
- `DataMap<TData>.RegisterTypes` registers that type as a transient yielding `NavigationDataProvider.GetData<TData>()`, which is `null` when the navigation carried none;
- the constructor's own `ArgumentNullException` guard threw;
- `ControlNavigator.CreateViewModel` swallowed it and returned nothing, leaving the page bare.

`[ActivatorUtilitiesConstructor]`, added by #1372, could not help: the attribute is not copied onto the generated bindable type, and the reflection path never reads it. Every other model in the client has exactly one constructor, which is why only Mail hung — Settings, Discover and the shell all bound correctly in the same session.

## The fix

`MailModel` now publishes one constructor and takes the opened conversation row as an optional parameter. That is the shape the framework's contract asks for, and it answers both routes into the space with one signature: the row where a route named one, `null` where it did not. The row is reduced to its key before the feed captures it, so a model that outlives the navigation does not hold one message's content.

`frontend/src/AGENTS.md` records the rule beside the rest of the MVUX contract.

## The regression test

`ClientNavigationTests.RegisterRoutes_EveryRoutedModel_PublishesOneConstructorForNavigationToBuildItThrough` reads the real route tree from `App.RegisterRoutes` and asserts that every model a `ViewMap` names publishes exactly one public constructor. It was confirmed red before the fix and green after:

```
Navigation cannot decide which constructor to build these models through:
  MailFathom.Client.Presentation.Spaces.Mail.MailModel: 2 public constructors
```

It sits in the navigation suite rather than the composition one deliberately: `ClientCompositionTests` builds models through `ActivatorUtilities`, which honours `[ActivatorUtilitiesConstructor]` and therefore passed throughout the defect. The rule is about how *navigation* picks a constructor, and nothing but the route tree can state it.

## Evidence

Both runs used the normal repository AppHost — Aspire with PostgreSQL, migrations, the service and the browser head — driven through sign-in into Mail with headless Chromium over the Chrome DevTools Protocol, against a real IMAP mailbox the owner supplied for the session.

**Before the fix.** `GET /api/client/session` 200 and `GET /api/client/folders` 200, then nothing: **no `/api/client/emails` request was ever made**. The mail column rendered the search overlay over a permanently loading timeline, three `LoadingView` "Source is still null" warnings appeared, and an instrumented `MailPage` reported `DataContext=null` with no `DataContextChanged` ever raised.

**After the fix.** The same drive signs in, opens Mail, and renders the mailbox:

```
204 OPTIONS /api/client/session
200 GET     /api/client/session
200 GET     /api/client/folders
204 OPTIONS /api/client/emails?order=newestFirst&direction=forward&pageSize=50
200 GET     /api/client/emails?order=newestFirst&direction=forward&pageSize=50
```

The timeline renders the folder's messages with the mailbox tree, the unread counts, and the conversation pane's empty state beside it. Zero console errors, zero exceptions, and none of the three `LoadingView` warnings. Opening a message issues `GET /api/client/threads/{id}` 200 and renders the conversation. The same drive at a 420 px viewport renders the phone layout and its `TabBar`, so the fix is not width-specific.

Screenshots and the raw console and network logs stay out of this repository: they show a real mailbox's contents, which is personal data.

## What this change does not settle

- **The Windows-to-WSL2 boundary named in the issue could not be reproduced here.** This host is a plain Ubuntu VM rather than WSL2 (`/proc/version` names no Microsoft kernel), so there is no Windows browser reaching a WSL2 listener to observe. Everything reported above is loopback on one Linux host. If the failure persists across that boundary it is a second defect, and the evidence above rules out the client-side hop as its cause.
- **The `MailThread` and `MailMessage` routes are registered but unreachable.** Nothing in the client requests either today — `MailPage` hosts `MailThreadView` directly, and the only `MessageRoute="MailMessage"` sits on `MailThreadPage`, which nothing navigates to. The change keeps them working by construction rather than by demonstration, and `MailModelTests.OpenedThreadMessage_ANavigationRow_ReadsTheLiveRowFromTheRunsOwnConversation` is what covers the data-carrying path.
- **Missing localization resources surfaced during the run** and belong to a follow-up rather than here: `SignInPage/Keeping/NotOfferedOnThisHead`, `Mailboxes/Standing/Synchronizing`, `Mailboxes/Standing/Failing`, `Thread/Participant/Messages`, and two format strings rendering as `Messages: {0}` and `To {0}`. They render their raw keys on screen. None of them is a data-context problem and none is touched by this change.

## Verification

- `scripts/verify-fast.sh` — green.
- `scripts/verify-full.sh` — green: 770 client tests, 264 contracts, both stacks' formatting.
- `scripts/review-obligations.sh` — one row against this change, `docs/decisions/0020-…client.md` for `MailModel.cs`; read, and it names neither the model nor its constructors, so nothing in it stopped being true.

No dependency pin, lock file, or licence record moves. `CHANGELOG.md` is untouched.

Closes #1371
