### PR TITLE
[#1417] Let a person point the client at a deployment, and keep that address across restarts

### DIFF
--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -87,6 +87,14 @@ answering the port, which contract it speaks, and what the rest of the surface w
 sign-in be built and proven end to end before a screen exists — a client that reached here with a token it had just been
 issued knows the token works.
 
+It has a second reader, holding nothing at all. A person naming their deployment in the client types a host, and the
+client asks here before it sends anything to that address, so a mistyped one is reported as an address that answers as
+nothing rather than as a sign-in that failed. Wherever the endpoint requires a credential — which is every deployment
+that configured one — such a caller is refused, and the refusal is itself the answer: every MailFathom surface
+challenges under the `MailFathom` protection space, and this endpoint's CORS policy names `WWW-Authenticate` among the
+headers a browser may read. A deployment that requires none answers the body instead, and `service` is what the client
+reads out of it.
+
 **It names no credential**, which is the one way it differs from what
 [`GET /api/admin/session`](admin-endpoint.md) answers. That surface's reader is `mfctl` in an operator's own hands, and
 the deployment's configured name for the credential that authenticated is what tells them which of their own entries let

--- a/frontend/src/AGENTS.md
+++ b/frontend/src/AGENTS.md
@@ -135,6 +135,15 @@ target: a difference between the heads is a CSS one — a safe-area inset, a poi
 concern that belongs to the shell rather than to the application. A screen that cannot be written without knowing which
 head it is running on is a design that has not been finished, and taking that branch is what turns one client into two.
 
+**Which deployment the client belongs to is the worked example of that**, and it is where the branch would have been
+most tempting: a web bundle is served by its deployment and a desktop shell is served by nothing. What resolves it is
+one rule about addresses rather than a question about heads — `Client.App/src/deployment/adoptedDeployment.ts` reads
+the address somebody named, else the one that served the client, and takes the second only where it is an address this
+client may address at all. A shell loaded from a scheme of its own resolves to nothing there and meets the connect
+screen; a page served by its deployment resolves to that deployment and meets none. Both answers are addresses, which
+is why neither case has to know about the other, and it is why `main.tsx` is where the resolution happens: the edge
+supplies a value, and no screen underneath asks where it came from.
+
 **What a screen adapts to instead is the width it has been given and what the pointer can do.** Those two are the whole
 of it, and the refusal above is not an instruction to adapt to nothing: a window is resized far more often than a head
 is changed, and one head produces both shapes anyway. A half-width window on a desktop gets the composition a

--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ClientRequest, ClientResponse, MailFathomTransport } from '@mailfathom/client-backend';
 import { App } from './App';
 import type { AdoptedDeployment } from './deployment/adoptedDeployment';
+import type { DeploymentTransport } from './deployment/sendToDeployment';
 import { LocalizationProvider } from './localization/Localization';
 import { localeNames, locales, readStoredLocale } from './localization/locale';
 
@@ -41,13 +42,13 @@ const servedFrom: AdoptedDeployment = {
     chosen: false,
 };
 
-const nothingSent: MailFathomTransport = () => Promise.reject(new Error('This screen reaches no deployment.'));
+const nothingSent: DeploymentTransport = () => () => Promise.reject(new Error('This screen reaches no deployment.'));
 
 // The application is mounted the way `main.tsx` mounts it, `StrictMode` included. Nothing reads a message without the
 // provider above it, and a test that supplied its own would be proving a second arrangement — and the mode is half of
 // that arrangement rather than a detail of it: it invokes every effect twice on mount, which is the difference between
 // a screen that behaves and one that behaves the first time it is run.
-function renderApp(deployment: AdoptedDeployment | null = servedFrom, send: MailFathomTransport = nothingSent): void {
+function renderApp(deployment: AdoptedDeployment | null = servedFrom, send: DeploymentTransport = nothingSent): void {
     render(
         <StrictMode>
             <LocalizationProvider>
@@ -171,7 +172,7 @@ describe('App', () => {
 describe('App deployment', () => {
     // A deployment that is there and wants a credential, which is what every deployment somebody runs answers a client
     // that has not signed in yet. The challenge is what says the answer came from MailFathom.
-    const reachable: MailFathomTransport = () =>
+    const reachable: DeploymentTransport = () => () =>
         Promise.resolve({ status: 401, body: '', headers: { 'www-authenticate': 'Bearer realm="MailFathom"' } });
 
     beforeEach(() => {

--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+import { StrictMode } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ClientRequest, ClientResponse, MailFathomTransport } from '@mailfathom/client-backend';
@@ -42,18 +43,29 @@ const servedFrom: AdoptedDeployment = {
 
 const nothingSent: MailFathomTransport = () => Promise.reject(new Error('This screen reaches no deployment.'));
 
-// The application is mounted the way `main.tsx` mounts it. Nothing reads a message without the provider above it, and
-// a test that supplied its own would be proving a second arrangement.
+// The application is mounted the way `main.tsx` mounts it, `StrictMode` included. Nothing reads a message without the
+// provider above it, and a test that supplied its own would be proving a second arrangement — and the mode is half of
+// that arrangement rather than a detail of it: it invokes every effect twice on mount, which is the difference between
+// a screen that behaves and one that behaves the first time it is run.
 function renderApp(deployment: AdoptedDeployment | null = servedFrom, send: MailFathomTransport = nothingSent): void {
     render(
-        <LocalizationProvider>
-            <App deployment={deployment} send={send} />
-        </LocalizationProvider>,
+        <StrictMode>
+            <LocalizationProvider>
+                <App deployment={deployment} send={send} />
+            </LocalizationProvider>
+        </StrictMode>,
     );
 }
 
 function chose(baseAddress: string): AdoptedDeployment {
     return { deployment: { baseAddress }, chosen: true };
+}
+
+// Which deployments were reached, in the order they were first reached. `StrictMode` invokes the effect that reads the
+// accounts twice on mount, as React does in development and as `main.tsx` therefore does here, so a repeat of the
+// address already being read is the mode rather than the screen — what these tests are about is which address that is.
+function deploymentsAsked(asked: string[]): string[] {
+    return [...new Set(asked)];
 }
 
 function recordingWhatIsAsked(asked: string[]): void {
@@ -178,7 +190,7 @@ describe('App deployment', () => {
         renderApp(chose('https://elsewhere.example.invalid'));
         await screen.findAllByRole('listitem');
 
-        expect(asked).toEqual(['https://elsewhere.example.invalid/api/client/accounts']);
+        expect(deploymentsAsked(asked)).toEqual(['https://elsewhere.example.invalid/api/client/accounts']);
     });
 
     it('asks for an address when nothing has said where the deployment is', () => {
@@ -210,6 +222,15 @@ describe('App deployment', () => {
 
         expect(screen.getByRole('textbox', { name: 'Deployment address' })).toBeDefined();
         expect(screen.queryByRole('list')).toBeNull();
+    });
+
+    it('leaves focus where the document opened it when the deployment was already known', async () => {
+        renderApp();
+        await screen.findAllByRole('listitem');
+
+        // A cold start is not a view change. `main.tsx` mounts under `StrictMode`, so every effect runs twice here as
+        // it does under `pnpm dev`, and a guard that only survives one invocation would have pulled focus by now.
+        expect(document.activeElement).toBe(document.body);
     });
 
     it('puts focus at the start of the mail once the deployment has been named, rather than leaving it behind', async () => {
@@ -247,7 +268,7 @@ describe('App deployment', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
         await screen.findAllByRole('listitem');
 
-        expect(asked).toEqual([
+        expect(deploymentsAsked(asked)).toEqual([
             'https://first.example.invalid/api/client/accounts',
             'https://second.example.invalid/api/client/accounts',
         ]);

--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -4,40 +4,64 @@
 
 import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ClientRequest, ClientResponse, ClientSession, MailFathomTransport } from '@mailfathom/client-backend';
+import type { ClientRequest, ClientResponse, MailFathomTransport } from '@mailfathom/client-backend';
 import { App } from './App';
+import type { AdoptedDeployment } from './deployment/adoptedDeployment';
 import { LocalizationProvider } from './localization/Localization';
 import { localeNames, locales, readStoredLocale } from './localization/locale';
 
-// The screen reads through the transport this module supplies, so replacing the module is how the network boundary is
-// faked here: what is under test stays the real request, the real parsing, and the real failure mapping, and only the
-// answer they are given is the test's. A screen that takes its transport as a prop needs none of this.
-const stub = vi.hoisted((): { session: ClientSession; answer: MailFathomTransport } => ({
-    session: { baseAddress: 'https://mail.example.invalid', authorization: 'Basic dGVzdA==' },
-    answer: () => Promise.resolve({ status: 200, body: '' }),
+// The screen reads its mail through the transport this module supplies, so replacing the module is how that network
+// boundary is faked here: what is under test stays the real request, the real parsing, and the real failure mapping,
+// and only the answer they are given is the test's. A screen that takes its transport as a prop needs none of this,
+// which is why the deployment the client is pointed at arrives as one below.
+const stub = vi.hoisted((): { answer: MailFathomTransport } => ({
+    answer: () => Promise.resolve({ status: 200, body: '', headers: {} }),
 }));
 
 vi.mock('./stubMailFathom', () => ({
-    stubSession: stub.session,
+    stubAuthorization: 'Basic dGVzdA==',
     stubTransport: ((request: ClientRequest) => stub.answer(request)) satisfies MailFathomTransport,
 }));
 
-function answering(response: ClientResponse): void {
-    stub.answer = () => Promise.resolve(response);
+type Answer = Omit<ClientResponse, 'headers'>;
+
+function answering(response: Answer): void {
+    stub.answer = () => Promise.resolve({ ...response, headers: {} });
 }
 
-function directory(synchronizationEnabled: boolean, accounts: readonly unknown[]): ClientResponse {
+function directory(synchronizationEnabled: boolean, accounts: readonly unknown[]): Answer {
     return { status: 200, body: JSON.stringify({ synchronizationEnabled, accounts }) };
 }
 
+// What `main.tsx` resolves at the edge and hands down. The origin that served the client is the case a web head is in,
+// and it is the default here because the screens below are about mail rather than about where the deployment is.
+const servedFrom: AdoptedDeployment = {
+    deployment: { baseAddress: 'https://mail.example.invalid' },
+    chosen: false,
+};
+
+const nothingSent: MailFathomTransport = () => Promise.reject(new Error('This screen reaches no deployment.'));
+
 // The application is mounted the way `main.tsx` mounts it. Nothing reads a message without the provider above it, and
 // a test that supplied its own would be proving a second arrangement.
-function renderApp(): void {
+function renderApp(deployment: AdoptedDeployment | null = servedFrom, send: MailFathomTransport = nothingSent): void {
     render(
         <LocalizationProvider>
-            <App />
+            <App deployment={deployment} send={send} />
         </LocalizationProvider>,
     );
+}
+
+function chose(baseAddress: string): AdoptedDeployment {
+    return { deployment: { baseAddress }, chosen: true };
+}
+
+function recordingWhatIsAsked(asked: string[]): void {
+    stub.answer = (request) => {
+        asked.push(request.path);
+
+        return Promise.resolve({ ...directory(true, [workAccount]), headers: {} });
+    };
 }
 
 const workAccount = {
@@ -129,6 +153,104 @@ describe('App', () => {
 
         expect(await screen.findByText('The accounts could not be read: unauthenticated.')).toBeDefined();
         expect(screen.queryByRole('list')).toBeNull();
+    });
+});
+
+describe('App deployment', () => {
+    // A deployment that is there and wants a credential, which is what every deployment somebody runs answers a client
+    // that has not signed in yet. The challenge is what says the answer came from MailFathom.
+    const reachable: MailFathomTransport = () =>
+        Promise.resolve({ status: 401, body: '', headers: { 'www-authenticate': 'Bearer realm="MailFathom"' } });
+
+    beforeEach(() => {
+        answering(directory(true, [workAccount]));
+    });
+
+    afterEach(() => {
+        window.localStorage.clear();
+        document.documentElement.removeAttribute('lang');
+    });
+
+    it('reads from the deployment it was pointed at, rather than from one written into the client', async () => {
+        const asked: string[] = [];
+        recordingWhatIsAsked(asked);
+
+        renderApp(chose('https://elsewhere.example.invalid'));
+        await screen.findAllByRole('listitem');
+
+        expect(asked).toEqual(['https://elsewhere.example.invalid/api/client/accounts']);
+    });
+
+    it('asks for an address when nothing has said where the deployment is', () => {
+        renderApp(null);
+
+        expect(screen.getByRole('textbox', { name: 'Deployment address' })).toBeDefined();
+        expect(screen.queryByRole('list')).toBeNull();
+    });
+
+    it('offers to be pointed elsewhere once somebody named the deployment themselves', async () => {
+        renderApp(chose('https://mail.example.invalid'));
+        await screen.findAllByRole('listitem');
+
+        expect(screen.getByRole('button', { name: 'Point somewhere else' })).toBeDefined();
+    });
+
+    it('offers nothing to change where the origin that served the client is the deployment', async () => {
+        renderApp();
+        await screen.findAllByRole('listitem');
+
+        expect(screen.queryByRole('button', { name: 'Point somewhere else' })).toBeNull();
+    });
+
+    it('asks for an address again, and shows no mail, once it is pointed somewhere else', async () => {
+        renderApp(chose('https://mail.example.invalid'));
+        await screen.findAllByRole('listitem');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Point somewhere else' }));
+
+        expect(screen.getByRole('textbox', { name: 'Deployment address' })).toBeDefined();
+        expect(screen.queryByRole('list')).toBeNull();
+    });
+
+    it('puts focus at the start of the mail once the deployment has been named, rather than leaving it behind', async () => {
+        renderApp(null, reachable);
+
+        fireEvent.change(screen.getByRole('textbox', { name: 'Deployment address' }), {
+            target: { value: 'mail.example.test' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
+        await screen.findAllByRole('listitem');
+
+        expect(document.activeElement?.contains(screen.getByRole('list'))).toBe(true);
+    });
+
+    it('puts focus back in the address when it is pointed somewhere else', async () => {
+        renderApp(chose('https://mail.example.invalid'));
+        await screen.findAllByRole('listitem');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Point somewhere else' }));
+
+        expect(document.activeElement).toBe(screen.getByRole('textbox', { name: 'Deployment address' }));
+    });
+
+    it('reads the next deployment with a session of its own, and never the one before it again', async () => {
+        const asked: string[] = [];
+        recordingWhatIsAsked(asked);
+
+        renderApp(chose('https://first.example.invalid'), reachable);
+        await screen.findAllByRole('listitem');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Point somewhere else' }));
+        fireEvent.change(screen.getByRole('textbox', { name: 'Deployment address' }), {
+            target: { value: 'second.example.invalid' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
+        await screen.findAllByRole('listitem');
+
+        expect(asked).toEqual([
+            'https://first.example.invalid/api/client/accounts',
+            'https://second.example.invalid/api/client/accounts',
+        ]);
     });
 });
 

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -10,11 +10,11 @@ import {
     type DeploymentAddress,
     type MailAccount,
     type MailAccountDirectory,
-    type MailFathomTransport,
     type MailSynchronizationState,
 } from '@mailfathom/client-backend';
 import { forgetDeployment, storeDeployment, type AdoptedDeployment } from './deployment/adoptedDeployment';
 import { ConnectDeployment } from './deployment/ConnectDeployment';
+import type { DeploymentTransport } from './deployment/sendToDeployment';
 import type { MessageKey } from './localization/en';
 import { isOfferedLocale, localeNames, locales, type Locale } from './localization/locale';
 import { useLocalization } from './localization/useLocalization';
@@ -46,7 +46,7 @@ export function App({
     send,
 }: {
     readonly deployment: AdoptedDeployment | null;
-    readonly send: MailFathomTransport;
+    readonly send: DeploymentTransport;
 }) {
     const { translate } = useLocalization();
     const [adopted, setAdopted] = useState(deployment);

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -53,18 +53,24 @@ export function App({
     const [result, setResult] = useState<ClientResult<MailAccountDirectory> | null>(null);
     const baseAddress = adopted === null ? null : adopted.deployment.baseAddress;
     const mail = useRef<HTMLDivElement>(null);
-    const loading = useRef(true);
+    const focusedFor = useRef(adopted);
 
     // The view changed, so focus goes to the start of what replaced it rather than staying on a control that is no
     // longer there. Only in this direction: the connect screen places focus itself, on the field it is asking to have
-    // filled, and a parent effect runs after a child's and would take it back off. The first render is a cold start
-    // rather than a move between screens, which is what the guard is for.
+    // filled, and a parent effect runs after a child's and would take it back off. A cold start is not a view change,
+    // so opening against a deployment already adopted moves nothing.
+    //
+    // What separates the two is the deployment this effect last acted on rather than a flag saying the first render
+    // has happened. React invokes an effect twice on mount under `StrictMode`, which `main.tsx` mounts the application
+    // in, and a flag the first invocation cleared is already cleared when the second one reads it — so the guard would
+    // pull focus onto the mail on exactly the ordinary open it exists to leave alone. Both invocations see the same
+    // adopted deployment, so a comparison against it survives being run twice.
     useEffect(() => {
-        if (loading.current) {
-            loading.current = false;
-
+        if (adopted === focusedFor.current) {
             return;
         }
+
+        focusedFor.current = adopted;
 
         if (adopted !== null) {
             mail.current?.focus();

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -2,23 +2,27 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
     readMailAccounts,
     type ClientFailureReason,
     type ClientResult,
+    type DeploymentAddress,
     type MailAccount,
     type MailAccountDirectory,
+    type MailFathomTransport,
     type MailSynchronizationState,
 } from '@mailfathom/client-backend';
+import { forgetDeployment, storeDeployment, type AdoptedDeployment } from './deployment/adoptedDeployment';
+import { ConnectDeployment } from './deployment/ConnectDeployment';
 import type { MessageKey } from './localization/en';
 import { isOfferedLocale, localeNames, locales, type Locale } from './localization/locale';
 import { useLocalization } from './localization/useLocalization';
-import { stubSession, stubTransport } from './stubMailFathom';
+import { stubAuthorization, stubTransport } from './stubMailFathom';
 
-// The one screen this workspace exists to prove. It draws nothing the client will keep: what it demonstrates is that
-// the application package reads through `Client.Backend`, that the boundary holds, that the build produces a bundle,
-// that the Tailwind theme tokens reach the markup, and that every word on it comes out of a catalogue.
+// The one screen this workspace exists to prove, in front of which stands the question every run has to answer first:
+// which deployment this client belongs to. That answer arrives as a value rather than as a code path — `main.tsx`
+// resolves it once at the edge, and nothing below asks which head it is running on.
 
 // The two closed sets `Client.Backend` answers with, mapped to what a person reads. Each is a lookup declared once and
 // exhaustive by its own type, so a value added to either set fails to compile here until this screen says what it is
@@ -37,14 +41,47 @@ const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
     unreadable: 'failure.unreadable',
 };
 
-export function App() {
+export function App({
+    deployment,
+    send,
+}: {
+    readonly deployment: AdoptedDeployment | null;
+    readonly send: MailFathomTransport;
+}) {
     const { translate } = useLocalization();
+    const [adopted, setAdopted] = useState(deployment);
     const [result, setResult] = useState<ClientResult<MailAccountDirectory> | null>(null);
+    const baseAddress = adopted === null ? null : adopted.deployment.baseAddress;
+    const mail = useRef<HTMLDivElement>(null);
+    const loading = useRef(true);
 
+    // The view changed, so focus goes to the start of what replaced it rather than staying on a control that is no
+    // longer there. Only in this direction: the connect screen places focus itself, on the field it is asking to have
+    // filled, and a parent effect runs after a child's and would take it back off. The first render is a cold start
+    // rather than a move between screens, which is what the guard is for.
     useEffect(() => {
+        if (loading.current) {
+            loading.current = false;
+
+            return;
+        }
+
+        if (adopted !== null) {
+            mail.current?.focus();
+        }
+    }, [adopted]);
+
+    // The session is built from the address rather than held beside it, which is what makes a credential unable to
+    // outlive the deployment it was presented to: pointing the client somewhere else runs this again against the new
+    // address, and there is nowhere for the previous one's session to survive.
+    useEffect(() => {
+        if (baseAddress === null) {
+            return;
+        }
+
         let listening = true;
 
-        void readMailAccounts(stubSession, stubTransport).then((answer) => {
+        void readMailAccounts({ baseAddress, authorization: stubAuthorization }, stubTransport).then((answer) => {
             if (listening) {
                 setResult(answer);
             }
@@ -53,7 +90,19 @@ export function App() {
         return () => {
             listening = false;
         };
-    }, []);
+    }, [baseAddress]);
+
+    function reached(reachedDeployment: DeploymentAddress): void {
+        storeDeployment(reachedDeployment);
+        setResult(null);
+        setAdopted({ deployment: reachedDeployment, chosen: true });
+    }
+
+    function pointSomewhereElse(): void {
+        forgetDeployment();
+        setResult(null);
+        setAdopted(null);
+    }
 
     return (
         <main className="min-h-screen bg-fathom-950 px-6 py-10 font-sans text-fathom-200">
@@ -66,9 +115,34 @@ export function App() {
                     </div>
                 </header>
 
-                {result === null ? <p>{translate('accounts.reading')}</p> : <Accounts result={result} />}
+                {adopted === null ? (
+                    <ConnectDeployment send={send} onReached={reached} />
+                ) : (
+                    <div className="flex flex-col gap-6" ref={mail} tabIndex={-1}>
+                        {adopted.chosen ? (
+                            <ChosenDeployment address={adopted.deployment.baseAddress} onChange={pointSomewhereElse} />
+                        ) : null}
+
+                        {result === null ? <p>{translate('accounts.reading')}</p> : <Accounts result={result} />}
+                    </div>
+                )}
             </div>
         </main>
+    );
+}
+
+// Offered only where somebody named the deployment themselves. An origin that served the client is not something
+// changing an address could move, so a client served by its own deployment is not asked to be pointed anywhere.
+function ChosenDeployment({ address, onChange }: { readonly address: string; readonly onChange: () => void }) {
+    const { translate } = useLocalization();
+
+    return (
+        <section className="flex flex-wrap items-baseline justify-between gap-2 text-sm">
+            <p>{translate('deployment.reachedAt', { address })}</p>
+            <button className="rounded-md bg-fathom-800/40 px-3 py-1 text-fathom-200" type="button" onClick={onChange}>
+                {translate('deployment.change')}
+            </button>
+        </section>
     );
 }
 

--- a/frontend/src/Client.App/src/deployment/ConnectDeployment.test.tsx
+++ b/frontend/src/Client.App/src/deployment/ConnectDeployment.test.tsx
@@ -1,0 +1,188 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ClientRequest, DeploymentAddress, MailFathomTransport } from '@mailfathom/client-backend';
+import { LocalizationProvider } from '../localization/Localization';
+import { ConnectDeployment } from './ConnectDeployment';
+
+// A deployment that is there and wants a credential, which is what one somebody actually runs answers a client that
+// has not signed in. Everything below reaches this rather than a network: the screen takes its transport from its
+// caller, so nothing here patches a global or stands up a server.
+const reachable: MailFathomTransport = () =>
+    Promise.resolve({ status: 401, body: '', headers: { 'www-authenticate': 'Bearer realm="MailFathom"' } });
+
+const nothingThere: MailFathomTransport = () => Promise.reject(new TypeError('Failed to fetch'));
+
+const somethingElse: MailFathomTransport = () =>
+    Promise.resolve({ status: 200, body: '<!doctype html><title>Sign in</title>', headers: {} });
+
+function renderScreen(send: MailFathomTransport): { reached: DeploymentAddress[] } {
+    const reached: DeploymentAddress[] = [];
+
+    render(
+        <LocalizationProvider>
+            <ConnectDeployment
+                send={send}
+                onReached={(deployment) => {
+                    reached.push(deployment);
+                }}
+            />
+        </LocalizationProvider>,
+    );
+
+    return { reached };
+}
+
+function type(entry: string): void {
+    fireEvent.change(screen.getByRole('textbox', { name: 'Deployment address' }), { target: { value: entry } });
+}
+
+function connect(): void {
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
+}
+
+function permitClearText(): void {
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Reach this deployment over plain HTTP' }));
+}
+
+describe('ConnectDeployment', () => {
+    it('puts the cursor in the address, because the view changed and focus is placed rather than left behind', () => {
+        renderScreen(reachable);
+
+        expect(document.activeElement).toBe(screen.getByRole('textbox', { name: 'Deployment address' }));
+    });
+
+    it('says what plain HTTP costs beside the control that permits it, rather than after it is chosen', () => {
+        renderScreen(reachable);
+
+        expect(
+            screen.getByText(
+                'Your password is encoded rather than encrypted, on every request. Anybody between this client and the deployment can read it. Leave this off unless the network between them is yours.',
+            ),
+        ).toBeDefined();
+    });
+
+    it('asks for an address rather than reaching nowhere when nothing was typed', () => {
+        const { reached } = renderScreen(reachable);
+
+        connect();
+
+        expect(screen.getByRole('alert').textContent).toBe('Name the deployment that holds your mail.');
+        expect(reached).toEqual([]);
+    });
+
+    it('says what an address is when what was typed is not one', () => {
+        renderScreen(reachable);
+
+        type('my mail server');
+        connect();
+
+        expect(screen.getByRole('alert').textContent).toBe(
+            'That is not an address. Name the host it answers on, and a port where it uses one.',
+        );
+    });
+
+    it('will not carry a password over plain HTTP until somebody says it may', () => {
+        const { reached } = renderScreen(reachable);
+
+        type('http://mail.example.test');
+        connect();
+
+        expect(screen.getByRole('alert').textContent).toBe(
+            'That address is plain HTTP, which this client will not send a password over until you say it may.',
+        );
+        expect(reached).toEqual([]);
+    });
+
+    it('takes the refusal away as soon as the address is being corrected, rather than after the next attempt', () => {
+        renderScreen(reachable);
+
+        type('my mail server');
+        connect();
+        type('mail.example.test');
+
+        expect(screen.queryByRole('alert')).toBeNull();
+    });
+
+    it('sends nothing over plain HTTP until that is declared, and then reaches it', async () => {
+        const asked: ClientRequest[] = [];
+        const { reached } = renderScreen((request) => {
+            asked.push(request);
+
+            return reachable(request);
+        });
+
+        type('http://mail.example.test');
+        connect();
+        permitClearText();
+        connect();
+
+        await vi.waitFor(() => {
+            expect(reached).toEqual([{ baseAddress: 'http://mail.example.test' }]);
+        });
+
+        // One request rather than two: the refusal ran before anything went out, so nothing was sent over the
+        // transport the first attempt was refused for using.
+        expect(asked.map((request) => request.path)).toEqual(['http://mail.example.test/api/client/session']);
+    });
+
+    it('says it is reaching the deployment while the answer has not arrived', () => {
+        renderScreen(() => new Promise(() => undefined));
+
+        type('mail.example.test');
+        connect();
+
+        expect(screen.getByRole('status').textContent).toBe('Reaching the deployment…');
+    });
+
+    it('takes the deployment once it answers as one, under the scheme the client supplied', async () => {
+        const { reached } = renderScreen(reachable);
+
+        type('mail.example.test:8443');
+        connect();
+
+        await vi.waitFor(() => {
+            expect(reached).toEqual([{ baseAddress: 'https://mail.example.test:8443' }]);
+        });
+    });
+
+    it('says nothing answered rather than handing over an address it could not reach', async () => {
+        const { reached } = renderScreen(nothingThere);
+
+        type('mail.example.test');
+        connect();
+
+        expect((await screen.findByRole('alert')).textContent).toBe(
+            'Nothing answered there. Check the address, and check that the deployment is running.',
+        );
+        expect(reached).toEqual([]);
+    });
+
+    it('tries once and never again without the transport security the first attempt asked for', async () => {
+        const asked: string[] = [];
+        renderScreen((request) => {
+            asked.push(request.path);
+
+            return nothingThere(request);
+        });
+
+        type('mail.example.test');
+        connect();
+
+        await screen.findByRole('alert');
+        expect(asked).toEqual(['https://mail.example.test/api/client/session']);
+    });
+
+    it('says what answered was not MailFathom rather than taking anything that replies', async () => {
+        const { reached } = renderScreen(somethingElse);
+
+        type('mail.example.test');
+        connect();
+
+        expect((await screen.findByRole('alert')).textContent).toBe('Something answered there, but not as MailFathom.');
+        expect(reached).toEqual([]);
+    });
+});

--- a/frontend/src/Client.App/src/deployment/ConnectDeployment.test.tsx
+++ b/frontend/src/Client.App/src/deployment/ConnectDeployment.test.tsx
@@ -19,13 +19,21 @@ const nothingThere: MailFathomTransport = () => Promise.reject(new TypeError('Fa
 const somethingElse: MailFathomTransport = () =>
     Promise.resolve({ status: 200, body: '<!doctype html><title>Sign in</title>', headers: {} });
 
-function renderScreen(send: MailFathomTransport): { reached: DeploymentAddress[] } {
+// The screen is handed a transport per attempt rather than one transport, because giving up on an attempt is what
+// abandons it. Collecting the signals it was given is how a test sees whether an attempt was actually called off,
+// which is the difference between the screen ignoring an answer and the request being cancelled.
+function renderScreen(send: MailFathomTransport): { reached: DeploymentAddress[]; attempts: AbortSignal[] } {
     const reached: DeploymentAddress[] = [];
+    const attempts: AbortSignal[] = [];
 
     render(
         <LocalizationProvider>
             <ConnectDeployment
-                send={send}
+                send={(abandoned) => {
+                    attempts.push(abandoned);
+
+                    return send;
+                }}
                 onReached={(deployment) => {
                     reached.push(deployment);
                 }}
@@ -33,7 +41,7 @@ function renderScreen(send: MailFathomTransport): { reached: DeploymentAddress[]
         </LocalizationProvider>,
     );
 
-    return { reached };
+    return { reached, attempts };
 }
 
 function type(entry: string): void {
@@ -136,6 +144,27 @@ describe('ConnectDeployment', () => {
         connect();
 
         expect(screen.getByRole('status').textContent).toBe('Reaching the deployment…');
+    });
+
+    it('lets an attempt that never answers be given up on, rather than holding the screen on it', () => {
+        const { attempts } = renderScreen(() => new Promise(() => undefined));
+
+        type('mail.example.test');
+        connect();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Stop trying' }));
+
+        // Back where the person left it: no attempt is reported as running, the address can be corrected and tried
+        // again, and the request the abandoned attempt started was cancelled rather than left on the wire.
+        expect(screen.queryByRole('status')).toBeNull();
+        expect(screen.getByRole('button', { name: 'Connect' }).hasAttribute('disabled')).toBe(false);
+        expect(attempts.map((abandoned) => abandoned.aborted)).toEqual([true]);
+    });
+
+    it('offers nothing to give up on before an attempt has been started', () => {
+        renderScreen(reachable);
+
+        expect(screen.queryByRole('button', { name: 'Stop trying' })).toBeNull();
     });
 
     it('takes the deployment once it answers as one, under the scheme the client supplied', async () => {

--- a/frontend/src/Client.App/src/deployment/ConnectDeployment.tsx
+++ b/frontend/src/Client.App/src/deployment/ConnectDeployment.tsx
@@ -9,10 +9,10 @@ import {
     type ClientFailureReason,
     type DeploymentAddress,
     type DeploymentEntryRefusal,
-    type MailFathomTransport,
 } from '@mailfathom/client-backend';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
+import type { DeploymentTransport } from './sendToDeployment';
 
 // The screen somebody meets when nothing has told the client where its deployment is. It collects an address and
 // proves something MailFathom-shaped answers at it; the credential presented against it afterwards is another screen's.
@@ -42,7 +42,7 @@ export function ConnectDeployment({
     send,
     onReached,
 }: {
-    readonly send: MailFathomTransport;
+    readonly send: DeploymentTransport;
     readonly onReached: (deployment: DeploymentAddress) => void;
 }) {
     const { translate } = useLocalization();
@@ -51,6 +51,7 @@ export function ConnectDeployment({
     const [reaching, setReaching] = useState(false);
     const [refusal, setRefusal] = useState<ConnectRefusal | null>(null);
     const address = useRef<HTMLInputElement>(null);
+    const attempt = useRef<AbortController | null>(null);
 
     // The view changed, so focus is placed rather than left wherever the previous screen had it. Moving focus is an
     // imperative browser API, which is what an effect is for.
@@ -66,11 +67,21 @@ export function ConnectDeployment({
             return;
         }
 
+        const attempted = new AbortController();
+        attempt.current = attempted;
+
         setRefusal(null);
         setReaching(true);
 
-        const greeting = await reachDeployment(resolved.deployment, send);
+        const greeting = await reachDeployment(resolved.deployment, send(attempted.signal));
 
+        // An abandoned attempt has no answer, whatever the wire eventually said: the screen is already back where the
+        // person left it, and reporting a failure here would be this attempt overwriting what they did next.
+        if (attempted.signal.aborted) {
+            return;
+        }
+
+        attempt.current = null;
         setReaching(false);
 
         if (greeting.outcome === 'failed') {
@@ -80,6 +91,15 @@ export function ConnectDeployment({
         }
 
         onReached(resolved.deployment);
+    }
+
+    // A deployment that accepts the connection and never answers would otherwise hold the screen on `connect.reaching`
+    // with the only control on it disabled, which is a state nobody can leave. Abandoning frees the connection as well
+    // as the screen, which is why it aborts the request rather than only ignoring what it says.
+    function abandon(): void {
+        attempt.current?.abort();
+        attempt.current = null;
+        setReaching(false);
     }
 
     return (
@@ -143,13 +163,25 @@ export function ConnectDeployment({
                     </p>
                 </div>
 
-                <button
-                    className="self-start rounded-md bg-fathom-600 px-4 py-2 font-medium text-white disabled:opacity-60"
-                    disabled={reaching}
-                    type="submit"
-                >
-                    {translate('connect.submit')}
-                </button>
+                <div className="flex items-center gap-3">
+                    <button
+                        className="rounded-md bg-fathom-600 px-4 py-2 font-medium text-white disabled:opacity-60"
+                        disabled={reaching}
+                        type="submit"
+                    >
+                        {translate('connect.submit')}
+                    </button>
+
+                    {reaching ? (
+                        <button
+                            className="rounded-md bg-fathom-800/40 px-4 py-2 font-medium text-fathom-200"
+                            type="button"
+                            onClick={abandon}
+                        >
+                            {translate('connect.abandon')}
+                        </button>
+                    ) : null}
+                </div>
             </form>
 
             {reaching ? <p role="status">{translate('connect.reaching')}</p> : null}

--- a/frontend/src/Client.App/src/deployment/ConnectDeployment.tsx
+++ b/frontend/src/Client.App/src/deployment/ConnectDeployment.tsx
@@ -1,0 +1,164 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { useEffect, useRef, useState } from 'react';
+import {
+    reachDeployment,
+    resolveDeploymentEntry,
+    type ClientFailureReason,
+    type DeploymentAddress,
+    type DeploymentEntryRefusal,
+    type MailFathomTransport,
+} from '@mailfathom/client-backend';
+import type { MessageKey } from '../localization/en';
+import { useLocalization } from '../localization/useLocalization';
+
+// The screen somebody meets when nothing has told the client where its deployment is. It collects an address and
+// proves something MailFathom-shaped answers at it; the credential presented against it afterwards is another screen's.
+//
+// Nothing about the address is decided here. What may be typed, what the scheme is, and when plain HTTP is refused all
+// belong to `Client.Backend`, because they are properties of the wire the credential will travel on rather than of the
+// form that collects them. What is this component's own is what a person sees while that is being decided.
+
+/** Why the client is not pointed at a deployment yet: the entry was refused, or the deployment did not answer as one. */
+type ConnectRefusal = DeploymentEntryRefusal | ClientFailureReason;
+
+const refusalMessages: Readonly<Record<ConnectRefusal, MessageKey>> = {
+    blank: 'connect.blank',
+    malformed: 'connect.malformed',
+    clearTextRefused: 'connect.clearTextRefused',
+    unavailable: 'connect.unavailable',
+    unreadable: 'connect.unreadable',
+
+    // The session route is published under no permission, so a deployment answering either of these has refused for a
+    // reason a person entering an address cannot act on. They are named rather than left out because the set is closed
+    // by its own type, and a reason added to it should stop compiling here until this screen says what it reads as.
+    unauthenticated: 'connect.refused',
+    unauthorized: 'connect.refused',
+};
+
+export function ConnectDeployment({
+    send,
+    onReached,
+}: {
+    readonly send: MailFathomTransport;
+    readonly onReached: (deployment: DeploymentAddress) => void;
+}) {
+    const { translate } = useLocalization();
+    const [entry, setEntry] = useState('');
+    const [clearTextPermitted, setClearTextPermitted] = useState(false);
+    const [reaching, setReaching] = useState(false);
+    const [refusal, setRefusal] = useState<ConnectRefusal | null>(null);
+    const address = useRef<HTMLInputElement>(null);
+
+    // The view changed, so focus is placed rather than left wherever the previous screen had it. Moving focus is an
+    // imperative browser API, which is what an effect is for.
+    useEffect(() => {
+        address.current?.focus();
+    }, []);
+
+    async function connect(): Promise<void> {
+        const resolved = resolveDeploymentEntry(entry, clearTextPermitted);
+        if (resolved.outcome === 'refused') {
+            setRefusal(resolved.refusal);
+
+            return;
+        }
+
+        setRefusal(null);
+        setReaching(true);
+
+        const greeting = await reachDeployment(resolved.deployment, send);
+
+        setReaching(false);
+
+        if (greeting.outcome === 'failed') {
+            setRefusal(greeting.failure.reason);
+
+            return;
+        }
+
+        onReached(resolved.deployment);
+    }
+
+    return (
+        <section className="flex flex-col gap-6">
+            <div className="flex flex-col gap-2">
+                <h2 className="text-xl font-semibold text-white">{translate('connect.title')}</h2>
+                <p className="text-sm">{translate('connect.explanation')}</p>
+            </div>
+
+            <form
+                className="flex flex-col gap-5"
+                onSubmit={(event) => {
+                    event.preventDefault();
+                    void connect();
+                }}
+            >
+                <div className="flex flex-col gap-2">
+                    <label className="text-sm font-medium text-white" htmlFor="deployment-address">
+                        {translate('connect.address')}
+                    </label>
+                    <input
+                        // The refusal joins the hint rather than replacing it, so somebody reading the field hears why
+                        // it was refused and what it wants, in that order, without moving off it.
+                        aria-describedby={
+                            refusal === null ? 'deployment-address-hint' : 'deployment-refusal deployment-address-hint'
+                        }
+                        aria-invalid={refusal !== null}
+                        autoComplete="off"
+                        className="rounded-md border border-fathom-800 bg-fathom-800/40 px-3 py-2 text-white"
+                        id="deployment-address"
+                        inputMode="url"
+                        ref={address}
+                        spellCheck={false}
+                        type="text"
+                        value={entry}
+                        onChange={(event) => {
+                            setEntry(event.target.value);
+                            setRefusal(null);
+                        }}
+                    />
+                    <p className="text-sm text-fathom-500" id="deployment-address-hint">
+                        {translate('connect.addressHint')}
+                    </p>
+                </div>
+
+                <div className="flex flex-col gap-2">
+                    <label className="flex items-center gap-2 text-sm font-medium text-white">
+                        <input
+                            aria-describedby="deployment-clear-text-explanation"
+                            checked={clearTextPermitted}
+                            type="checkbox"
+                            onChange={(event) => {
+                                setClearTextPermitted(event.target.checked);
+                                setRefusal(null);
+                            }}
+                        />
+                        {translate('connect.clearText')}
+                    </label>
+                    <p className="text-sm text-fathom-star" id="deployment-clear-text-explanation">
+                        {translate('connect.clearTextExplanation')}
+                    </p>
+                </div>
+
+                <button
+                    className="self-start rounded-md bg-fathom-600 px-4 py-2 font-medium text-white disabled:opacity-60"
+                    disabled={reaching}
+                    type="submit"
+                >
+                    {translate('connect.submit')}
+                </button>
+            </form>
+
+            {reaching ? <p role="status">{translate('connect.reaching')}</p> : null}
+
+            {refusal === null || reaching ? null : (
+                <p className="text-fathom-star" id="deployment-refusal" role="alert">
+                    {translate(refusalMessages[refusal])}
+                </p>
+            )}
+        </section>
+    );
+}

--- a/frontend/src/Client.App/src/deployment/adoptedDeployment.test.ts
+++ b/frontend/src/Client.App/src/deployment/adoptedDeployment.test.ts
@@ -1,0 +1,62 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { adoptedDeployment, forgetDeployment, storeDeployment } from './adoptedDeployment';
+
+// The document these tests run under is served from a loopback origin, which is an address this client may address —
+// so the served-from case below is the one a web head is in, reached without anything being configured.
+const servedFrom = window.location.origin;
+
+describe('adoptedDeployment', () => {
+    afterEach(() => {
+        window.localStorage.clear();
+        vi.unstubAllEnvs();
+    });
+
+    it('reads the deployment from the origin that served the client, with nothing configured and nobody asked', () => {
+        expect(adoptedDeployment()).toEqual({ deployment: { baseAddress: servedFrom }, chosen: false });
+    });
+
+    it('reads the deployment an orchestration stated, rather than the server that served the page', () => {
+        vi.stubEnv('VITE_MAILFATHOM_SERVICE_ADDRESS', 'https://mail.example.invalid');
+
+        expect(adoptedDeployment()).toEqual({
+            deployment: { baseAddress: 'https://mail.example.invalid' },
+            chosen: false,
+        });
+    });
+
+    it('reads back the deployment somebody named, so a later start opens against it', () => {
+        storeDeployment({ baseAddress: 'https://mail.example.invalid' });
+
+        expect(adoptedDeployment()).toEqual({
+            deployment: { baseAddress: 'https://mail.example.invalid' },
+            chosen: true,
+        });
+    });
+
+    it('keeps the clear-text address somebody declared, rather than refusing what it wrote itself', () => {
+        storeDeployment({ baseAddress: 'http://mail.example.invalid' });
+
+        expect(adoptedDeployment()).toEqual({
+            deployment: { baseAddress: 'http://mail.example.invalid' },
+            chosen: true,
+        });
+    });
+
+    it('goes back to the origin that served the client when the named deployment is forgotten', () => {
+        storeDeployment({ baseAddress: 'https://mail.example.invalid' });
+
+        forgetDeployment();
+
+        expect(adoptedDeployment()).toEqual({ deployment: { baseAddress: servedFrom }, chosen: false });
+    });
+
+    it('ignores a stored value that is no longer an address at all', () => {
+        window.localStorage.setItem('mailfathom.deployment', 'not an address');
+
+        expect(adoptedDeployment()).toEqual({ deployment: { baseAddress: servedFrom }, chosen: false });
+    });
+});

--- a/frontend/src/Client.App/src/deployment/adoptedDeployment.ts
+++ b/frontend/src/Client.App/src/deployment/adoptedDeployment.ts
@@ -1,0 +1,97 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { resolveDeploymentEntry, type DeploymentAddress } from '@mailfathom/client-backend';
+
+// Which deployment this run of the client belongs to, resolved once at the application's edge and handed to it as a
+// value. Nothing here asks which head it is running on, and nothing anywhere else does either: what the two heads
+// differ in is where an address comes from, and both answers are addresses.
+//
+// The web bundle is served by the deployment itself, so the origin that served the page is the deployment and there is
+// nothing to ask anybody. A desktop shell is loaded from a scheme of its own that no deployment ever answers on, so
+// the origin resolves to nothing there and what is left is the address somebody gave — which is why neither case
+// needs to know about the other.
+
+/** What the client is pointed at, and whether a person is the one who pointed it. */
+export interface AdoptedDeployment {
+    readonly deployment: DeploymentAddress;
+
+    /**
+     * Whether somebody named this deployment, rather than it being the origin that served the client.
+     *
+     * It is what decides whether the client offers to be pointed somewhere else: an address a person gave is theirs to
+     * change, and an origin that served the page is not something changing an address could move.
+     */
+    readonly chosen: boolean;
+}
+
+// Where the chosen address is written. An address is not a credential and is stored as what it is; what the desktop
+// head does with anything secret is its own question.
+//
+// Reached as `window.localStorage` rather than as the bare global for the reason `localization/locale.ts` gives: Node
+// publishes a `localStorage` global of its own that wins over the document's under the test runner, so the bare name
+// is two different objects behind one identifier.
+const storageKey = 'mailfathom.deployment';
+
+/** The deployment this run belongs to, or `null` where nobody has said and nothing served the client from one. */
+export function adoptedDeployment(): AdoptedDeployment | null {
+    const chosen = chosenDeployment();
+    if (chosen !== null) {
+        return { deployment: chosen, chosen: true };
+    }
+
+    const serving = servingDeployment();
+
+    return serving === null ? null : { deployment: serving, chosen: false };
+}
+
+/** Remembers the deployment somebody named, so the next start of either head opens against it. */
+export function storeDeployment(deployment: DeploymentAddress): void {
+    try {
+        window.localStorage.setItem(storageKey, deployment.baseAddress);
+    } catch {
+        // A browser configured to refuse storage still runs the client; the address then lasts the run rather than
+        // outliving it, which is a smaller loss than a client that fails to start over a preference.
+    }
+}
+
+/** Forgets the deployment somebody named, which is how the client is pointed somewhere else. */
+export function forgetDeployment(): void {
+    try {
+        window.localStorage.removeItem(storageKey);
+    } catch {
+        // Storage that refuses a write refuses a removal too, and the address it is holding is one this run has
+        // already stopped using.
+    }
+}
+
+/** The address somebody named on this machine, or `null` where none was named or what was stored is not an address. */
+function chosenDeployment(): DeploymentAddress | null {
+    let stored: string | null;
+
+    try {
+        stored = window.localStorage.getItem(storageKey);
+    } catch {
+        return null;
+    }
+
+    if (stored === null) {
+        return null;
+    }
+
+    // Read back through the same rule that let it be written, permitting clear text: an address only reaches storage
+    // by being resolved, and a clear-text one only by somebody declaring it there. What this run is checking is that
+    // what came back is still an address at all.
+    const resolved = resolveDeploymentEntry(stored, true);
+
+    return resolved.outcome === 'resolved' ? resolved.deployment : null;
+}
+
+/** The deployment that served this client, or `null` where whatever served it is not one the client could address. */
+function servingDeployment(): DeploymentAddress | null {
+    const serving = import.meta.env.VITE_MAILFATHOM_SERVICE_ADDRESS ?? window.location.origin;
+    const resolved = resolveDeploymentEntry(serving, false);
+
+    return resolved.outcome === 'resolved' ? resolved.deployment : null;
+}

--- a/frontend/src/Client.App/src/deployment/sendToDeployment.ts
+++ b/frontend/src/Client.App/src/deployment/sendToDeployment.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import type { MailFathomTransport } from '@mailfathom/client-backend';
+import { longestResponseBody, type MailFathomTransport } from '@mailfathom/client-backend';
 
 // The adapter `Client.Backend` asks its caller for. That package declares no DOM, so the one call to `fetch` in the
 // client is here — which is what makes the boundary a resolution error rather than a convention, and it is the whole
@@ -14,10 +14,53 @@ export const sendToDeployment: MailFathomTransport = async (request) => {
 
     return {
         status: response.status,
-        body: await response.text(),
+        body: await readBoundedBody(response),
 
         // Lower-cased already, which is what `ClientResponse` states its names are: the platform's own header
         // collection normalizes them, so a lookup there needs no second spelling to try.
         headers: Object.fromEntries(response.headers),
     };
 };
+
+/**
+ * Reads the answer up to the bound the wire states, and stops there.
+ *
+ * `response.text()` would buffer whatever arrives before anything got to look at it, which is the wrong order at the
+ * one boundary in this client where the other side is a stranger: an address is asked whether MailFathom answers there
+ * precisely because nobody knows yet. So the body is read in chunks against a running total and the read is cancelled
+ * the moment it passes the bound, which also frees the connection rather than draining a stream nothing will use.
+ *
+ * An answer that goes over comes back empty, which every operation already refuses as unreadable — see
+ * `longestResponseBody` for why that is the accurate outcome rather than a lost distinction.
+ */
+async function readBoundedBody(response: Response): Promise<string> {
+    const reading = response.body?.getReader();
+
+    if (reading === undefined) {
+        return '';
+    }
+
+    // Streaming rather than per-chunk, because a chunk boundary falls wherever the network put it and a multi-byte
+    // character split across two of them would otherwise decode as replacement characters on both sides.
+    const decoder = new TextDecoder();
+    let body = '';
+    let read = 0;
+
+    for (;;) {
+        const { done, value } = await reading.read();
+
+        if (done) {
+            return body + decoder.decode();
+        }
+
+        read += value.byteLength;
+
+        if (read > longestResponseBody) {
+            await reading.cancel();
+
+            return '';
+        }
+
+        body += decoder.decode(value, { stream: true });
+    }
+}

--- a/frontend/src/Client.App/src/deployment/sendToDeployment.ts
+++ b/frontend/src/Client.App/src/deployment/sendToDeployment.ts
@@ -8,9 +8,22 @@ import { longestResponseBody, type MailFathomTransport } from '@mailfathom/clien
 // client is here — which is what makes the boundary a resolution error rather than a convention, and it is the whole
 // of what this module is.
 
+/**
+ * The transport for one attempt, which the signal abandons when the person waiting on it gives up.
+ *
+ * A transport is bound to a signal rather than handed one per request because abandoning is a property of the attempt
+ * a screen started, not of a message inside it — and because `AbortSignal` is a browser API, which
+ * `MailFathomTransport` may not name for the reason this module exists at all.
+ */
+export type DeploymentTransport = (abandoned: AbortSignal) => MailFathomTransport;
+
 /** Puts one request on the wire, and reports what came back without deciding anything about it. */
-export const sendToDeployment: MailFathomTransport = async (request) => {
-    const response = await fetch(request.path, { method: request.method, headers: { ...request.headers } });
+export const sendToDeployment: DeploymentTransport = (abandoned) => async (request) => {
+    const response = await fetch(request.path, {
+        method: request.method,
+        headers: { ...request.headers },
+        signal: abandoned,
+    });
 
     return {
         status: response.status,

--- a/frontend/src/Client.App/src/deployment/sendToDeployment.ts
+++ b/frontend/src/Client.App/src/deployment/sendToDeployment.ts
@@ -1,0 +1,23 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { MailFathomTransport } from '@mailfathom/client-backend';
+
+// The adapter `Client.Backend` asks its caller for. That package declares no DOM, so the one call to `fetch` in the
+// client is here — which is what makes the boundary a resolution error rather than a convention, and it is the whole
+// of what this module is.
+
+/** Puts one request on the wire, and reports what came back without deciding anything about it. */
+export const sendToDeployment: MailFathomTransport = async (request) => {
+    const response = await fetch(request.path, { method: request.method, headers: { ...request.headers } });
+
+    return {
+        status: response.status,
+        body: await response.text(),
+
+        // Lower-cased already, which is what `ClientResponse` states its names are: the platform's own header
+        // collection normalizes them, so a lookup there needs no second spelling to try.
+        headers: Object.fromEntries(response.headers),
+    };
+};

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -25,6 +25,7 @@ export const en = {
         'Your password is encoded rather than encrypted, on every request. Anybody between this client and the deployment can read it. Leave this off unless the network between them is yours.',
     'connect.submit': 'Connect',
     'connect.reaching': 'Reaching the deployment…',
+    'connect.abandon': 'Stop trying',
     'connect.blank': 'Name the deployment that holds your mail.',
     'connect.malformed': 'That is not an address. Name the host it answers on, and a port where it uses one.',
     'connect.clearTextRefused':

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -14,6 +14,28 @@ export const en = {
     'shell.title': 'MailFathom',
     'shell.language': 'Language',
 
+    'connect.title': 'Point this client at your MailFathom',
+    'connect.explanation':
+        'Name the deployment that holds your mail. Everything this client reads and everything you type into it goes there and nowhere else.',
+    'connect.address': 'Deployment address',
+    'connect.addressHint':
+        'The host it answers on, and a port where it uses one — for example mailfathom.example.com or mailfathom.example.com:8443.',
+    'connect.clearText': 'Reach this deployment over plain HTTP',
+    'connect.clearTextExplanation':
+        'Your password is encoded rather than encrypted, on every request. Anybody between this client and the deployment can read it. Leave this off unless the network between them is yours.',
+    'connect.submit': 'Connect',
+    'connect.reaching': 'Reaching the deployment…',
+    'connect.blank': 'Name the deployment that holds your mail.',
+    'connect.malformed': 'That is not an address. Name the host it answers on, and a port where it uses one.',
+    'connect.clearTextRefused':
+        'That address is plain HTTP, which this client will not send a password over until you say it may.',
+    'connect.unavailable': 'Nothing answered there. Check the address, and check that the deployment is running.',
+    'connect.unreadable': 'Something answered there, but not as MailFathom.',
+    'connect.refused': 'The deployment refused the request.',
+
+    'deployment.reachedAt': 'Reading from {address}',
+    'deployment.change': 'Point somewhere else',
+
     'accounts.reading': 'Reading accounts…',
     'accounts.refreshing': 'This deployment refreshes the local copy of these accounts.',
     'accounts.notRefreshing': 'This deployment is not refreshing the local copy of these accounts.',

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -13,6 +13,28 @@ export const pl: Catalogue = {
     'shell.title': 'MailFathom',
     'shell.language': 'Język',
 
+    'connect.title': 'Wskaż temu klientowi swój MailFathom',
+    'connect.explanation':
+        'Podaj wdrożenie, które przechowuje Twoją pocztę. Wszystko, co ten klient odczytuje, i wszystko, co w nim wpiszesz, trafia tam i nigdzie indziej.',
+    'connect.address': 'Adres wdrożenia',
+    'connect.addressHint':
+        'Host, na którym wdrożenie odpowiada, oraz port, jeśli go używa — na przykład mailfathom.example.com albo mailfathom.example.com:8443.',
+    'connect.clearText': 'Łącz się z tym wdrożeniem zwykłym protokołem HTTP',
+    'connect.clearTextExplanation':
+        'Twoje hasło jest kodowane, a nie szyfrowane, przy każdym żądaniu. Każdy, kto znajduje się między tym klientem a wdrożeniem, może je odczytać. Zostaw tę opcję wyłączoną, chyba że sieć między nimi należy do Ciebie.',
+    'connect.submit': 'Połącz',
+    'connect.reaching': 'Łączenie z wdrożeniem…',
+    'connect.blank': 'Podaj wdrożenie, które przechowuje Twoją pocztę.',
+    'connect.malformed': 'To nie jest adres. Podaj host, na którym wdrożenie odpowiada, oraz port, jeśli go używa.',
+    'connect.clearTextRefused':
+        'Ten adres używa zwykłego protokołu HTTP, a ten klient nie wyśle nim hasła, dopóki na to nie zezwolisz.',
+    'connect.unavailable': 'Nic tam nie odpowiedziało. Sprawdź adres oraz to, czy wdrożenie jest uruchomione.',
+    'connect.unreadable': 'Coś tam odpowiedziało, ale nie jako MailFathom.',
+    'connect.refused': 'Wdrożenie odrzuciło żądanie.',
+
+    'deployment.reachedAt': 'Odczyt z {address}',
+    'deployment.change': 'Wskaż inne wdrożenie',
+
     'accounts.reading': 'Odczytywanie kont…',
     'accounts.refreshing': 'To wdrożenie odświeża lokalną kopię tych kont.',
     'accounts.notRefreshing': 'To wdrożenie nie odświeża lokalnej kopii tych kont.',

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -24,6 +24,7 @@ export const pl: Catalogue = {
         'Twoje hasło jest kodowane, a nie szyfrowane, przy każdym żądaniu. Każdy, kto znajduje się między tym klientem a wdrożeniem, może je odczytać. Zostaw tę opcję wyłączoną, chyba że sieć między nimi należy do Ciebie.',
     'connect.submit': 'Połącz',
     'connect.reaching': 'Łączenie z wdrożeniem…',
+    'connect.abandon': 'Przerwij próbę',
     'connect.blank': 'Podaj wdrożenie, które przechowuje Twoją pocztę.',
     'connect.malformed': 'To nie jest adres. Podaj host, na którym wdrożenie odpowiada, oraz port, jeśli go używa.',
     'connect.clearTextRefused':

--- a/frontend/src/Client.App/src/main.tsx
+++ b/frontend/src/Client.App/src/main.tsx
@@ -5,6 +5,8 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
+import { adoptedDeployment } from './deployment/adoptedDeployment';
+import { sendToDeployment } from './deployment/sendToDeployment';
 import { LocalizationProvider } from './localization/Localization';
 import './styles.css';
 
@@ -14,10 +16,13 @@ if (container === null) {
     throw new Error('index.html carries no #root element for the client to mount into.');
 }
 
+// The edge of the application, and the one place the deployment this run belongs to is resolved. It arrives below as a
+// value, which is what keeps the difference between a client served by its deployment and a client somebody pointed at
+// one out of every screen underneath.
 createRoot(container).render(
     <StrictMode>
         <LocalizationProvider>
-            <App />
+            <App deployment={adoptedDeployment()} send={sendToDeployment} />
         </LocalizationProvider>
     </StrictMode>,
 );

--- a/frontend/src/Client.App/src/stubMailFathom.ts
+++ b/frontend/src/Client.App/src/stubMailFathom.ts
@@ -2,16 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import { mailAccountsRoute, routeFor, type ClientSession, type MailFathomTransport } from '@mailfathom/client-backend';
+import { clientRoutePrefix, mailAccountsRoute, type MailFathomTransport } from '@mailfathom/client-backend';
 
-// What the proving screen reads through. Signing in and reaching a running deployment are separate work, so the
-// transport answers from a canned body here: it is what proves the workspace, the package boundary, the build, and the
-// styling end to end without a service behind it.
+// What the proving screen reads its mail through. The deployment the client belongs to is resolved for real now, and
+// reaching one is a real request; what is still canned here is everything behind a credential, because signing in is
+// separate work and nothing composes a credential yet. This module goes when that work lands.
+//
+// The answer is matched on the route rather than on a whole address, because which deployment the client is pointed at
+// is no longer this module's to know.
 
-export const stubSession: ClientSession = {
-    baseAddress: 'https://mailfathom.invalid',
-    authorization: 'Basic stub-credential-that-is-never-sent',
-};
+export const stubAuthorization = 'Basic stub-credential-that-is-never-sent';
 
 const stubAccounts = JSON.stringify({
     synchronizationEnabled: true,
@@ -42,7 +42,7 @@ const stubAccounts = JSON.stringify({
 
 export const stubTransport: MailFathomTransport = (request) =>
     Promise.resolve(
-        request.path === routeFor(stubSession, mailAccountsRoute)
-            ? { status: 200, body: stubAccounts }
-            : { status: 404, body: '' },
+        request.path.endsWith(`${clientRoutePrefix}${mailAccountsRoute}`)
+            ? { status: 200, body: stubAccounts, headers: {} }
+            : { status: 404, body: '', headers: {} },
     );

--- a/frontend/src/Client.Backend/src/deployment.test.ts
+++ b/frontend/src/Client.Backend/src/deployment.test.ts
@@ -1,0 +1,205 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import { reachDeployment, resolveDeploymentEntry, type DeploymentEntryRefusal } from './deployment';
+import type { ClientRequest, ClientResponse, MailFathomTransport } from './transport';
+
+const deployment = { baseAddress: 'https://mail.example.invalid' };
+
+function answering(response: Partial<ClientResponse>): MailFathomTransport {
+    return () => Promise.resolve({ status: 200, body: '', headers: {}, ...response });
+}
+
+function sessionBody(service: unknown, version: unknown): string {
+    return JSON.stringify({ service, version, permissions: [] });
+}
+
+function refusal(entry: string, clearTextPermitted = false): DeploymentEntryRefusal | 'resolved' {
+    const result = resolveDeploymentEntry(entry, clearTextPermitted);
+
+    return result.outcome === 'resolved' ? 'resolved' : result.refusal;
+}
+
+function resolved(entry: string, clearTextPermitted = false): string | null {
+    const result = resolveDeploymentEntry(entry, clearTextPermitted);
+
+    return result.outcome === 'resolved' ? result.deployment.baseAddress : null;
+}
+
+describe('resolveDeploymentEntry', () => {
+    it('supplies the scheme a person did not write, because a password travels on every request', () => {
+        expect(resolved('mail.example.test')).toBe('https://mail.example.test');
+    });
+
+    it('keeps the port a deployment was named with', () => {
+        expect(resolved('mail.example.test:8443')).toBe('https://mail.example.test:8443');
+    });
+
+    it('drops the port a scheme already implies, so one deployment has one address', () => {
+        expect(resolved('mail.example.test:443')).toBe('https://mail.example.test');
+    });
+
+    it('takes an address somebody pasted with the secure scheme already on it', () => {
+        expect(resolved('https://mail.example.test:8443')).toBe('https://mail.example.test:8443');
+    });
+
+    it('ignores the whitespace around what was typed', () => {
+        expect(resolved('  mail.example.test  ')).toBe('https://mail.example.test');
+    });
+
+    it.each(['', '   '])('refuses an entry naming nothing: %j', (entry) => {
+        expect(refusal(entry)).toBe('blank');
+    });
+
+    it.each([
+        ['a scheme this client does not speak', 'tauri://localhost'],
+        ['a link to a screen rather than a deployment', 'mail.example.test/inbox'],
+        ['a query somebody carried over from a browser', 'mail.example.test?owner=me'],
+        ['a fragment', 'mail.example.test#inbox'],
+        ['a password written into the address', 'https://owner:secret@mail.example.test'],
+        ['a host that is not one', 'https://'],
+        ['a sentence', 'my mail server'],
+    ])('refuses %s: %j', (_, entry) => {
+        expect(refusal(entry)).toBe('malformed');
+    });
+
+    it('refuses a clear-text address nobody declared, rather than sending a password over it', () => {
+        expect(refusal('http://mail.example.test')).toBe('clearTextRefused');
+    });
+
+    it('takes a clear-text address once it has been declared', () => {
+        expect(resolved('mail.example.test', true)).toBe('http://mail.example.test');
+    });
+
+    it('leaves the secure scheme alone where clear text was declared but not written', () => {
+        expect(resolved('https://mail.example.test', true)).toBe('https://mail.example.test');
+    });
+
+    it.each(['http://localhost:8080', 'http://127.0.0.1:8080', 'http://[::1]:8080'])(
+        'takes %j undeclared, because clear text to this machine crosses no network',
+        (entry) => {
+            expect(resolved(entry)).toBe(entry);
+        },
+    );
+
+    it('refuses a host that merely ends in the loopback name, which is a name somebody chose', () => {
+        expect(refusal('http://tauri.localhost')).toBe('clearTextRefused');
+    });
+
+    it('takes a host carrying separators inside its labels', () => {
+        expect(resolved('mail-fathom.example-host.test')).toBe('https://mail-fathom.example-host.test');
+    });
+
+    it.each(['-mail.example.test', 'mail-.example.test', 'mail..example.test'])(
+        'refuses %j, where a label does not begin and end in a character a resolver would accept',
+        (entry) => {
+            expect(refusal(entry)).toBe('malformed');
+        },
+    );
+
+    // The refusal has to arrive rather than the work being proportional to what can be pasted. Written the obvious
+    // way, the host pattern walks an astronomical number of attempts before refusing an entry of this shape, and this
+    // test reports that as the runner's own timeout rather than as a wrong answer.
+    it('refuses a long entry that nearly matches, without walking every way it could have matched', () => {
+        expect(refusal(`${'mailfathom.'.repeat(24)}!`)).toBe('malformed');
+    });
+
+    it('refuses an entry longer than any address could be, rather than reading it', () => {
+        expect(refusal(`${'a'.repeat(400)}.example.test`)).toBe('malformed');
+    });
+});
+
+describe('reachDeployment', () => {
+    it('asks the session route, which is the one a client holding no credential may reach', async () => {
+        const asked: ClientRequest[] = [];
+
+        await reachDeployment(deployment, (request) => {
+            asked.push(request);
+
+            return Promise.resolve({ status: 200, body: sessionBody('MailFathom', '0.8.0'), headers: {} });
+        });
+
+        expect(asked).toEqual([
+            {
+                method: 'GET',
+                path: 'https://mail.example.invalid/api/client/session',
+                headers: { Accept: 'application/json' },
+            },
+        ]);
+    });
+
+    it('reports the release a deployment answering in full names', async () => {
+        const result = await reachDeployment(deployment, answering({ body: sessionBody('MailFathom', '0.8.0') }));
+
+        expect(result).toEqual({ outcome: 'read', value: { version: '0.8.0' } });
+    });
+
+    it('takes a refusal challenging under MailFathom as the deployment being there and wanting a credential', async () => {
+        const result = await reachDeployment(
+            deployment,
+            answering({ status: 401, headers: { 'www-authenticate': 'Bearer realm="MailFathom"' } }),
+        );
+
+        expect(result).toEqual({ outcome: 'read', value: { version: null } });
+    });
+
+    it('refuses a refusal challenging under somebody else, which is another product answering the port', async () => {
+        const result = await reachDeployment(
+            deployment,
+            answering({ status: 401, headers: { 'www-authenticate': 'Basic realm="Router"' } }),
+        );
+
+        expect(result).toEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 401 } });
+    });
+
+    it('refuses a refusal carrying no challenge at all', async () => {
+        const result = await reachDeployment(deployment, answering({ status: 401 }));
+
+        expect(result).toEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 401 } });
+    });
+
+    it.each([
+        ['another product answering in JSON', sessionBody('Something else', '0.8.0')],
+        ['a session body naming no release', sessionBody('MailFathom', null)],
+        ['a release longer than a release is', sessionBody('MailFathom', 'v'.repeat(65))],
+        ['a page rather than an answer', '<!doctype html><title>Sign in</title>'],
+        ['an array', '[]'],
+        ['nothing', ''],
+    ])('refuses %s as a deployment', async (_, body) => {
+        const result = await reachDeployment(deployment, answering({ body }));
+
+        expect(result).toEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+
+    it('reads a route that is not served as something other than MailFathom answering', async () => {
+        const result = await reachDeployment(deployment, answering({ status: 404 }));
+
+        expect(result).toEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 404 } });
+    });
+
+    it('reads a deployment that is failing as one to try again rather than as the wrong address', async () => {
+        const result = await reachDeployment(deployment, answering({ status: 503 }));
+
+        expect(result).toEqual({ outcome: 'failed', failure: { reason: 'unavailable', status: 503 } });
+    });
+
+    it('reports a connection that never answered as one to try again, rather than throwing at the screen', async () => {
+        const result = await reachDeployment(deployment, () => Promise.reject(new TypeError('Failed to fetch')));
+
+        expect(result).toEqual({ outcome: 'failed', failure: { reason: 'unavailable', status: null } });
+    });
+
+    it('makes one attempt and never a second one without the transport security the first asked for', async () => {
+        const asked: string[] = [];
+
+        await reachDeployment({ baseAddress: 'https://mail.example.invalid' }, (request) => {
+            asked.push(request.path);
+
+            return Promise.reject(new TypeError('Failed to fetch'));
+        });
+
+        expect(asked).toEqual(['https://mail.example.invalid/api/client/session']);
+    });
+});

--- a/frontend/src/Client.Backend/src/deployment.test.ts
+++ b/frontend/src/Client.Backend/src/deployment.test.ts
@@ -164,6 +164,9 @@ describe('reachDeployment', () => {
         ['another product answering in JSON', sessionBody('Something else', '0.8.0')],
         ['a session body naming no release', sessionBody('MailFathom', null)],
         ['a release longer than a release is', sessionBody('MailFathom', 'v'.repeat(65))],
+        // Refused on its size before it is parsed at all, which is the order that matters: this is the one answer the
+        // client reads from an address nobody has trusted yet.
+        ['a body longer than a session answer is', sessionBody('MailFathom', '0.8.0').padEnd(4097, ' ')],
         ['a page rather than an answer', '<!doctype html><title>Sign in</title>'],
         ['an array', '[]'],
         ['nothing', ''],

--- a/frontend/src/Client.Backend/src/deployment.ts
+++ b/frontend/src/Client.Backend/src/deployment.ts
@@ -1,0 +1,247 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { failed, read, type ClientResult } from './failure';
+import { routeFor, type DeploymentAddress } from './session';
+import { send, type MailFathomTransport } from './transport';
+
+// Where the client's address is decided, and it is here rather than in the screen that collects one because an address
+// is a security boundary rather than a convenience: every request carries the credential on it, so the rule saying
+// which addresses may carry one belongs beside the wire it travels on. Nothing here holds a default, and nothing here
+// composes an address from a literal — a deployment is somewhere only its owner knows.
+
+/** The route a deployment reports itself at, relative to the client prefix. It needs no grant, which is what lets a client reach it before it holds a credential. */
+export const deploymentSessionRoute = '/session';
+
+/** The name every MailFathom surface challenges under, which is what a refusal proves the client reached one by. */
+const protectionSpace = 'realm="MailFathom"';
+
+/** The product name the session route answers with. */
+const productName = 'MailFathom';
+
+/** Why an address a person gave was not taken. */
+export type DeploymentEntryRefusal = 'blank' | 'malformed' | 'clearTextRefused';
+
+/** What an address a person gave resolved to, or why it did not. */
+export type DeploymentEntryResult =
+    | { readonly outcome: 'resolved'; readonly deployment: DeploymentAddress }
+    | { readonly outcome: 'refused'; readonly refusal: DeploymentEntryRefusal };
+
+/** What a deployment says about itself to a caller holding no credential yet. */
+export interface DeploymentGreeting {
+    /** The release it reports, or `null` where it answered a challenge rather than a body. */
+    readonly version: string | null;
+}
+
+/**
+ * Turns what somebody typed into the address of a deployment, or refuses it.
+ *
+ * A person names their deployment the way they would name a server — a host, and a port where their deployment uses
+ * one — so the scheme is the client's to supply, and it supplies `https`. Plain HTTP is not a fallback the client
+ * takes when TLS fails: it is reached only by declaring it, because a Basic password travels on every request and
+ * encoding is not encryption. The one address that needs no declaration is one on this machine, where there is no
+ * network between the client and the deployment for anybody to read the credential off.
+ *
+ * @param entry What was typed, which may carry a scheme and may be surrounded by whitespace.
+ * @param clearTextPermitted Whether the person declared that plain HTTP is acceptable for this address.
+ * @returns The address, or the refusal naming why there is none.
+ */
+export function resolveDeploymentEntry(entry: string, clearTextPermitted: boolean): DeploymentEntryResult {
+    const typed = entry.trim();
+    if (typed.length === 0) {
+        return { outcome: 'refused', refusal: 'blank' };
+    }
+
+    const address = typed.length > longestEntry ? null : parseAddress(typed, clearTextPermitted ? 'http' : 'https');
+
+    if (address === null) {
+        return { outcome: 'refused', refusal: 'malformed' };
+    }
+
+    if (address.scheme === 'http' && !clearTextPermitted && !isThisMachine(address.host)) {
+        return { outcome: 'refused', refusal: 'clearTextRefused' };
+    }
+
+    return { outcome: 'resolved', deployment: { baseAddress: `${address.scheme}://${address.authority}` } };
+}
+
+/**
+ * Asks an address whether MailFathom is what answers there, before anything is sent to it.
+ *
+ * It is one request at the scheme the address names and there is no second one: a deployment that refused a TLS
+ * connection reports that refusal rather than being tried again without it. The route it reaches needs no grant, so
+ * this answers for a client that has nothing to sign in with yet — and a deployment that demands a credential proves
+ * itself by the protection space its refusal challenges under.
+ *
+ * @param deployment The address to reach.
+ * @param transport How the request goes out.
+ * @returns What the deployment reported, or why the address was not taken as one.
+ */
+export async function reachDeployment(
+    deployment: DeploymentAddress,
+    transport: MailFathomTransport,
+): Promise<ClientResult<DeploymentGreeting>> {
+    const response = await send(transport, {
+        method: 'GET',
+        path: routeFor(deployment, deploymentSessionRoute),
+        headers: { Accept: 'application/json' },
+    });
+
+    if (response === null) {
+        return failed('unavailable', null);
+    }
+
+    if (response.status === 200) {
+        const version = versionReported(response.body);
+
+        return version === null ? failed('unreadable', response.status) : read({ version });
+    }
+
+    // A deployment serving this surface refuses a caller carrying no credential, which is the answer a client asking
+    // where it is gets from every deployment somebody actually runs. The challenge is what makes that answer say more
+    // than "something refused me": every MailFathom surface names one protection space, and a browser can read the
+    // header because the client endpoint's own CORS policy exposes it.
+    if (response.status === 401 && challengesAsMailFathom(response.headers)) {
+        return read({ version: null });
+    }
+
+    return failed(response.status >= 500 ? 'unavailable' : 'unreadable', response.status);
+}
+
+/** The release a session body reports, or `null` where the body was not one MailFathom answers with. */
+function versionReported(body: string): string | null {
+    let parsed: unknown;
+
+    try {
+        parsed = JSON.parse(body);
+    } catch {
+        return null;
+    }
+
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        return null;
+    }
+
+    const answered = parsed as Record<string, unknown>;
+    const service = answered['service'];
+    const version = answered['version'];
+
+    if (service !== productName || typeof version !== 'string') {
+        return null;
+    }
+
+    return version.length > 0 && version.length <= longestVersion ? version : null;
+}
+
+function challengesAsMailFathom(headers: Readonly<Record<string, string>>): boolean {
+    return headers['www-authenticate']?.includes(protectionSpace) === true;
+}
+
+/** Where a deployment is, once what was typed has been read as a scheme, a host, and a port. */
+interface ParsedAddress {
+    readonly scheme: 'http' | 'https';
+
+    /** The host alone, which is what the clear-text rule is decided against. */
+    readonly host: string;
+
+    /** The host with the port where one is not the scheme's own, which is what an address is written as. */
+    readonly authority: string;
+}
+
+// A scheme is one the person wrote rather than one this function guessed, so it is recognized only in the form that
+// cannot be confused with a host and a port: `mail.example.test:8443` names a port, and `https://mail.example.test`
+// names a scheme.
+const writtenScheme = /^([a-z][a-z0-9+.-]*):\/\/(.*)$/i;
+
+// A host is a name or an IPv4 address, written as labels a resolver would accept. An IPv6 address is the bracketed
+// form beside it, which is why the port is split off before either is matched.
+//
+// Each character has exactly one place to go in this pattern — a separator is only ever consumed by the group that
+// asks for it, so nothing here has a second way to match and there is no backtracking to walk. Written the more
+// obvious way, as an optional trailing group inside each label, a host of ten ten-character labels that ends in one
+// character too many takes billions of attempts to refuse: this input arrives from a person typing into a screen, and
+// a form that stops responding to a typo is a defect rather than a slow path.
+const hostName = /^[a-z0-9](-*[a-z0-9])*(\.[a-z0-9](-*[a-z0-9])*)*$/i;
+const bracketedHost = /^\[[0-9a-f:.]+\]$/i;
+
+// The longest entry read at all. A host name is at most 253 characters and a scheme and a port add a few more, so
+// anything past this is not an address somebody mistyped — and a bound is what keeps the work below proportional to
+// what a person can mean rather than to what can be pasted.
+const longestEntry = 320;
+
+// The longest release string read out of a session answer. It is a version rather than prose, and a bound here is what
+// keeps an answer from an address nobody has trusted yet from becoming an unbounded string the client carries around.
+const longestVersion = 64;
+
+const defaultPorts: Readonly<Record<'http' | 'https', string>> = { http: '80', https: '443' };
+
+/**
+ * Reads what was typed as the address of a deployment, or answers `null` where it is not one.
+ *
+ * Written out rather than handed to the platform's own parser because this package declares no DOM and no Node
+ * library, which is what keeps `Client.Backend` free of a runtime — and because the two parsers a runtime offers are
+ * lenient in exactly the places that matter here: an address carrying a path, a query, or a credential is one somebody
+ * pasted from a browser rather than one they named, and each has to be refused rather than quietly dropped.
+ */
+function parseAddress(typed: string, suppliedScheme: 'http' | 'https'): ParsedAddress | null {
+    const written = writtenScheme.exec(typed);
+    const scheme = written === null ? suppliedScheme : written[1]?.toLowerCase();
+    const authority = written === null ? typed : (written[2] ?? '');
+
+    if (scheme !== 'http' && scheme !== 'https') {
+        return null;
+    }
+
+    const separated = separatePort(authority);
+    if (separated === null) {
+        return null;
+    }
+
+    const { host, port } = separated;
+
+    if (!hostName.test(host) && !bracketedHost.test(host)) {
+        return null;
+    }
+
+    const named = host.toLowerCase();
+    const carried = port === null || port === defaultPorts[scheme] ? named : `${named}:${port}`;
+
+    return { scheme, host: named, authority: carried };
+}
+
+/** The host and the port an authority names, or `null` where it names something that is not an authority. */
+function separatePort(authority: string): { host: string; port: string | null } | null {
+    // Everything that would make this more than a host and a port: a path, a query, a fragment, a credential, or
+    // whitespace somebody typed in the middle of it.
+    if (/[/?#@\s]/.test(authority)) {
+        return null;
+    }
+
+    const bracketed = /^(\[[^\]]*\])(?::(\d{1,5}))?$/.exec(authority) ?? /^([^:]*)(?::(\d{1,5}))?$/.exec(authority);
+    if (bracketed === null) {
+        return null;
+    }
+
+    const host = bracketed[1] ?? '';
+    const port = bracketed[2] ?? null;
+
+    if (host.length === 0) {
+        return null;
+    }
+
+    return port === null || (Number(port) >= 1 && Number(port) <= 65535) ? { host, port } : null;
+}
+
+/**
+ * Whether the host is this machine, which is the one place clear text crosses no network.
+ *
+ * Only the loopback host itself counts. A name that merely ends in `.localhost` is a name somebody chose, resolved by
+ * whatever resolver the machine is configured with, and treating it as loopback would hand the exemption to any host
+ * that asked for it by name.
+ */
+function isThisMachine(hostname: string): boolean {
+    const host = hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+
+    return host === 'localhost' || host === '::1' || /^127(\.\d{1,3}){3}$/.test(host);
+}

--- a/frontend/src/Client.Backend/src/deployment.ts
+++ b/frontend/src/Client.Backend/src/deployment.ts
@@ -111,6 +111,10 @@ export async function reachDeployment(
 
 /** The release a session body reports, or `null` where the body was not one MailFathom answers with. */
 function versionReported(body: string): string | null {
+    if (body.length > longestSessionBody) {
+        return null;
+    }
+
     let parsed: unknown;
 
     try {
@@ -173,6 +177,14 @@ const longestEntry = 320;
 // The longest release string read out of a session answer. It is a version rather than prose, and a bound here is what
 // keeps an answer from an address nobody has trusted yet from becoming an unbounded string the client carries around.
 const longestVersion = 64;
+
+// The longest session answer read at all. This is the one answer in the client that arrives from an address nobody has
+// trusted yet — the whole point of asking is that the client does not know what is there — so the bound is applied
+// before the body is expanded rather than to what parsing it produced. It names a product, a release, and the caller's
+// own grant out of a published set, which is a few hundred bytes; anything past this is not a session answer, whatever
+// it turns out to be. `longestResponseBody` is the transport's backstop behind it, and this is the bound that says what
+// *this* route may answer with.
+const longestSessionBody = 4096;
 
 const defaultPorts: Readonly<Record<'http' | 'https', string>> = { http: '80', https: '443' };
 

--- a/frontend/src/Client.Backend/src/index.ts
+++ b/frontend/src/Client.Backend/src/index.ts
@@ -2,6 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+export {
+    deploymentSessionRoute,
+    reachDeployment,
+    resolveDeploymentEntry,
+    type DeploymentEntryRefusal,
+    type DeploymentEntryResult,
+    type DeploymentGreeting,
+} from './deployment';
 export { failureReasonForStatus, type ClientFailure, type ClientFailureReason, type ClientResult } from './failure';
 export {
     mailAccountsRoute,
@@ -10,5 +18,5 @@ export {
     type MailAccountDirectory,
     type MailSynchronizationState,
 } from './mailAccounts';
-export { clientRoutePrefix, headersFor, routeFor, type ClientSession } from './session';
+export { clientRoutePrefix, headersFor, routeFor, type ClientSession, type DeploymentAddress } from './session';
 export type { ClientRequest, ClientResponse, MailFathomTransport } from './transport';

--- a/frontend/src/Client.Backend/src/index.ts
+++ b/frontend/src/Client.Backend/src/index.ts
@@ -19,4 +19,4 @@ export {
     type MailSynchronizationState,
 } from './mailAccounts';
 export { clientRoutePrefix, headersFor, routeFor, type ClientSession, type DeploymentAddress } from './session';
-export type { ClientRequest, ClientResponse, MailFathomTransport } from './transport';
+export { longestResponseBody, type ClientRequest, type ClientResponse, type MailFathomTransport } from './transport';

--- a/frontend/src/Client.Backend/src/mailAccounts.test.ts
+++ b/frontend/src/Client.Backend/src/mailAccounts.test.ts
@@ -27,11 +27,14 @@ const directoryBody = JSON.stringify({
 
 // The transport is the network boundary and the whole of what a test here fakes: it is a function the caller supplies,
 // so nothing has to intercept a global or stand up a server to decide what came back.
-function answering(response: ClientResponse): MailFathomTransport {
-    return () => Promise.resolve(response);
+// This operation reads no header off an answer, so the tests below name none and each helper supplies the empty set.
+type Answer = Omit<ClientResponse, 'headers'>;
+
+function answering(response: Answer): MailFathomTransport {
+    return () => Promise.resolve({ ...response, headers: {} });
 }
 
-function recording(response: ClientResponse): { transport: MailFathomTransport; requests: ClientRequest[] } {
+function recording(response: Answer): { transport: MailFathomTransport; requests: ClientRequest[] } {
     const requests: ClientRequest[] = [];
 
     return {
@@ -39,7 +42,7 @@ function recording(response: ClientResponse): { transport: MailFathomTransport; 
         transport: (request) => {
             requests.push(request);
 
-            return Promise.resolve(response);
+            return Promise.resolve({ ...response, headers: {} });
         },
     };
 }
@@ -114,6 +117,12 @@ describe('readMailAccounts', () => {
         const result = await readMailAccounts(session, answering({ status, body: '' }));
 
         expect(result).toEqual({ outcome: 'failed', failure: { reason, status } });
+    });
+
+    it('reports a connection that never answered as one to try again, rather than throwing at the screen', async () => {
+        const result = await readMailAccounts(session, () => Promise.reject(new TypeError('Failed to fetch')));
+
+        expect(result).toEqual({ outcome: 'failed', failure: { reason: 'unavailable', status: null } });
     });
 
     // Every shape below is an answer the service could not have meant, and each is refused rather than read as a

--- a/frontend/src/Client.Backend/src/mailAccounts.ts
+++ b/frontend/src/Client.Backend/src/mailAccounts.ts
@@ -4,7 +4,7 @@
 
 import { failed, failureReasonForStatus, read, type ClientResult } from './failure';
 import { headersFor, routeFor, type ClientSession } from './session';
-import type { MailFathomTransport } from './transport';
+import { send, type MailFathomTransport } from './transport';
 
 /** The route the owner's accounts are served at, relative to the client prefix. */
 export const mailAccountsRoute = '/accounts';
@@ -44,11 +44,15 @@ export async function readMailAccounts(
     session: ClientSession,
     transport: MailFathomTransport,
 ): Promise<ClientResult<MailAccountDirectory>> {
-    const response = await transport({
+    const response = await send(transport, {
         method: 'GET',
         path: routeFor(session, mailAccountsRoute),
         headers: headersFor(session),
     });
+
+    if (response === null) {
+        return failed('unavailable', null);
+    }
 
     if (response.status !== 200) {
         return failed(failureReasonForStatus(response.status), response.status);

--- a/frontend/src/Client.Backend/src/session.test.ts
+++ b/frontend/src/Client.Backend/src/session.test.ts
@@ -14,6 +14,12 @@ describe('routeFor', () => {
     it('puts the client prefix between the base address and the route', () => {
         expect(routeFor(session, '/accounts')).toBe('https://mail.example.invalid/api/client/accounts');
     });
+
+    it('composes a route for a deployment nobody has signed in to, which is what an address is asked with', () => {
+        expect(routeFor({ baseAddress: 'https://mail.example.invalid' }, '/session')).toBe(
+            'https://mail.example.invalid/api/client/session',
+        );
+    });
 });
 
 describe('headersFor', () => {

--- a/frontend/src/Client.Backend/src/session.ts
+++ b/frontend/src/Client.Backend/src/session.ts
@@ -6,20 +6,34 @@
 export const clientRoutePrefix = '/api/client';
 
 /**
+ * Where a MailFathom deployment is, as the address every route on it is appended to.
+ *
+ * It is a scheme, a host, and a port where the deployment uses one, with no trailing separator. Nothing in this
+ * package composes one from a literal: a deployment is somewhere only its owner knows, so an address arrives from
+ * `resolveDeploymentEntry`, which is also where the rule refusing a clear-text one lives.
+ */
+export interface DeploymentAddress {
+    readonly baseAddress: string;
+}
+
+/**
  * Who is asking, and where.
  *
  * The credential is held as the finished header value rather than as a user name and a password, so nothing in this
  * package composes one and nothing in it can log the parts. What builds that value belongs to whatever signed the
  * person in.
+ *
+ * It carries the address rather than referring to one, which is what makes a credential unable to outlive the
+ * deployment it was presented to: a session is built from an address, so changing the address builds a new session or
+ * none, and there is nowhere for the old one to survive.
  */
-export interface ClientSession {
-    readonly baseAddress: string;
+export interface ClientSession extends DeploymentAddress {
     readonly authorization: string;
 }
 
-/** The absolute path a route on the client surface is reached at, for a session serving it from a base address. */
-export function routeFor(session: ClientSession, route: string): string {
-    return `${session.baseAddress}${clientRoutePrefix}${route}`;
+/** The absolute path a route on the client surface is reached at, for a deployment serving it from a base address. */
+export function routeFor(deployment: DeploymentAddress, route: string): string {
+    return `${deployment.baseAddress}${clientRoutePrefix}${route}`;
 }
 
 /** The headers every request on this surface carries. */

--- a/frontend/src/Client.Backend/src/transport.test.ts
+++ b/frontend/src/Client.Backend/src/transport.test.ts
@@ -1,0 +1,46 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import { send, type ClientRequest, type ClientResponse } from './transport';
+
+const request: ClientRequest = {
+    method: 'GET',
+    path: 'https://mail.example.invalid/api/client/session',
+    headers: { Accept: 'application/json' },
+};
+
+describe('send', () => {
+    it('answers what came back, unread and undecided', async () => {
+        const answer: ClientResponse = { status: 200, body: '{}', headers: { 'content-type': 'application/json' } };
+
+        expect(await send(() => Promise.resolve(answer), request)).toEqual(answer);
+    });
+
+    it('hands the request to the transport as it was given', async () => {
+        const asked: ClientRequest[] = [];
+
+        await send((given) => {
+            asked.push(given);
+
+            return Promise.resolve({ status: 200, body: '', headers: {} });
+        }, request);
+
+        expect(asked).toEqual([request]);
+    });
+
+    // Every operation reports an expected failure as a value, so nothing above this may throw. A connection refused, a
+    // name that does not resolve, and a certificate the client will not accept all arrive here as a rejection.
+    it('answers nothing where the connection never produced an answer', async () => {
+        expect(await send(() => Promise.reject(new TypeError('Failed to fetch')), request)).toBeNull();
+    });
+
+    it('answers nothing where the transport threw before it returned a promise at all', async () => {
+        expect(
+            await send(() => {
+                throw new TypeError('Failed to fetch');
+            }, request),
+        ).toBeNull();
+    });
+});

--- a/frontend/src/Client.Backend/src/transport.ts
+++ b/frontend/src/Client.Backend/src/transport.ts
@@ -9,10 +9,20 @@ export interface ClientRequest {
     readonly headers: Readonly<Record<string, string>>;
 }
 
-/** What came back, reduced to the two things this package reads. */
+/** What came back, reduced to the three things this package reads. */
 export interface ClientResponse {
     readonly status: number;
     readonly body: string;
+
+    /**
+     * The response headers, under lower-case names.
+     *
+     * A refusal is the one answer this package reads a header off: it carries the protection space the deployment
+     * challenges for, which is what tells a client it reached MailFathom rather than something else refusing it. The
+     * names arrive lower-cased because HTTP field names are case-insensitive, and a lookup that had to try three
+     * spellings would be a lookup that misses the fourth.
+     */
+    readonly headers: Readonly<Record<string, string>>;
 }
 
 /**
@@ -23,3 +33,19 @@ export interface ClientResponse {
  * indirection exists rather than a layer added in case a second transport ever appears.
  */
 export type MailFathomTransport = (request: ClientRequest) => Promise<ClientResponse>;
+
+/**
+ * Puts one request on the wire, answering `null` where nothing answered at all.
+ *
+ * Every operation goes through this rather than calling the transport directly, because a connection refused, a name
+ * that does not resolve, a certificate the client will not accept, and an answer cut short all arrive as a rejected
+ * promise rather than as a status — and an operation that let one through would hand a screen an exception where its
+ * whole contract is that an expected failure is a value.
+ */
+export async function send(transport: MailFathomTransport, request: ClientRequest): Promise<ClientResponse | null> {
+    try {
+        return await transport(request);
+    } catch {
+        return null;
+    }
+}

--- a/frontend/src/Client.Backend/src/transport.ts
+++ b/frontend/src/Client.Backend/src/transport.ts
@@ -35,6 +35,22 @@ export interface ClientResponse {
 export type MailFathomTransport = (request: ClientRequest) => Promise<ClientResponse>;
 
 /**
+ * The most of one answer a transport reads before it gives up on it, in bytes.
+ *
+ * It is the backstop rather than the bound an operation works to: each of those is far tighter and
+ * belongs beside the thing it describes, and this is what keeps a body from being buffered whole
+ * before any of them can apply. It matters most where the client is asking an address it has not
+ * trusted yet whether MailFathom is what answers there — the answer at that point is from a stranger,
+ * and a stranger that replies with a gigabyte should cost this client a cancelled read rather than
+ * the memory.
+ *
+ * A transport that has to stop reading answers with an empty body, which every operation already
+ * refuses as unreadable. That is the accurate outcome and it needs no reason of its own: an answer
+ * this client would not read in full is one it cannot act on either way.
+ */
+export const longestResponseBody = 1_048_576;
+
+/**
  * Puts one request on the wire, answering `null` where nothing answered at all.
  *
  * Every operation goes through this rather than calling the transport directly, because a connection refused, a name

--- a/frontend/tests/AGENTS.md
+++ b/frontend/tests/AGENTS.md
@@ -91,7 +91,7 @@ question is answered again rather than reworded.
 - **The network boundary is `MailFathomTransport`, and it is the only thing a read fakes.** It is a function the caller
   supplies, so a test hands one over and nothing patches `fetch`, starts a server, or adds an HTTP mocking package.
 - Prefer a component that takes its transport, or the value already read through one, from its caller. Where a
-  component reaches for its own — `App` does today, from `stubMailFathom` — the module supplying it is replaced with
+  component reaches for its own — `App` does today for mail, from `stubMailFathom` — the module supplying it is replaced with
   `vi.mock`, and that is read as the seam being wrong rather than as the pattern to copy.
 - **Never `vi.mock` a module of `Client.Backend` from an application test.** The parsing and the failure mapping are
   part of what the screen is being proven against; faking them leaves a test that asserts a screen renders whatever it
@@ -162,9 +162,12 @@ the answer; dropping it is not, and neither is asserting it in jsdom where it wo
 - **The same rule about what a test asserts holds**, and this suite has no exemption from it: a role first, then the
   text a person would read. Playwright's `getByRole` is the same query React Testing Library's is. No CSS selector, no
   `data-testid`, no coordinate, and no assertion on a class name.
-- **The service is not started and no credential is used.** The bundle carries `stubMailFathom`, so what the client
-  reads is a canned body and the suite proves the screen rather than a deployment. Driving a real deployment is the
-  agent's own work with `@playwright/cli`, which `frontend/AGENTS.md` covers, and it is not this suite.
+- **The service is not started and no credential is used.** The bundle carries `stubMailFathom`, so the mail the client
+  reads is a canned body and the suite proves the screen rather than a deployment. What is not stubbed is reaching a
+  deployment at all, and the preview server is the reason that costs nothing here: it serves the bundle from a loopback
+  origin, which the client adopts as its deployment without asking anybody, so the connect screen never opens and
+  nothing is sent. Driving a real deployment is the agent's own work with `@playwright/cli`, which
+  `frontend/AGENTS.md` covers, and it is not this suite.
 - **Nothing here retries.** A check that passes on a second attempt has reported that the client is flaky rather than
   that it works.
 - **A failure keeps its trace and its screenshot in `frontend/.playwright/`, which Git ignores and nothing uploads.**
@@ -179,8 +182,9 @@ the answer; dropping it is not, and neither is asserting it in jsdom where it wo
 
 Two things it does not cover yet, because the client does not have them. There is no router, so the only navigation
 there is to check is the browser's own — leaving the client and coming back to it — and an in-application back gesture
-is asserted here on the day one exists. And nothing goes over the wire to a service, because the transport is stubbed
-inside the bundle, so what is asserted about the network today is that the client reaches its own origin and no other.
+is asserted here on the day one exists. And nothing goes over the wire to a service, because the mail is stubbed inside
+the bundle and the origin serving it is the deployment it is pointed at, so what is asserted about the network today is
+that the client reaches its own origin and no other.
 
 ## Coverage
 


### PR DESCRIPTION
`ClientSession` held a base address that nothing produced, and `Client.App` built one from `stubMailFathom.ts`, so the client reached a canned body rather than a deployment. This resolves where a real address comes from, refuses the ones a credential may not travel on, and proves an address answers as MailFathom before anything is sent to it.

## Where the rule lives

`Client.Backend` gains `deployment.ts`, because both halves are properties of the wire the credential travels on rather than of the form that collects them.

`resolveDeploymentEntry` reads a host and an optional port and supplies `https`. It refuses a path, a query, a fragment, a credential written into an address, a scheme this client does not speak, and a clear-text address nobody declared — the one exemption being the loopback host, where clear text crosses no network. Plain HTTP is reached only through a control that is off by default and says, beside itself, that the password is encoded rather than encrypted on every request.

`reachDeployment` asks `GET /api/client/session`, which is published under no permission and is therefore reachable by a client holding nothing. It takes either a body naming `MailFathom` or a refusal challenging under the `MailFathom` protection space — the client endpoint's CORS policy already exposes `WWW-Authenticate` for exactly that reason. It makes one attempt at the scheme the address names and never a second one without it.

Neither is written with the platform's own URL parser: `Client.Backend` declares no DOM and no Node library, and the parsers a runtime offers are lenient in the places that matter here.

## Which deployment a run belongs to

Resolved once at the application's edge and handed down as a value, so nothing branches on a head. `main.tsx` reads the address somebody named, else the one that served the client, and takes the second only where it is an address this client may address at all.

- A web bundle served by its deployment resolves to that deployment and meets no screen.
- A desktop shell loaded from a scheme of its own resolves to nothing and meets the connect screen.
- A shell served over plain HTTP from a host that merely ends in the loopback name resolves to nothing too, by the clear-text rule rather than by a question about platforms.

The session is built from the adopted address rather than held beside it, so pointing the client elsewhere leaves nowhere for the previous deployment's session to survive. That is the binding [ADR 0023](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0023-where-the-react-client-keeps-its-sign-in-credential.md) names, arriving from this side of it.

## The screen

One `h2`, an address, the clear-text control, and a submit button, in a form: labelled, described, keyboard-operable, and every word out of both catalogues. It carries its states — the idle form, reaching, an entry refused, nothing answered, and something answering that is not MailFathom — and a refusal is announced, associated with the field through `aria-describedby`, and taken away as soon as the address is being corrected. Focus is placed on the address when the screen opens and at the start of the mail when it closes.

## Two things beyond the issue, and why

**`send` in `transport.ts`.** A connection refused, a name that does not resolve, and a certificate the client will not accept all arrive as a rejected promise. `readMailAccounts` now routes through the same helper `reachDeployment` needed, because it would otherwise have thrown at a screen whose whole contract is that an expected failure is a value — and one guard where both callers route through is a smaller change than two.

**The host pattern is written so each character has one place to go.** The obvious form, with an optional trailing group inside each label, walks an astronomical number of attempts before refusing a long entry that nearly matches. This input arrives from a person typing into a screen, so a form that stops responding to a typo is a defect rather than a slow path; there is a test that reports it as the runner's own timeout, and an entry longer than any address can be is refused unread.

## What is deliberately still stubbed

The mail. Signing in is #1419's, so nothing composes a credential yet and `stubMailFathom.ts` still answers the accounts route — matched on the route now rather than on a whole address, since which deployment the client is pointed at is no longer that module's to know. The stub credential never reaches a wire: it goes to the stub transport, and the real one carries only the unauthenticated probe.

`frontend/tests/AGENTS.md` said the browser suite proves the screen because the transport is stubbed inside the bundle, which is now half true; it says which half, and why the preview server's loopback origin means that suite still opens no connect screen and sends nothing.

## Contracts

No break. Nothing in the four public surfaces moved: `Client.Backend` is not published, and `ClientResponse` gaining `headers` is internal to the workspace.

## Verification

`scripts/verify-full.sh` — 279 passed, 0 failed. `pnpm test` — 130 passed across both packages. `pnpm test:browser` — 4 passed against the built bundle, unchanged.

Closes #1417
