### PR TITLE
[#1432] Name the client a single-page application and state what a screen adapts to

### DIFF
--- a/frontend/src/AGENTS.md
+++ b/frontend/src/AGENTS.md
@@ -19,6 +19,16 @@ credential is composed, or a permission is judged — each of those is the servi
 a second implementation that will disagree with the first. When a screen appears to need one, the answer is a route on
 `/api/client` that answers it, which is service work with an issue of its own.
 
+It is also a **single-page application**: one document, loaded once, whose every later screen is rendered rather than
+fetched. Both heads are that same page — the web head is the bundle `Client.App/vite.config.ts` builds, and the desktop
+head is that bundle in a WebView — so it is a property of the client rather than a fact about browsers. Three things
+follow. Navigation is the application's own state, so moving between screens changes what is rendered and never asks
+for a document. A reload is a cold start rather than a way out, which is why § _UX_ refuses it as the only escape from
+an error state: it discards everything the session holds in order to recover from something the screen could have
+recovered from itself. And whatever carries routes is a decision rather than an import — the workspace pins no router,
+`frontend/AGENTS.md` holds that among four deliberate absences, and adopting one is an issue with a licence review
+rather than a line added by the first screen that wanted a second address.
+
 ## The package boundary, and what may never cross it
 
 The two packages and the three mechanisms that hold them apart are in [`frontend/README.md`](../README.md). What that
@@ -122,6 +132,21 @@ target: a difference between the heads is a CSS one — a safe-area inset, a poi
 concern that belongs to the shell rather than to the application. A screen that cannot be written without knowing which
 head it is running on is a design that has not been finished, and taking that branch is what turns one client into two.
 
+**What a screen adapts to instead is the width it has been given and what the pointer can do.** Those two are the whole
+of it, and the refusal above is not an instruction to adapt to nothing: a window is resized far more often than a head
+is changed, and one head produces both shapes anyway. A half-width window on a desktop gets the composition a
+phone-width viewport gets — a stack, not a wide layout that stopped fitting — and the same desktop maximized gets the
+wide one, out of the same tree at the same breakpoint. `pointer: coarse` is asked where a target has to be big enough
+for a finger and `hover` where an affordance would otherwise exist only under one; neither is a question about the
+operating system, and a touch screen on a desktop answers both the way a phone does.
+
+The bar is stated rather than left to taste. Every screen is usable from 320 CSS pixels upward and at every width above
+it, with no horizontal scrolling of the page: content reflows, and what a narrow width cannot show at once is reached
+rather than dropped. Nothing is hidden by width alone — a control that disappears below a breakpoint has moved
+somewhere a reader can still get to, or it was not needed at the wide width either. The number is the narrowest
+viewport a supported head presents rather than a threshold anybody measured a failure at, and a window dragged narrower
+than any phone is where the client is allowed to scroll.
+
 ## UX: nothing waits in silence, and nothing waits without a way out
 
 This is the contract's oldest rule and it survived the platform it was written for. It is an obligation on every surface,
@@ -155,6 +180,10 @@ so this is written to be mechanically visible in a diff rather than remembered.
   plus the `@theme` block in `Client.App/src/styles.css`, which is where MailFathom's own values are declared and the
   only place a hexadecimal colour is written. An arbitrary-value utility — `text-[#0048e0]`, `p-[13px]`, `text-[15px]` —
   is the thing this rule refuses: a value that needs one is a token missing from the theme, so add it there.
+- **A breakpoint is a token like any other.** The widths a composition changes at are declared once, beside the colours,
+  and every screen composes against those names — so the point where narrow stops is one decision rather than one per
+  screen. An arbitrary width such as `min-[734px]:` is the same defect as `text-[#0048e0]`, and is answered the same
+  way: add the breakpoint to the theme.
 - **A repeated structure has one shape, stated once.** The second screen needing a card, a list row, a section header,
   or a page title uses the first one's component rather than a similar arrangement of utilities. Two implementations of
   one shape is how a client stops looking like one product, and it is invisible in review because each diff is fine.


### PR DESCRIPTION
## What this changes

`frontend/src/AGENTS.md` stated every consequence of the client being a single page and never the premise, and it refused a platform branch without saying what a screen is then allowed to adapt to. Both gaps were already being written against: #1420 commits the shell to a composition that "follows the width and never the head" and cites this file as its authority for a sentence that was not in it.

Three additions, each written where its neighbouring rule already lives rather than in a section of its own:

- **§ *What the application is, and is not*** now names the client a **single-page application** and states the three things that follow — navigation is the application's own state, a reload is a cold start rather than a way out (which is what § *UX* was already refusing without saying why), and whatever carries routes is a decision rather than an import. Both heads are that same page, so the property is the client's rather than the browser's.
- **§ *The two heads*** gains what a screen adapts to instead of a platform: the width it has been given and what the pointer can do. A half-width window on a desktop gets the composition a phone-width viewport gets, out of the same tree at the same breakpoint. The bar is stated rather than left to taste — usable from 320 CSS pixels upward, no horizontal scrolling of the page, nothing hidden by width alone.
- **§ *UI*** gains one bullet: a breakpoint is a token like any other, declared beside the colours, so `min-[734px]:` is the same defect as `text-[#0048e0]` and is answered the same way.

## Why here

The refusal to branch on a platform is what makes the layout rule necessary rather than optional: with `if (isDesktop)` gone, width and pointer capability are the only criteria left, and stating the refusal without stating the replacement reads as *do not adapt*. Every screen under #1430 and the stage parents beneath it would otherwise be written against that absence.

## What this does not do

No component, no `@theme` block, and no breakpoint value is written — the token layer gains its breakpoints when a screen needs them. Choosing a routing package stays #1420's call and a pin recorded like any other.

## Verification

- `scripts/verify-full.sh` — passed, 276 workflow-contract assertions, 0 failed, on the rebased head.
- `scripts/review-obligations.sh` — names ADR 0021 and ADR 0022 as the pages whose `describes:` marker covers `frontend/**`. Both read; neither owes an edit. ADR 0021 records the stack and already says the platform-shaped part of one tree is CSS plus `env(safe-area-inset-bottom)`, which this is consistent with and adds nothing to; ADR 0022 covers cost, cancellation, and model reporting and says nothing about layout.
- `$check-docs-licenses` — Docs `pass`, Changelog `n/a`, Licenses `n/a` (inventory empty; naming a router that is not adopted earns no register row).

## Breaking changes

None. No configuration key, database column, MCP tool argument, or deployment contract moves.

Closes #1432
