### PR TITLE
Carry the Qwen Code configuration into every worktree

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -20,3 +20,9 @@
 
 # Codex copies this ignored machine-local configuration into worktrees it creates.
 .codex/config.toml
+
+# Qwen Code keeps everything a session needs in one directory: settings.json wiring its tools, and
+# QWEN.local.md holding the instructions it loads. The whole directory rather than the two names,
+# because what belongs in it is Qwen's decision rather than this file's, and a worktree missing half
+# of it is a session configured differently from the checkout it was branched from.
+.qwen/


### PR DESCRIPTION
Adds `.qwen/` to `.worktreeinclude`, so a linked worktree carries the Qwen Code configuration the checkout it was branched from has.

Qwen Code keeps both halves of a session's setup in that one directory: `settings.json` wires its tools, and `QWEN.local.md` holds the instructions it loads. Neither reaches a worktree today, so a `run:qwen` session dispatched into one runs configured differently from the checkout it came out of — the same gap `.codex/config.toml` was added above it to close.

The whole directory rather than the two file names, because what belongs in it is Qwen's decision rather than this file's. Only gitignored paths are copied and `.git/info/exclude` already covers `.qwen/`, so the pattern is exactly as wide as the ignore rule it mirrors — the reasoning the `*.local.md` entry already carries.

No issue and no verification run: requested directly by the owner as a one-line configuration change that no build reads. `.worktreeinclude` is a protected path, and this is the owner's checkout.
