### PR TITLE
[#1414] Start the React client from the Aspire app host, and leave it out of the integration-test topology

### DIFF
--- a/backend/src/AppHost/OrchestrationContract.cs
+++ b/backend/src/AppHost/OrchestrationContract.cs
@@ -286,6 +286,79 @@ public static class OrchestrationContract
     /// <summary>The EF Core migration tool resource.</summary>
     public const string MigrationsResourceName = "mailfathom-migrations";
 
+    /// <summary>The MailFathom client resource, which serves the client beside the service it calls.</summary>
+    /// <remarks>
+    /// <para>
+    /// An executable resource, because the client is a Vite development server started by the workspace's package
+    /// manager rather than anything MSBuild builds. A project resource would need a project, and no project under
+    /// <c>frontend/</c> enters <c>backend/MailFathom.slnx</c> — what the app model reaches into the other stack with is
+    /// a directory and a command.
+    /// </para>
+    /// <para>
+    /// Present only in a developer's topology. The integration suite starts this same app model to test the service,
+    /// and a development server there would install a package graph on every run that no test reads.
+    /// </para>
+    /// </remarks>
+    public const string ClientResourceName = "mailfathom-client";
+
+    /// <summary>The client workspace's directory, relative to the app host's own.</summary>
+    /// <remarks>
+    /// A path rather than a reference, which is the whole of what the app model asks of the other stack: MSBuild is
+    /// never told the two are related, so <c>backend/MailFathom.slnx</c> still names nothing under <c>frontend/</c> and
+    /// building or testing the service restores no JavaScript. What the app host holds is a directory it starts a
+    /// process in.
+    /// </remarks>
+    public const string ClientWorkspaceDirectory = "../../../frontend";
+
+    /// <summary>The command the client's development server is started through.</summary>
+    /// <remarks>
+    /// The workspace's own package manager, which <c>frontend/package.json</c> declares under <c>packageManager</c>,
+    /// and the one thing this resource needs that the .NET SDK does not bring. A machine without it fails on this
+    /// resource alone — nothing waits for the client — while PostgreSQL, the migrations, and the host still start.
+    /// </remarks>
+    public const string ClientPackageManagerCommand = "pnpm";
+
+    /// <summary>The workspace script that starts the client's development server.</summary>
+    /// <remarks>
+    /// The script <c>frontend/package.json</c> declares, run from the workspace root rather than from the application
+    /// package, so what the orchestration starts is the command a developer would type. It forwards the arguments below
+    /// through the workspace filter to Vite unchanged.
+    /// </remarks>
+    public const string ClientDevelopmentServerScript = "dev";
+
+    /// <summary>The argument the client's development server takes the address it binds from.</summary>
+    public const string ClientDevelopmentServerHostArgument = "--host";
+
+    /// <summary>The argument the client's development server takes the port it binds from.</summary>
+    public const string ClientDevelopmentServerPortArgument = "--port";
+
+    /// <summary>The argument that makes the development server fail rather than move when its port is taken.</summary>
+    /// <remarks>
+    /// Vite otherwise looks for the next free port, which would serve the client somewhere the app model never
+    /// published — so the dashboard would link a socket nothing answers on while the page was alive elsewhere. Failing
+    /// says which port was wanted, which is the answer a pinned port needs.
+    /// </remarks>
+    public const string ClientDevelopmentServerStrictPortArgument = "--strictPort";
+
+    /// <summary>The endpoint the client's development server serves the page on.</summary>
+    public const string ClientHttpEndpointName = "http";
+
+    /// <summary>The environment variable the client reads the service's client surface address from.</summary>
+    /// <remarks>
+    /// <para>
+    /// Handed to the development server's own process rather than to a build, which is what the React stack made
+    /// possible: Vite exposes every <c>VITE_</c>-prefixed variable of its process environment on
+    /// <c>import.meta.env</c>, so the address a run took reaches the page the server serves without a property, a
+    /// generated file, or a rebuild. <c>frontend/src/Client.App/src/environment.d.ts</c> is where the client declares
+    /// it.
+    /// </para>
+    /// <para>
+    /// The prefix is Vite's own boundary rather than a convention: a variable without it is deliberately withheld from
+    /// the bundle, so renaming this to something unprefixed would leave the page reading nothing.
+    /// </para>
+    /// </remarks>
+    public const string ClientServiceAddressVariable = "VITE_MAILFATHOM_SERVICE_ADDRESS";
+
     /// <summary>The address a developer's own machine serves the service's own surfaces on.</summary>
     /// <remarks>
     /// Loopback, because a development run authenticates nobody on the MCP and administrative surfaces and its client
@@ -617,6 +690,27 @@ public static class OrchestrationContract
     /// </remarks>
     public const string PinnedClientEndpointPortKey = "Ports:ClientEndpoint";
 
+    /// <summary>The configuration key a developer states the client's development server port under to pin it.</summary>
+    /// <remarks>Read the way <see cref="PinnedMcpEndpointPortKey" /> is. Pinning it is what a bookmarked browser tab wants; leaving it unset is what lets a second checkout serve a client of its own.</remarks>
+    public const string PinnedClientPortKey = "Ports:Client";
+
+    /// <summary>The configuration key a developer states <see langword="false" /> under to run the orchestration without the client.</summary>
+    /// <remarks>
+    /// <para>
+    /// Starting the client needs Node and <see cref="ClientPackageManagerCommand" />, which the .NET SDK does not
+    /// bring. That is a fact about one machine rather than about this repository, so it is stated where the pinned
+    /// ports are — the app host's own user secrets, out of every checkout — and its environment form,
+    /// <c>Client__Enabled</c>, is what leaves the client out of a single run.
+    /// </para>
+    /// <para>
+    /// Read from configuration rather than from the argument list, unlike <see cref="IntegrationTestingArgument" />,
+    /// and the difference is what each one decides. The argument selects a topology, so an ambient value could divert
+    /// an ordinary run onto the ephemeral database; this removes one resource from a topology already selected, which
+    /// is a thing a developer who set it meant and a thing no other run is harmed by.
+    /// </para>
+    /// </remarks>
+    public const string ClientEnabledKey = "Client:Enabled";
+
     /// <summary>The fixed configuration a normal local run supplies beside its interactive mailbox values.</summary>
     /// <remarks>
     /// Every listener is restricted to loopback because the MCP and administrative surfaces deliberately authenticate
@@ -749,6 +843,45 @@ public static class OrchestrationContract
 
         return port;
     }
+
+    /// <summary>Reads whether this run starts the client, from the value configuration holds under <see cref="ClientEnabledKey" />.</summary>
+    /// <param name="statedValue">The value configuration holds under that key, or <see langword="null" /> when it holds none.</param>
+    /// <returns><see langword="true" /> unless the developer stated otherwise, which is what makes one command bring up a working MailFathom.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when a stated value is not a boolean.</exception>
+    /// <remarks>
+    /// A stated value that is not a boolean is refused rather than ignored, for the reason an unusable pinned port is:
+    /// a developer who wrote <c>0</c> or <c>no</c> asked for the client to stay out of the run, and starting it anyway
+    /// would run a toolchain they were avoiding while nothing said why.
+    /// </remarks>
+    public static bool ResolveClientEnabled(string? statedValue)
+    {
+        if (string.IsNullOrWhiteSpace(statedValue))
+        {
+            return true;
+        }
+
+        var statedBoolean = statedValue.Trim();
+
+        if (!bool.TryParse(statedBoolean, out var clientEnabled))
+        {
+            throw new InvalidOperationException(
+                $"{ClientEnabledKey} is '{statedBoolean}', which is not true or false. State one of those, or leave it unset to start the client with the rest of the orchestration.");
+        }
+
+        return clientEnabled;
+    }
+
+    /// <summary>Composes the address the running client reaches the service's client surface at.</summary>
+    /// <param name="clientEndpointPort">The port this run serves the client surface on.</param>
+    /// <returns>The origin that surface answers on, with no trailing separator.</returns>
+    /// <remarks>
+    /// No trailing separator, because the client appends its own route prefix to this value: a base address ending in
+    /// one would compose <c>//api/client</c>, which the surface does not serve. Loopback for the reason
+    /// <see cref="DeveloperLoopbackAddress" /> gives, and it is the same address the surface binds, so the page reaches
+    /// the socket Kestrel opened rather than a spelling that resolves elsewhere.
+    /// </remarks>
+    public static string ResolveDevelopmentServiceAddress(int clientEndpointPort) =>
+        $"http://{DeveloperLoopbackAddress}:{clientEndpointPort.ToString(CultureInfo.InvariantCulture)}";
 
     /// <summary>Finds free TCP ports for the sockets the orchestration publishes without a proxy in front of them.</summary>
     /// <param name="count">How many ports the caller needs, which is how many sockets it declares.</param>

--- a/backend/src/AppHost/Program.cs
+++ b/backend/src/AppHost/Program.cs
@@ -455,20 +455,21 @@ if (runsIntegrationTests)
 }
 else
 {
-    // The four host sockets, each stated by the section that owns it and each on a free port this run found unless this
-    // checkout pinned one. Found here rather than left to the orchestrator, which allocates a port for the proxy it
-    // would put in front of a resource and refuses an endpoint that declares none while asking for no proxy — and no
-    // proxy is what keeps the socket a client reaches the socket Kestrel opened.
+    // The four host sockets and the client's own, each stated by the section that owns it and each on a free port this
+    // run found unless this checkout pinned one. Found here rather than left to the orchestrator, which allocates a
+    // port for the proxy it would put in front of a resource and refuses an endpoint that declares none while asking
+    // for no proxy — and no proxy is what keeps the socket a client reaches the socket Kestrel opened.
     //
-    // All four are found in one call whether or not any is pinned, because that is what makes them different from each
-    // other; a pinned value then replaces the one it was found for and the others stay where they were put. A second
-    // call would release these before choosing, and two sockets handed one number is a run that fails on whichever
-    // binds second.
-    var foundPorts = OrchestrationContract.FindFreePorts(4);
+    // All five are found in one call whether or not any is pinned, because that is what makes them different from each
+    // other; a pinned value then replaces the one it was found for and the others stay where they were put. The last
+    // one belongs to the client below, and is found here rather than beside it for that reason: a second call would
+    // release these before choosing, and two sockets handed one number is a run that fails on whichever binds second.
+    var foundPorts = OrchestrationContract.FindFreePorts(5);
     var mcpEndpointPort = PinnedPort(OrchestrationContract.PinnedMcpEndpointPortKey) ?? foundPorts[0];
     var healthEndpointsPort = PinnedPort(OrchestrationContract.PinnedHealthEndpointsPortKey) ?? foundPorts[1];
     var adminEndpointPort = foundPorts[2];
     var clientEndpointPort = PinnedPort(OrchestrationContract.PinnedClientEndpointPortKey) ?? foundPorts[3];
+    var clientPort = PinnedPort(OrchestrationContract.PinnedClientPortKey) ?? foundPorts[4];
 
     var mailAccountHost = builder
         .AddParameter("mail-account-host")
@@ -547,9 +548,8 @@ else
             env: "AdminEndpoint__Port")
         // The client surface's socket, declared exactly as the MCP endpoint's is. The normal app model enables it and
         // admits the password method so a client has a usable service on its first run; the credential itself is
-        // provisioned through the administrative API after the host reports startup readiness. No client is started
-        // beside it — the Uno one was withdrawn and the React one has not landed — so what this serves today is the
-        // surface itself, for whoever calls it by hand.
+        // provisioned through the administrative API after the host reports startup readiness. The client resource
+        // below is served its address, so a developer reaches this surface without typing a port anywhere.
         //
         // A socket of its own rather than the MCP endpoint's, though every surface's default port would have shared
         // one. What cannot be shared is the bind address: a wildcard beside a specific address on one port is two
@@ -576,6 +576,62 @@ else
         mailFathomHost.GetEndpoint(OrchestrationContract.HostAdminEndpointName),
         TimeProvider.System,
         provider.GetRequiredService<ILogger<DevelopmentCredentialProvisioningWorker>>()));
+
+    // The client, in the one topology it belongs to. What the app model reaches into the other stack with is a
+    // directory and a command: no package under frontend/ enters backend/MailFathom.slnx, no backend project references
+    // one, and MSBuild is never told the two are related — so a build of the service still restores nothing the client
+    // needs. The boundary the repository keeps is a compile-time one, and this is a process the orchestration starts
+    // beside another process.
+    //
+    // An executable rather than a project resource, because there is no project: the client is a Vite development
+    // server, and what starts it is the workspace's own `dev` script run from frontend/ by its package manager. The
+    // script forwards these arguments through the workspace filter to Vite unchanged, so the socket stated here is the
+    // socket the server binds rather than one it chose.
+    //
+    // It waits for nothing. A development server serves the page whether or not the service behind it has started, and
+    // waiting would trade a working page for a slower one; the client's own first request is what discovers the state
+    // of the service.
+    if (OrchestrationContract.ResolveClientEnabled(builder.Configuration[OrchestrationContract.ClientEnabledKey]))
+    {
+        builder
+            .AddExecutable(
+                OrchestrationContract.ClientResourceName,
+                OrchestrationContract.ClientPackageManagerCommand,
+                Path.Combine(builder.AppHostDirectory, OrchestrationContract.ClientWorkspaceDirectory),
+                OrchestrationContract.ClientDevelopmentServerScript,
+                OrchestrationContract.ClientDevelopmentServerHostArgument,
+                OrchestrationContract.DeveloperLoopbackAddress,
+                OrchestrationContract.ClientDevelopmentServerPortArgument,
+                clientPort.ToString(CultureInfo.InvariantCulture),
+                OrchestrationContract.ClientDevelopmentServerStrictPortArgument)
+            // Where the service is, handed to the development server's process rather than to a build. Vite exposes
+            // its own VITE_-prefixed environment on `import.meta.env`, so the page the server serves reads the port
+            // this run took without a property, a generated file, or a rebuild — which is what the React stack made
+            // possible and the WebAssembly one did not.
+            //
+            // CORS is not part of the join. The local topology leaves ClientEndpoint:Cors:AllowedOrigins unstated,
+            // which is the product default of every browser origin, so a page served under either loopback spelling is
+            // answered — naming one of them here is what made a tab opened as `localhost` look like an empty mailbox
+            // while the same tab opened as `127.0.0.1` worked.
+            .WithEnvironment(
+                OrchestrationContract.ClientServiceAddressVariable,
+                OrchestrationContract.ResolveDevelopmentServiceAddress(clientEndpointPort))
+            // Unproxied for the reason the host's sockets are: what the app model publishes is then what a browser
+            // connects to. On loopback, because a development build served against a developer's own machine is not
+            // something anything on a local network has any business loading.
+            .WithHttpEndpoint(
+                name: OrchestrationContract.ClientHttpEndpointName,
+                port: clientPort,
+                targetPort: clientPort,
+                isProxied: false)
+            // Aspire's default endpoint host is `localhost`, which resolves to the IPv6 loopback before the IPv4 one on
+            // an ordinary machine — and the development server binds only the address stated above. Left at the
+            // default, the dashboard would link a socket nothing answers on while the page was alive beside it.
+            .WithEndpoint(
+                OrchestrationContract.ClientHttpEndpointName,
+                endpoint => endpoint.TargetHost = OrchestrationContract.DeveloperLoopbackAddress,
+                createIfNotExists: false);
+    }
 }
 
 // Host is the startup project because it is the project resource the connection string is issued to; Infrastructure

--- a/backend/tests/AppHost.UnitTests/OrchestrationContractTests.cs
+++ b/backend/tests/AppHost.UnitTests/OrchestrationContractTests.cs
@@ -206,6 +206,7 @@ public sealed class OrchestrationContractTests
             OrchestrationContract.PinnedHealthEndpointsPortKey,
             OrchestrationContract.PinnedPostgresPortKey,
             OrchestrationContract.PinnedClientEndpointPortKey,
+            OrchestrationContract.PinnedClientPortKey,
         ];
 
         // Assert
@@ -362,11 +363,12 @@ public sealed class OrchestrationContractTests
 
     /// <summary>The address the client and the service are wired together on is one nothing outside this machine reaches.</summary>
     /// <remarks>
-    /// The one property of that constant the compiler cannot state. Three things are built from it — the socket the
-    /// client's development server binds, the endpoint Aspire publishes, and the address the head is built to call —
-    /// so a value that stopped being loopback would publish a Debug WebAssembly bundle to every interface of a
-    /// developer's machine without any of the three disagreeing about it. CORS is not the fourth: the local topology
-    /// leaves <c>ClientEndpoint:Cors:AllowedOrigins</c> unstated, which is the product default of every origin.
+    /// The one property of that constant the compiler cannot state. Four things are built from it — the sockets the
+    /// host binds, the socket the client's development server binds, the endpoint Aspire publishes for it, and the
+    /// address the client is handed — so a value that stopped being loopback would serve a development build to every
+    /// interface of a developer's machine without any of the four disagreeing about it. CORS is not the fifth: the
+    /// local topology leaves <c>ClientEndpoint:Cors:AllowedOrigins</c> unstated, which is the product default of every
+    /// origin.
     /// </remarks>
     [Fact]
     public void DeveloperLoopbackAddress_IsAnAddressOnlyThisMachineReaches()
@@ -393,6 +395,126 @@ public sealed class OrchestrationContractTests
         // Act, Assert
         Assert.DoesNotContain("ClientEndpoint__Cors__AllowedOrigins", program, StringComparison.Ordinal);
         Assert.DoesNotContain("AdminEndpoint__Cors__AllowedOrigins", program, StringComparison.Ordinal);
+    }
+
+    /// <summary>One command brings up a working MailFathom, so a checkout that states nothing gets the client.</summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResolveClientEnabled_NothingStated_StartsTheClient(string? statedValue)
+    {
+        // Act
+        var clientEnabled = OrchestrationContract.ResolveClientEnabled(statedValue);
+
+        // Assert
+        Assert.True(clientEnabled);
+    }
+
+    /// <summary>A machine without the client's toolchain leaves it out of every run, which is what the key is for.</summary>
+    [Theory]
+    [InlineData("false", false)]
+    [InlineData("False", false)]
+    [InlineData(" false ", false)]
+    [InlineData("true", true)]
+    public void ResolveClientEnabled_ValueStated_IsTheAnswerTheDeveloperWrote(string statedValue, bool expected)
+    {
+        // Act
+        var clientEnabled = OrchestrationContract.ResolveClientEnabled(statedValue);
+
+        // Assert
+        Assert.Equal(expected, clientEnabled);
+    }
+
+    /// <summary>A developer who wrote something else asked for the client to stay out, so the run says why rather than starting it.</summary>
+    [Theory]
+    [InlineData("0")]
+    [InlineData("1")]
+    [InlineData("no")]
+    [InlineData("off")]
+    [InlineData("disabled")]
+    public void ResolveClientEnabled_ValueIsNotABoolean_FailsNamingTheKey(string statedValue)
+    {
+        // Act
+        var failure = Assert.Throws<InvalidOperationException>(
+            () => OrchestrationContract.ResolveClientEnabled(statedValue));
+
+        // Assert
+        Assert.Contains(OrchestrationContract.ClientEnabledKey, failure.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>The address the client is handed is the surface's own origin, and the client appends its route prefix to it.</summary>
+    /// <remarks>
+    /// The trailing separator is the whole of what this establishes and nothing states it twice: the client composes a
+    /// request as the base address followed by <c>/api/client</c>, so a value ending in one would ask for a path the
+    /// surface does not serve — and the refusal would arrive as a route that does not exist rather than as an address
+    /// that was composed wrongly.
+    /// </remarks>
+    [Fact]
+    public void ResolveDevelopmentServiceAddress_TheClientSurfacePort_IsALoopbackOriginWithNoTrailingSeparator()
+    {
+        // Act
+        var address = OrchestrationContract.ResolveDevelopmentServiceAddress(8082);
+
+        // Assert
+        var parsed = new Uri(address, UriKind.Absolute);
+
+        Assert.Equal(OrchestrationContract.DeveloperLoopbackAddress, parsed.Host, StringComparer.Ordinal);
+        Assert.Equal(8082, parsed.Port);
+        Assert.Equal(Uri.UriSchemeHttp, parsed.Scheme, StringComparer.Ordinal);
+        Assert.False(address.EndsWith('/'));
+    }
+
+    /// <summary>The variable is one Vite will actually hand to the page rather than one it withholds.</summary>
+    /// <remarks>
+    /// Vite exposes only the prefixed part of its process environment on <c>import.meta.env</c>, deliberately, so a
+    /// name that lost the prefix would be written by the app model, carried by the development server, and read by
+    /// nothing — a client that reported no service rather than a run that failed.
+    /// </remarks>
+    [Fact]
+    public void ClientServiceAddressVariable_IsPrefixedSoTheDevelopmentServerExposesIt()
+    {
+        // Assert
+        Assert.StartsWith("VITE_", OrchestrationContract.ClientServiceAddressVariable, StringComparison.Ordinal);
+    }
+
+    /// <summary>The client is started from the workspace root rather than from a package inside it, and by path alone.</summary>
+    /// <remarks>
+    /// A relative path is what keeps the two stacks apart: the app model holds a directory it starts a process in, so
+    /// an absolute one taken from a machine, or a path that reached inside a package, would be the point at which the
+    /// boundary stopped being a directory and a command.
+    /// </remarks>
+    [Fact]
+    public void ClientWorkspaceDirectory_IsTheWorkspaceRootStatedRelativeToTheAppHost()
+    {
+        // Act
+        var directory = OrchestrationContract.ClientWorkspaceDirectory;
+
+        // Assert
+        Assert.False(Path.IsPathRooted(directory));
+        Assert.EndsWith("/frontend", directory, StringComparison.Ordinal);
+    }
+
+    /// <summary>The client is composed once, in the topology it belongs to, so a suite run starts no development server.</summary>
+    /// <remarks>
+    /// The integration suite starts this same app model, and the resource is added inside the branch that run does not
+    /// take. Nothing in the type system says so, and a second block copied into the ephemeral branch would install a
+    /// package graph on every suite run that no test reads — so what is asserted is that exactly one block composes it
+    /// and exactly one reads the switch in front of it.
+    /// </remarks>
+    [Fact]
+    public void Program_TheClientResource_IsComposedOnceBehindTheSwitchThatSelectsIt()
+    {
+        // Arrange
+        var program = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Build", "Program.cs"));
+
+        // Act
+        var resources = program.Split(nameof(OrchestrationContract.ClientResourceName)).Length - 1;
+        var switches = program.Split(nameof(OrchestrationContract.ClientEnabledKey)).Length - 1;
+
+        // Assert
+        Assert.Equal(1, resources);
+        Assert.Equal(1, switches);
     }
 
     private static string IdentifierOf(string prefix) =>

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -219,13 +219,14 @@ named `local`, over implicit TLS on port 993, with its inbox as the default fold
 the AppHost's user secrets; leaving any of them unanswered leaves the application waiting rather than starting a host
 with no mailbox.
 
-Three resources come up, in dependency order. The `postgres` container starts first and has to report
+Four resources come up, three of them in dependency order. The `postgres` container starts first and has to report
 healthy; the `mailfathom-migrations` resource then applies every pending migration to it; and `mailfathom-host` waits
 for that run
 to complete before starting, which is why the schema gate that fails a fresh deployment on purpose never fires on a
 local run — the explicit schema step the deployments require is performed here by the orchestration, before the host
-looks. There is no client resource: the Uno Platform client this topology used to start was withdrawn, and what
-replaces it will be started however a React toolchain is started.
+looks. The fourth is `mailfathom-client`, which serves the client's development server and waits for none of them,
+since a development server serves the page whether or not the service behind it has started; it is
+[described below](#the-client-resource).
 Because the host runs in `Development`, it also publishes [the HTTP API document and the explorer](http-api-documentation.md)
 at `/openapi/v1.json` and `/scalar` on every port this run actually binds. Neither exists in any other environment, and
 neither is on a port of its own. The normal orchestration enables the MCP, administrative, and client surfaces, so the
@@ -256,11 +257,60 @@ and MailFathom refuses that variable outright, because each surface states where
 endpoint is published without ever reaching it. That is also why the resource carries no `WithHttpHealthCheck`, which
 derives its address from an HTTP endpoint this app model declares none of.
 
+### The client resource
+
+`mailfathom-client` is the client under `frontend/`, served on a socket of its own that the dashboard lists like any
+other endpoint. It is what makes one command bring up a MailFathom with a face on it rather than a service and a second
+terminal.
+
+It is an **executable** resource, because there is no project to make it a project one: the client is a Vite
+development server, and what starts it is the workspace's own `dev` script. The app model runs
+`pnpm dev --host 127.0.0.1 --port <the port this run took> --strictPort` with `frontend/` as the working directory —
+the command a developer would type, with the socket stated rather than chosen. `--strictPort` is what makes the number
+binding: Vite otherwise moves to the next free port, which would serve the page somewhere the dashboard never linked.
+
+Nothing about this is a reference. The app host holds a path and a command, MSBuild is never told the two stacks are
+related, and `backend/MailFathom.slnx` still names nothing under `frontend/` — so building or testing the service
+restores no JavaScript, and starting this resource is what pays for the client's own toolchain.
+
+**The client needs Node and pnpm, which the .NET SDK does not bring** — [Building and testing the
+client](#building-and-testing-the-client) is the same requirement stated for the verification gates. On a machine
+without them this resource fails on its own, naming the command it could not start, while PostgreSQL, the migrations,
+and the host still come up: nothing waits for the client. The orchestration installs nothing either, so a fresh
+checkout runs `pnpm install --frozen-lockfile` in `frontend/` once before the resource can start; a restore on every
+orchestration start would be seconds paid on every run for something that changes when the lock file does.
+
+To run the orchestration without it at all, state so in the app host's own user secrets, where the pinned ports live
+and for the same reason — it is a decision about one machine rather than about a checkout:
+
+```bash
+dotnet user-secrets --project backend/src/AppHost/AppHost.csproj set "Client:Enabled" "false"
+```
+
+Its environment form leaves the client out of a single run: `Client__Enabled=false dotnet run --project
+backend/src/AppHost/AppHost.csproj`. A value that is neither `true` nor `false` fails the app host at startup naming the
+key, rather than being ignored and starting the resource the developer was avoiding.
+
+The `IntegrationTesting=true` switch that selects the ephemeral topology leaves the client out of it entirely, the way
+it decides every other resource there: a suite that tests the service would otherwise install a package graph on every
+run that no test reads.
+
+**What tells the client where the service is, is the process rather than the build.** The app model writes
+`VITE_MAILFATHOM_SERVICE_ADDRESS` into the development server's environment, holding the client surface's own origin —
+`http://127.0.0.1:<the port the client surface took>`, with no trailing separator, because the client appends its own
+`/api/client` prefix to it. Vite exposes every `VITE_`-prefixed variable of its process environment on
+`import.meta.env`, so the page reads the port this run took without a property, a generated file, or a rebuild;
+`frontend/src/Client.App/src/environment.d.ts` is where the client declares it. It is optional there, and deliberately:
+a bundle served from the deployment's own container image is fetched from the service it calls, so the origin it was
+loaded from is the answer.
+
+The dashboard publishes the client's endpoint under `127.0.0.1`, the same spelling the development server binds.
+Aspire's default endpoint host is `localhost`, which resolves to the IPv6 loopback before the IPv4 one on an ordinary
+machine; left at the default, the dashboard would link a socket nothing answers on while the page was alive beside it.
+
 ### The client surface
 
-There is no client resource in this app model. The Uno Platform head it used to start was withdrawn, and the client is
-being rebuilt in React; whatever starts the new one is decided with it. What the orchestration still brings up is the
-**surface a client calls**, which is the service's own and was never the client's.
+What the client calls is the **surface the service serves**, which is the service's own and was never the client's.
 
 **It is enabled by the normal orchestration.** The app model supplies its port and loopback bind and enables the
 password method, then provisions `test` / `test-password` through the ordinary administrative API — so password policy,
@@ -272,7 +322,8 @@ opened as the other. A deployment names the origin it actually serves.
 It is on `127.0.0.1`, because the only thing that calls it is something running on this machine, and that is also why
 it is a socket of its own rather than a share of the MCP endpoint's: a wildcard bind beside a specific one on a single
 port is two sockets the operating system grants only one of, so sharing would have published the client surface
-wherever the MCP endpoint is published.
+wherever the MCP endpoint is published. A run started with `Client:Enabled` false starts no client, and the surface and
+its Basic credential stay available for a client started by hand or for a direct request.
 
 ### Pinning a port
 
@@ -289,12 +340,14 @@ dotnet user-secrets --project backend/src/AppHost/AppHost.csproj set "Ports:McpE
 dotnet user-secrets --project backend/src/AppHost/AppHost.csproj set "Ports:HealthEndpoints" "8081"
 dotnet user-secrets --project backend/src/AppHost/AppHost.csproj set "Ports:Postgres" "5432"
 dotnet user-secrets --project backend/src/AppHost/AppHost.csproj set "Ports:ClientEndpoint" "8082"
+dotnet user-secrets --project backend/src/AppHost/AppHost.csproj set "Ports:Client" "5173"
 ```
 
 `8080` and `8081` are the ports [the container image](container-image.md) publishes and `5432` is PostgreSQL's own, so
-those three values are what makes a local run answer where a deployment does; the last answers a different want.
-`Ports:ClientEndpoint` is a request written once against `/api/client`. Each key is read on its own, so pinning the MCP
-endpoint leaves the probes, the database, and the client surface on whatever the run takes. A value that is not a port
+those three values are what makes a local run answer where a deployment does; the last two answer a different want.
+`Ports:ClientEndpoint` is a request written once against `/api/client`, and `Ports:Client` is a bookmarked browser
+tab — `5173` is Vite's own default. Each key is read on its own, so pinning the MCP endpoint leaves the probes, the
+database, the client surface, and the client on whatever the run takes. A value that is not a port
 number between `1` and `65535` fails the app host at startup naming the key, rather than being ignored and leaving the
 address to move anyway.
 
@@ -302,8 +355,8 @@ That store is keyed by the `UserSecretsId` in `backend/src/AppHost/AppHost.cspro
 pinned there is pinned for **every checkout on the machine** — which is the collision above, taken deliberately for the
 address it buys. It is also loaded in the `Development` environment only, which is what the app host's only launch
 profile runs it in. The environment form of each key is what pins a port for one run: `Ports__McpEndpoint`,
-`Ports__HealthEndpoints`, `Ports__Postgres`, and `Ports__ClientEndpoint` are read after the store and therefore win
-over it.
+`Ports__HealthEndpoints`, `Ports__Postgres`, `Ports__ClientEndpoint`, and `Ports__Client` are read after the store and
+therefore win over it.
 
 ```bash
 Ports__McpEndpoint=8080 dotnet run --project backend/src/AppHost/AppHost.csproj

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -21,6 +21,11 @@ field is what says which version to install. `.npmrc` declares the registry thos
 leaving it to whatever a machine configured. [Local development](../docs/operations/local-development.md) has the
 prerequisites and how the verification gates run all of this.
 
+`pnpm dev` is also what the Aspire app host starts as its `mailfathom-client` resource, so one command brings up the
+database, the service, and this development server already pointed at the client surface — [the client
+resource](../docs/operations/local-development.md#the-client-resource) is that arrangement, including the environment
+variable it hands over and how to leave the client out of a run.
+
 ## Two packages, and the resolver is what separates them
 
 - **`src/Client.Backend/`** is everything that reaches the service: the request and response types, the session, the

--- a/frontend/src/Client.App/src/environment.d.ts
+++ b/frontend/src/Client.App/src/environment.d.ts
@@ -9,3 +9,17 @@
  * declared rather than imported so that no source file and no manifest carries the number itself.
  */
 declare const __MAILFATHOM_VERSION__: string;
+
+interface ImportMetaEnv {
+    /**
+     * Where the service serves its client surface, as an origin with no trailing separator, or absent when nothing
+     * stated one.
+     *
+     * The Aspire app host writes it into the development server's environment so a local run reaches the service on
+     * the port it happened to take. It is optional because every other way of serving this application states nothing:
+     * a bundle served from the deployment's own container image is fetched from the service it calls, so the origin it
+     * was loaded from is the answer, and a page opened from a development server without an orchestration behind it
+     * has no service to name.
+     */
+    readonly VITE_MAILFATHOM_SERVICE_ADDRESS?: string;
+}


### PR DESCRIPTION
The normal orchestration already served the surface a client calls — enabled, on its own loopback
socket, with `test` / `test-password` provisioned through the administrative API — and started
nothing that calls it. Running a screen against a locally orchestrated service therefore meant a
second terminal, `pnpm dev` in `frontend/`, and the port the run happened to take typed in by hand.

`mailfathom-client` closes that. It is an executable resource running the workspace's own command:

```
pnpm dev --host 127.0.0.1 --port <this run's port> --strictPort
```

with `frontend/` as its working directory. `--strictPort` is what makes the number binding — Vite
otherwise moves to the next free port and the dashboard would link a socket nothing answers on.

## The React stack makes it simpler than the resource #1392 removed

There is no multi-targeted project to name a framework for, and — the substantive difference — the
service address no longer has to travel through a build. The app model writes
`VITE_MAILFATHOM_SERVICE_ADDRESS` into the development server's own environment, holding the client
surface's origin with no trailing separator, because the client appends its own `/api/client` prefix
to it. Vite exposes every `VITE_`-prefixed variable of its process environment on `import.meta.env`,
so the page reads the port this run took without a property, a generated file, or a rebuild.

`frontend/src/Client.App/src/environment.d.ts` declares it, optional there and deliberately: a
bundle served from the deployment's own container image is fetched from the service it calls, so the
origin it was loaded from is the answer, and a development server started without an orchestration
behind it has no service to name. No screen, component, or client behaviour changed — the page this
starts is whatever `Client.App` serves at the time it lands.

No hosting package was added. An executable resource with a working directory carries the whole of
this, so nothing was pinned in `backend/Directory.Packages.props`.

## What crosses the stack boundary is a path and a process

No package under `frontend/` enters `backend/MailFathom.slnx`, no reference crosses, and MSBuild is
never told the two are related. `dotnet build backend/src/AppHost/AppHost.csproj` restored and built
the eight service projects and nothing under `frontend/`, read from the run's own output.

## CORS needs nothing stated

The local topology leaves `ClientEndpoint:Cors:AllowedOrigins` unset, which `ClientEndpointOptions`
reads as the product default of every browser origin, so a page served under either loopback
spelling is answered. Naming one of them is what previously made a tab opened as `localhost` look
like an empty mailbox while the same tab opened as `127.0.0.1` worked.

## The two switches, and the topology it is absent from

`Client:Enabled` returns as the way to leave the client out of a run, and `Ports:Client` as the pin
for its port — both read from the app host's own configuration, as every other pin is, with the
environment forms `Client__Enabled` and `Ports__Client`. A machine without Node and pnpm fails on
this resource alone, naming the command it could not start, while PostgreSQL, the migrations, and
the host still come up: nothing waits for the client.

The resource is composed in the branch `IntegrationTesting=true` does not take, so a suite run
starts no development server. `Program_TheClientResource_IsComposedOnceBehindTheSwitchThatSelectsIt`
holds that to one block and one switch.

## Verified rather than asserted

- `pnpm dev --host 127.0.0.1 --port 45123 --strictPort` from `frontend/`: both pnpm hops forward the
  arguments to Vite unchanged and the server binds `http://127.0.0.1:45123/`.
- Vite's own `loadEnv` returns `VITE_MAILFATHOM_SERVICE_ADDRESS` from the process environment, which
  is the path `import.meta.env` is populated from.
- The service build restores nothing under `frontend/`.
- `scripts/verify-full.sh`.

**Not run:** a whole `aspire run`. It needs Docker, the three interactive mailbox parameters, and a
PostgreSQL container this machine shares with other sessions, so the resource's start under DCP is
argued from the two measurements above rather than observed end to end.

## Deliberately not done

The orchestration installs nothing — a `pnpm install --frozen-lockfile` resource in front of the
client would be seconds paid on every run for something that changes when the lock file does. A
fresh checkout restores the workspace once by hand, which
`docs/operations/local-development.md` now says.

No public surface moved: `Client:Enabled` and `Ports:Client` are the app host's own developer
configuration rather than the product's configuration schema, so there is no break to record.

Closes #1414
