### PR TITLE
[#1435] Bind the client's preview server to the address the browser suite navigates to

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -77,8 +77,16 @@ export default defineConfig({
     ],
 
     webServer: {
-        command: `pnpm --filter @mailfathom/client-app exec vite preview --port ${String(previewPort)} --strictPort`,
+        // `--host 127.0.0.1` rather than the default, which is the name `localhost`: where that name resolves to `::1`
+        // first — as it does on a GitHub-hosted runner — the server listens on the IPv6 loopback alone and the address
+        // below is unreachable, which arrives as the web server timing out rather than as an address mismatch. Binding
+        // the same literal the suite navigates to removes the resolution from the question.
+        command: `pnpm --filter @mailfathom/client-app exec vite preview --host 127.0.0.1 --port ${String(previewPort)} --strictPort`,
         url: previewOrigin,
+
+        // Piped rather than ignored, so a server that refuses to start says why in the run that failed. It prints one
+        // line naming the address it bound, which is the whole diagnosis for this class of failure.
+        stdout: 'pipe',
 
         // Never reused, even though the port is this worktree's own. A server already listening on it is either a
         // stale one from a crashed run, serving a bundle this one did not build, or somebody else's — and a suite that


### PR DESCRIPTION
Closes #1435

`main` currently fails its own `Frontend / Build the client and check it in a real browser` job, and so does every pull request that reaches the client stack. This repairs it.

## What was wrong

`frontend/playwright.config.ts` started `vite preview` without naming a bind address, so Vite bound the *name* `localhost`. The suite navigates to the *literal* `127.0.0.1`, because the port it derives from the workspace path is composed into an origin. On a GitHub-hosted runner `localhost` resolves to `::1` first, so the server listened on the IPv6 loopback alone and the address the browser was pointed at was never bound. Locally the two agree, which is why the suite passed on the machine it was written on and failed on its first pipeline run.

The failure named none of that:

```
Error: Timed out waiting 60000ms from config.webServer.
```

Playwright reports only that its web server did not come up, and the configuration ignored the server's stdout — so the one line that would have said which address was bound was discarded.

## What changes

Two lines in `frontend/playwright.config.ts`, and nothing else in the repository:

- `vite preview --host 127.0.0.1`, binding the same literal the suite navigates to, which takes name resolution out of the question entirely rather than leaving it to agree by luck.
- `stdout: 'pipe'` on the web server, so a run that fails this way prints the address it bound. That is the second half of the defect rather than a nicety: this class of failure is diagnosed by one line the runner already produced and was throwing away.

Locally the suite now prints it on every run, which is the evidence the fix is doing what it says:

```
[WebServer]   ➜  Local:   http://127.0.0.1:24257/
```

Nothing about what the suite asserts changes, and the port derivation — which is what keeps parallel sessions on one machine from contending — is untouched.

## Verification

- `scripts/verify-full.sh` — passed, 276 contracts, digest recorded. A first run failed on `fathom_review_collects_at_once_when_nobody_has_commented` with `Expected fewer than 2s to elapse, but 2s did`, which is that test's known settle timing under machine load rather than anything this change reaches; the rerun over the same tree is the one that recorded.
- `pnpm test:browser` — 3 passed locally, with the bound address now in the output.
- The real evidence is this pull request's own `Frontend` job, which is what the issue's acceptance asks for and what the previous run could not produce.

https://claude.ai/code/session_01GzEmXPDefHrU9G2yKe3SF9
