### PR TITLE
[#1420] Give the client its three-space shell, its routes, and its two compositions

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -76,6 +76,10 @@ component library, which ADR 0021 excluded deliberately; a router; a state conta
 Adopting one is a decision with its own issue, its own licence review, and its own reasoning about what it buys — never
 a side effect of writing the screen that wanted one thing it does.
 
+The router is the one of the four whose absence has already been argued rather than merely inherited: the client
+reaches each space at a fragment address and reads it back through `hashchange`, which
+[the workspace's page](README.md) describes. So a change proposing one is answering that argument, not filling a gap.
+
 ## Driving the running client in a real browser
 
 A screen is not proven by compiling. The client is served by `pnpm dev` and driven with

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -158,8 +158,9 @@ root. No threshold is enforced on the figure.
 
 `pnpm test:browser` is the other one. It runs `pnpm build`, serves `src/Client.App/dist/` with Vite's preview server,
 and drives it with Playwright, so what it proves is the bundle a deployment publishes rather than the source: the
-application loading, the version the build stamped, the screen rendering through roles and accessible names, the
-browser's own back navigation, and the requests the page actually issued. It needs a browser of its own —
+application loading, the version the build stamped, the screen rendering through roles and accessible names, each space
+reloading at its own address and the back gesture moving through the client's own history, which composition a width
+produces, and the requests the page actually issued. It needs a browser of its own —
 `pnpm exec playwright install chromium` — which is why neither verification gate runs it and the pipeline does, on every
 pull request that reaches this stack. Its configuration is `playwright.config.ts` and its specs are under `tests/`.
 
@@ -172,11 +173,37 @@ client's file types. Prettier reads it: its CLI respects `.editorconfig` by defa
 those values in a second file that would drift. Prettier's own configuration here is `.prettierignore` and nothing
 more.
 
-## Styling
+## Three spaces, one frame, and no router
 
-Tailwind is wired CSS-first through `@tailwindcss/vite`. The palette and the type scale are `@theme` tokens in
-`src/Client.App/src/styles.css`, and there is no JavaScript configuration file. The colours are MailFathom's own,
-sampled from the product icon.
+The client is **Discover**, **Mail**, and **Cases**, and they are one application rather than three: `src/App.tsx` is
+the frame that holds them, and it is what a person carries their question, their scope, and their selection across.
+The frame is one tree laid out two ways by the width it is given — a navigation rail beside the workspace at or above
+the `workspace` breakpoint, bottom navigation under a stack of screens below it — and nothing in it reads which head or
+which platform it is running on.
+
+Each space is reached at a **fragment address** of its own: `#/discover`, `#/mail`, `#/cases`. `src/routing/` is the
+whole of it, and it is deliberately not a package — three addresses with no segment, no parameter, and no nested tree
+are what `location.hash` and `hashchange` already are, and the browser keeps the history for us. A fragment rather than
+a path because a path would have to be reloadable, and the service serves the bundle with no fallback mapping an
+unmatched path onto the entry document; a fragment never reaches a server, so every address reloads on both heads with
+nothing configured.
+
+`src/workspace/` is what survives moving between spaces, and it is mounted above the frame for exactly that reason.
+
+## Styling, and the two themes
+
+Tailwind is wired CSS-first through `@tailwindcss/vite`. The palette, the type scale, the breakpoint the composition
+changes at, the safe-area insets, and the motion defaults are `@theme` tokens in `src/Client.App/src/styles.css`, and
+there is no JavaScript configuration file.
+
+The colours come in two layers. `--color-fathom-*` is MailFathom's own ramp, sampled from the product icon; everything
+a screen actually composes against is a **semantic** name set from it — a panel, a rail, a sunken region, two line
+weights, four text weights, an accent, a healthy state, a warning. Both themes declare the same names, which is what
+lets the light and the dark client be one set of utilities rather than a `dark:` variant on every one of them.
+
+`src/theme/` decides which of the two is painted, from the person's choice of light, dark, or following the machine.
+It writes one `data-theme` attribute on the document before the first paint, so nothing on a screen ever asks which
+theme is in force — the same rule that keeps a screen from asking which language it is in.
 
 ## What the build produces
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -181,6 +181,11 @@ The frame is one tree laid out two ways by the width it is given — a navigatio
 the `workspace` breakpoint, bottom navigation under a stack of screens below it — and nothing in it reads which head or
 which platform it is running on.
 
+One question is answered before the frame is drawn at all: which deployment this client belongs to. Where nothing has
+said, the connect screen stands in front of the frame rather than inside it, because three spaces with nothing behind
+them are a frame around nothing — and once a deployment is adopted, focus moves to the start of the workspace rather
+than staying on the control that reached it.
+
 Each space is reached at a **fragment address** of its own: `#/discover`, `#/mail`, `#/cases`. `src/routing/` is the
 whole of it, and it is deliberately not a package — three addresses with no segment, no parameter, and no nested tree
 are what `location.hash` and `hashchange` already are, and the browser keeps the history for us. A fragment rather than

--- a/frontend/src/AGENTS.md
+++ b/frontend/src/AGENTS.md
@@ -90,8 +90,8 @@ Four things may never cross, in either direction:
 ## Components, props, and names
 
 - **A component is one thing a reader can name.** When naming it needs "and", it is two components. When it renders a
-  list, the row is its own component: `AccountRow` beside `Accounts` is the shape, because the row is what gains state,
-  a keyboard path, and a test.
+  list, the row is its own component: `SpaceLink` beside `SpaceNavigation` is the shape, because the row is what gains
+  state, a keyboard path, and a test.
 - **A prop travels at most one component that does not read it.** A second such hop means the tree is wrong rather than
   that context is needed — move the component that reads the value to where the value is, or render it as a child.
   Reach for context only for what genuinely belongs to the whole screen, such as the session.
@@ -121,9 +121,9 @@ computation, a decision with more than one branch, a mapping from a service valu
 named function or constant above the component, not an expression inside the markup.
 
 The line is drawn where a reader stops being able to see the structure: a ternary choosing between two elements is
-markup, a ternary chain choosing between four is a function returning one. `synchronizationLabels` in
-`Client.App/src/App.tsx` is the shape a mapping takes — a lookup declared once, exhaustive by its own type, rather than a
-chain inside the element that renders it.
+markup, a ternary chain choosing between four is a function returning one. `failureLabels` in
+`Client.App/src/shell/ConnectionSummary.tsx` is the shape a mapping takes — a lookup declared once, exhaustive by its
+own type, rather than a chain inside the element that renders it.
 
 ## The two heads
 

--- a/frontend/src/Client.App/index.html
+++ b/frontend/src/Client.App/index.html
@@ -7,7 +7,13 @@ Project repository: https://github.com/Krzysztof318/MailFathom
 <html lang="en">
     <head>
         <meta charset="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <!-- viewport-fit=cover is what makes the safe-area insets report anything: without it a window with a notch,
+             a rounded corner, or a system bar is laid out inside them and `env(safe-area-inset-*)` is zero, so the
+             tokens the frame pads with would silently do nothing. -->
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+        <!-- What the browser paints its own canvas from before the bundle has loaded, so a reader whose machine is
+             dark does not get a white document while it does. -->
+        <meta name="color-scheme" content="light dark" />
         <title>MailFathom</title>
     </head>
     <body>

--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -3,7 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { StrictMode } from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ClientRequest, ClientResponse, MailFathomTransport } from '@mailfathom/client-backend';
 import { App } from './App';
@@ -11,8 +11,10 @@ import type { AdoptedDeployment } from './deployment/adoptedDeployment';
 import type { DeploymentTransport } from './deployment/sendToDeployment';
 import { LocalizationProvider } from './localization/Localization';
 import { localeNames, locales, readStoredLocale } from './localization/locale';
+import { ThemeProvider } from './theme/Theme';
+import { WorkspaceProvider } from './workspace/Workspace';
 
-// The screen reads its mail through the transport this module supplies, so replacing the module is how that network
+// The frame reads its mail through the transport this module supplies, so replacing the module is how that network
 // boundary is faked here: what is under test stays the real request, the real parsing, and the real failure mapping,
 // and only the answer they are given is the test's. A screen that takes its transport as a prop needs none of this,
 // which is why the deployment the client is pointed at arrives as one below.
@@ -36,7 +38,7 @@ function directory(synchronizationEnabled: boolean, accounts: readonly unknown[]
 }
 
 // What `main.tsx` resolves at the edge and hands down. The origin that served the client is the case a web head is in,
-// and it is the default here because the screens below are about mail rather than about where the deployment is.
+// and it is the default here because the screens below are about the spaces rather than about where the deployment is.
 const servedFrom: AdoptedDeployment = {
     deployment: { baseAddress: 'https://mail.example.invalid' },
     chosen: false,
@@ -44,15 +46,27 @@ const servedFrom: AdoptedDeployment = {
 
 const nothingSent: DeploymentTransport = () => () => Promise.reject(new Error('This screen reaches no deployment.'));
 
-// The application is mounted the way `main.tsx` mounts it, `StrictMode` included. Nothing reads a message without the
-// provider above it, and a test that supplied its own would be proving a second arrangement — and the mode is half of
-// that arrangement rather than a detail of it: it invokes every effect twice on mount, which is the difference between
-// a screen that behaves and one that behaves the first time it is run.
+const workAccount = {
+    id: 'work',
+    displayName: 'Work',
+    synchronizationState: 'Synchronized',
+    lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
+    behind: false,
+};
+
+// The application is mounted the way `main.tsx` mounts it, `StrictMode` and all four providers included. Nothing below
+// the frame may decide the language, the theme, or what the person is carrying, so a test that supplied fewer would be
+// proving a second arrangement — and the mode is half of that arrangement rather than a detail of it: it invokes every
+// effect twice on mount, which is the difference between a screen that behaves and one that behaves the first time.
 function renderApp(deployment: AdoptedDeployment | null = servedFrom, send: DeploymentTransport = nothingSent): void {
     render(
         <StrictMode>
             <LocalizationProvider>
-                <App deployment={deployment} send={send} />
+                <ThemeProvider>
+                    <WorkspaceProvider>
+                        <App deployment={deployment} send={send} />
+                    </WorkspaceProvider>
+                </ThemeProvider>
             </LocalizationProvider>
         </StrictMode>,
     );
@@ -77,40 +91,35 @@ function recordingWhatIsAsked(asked: string[]): void {
     };
 }
 
-const workAccount = {
-    id: 'work',
-    displayName: 'Work',
-    synchronizationState: 'Synchronized',
-    lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
-    behind: false,
-};
+// The frame is on the screen once the summary above the space has an answer to state, which is what every test that
+// acts on the frame waits for rather than for a timer.
+async function framed(): Promise<void> {
+    await screen.findByText('Every account is up to date.');
+}
 
-const archiveAccount = {
-    id: 'archive',
-    displayName: 'Archive',
-    synchronizationState: 'Unreachable',
-    lastSynchronizedAt: '2026-08-28T18:02:00+00:00',
-    behind: true,
-};
+function openingAt(address: string): void {
+    window.history.replaceState(null, '', address);
+}
 
-const neverSynchronizedAccount = {
-    id: 'personal',
-    displayName: 'Personal',
-    synchronizationState: 'NeverSynchronized',
-    lastSynchronizedAt: null,
-    behind: false,
-};
+async function goTo(space: string): Promise<void> {
+    fireEvent.click(screen.getByRole('link', { name: space }));
+
+    await screen.findByRole('heading', { name: space, level: 1 });
+}
+
+beforeEach(() => {
+    answering(directory(true, [workAccount]));
+    openingAt('/');
+});
+
+afterEach(() => {
+    openingAt('/');
+    window.localStorage.clear();
+    document.documentElement.removeAttribute('lang');
+    document.documentElement.removeAttribute('data-theme');
+});
 
 describe('App', () => {
-    beforeEach(() => {
-        answering(directory(true, [workAccount]));
-    });
-
-    afterEach(() => {
-        window.localStorage.clear();
-        document.documentElement.removeAttribute('lang');
-    });
-
     it('says it is reading while the answer has not arrived', () => {
         stub.answer = () => new Promise<ClientResponse>(() => undefined);
 
@@ -119,34 +128,79 @@ describe('App', () => {
         expect(screen.getByText('Reading accounts…')).toBeDefined();
     });
 
-    it('names each account beside the state it is in', async () => {
-        answering(directory(true, [workAccount, archiveAccount]));
-
+    it('opens in Discover when the address names no space', async () => {
         renderApp();
 
-        // One row's whole text, which is what a person reads off it and what a screen reader announces. The name, the
-        // state, and the time are adjacent elements rather than one string, so the gaps between them here are the
-        // markup's; what separates them on the screen is layout, and layout is not something this suite may claim.
-        const accounts = await screen.findAllByRole('listitem');
-        expect(accounts.map((account) => account.textContent)).toEqual([
-            `Worksynchronizedlast synchronized ${whenEnglishWrites(workAccount.lastSynchronizedAt)}`,
-            `Archiveunreachable, behindlast synchronized ${whenEnglishWrites(archiveAccount.lastSynchronizedAt)}`,
-        ]);
+        expect(await screen.findByRole('heading', { name: 'Discover', level: 1 })).toBeDefined();
     });
 
-    it('shows no time against an account that has never synchronized', async () => {
-        answering(directory(true, [neverSynchronizedAccount]));
-
+    it('writes the space it is showing into an address that named none, so it can be reloaded', async () => {
         renderApp();
 
-        const account = await screen.findByRole('listitem');
-        expect(account.textContent).toBe('Personalnever synchronized');
+        await waitFor(() => {
+            expect(window.location.hash).toBe('#/discover');
+        });
     });
 
-    it('says the deployment is refreshing these accounts when it is', async () => {
+    it('corrects an address naming a space the client does not have, rather than showing one it does not name', async () => {
+        openingAt('#/nowhere');
+
         renderApp();
 
-        expect(await screen.findByText('This deployment refreshes the local copy of these accounts.')).toBeDefined();
+        expect(await screen.findByRole('heading', { name: 'Discover', level: 1 })).toBeDefined();
+        await waitFor(() => {
+            expect(window.location.hash).toBe('#/discover');
+        });
+    });
+
+    it.each(['Mail', 'Cases'])('opens in %s when that is what the address names', async (space) => {
+        openingAt(`#/${space.toLowerCase()}`);
+
+        renderApp();
+
+        expect(await screen.findByRole('heading', { name: space, level: 1 })).toBeDefined();
+    });
+
+    it('shows the space whose link was activated, and marks it as the current one', async () => {
+        renderApp();
+        await screen.findByRole('heading', { name: 'Discover', level: 1 });
+
+        await goTo('Cases');
+
+        expect(screen.getByRole('link', { current: 'page' }).textContent).toBe('Cases');
+    });
+
+    it('keeps the question and the mailbox in scope while the person moves between spaces', async () => {
+        renderApp();
+        await framed();
+
+        fireEvent.change(screen.getByRole('searchbox', { name: 'Ask your mail' }), {
+            target: { value: 'the renewal Nordwind sent' },
+        });
+        fireEvent.change(screen.getByRole('combobox', { name: 'Mailbox in scope' }), { target: { value: 'work' } });
+
+        await goTo('Mail');
+
+        expect(screen.getByRole('searchbox', { name: 'Ask your mail' })).toHaveProperty(
+            'value',
+            'the renewal Nordwind sent',
+        );
+        expect(screen.getByRole('combobox', { name: 'Mailbox in scope' })).toHaveProperty('value', 'work');
+    });
+
+    it('offers every mailbox the owner holds as a scope, beside all of them at once', async () => {
+        answering(directory(true, [workAccount, { ...workAccount, id: 'archive', displayName: 'Archive' }]));
+
+        renderApp();
+
+        const scope = await screen.findByRole('combobox', { name: 'Mailbox in scope' });
+        await waitFor(() => {
+            expect([...scope.querySelectorAll('option')].map((option) => option.textContent)).toEqual([
+                'All mailboxes',
+                'Work',
+                'Archive',
+            ]);
+        });
     });
 
     it('says the deployment is not refreshing these accounts when it is not', async () => {
@@ -159,13 +213,24 @@ describe('App', () => {
         ).toBeDefined();
     });
 
-    it('reports why the accounts could not be read instead of an empty list', async () => {
+    it('reports why the accounts could not be read instead of saying nothing about them', async () => {
         answering({ status: 401, body: '' });
 
         renderApp();
 
         expect(await screen.findByText('The accounts could not be read: unauthenticated.')).toBeDefined();
-        expect(screen.queryByRole('list')).toBeNull();
+    });
+
+    it('reads the accounts again when the person asks it to, rather than only on a reload', async () => {
+        answering({ status: 503, body: '' });
+
+        renderApp();
+        const retry = await screen.findByRole('button', { name: 'Try again' });
+
+        answering(directory(true, [workAccount]));
+        fireEvent.click(retry);
+
+        expect(await screen.findByText('Every account is up to date.')).toBeDefined();
     });
 });
 
@@ -175,21 +240,12 @@ describe('App deployment', () => {
     const reachable: DeploymentTransport = () => () =>
         Promise.resolve({ status: 401, body: '', headers: { 'www-authenticate': 'Bearer realm="MailFathom"' } });
 
-    beforeEach(() => {
-        answering(directory(true, [workAccount]));
-    });
-
-    afterEach(() => {
-        window.localStorage.clear();
-        document.documentElement.removeAttribute('lang');
-    });
-
     it('reads from the deployment it was pointed at, rather than from one written into the client', async () => {
         const asked: string[] = [];
         recordingWhatIsAsked(asked);
 
         renderApp(chose('https://elsewhere.example.invalid'));
-        await screen.findAllByRole('listitem');
+        await framed();
 
         expect(deploymentsAsked(asked)).toEqual(['https://elsewhere.example.invalid/api/client/accounts']);
     });
@@ -198,57 +254,57 @@ describe('App deployment', () => {
         renderApp(null);
 
         expect(screen.getByRole('textbox', { name: 'Deployment address' })).toBeDefined();
-        expect(screen.queryByRole('list')).toBeNull();
+        expect(screen.queryByRole('navigation', { name: 'Spaces' })).toBeNull();
     });
 
     it('offers to be pointed elsewhere once somebody named the deployment themselves', async () => {
         renderApp(chose('https://mail.example.invalid'));
-        await screen.findAllByRole('listitem');
+        await framed();
 
         expect(screen.getByRole('button', { name: 'Point somewhere else' })).toBeDefined();
     });
 
     it('offers nothing to change where the origin that served the client is the deployment', async () => {
         renderApp();
-        await screen.findAllByRole('listitem');
+        await framed();
 
         expect(screen.queryByRole('button', { name: 'Point somewhere else' })).toBeNull();
     });
 
-    it('asks for an address again, and shows no mail, once it is pointed somewhere else', async () => {
+    it('asks for an address again, and shows no space, once it is pointed somewhere else', async () => {
         renderApp(chose('https://mail.example.invalid'));
-        await screen.findAllByRole('listitem');
+        await framed();
 
         fireEvent.click(screen.getByRole('button', { name: 'Point somewhere else' }));
 
         expect(screen.getByRole('textbox', { name: 'Deployment address' })).toBeDefined();
-        expect(screen.queryByRole('list')).toBeNull();
+        expect(screen.queryByRole('navigation', { name: 'Spaces' })).toBeNull();
     });
 
     it('leaves focus where the document opened it when the deployment was already known', async () => {
         renderApp();
-        await screen.findAllByRole('listitem');
+        await framed();
 
         // A cold start is not a view change. `main.tsx` mounts under `StrictMode`, so every effect runs twice here as
         // it does under `pnpm dev`, and a guard that only survives one invocation would have pulled focus by now.
         expect(document.activeElement).toBe(document.body);
     });
 
-    it('puts focus at the start of the mail once the deployment has been named, rather than leaving it behind', async () => {
+    it('puts focus at the start of the workspace once the deployment has been named, rather than leaving it behind', async () => {
         renderApp(null, reachable);
 
         fireEvent.change(screen.getByRole('textbox', { name: 'Deployment address' }), {
             target: { value: 'mail.example.test' },
         });
         fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
-        await screen.findAllByRole('listitem');
+        await framed();
 
-        expect(document.activeElement?.contains(screen.getByRole('list'))).toBe(true);
+        expect(document.activeElement?.contains(screen.getByRole('main'))).toBe(true);
     });
 
     it('puts focus back in the address when it is pointed somewhere else', async () => {
         renderApp(chose('https://mail.example.invalid'));
-        await screen.findAllByRole('listitem');
+        await framed();
 
         fireEvent.click(screen.getByRole('button', { name: 'Point somewhere else' }));
 
@@ -260,14 +316,14 @@ describe('App deployment', () => {
         recordingWhatIsAsked(asked);
 
         renderApp(chose('https://first.example.invalid'), reachable);
-        await screen.findAllByRole('listitem');
+        await framed();
 
         fireEvent.click(screen.getByRole('button', { name: 'Point somewhere else' }));
         fireEvent.change(screen.getByRole('textbox', { name: 'Deployment address' }), {
             target: { value: 'second.example.invalid' },
         });
         fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
-        await screen.findAllByRole('listitem');
+        await framed();
 
         expect(deploymentsAsked(asked)).toEqual([
             'https://first.example.invalid/api/client/accounts',
@@ -277,15 +333,6 @@ describe('App deployment', () => {
 });
 
 describe('App language', () => {
-    beforeEach(() => {
-        answering(directory(true, [workAccount]));
-    });
-
-    afterEach(() => {
-        window.localStorage.clear();
-        document.documentElement.removeAttribute('lang');
-    });
-
     it('offers each language under its own name, and no other', () => {
         renderApp();
 
@@ -297,11 +344,11 @@ describe('App language', () => {
 
     it('rewrites the screen when another language is chosen, without anything being restarted', async () => {
         renderApp();
-        await screen.findByText('This deployment refreshes the local copy of these accounts.');
+        await screen.findByRole('heading', { name: 'Discover', level: 1 });
 
         fireEvent.change(screen.getByRole('combobox', { name: 'Language' }), { target: { value: 'pl' } });
 
-        expect(screen.getByText('To wdrożenie odświeża lokalną kopię tych kont.')).toBeDefined();
+        expect(screen.getByRole('heading', { name: 'Odkrywaj', level: 1 })).toBeDefined();
         expect(document.documentElement.lang).toBe('pl');
     });
 
@@ -312,27 +359,4 @@ describe('App language', () => {
 
         expect(readStoredLocale()).toBe('pl');
     });
-
-    it('writes a time under the chosen language rather than under the one the catalogue was written in', async () => {
-        renderApp();
-        await screen.findAllByRole('listitem');
-
-        fireEvent.change(screen.getByRole('combobox', { name: 'Language' }), { target: { value: 'pl' } });
-
-        const account = screen.getByRole('listitem');
-        expect(account.textContent).toBe(
-            `Workzsynchronizowanoostatnia synchronizacja ${whenLocaleWrites('pl', workAccount.lastSynchronizedAt)}`,
-        );
-    });
 });
-
-// What `Intl` makes of the instant, rather than a string this file spells out. The machine's own time zone decides what
-// a person actually reads, so an expectation written by hand would be an expectation about the machine; asking `Intl`
-// the same question the screen asks it is what makes the assertion about the locale reaching the formatter.
-function whenLocaleWrites(locale: string, instant: string): string {
-    return new Intl.DateTimeFormat(locale, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(instant));
-}
-
-function whenEnglishWrites(instant: string): string {
-    return whenLocaleWrites('en', instant);
-}

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -113,9 +113,7 @@ export function App({
     }
 
     return (
-        <div className="flex h-dvh flex-col-reverse bg-rail pt-safe-top pr-safe-right pb-safe-bottom pl-safe-left workspace:flex-row">
-            <SpaceNavigation current={space} />
-
+        <div className="flex h-dvh flex-col bg-rail pt-safe-top pr-safe-right pb-safe-bottom pl-safe-left workspace:flex-row">
             <div ref={workspace} tabIndex={-1} className="flex min-h-0 min-w-0 flex-1 flex-col bg-page">
                 <header className="flex flex-wrap items-center gap-3 border-b border-line-soft bg-panel px-4 py-2 workspace:px-8">
                     <ConnectionSummary accounts={accounts} reread={reread} />
@@ -135,6 +133,14 @@ export function App({
 
                 <Space space={space} />
             </div>
+
+            {/* Navigation is last in the document because the keyboard follows the document rather than the layout,
+                and the narrow composition puts it at the bottom of the screen: written the other way round, a reader
+                tabbing into a narrow window would reach the bottom bar before the header above it. The wide
+                composition then carries the one mismatch CSS cannot remove — a rail drawn on the left out of a node
+                that comes last — because no single document order matches both shapes, and content before navigation
+                is the direction a skip link exists to manufacture rather than the one it works around. */}
+            <SpaceNavigation current={space} />
         </div>
     );
 }

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -5,41 +5,31 @@
 import { useEffect, useRef, useState } from 'react';
 import {
     readMailAccounts,
-    type ClientFailureReason,
     type ClientResult,
     type DeploymentAddress,
-    type MailAccount,
     type MailAccountDirectory,
-    type MailSynchronizationState,
 } from '@mailfathom/client-backend';
 import { forgetDeployment, storeDeployment, type AdoptedDeployment } from './deployment/adoptedDeployment';
 import { ConnectDeployment } from './deployment/ConnectDeployment';
 import type { DeploymentTransport } from './deployment/sendToDeployment';
-import type { MessageKey } from './localization/en';
-import { isOfferedLocale, localeNames, locales, type Locale } from './localization/locale';
 import { useLocalization } from './localization/useLocalization';
+import { useSpace } from './routing/useSpace';
+import { ConnectionSummary } from './shell/ConnectionSummary';
+import { IntentField } from './shell/IntentField';
+import { LanguageChoice, ThemeChoice } from './shell/Preferences';
+import { Space } from './shell/Space';
+import { SpaceNavigation } from './shell/SpaceNavigation';
 import { stubAuthorization, stubTransport } from './stubMailFathom';
 
-// The one screen this workspace exists to prove, in front of which stands the question every run has to answer first:
-// which deployment this client belongs to. That answer arrives as a value rather than as a code path — `main.tsx`
-// resolves it once at the edge, and nothing below asks which head it is running on.
-
-// The two closed sets `Client.Backend` answers with, mapped to what a person reads. Each is a lookup declared once and
-// exhaustive by its own type, so a value added to either set fails to compile here until this screen says what it is
-// called — which is the whole reason the mapping is a table rather than a key assembled from the value at the call site.
-const synchronizationLabels: Readonly<Record<MailSynchronizationState, MessageKey>> = {
-    NeverSynchronized: 'synchronization.neverSynchronized',
-    Synchronized: 'synchronization.synchronized',
-    Failing: 'synchronization.failing',
-    Unreachable: 'synchronization.unreachable',
-};
-
-const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
-    unauthenticated: 'failure.unauthenticated',
-    unauthorized: 'failure.unauthorized',
-    unavailable: 'failure.unavailable',
-    unreadable: 'failure.unreadable',
-};
+// The frame Discover, Mail, and Cases are held in, and the only thing in the client that survives moving between them.
+// It is one tree laid out two ways by the width it is given — a rail beside a workspace, or bottom navigation under a
+// stack of screens — and nothing in it asks which head or which platform it is running on.
+//
+// In front of it stands the question every run answers first: which deployment this client belongs to. That is a
+// screen rather than a state of the frame, because three spaces with nothing behind them are a frame around nothing.
+//
+// What the accounts are read for here is the line above the space and the mailboxes the scope offers. Each account's
+// own freshness, the session behind it, and the grants that decide what a space may show are the next stage's.
 
 export function App({
     deployment,
@@ -48,11 +38,12 @@ export function App({
     readonly deployment: AdoptedDeployment | null;
     readonly send: DeploymentTransport;
 }) {
-    const { translate } = useLocalization();
+    const space = useSpace();
     const [adopted, setAdopted] = useState(deployment);
-    const [result, setResult] = useState<ClientResult<MailAccountDirectory> | null>(null);
+    const [accounts, setAccounts] = useState<ClientResult<MailAccountDirectory> | null>(null);
+    const [attempt, setAttempt] = useState(0);
     const baseAddress = adopted === null ? null : adopted.deployment.baseAddress;
-    const mail = useRef<HTMLDivElement>(null);
+    const workspace = useRef<HTMLDivElement>(null);
     const focusedFor = useRef(adopted);
 
     // The view changed, so focus goes to the start of what replaced it rather than staying on a control that is no
@@ -63,8 +54,8 @@ export function App({
     // What separates the two is the deployment this effect last acted on rather than a flag saying the first render
     // has happened. React invokes an effect twice on mount under `StrictMode`, which `main.tsx` mounts the application
     // in, and a flag the first invocation cleared is already cleared when the second one reads it — so the guard would
-    // pull focus onto the mail on exactly the ordinary open it exists to leave alone. Both invocations see the same
-    // adopted deployment, so a comparison against it survives being run twice.
+    // pull focus onto the workspace on exactly the ordinary open it exists to leave alone. Both invocations see the
+    // same adopted deployment, so a comparison against it survives being run twice.
     useEffect(() => {
         if (adopted === focusedFor.current) {
             return;
@@ -73,7 +64,7 @@ export function App({
         focusedFor.current = adopted;
 
         if (adopted !== null) {
-            mail.current?.focus();
+            workspace.current?.focus();
         }
     }, [adopted]);
 
@@ -89,49 +80,91 @@ export function App({
 
         void readMailAccounts({ baseAddress, authorization: stubAuthorization }, stubTransport).then((answer) => {
             if (listening) {
-                setResult(answer);
+                setAccounts(answer);
             }
         });
 
         return () => {
             listening = false;
         };
-    }, [baseAddress]);
+    }, [baseAddress, attempt]);
+
+    // Reading again is a new attempt rather than a second copy of the read above: the effect owns the cancellation, so
+    // the retry only says that the answer it holds is stale.
+    function reread(): void {
+        setAccounts(null);
+        setAttempt((previous) => previous + 1);
+    }
 
     function reached(reachedDeployment: DeploymentAddress): void {
         storeDeployment(reachedDeployment);
-        setResult(null);
+        setAccounts(null);
         setAdopted({ deployment: reachedDeployment, chosen: true });
     }
 
     function pointSomewhereElse(): void {
         forgetDeployment();
-        setResult(null);
+        setAccounts(null);
         setAdopted(null);
     }
 
+    if (adopted === null) {
+        return <ConnectScreen send={send} onReached={reached} />;
+    }
+
     return (
-        <main className="min-h-screen bg-fathom-950 px-6 py-10 font-sans text-fathom-200">
-            <div className="mx-auto flex max-w-2xl flex-col gap-6">
-                <header className="flex items-baseline justify-between border-b border-fathom-800 pb-4">
-                    <h1 className="text-2xl font-semibold text-white">{translate('shell.title')}</h1>
-                    <div className="flex items-baseline gap-4">
+        <div className="flex h-dvh flex-col-reverse bg-rail pt-safe-top pr-safe-right pb-safe-bottom pl-safe-left workspace:flex-row">
+            <SpaceNavigation current={space} />
+
+            <div ref={workspace} tabIndex={-1} className="flex min-h-0 min-w-0 flex-1 flex-col bg-page">
+                <header className="flex flex-wrap items-center gap-3 border-b border-line-soft bg-panel px-4 py-2 workspace:px-8">
+                    <ConnectionSummary accounts={accounts} reread={reread} />
+
+                    {adopted.chosen ? (
+                        <ChosenDeployment address={adopted.deployment.baseAddress} onChange={pointSomewhereElse} />
+                    ) : null}
+
+                    <div className="ms-auto flex items-center gap-2">
+                        <p className="font-mono text-xs text-faint">{__MAILFATHOM_VERSION__}</p>
+                        <ThemeChoice />
                         <LanguageChoice />
-                        <p className="font-mono text-sm text-fathom-500">{__MAILFATHOM_VERSION__}</p>
                     </div>
                 </header>
 
-                {adopted === null ? (
-                    <ConnectDeployment send={send} onReached={reached} />
-                ) : (
-                    <div className="flex flex-col gap-6" ref={mail} tabIndex={-1}>
-                        {adopted.chosen ? (
-                            <ChosenDeployment address={adopted.deployment.baseAddress} onChange={pointSomewhereElse} />
-                        ) : null}
+                <IntentField accounts={accounts?.outcome === 'read' ? accounts.value.accounts : []} />
 
-                        {result === null ? <p>{translate('accounts.reading')}</p> : <Accounts result={result} />}
+                <Space space={space} />
+            </div>
+        </div>
+    );
+}
+
+// The screen in front of the frame, which carries the theme and the language controls itself: they belong to somebody
+// who has not reached a deployment yet exactly as much as to somebody who has, and the frame that usually holds them
+// is not on the screen at this point.
+function ConnectScreen({
+    send,
+    onReached,
+}: {
+    readonly send: DeploymentTransport;
+    readonly onReached: (reached: DeploymentAddress) => void;
+}) {
+    const { translate } = useLocalization();
+
+    return (
+        <main className="min-h-dvh bg-page px-4 py-8 pt-safe-top pr-safe-right pb-safe-bottom pl-safe-left">
+            <div className="mx-auto flex w-full max-w-2xl flex-col gap-6">
+                <header className="flex flex-wrap items-center justify-between gap-3 border-b border-line-soft pb-4">
+                    <h1 className="text-2xl font-semibold tracking-tight">{translate('shell.title')}</h1>
+
+                    <div className="flex items-center gap-2">
+                        <p className="font-mono text-xs text-faint">{__MAILFATHOM_VERSION__}</p>
+                        <ThemeChoice />
+                        <LanguageChoice />
                     </div>
-                )}
+                </header>
+
+                <ConnectDeployment send={send} onReached={onReached} />
             </div>
         </main>
     );
@@ -143,88 +176,15 @@ function ChosenDeployment({ address, onChange }: { readonly address: string; rea
     const { translate } = useLocalization();
 
     return (
-        <section className="flex flex-wrap items-baseline justify-between gap-2 text-sm">
-            <p>{translate('deployment.reachedAt', { address })}</p>
-            <button className="rounded-md bg-fathom-800/40 px-3 py-1 text-fathom-200" type="button" onClick={onChange}>
+        <p className="flex items-center gap-2 text-sm text-muted">
+            {translate('deployment.reachedAt', { address })}
+            <button
+                type="button"
+                onClick={onChange}
+                className="rounded-md border border-line px-2 py-0.5 text-sm text-text-soft transition hover:bg-hover"
+            >
                 {translate('deployment.change')}
             </button>
-        </section>
+        </p>
     );
-}
-
-function LanguageChoice() {
-    const { locale, setLocale, translate } = useLocalization();
-
-    return (
-        <select
-            aria-label={translate('shell.language')}
-            className="rounded-md bg-fathom-800/40 px-2 py-1 text-sm text-fathom-200"
-            value={locale}
-            onChange={(event) => {
-                if (isOfferedLocale(event.target.value)) {
-                    setLocale(event.target.value);
-                }
-            }}
-        >
-            {locales.map((offered) => (
-                <option key={offered} value={offered}>
-                    {localeNames[offered]}
-                </option>
-            ))}
-        </select>
-    );
-}
-
-function Accounts({ result }: { readonly result: ClientResult<MailAccountDirectory> }) {
-    const { translate } = useLocalization();
-
-    if (result.outcome === 'failed') {
-        return (
-            <p className="text-fathom-star">
-                {translate('accounts.failed', { reason: translate(failureLabels[result.failure.reason]) })}
-            </p>
-        );
-    }
-
-    return (
-        <section className="flex flex-col gap-3">
-            <p className="text-sm">
-                {translate(result.value.synchronizationEnabled ? 'accounts.refreshing' : 'accounts.notRefreshing')}
-            </p>
-
-            <ul className="flex flex-col gap-2">
-                {result.value.accounts.map((account) => (
-                    <AccountRow key={account.id} account={account} />
-                ))}
-            </ul>
-        </section>
-    );
-}
-
-function AccountRow({ account }: { readonly account: MailAccount }) {
-    const { locale, translate } = useLocalization();
-    const state = translate(synchronizationLabels[account.synchronizationState]);
-
-    return (
-        <li className="flex items-center justify-between rounded-md bg-fathom-800/40 px-4 py-3">
-            <span className="font-medium text-white">{account.displayName}</span>
-            <span className="text-sm">
-                {account.behind ? translate('account.stateBehind', { state }) : state}
-                {account.lastSynchronizedAt === null ? null : (
-                    <span className="ml-2 text-fathom-500">
-                        {translate('account.lastSynchronized', {
-                            when: formatInstant(locale, account.lastSynchronizedAt),
-                        })}
-                    </span>
-                )}
-            </span>
-        </li>
-    );
-}
-
-// The one place this screen turns a value into words the platform already knows how to write. `Intl` reads the active
-// locale, so a Polish reader gets a Polish month and a Polish ordering without a second copy of any of that living in
-// the catalogues — which is the rule for numbers and relative times too, whichever screen first shows one.
-function formatInstant(locale: Locale, instant: string): string {
-    return new Intl.DateTimeFormat(locale, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(instant));
 }

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -13,6 +13,24 @@
 export const en = {
     'shell.title': 'MailFathom',
     'shell.language': 'Language',
+    'shell.theme': 'Theme',
+    'shell.spaces': 'Spaces',
+
+    'theme.system': 'Follow the system',
+    'theme.light': 'Light',
+    'theme.dark': 'Dark',
+
+    'space.discover': 'Discover',
+    'space.mail': 'Mail',
+    'space.cases': 'Cases',
+    'space.pending':
+        'This space is not built yet. What is here is the frame around it: its address, its navigation, and the scope every question is asked against.',
+
+    'intent.label': 'Ask your mail',
+    'intent.placeholder': 'What do you want to ask your mail?',
+
+    'scope.mailbox': 'Mailbox in scope',
+    'scope.allMailboxes': 'All mailboxes',
 
     'connect.title': 'Point this client at your MailFathom',
     'connect.explanation':
@@ -38,22 +56,18 @@ export const en = {
     'deployment.change': 'Point somewhere else',
 
     'accounts.reading': 'Reading accounts…',
-    'accounts.refreshing': 'This deployment refreshes the local copy of these accounts.',
     'accounts.notRefreshing': 'This deployment is not refreshing the local copy of these accounts.',
     'accounts.failed': 'The accounts could not be read: {reason}.',
+
+    'connection.current': 'Every account is up to date.',
+    'connection.behind': 'Some accounts are behind.',
+    'connection.noAccounts': 'No mail account is configured for this owner yet.',
+    'connection.retry': 'Try again',
 
     'failure.unauthenticated': 'unauthenticated',
     'failure.unauthorized': 'unauthorized',
     'failure.unavailable': 'unavailable',
     'failure.unreadable': 'unreadable',
-
-    'synchronization.neverSynchronized': 'never synchronized',
-    'synchronization.synchronized': 'synchronized',
-    'synchronization.failing': 'failing',
-    'synchronization.unreachable': 'unreachable',
-
-    'account.stateBehind': '{state}, behind',
-    'account.lastSynchronized': 'last synchronized {when}',
 } as const;
 
 /** Every message a screen may ask for. A key absent here does not compile at the call site. */

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -61,6 +61,7 @@ export const en = {
 
     'connection.current': 'Every account is up to date.',
     'connection.behind': 'Some accounts are behind.',
+    'connection.failing': 'Some accounts stopped synchronizing.',
     'connection.noAccounts': 'No mail account is configured for this owner yet.',
     'connection.retry': 'Try again',
 

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -60,6 +60,7 @@ export const pl: Catalogue = {
 
     'connection.current': 'Wszystkie konta są aktualne.',
     'connection.behind': 'Część kont ma zaległości.',
+    'connection.failing': 'Część kont przestała się synchronizować.',
     'connection.noAccounts': 'Dla tego właściciela nie skonfigurowano jeszcze żadnego konta pocztowego.',
     'connection.retry': 'Spróbuj ponownie',
 

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -12,6 +12,24 @@ import type { Catalogue } from './en';
 export const pl: Catalogue = {
     'shell.title': 'MailFathom',
     'shell.language': 'Język',
+    'shell.theme': 'Motyw',
+    'shell.spaces': 'Przestrzenie',
+
+    'theme.system': 'Zgodnie z systemem',
+    'theme.light': 'Jasny',
+    'theme.dark': 'Ciemny',
+
+    'space.discover': 'Odkrywaj',
+    'space.mail': 'Poczta',
+    'space.cases': 'Sprawy',
+    'space.pending':
+        'Ta przestrzeń nie jest jeszcze zbudowana. Jest tu rama wokół niej: jej adres, nawigacja i zakres, w którym zadawane jest każde pytanie.',
+
+    'intent.label': 'Zapytaj swoją pocztę',
+    'intent.placeholder': 'O co chcesz zapytać swoją pocztę?',
+
+    'scope.mailbox': 'Skrzynka w zakresie',
+    'scope.allMailboxes': 'Wszystkie skrzynki',
 
     'connect.title': 'Wskaż temu klientowi swój MailFathom',
     'connect.explanation':
@@ -37,20 +55,16 @@ export const pl: Catalogue = {
     'deployment.change': 'Wskaż inne wdrożenie',
 
     'accounts.reading': 'Odczytywanie kont…',
-    'accounts.refreshing': 'To wdrożenie odświeża lokalną kopię tych kont.',
     'accounts.notRefreshing': 'To wdrożenie nie odświeża lokalnej kopii tych kont.',
     'accounts.failed': 'Nie udało się odczytać kont: {reason}.',
+
+    'connection.current': 'Wszystkie konta są aktualne.',
+    'connection.behind': 'Część kont ma zaległości.',
+    'connection.noAccounts': 'Dla tego właściciela nie skonfigurowano jeszcze żadnego konta pocztowego.',
+    'connection.retry': 'Spróbuj ponownie',
 
     'failure.unauthenticated': 'brak uwierzytelnienia',
     'failure.unauthorized': 'brak uprawnień',
     'failure.unavailable': 'usługa niedostępna',
     'failure.unreadable': 'odpowiedź nie do odczytania',
-
-    'synchronization.neverSynchronized': 'nigdy nie zsynchronizowano',
-    'synchronization.synchronized': 'zsynchronizowano',
-    'synchronization.failing': 'niepowodzenie',
-    'synchronization.unreachable': 'nieosiągalne',
-
-    'account.stateBehind': '{state}, zaległości',
-    'account.lastSynchronized': 'ostatnia synchronizacja {when}',
 };

--- a/frontend/src/Client.App/src/main.tsx
+++ b/frontend/src/Client.App/src/main.tsx
@@ -8,6 +8,8 @@ import { App } from './App';
 import { adoptedDeployment } from './deployment/adoptedDeployment';
 import { sendToDeployment } from './deployment/sendToDeployment';
 import { LocalizationProvider } from './localization/Localization';
+import { ThemeProvider } from './theme/Theme';
+import { WorkspaceProvider } from './workspace/Workspace';
 import './styles.css';
 
 const container = document.getElementById('root');
@@ -19,10 +21,19 @@ if (container === null) {
 // The edge of the application, and the one place the deployment this run belongs to is resolved. It arrives below as a
 // value, which is what keeps the difference between a client served by its deployment and a client somebody pointed at
 // one out of every screen underneath.
+//
+// The three things that outlive every screen stand above it: the language it reads in, the theme it is painted in, and
+// what the person is carrying between the spaces. Each is above the frame because nothing below the frame may be what
+// decides it, and each is above the connect screen for the same reason — somebody who has not reached a deployment yet
+// reads in a language and is painted in a theme exactly as somebody who has.
 createRoot(container).render(
     <StrictMode>
         <LocalizationProvider>
-            <App deployment={adoptedDeployment()} send={sendToDeployment} />
+            <ThemeProvider>
+                <WorkspaceProvider>
+                    <App deployment={adoptedDeployment()} send={sendToDeployment} />
+                </WorkspaceProvider>
+            </ThemeProvider>
         </LocalizationProvider>
     </StrictMode>,
 );

--- a/frontend/src/Client.App/src/routing/spaces.test.ts
+++ b/frontend/src/Client.App/src/routing/spaces.test.ts
@@ -1,0 +1,34 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import { addressOf, isSpace, spaceAt, spaces } from './spaces';
+
+describe('addressOf', () => {
+    it.each(spaces)('writes %s as a fragment, so the address reloads without a server rule', (space) => {
+        expect(addressOf(space)).toBe(`#/${space}`);
+    });
+});
+
+describe('spaceAt', () => {
+    it.each(spaces)('reads back the address %s was written to', (space) => {
+        expect(spaceAt(addressOf(space))).toBe(space);
+    });
+
+    it('reads an address that has lost its separators, which is what a hand-typed one arrives as', () => {
+        expect(spaceAt('mail')).toBe('mail');
+    });
+
+    it.each(['', '#', '#/', '#/nowhere', '#/mail/thread'])('names no space in %s', (address) => {
+        expect(spaceAt(address)).toBeNull();
+    });
+});
+
+describe('isSpace', () => {
+    it('refuses a value that is not one of the three, whatever its type', () => {
+        expect(isSpace('agent')).toBe(false);
+        expect(isSpace(null)).toBe(false);
+        expect(isSpace(0)).toBe(false);
+    });
+});

--- a/frontend/src/Client.App/src/routing/spaces.ts
+++ b/frontend/src/Client.App/src/routing/spaces.ts
@@ -1,0 +1,46 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { MessageKey } from '../localization/en';
+
+// The client's three spaces, and the addresses they are reached at. There is no routing package behind this and the
+// workspace pins none: three addresses with no segment, no parameter, and no nested tree is what the fragment and
+// `hashchange` already are, and the platform keeps the history for us — a router here would be a dependency, a licence
+// review, and a census entry bought for `spaceAt` and `addressOf` below.
+//
+// The address is a fragment rather than a path for a reason that outlives the size of this file: a path would have to
+// be reloadable, and `backend/src/Host/Hosting/ClientApplicationFiles.cs` serves the bundle with no fallback mapping an
+// unmatched path onto the entry document — deliberately, because the client surface may share a socket with the MCP
+// one. A fragment is never sent to a server at all, so every address below reloads on both heads with nothing
+// configured, and the desktop shell's WebView needs no rule of its own either.
+
+export const spaces = ['discover', 'mail', 'cases'] as const;
+
+export type Space = (typeof spaces)[number];
+
+/** Where the client opens, and where an address naming no space resolves to. */
+export const defaultSpace: Space = 'discover';
+
+/** What each space is called on the screen. Exhaustive by its own type, so a fourth space fails to compile until it has a name. */
+export const spaceLabels: Readonly<Record<Space, MessageKey>> = {
+    discover: 'space.discover',
+    mail: 'space.mail',
+    cases: 'space.cases',
+};
+
+export function isSpace(value: unknown): value is Space {
+    return typeof value === 'string' && (spaces as readonly string[]).includes(value);
+}
+
+/** The address a space is reached at, in the form an `href` takes. */
+export function addressOf(space: Space): string {
+    return `#/${space}`;
+}
+
+/** The space an address names, or `null` where it names none — a first load at the root among them. */
+export function spaceAt(address: string): Space | null {
+    const named = address.replace(/^#?\/?/, '');
+
+    return isSpace(named) ? named : null;
+}

--- a/frontend/src/Client.App/src/routing/useSpace.ts
+++ b/frontend/src/Client.App/src/routing/useSpace.ts
@@ -1,0 +1,49 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { useEffect, useSyncExternalStore } from 'react';
+import { addressOf, defaultSpace, spaceAt, type Space } from './spaces';
+
+// The address bar is state that lives outside React and that the person changes with the back gesture as often as the
+// client changes it, so it is read through `useSyncExternalStore` rather than copied into a component. Nothing here
+// stores the current space: it is what the address says, and the address is the one copy of it.
+
+function subscribeToAddress(changed: () => void): () => void {
+    window.addEventListener('hashchange', changed);
+
+    return () => {
+        window.removeEventListener('hashchange', changed);
+    };
+}
+
+function currentAddress(): string {
+    return window.location.hash;
+}
+
+/**
+ * The space the address names, re-read whenever it changes — including when the browser moves back to an earlier one.
+ * An address naming no space is written back to the one actually being shown, so the two never disagree.
+ */
+export function useSpace(): Space {
+    const address = useSyncExternalStore(subscribeToAddress, currentAddress);
+    const space = spaceAt(address) ?? defaultSpace;
+
+    // Replaced rather than pushed: a first load at the root, or a fragment nobody answers, would otherwise leave the
+    // back gesture landing on an address that immediately corrects itself again.
+    useEffect(() => {
+        if (spaceAt(address) === null) {
+            window.history.replaceState(null, '', addressOf(space));
+        }
+    }, [address, space]);
+
+    return space;
+}
+
+/**
+ * Moves to a space from something that is not a link, adding a history entry the back gesture returns through.
+ * Navigation a person can see is an anchor instead, which is what the navigation itself renders.
+ */
+export function goToSpace(space: Space): void {
+    window.location.hash = addressOf(space);
+}

--- a/frontend/src/Client.App/src/shell/ConnectionSummary.test.tsx
+++ b/frontend/src/Client.App/src/shell/ConnectionSummary.test.tsx
@@ -99,6 +99,16 @@ describe('ConnectionSummary', () => {
         expect(screen.getByRole('button', { name: 'Try again' })).toBeDefined();
     });
 
+    it.each(['unauthenticated', 'unauthorized', 'unreadable'] as const)(
+        'still says what failed at a %s failure, and offers no second attempt that would repeat it',
+        (reason) => {
+            renderSummary({ outcome: 'failed', failure: { reason, status: 401 } });
+
+            expect(screen.getByText(/The accounts could not be read:/)).toBeDefined();
+            expect(screen.queryByRole('button', { name: 'Try again' })).toBeNull();
+        },
+    );
+
     it('puts no status code on the screen', () => {
         renderSummary({ outcome: 'failed', failure: { reason: 'unavailable', status: 503 } });
 

--- a/frontend/src/Client.App/src/shell/ConnectionSummary.test.tsx
+++ b/frontend/src/Client.App/src/shell/ConnectionSummary.test.tsx
@@ -18,6 +18,15 @@ const workAccount: MailAccount = {
 
 const archiveAccount: MailAccount = { ...workAccount, id: 'archive', displayName: 'Archive', behind: true };
 
+const failingAccount: MailAccount = {
+    ...workAccount,
+    id: 'failing',
+    displayName: 'Newsletters',
+    synchronizationState: 'Failing',
+};
+
+const unreachableAccount: MailAccount = { ...failingAccount, synchronizationState: 'Unreachable' };
+
 function directory(
     synchronizationEnabled: boolean,
     accounts: readonly MailAccount[],
@@ -50,6 +59,25 @@ describe('ConnectionSummary', () => {
         renderSummary(directory(true, [workAccount, archiveAccount]));
 
         expect(screen.getByText('Some accounts are behind.')).toBeDefined();
+    });
+
+    it('says an account stopped synchronizing rather than reporting it as merely behind', () => {
+        renderSummary(directory(true, [workAccount, failingAccount]));
+
+        expect(screen.getByText('Some accounts stopped synchronizing.')).toBeDefined();
+        expect(screen.queryByText('Some accounts are behind.')).toBeNull();
+    });
+
+    it('reads an account it cannot reach the same way as one that is failing', () => {
+        renderSummary(directory(true, [workAccount, unreachableAccount]));
+
+        expect(screen.getByText('Some accounts stopped synchronizing.')).toBeDefined();
+    });
+
+    it('says an account stopped synchronizing even where another is only behind', () => {
+        renderSummary(directory(true, [archiveAccount, failingAccount]));
+
+        expect(screen.getByText('Some accounts stopped synchronizing.')).toBeDefined();
     });
 
     it('says the deployment is not refreshing these accounts when it is not', () => {

--- a/frontend/src/Client.App/src/shell/ConnectionSummary.test.tsx
+++ b/frontend/src/Client.App/src/shell/ConnectionSummary.test.tsx
@@ -1,0 +1,79 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { ClientResult, MailAccount, MailAccountDirectory } from '@mailfathom/client-backend';
+import { LocalizationProvider } from '../localization/Localization';
+import { ConnectionSummary } from './ConnectionSummary';
+
+const workAccount: MailAccount = {
+    id: 'work',
+    displayName: 'Work',
+    synchronizationState: 'Synchronized',
+    lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
+    behind: false,
+};
+
+const archiveAccount: MailAccount = { ...workAccount, id: 'archive', displayName: 'Archive', behind: true };
+
+function directory(
+    synchronizationEnabled: boolean,
+    accounts: readonly MailAccount[],
+): ClientResult<MailAccountDirectory> {
+    return { outcome: 'read', value: { synchronizationEnabled, accounts } };
+}
+
+function renderSummary(accounts: ClientResult<MailAccountDirectory> | null): void {
+    render(
+        <LocalizationProvider>
+            <ConnectionSummary accounts={accounts} reread={() => undefined} />
+        </LocalizationProvider>,
+    );
+}
+
+describe('ConnectionSummary', () => {
+    it('says it is reading while the answer has not arrived', () => {
+        renderSummary(null);
+
+        expect(screen.getByText('Reading accounts…')).toBeDefined();
+    });
+
+    it('says every account is current when none of them is behind', () => {
+        renderSummary(directory(true, [workAccount]));
+
+        expect(screen.getByText('Every account is up to date.')).toBeDefined();
+    });
+
+    it('says some accounts are behind when one of them is', () => {
+        renderSummary(directory(true, [workAccount, archiveAccount]));
+
+        expect(screen.getByText('Some accounts are behind.')).toBeDefined();
+    });
+
+    it('says the deployment is not refreshing these accounts when it is not', () => {
+        renderSummary(directory(false, [workAccount]));
+
+        expect(screen.getByText('This deployment is not refreshing the local copy of these accounts.')).toBeDefined();
+    });
+
+    it('tells an owner holding no account that, rather than showing a failure', () => {
+        renderSummary(directory(true, []));
+
+        expect(screen.getByText('No mail account is configured for this owner yet.')).toBeDefined();
+    });
+
+    it('names why the accounts could not be read, and offers the way out', () => {
+        renderSummary({ outcome: 'failed', failure: { reason: 'unavailable', status: 503 } });
+
+        expect(screen.getByText(/The accounts could not be read: unavailable\./)).toBeDefined();
+        expect(screen.getByRole('button', { name: 'Try again' })).toBeDefined();
+    });
+
+    it('puts no status code on the screen', () => {
+        renderSummary({ outcome: 'failed', failure: { reason: 'unavailable', status: 503 } });
+
+        expect(screen.queryByText(/503/)).toBeNull();
+    });
+});

--- a/frontend/src/Client.App/src/shell/ConnectionSummary.tsx
+++ b/frontend/src/Client.App/src/shell/ConnectionSummary.tsx
@@ -78,13 +78,21 @@ export function ConnectionSummary({
         return (
             <Line tone="attention">
                 {translate('accounts.failed', { reason: translate(failureLabels[accounts.failure.reason]) })}
-                <button
-                    type="button"
-                    onClick={reread}
-                    className="rounded-md border border-line px-2 py-0.5 text-sm text-text-soft transition hover:bg-hover"
-                >
-                    {translate('connection.retry')}
-                </button>
+
+                {/* Reading again is the way out of exactly one of the four failures. A refused credential, a missing
+                    grant, and an answer this client cannot parse each repeat identically on a second attempt, so
+                    offering the button there hands somebody an action that cannot work and says nothing about why.
+                    Their next steps — signing in again, saying the grant is missing, reporting a defect — are actions
+                    this frame has nowhere to send anybody to yet, and each arrives with the screen that can. */}
+                {accounts.failure.reason === 'unavailable' && (
+                    <button
+                        type="button"
+                        onClick={reread}
+                        className="rounded-md border border-line px-2 py-0.5 text-sm text-text-soft transition hover:bg-hover"
+                    >
+                        {translate('connection.retry')}
+                    </button>
+                )}
             </Line>
         );
     }

--- a/frontend/src/Client.App/src/shell/ConnectionSummary.tsx
+++ b/frontend/src/Client.App/src/shell/ConnectionSummary.tsx
@@ -3,7 +3,12 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import type { ReactNode } from 'react';
-import type { ClientFailureReason, ClientResult, MailAccountDirectory } from '@mailfathom/client-backend';
+import type {
+    ClientFailureReason,
+    ClientResult,
+    MailAccountDirectory,
+    MailSynchronizationState,
+} from '@mailfathom/client-backend';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
 
@@ -25,6 +30,10 @@ const toneColours: Readonly<Record<Tone, string>> = {
     quiet: 'bg-faint',
 };
 
+// The two states in which an account is not going to catch up on its own. They are read before the lag below, because
+// an account nothing is fixing says something a lagging one does not, and "behind" would let it wait unnoticed.
+const brokenStates: readonly MailSynchronizationState[] = ['Failing', 'Unreachable'];
+
 interface Freshness {
     readonly message: MessageKey;
     readonly tone: Tone;
@@ -37,6 +46,10 @@ function freshnessOf(directory: MailAccountDirectory): Freshness {
 
     if (!directory.synchronizationEnabled) {
         return { message: 'accounts.notRefreshing', tone: 'quiet' };
+    }
+
+    if (directory.accounts.some((account) => brokenStates.includes(account.synchronizationState))) {
+        return { message: 'connection.failing', tone: 'attention' };
     }
 
     const current = directory.accounts.every(

--- a/frontend/src/Client.App/src/shell/ConnectionSummary.tsx
+++ b/frontend/src/Client.App/src/shell/ConnectionSummary.tsx
@@ -1,0 +1,91 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { ReactNode } from 'react';
+import type { ClientFailureReason, ClientResult, MailAccountDirectory } from '@mailfathom/client-backend';
+import type { MessageKey } from '../localization/en';
+import { useLocalization } from '../localization/useLocalization';
+
+// The line above every space saying what the client is looking at and how current it is. It summarizes rather than
+// enumerates: what each account was last synchronized at, and what a grant allows, is read by the space that shows it.
+
+const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
+    unauthenticated: 'failure.unauthenticated',
+    unauthorized: 'failure.unauthorized',
+    unavailable: 'failure.unavailable',
+    unreadable: 'failure.unreadable',
+};
+
+type Tone = 'healthy' | 'attention' | 'quiet';
+
+const toneColours: Readonly<Record<Tone, string>> = {
+    healthy: 'bg-healthy',
+    attention: 'bg-warning',
+    quiet: 'bg-faint',
+};
+
+interface Freshness {
+    readonly message: MessageKey;
+    readonly tone: Tone;
+}
+
+function freshnessOf(directory: MailAccountDirectory): Freshness {
+    if (directory.accounts.length === 0) {
+        return { message: 'connection.noAccounts', tone: 'quiet' };
+    }
+
+    if (!directory.synchronizationEnabled) {
+        return { message: 'accounts.notRefreshing', tone: 'quiet' };
+    }
+
+    const current = directory.accounts.every(
+        (account) => !account.behind && account.synchronizationState === 'Synchronized',
+    );
+
+    return current
+        ? { message: 'connection.current', tone: 'healthy' }
+        : { message: 'connection.behind', tone: 'attention' };
+}
+
+export function ConnectionSummary({
+    accounts,
+    reread,
+}: {
+    readonly accounts: ClientResult<MailAccountDirectory> | null;
+    readonly reread: () => void;
+}) {
+    const { translate } = useLocalization();
+
+    if (accounts === null) {
+        return <Line tone="quiet">{translate('accounts.reading')}</Line>;
+    }
+
+    if (accounts.outcome === 'failed') {
+        return (
+            <Line tone="attention">
+                {translate('accounts.failed', { reason: translate(failureLabels[accounts.failure.reason]) })}
+                <button
+                    type="button"
+                    onClick={reread}
+                    className="rounded-md border border-line px-2 py-0.5 text-sm text-text-soft transition hover:bg-hover"
+                >
+                    {translate('connection.retry')}
+                </button>
+            </Line>
+        );
+    }
+
+    const freshness = freshnessOf(accounts.value);
+
+    return <Line tone={freshness.tone}>{translate(freshness.message)}</Line>;
+}
+
+function Line({ tone, children }: { readonly tone: Tone; readonly children: ReactNode }) {
+    return (
+        <p className="flex items-center gap-2 text-sm text-muted">
+            <span aria-hidden="true" className={`size-2 shrink-0 rounded-full ${toneColours[tone]}`} />
+            {children}
+        </p>
+    );
+}

--- a/frontend/src/Client.App/src/shell/IntentField.test.tsx
+++ b/frontend/src/Client.App/src/shell/IntentField.test.tsx
@@ -1,0 +1,67 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { MailAccount } from '@mailfathom/client-backend';
+import { LocalizationProvider } from '../localization/Localization';
+import { WorkspaceProvider } from '../workspace/Workspace';
+import { IntentField } from './IntentField';
+
+const workAccount: MailAccount = {
+    id: 'work',
+    displayName: 'Work',
+    synchronizationState: 'Synchronized',
+    lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
+    behind: false,
+};
+
+function renderField(accounts: readonly MailAccount[] = [workAccount]): void {
+    render(
+        <LocalizationProvider>
+            <WorkspaceProvider>
+                <IntentField accounts={accounts} />
+            </WorkspaceProvider>
+        </LocalizationProvider>,
+    );
+}
+
+afterEach(() => {
+    window.history.replaceState(null, '', '/');
+});
+
+describe('IntentField', () => {
+    it('asks nothing itself, and goes to the space that will answer', () => {
+        window.history.replaceState(null, '', '#/cases');
+
+        renderField();
+        fireEvent.change(screen.getByRole('searchbox', { name: 'Ask your mail' }), {
+            target: { value: 'what did Nordwind send' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+
+        expect(window.location.hash).toBe('#/discover');
+    });
+
+    it('keeps the question it was given rather than clearing it on the way', () => {
+        renderField();
+
+        fireEvent.change(screen.getByRole('searchbox', { name: 'Ask your mail' }), {
+            target: { value: 'what did Nordwind send' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+
+        expect(screen.getByRole('searchbox', { name: 'Ask your mail' })).toHaveProperty(
+            'value',
+            'what did Nordwind send',
+        );
+    });
+
+    it('says every mailbox is in scope until one is chosen', () => {
+        renderField();
+
+        expect(screen.getByRole('combobox', { name: 'Mailbox in scope' })).toHaveProperty('value', '');
+        expect(screen.getByRole('option', { name: 'All mailboxes' })).toBeDefined();
+    });
+});

--- a/frontend/src/Client.App/src/shell/IntentField.tsx
+++ b/frontend/src/Client.App/src/shell/IntentField.tsx
@@ -1,0 +1,57 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { MailAccount } from '@mailfathom/client-backend';
+import { useLocalization } from '../localization/useLocalization';
+import { goToSpace } from '../routing/useSpace';
+import { useWorkspace } from '../workspace/useWorkspace';
+
+// What the product puts at the centre of the application, above whichever space is open. It asks nothing here: running
+// a question is Discover's work, so submitting goes to the space that will answer and carries the question there in the
+// workspace rather than starting anything. The scope beside it always says what that question would be asked against.
+
+export function IntentField({ accounts }: { readonly accounts: readonly MailAccount[] }) {
+    const { translate } = useLocalization();
+    const { workspace, revise } = useWorkspace();
+
+    return (
+        <form
+            // The one landmark the platform has no element for, and the one this frame genuinely is: a region a reader
+            // moves to in order to ask something, rather than a form that submits a record.
+            role="search"
+            className="flex flex-wrap items-center gap-2 border-b border-line bg-panel px-4 py-3 workspace:px-8"
+            onSubmit={(event) => {
+                event.preventDefault();
+                goToSpace('discover');
+            }}
+        >
+            <input
+                type="search"
+                aria-label={translate('intent.label')}
+                placeholder={translate('intent.placeholder')}
+                value={workspace.question}
+                onChange={(event) => {
+                    revise({ question: event.target.value });
+                }}
+                className="min-w-60 flex-1 rounded-lg border-2 border-accent bg-panel px-3 py-2 text-base text-text placeholder:text-faint"
+            />
+
+            <select
+                aria-label={translate('scope.mailbox')}
+                value={workspace.accountId ?? ''}
+                onChange={(event) => {
+                    revise({ accountId: event.target.value === '' ? null : event.target.value });
+                }}
+                className="rounded-full border border-line bg-sunken px-3 py-1.5 text-sm text-text-soft"
+            >
+                <option value="">{translate('scope.allMailboxes')}</option>
+                {accounts.map((account) => (
+                    <option key={account.id} value={account.id}>
+                        {account.displayName}
+                    </option>
+                ))}
+            </select>
+        </form>
+    );
+}

--- a/frontend/src/Client.App/src/shell/Preferences.tsx
+++ b/frontend/src/Client.App/src/shell/Preferences.tsx
@@ -1,0 +1,69 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { MessageKey } from '../localization/en';
+import { isOfferedLocale, localeNames, locales } from '../localization/locale';
+import { useLocalization } from '../localization/useLocalization';
+import { isThemeChoice, themeChoices } from '../theme/theme';
+import { useTheme } from '../theme/useTheme';
+
+// The two settings that belong to the person rather than to the deployment. They sit in the header rather than on the
+// navigation the prototype puts the theme control on, because that navigation is the bottom bar of a narrow window —
+// where a third kind of control cannot go, and where a control that vanished with the width would be one the reader
+// can no longer reach. The header is the one place present at both widths.
+
+const themeNames: Readonly<Record<(typeof themeChoices)[number], MessageKey>> = {
+    system: 'theme.system',
+    light: 'theme.light',
+    dark: 'theme.dark',
+};
+
+const choiceStyle = 'rounded-md border border-line bg-panel px-2 py-1 text-sm text-text-soft transition hover:bg-hover';
+
+export function ThemeChoice() {
+    const { translate } = useLocalization();
+    const { choice, setThemeChoice } = useTheme();
+
+    return (
+        <select
+            aria-label={translate('shell.theme')}
+            className={choiceStyle}
+            value={choice}
+            onChange={(event) => {
+                if (isThemeChoice(event.target.value)) {
+                    setThemeChoice(event.target.value);
+                }
+            }}
+        >
+            {themeChoices.map((offered) => (
+                <option key={offered} value={offered}>
+                    {translate(themeNames[offered])}
+                </option>
+            ))}
+        </select>
+    );
+}
+
+export function LanguageChoice() {
+    const { locale, setLocale, translate } = useLocalization();
+
+    return (
+        <select
+            aria-label={translate('shell.language')}
+            className={choiceStyle}
+            value={locale}
+            onChange={(event) => {
+                if (isOfferedLocale(event.target.value)) {
+                    setLocale(event.target.value);
+                }
+            }}
+        >
+            {locales.map((offered) => (
+                <option key={offered} value={offered}>
+                    {localeNames[offered]}
+                </option>
+            ))}
+        </select>
+    );
+}

--- a/frontend/src/Client.App/src/shell/Space.test.tsx
+++ b/frontend/src/Client.App/src/shell/Space.test.tsx
@@ -1,0 +1,45 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { StrictMode, type ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { LocalizationProvider } from '../localization/Localization';
+import type { Space as SpaceName } from '../routing/spaces';
+import { Space } from './Space';
+
+// Every case here renders under `StrictMode`, which is what `main.tsx` mounts and what makes React invoke an effect
+// twice on the first mount. A focus rule written against "has this effect run before" passes without it and moves
+// focus on landing with it, so the wrapper is the point of the test rather than a detail of the harness.
+function inStrictMode(space: SpaceName): ReactNode {
+    return (
+        <StrictMode>
+            <LocalizationProvider>
+                <Space space={space} />
+            </LocalizationProvider>
+        </StrictMode>
+    );
+}
+
+describe('Space', () => {
+    it('leaves focus where it was on landing, rather than pulling it into the content nobody navigated to', () => {
+        render(inStrictMode('discover'));
+
+        expect(document.activeElement).toBe(document.body);
+    });
+
+    it('puts focus at the start of the new content when the address changes', () => {
+        const { rerender } = render(inStrictMode('discover'));
+
+        rerender(inStrictMode('mail'));
+
+        expect(document.activeElement).toBe(screen.getByRole('main'));
+    });
+
+    it('names the space it is showing', () => {
+        render(inStrictMode('cases'));
+
+        expect(screen.getByRole('heading', { name: 'Cases' })).toBeDefined();
+    });
+});

--- a/frontend/src/Client.App/src/shell/Space.tsx
+++ b/frontend/src/Client.App/src/shell/Space.tsx
@@ -1,0 +1,37 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { useEffect, useRef } from 'react';
+import { useLocalization } from '../localization/useLocalization';
+import { spaceLabels, type Space as SpaceName } from '../routing/spaces';
+
+// The region the address decides the contents of. What each of the three spaces actually holds is built by its own
+// issue; what this owns permanently is where a space is rendered and what happens to focus when the address changes.
+
+export function Space({ space }: { readonly space: SpaceName }) {
+    const { translate } = useLocalization();
+    const region = useRef<HTMLElement>(null);
+    const arrived = useRef(false);
+
+    // Navigation puts focus at the start of the new content, which is where keyboard and screen-reader use otherwise
+    // silently stops working: focus would stay on the link that was activated, in navigation the reader has left.
+    // Not on the first render — landing in the client is not a navigation, and moving focus there would scroll the
+    // page out from under somebody who has not asked to go anywhere.
+    useEffect(() => {
+        if (arrived.current) {
+            region.current?.focus();
+        }
+
+        arrived.current = true;
+    }, [space]);
+
+    return (
+        <main ref={region} tabIndex={-1} className="flex-1 overflow-y-auto px-4 py-6 workspace:px-8">
+            <div className="flex max-w-3xl flex-col gap-3">
+                <h1 className="text-2xl font-semibold tracking-tight">{translate(spaceLabels[space])}</h1>
+                <p className="text-sm text-muted">{translate('space.pending')}</p>
+            </div>
+        </main>
+    );
+}

--- a/frontend/src/Client.App/src/shell/Space.tsx
+++ b/frontend/src/Client.App/src/shell/Space.tsx
@@ -12,18 +12,19 @@ import { spaceLabels, type Space as SpaceName } from '../routing/spaces';
 export function Space({ space }: { readonly space: SpaceName }) {
     const { translate } = useLocalization();
     const region = useRef<HTMLElement>(null);
-    const arrived = useRef(false);
+    const shown = useRef(space);
 
     // Navigation puts focus at the start of the new content, which is where keyboard and screen-reader use otherwise
     // silently stops working: focus would stay on the link that was activated, in navigation the reader has left.
     // Not on the first render — landing in the client is not a navigation, and moving focus there would scroll the
-    // page out from under somebody who has not asked to go anywhere.
+    // page out from under somebody who has not asked to go anywhere. What the ref holds is therefore the space that
+    // was last shown rather than whether the effect has run before: the second is what StrictMode's extra invocation
+    // makes true on the first mount, which would move focus on landing in every development run.
     useEffect(() => {
-        if (arrived.current) {
+        if (shown.current !== space) {
             region.current?.focus();
+            shown.current = space;
         }
-
-        arrived.current = true;
     }, [space]);
 
     return (

--- a/frontend/src/Client.App/src/shell/SpaceNavigation.test.tsx
+++ b/frontend/src/Client.App/src/shell/SpaceNavigation.test.tsx
@@ -1,0 +1,41 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { LocalizationProvider } from '../localization/Localization';
+import { SpaceNavigation } from './SpaceNavigation';
+
+function renderNavigation(): void {
+    render(
+        <LocalizationProvider>
+            <SpaceNavigation current="mail" />
+        </LocalizationProvider>,
+    );
+}
+
+describe('SpaceNavigation', () => {
+    it('offers the three spaces as links, each at an address of its own', () => {
+        renderNavigation();
+
+        const spaces = screen.getAllByRole('link');
+        expect(spaces.map((space) => [space.textContent, space.getAttribute('href')])).toEqual([
+            ['Discover', '#/discover'],
+            ['Mail', '#/mail'],
+            ['Cases', '#/cases'],
+        ]);
+    });
+
+    it('marks the space being shown as the current one, and no other', () => {
+        renderNavigation();
+
+        expect(screen.getByRole('link', { current: 'page' }).textContent).toBe('Mail');
+    });
+
+    it('is named, so it is one landmark a reader can move to rather than three loose links', () => {
+        renderNavigation();
+
+        expect(screen.getByRole('navigation', { name: 'Spaces' })).toBeDefined();
+    });
+});

--- a/frontend/src/Client.App/src/shell/SpaceNavigation.tsx
+++ b/frontend/src/Client.App/src/shell/SpaceNavigation.tsx
@@ -1,0 +1,53 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { useLocalization } from '../localization/useLocalization';
+import { addressOf, spaceLabels, spaces, type Space } from '../routing/spaces';
+
+// One list of links, laid out two ways by the width it is given: a rail down the side of a wide window, and bottom
+// navigation across a narrow one. Nothing here asks which head it is running on, and nothing disappears at either
+// width — the same three destinations are present in both, which is what makes the two shapes one navigation.
+//
+// Links rather than buttons, because these navigate: the browser then supplies the keyboard path, the history entry,
+// and opening one in a window of its own, none of which a click handler would have.
+
+const spaceGlyphs: Readonly<Record<Space, string>> = {
+    discover: 'M11 3a8 8 0 1 0 4.9 14.3l3.9 3.9 1.4-1.4-3.9-3.9A8 8 0 0 0 11 3Zm0 2a6 6 0 1 1 0 12 6 6 0 0 1 0-12Z',
+    mail: 'M3 6.5A1.5 1.5 0 0 1 4.5 5h15A1.5 1.5 0 0 1 21 6.5v11a1.5 1.5 0 0 1-1.5 1.5h-15A1.5 1.5 0 0 1 3 17.5v-11ZM5.6 7 12 11.7 18.4 7H5.6ZM19 8.9l-6.4 4.7a1 1 0 0 1-1.2 0L5 8.9V17h14V8.9Z',
+    cases: 'M9 3h6a2 2 0 0 1 2 2v1h3a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h3V5a2 2 0 0 1 2-2Zm0 3h6V5H9v1ZM4 8v10h16V8H4Z',
+};
+
+export function SpaceNavigation({ current }: { readonly current: Space }) {
+    const { translate } = useLocalization();
+
+    return (
+        <nav
+            aria-label={translate('shell.spaces')}
+            className="flex shrink-0 justify-around gap-1 border-t border-line bg-rail p-1 workspace:w-24 workspace:flex-col workspace:justify-start workspace:gap-2 workspace:border-t-0 workspace:border-e workspace:p-3"
+        >
+            {spaces.map((space) => (
+                <SpaceLink key={space} space={space} current={space === current} />
+            ))}
+        </nav>
+    );
+}
+
+function SpaceLink({ space, current }: { readonly space: Space; readonly current: boolean }) {
+    const { translate } = useLocalization();
+
+    return (
+        <a
+            href={addressOf(space)}
+            aria-current={current ? 'page' : undefined}
+            className={`flex flex-1 flex-col items-center gap-1 rounded-lg px-2 py-2 text-xs font-medium transition workspace:flex-none ${
+                current ? 'bg-accent-soft text-accent-strong' : 'text-muted hover:bg-hover hover:text-text'
+            }`}
+        >
+            <svg viewBox="0 0 24 24" aria-hidden="true" className="size-5 fill-current">
+                <path d={spaceGlyphs[space]} />
+            </svg>
+            {translate(spaceLabels[space])}
+        </a>
+    );
+}

--- a/frontend/src/Client.App/src/shell/SpaceNavigation.tsx
+++ b/frontend/src/Client.App/src/shell/SpaceNavigation.tsx
@@ -24,7 +24,7 @@ export function SpaceNavigation({ current }: { readonly current: Space }) {
     return (
         <nav
             aria-label={translate('shell.spaces')}
-            className="flex shrink-0 justify-around gap-1 border-t border-line bg-rail p-1 workspace:w-24 workspace:flex-col workspace:justify-start workspace:gap-2 workspace:border-t-0 workspace:border-e workspace:p-3"
+            className="flex shrink-0 justify-around gap-1 border-t border-line bg-rail p-1 workspace:order-first workspace:w-24 workspace:flex-col workspace:justify-start workspace:gap-2 workspace:border-t-0 workspace:border-e workspace:p-3"
         >
             {spaces.map((space) => (
                 <SpaceLink key={space} space={space} current={space === current} />

--- a/frontend/src/Client.App/src/styles.css
+++ b/frontend/src/Client.App/src/styles.css
@@ -5,16 +5,27 @@
  */
 
 /*
- * The whole of the client's styling configuration. Tailwind is wired CSS-first through its Vite plugin, so the palette
- * and the type scale are `@theme` tokens here and there is no JavaScript configuration file to keep in step with them.
+ * The whole of the client's styling configuration. Tailwind is wired CSS-first through its Vite plugin, so the palette,
+ * the type scale, the breakpoints, and the motion defaults are `@theme` tokens here and there is no JavaScript
+ * configuration file to keep in step with them.
  *
- * The colours are MailFathom's own, sampled from `assets/icon-900.png` rather than picked by eye: the near-black navy
- * the mark sits on, the blue ramp across it, the pale blue of the lettering, and the gold of the star.
+ * Two layers of colour, and only the first one names a hue. `--color-fathom-*` is MailFathom's own ramp, sampled from
+ * `assets/icon-900.png` rather than picked by eye: the near-black navy the mark sits on, the blue across it, the pale
+ * blue of the lettering, and the gold of the star. Everything below it is *semantic* — a panel, a rail, a line, a text
+ * weight, a healthy state — and a screen composes against those names alone, which is what lets the second theme exist
+ * as a block of values rather than as a `dark:` variant on every utility a screen writes.
+ *
+ * The light values are the ones declared in `@theme`; the block after it redeclares exactly the same names for dark and
+ * nothing else. It sits outside every cascade layer deliberately: Tailwind emits `@theme` into its own `theme` layer,
+ * and an unlayered declaration wins over any layered one whatever its specificity, so the override cannot be reordered
+ * out of effect by a later import.
  */
 
 @import 'tailwindcss';
 
 @theme {
+    /* MailFathom's own ramp. Nothing outside this file uses these directly — they are what the semantic names below
+       are set from, so the brand lives in one place and a screen never learns a hue. */
     --color-fathom-950: #010d33;
     --color-fathom-800: #0028a0;
     --color-fathom-600: #0048e0;
@@ -22,7 +33,120 @@
     --color-fathom-200: #a8c8f8;
     --color-fathom-star: #f8d848;
 
+    /* Surfaces, from the page underneath everything to the chrome that sits on it. `sunken` is a region set into a
+       panel — a side column, a summary strip — and `hover` is what any of them becomes under a pointer. */
+    --color-page: #f6f7fb;
+    --color-panel: #ffffff;
+    --color-rail: #eef0f7;
+    --color-sunken: #f1f3f9;
+    --color-hover: #e4e8f3;
+
+    /* Two line weights and no more: one that separates regions, one that separates rows inside a region. */
+    --color-line: #d7dced;
+    --color-line-soft: #e8ebf5;
+
+    /* Four text weights, from what a sentence is written in down to what a timestamp is. */
+    --color-text: #0b1020;
+    --color-text-soft: #38405a;
+    --color-muted: #515a72;
+    --color-faint: #666f8a;
+
+    /* The accent is MailFathom's blue, `strong` is what it becomes as text on its own tint, and `soft` is that tint. */
+    --color-accent: var(--color-fathom-600);
+    --color-accent-strong: var(--color-fathom-800);
+    --color-accent-soft: #e6edfd;
+    --color-on-accent: #ffffff;
+
+    /* The two states a mail client cannot avoid saying out loud: everything is current, or something is not. */
+    --color-healthy: #1a7f4b;
+    --color-healthy-soft: #e6f4ec;
+    --color-warning: #b45309;
+    --color-warning-soft: #fdf0e2;
+
+    /* The one width the composition changes at: below it the workspace is a stack of screens under bottom navigation,
+       and at or above it a rail beside columns. Declared here so the point where narrow stops is one decision rather
+       than one per screen. The number is the prototype's, and it is a width rather than a device. */
+    --breakpoint-workspace: 48.75rem;
+
+    /* What a notch, a rounded corner, or a system bar takes out of the viewport. Zero everywhere a window has none,
+       which is every head this repository builds today; declaring it as a token is what keeps a screen from reaching
+       for a fixed padding the day one of them has one. */
+    --spacing-safe-top: env(safe-area-inset-top, 0px);
+    --spacing-safe-bottom: env(safe-area-inset-bottom, 0px);
+    --spacing-safe-left: env(safe-area-inset-left, 0px);
+    --spacing-safe-right: env(safe-area-inset-right, 0px);
+
+    /* Motion is decided once. A component writes `transition` and gets these; one that writes a duration of its own is
+       the same drift as one that writes a hexadecimal colour. */
+    --default-transition-duration: 140ms;
+    --default-transition-timing-function: ease;
+
     --font-sans:
         'Inter', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
     --font-mono: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, monospace;
+}
+
+/* The same names, dark. `data-theme` is written by `theme/Theme.tsx`, which resolves the follow-the-system choice
+   before the first paint, so nothing on a screen ever asks which theme is in force. */
+:root[data-theme='dark'] {
+    --color-page: #070d20;
+    --color-panel: #0f1730;
+    --color-rail: #0a1128;
+    --color-sunken: #0c142c;
+    --color-hover: #182242;
+
+    --color-line: #232e4d;
+    --color-line-soft: #182140;
+
+    --color-text: #e9edf8;
+    --color-text-soft: #c2c9dc;
+    --color-muted: #9aa2ba;
+    --color-faint: #7e87a1;
+
+    --color-accent: var(--color-fathom-500);
+    --color-accent-strong: var(--color-fathom-200);
+    --color-accent-soft: #0c1c3f;
+    --color-on-accent: #ffffff;
+
+    --color-healthy: #4ec98a;
+    --color-healthy-soft: #10291d;
+    --color-warning: #f0a14a;
+    --color-warning-soft: #2e2013;
+}
+
+@layer base {
+    /* What the browser draws its own furniture from: the scrollbar, a form control it renders itself, and the canvas
+       behind the document before any rule of ours has painted. */
+    :root {
+        color-scheme: light;
+    }
+
+    :root[data-theme='dark'] {
+        color-scheme: dark;
+    }
+
+    body {
+        background-color: var(--color-rail);
+        color: var(--color-text);
+    }
+
+    /* Focus is always visible, and it is decided once here rather than by every control remembering a ring utility.
+       The browser's own outline is replaced rather than removed, which is the part a screen is refused for skipping. */
+    :focus-visible {
+        outline: 2px solid var(--color-accent);
+        outline-offset: 2px;
+    }
+
+    /* An accessibility obligation rather than a nicety: motion is removed under the preference rather than shortened,
+       and a transition that carried meaning still lands on its final value because only its duration is taken away. */
+    @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+            animation-duration: 0s !important;
+            animation-iteration-count: 1 !important;
+            transition-duration: 0s !important;
+            scroll-behavior: auto !important;
+        }
+    }
 }

--- a/frontend/src/Client.App/src/theme/Theme.test.tsx
+++ b/frontend/src/Client.App/src/theme/Theme.test.tsx
@@ -1,0 +1,145 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { LocalizationProvider } from '../localization/Localization';
+import { ThemeChoice } from '../shell/Preferences';
+import { ThemeProvider } from './Theme';
+import { readStoredThemeChoice } from './theme';
+
+// What the machine itself is set to. jsdom answers every media query with `matches: false` and never changes its
+// answer, so a test that states a machine preference — or changes one while the client is open — defines the query
+// itself and puts back what was there afterwards, the way `Localization.test.tsx` states a language preference.
+const declaredMatchMedia = Object.getOwnPropertyDescriptor(window, 'matchMedia');
+
+let listeners: (() => void)[] = [];
+let machineIsDark = false;
+
+function machineTurns(dark: boolean): void {
+    machineIsDark = dark;
+    act(() => {
+        for (const listener of listeners) {
+            listener();
+        }
+    });
+}
+
+beforeEach(() => {
+    listeners = [];
+    machineIsDark = false;
+
+    Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        value: (query: string) => ({
+            media: query,
+            matches: machineIsDark && query.includes('dark'),
+            addEventListener: (_: string, listener: () => void) => {
+                listeners.push(listener);
+            },
+            removeEventListener: (_: string, listener: () => void) => {
+                listeners = listeners.filter((listening) => listening !== listener);
+            },
+        }),
+    });
+});
+
+afterEach(() => {
+    if (declaredMatchMedia !== undefined) {
+        Object.defineProperty(window, 'matchMedia', declaredMatchMedia);
+    }
+
+    window.localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+});
+
+// The theme reaches a screen as one attribute on the document, which every semantic token in `styles.css` is declared
+// against twice. It is what a person sees, as closely as a suite that computes no styles can ask about it.
+function paintedTheme(): string | undefined {
+    return document.documentElement.dataset['theme'];
+}
+
+function renderChoice(): void {
+    render(
+        <LocalizationProvider>
+            <ThemeProvider>
+                <ThemeChoice />
+            </ThemeProvider>
+        </LocalizationProvider>,
+    );
+}
+
+describe('ThemeProvider', () => {
+    it('paints light where nothing was chosen and the machine is light', () => {
+        renderChoice();
+
+        expect(paintedTheme()).toBe('light');
+    });
+
+    it('paints dark where nothing was chosen and the machine is dark', () => {
+        machineIsDark = true;
+
+        renderChoice();
+
+        expect(paintedTheme()).toBe('dark');
+    });
+
+    it('repaints when the machine changes while the client is open', () => {
+        renderChoice();
+
+        machineTurns(true);
+
+        expect(paintedTheme()).toBe('dark');
+    });
+
+    it('leaves an explicit choice alone when the machine changes under it', () => {
+        renderChoice();
+        fireEvent.change(screen.getByRole('combobox', { name: 'Theme' }), { target: { value: 'light' } });
+
+        machineTurns(true);
+
+        expect(paintedTheme()).toBe('light');
+    });
+});
+
+describe('useTheme', () => {
+    it('refuses to answer outside the provider rather than painting a theme of its own', () => {
+        expect(() => {
+            render(
+                <LocalizationProvider>
+                    <ThemeChoice />
+                </LocalizationProvider>,
+            );
+        }).toThrow(/ThemeProvider/);
+    });
+});
+
+describe('ThemeChoice', () => {
+    it('offers following the machine beside each of the two themes', () => {
+        renderChoice();
+
+        const choice = screen.getByRole('combobox', { name: 'Theme' });
+        expect([...choice.querySelectorAll('option')].map((option) => option.textContent)).toEqual([
+            'Follow the system',
+            'Light',
+            'Dark',
+        ]);
+    });
+
+    it('repaints the client when another theme is chosen, without anything being restarted', () => {
+        renderChoice();
+
+        fireEvent.change(screen.getByRole('combobox', { name: 'Theme' }), { target: { value: 'dark' } });
+
+        expect(paintedTheme()).toBe('dark');
+    });
+
+    it('remembers the choice, so a later run of either head opens in it', () => {
+        renderChoice();
+
+        fireEvent.change(screen.getByRole('combobox', { name: 'Theme' }), { target: { value: 'dark' } });
+
+        expect(readStoredThemeChoice()).toBe('dark');
+    });
+});

--- a/frontend/src/Client.App/src/theme/Theme.tsx
+++ b/frontend/src/Client.App/src/theme/Theme.tsx
@@ -1,0 +1,47 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { useLayoutEffect, useMemo, useState, useSyncExternalStore, type ReactNode } from 'react';
+import {
+    machinePrefersDark,
+    preferredThemeChoice,
+    storeThemeChoice,
+    watchMachineTheme,
+    type ThemeChoice,
+} from './theme';
+import { ThemeContext, type Themed } from './useTheme';
+
+// Which of the two themes is painted is decided here and nowhere else. A screen composes against the semantic tokens in
+// `styles.css`, both themes declare the same names, and this writes the one attribute that picks between the two — so
+// no component ever asks which theme is in force, exactly as none asks which language is.
+
+export function ThemeProvider({ children }: { readonly children: ReactNode }) {
+    const [choice, setChoice] = useState(preferredThemeChoice);
+
+    // Following the machine means the answer changes while the client is open, so the preference is subscribed to
+    // rather than read once. `useSyncExternalStore` is what React reads a value living outside it through, and it
+    // leaves the theme derived during render instead of a second piece of state kept in step with this one.
+    const machineIsDark = useSyncExternalStore(watchMachineTheme, machinePrefersDark);
+    const theme = choice === 'system' ? (machineIsDark ? 'dark' : 'light') : choice;
+
+    // A layout effect rather than an ordinary one, because this runs before the browser paints: a reader whose machine
+    // is dark would otherwise see one light frame on every cold start, which is the flash a theme is chosen to avoid.
+    useLayoutEffect(() => {
+        document.documentElement.dataset['theme'] = theme;
+    }, [theme]);
+
+    const themed = useMemo<Themed>(
+        () => ({
+            choice,
+            theme,
+            setThemeChoice: (chosen: ThemeChoice) => {
+                storeThemeChoice(chosen);
+                setChoice(chosen);
+            },
+        }),
+        [choice, theme],
+    );
+
+    return <ThemeContext value={themed}>{children}</ThemeContext>;
+}

--- a/frontend/src/Client.App/src/theme/theme.test.ts
+++ b/frontend/src/Client.App/src/theme/theme.test.ts
@@ -1,0 +1,47 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { isThemeChoice, preferredThemeChoice, readStoredThemeChoice, storeThemeChoice, themeChoices } from './theme';
+
+afterEach(() => {
+    window.localStorage.clear();
+});
+
+describe('isThemeChoice', () => {
+    it.each(themeChoices)('recognizes %s', (choice) => {
+        expect(isThemeChoice(choice)).toBe(true);
+    });
+
+    it('refuses a value that is not one of the three, whatever its type', () => {
+        expect(isThemeChoice('contrast')).toBe(false);
+        expect(isThemeChoice(null)).toBe(false);
+    });
+});
+
+describe('readStoredThemeChoice', () => {
+    it('reads back what was stored, which is how a later run of either head opens in it', () => {
+        storeThemeChoice('dark');
+
+        expect(readStoredThemeChoice()).toBe('dark');
+    });
+
+    it('reads nothing where a value the client does not offer was left behind', () => {
+        window.localStorage.setItem('mailfathom.theme', 'contrast');
+
+        expect(readStoredThemeChoice()).toBeNull();
+    });
+});
+
+describe('preferredThemeChoice', () => {
+    it('follows the machine where nothing was chosen', () => {
+        expect(preferredThemeChoice()).toBe('system');
+    });
+
+    it('takes the explicit choice over following the machine', () => {
+        storeThemeChoice('light');
+
+        expect(preferredThemeChoice()).toBe('light');
+    });
+});

--- a/frontend/src/Client.App/src/theme/theme.ts
+++ b/frontend/src/Client.App/src/theme/theme.ts
@@ -1,0 +1,69 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+/** What a person may choose: one of the two themes, or whatever the machine is set to. */
+export const themeChoices = ['system', 'light', 'dark'] as const;
+
+export type ThemeChoice = (typeof themeChoices)[number];
+
+/** What is actually painted. `system` resolves to one of these before anything reads it. */
+export type Theme = 'light' | 'dark';
+
+/** What a first run resolves to when nothing it reads names a choice: the machine's own. */
+export const defaultThemeChoice: ThemeChoice = 'system';
+
+// What the explicit choice is written under, beside the language. It survives a restart of either head because both
+// store it in the same place: the web bundle in the browser's origin storage, the desktop shell in its WebView's.
+//
+// Reached as `window.localStorage` rather than as the bare global, for the reason `localization/locale.ts` gives.
+const storageKey = 'mailfathom.theme';
+
+const darkQuery = '(prefers-color-scheme: dark)';
+
+export function isThemeChoice(value: unknown): value is ThemeChoice {
+    return typeof value === 'string' && (themeChoices as readonly string[]).includes(value);
+}
+
+/** The theme explicitly chosen on this machine, or `null` where none was chosen or what was stored is not offered. */
+export function readStoredThemeChoice(): ThemeChoice | null {
+    try {
+        const stored = window.localStorage.getItem(storageKey);
+        return isThemeChoice(stored) ? stored : null;
+    } catch {
+        return null;
+    }
+}
+
+export function storeThemeChoice(choice: ThemeChoice): void {
+    try {
+        window.localStorage.setItem(storageKey, choice);
+    } catch {
+        // A browser configured to refuse storage still runs the client; the choice then lasts the session rather than
+        // outliving it, which is a smaller loss than a screen that fails to mount over a preference.
+    }
+}
+
+/** What the client opens in: the explicit choice, else following the machine. */
+export function preferredThemeChoice(): ThemeChoice {
+    return readStoredThemeChoice() ?? defaultThemeChoice;
+}
+
+/** Whether the machine itself is set to a dark appearance right now. */
+export function machinePrefersDark(): boolean {
+    return window.matchMedia(darkQuery).matches;
+}
+
+/**
+ * Calls back whenever the machine's own appearance changes, and answers with the function that stops listening.
+ * Only worth subscribing to while the choice is to follow it; an explicit choice is unaffected by the machine.
+ */
+export function watchMachineTheme(changed: () => void): () => void {
+    const query = window.matchMedia(darkQuery);
+
+    query.addEventListener('change', changed);
+
+    return () => {
+        query.removeEventListener('change', changed);
+    };
+}

--- a/frontend/src/Client.App/src/theme/useTheme.ts
+++ b/frontend/src/Client.App/src/theme/useTheme.ts
@@ -1,0 +1,31 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { createContext, useContext } from 'react';
+import type { Theme, ThemeChoice } from './theme';
+
+// The context and its hook sit apart from the provider that fills them for the reason `localization/useLocalization.ts`
+// gives: a module Vite hot-reloads may export components alone.
+
+export interface Themed {
+    /** What the person chose, which may be to follow the machine. */
+    readonly choice: ThemeChoice;
+
+    /** What that choice actually paints right now. */
+    readonly theme: Theme;
+
+    readonly setThemeChoice: (choice: ThemeChoice) => void;
+}
+
+export const ThemeContext = createContext<Themed | null>(null);
+
+export function useTheme(): Themed {
+    const themed = useContext(ThemeContext);
+
+    if (themed === null) {
+        throw new Error('A component read the theme outside the ThemeProvider that main.tsx mounts.');
+    }
+
+    return themed;
+}

--- a/frontend/src/Client.App/src/workspace/Workspace.test.tsx
+++ b/frontend/src/Client.App/src/workspace/Workspace.test.tsx
@@ -1,0 +1,71 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { WorkspaceProvider } from './Workspace';
+import { useWorkspace, type Workspace } from './useWorkspace';
+
+// A space writes what it owns and reads what the others left, so what is proven here is that one part of the workspace
+// can be revised without any other part of it being lost. Which spaces write which part is decided by the space:
+// today the frame writes the question and the mailbox in scope, and the folder and the selection arrive with Mail.
+
+function Probe({ change }: { readonly change: Partial<Workspace> }) {
+    const { workspace, revise } = useWorkspace();
+
+    return (
+        <div>
+            <button
+                type="button"
+                onClick={() => {
+                    revise(change);
+                }}
+            >
+                {JSON.stringify(change)}
+            </button>
+            <output>{JSON.stringify(workspace)}</output>
+        </div>
+    );
+}
+
+function renderProbe(change: Partial<Workspace>): void {
+    render(
+        <WorkspaceProvider>
+            <Probe change={change} />
+        </WorkspaceProvider>,
+    );
+}
+
+function carried(): Workspace {
+    return JSON.parse(screen.getByRole('status').textContent) as Workspace;
+}
+
+describe('WorkspaceProvider', () => {
+    it('carries nothing until a space puts something in it', () => {
+        renderProbe({});
+
+        expect(carried()).toEqual({ accountId: null, folder: null, selection: null, question: '' });
+    });
+
+    it.each([
+        { accountId: 'work' },
+        { folder: 'Archive/2026' },
+        { selection: 'AAMkAD-42' },
+        { question: 'what did Nordwind send' },
+    ])('changes %o and leaves the rest of the workspace as it was', (change) => {
+        renderProbe(change);
+
+        fireEvent.click(screen.getByRole('button'));
+
+        expect(carried()).toEqual({ accountId: null, folder: null, selection: null, question: '', ...change });
+    });
+});
+
+describe('useWorkspace', () => {
+    it('refuses to answer outside the provider rather than inventing a workspace of its own', () => {
+        expect(() => {
+            render(<Probe change={{}} />);
+        }).toThrow(/WorkspaceProvider/);
+    });
+});

--- a/frontend/src/Client.App/src/workspace/Workspace.tsx
+++ b/frontend/src/Client.App/src/workspace/Workspace.tsx
@@ -1,0 +1,21 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { useCallback, useMemo, useState, type ReactNode } from 'react';
+import { emptyWorkspace, WorkspaceContext, type Workspace, type WorkspaceRevision } from './useWorkspace';
+
+// Mounted above the frame rather than inside a space, which is the whole mechanism: a space is what the address
+// changes, and this is not below the address.
+
+export function WorkspaceProvider({ children }: { readonly children: ReactNode }) {
+    const [workspace, setWorkspace] = useState<Workspace>(emptyWorkspace);
+
+    const revise = useCallback((change: Partial<Workspace>) => {
+        setWorkspace((current) => ({ ...current, ...change }));
+    }, []);
+
+    const revision = useMemo<WorkspaceRevision>(() => ({ workspace, revise }), [workspace, revise]);
+
+    return <WorkspaceContext value={revision}>{children}</WorkspaceContext>;
+}

--- a/frontend/src/Client.App/src/workspace/useWorkspace.ts
+++ b/frontend/src/Client.App/src/workspace/useWorkspace.ts
@@ -1,0 +1,52 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { createContext, useContext } from 'react';
+
+// What a person carries between the spaces. Discover, Mail, and Cases are one application rather than three, and this
+// is what makes them one: the frame owns it, so moving to another space re-renders what is under the frame and leaves
+// every value below untouched.
+//
+// The context and its hook sit apart from the provider that fills them for the reason `localization/useLocalization.ts`
+// gives: a module Vite hot-reloads may export components alone.
+
+export interface Workspace {
+    /** The account every question is asked against, or `null` for all of the owner's accounts at once. */
+    readonly accountId: string | null;
+
+    /** The folder within that account, once a space offers one to choose. */
+    readonly folder: string | null;
+
+    /** What the person has open, once a space offers something to open. */
+    readonly selection: string | null;
+
+    /** What has been typed into the intent field, which the next question would be asked with. */
+    readonly question: string;
+}
+
+export interface WorkspaceRevision {
+    readonly workspace: Workspace;
+
+    /** Changes the named parts and leaves the rest of the workspace as it was. */
+    readonly revise: (change: Partial<Workspace>) => void;
+}
+
+export const emptyWorkspace: Workspace = {
+    accountId: null,
+    folder: null,
+    selection: null,
+    question: '',
+};
+
+export const WorkspaceContext = createContext<WorkspaceRevision | null>(null);
+
+export function useWorkspace(): WorkspaceRevision {
+    const revision = useContext(WorkspaceContext);
+
+    if (revision === null) {
+        throw new Error('A component read the workspace outside the WorkspaceProvider that main.tsx mounts.');
+    }
+
+    return revision;
+}

--- a/frontend/src/Client.App/vitest.setup.ts
+++ b/frontend/src/Client.App/vitest.setup.ts
@@ -24,3 +24,20 @@ if (jsdomStorage instanceof Storage) {
         writable: false,
     });
 }
+
+// jsdom evaluates no media query and publishes no `matchMedia` at all, so a component asking what appearance the
+// machine is set to fails on a missing function rather than reading a preference. What is put back answers the way a
+// browser whose machine matches nothing does, and never changes its answer — this environment has no machine
+// preference to report and computes no styles. A test that states one defines its own over this, the way
+// `src/theme/Theme.test.tsx` does, which is the same shape `Localization.test.tsx` states a language preference in.
+if (typeof window.matchMedia !== 'function') {
+    Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        value: (query: string) => ({
+            media: query,
+            matches: false,
+            addEventListener: () => undefined,
+            removeEventListener: () => undefined,
+        }),
+    });
+}

--- a/frontend/tests/AGENTS.md
+++ b/frontend/tests/AGENTS.md
@@ -180,11 +180,15 @@ the answer; dropping it is not, and neither is asserting it in jsdom where it wo
   Neither verification gate runs it, because it needs a browser install the gates would otherwise demand of every
   machine.
 
-Two things it does not cover yet, because the client does not have them. There is no router, so the only navigation
-there is to check is the browser's own — leaving the client and coming back to it — and an in-application back gesture
-is asserted here on the day one exists. And nothing goes over the wire to a service, because the mail is stubbed inside
-the bundle and the origin serving it is the deployment it is pointed at, so what is asserted about the network today is
-that the client reaches its own origin and no other.
+One thing it does not cover yet, because the client does not have it: nothing goes over the wire to a service, because
+the mail is stubbed inside the bundle and the origin serving it is the deployment it is pointed at, so what is asserted
+about the network today is that the client reaches its own origin and no other.
+
+Navigation is no longer on that list. Each space is reached at a fragment address of its own, so this suite moves
+between them, reloads one, and moves back and forward through the client's own history — which is the whole reason the
+address is a fragment, and which nothing but a real document with a history can answer. Where the composition changes
+is here as well, because it is geometry: the navigation sits beside the workspace in a wide window and under it in a
+narrow one, asked of two viewport widths rather than of two heads.
 
 ## Coverage
 

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -117,6 +117,25 @@ test('puts the navigation beside the workspace in a wide window and under it in 
     await expect(page.getByRole('link', { name: 'Cases' })).toBeVisible();
 });
 
+test('moves a keyboard through a narrow window in the order the window shows', async ({ page }) => {
+    await page.setViewportSize(narrowWindow);
+    await page.goto('/');
+
+    // The narrow composition draws the navigation at the bottom of the screen, and the keyboard follows the document
+    // rather than the layout — so a document that put the navigation first would hand a reader the bottom bar before
+    // the header at the top of the window. Only a browser answers this: jsdom has no sequential focus navigation.
+    await page.keyboard.press('Tab');
+    await expect(page.getByRole('combobox', { name: 'Theme' })).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await expect(page.getByRole('searchbox', { name: 'Ask your mail' })).toBeFocused();
+
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await expect(page.getByRole('link', { name: 'Discover' })).toBeFocused();
+});
+
 test('stays usable at the narrowest width a supported head presents', async ({ page }) => {
     await page.setViewportSize({ width: 320, height: 640 });
     await page.goto('/');

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -4,12 +4,12 @@
 
 import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
-import { expect, test } from '@playwright/test';
+import { expect, test, type Locator } from '@playwright/test';
 
 // What the unit suite structurally cannot answer, asked of the directory of static files `pnpm build` writes, in a
-// browser. Everything below would pass or fail identically under jsdom except for the reason it is here: the bundle is
-// the built one rather than the source, the document is a real one with a history, and the requests are the requests a
-// browser actually issued. `frontend/tests/AGENTS.md` is where that boundary is decided.
+// browser: the bundle is the built one rather than the source, the document is a real one with a history, the window
+// has a width that decides a layout, and the requests are the requests a browser actually issued.
+// `frontend/tests/AGENTS.md` is where that boundary is decided.
 
 // Read the way `src/Client.App/vite.config.ts` reads it, so the assertion below is against the number the build
 // substituted rather than against a second copy of it written here.
@@ -17,20 +17,148 @@ const declaredVersion = execFileSync(resolve(import.meta.dirname, '../../scripts
     encoding: 'utf8',
 }).trim();
 
-const clientHeading = { name: 'MailFathom', level: 1 } as const;
+const wideWindow = { width: 1280, height: 720 };
+const narrowWindow = { width: 380, height: 720 };
 
-test('renders the accounts it read, under the version it was built from', async ({ page }) => {
+interface Box {
+    readonly x: number;
+    readonly y: number;
+    readonly width: number;
+    readonly height: number;
+}
+
+// Playwright answers with nothing for an element that is not laid out, which is a different thing from an element in
+// the wrong place — so it is refused by name here rather than asserted through a non-null assertion.
+async function boxOf(element: Locator): Promise<Box> {
+    const box = await element.boundingBox();
+
+    if (box === null) {
+        throw new Error('The element is in the document but has no layout box to read a position off.');
+    }
+
+    return box;
+}
+
+test('opens in Discover, under the version it was built from', async ({ page }) => {
     await page.goto('/');
 
-    await expect(page.getByRole('heading', clientHeading)).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Discover', level: 1 })).toBeVisible();
     await expect(page.getByText(declaredVersion, { exact: true })).toBeVisible();
 
-    const accounts = page.getByRole('listitem');
+    // A first load at the root is written back to the address the space is actually reached at, which is what makes
+    // the next assertion — reloading it — mean anything.
+    await expect(page).toHaveURL(/#\/discover$/);
+});
 
-    await expect(accounts).toHaveCount(3);
-    await expect(accounts.filter({ hasText: 'Work' })).toContainText('synchronized');
-    await expect(accounts.filter({ hasText: 'Archive' })).toContainText('unreachable, behind');
-    await expect(accounts.filter({ hasText: 'Personal' })).toContainText('never synchronized');
+test('reaches each space by its own address, and reloads there', async ({ page }) => {
+    await page.goto('/#/cases');
+
+    await expect(page.getByRole('heading', { name: 'Cases', level: 1 })).toBeVisible();
+
+    // The whole reason the address is a fragment: nothing is asked of a server, so the bundle that answers `/` answers
+    // this too and the client reads the space back out of the address it was reloaded at. A path would need a fallback
+    // mapping every unmatched address onto the entry document, which the service deliberately does not serve.
+    await page.reload();
+
+    await expect(page.getByRole('heading', { name: 'Cases', level: 1 })).toBeVisible();
+});
+
+test('moves back and forward through its own spaces without leaving the application', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: 'Discover', level: 1 })).toBeVisible();
+
+    await page.getByRole('link', { name: 'Mail' }).click();
+    await expect(page.getByRole('heading', { name: 'Mail', level: 1 })).toBeVisible();
+
+    await page.goBack();
+    await expect(page.getByRole('heading', { name: 'Discover', level: 1 })).toBeVisible();
+
+    await page.goForward();
+    await expect(page.getByRole('heading', { name: 'Mail', level: 1 })).toBeVisible();
+});
+
+test('carries the question and the mailbox in scope from one space to the next', async ({ page }) => {
+    await page.goto('/');
+
+    const question = page.getByRole('searchbox', { name: 'Ask your mail' });
+    await question.fill('the renewal Nordwind sent');
+    await page.getByRole('combobox', { name: 'Mailbox in scope' }).selectOption({ label: 'Work' });
+
+    await page.getByRole('link', { name: 'Cases' }).click();
+    await expect(page.getByRole('heading', { name: 'Cases', level: 1 })).toBeVisible();
+
+    await expect(question).toHaveValue('the renewal Nordwind sent');
+    await expect(page.getByRole('combobox', { name: 'Mailbox in scope' })).toHaveValue('work');
+});
+
+test('puts the navigation beside the workspace in a wide window and under it in a narrow one', async ({ page }) => {
+    await page.setViewportSize(wideWindow);
+    await page.goto('/');
+
+    const navigation = page.getByRole('navigation', { name: 'Spaces' });
+    const space = page.getByRole('main');
+
+    await expect(navigation).toBeVisible();
+
+    // Only a browser answers this: jsdom computes no geometry, so where the two regions sit relative to each other is
+    // outside what the unit suite may claim. It is asked of the width alone — nothing in the client reads which head
+    // it is running on, and this same tree produces both shapes.
+    const rail = await boxOf(navigation);
+    const wideSpace = await boxOf(space);
+    expect(rail.x + rail.width).toBeLessThanOrEqual(wideSpace.x);
+
+    await page.setViewportSize(narrowWindow);
+
+    const bottomBar = await boxOf(navigation);
+    const narrowSpace = await boxOf(space);
+    expect(bottomBar.y).toBeGreaterThanOrEqual(narrowSpace.y + narrowSpace.height);
+
+    // Nothing is hidden by width alone: the same three destinations are reachable in both shapes.
+    await expect(page.getByRole('link', { name: 'Cases' })).toBeVisible();
+});
+
+test('stays usable at the narrowest width a supported head presents', async ({ page }) => {
+    await page.setViewportSize({ width: 320, height: 640 });
+    await page.goto('/');
+
+    // 320 CSS pixels is the bar `frontend/src/AGENTS.md` sets, and what is asked of it is that the frame still holds
+    // everything rather than that it looks the same: the space, the intent field, its scope, and all three
+    // destinations. Nothing is dropped by width, and the window it is measured in is the width alone.
+    await expect(page.getByRole('heading', { name: 'Discover', level: 1 })).toBeVisible();
+    await expect(page.getByRole('searchbox', { name: 'Ask your mail' })).toBeVisible();
+    await expect(page.getByRole('combobox', { name: 'Mailbox in scope' })).toBeVisible();
+    await expect(page.getByRole('navigation', { name: 'Spaces' }).getByRole('link')).toHaveCount(3);
+});
+
+test('opens again in the theme that was chosen, after the page is loaded afresh', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'light');
+
+    await page.getByRole('combobox', { name: 'Theme' }).selectOption('dark');
+    await page.reload();
+
+    // Only a real document loaded a second time proves the choice was written and read back. What it is asserted
+    // through is the one attribute the whole token layer is declared against, which is what a screen is painted by.
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+});
+
+test('opens again in the language that was chosen, after the page is loaded afresh', async ({ page }) => {
+    await page.goto('/');
+
+    const discover = page.getByRole('heading', { name: 'Discover', level: 1 });
+    await expect(discover).toBeVisible();
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+
+    await page.getByRole('combobox', { name: 'Language' }).selectOption('pl');
+    await page.reload();
+
+    // The assertion is the English heading being gone and the document declaring the other language, rather than the
+    // Polish one being present — the catalogue is the one file in this repository deliberately not in English, and a
+    // second copy of its wording here would be a string to keep in step with it and a word for the spell check to
+    // object to.
+    await expect(discover).toHaveCount(0);
+    await expect(page.locator('html')).toHaveAttribute('lang', 'pl');
 });
 
 test('issues every request to the origin it was served from and to no other', async ({ page }) => {
@@ -41,44 +169,10 @@ test('issues every request to the origin it was served from and to no other', as
     });
 
     await page.goto('/');
-    await expect(page.getByRole('heading', clientHeading)).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Discover', level: 1 })).toBeVisible();
 
     // A client of one person's own mail reaches the deployment serving it and nothing else, so a font, an analytics
     // beacon, or a stray CDN reference arriving in the bundle is a privacy defect rather than a slow page. Only a
     // browser can answer this: jsdom loads no subresource, and the source says nothing about what a build inlined.
     expect([...origins]).toStrictEqual([new URL(page.url()).origin]);
-});
-
-test('renders again when the browser goes back to it', async ({ page }) => {
-    await page.goto('/');
-    await expect(page.getByRole('heading', clientHeading)).toBeVisible();
-
-    await page.goto('about:blank');
-    await page.goBack();
-
-    // The application remounts and reads its accounts again, rather than coming back as the empty document a bundle
-    // restored from the back-forward cache without rerunning would leave. The client carries no router yet, so this is
-    // the whole of the navigation it has; an in-application back gesture is checked here on the day one exists.
-    await expect(page.getByRole('heading', clientHeading)).toBeVisible();
-    await expect(page.getByRole('listitem')).toHaveCount(3);
-});
-
-test('opens again in the language that was chosen, after the page is loaded afresh', async ({ page }) => {
-    await page.goto('/');
-
-    const accountsAreRefreshing = page.getByText('This deployment refreshes the local copy of these accounts.');
-    await expect(accountsAreRefreshing).toBeVisible();
-    await expect(page.locator('html')).toHaveAttribute('lang', 'en');
-
-    await page.getByRole('combobox', { name: 'Language' }).selectOption('pl');
-    await page.reload();
-
-    // The whole of what the unit suite cannot answer about this: it proves the choice was written, and only a real
-    // document loaded a second time proves a later run reads it back. The assertion is the English sentence being gone
-    // and the document declaring the other language, rather than the Polish sentence being present — the catalogue is
-    // the one file in this repository deliberately not in English, and a second copy of its wording here would be a
-    // string to keep in step with it and a word for the spell check to object to.
-    await expect(accountsAreRefreshing).toHaveCount(0);
-    await expect(page.locator('html')).toHaveAttribute('lang', 'pl');
-    await expect(page.getByRole('listitem')).toHaveCount(3);
 });


### PR DESCRIPTION
Closes #1420

`Client.App` was one `App.tsx` rendering the owner's mail accounts — the workspace proving itself. It is now the frame **Discover**, **Mail**, and **Cases** are held in, built before any of the three exists because what makes them one application is what survives moving between them.

## The design read

The prototype settles the structure and the vocabulary: three spaces on a rail, a header line saying what is connected and how fresh it is, and the intent field with its scope above whatever the space shows. What is built here is that structure, from this repository's own values rather than the prototype's — its palette is a sample, and the accent stays MailFathom's.

**Two departures, argued rather than made silently:**

- **The theme and language controls sit in the header, not on the rail.** The rail *is* the bottom bar in a narrow window, where a third kind of control has nowhere to go — and a control that disappears with the width is one the reader can no longer reach. The header is the one region present in both compositions.
- **There is no wordmark, no user menu, and no fourth space.** The prototype's rail also carries Agent, Tasks, Calendar, and People; this issue's product is three spaces, and inventing the others here would be building the frame around a product that has not been decided.

## No router, and a fragment rather than a path

`frontend/AGENTS.md` lists a router among four deliberate absences, each staying absent until a change argues for it. This change argues it stays absent.

Three addresses with no segment, no parameter, and no nested tree are what `location.hash` and `hashchange` already are, and the browser keeps the history for us — so `frontend/src/Client.App/src/routing/` is a closed set of three spaces, a parse, a format, and one `useSyncExternalStore`. A package would have bought that at the price of a pin, a licence review, and a re-run of the register's client census.

**The address is a fragment because a path would not reload.** `backend/src/Host/Hosting/ClientApplicationFiles.cs` serves the bundle with no fallback mapping an unmatched path onto the entry document — deliberately, because the client surface may share a socket with the MCP one. A fragment never reaches a server, so `#/mail` reloads on both heads with nothing configured and no change to the service.

## The token layer

`styles.css` gains the semantic names a screen actually asks for, in two layers. `--color-fathom-*` stays the brand ramp sampled from the product icon; everything a screen composes against is a semantic name set from it — page, panel, rail, sunken, hover; two line weights; four text weights; an accent, a healthy state, a warning. Both themes declare the same names, which is what lets one set of utilities paint a light and a dark client with no `dark:` variant anywhere.

`theme/` resolves light, dark, or following the machine — subscribed rather than read once, so the machine changing while the client is open repaints it — and writes one `data-theme` attribute before the first paint, in a layout effect, so a reader whose machine is dark never sees a light frame. The breakpoint the composition changes at, the safe-area insets, the motion defaults, and the focus ring are tokens beside the colours.

## What a person carries

`workspace/` is mounted above the frame, so a space change re-renders what is under the frame and leaves the account in scope, the folder, the selection, and the question untouched. The intent field and its scope indicator answer nothing here — submitting goes to the space that will answer, and Discover fills them in later.

## Contracts

No break to the MCP tool contract, the configuration schema, the database schema, or the deployment contract. No dependency added, moved, or removed; routing, theming, and persistence are platform APIs both heads already have.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — green
- `pnpm test` — 114 passed, coverage 96.9% of statements over both packages
- `pnpm test:browser` — 10 passed: each space reloading at its own address, back and forward through the client's own history, the composition at two viewport widths, the tab order a narrow window hands a keyboard, the theme and the language surviving a reload, and every request going to the origin it was served from
- `scripts/verify-full.sh` — 284 passed, 0 failed
- Driven in a real browser at 1280 and at 420 CSS pixels, light and dark

## Acceptance

- [x] Three spaces as routes, each reachable and reloadable by its own address, on both heads
- [x] A rail beside a multi-column workspace at or above the `workspace` breakpoint, bottom navigation over a screen stack below it, with nothing reading which head it is
- [x] Back and forward move through the client's own history without leaving the application
- [x] The absence of a routing dependency argued rather than a package added in passing
- [x] The intent field and its scope indicator present in the frame, showing the current scope, reachable from every space
- [x] Moving between spaces preserves the account in scope, the folder, the selection, and the question
- [x] Light, dark, and follow-the-system offered, the choice persisted, both themes declared in the token layer with no colour written outside it
- [x] The token layer gains surfaces, lines, text weights, accent, healthy, and warning, declared once for both themes
- [x] The shell follows the prototype's structure, with the two departures above argued
- [x] Safe-area insets rather than fixed padding
- [x] Keyboard-operable navigation, focus moved to the start of the new content on every route change, an accessible name on every control, and `prefers-reduced-motion` removing motion rather than shortening it
- [x] No user-visible string written inside the component that shows it

https://claude.ai/code/session_01VcW4hVZ9VZKgoNFxt1E3po


