### PR TITLE
[#1421] Let the session's grants, the deployment's features, and each account's freshness decide what the client offers

### DIFF
--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -3,8 +3,8 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { StrictMode } from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ClientRequest, ClientResponse } from '@mailfathom/client-backend';
 import { App } from './App';
 import type { AdoptedDeployment } from './deployment/adoptedDeployment';
@@ -12,6 +12,7 @@ import type { DeploymentTransport } from './deployment/sendToDeployment';
 import { LocalizationProvider } from './localization/Localization';
 import { localeNames, locales, readStoredLocale } from './localization/locale';
 import type { CredentialLifetime, CredentialStore } from './signIn/credentialStore';
+import { mostReconnectionAttempts } from './shell/useConnection';
 import { ThemeProvider } from './theme/Theme';
 import { LinkOpenerContext } from './shellOperations/linkOpener';
 import { WorkspaceProvider } from './workspace/Workspace';
@@ -23,7 +24,15 @@ import { WorkspaceProvider } from './workspace/Workspace';
 type Answer = Omit<ClientResponse, 'headers'> & { readonly headers?: Readonly<Record<string, string>> };
 
 /** What a deployment answers a caller it accepts, which is what proves the address is MailFathom and the password works. */
-const accepted: Answer = { status: 200, body: JSON.stringify({ service: 'MailFathom', version: '0.8.0' }) };
+const accepted = sessionAnswering(['mailfathom.mail.read', 'mailfathom.mail.ask']);
+
+/** A deployment reporting itself and what it grants the credential that just reached it. */
+function sessionAnswering(permissions: readonly string[]): Answer {
+    return {
+        status: 200,
+        body: JSON.stringify({ service: 'MailFathom', version: '0.8.7', permissions }),
+    };
+}
 
 // The two challenges a MailFathom surface answers a refusal with, in one header value: the bearer one every deployment
 // produces, and the password one beside it where the deployment accepts passwords.
@@ -60,12 +69,15 @@ function routesAsked(): string[] {
     return [...new Set(asked.map((request) => request.path))];
 }
 
-/** A deployment that accepts any credential and answers the accounts with what a test named. */
-function deploymentAnswering(accounts: Answer = directory(true, [workAccount])): DeploymentTransport {
+/** A deployment that accepts any credential and answers the session and the accounts with what a test named. */
+function deploymentAnswering(
+    accounts: Answer = directory(true, [workAccount]),
+    session: Answer = accepted,
+): DeploymentTransport {
     return () => (request) => {
         asked.push(request);
 
-        return Promise.resolve(complete(request.path.endsWith('/session') ? accepted : accounts));
+        return Promise.resolve(complete(request.path.endsWith('/session') ? session : accounts));
     };
 }
 
@@ -233,6 +245,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
     openingAt('/');
     asked.length = 0;
     window.localStorage.clear();
@@ -242,10 +256,21 @@ afterEach(() => {
 });
 
 describe('App', () => {
-    it('says it is reading while the answer has not arrived', () => {
+    it('says it is reaching the deployment while nothing has answered', () => {
         renderApp(servedFrom, heldCredential, () => () => new Promise<ClientResponse>(() => undefined));
 
-        expect(screen.getByText('Reading accounts…')).toBeDefined();
+        expect(screen.getByText('Reaching your deployment…')).toBeDefined();
+    });
+
+    it('says it is reading the accounts once the deployment has said what the credential may do', async () => {
+        const send: DeploymentTransport = () => (request) =>
+            request.path.endsWith('/session')
+                ? Promise.resolve(complete(accepted))
+                : new Promise<ClientResponse>(() => undefined);
+
+        renderApp(servedFrom, heldCredential, send);
+
+        expect(await screen.findByText('Reading accounts…')).toBeDefined();
     });
 
     it('opens in Discover when the address names no space', async () => {
@@ -339,11 +364,13 @@ describe('App', () => {
         });
     });
 
-    it('says the deployment is not refreshing these accounts when it is not', async () => {
+    it('says the deployment is not refreshing these accounts when it is not, as its setting rather than a grant', async () => {
         renderApp(servedFrom, heldCredential, deploymentAnswering(directory(false, [workAccount])));
 
         expect(
-            await screen.findByText('This deployment is not refreshing the local copy of these accounts.'),
+            await screen.findByText(
+                'This deployment is not refreshing the local copy of these accounts, so what you see is as current as its last run left it. That is a setting on the deployment rather than a permission you are missing.',
+            ),
         ).toBeDefined();
     });
 
@@ -372,6 +399,170 @@ describe('App', () => {
         await framed();
 
         expect([...new Set(asked.map((request) => request.headers['Authorization']))]).toEqual([typedCredential]);
+    });
+});
+
+describe('App session', () => {
+    /** A deployment that grants the credential exactly these names, and answers the accounts normally. */
+    function granting(...permissions: readonly string[]): DeploymentTransport {
+        return deploymentAnswering(directory(true, [workAccount]), sessionAnswering(permissions));
+    }
+
+    it('offers only the spaces the grant permits, rather than ones the deployment would refuse', async () => {
+        renderApp(servedFrom, heldCredential, granting('mailfathom.mail.read'));
+        await framed();
+
+        expect(screen.getAllByRole('link').map((space) => space.textContent)).toEqual(['Mail', 'Cases']);
+    });
+
+    it('says what the credential may not do, so an absence is not read as a client that is broken', async () => {
+        renderApp(servedFrom, heldCredential, granting('mailfathom.mail.read'));
+        await framed();
+
+        expect(
+            screen.getByText(
+                'This credential may not ask questions of your mail on this deployment, so asking is not offered. Whoever runs the deployment can grant that.',
+            ),
+        ).toBeDefined();
+    });
+
+    it('offers nothing to ask with where the credential may not ask', async () => {
+        renderApp(servedFrom, heldCredential, granting('mailfathom.mail.read'));
+        await framed();
+
+        expect(screen.queryByRole('searchbox', { name: 'Ask your mail' })).toBeNull();
+    });
+
+    it('never asks for the mail a credential may not read, rather than letting the read be refused', async () => {
+        renderApp(servedFrom, heldCredential, granting('mailfathom.mail.ask'));
+        await screen.findByRole('heading', { name: 'Discover', level: 1 });
+
+        await waitFor(() => {
+            expect(routesAsked()).toEqual(['https://mail.example.invalid/api/client/session']);
+        });
+        expect(screen.queryByText(/The accounts could not be read/)).toBeNull();
+    });
+
+    it('answers an address naming a space this credential may not open with one it may', async () => {
+        openingAt('#/discover');
+
+        renderApp(servedFrom, heldCredential, granting('mailfathom.mail.read'));
+
+        expect(await screen.findByRole('heading', { name: 'Mail', level: 1 })).toBeDefined();
+        await waitFor(() => {
+            expect(window.location.hash).toBe('#/mail');
+        });
+    });
+
+    it('tells a credential granted nothing everything it may not do, rather than leaving it to guess', async () => {
+        renderApp(servedFrom, heldCredential, granting());
+
+        expect(await screen.findByText(/This credential may not read mail on this deployment/)).toBeDefined();
+        expect(screen.getByText(/This credential may not ask questions of your mail/)).toBeDefined();
+        expect(screen.queryByRole('link', { name: 'Mail' })).toBeNull();
+    });
+
+    it('reaches for a deployment that did not answer on its own, and says which attempt it is on', async () => {
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+
+        renderApp(servedFrom, heldCredential, deploymentRefusing({ status: 503, body: '' }));
+        await screen.findByText(/Trying again — attempt 1 of/);
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(10_000);
+        });
+
+        expect(screen.getByText(/Trying again — attempt 2 of/)).toBeDefined();
+    });
+
+    it('stops reaching once the budget is spent, and hands the way out to the person', async () => {
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+
+        renderApp(servedFrom, heldCredential, deploymentRefusing({ status: 503, body: '' }));
+        await screen.findByText(/Trying again — attempt 1 of/);
+
+        // One pass per wait in the budget, because each attempt is only scheduled once the one before it has answered:
+        // a single long advance would find no timer to fire past the first.
+        for (let attempt = 0; attempt < mostReconnectionAttempts; attempt += 1) {
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(60_000);
+            });
+        }
+
+        expect(await screen.findByText(/Your deployment has not answered after/)).toBeDefined();
+        expect(screen.getByRole('button', { name: 'Try again' })).toBeDefined();
+    });
+
+    it('asks a deployment for nothing while this machine has no network, and says that rather than blaming it', () => {
+        vi.spyOn(window.navigator, 'onLine', 'get').mockReturnValue(false);
+
+        renderApp();
+
+        expect(
+            screen.getByText('This machine is offline. The client reconnects on its own when the network comes back.'),
+        ).toBeDefined();
+        expect(asked).toEqual([]);
+    });
+
+    it('reads again on its own when the network comes back, without anybody restarting the client', async () => {
+        const connected = vi.spyOn(window.navigator, 'onLine', 'get').mockReturnValue(false);
+
+        renderApp();
+        await screen.findByText(/This machine is offline\./);
+
+        connected.mockReturnValue(true);
+        fireEvent(window, new Event('online'));
+
+        await framed();
+    });
+
+    it('offers the next person nothing of the last one until their own grant has been read', async () => {
+        renderApp(servedFrom, null, deploymentAnswering(), storeKeeping());
+        signIn();
+        await framed();
+        expect(screen.getByRole('navigation', { name: 'Spaces' })).toBeDefined();
+
+        // No network from here on, so nothing can arrive to replace what is on the screen: what has to clear it is the
+        // credential changing rather than an answer about the new one.
+        vi.spyOn(window.navigator, 'onLine', 'get').mockReturnValue(false);
+        fireEvent(window, new Event('offline'));
+
+        fireEvent.click(screen.getByRole('button', { name: 'Sign out' }));
+        signIn('somebody', 'else');
+        await screen.findByText(/This machine is offline\./);
+
+        expect(screen.queryByRole('navigation', { name: 'Spaces' })).toBeNull();
+    });
+
+    it('reports the deployment it is reading from beside the client it is running', async () => {
+        renderApp();
+        await framed();
+
+        expect(screen.getByText(`Client ${__MAILFATHOM_VERSION__}, deployment 0.8.7`)).toBeDefined();
+    });
+
+    it('names each account and what its last attempt did, behind the line that summarizes them', async () => {
+        const failing = { ...workAccount, id: 'news', displayName: 'Newsletters', synchronizationState: 'Unreachable' };
+
+        renderApp(servedFrom, heldCredential, deploymentAnswering(directory(true, [workAccount, failing])));
+        await screen.findByText('Some accounts stopped synchronizing.');
+
+        // Scoped to the panel, because the mailbox in scope offers the same names and this is about the freshness
+        // reading rather than about the field beside it.
+        const panel = within(screen.getByRole('group'));
+        expect(panel.getByText('Work')).toBeDefined();
+        expect(panel.getByText('Up to date')).toBeDefined();
+        expect(panel.getByText('Newsletters')).toBeDefined();
+        expect(panel.getByText('The mail server did not answer')).toBeDefined();
+    });
+
+    it('tells an owner holding no account what would fill it, rather than showing a failure', async () => {
+        renderApp(servedFrom, heldCredential, deploymentAnswering(directory(true, [])));
+
+        expect(await screen.findByText(/No mail account is configured for this owner yet\./)).toBeDefined();
+        expect(
+            screen.getByText(/Whoever runs this deployment declares which mailboxes it reads for you/),
+        ).toBeDefined();
     });
 });
 
@@ -628,7 +819,10 @@ describe('App deployment', () => {
         renderApp(chose('https://elsewhere.example.invalid'));
         await framed();
 
-        expect(routesAsked()).toEqual(['https://elsewhere.example.invalid/api/client/accounts']);
+        expect(routesAsked()).toEqual([
+            'https://elsewhere.example.invalid/api/client/session',
+            'https://elsewhere.example.invalid/api/client/accounts',
+        ]);
     });
 
     it('asks for an address when nothing has said where the deployment is', () => {
@@ -780,6 +974,7 @@ describe('App deployment', () => {
         await framed();
 
         expect(routesAsked()).toEqual([
+            'https://first.example.invalid/api/client/session',
             'https://first.example.invalid/api/client/accounts',
             'https://second.example.invalid/api/client/session',
             'https://second.example.invalid/api/client/accounts',

--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -545,11 +545,15 @@ describe('App session', () => {
         const failing = { ...workAccount, id: 'news', displayName: 'Newsletters', synchronizationState: 'Unreachable' };
 
         renderApp(servedFrom, heldCredential, deploymentAnswering(directory(true, [workAccount, failing])));
-        await screen.findByText('Some accounts stopped synchronizing.');
+
+        // The one gesture the design asks for: the reading is closed when the frame is drawn, and this is what a
+        // person does to it.
+        fireEvent.click(await screen.findByText('Some accounts stopped synchronizing.'));
 
         // Scoped to the panel, because the mailbox in scope offers the same names and this is about the freshness
         // reading rather than about the field beside it.
         const panel = within(screen.getByRole('group'));
+        expect(screen.getByRole('group')).toHaveProperty('open', true);
         expect(panel.getByText('Work')).toBeDefined();
         expect(panel.getByText('Up to date')).toBeDefined();
         expect(panel.getByText('Newsletters')).toBeDefined();

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -2,24 +2,22 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import { useEffect, useMemo, useRef, useState } from 'react';
-import {
-    readMailAccounts,
-    type ClientResult,
-    type DeploymentAddress,
-    type MailAccountDirectory,
-} from '@mailfathom/client-backend';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { DeploymentAddress } from '@mailfathom/client-backend';
 import { SecondaryButton } from './controls/SecondaryButton';
 import { forgetDeployment, storeDeployment, type AdoptedDeployment } from './deployment/adoptedDeployment';
 import type { DeploymentTransport } from './deployment/sendToDeployment';
 import { useLocalization } from './localization/useLocalization';
 import { Message } from './messageBody/Message';
 import { useSpace } from './routing/useSpace';
+import { offers, spacesOffered, withheldFrom } from './shell/capabilities';
 import { ConnectionSummary } from './shell/ConnectionSummary';
+import { GrantNotice } from './shell/GrantNotice';
 import { IntentField } from './shell/IntentField';
 import { LanguageChoice, ThemeChoice } from './shell/Preferences';
 import { Space } from './shell/Space';
 import { SpaceNavigation } from './shell/SpaceNavigation';
+import { useConnection } from './shell/useConnection';
 import { CredentialNotices, type CredentialNotice } from './signIn/CredentialNotices';
 import type { CredentialStore } from './signIn/credentialStore';
 import { SignIn } from './signIn/SignIn';
@@ -39,8 +37,9 @@ const provingRead = '00000000-0000-4000-8000-000000000000';
 // That is a screen rather than a state of the frame, because three spaces with nothing behind them are a frame around
 // nothing — and the two halves of the answer are one screen because a person was handed all of it together.
 //
-// What the accounts are read for here is the line above the space and the mailboxes the scope offers. Each account's
-// own freshness and the grants that decide what a space may show are the next stage's.
+// What the frame holds is then the session's answer rather than a fixed set: the deployment says what this credential
+// may do, and a space, a control, or a read it does not permit is absent here instead of present and refused when it
+// is pressed. Enforcing that is the service's; declining to offer it is this frame's.
 
 export function App({
     deployment,
@@ -53,12 +52,9 @@ export function App({
     readonly credentials: CredentialStore;
     readonly send: DeploymentTransport;
 }) {
-    const space = useSpace();
     const { revise } = useWorkspace();
     const [adopted, setAdopted] = useState(deployment);
     const [authorization, setAuthorization] = useState(signedInWith);
-    const [accounts, setAccounts] = useState<ClientResult<MailAccountDirectory> | null>(null);
-    const [attempt, setAttempt] = useState(0);
     const [notices, setNotices] = useState<readonly CredentialNotice[]>([]);
     const baseAddress = adopted === null ? null : adopted.deployment.baseAddress;
     const workspace = useRef<HTMLDivElement>(null);
@@ -98,55 +94,37 @@ export function App({
         }
     }, [authorization]);
 
-    // The session is built from the address and the credential rather than held beside them, which is what makes a
-    // credential unable to outlive the deployment it was presented to: pointing the client somewhere else, or signing
-    // out, runs this again with nothing to present, and there is nowhere for the previous one's session to survive.
-    useEffect(() => {
-        if (baseAddress === null || authorization === null) {
+    // A credential the deployment has stopped accepting is acted on once rather than left to produce the same refusal
+    // on every later read, which is why this is the one failure the frame does not render. What was kept goes with it:
+    // a stored password the service refuses is a password nothing will make work again.
+    //
+    // It is held steady across renders because the connection below reads again whenever it changes, and a callback
+    // rebuilt every render would be a read started every render.
+    const credentialRefused = useCallback(() => {
+        setNotices(['credentialNoLongerAccepted']);
+        setAuthorization(null);
+        revise(emptyWorkspace);
+
+        if (baseAddress === null) {
             return;
         }
 
-        const attempted = new AbortController();
-        let listening = true;
-
-        void readMailAccounts({ baseAddress, authorization }, send(attempted.signal)).then((answer) => {
-            if (!listening) {
-                return;
+        void credentials.forget({ baseAddress }).then((removed) => {
+            if (!removed) {
+                setNotices((shown) => [...shown, 'passwordNotRemoved']);
             }
-
-            // A credential the deployment has stopped accepting is acted on once rather than left to produce the same
-            // refusal on every later read, which is why this is the one failure the frame does not render. What was
-            // kept goes with it: a stored password the service refuses is a password nothing will make work again.
-            if (answer.outcome === 'failed' && answer.failure.reason === 'unauthenticated') {
-                setNotices(['credentialNoLongerAccepted']);
-                setAuthorization(null);
-                setAccounts(null);
-                revise(emptyWorkspace);
-
-                void credentials.forget({ baseAddress }).then((removed) => {
-                    if (!removed) {
-                        setNotices((shown) => [...shown, 'passwordNotRemoved']);
-                    }
-                });
-
-                return;
-            }
-
-            setAccounts(answer);
         });
+    }, [baseAddress, credentials, revise]);
 
-        return () => {
-            listening = false;
-            attempted.abort();
-        };
-    }, [baseAddress, authorization, attempt, credentials, revise, send]);
-
-    // Reading again is a new attempt rather than a second copy of the read above: the effect owns the cancellation, so
-    // the retry only says that the answer it holds is stale.
-    function reread(): void {
-        setAccounts(null);
-        setAttempt((previous) => previous + 1);
-    }
+    // What the deployment says is read from the address and the credential rather than held beside them, which is what
+    // makes a credential unable to outlive the deployment it was presented to: pointing the client somewhere else, or
+    // signing out, runs this again with nothing to present, and nothing of the previous one's answers survives it.
+    const connection = useConnection(baseAddress, authorization, send, credentialRefused);
+    const deploymentSession = connection.session?.outcome === 'read' ? connection.session.value : null;
+    const offeredSpaces = deploymentSession === null ? [] : spacesOffered(deploymentSession);
+    const space = useSpace(offeredSpaces);
+    const withheld = deploymentSession === null ? [] : withheldFrom(deploymentSession);
+    const mailAccounts = connection.accounts?.outcome === 'read' ? connection.accounts.value.accounts : [];
 
     function signedIn(reached: DeploymentAddress, presented: string): void {
         if (adopted === null) {
@@ -164,7 +142,6 @@ export function App({
                 setNotices(['passwordNotKept']);
             }
         });
-        setAccounts(null);
         setAuthorization(presented);
     }
 
@@ -177,7 +154,6 @@ export function App({
     // the person believes they signed out.
     function signOut(): void {
         setNotices([]);
-        setAccounts(null);
         setAuthorization(null);
         revise(emptyWorkspace);
 
@@ -214,14 +190,14 @@ export function App({
         <div className="flex h-dvh flex-col bg-rail pt-safe-top pr-safe-right pb-safe-bottom pl-safe-left workspace:flex-row">
             <div ref={workspace} tabIndex={-1} className="flex min-h-0 min-w-0 flex-1 flex-col bg-page">
                 <header className="flex flex-wrap items-center gap-3 border-b border-line-soft bg-panel px-4 py-2 workspace:px-8">
-                    <ConnectionSummary accounts={accounts} reread={reread} />
+                    <ConnectionSummary connection={connection} />
 
                     {adopted?.chosen === true ? (
                         <ChosenDeployment address={baseAddress} onChange={pointSomewhereElse} />
                     ) : null}
 
                     <div className="ms-auto flex items-center gap-2">
-                        <p className="font-mono text-xs text-faint">{__MAILFATHOM_VERSION__}</p>
+                        <Versions deployment={deploymentSession?.version ?? null} />
                         <ThemeChoice />
                         <LanguageChoice />
                         <SignOut onSignOut={signOut} />
@@ -230,23 +206,36 @@ export function App({
 
                 {/* Inside the frame as well as on the sign-in screen, because a credential that could not be kept is
                     learned about at the moment somebody successfully signed in — which is the one of these sentences
-                    whose reader is already past that screen. */}
-                {notices.length === 0 ? null : (
-                    <div className="border-b border-line-soft bg-panel px-4 py-2 workspace:px-8">
+                    whose reader is already past that screen. Beside it, and in the same strip, is what this credential
+                    may not do: both are statements about the credential rather than about anything it read. */}
+                {notices.length === 0 && withheld.length === 0 ? null : (
+                    <div className="flex flex-col gap-2 border-b border-line-soft bg-panel px-4 py-2 workspace:px-8">
                         <CredentialNotices notices={notices} />
+                        <GrantNotice withheld={withheld} />
                     </div>
                 )}
 
-                <IntentField accounts={accounts?.outcome === 'read' ? accounts.value.accounts : []} />
+                {/* Asking is what the field is for, so a credential that may not ask is not shown one. It is absent
+                    rather than disabled: a control nobody can use says less about why than the sentence above does. */}
+                {deploymentSession !== null && offers(deploymentSession, 'askMail') ? (
+                    <IntentField accounts={mailAccounts} />
+                ) : null}
 
-                <Space
-                    space={space}
-                    mail={
-                        session === null ? null : (
-                            <Message session={session} transport={readMessage} storedEmailId={provingRead} />
-                        )
-                    }
-                />
+                {/* The region the space is drawn in is there before the deployment says which space that is, so
+                    nothing on the screen moves under a reader when the answer arrives. What is waiting is said once,
+                    above, where the answer will appear rather than twice. */}
+                {space === null ? (
+                    <main className="flex-1" />
+                ) : (
+                    <Space
+                        space={space}
+                        mail={
+                            session === null ? null : (
+                                <Message session={session} transport={readMessage} storedEmailId={provingRead} />
+                            )
+                        }
+                    />
+                )}
             </div>
 
             {/* Navigation is last in the document because the keyboard follows the document rather than the layout,
@@ -255,8 +244,23 @@ export function App({
                 composition then carries the one mismatch CSS cannot remove — a rail drawn on the left out of a node
                 that comes last — because no single document order matches both shapes, and content before navigation
                 is the direction a skip link exists to manufacture rather than the one it works around. */}
-            <SpaceNavigation current={space} />
+            {space === null ? null : <SpaceNavigation offered={offeredSpaces} current={space} />}
         </div>
+    );
+}
+
+// What the client is running and what the deployment it is reading from is running, beside each other because a
+// mismatch between them is the first thing to look at when a screen behaves oddly. The client's own is substituted
+// into the bundle at build time rather than retyped, and the deployment's is what the session route answered.
+function Versions({ deployment }: { readonly deployment: string | null }) {
+    const { translate } = useLocalization();
+
+    return (
+        <p className="font-mono text-xs text-faint">
+            {deployment === null
+                ? translate('shell.clientVersion', { client: __MAILFATHOM_VERSION__ })
+                : translate('shell.versions', { client: __MAILFATHOM_VERSION__, deployment })}
+        </p>
     );
 }
 

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -16,6 +16,8 @@ export const en = {
     'shell.theme': 'Theme',
     'shell.spaces': 'Spaces',
     'shell.signOut': 'Sign out',
+    'shell.clientVersion': 'Client {client}',
+    'shell.versions': 'Client {client}, deployment {deployment}',
 
     'theme.system': 'Follow the system',
     'theme.light': 'Light',
@@ -79,14 +81,37 @@ export const en = {
     'deployment.change': 'Point somewhere else',
 
     'accounts.reading': 'Reading accounts…',
-    'accounts.notRefreshing': 'This deployment is not refreshing the local copy of these accounts.',
+    'accounts.notRefreshing':
+        'This deployment is not refreshing the local copy of these accounts, so what you see is as current as its last run left it. That is a setting on the deployment rather than a permission you are missing.',
     'accounts.failed': 'The accounts could not be read: {reason}.',
+    'accounts.oldest': 'The oldest of these was last refreshed {age}.',
+    'accounts.noneDeclared':
+        'Whoever runs this deployment declares which mailboxes it reads for you, and none is declared yet.',
+
+    'account.synchronized': 'Up to date',
+    'account.behind': 'Catching up',
+    'account.failing': 'Stopped synchronizing',
+    'account.unreachable': 'The mail server did not answer',
+    'account.neverSynchronized': 'Nothing taken in yet',
+    'account.lastRefreshed': 'Last refreshed {age}',
+    'account.neverRefreshed': 'Never refreshed',
 
     'connection.current': 'Every account is up to date.',
     'connection.behind': 'Some accounts are behind.',
     'connection.failing': 'Some accounts stopped synchronizing.',
     'connection.noAccounts': 'No mail account is configured for this owner yet.',
     'connection.retry': 'Try again',
+    'connection.connecting': 'Reaching your deployment…',
+    'connection.reconnecting': 'Your deployment did not answer. Trying again — attempt {attempt} of {total}.',
+    'connection.lost': 'Your deployment has not answered after {total} attempts.',
+    'connection.unreadable': 'Your deployment answered, but this client could not act on the answer: {reason}.',
+    'connection.offline': 'This machine is offline. The client reconnects on its own when the network comes back.',
+
+    'grant.heading': 'What this credential may not do here',
+    'grant.readMail':
+        'This credential may not read mail on this deployment, so no mailbox and no message is shown. Whoever runs the deployment can grant that.',
+    'grant.askMail':
+        'This credential may not ask questions of your mail on this deployment, so asking is not offered. Whoever runs the deployment can grant that.',
 
     'failure.unauthenticated': 'unauthenticated',
     'failure.unauthorized': 'unauthorized',

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -15,6 +15,8 @@ export const pl: Catalogue = {
     'shell.theme': 'Motyw',
     'shell.spaces': 'Przestrzenie',
     'shell.signOut': 'Wyloguj się',
+    'shell.clientVersion': 'Klient {client}',
+    'shell.versions': 'Klient {client}, wdrożenie {deployment}',
 
     'theme.system': 'Zgodnie z systemem',
     'theme.light': 'Jasny',
@@ -79,14 +81,37 @@ export const pl: Catalogue = {
     'deployment.change': 'Wskaż inne wdrożenie',
 
     'accounts.reading': 'Odczytywanie kont…',
-    'accounts.notRefreshing': 'To wdrożenie nie odświeża lokalnej kopii tych kont.',
+    'accounts.notRefreshing':
+        'To wdrożenie nie odświeża lokalnej kopii tych kont, więc widzisz je w takim stanie, w jakim zostawił je jego ostatni przebieg. To ustawienie wdrożenia, a nie brakujące Ci uprawnienie.',
     'accounts.failed': 'Nie udało się odczytać kont: {reason}.',
+    'accounts.oldest': 'Najstarsze z nich odświeżono {age}.',
+    'accounts.noneDeclared':
+        'To osoba prowadząca to wdrożenie wskazuje skrzynki, które są dla Ciebie odczytywane, a nie wskazano jeszcze żadnej.',
+
+    'account.synchronized': 'Aktualne',
+    'account.behind': 'Nadrabia zaległości',
+    'account.failing': 'Przestało się synchronizować',
+    'account.unreachable': 'Serwer pocztowy nie odpowiedział',
+    'account.neverSynchronized': 'Nic jeszcze nie pobrano',
+    'account.lastRefreshed': 'Ostatnio odświeżono {age}',
+    'account.neverRefreshed': 'Nigdy nie odświeżono',
 
     'connection.current': 'Wszystkie konta są aktualne.',
     'connection.behind': 'Część kont ma zaległości.',
     'connection.failing': 'Część kont przestała się synchronizować.',
     'connection.noAccounts': 'Dla tego właściciela nie skonfigurowano jeszcze żadnego konta pocztowego.',
     'connection.retry': 'Spróbuj ponownie',
+    'connection.connecting': 'Łączenie z Twoim wdrożeniem…',
+    'connection.reconnecting': 'Twoje wdrożenie nie odpowiedziało. Próbujemy ponownie — próba {attempt} z {total}.',
+    'connection.lost': 'Twoje wdrożenie nie odpowiedziało po {total} próbach.',
+    'connection.unreadable': 'Twoje wdrożenie odpowiedziało, ale klient nie mógł wykorzystać tej odpowiedzi: {reason}.',
+    'connection.offline': 'Ta maszyna nie ma połączenia z siecią. Klient połączy się ponownie sam, gdy sieć wróci.',
+
+    'grant.heading': 'Czego to poświadczenie nie może tutaj zrobić',
+    'grant.readMail':
+        'To poświadczenie nie może odczytywać poczty w tym wdrożeniu, więc nie pokazujemy żadnej skrzynki ani wiadomości. Osoba prowadząca wdrożenie może nadać takie uprawnienie.',
+    'grant.askMail':
+        'To poświadczenie nie może zadawać pytań Twojej poczcie w tym wdrożeniu, więc nie oferujemy pytania. Osoba prowadząca wdrożenie może nadać takie uprawnienie.',
 
     'failure.unauthenticated': 'brak uwierzytelnienia',
     'failure.unauthorized': 'brak uprawnień',

--- a/frontend/src/Client.App/src/routing/useSpace.ts
+++ b/frontend/src/Client.App/src/routing/useSpace.ts
@@ -23,21 +23,32 @@ function currentAddress(): string {
 
 /**
  * The space the address names, re-read whenever it changes — including when the browser moves back to an earlier one.
- * An address naming no space is written back to the one actually being shown, so the two never disagree.
+ * An address naming no space, or naming one this credential is not offered, is written back to the one actually being
+ * shown, so the two never disagree and a bookmarked address is answered rather than left standing over a blank frame.
+ *
+ * @param offered The spaces this credential may open, which the session decides and which is empty while it is unknown.
+ * @returns The space to render, or `null` where there is none to render — a grant carrying nothing among them.
  */
-export function useSpace(): Space {
+export function useSpace(offered: readonly Space[]): Space | null {
     const address = useSyncExternalStore(subscribeToAddress, currentAddress);
-    const space = spaceAt(address) ?? defaultSpace;
+    const named = spaceAt(address);
+    const space = named !== null && offered.includes(named) ? named : (fallbackAmong(offered) ?? null);
 
     // Replaced rather than pushed: a first load at the root, or a fragment nobody answers, would otherwise leave the
-    // back gesture landing on an address that immediately corrects itself again.
+    // back gesture landing on an address that immediately corrects itself again. Nothing is written while the offered
+    // spaces are unknown, so an address somebody arrived at survives the session being read.
     useEffect(() => {
-        if (spaceAt(address) === null) {
+        if (space !== null && named !== space) {
             window.history.replaceState(null, '', addressOf(space));
         }
-    }, [address, space]);
+    }, [address, named, space]);
 
     return space;
+}
+
+/** Where the client opens among what it may open: its own default where that is offered, else the first that is. */
+function fallbackAmong(offered: readonly Space[]): Space | undefined {
+    return offered.includes(defaultSpace) ? defaultSpace : offered[0];
 }
 
 /**

--- a/frontend/src/Client.App/src/shell/AccountLine.tsx
+++ b/frontend/src/Client.App/src/shell/AccountLine.tsx
@@ -1,0 +1,42 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { MailAccount, MailSynchronizationState } from '@mailfathom/client-backend';
+import type { MessageKey } from '../localization/en';
+import { useLocalization } from '../localization/useLocalization';
+import { ageOf } from './synchronizationAge';
+
+// One account, and how current the deployment's copy of it is. It is its own component because it is the row of a list
+// and because the three facts on it answer different questions: what the last finished attempt did, whether mail was
+// left behind by it, and when anything was last taken in.
+
+const stateLabels: Readonly<Record<MailSynchronizationState, MessageKey>> = {
+    Synchronized: 'account.synchronized',
+    Failing: 'account.failing',
+    Unreachable: 'account.unreachable',
+    NeverSynchronized: 'account.neverSynchronized',
+};
+
+// An account nothing is fixing is read before one that is merely catching up, for the reason the summary above the
+// list reads them in that order: "behind" would let a mailbox nobody is refreshing wait unnoticed.
+function stateOf(account: MailAccount): MessageKey {
+    return account.synchronizationState === 'Synchronized' && account.behind
+        ? 'account.behind'
+        : stateLabels[account.synchronizationState];
+}
+
+export function AccountLine({ account, readAt }: { readonly account: MailAccount; readonly readAt: Date }) {
+    const { locale, translate } = useLocalization();
+    const age = ageOf(account.lastSynchronizedAt, readAt, locale);
+
+    return (
+        <li className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+            <span className="font-medium text-text">{account.displayName}</span>
+            <span className="text-muted">{translate(stateOf(account))}</span>
+            <span className="text-faint">
+                {age === null ? translate('account.neverRefreshed') : translate('account.lastRefreshed', { age })}
+            </span>
+        </li>
+    );
+}

--- a/frontend/src/Client.App/src/shell/ConnectionSummary.test.tsx
+++ b/frontend/src/Client.App/src/shell/ConnectionSummary.test.tsx
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import type {
     ClientFailureReason,
@@ -75,6 +75,14 @@ function renderSummary(connection: Partial<Connection>): void {
 /** The accounts read and on the screen, which is the shape every freshness assertion below is made against. */
 function showing(accounts: ClientResult<MailAccountDirectory>): Partial<Connection> {
     return { session: reading, accounts, readAt };
+}
+
+/**
+ * The one gesture the design asks for. The account-by-account reading sits behind a disclosure that is closed when the
+ * screen is drawn, so a test asserting on a row opens it exactly as a person would rather than reading through it.
+ */
+function reveal(freshness: string): void {
+    fireEvent.click(screen.getByText(freshness));
 }
 
 /** The age a person reads, asked of `Intl` the way the screen asks it rather than spelled out here. */
@@ -194,8 +202,20 @@ describe('ConnectionSummary', () => {
         ).toBeDefined();
     });
 
+    it('keeps the account-by-account reading behind the line that summarizes them until it is asked for', () => {
+        renderSummary(showing(directory(true, [workAccount])));
+
+        expect(screen.getByRole('group')).not.toHaveProperty('open', true);
+
+        reveal('Every account is up to date.');
+
+        expect(screen.getByRole('group')).toHaveProperty('open', true);
+    });
+
     it('names each account and when it was last refreshed, behind the line that summarizes them', () => {
         renderSummary(showing(directory(true, [workAccount, unreachableAccount])));
+
+        reveal('Some accounts stopped synchronizing.');
 
         expect(screen.getByText('Work')).toBeDefined();
         expect(screen.getByText('Up to date')).toBeDefined();
@@ -213,12 +233,16 @@ describe('ConnectionSummary', () => {
 
         renderSummary(showing(directory(true, [fresh])));
 
+        reveal('Some accounts are behind.');
+
         expect(screen.getByText('Nothing taken in yet')).toBeDefined();
         expect(screen.getByText('Never refreshed')).toBeDefined();
     });
 
     it('reads an account that is merely catching up as that rather than as one that stopped', () => {
         renderSummary(showing(directory(true, [archiveAccount])));
+
+        reveal('Some accounts are behind.');
 
         expect(screen.getByText('Catching up')).toBeDefined();
     });
@@ -227,6 +251,8 @@ describe('ConnectionSummary', () => {
         const older: MailAccount = { ...archiveAccount, lastSynchronizedAt: '2026-08-29T12:41:00+00:00' };
 
         renderSummary(showing(directory(true, [workAccount, older])));
+
+        reveal('Some accounts are behind.');
 
         expect(screen.getByText(`The oldest of these was last refreshed ${ageIn(-2, 'day')}.`)).toBeDefined();
     });

--- a/frontend/src/Client.App/src/shell/ConnectionSummary.test.tsx
+++ b/frontend/src/Client.App/src/shell/ConnectionSummary.test.tsx
@@ -4,9 +4,20 @@
 
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import type { ClientResult, MailAccount, MailAccountDirectory } from '@mailfathom/client-backend';
+import type {
+    ClientFailureReason,
+    ClientResult,
+    DeploymentSession,
+    MailAccount,
+    MailAccountDirectory,
+} from '@mailfathom/client-backend';
 import { LocalizationProvider } from '../localization/Localization';
 import { ConnectionSummary } from './ConnectionSummary';
+import { mostReconnectionAttempts, type Connection } from './useConnection';
+
+// When the answers on the screen were read, which every age beside an account is measured from. Handed in rather than
+// taken off a clock, so what a test asserts is what a person reads rather than what day the suite ran on.
+const readAt = new Date('2026-08-31T12:41:00Z');
 
 const workAccount: MailAccount = {
     id: 'work',
@@ -27,6 +38,11 @@ const failingAccount: MailAccount = {
 
 const unreachableAccount: MailAccount = { ...failingAccount, synchronizationState: 'Unreachable' };
 
+const reading: ClientResult<DeploymentSession> = {
+    outcome: 'read',
+    value: { version: '0.8.7', permissions: ['mailfathom.mail.read'] },
+};
+
 function directory(
     synchronizationEnabled: boolean,
     accounts: readonly MailAccount[],
@@ -34,66 +50,189 @@ function directory(
     return { outcome: 'read', value: { synchronizationEnabled, accounts } };
 }
 
-function renderSummary(accounts: ClientResult<MailAccountDirectory> | null): void {
+function failing(reason: ClientFailureReason, status: number | null = 503): ClientResult<never> {
+    return { outcome: 'failed', failure: { reason, status } };
+}
+
+function renderSummary(connection: Partial<Connection>): void {
     render(
         <LocalizationProvider>
-            <ConnectionSummary accounts={accounts} reread={() => undefined} />
+            <ConnectionSummary
+                connection={{
+                    session: reading,
+                    accounts: null,
+                    readAt: null,
+                    online: true,
+                    attempts: 0,
+                    reread: () => undefined,
+                    ...connection,
+                }}
+            />
         </LocalizationProvider>,
     );
 }
 
+/** The accounts read and on the screen, which is the shape every freshness assertion below is made against. */
+function showing(accounts: ClientResult<MailAccountDirectory>): Partial<Connection> {
+    return { session: reading, accounts, readAt };
+}
+
+/** The age a person reads, asked of `Intl` the way the screen asks it rather than spelled out here. */
+function ageIn(value: number, unit: Intl.RelativeTimeFormatUnit): string {
+    return new Intl.RelativeTimeFormat('en', { numeric: 'auto' }).format(value, unit);
+}
+
 describe('ConnectionSummary', () => {
-    it('says it is reading while the answer has not arrived', () => {
-        renderSummary(null);
+    it('says it is reaching the deployment before anything has answered', () => {
+        renderSummary({ session: null });
+
+        expect(screen.getByText('Reaching your deployment…')).toBeDefined();
+    });
+
+    it('says this machine is offline rather than blaming a deployment it never asked', () => {
+        renderSummary({ session: null, online: false });
+
+        expect(
+            screen.getByText('This machine is offline. The client reconnects on its own when the network comes back.'),
+        ).toBeDefined();
+    });
+
+    it('says which attempt it is on while it reaches for a deployment that did not answer', () => {
+        renderSummary({ session: null, attempts: 2 });
+
+        expect(
+            screen.getByText(
+                `Your deployment did not answer. Trying again — attempt 2 of ${String(mostReconnectionAttempts)}.`,
+            ),
+        ).toBeDefined();
+    });
+
+    it('says another attempt is coming while the budget for one is left, and offers nothing to press', () => {
+        renderSummary({ session: failing('unavailable'), attempts: 0 });
+
+        expect(screen.getByText(/Trying again — attempt 1 of/)).toBeDefined();
+        expect(screen.queryByRole('button', { name: 'Try again' })).toBeNull();
+    });
+
+    it('offers the way out once it has stopped trying on its own', () => {
+        renderSummary({ session: failing('unavailable'), attempts: mostReconnectionAttempts });
+
+        expect(
+            screen.getByText(`Your deployment has not answered after ${String(mostReconnectionAttempts)} attempts.`),
+        ).toBeDefined();
+        expect(screen.getByRole('button', { name: 'Try again' })).toBeDefined();
+    });
+
+    it('names a session answer it could not read, and offers no attempt that would repeat it', () => {
+        renderSummary({ session: failing('unreadable', 200) });
+
+        expect(
+            screen.getByText('Your deployment answered, but this client could not act on the answer: unreadable.'),
+        ).toBeDefined();
+        expect(screen.queryByRole('button', { name: 'Try again' })).toBeNull();
+    });
+
+    it('says nothing about freshness where the credential may not read mail, that being said elsewhere', () => {
+        renderSummary({ session: { outcome: 'read', value: { version: '0.8.7', permissions: [] } } });
+
+        expect(screen.queryByText(/account/i)).toBeNull();
+    });
+
+    it('says it is reading while the accounts have not arrived', () => {
+        renderSummary({ session: reading, accounts: null });
 
         expect(screen.getByText('Reading accounts…')).toBeDefined();
     });
 
     it('says every account is current when none of them is behind', () => {
-        renderSummary(directory(true, [workAccount]));
+        renderSummary(showing(directory(true, [workAccount])));
 
         expect(screen.getByText('Every account is up to date.')).toBeDefined();
     });
 
     it('says some accounts are behind when one of them is', () => {
-        renderSummary(directory(true, [workAccount, archiveAccount]));
+        renderSummary(showing(directory(true, [workAccount, archiveAccount])));
 
         expect(screen.getByText('Some accounts are behind.')).toBeDefined();
     });
 
     it('says an account stopped synchronizing rather than reporting it as merely behind', () => {
-        renderSummary(directory(true, [workAccount, failingAccount]));
+        renderSummary(showing(directory(true, [workAccount, failingAccount])));
 
         expect(screen.getByText('Some accounts stopped synchronizing.')).toBeDefined();
         expect(screen.queryByText('Some accounts are behind.')).toBeNull();
     });
 
     it('reads an account it cannot reach the same way as one that is failing', () => {
-        renderSummary(directory(true, [workAccount, unreachableAccount]));
+        renderSummary(showing(directory(true, [workAccount, unreachableAccount])));
 
         expect(screen.getByText('Some accounts stopped synchronizing.')).toBeDefined();
     });
 
     it('says an account stopped synchronizing even where another is only behind', () => {
-        renderSummary(directory(true, [archiveAccount, failingAccount]));
+        renderSummary(showing(directory(true, [archiveAccount, failingAccount])));
 
         expect(screen.getByText('Some accounts stopped synchronizing.')).toBeDefined();
     });
 
-    it('says the deployment is not refreshing these accounts when it is not', () => {
-        renderSummary(directory(false, [workAccount]));
+    it('says the deployment is not refreshing these accounts as its own setting rather than a missing grant', () => {
+        renderSummary(showing(directory(false, [workAccount])));
 
-        expect(screen.getByText('This deployment is not refreshing the local copy of these accounts.')).toBeDefined();
+        expect(
+            screen.getByText(
+                'This deployment is not refreshing the local copy of these accounts, so what you see is as current as its last run left it. That is a setting on the deployment rather than a permission you are missing.',
+            ),
+        ).toBeDefined();
     });
 
-    it('tells an owner holding no account that, rather than showing a failure', () => {
-        renderSummary(directory(true, []));
+    it('tells an owner holding no account that, and what would fill it, rather than showing a failure', () => {
+        renderSummary(showing(directory(true, [])));
 
-        expect(screen.getByText('No mail account is configured for this owner yet.')).toBeDefined();
+        expect(screen.getByText(/No mail account is configured for this owner yet\./)).toBeDefined();
+        expect(
+            screen.getByText(/Whoever runs this deployment declares which mailboxes it reads for you/),
+        ).toBeDefined();
+    });
+
+    it('names each account and when it was last refreshed, behind the line that summarizes them', () => {
+        renderSummary(showing(directory(true, [workAccount, unreachableAccount])));
+
+        expect(screen.getByText('Work')).toBeDefined();
+        expect(screen.getByText('Up to date')).toBeDefined();
+        expect(screen.getByText('Newsletters')).toBeDefined();
+        expect(screen.getByText('The mail server did not answer')).toBeDefined();
+        expect(screen.getAllByText(`Last refreshed ${ageIn(-3, 'hour')}`)).toHaveLength(2);
+    });
+
+    it('reads an account that has never synchronized as one with no time on it', () => {
+        const fresh: MailAccount = {
+            ...workAccount,
+            synchronizationState: 'NeverSynchronized',
+            lastSynchronizedAt: null,
+        };
+
+        renderSummary(showing(directory(true, [fresh])));
+
+        expect(screen.getByText('Nothing taken in yet')).toBeDefined();
+        expect(screen.getByText('Never refreshed')).toBeDefined();
+    });
+
+    it('reads an account that is merely catching up as that rather than as one that stopped', () => {
+        renderSummary(showing(directory(true, [archiveAccount])));
+
+        expect(screen.getByText('Catching up')).toBeDefined();
+    });
+
+    it('says how long ago the least recently refreshed of them took anything in', () => {
+        const older: MailAccount = { ...archiveAccount, lastSynchronizedAt: '2026-08-29T12:41:00+00:00' };
+
+        renderSummary(showing(directory(true, [workAccount, older])));
+
+        expect(screen.getByText(`The oldest of these was last refreshed ${ageIn(-2, 'day')}.`)).toBeDefined();
     });
 
     it('names why the accounts could not be read, and offers the way out', () => {
-        renderSummary({ outcome: 'failed', failure: { reason: 'unavailable', status: 503 } });
+        renderSummary({ session: reading, accounts: failing('unavailable'), readAt });
 
         expect(screen.getByText(/The accounts could not be read: unavailable\./)).toBeDefined();
         expect(screen.getByRole('button', { name: 'Try again' })).toBeDefined();
@@ -102,7 +241,7 @@ describe('ConnectionSummary', () => {
     it.each(['unauthenticated', 'unauthorized', 'unreadable'] as const)(
         'still says what failed at a %s failure, and offers no second attempt that would repeat it',
         (reason) => {
-            renderSummary({ outcome: 'failed', failure: { reason, status: 401 } });
+            renderSummary({ session: reading, accounts: failing(reason, 401), readAt });
 
             expect(screen.getByText(/The accounts could not be read:/)).toBeDefined();
             expect(screen.queryByRole('button', { name: 'Try again' })).toBeNull();
@@ -110,7 +249,7 @@ describe('ConnectionSummary', () => {
     );
 
     it('puts no status code on the screen', () => {
-        renderSummary({ outcome: 'failed', failure: { reason: 'unavailable', status: 503 } });
+        renderSummary({ session: reading, accounts: failing('unavailable'), readAt });
 
         expect(screen.queryByText(/503/)).toBeNull();
     });

--- a/frontend/src/Client.App/src/shell/ConnectionSummary.tsx
+++ b/frontend/src/Client.App/src/shell/ConnectionSummary.tsx
@@ -3,18 +3,22 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import type { ReactNode } from 'react';
-import type {
-    ClientFailureReason,
-    ClientResult,
-    MailAccountDirectory,
-    MailSynchronizationState,
-} from '@mailfathom/client-backend';
+import type { ClientFailureReason, MailAccountDirectory, MailSynchronizationState } from '@mailfathom/client-backend';
 import { SecondaryButton } from '../controls/SecondaryButton';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
+import { AccountLine } from './AccountLine';
+import { offers } from './capabilities';
+import { ageOf } from './synchronizationAge';
+import { mostReconnectionAttempts, type Connection } from './useConnection';
 
-// The line above every space saying what the client is looking at and how current it is. It summarizes rather than
-// enumerates: what each account was last synchronized at, and what a grant allows, is read by the space that shows it.
+// The line above every space saying what the client is looking at and how current it is, and the short panel behind it
+// naming each account. Three different things blur into one spinner unless they are kept apart, so each has its own
+// sentence: whether this client can reach its deployment at all, whether that deployment is refreshing these accounts,
+// and when each of them last took mail in.
+//
+// A credential that may not read mail says nothing here. There is no freshness to report and the reason is not about
+// this line, so it is said once, where everything this credential may not do is said.
 
 const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
     unauthenticated: 'failure.unauthenticated',
@@ -62,17 +66,60 @@ function freshnessOf(directory: MailAccountDirectory): Freshness {
         : { message: 'connection.behind', tone: 'attention' };
 }
 
-export function ConnectionSummary({
-    accounts,
-    reread,
-}: {
-    readonly accounts: ClientResult<MailAccountDirectory> | null;
-    readonly reread: () => void;
-}) {
-    const { translate } = useLocalization();
+/** The instant the least recently refreshed account last took mail in, or `null` where none of them ever has. */
+function oldestSynchronization(directory: MailAccountDirectory): string | null {
+    return directory.accounts.reduce<string | null>((oldest, account) => {
+        const at = account.lastSynchronizedAt;
 
-    if (accounts === null) {
-        return <Line tone="quiet">{translate('accounts.reading')}</Line>;
+        if (at === null) {
+            return oldest;
+        }
+
+        return oldest === null || Date.parse(at) < Date.parse(oldest) ? at : oldest;
+    }, null);
+}
+
+export function ConnectionSummary({ connection }: { readonly connection: Connection }) {
+    const { locale, translate } = useLocalization();
+    const { session, accounts, readAt, online, attempts, reread } = connection;
+
+    // Nothing is being read and nothing will be until the network comes back, which is a different sentence from a
+    // deployment that is not answering: one of them is this machine's to fix and the other is not.
+    if (!online) {
+        return (
+            <Line tone="attention" announced>
+                {translate('connection.offline')}
+            </Line>
+        );
+    }
+
+    if (session === null) {
+        return (
+            <Line tone="quiet" announced>
+                {attempts === 0
+                    ? translate('connection.connecting')
+                    : translate('connection.reconnecting', {
+                          attempt: formatCount(locale, attempts),
+                          total: formatCount(locale, mostReconnectionAttempts),
+                      })}
+            </Line>
+        );
+    }
+
+    if (session.outcome === 'failed') {
+        return <Unreachable failure={session.failure.reason} attempts={attempts} reread={reread} />;
+    }
+
+    if (!offers(session.value, 'readMail')) {
+        return null;
+    }
+
+    if (accounts === null || readAt === null) {
+        return (
+            <Line tone="quiet" announced>
+                {translate('accounts.reading')}
+            </Line>
+        );
     }
 
     if (accounts.outcome === 'failed') {
@@ -92,15 +139,104 @@ export function ConnectionSummary({
         );
     }
 
-    const freshness = freshnessOf(accounts.value);
+    const directory = accounts.value;
+    const freshness = freshnessOf(directory);
 
-    return <Line tone={freshness.tone}>{translate(freshness.message)}</Line>;
+    // An owner holding no account is told so and told what would fill it, rather than being handed a disclosure with
+    // nothing behind it. Everything else opens onto the account-by-account reading of the same sentence.
+    if (directory.accounts.length === 0) {
+        return (
+            <Line tone={freshness.tone}>
+                {translate(freshness.message)} {translate('accounts.noneDeclared')}
+            </Line>
+        );
+    }
+
+    const oldest = ageOf(oldestSynchronization(directory), readAt, locale);
+
+    return (
+        <details className="text-sm text-muted">
+            <summary className="flex cursor-pointer items-center gap-2">
+                <Dot tone={freshness.tone} />
+                {translate(freshness.message)}
+            </summary>
+
+            <div className="mt-2 flex flex-col gap-2 rounded-lg bg-sunken px-3 py-2">
+                {oldest === null ? null : <p>{translate('accounts.oldest', { age: oldest })}</p>}
+
+                <ul className="flex flex-col gap-1">
+                    {directory.accounts.map((account) => (
+                        <AccountLine key={account.id} account={account} readAt={readAt} />
+                    ))}
+                </ul>
+            </div>
+        </details>
+    );
 }
 
-function Line({ tone, children }: { readonly tone: Tone; readonly children: ReactNode }) {
+// A deployment that did not answer is reached for again on its own, so what this says is which of those two moments it
+// is: another attempt is coming, or the budget is spent and it is a person's turn to ask. Every other failure of the
+// session read repeats identically however often it is asked, so it is named and offers nothing.
+function Unreachable({
+    failure,
+    attempts,
+    reread,
+}: {
+    readonly failure: ClientFailureReason;
+    readonly attempts: number;
+    readonly reread: () => void;
+}) {
+    const { locale, translate } = useLocalization();
+    const total = formatCount(locale, mostReconnectionAttempts);
+
+    // What could not be read here is the session rather than the accounts, and the sentence says so: an answer this
+    // client cannot act on is a different situation from a deployment that would not give up the mailboxes.
+    if (failure !== 'unavailable') {
+        return (
+            <Line tone="attention">
+                {translate('connection.unreadable', { reason: translate(failureLabels[failure]) })}
+            </Line>
+        );
+    }
+
+    if (attempts < mostReconnectionAttempts) {
+        return (
+            <Line tone="attention" announced>
+                {translate('connection.reconnecting', { attempt: formatCount(locale, attempts + 1), total })}
+            </Line>
+        );
+    }
+
     return (
-        <p className="flex items-center gap-2 text-sm text-muted">
-            <span aria-hidden="true" className={`size-2 shrink-0 rounded-full ${toneColours[tone]}`} />
+        <Line tone="attention">
+            {translate('connection.lost', { total })}
+            <SecondaryButton label={translate('connection.retry')} onActivate={reread} />
+        </Line>
+    );
+}
+
+// Small whole numbers, formatted rather than interpolated, for the reason no date is spelled into a catalogue: which
+// digits a language writes is `Intl`'s answer rather than JavaScript's default one.
+function formatCount(locale: string, count: number): string {
+    return new Intl.NumberFormat(locale).format(count);
+}
+
+function Dot({ tone }: { readonly tone: Tone }) {
+    return <span aria-hidden="true" className={`size-2 shrink-0 rounded-full ${toneColours[tone]}`} />;
+}
+
+function Line({
+    tone,
+    announced = false,
+    children,
+}: {
+    readonly tone: Tone;
+    readonly announced?: boolean;
+    readonly children: ReactNode;
+}) {
+    return (
+        <p className="flex items-center gap-2 text-sm text-muted" role={announced ? 'status' : undefined}>
+            <Dot tone={tone} />
             {children}
         </p>
     );

--- a/frontend/src/Client.App/src/shell/GrantNotice.tsx
+++ b/frontend/src/Client.App/src/shell/GrantNotice.tsx
@@ -1,0 +1,38 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { MessageKey } from '../localization/en';
+import { useLocalization } from '../localization/useLocalization';
+import type { ClientCapability } from './capabilities';
+
+// What this credential may not do here, said once and in one place. Everything it may not do is simply absent from the
+// screen, which is what keeps somebody from pressing an action that would be refused — and an absence nobody explained
+// is a client that looks broken, so this is the sentence that turns one into the other.
+//
+// Each of these is about the credential rather than about the deployment, and the two are never worded alike: a grant
+// is something whoever runs the deployment can give, and a deployment that does not do something at all is a different
+// situation with a different next step. `accounts.notRefreshing` is that other kind, and it says so in its own words.
+
+const capabilityNotices: Readonly<Record<ClientCapability, MessageKey>> = {
+    readMail: 'grant.readMail',
+    askMail: 'grant.askMail',
+};
+
+export function GrantNotice({ withheld }: { readonly withheld: readonly ClientCapability[] }) {
+    const { translate } = useLocalization();
+
+    if (withheld.length === 0) {
+        return null;
+    }
+
+    // A named region rather than a heading, because the frame's one heading belongs to the space below it and a second
+    // one written above it would put the document's headings out of the order a reader moves through them in.
+    return (
+        <section aria-label={translate('grant.heading')} className="flex flex-col gap-2 text-sm text-muted">
+            {withheld.map((capability) => (
+                <p key={capability}>{translate(capabilityNotices[capability])}</p>
+            ))}
+        </section>
+    );
+}

--- a/frontend/src/Client.App/src/shell/SpaceNavigation.test.tsx
+++ b/frontend/src/Client.App/src/shell/SpaceNavigation.test.tsx
@@ -5,12 +5,13 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { LocalizationProvider } from '../localization/Localization';
+import { spaces, type Space } from '../routing/spaces';
 import { SpaceNavigation } from './SpaceNavigation';
 
-function renderNavigation(): void {
+function renderNavigation(offered: readonly Space[] = spaces): void {
     render(
         <LocalizationProvider>
-            <SpaceNavigation current="mail" />
+            <SpaceNavigation offered={offered} current="mail" />
         </LocalizationProvider>,
     );
 }
@@ -37,5 +38,11 @@ describe('SpaceNavigation', () => {
         renderNavigation();
 
         expect(screen.getByRole('navigation', { name: 'Spaces' })).toBeDefined();
+    });
+
+    it('offers only what it was given, so a space this credential may not open is absent from the rail', () => {
+        renderNavigation(['mail', 'cases']);
+
+        expect(screen.getAllByRole('link').map((space) => space.textContent)).toEqual(['Mail', 'Cases']);
     });
 });

--- a/frontend/src/Client.App/src/shell/SpaceNavigation.tsx
+++ b/frontend/src/Client.App/src/shell/SpaceNavigation.tsx
@@ -3,11 +3,14 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { useLocalization } from '../localization/useLocalization';
-import { addressOf, spaceLabels, spaces, type Space } from '../routing/spaces';
+import { addressOf, spaceLabels, type Space } from '../routing/spaces';
 
 // One list of links, laid out two ways by the width it is given: a rail down the side of a wide window, and bottom
 // navigation across a narrow one. Nothing here asks which head it is running on, and nothing disappears at either
-// width — the same three destinations are present in both, which is what makes the two shapes one navigation.
+// width — the same destinations are present in both, which is what makes the two shapes one navigation.
+//
+// Which destinations those are is the session's answer rather than this component's: a space this credential may not
+// open is absent from both shapes, because offering it would offer an action the deployment is going to refuse.
 //
 // Links rather than buttons, because these navigate: the browser then supplies the keyboard path, the history entry,
 // and opening one in a window of its own, none of which a click handler would have.
@@ -18,7 +21,7 @@ const spaceGlyphs: Readonly<Record<Space, string>> = {
     cases: 'M9 3h6a2 2 0 0 1 2 2v1h3a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h3V5a2 2 0 0 1 2-2Zm0 3h6V5H9v1ZM4 8v10h16V8H4Z',
 };
 
-export function SpaceNavigation({ current }: { readonly current: Space }) {
+export function SpaceNavigation({ offered, current }: { readonly offered: readonly Space[]; readonly current: Space }) {
     const { translate } = useLocalization();
 
     return (
@@ -26,7 +29,7 @@ export function SpaceNavigation({ current }: { readonly current: Space }) {
             aria-label={translate('shell.spaces')}
             className="flex shrink-0 justify-around gap-1 border-t border-line bg-rail p-1 workspace:order-first workspace:w-24 workspace:flex-col workspace:justify-start workspace:gap-2 workspace:border-t-0 workspace:border-e workspace:p-3"
         >
-            {spaces.map((space) => (
+            {offered.map((space) => (
                 <SpaceLink key={space} space={space} current={space === current} />
             ))}
         </nav>

--- a/frontend/src/Client.App/src/shell/capabilities.ts
+++ b/frontend/src/Client.App/src/shell/capabilities.ts
@@ -1,0 +1,53 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { DeploymentSession, MailFathomPermission } from '@mailfathom/client-backend';
+import { spaces, type Space } from '../routing/spaces';
+
+// What the client offers follows the grant the deployment reported for the credential that signed in, so a capability
+// the credential does not carry is absent rather than present and refused when it is pressed. The service is what
+// enforces; nothing here is a second copy of that decision, and a screen the client did offer is still refused by the
+// route behind it if the grant changed underneath.
+//
+// A capability is named for what a person does with it rather than for the permission behind it, because that is what
+// a sentence on the screen has to say. The one table below is where the two meet, and it is exhaustive by its own type
+// so a capability added later does not compile until it says which grant it is reached under.
+
+export const clientCapabilities = ['readMail', 'askMail'] as const;
+
+/** Something the client offers a person, where the grant permits it. */
+export type ClientCapability = (typeof clientCapabilities)[number];
+
+const capabilityGrants: Readonly<Record<ClientCapability, MailFathomPermission>> = {
+    readMail: 'mailfathom.mail.read',
+    askMail: 'mailfathom.mail.ask',
+};
+
+// Which capability each space is reached under. `cases` carries none because nothing behind it is reached over a grant
+// yet; the space that fills it is what decides what it needs, and naming a permission here before then would be a
+// guess enforced on a screen that does not exist.
+const spaceCapabilities: Readonly<Record<Space, ClientCapability | null>> = {
+    discover: 'askMail',
+    mail: 'readMail',
+    cases: null,
+};
+
+/** Whether this credential may do that here. */
+export function offers(session: DeploymentSession, capability: ClientCapability): boolean {
+    return session.permissions.includes(capabilityGrants[capability]);
+}
+
+/** What the client offers and this credential may not do, in the order the client would have offered them. */
+export function withheldFrom(session: DeploymentSession): readonly ClientCapability[] {
+    return clientCapabilities.filter((capability) => !offers(session, capability));
+}
+
+/** The spaces this credential may open, which is what the navigation is drawn from and what an address is answered against. */
+export function spacesOffered(session: DeploymentSession): readonly Space[] {
+    return spaces.filter((space) => {
+        const needed = spaceCapabilities[space];
+
+        return needed === null || offers(session, needed);
+    });
+}

--- a/frontend/src/Client.App/src/shell/synchronizationAge.test.ts
+++ b/frontend/src/Client.App/src/shell/synchronizationAge.test.ts
@@ -34,13 +34,14 @@ describe('ageOf', () => {
         expect(ageOf(instant, readAt, 'en')).toBe(expected);
     });
 
-    // Polish has three plural forms where English has one, which is why nothing here is spelled into a catalogue.
-    it.each([
-        [1, '1 minutę temu'],
-        [2, '2 minuty temu'],
-        [5, '5 minut temu'],
-    ])('agrees with the language it is asked in, here %s minute(s) in Polish', (elapsed, expected) => {
-        expect(ageOf(before(elapsed * minute), readAt, 'pl')).toBe(expected);
+    // Asked of `Intl` rather than spelled out, for both reasons at once: the wording is the platform's and a suite
+    // that repeated it would be asserting against a copy of it, and Polish spellings do not go into a file the typo
+    // checker reads as English. What this proves is the part that is this module's — that the language reaches the
+    // formatter at all, over the three plural forms Polish needs where English has one.
+    it.each([1, 2, 5])('agrees with the language it is asked in, here %s minute(s) in Polish', (elapsed) => {
+        expect(ageOf(before(elapsed * minute), readAt, 'pl')).toBe(
+            new Intl.RelativeTimeFormat('pl', { numeric: 'auto' }).format(-elapsed, 'minute'),
+        );
     });
 
     it('has no age for an account the deployment named no instant for', () => {

--- a/frontend/src/Client.App/src/shell/synchronizationAge.test.ts
+++ b/frontend/src/Client.App/src/shell/synchronizationAge.test.ts
@@ -1,0 +1,57 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import { ageOf } from './synchronizationAge';
+
+// The instant every age below is measured against, handed in rather than taken off a clock — which is the whole reason
+// `ageOf` accepts one, and what lets a suite state the wording a person reads rather than the day it ran on.
+const readAt = new Date('2026-08-31T12:00:00Z');
+
+const second = 1_000;
+const minute = 60 * second;
+const hour = 60 * minute;
+const day = 24 * hour;
+
+/** An instant that long before the answer was read, in the form a deployment reports one. */
+function before(elapsed: number): string {
+    return new Date(readAt.getTime() - elapsed).toISOString();
+}
+
+describe('ageOf', () => {
+    // One case per unit the ladder climbs, because a wrong ratio between two of them is invisible in the unit above and
+    // shows the wrong age on the freshness panel rather than failing anywhere.
+    it.each([
+        ['seconds', before(30 * second), '30 seconds ago'],
+        ['minutes', before(5 * minute), '5 minutes ago'],
+        ['hours', before(3 * hour), '3 hours ago'],
+        ['days', before(2 * day), '2 days ago'],
+        ['weeks', before(20 * day), '3 weeks ago'],
+        ['months', before(60 * day), '2 months ago'],
+        ['years', before(900 * day), '2 years ago'],
+    ])('words an age of %s the way a person reads it', (_, instant, expected) => {
+        expect(ageOf(instant, readAt, 'en')).toBe(expected);
+    });
+
+    // Polish has three plural forms where English has one, which is why nothing here is spelled into a catalogue.
+    it.each([
+        [1, '1 minutę temu'],
+        [2, '2 minuty temu'],
+        [5, '5 minut temu'],
+    ])('agrees with the language it is asked in, here %s minute(s) in Polish', (elapsed, expected) => {
+        expect(ageOf(before(elapsed * minute), readAt, 'pl')).toBe(expected);
+    });
+
+    it('has no age for an account the deployment named no instant for', () => {
+        expect(ageOf(null, readAt, 'en')).toBeNull();
+    });
+
+    it('has no age for an instant this client cannot read, rather than putting a broken date on the screen', () => {
+        expect(ageOf('the day before yesterday', readAt, 'en')).toBeNull();
+    });
+
+    it('reads an instant after the answer was read as one, rather than as an age it cannot word', () => {
+        expect(ageOf(new Date(readAt.getTime() + 5 * minute).toISOString(), readAt, 'en')).toBe('in 5 minutes');
+    });
+});

--- a/frontend/src/Client.App/src/shell/synchronizationAge.ts
+++ b/frontend/src/Client.App/src/shell/synchronizationAge.ts
@@ -1,0 +1,54 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { Locale } from '../localization/locale';
+
+// How long ago an account last took mail in, worded rather than stamped. The whole wording is `Intl`'s under the active
+// locale — Polish alone has three plural forms for most of these units, and a catalogue entry spelling any of them out
+// would be a second copy of something the platform already gets right in both languages.
+
+// The units an age is expressed in, largest last, each with how many of it go into the next one.
+const divisions = [
+    { unit: 'second', per: 60 },
+    { unit: 'minute', per: 60 },
+    { unit: 'hour', per: 24 },
+    { unit: 'day', per: 7 },
+    { unit: 'week', per: 4.34524 },
+    { unit: 'month', per: 12 },
+    { unit: 'year', per: Number.POSITIVE_INFINITY },
+] as const;
+
+/**
+ * How long before `readAt` that instant was, worded under the active language.
+ *
+ * @param instant When the account last took mail in, as the deployment reported it.
+ * @param readAt When the answer holding it was read, which is what the age is measured against rather than a clock a
+ * component reads for itself.
+ * @param locale The language the wording is asked for in.
+ * @returns The age as a person reads it, or `null` where the deployment named no instant this client can read.
+ */
+export function ageOf(instant: string | null, readAt: Date, locale: Locale): string | null {
+    if (instant === null) {
+        return null;
+    }
+
+    const at = Date.parse(instant);
+
+    if (Number.isNaN(at)) {
+        return null;
+    }
+
+    const worded = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+    let elapsed = (at - readAt.getTime()) / 1000;
+
+    for (const division of divisions) {
+        if (Math.abs(elapsed) < division.per) {
+            return worded.format(Math.round(elapsed), division.unit);
+        }
+
+        elapsed /= division.per;
+    }
+
+    return worded.format(Math.round(elapsed), 'year');
+}

--- a/frontend/src/Client.App/src/shell/useConnection.test.ts
+++ b/frontend/src/Client.App/src/shell/useConnection.test.ts
@@ -1,0 +1,33 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import { reconnectionDelay } from './useConnection';
+
+// The waiting the hook does between attempts, as a function of its arguments rather than of a clock or of a draw it
+// made itself — which is what lets it be stated here without a fake timer and without stubbing randomness.
+
+describe('reconnectionDelay', () => {
+    it('waits longer after each attempt that did not answer', () => {
+        const waits = [0, 1, 2, 3].map((made) => reconnectionDelay(made, 0.5));
+
+        expect(waits).toEqual([...waits].sort((first, second) => first - second));
+        expect(new Set(waits).size).toBe(waits.length);
+    });
+
+    it('stops lengthening the wait, so a deployment that is down is not left an hour behind', () => {
+        expect(reconnectionDelay(20, 0.5)).toBe(reconnectionDelay(30, 0.5));
+    });
+
+    it('spreads the wait around the nominal one, so clients that lost one deployment do not return in step', () => {
+        const nominal = reconnectionDelay(0, 0.5);
+
+        expect(reconnectionDelay(0, 0)).toBeLessThan(nominal);
+        expect(reconnectionDelay(0, 0.999)).toBeGreaterThan(nominal);
+    });
+
+    it.each([0, 0.25, 0.5, 0.75, 0.999])('waits a positive time whatever is drawn, here %s', (drawn) => {
+        expect(reconnectionDelay(0, drawn)).toBeGreaterThan(0);
+    });
+});

--- a/frontend/src/Client.App/src/shell/useConnection.test.ts
+++ b/frontend/src/Client.App/src/shell/useConnection.test.ts
@@ -2,8 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import { describe, expect, it } from 'vitest';
-import { reconnectionDelay } from './useConnection';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ClientResponse } from '@mailfathom/client-backend';
+import type { DeploymentTransport } from '../deployment/sendToDeployment';
+import { mostReconnectionAttempts, reconnectionDelay, useConnection } from './useConnection';
 
 // The waiting the hook does between attempts, as a function of its arguments rather than of a clock or of a draw it
 // made itself — which is what lets it be stated here without a fake timer and without stubbing randomness.
@@ -29,5 +32,104 @@ describe('reconnectionDelay', () => {
 
     it.each([0, 0.25, 0.5, 0.75, 0.999])('waits a positive time whatever is drawn, here %s', (drawn) => {
         expect(reconnectionDelay(0, drawn)).toBeGreaterThan(0);
+    });
+});
+
+// What the hook itself does with two things no screen can reach through it: the instant it stamps an answer with, and
+// the budget it spends reaching for a deployment that is not answering. Everything the frame shows for either of them
+// is asserted where a person would read it, in `App.test.tsx` and `ConnectionSummary.test.tsx`.
+
+const baseAddress = 'https://mail.example.invalid';
+const firstCredential = 'Basic b3duZXI6b3Blbg==';
+const secondCredential = 'Basic c29tZWJvZHk6ZWxzZQ==';
+
+// The instant this suite decided, which is what an answer is stamped with when the hook is handed it — never a system
+// clock, so nothing here depends on the day it ran.
+const readAt = new Date('2026-08-31T12:41:00Z');
+const clock = (): Date => readAt;
+
+// Stable across renders, all four of them: a new function each render is a new dependency each render, and the read
+// effect would restart forever rather than answering once.
+const nothingToDo = (): void => undefined;
+
+function answering(body: Readonly<Record<string, unknown>>, status = 200): ClientResponse {
+    return { status, body: JSON.stringify(body), headers: {} };
+}
+
+const readsMail = answering({
+    service: 'MailFathom',
+    version: '0.8.7',
+    permissions: ['mailfathom.mail.read'],
+});
+
+const oneAccount = answering({
+    synchronizationEnabled: true,
+    accounts: [
+        {
+            id: 'work',
+            displayName: 'Work',
+            synchronizationState: 'Synchronized',
+            lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
+            behind: false,
+        },
+    ],
+});
+
+const deploymentAnswering: DeploymentTransport = () => (request) =>
+    Promise.resolve(request.path.endsWith('/session') ? readsMail : oneAccount);
+
+const deploymentFailing: DeploymentTransport = () => () => Promise.resolve({ status: 503, body: '', headers: {} });
+
+describe('useConnection', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('stamps what it read with the instant its caller decided rather than with a clock of its own', async () => {
+        const { result } = renderHook(() =>
+            useConnection(baseAddress, firstCredential, deploymentAnswering, nothingToDo, clock),
+        );
+
+        await waitFor(() => {
+            expect(result.current.accounts?.outcome).toBe('read');
+        });
+
+        expect(result.current.readAt).toEqual(readAt);
+    });
+
+    it('hands the next person a budget of their own rather than one the last one spent', async () => {
+        vi.useFakeTimers();
+
+        const { result, rerender } = renderHook(
+            ({ authorization }: { authorization: string }) =>
+                useConnection(baseAddress, authorization, deploymentFailing, nothingToDo, clock),
+            { initialProps: { authorization: firstCredential } },
+        );
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(0);
+        });
+
+        // Each attempt is only scheduled once the one before it has answered, so the waiting is advanced once per
+        // attempt rather than far enough to cover all of them at once.
+        for (let spent = 0; spent < mostReconnectionAttempts; spent += 1) {
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(60_000);
+            });
+        }
+
+        expect(result.current.attempts).toBe(mostReconnectionAttempts);
+
+        rerender({ authorization: secondCredential });
+
+        expect(result.current.attempts).toBe(0);
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(0);
+        });
+
+        // The new credential's first read has failed once, which is one failure rather than a spent budget: the client
+        // still owes them every automatic attempt instead of telling them the deployment has stopped answering.
+        expect(result.current.attempts).toBe(0);
     });
 });

--- a/frontend/src/Client.App/src/shell/useConnection.ts
+++ b/frontend/src/Client.App/src/shell/useConnection.ts
@@ -97,6 +97,28 @@ const nothingRead: Answered = {
     presenting: null,
 };
 
+/**
+ * How many automatic attempts have been made, and against which identity.
+ *
+ * The budget belongs to the identity that spent it for the same reason an answer does. Counting it on its own would
+ * carry a spent budget across a sign-out: the next person's first read would be announced as somebody else's fifth,
+ * and once the count had reached its ceiling they would be told the deployment has stopped answering before their own
+ * read had failed even once — with no automatic attempt left to correct it.
+ */
+interface Reaching {
+    readonly made: number;
+    readonly presentedAt: string | null;
+    readonly presenting: string | null;
+}
+
+// Nothing spent, against an identity no credential will ever match, which is also what a person asking again resets to.
+const noneMade: Reaching = { made: 0, presentedAt: null, presenting: null };
+
+// Reading the clock is the caller's, so a screen measuring an age against this instant is measured against one a test
+// decided rather than against the day the suite ran on. Declared once rather than defaulted inline: a new function on
+// every render is a new dependency on every render, and the read effect below would restart forever.
+const systemClock = (): Date => new Date();
+
 function subscribeToConnectivity(changed: () => void): () => void {
     window.addEventListener('online', changed);
     window.addEventListener('offline', changed);
@@ -120,6 +142,7 @@ function isOnline(): boolean {
  * @param onCredentialRefused What to do about a credential the deployment has stopped accepting, which is the one
  * answer this hook reports rather than renders: it is acted on once, by whatever owns signing in, instead of producing
  * the same refusal on every later read.
+ * @param now What the current instant is, which is what every age beside an account is measured from.
  * @returns Everything a screen needs to say what it is looking at and how current it is.
  */
 export function useConnection(
@@ -127,11 +150,16 @@ export function useConnection(
     authorization: string | null,
     send: DeploymentTransport,
     onCredentialRefused: () => void,
+    now: () => Date = systemClock,
 ): Connection {
     const online = useSyncExternalStore(subscribeToConnectivity, isOnline);
     const [read, setRead] = useState(0);
-    const [attempts, setAttempts] = useState(0);
+    const [reaching, setReaching] = useState<Reaching>(noneMade);
     const [answered, setAnswered] = useState<Answered>(nothingRead);
+
+    // Worked out during a render for the same reason the answer is: a budget spent against one identity is nothing to
+    // the next one, so signing in as somebody else starts at nothing without an effect having to clear it.
+    const attempts = reaching.presentedAt === baseAddress && reaching.presenting === authorization ? reaching.made : 0;
 
     useEffect(() => {
         // Nothing is read without a network, and what was read before it went is left on the screen rather than
@@ -178,7 +206,7 @@ export function useConnection(
                 return;
             }
 
-            setAttempts(0);
+            setReaching({ made: 0, presentedAt: baseAddress, presenting: authorization });
 
             // On the screen as soon as it is known rather than once the accounts beside it are: what it decides — the
             // spaces, the controls, the deployment's version — is answerable now, and holding it back would leave the
@@ -214,7 +242,7 @@ export function useConnection(
             setAnswered({
                 session,
                 accounts,
-                readAt: new Date(),
+                readAt: now(),
                 answering: read,
                 presentedAt: baseAddress,
                 presenting: authorization,
@@ -224,7 +252,7 @@ export function useConnection(
         return () => {
             attempted.abort();
         };
-    }, [baseAddress, authorization, online, read, send, onCredentialRefused]);
+    }, [baseAddress, authorization, online, read, send, onCredentialRefused, now]);
 
     // An answer belonging to an earlier attempt, or to a credential this client is no longer signed in with, is not
     // this attempt's, and nothing on the screen may be drawn from it: what a person is looking at then is a read in
@@ -246,7 +274,7 @@ export function useConnection(
 
         const waiting = setTimeout(
             () => {
-                setAttempts((made) => made + 1);
+                setReaching({ made: attempts + 1, presentedAt: baseAddress, presenting: authorization });
                 setRead((token) => token + 1);
             },
             reconnectionDelay(attempts, Math.random()),
@@ -255,7 +283,7 @@ export function useConnection(
         return () => {
             clearTimeout(waiting);
         };
-    }, [lost, attempts]);
+    }, [lost, attempts, baseAddress, authorization]);
 
     return {
         session: connection.session,
@@ -264,7 +292,7 @@ export function useConnection(
         online,
         attempts,
         reread: () => {
-            setAttempts(0);
+            setReaching(noneMade);
             setRead((token) => token + 1);
         },
     };

--- a/frontend/src/Client.App/src/shell/useConnection.ts
+++ b/frontend/src/Client.App/src/shell/useConnection.ts
@@ -1,0 +1,271 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { useEffect, useState, useSyncExternalStore } from 'react';
+import {
+    readDeploymentSession,
+    readMailAccounts,
+    type ClientResult,
+    type DeploymentSession,
+    type MailAccountDirectory,
+} from '@mailfathom/client-backend';
+import type { DeploymentTransport } from '../deployment/sendToDeployment';
+import { offers } from './capabilities';
+
+// What the client knows about the deployment it is signed in to: what the credential may do there, how current each of
+// the owner's accounts is, and whether the deployment is answering at all. It is one thing rather than three because it
+// arrives as one exchange — the grant decides whether the accounts are asked for at all, and a deployment that stopped
+// answering stops both.
+//
+// The session is re-read on every attempt rather than kept from the sign-in that produced it. A grant is the
+// deployment's to narrow while the client is open, and a client acting on the grant it was handed at sign-in would keep
+// offering what the service has since begun refusing.
+
+/** The most times the client reaches for a deployment that is not answering before it waits to be asked. */
+export const mostReconnectionAttempts = 5;
+
+const firstReconnectionDelay = 1_000;
+const longestReconnectionDelay = 30_000;
+
+/**
+ * How long to wait before the attempt after this one, in milliseconds.
+ *
+ * The wait doubles and is capped, so a deployment that is down for a while is not asked hundreds of times, and the
+ * spread keeps a fleet of clients that all lost the same deployment from coming back in step with each other.
+ *
+ * @param made How many automatic attempts have already been made since the last answer.
+ * @param drawn A value in `[0, 1)`, which the caller draws so that this stays a function of its arguments.
+ * @returns The delay to wait, between three quarters and five quarters of the nominal one for that attempt.
+ */
+export function reconnectionDelay(made: number, drawn: number): number {
+    const nominal = Math.min(firstReconnectionDelay * 2 ** made, longestReconnectionDelay);
+
+    return Math.round(nominal * (0.75 + drawn / 2));
+}
+
+/** What the deployment last said, and how current what is on the screen therefore is. */
+export interface Connection {
+    /** What the deployment says the credential may do, or `null` while that is being read for the first time on this attempt. */
+    readonly session: ClientResult<DeploymentSession> | null;
+
+    /** The owner's accounts, or `null` where they have not been read — which includes a credential not allowed to. */
+    readonly accounts: ClientResult<MailAccountDirectory> | null;
+
+    /** When the accounts on the screen were read, which is what every age beside one is measured from. */
+    readonly readAt: Date | null;
+
+    /** Whether this machine has a network at all, which is a different sentence from a deployment that is not answering. */
+    readonly online: boolean;
+
+    /** How many automatic attempts have been made since the deployment last answered. */
+    readonly attempts: number;
+
+    /** Reads everything again, from a person asking rather than from the client trying on its own. */
+    readonly reread: () => void;
+}
+
+/**
+ * What one attempt answered, tagged with the attempt and the identity it answered for.
+ *
+ * The tag is what makes "still waiting" a thing this hook works out during a render rather than a second piece of state
+ * set beside the first: an answer that is not the current attempt's is a stale answer, and clearing it in the effect
+ * that starts the next read would be a render spent saying what the tag already says.
+ *
+ * The identity is half of that tag rather than the attempt alone, and it is the half that matters most: signing out and
+ * back in as somebody else changes the credential without changing the attempt, so an answer tagged by attempt alone
+ * would put the previous owner's accounts and the previous owner's grants in front of the next person for as long as
+ * their own read takes. It holds the credential the frame is already holding rather than a second copy of anything, it
+ * is compared and never read, and nothing renders it.
+ */
+interface Answered {
+    readonly session: ClientResult<DeploymentSession> | null;
+    readonly accounts: ClientResult<MailAccountDirectory> | null;
+    readonly readAt: Date | null;
+    readonly answering: number;
+    readonly presentedAt: string | null;
+    readonly presenting: string | null;
+}
+
+// Before the first attempt there is nothing, tagged with an attempt and an identity no read will ever carry.
+const nothingRead: Answered = {
+    session: null,
+    accounts: null,
+    readAt: null,
+    answering: -1,
+    presentedAt: null,
+    presenting: null,
+};
+
+function subscribeToConnectivity(changed: () => void): () => void {
+    window.addEventListener('online', changed);
+    window.addEventListener('offline', changed);
+
+    return () => {
+        window.removeEventListener('online', changed);
+        window.removeEventListener('offline', changed);
+    };
+}
+
+function isOnline(): boolean {
+    return window.navigator.onLine;
+}
+
+/**
+ * Holds what the deployment says, and reaches for it again on its own while it says nothing.
+ *
+ * @param baseAddress Where the deployment is, or `null` where none has been adopted.
+ * @param authorization The finished header value this client signed in with, or `null` where nobody is signed in.
+ * @param send How a request reaches the deployment.
+ * @param onCredentialRefused What to do about a credential the deployment has stopped accepting, which is the one
+ * answer this hook reports rather than renders: it is acted on once, by whatever owns signing in, instead of producing
+ * the same refusal on every later read.
+ * @returns Everything a screen needs to say what it is looking at and how current it is.
+ */
+export function useConnection(
+    baseAddress: string | null,
+    authorization: string | null,
+    send: DeploymentTransport,
+    onCredentialRefused: () => void,
+): Connection {
+    const online = useSyncExternalStore(subscribeToConnectivity, isOnline);
+    const [read, setRead] = useState(0);
+    const [attempts, setAttempts] = useState(0);
+    const [answered, setAnswered] = useState<Answered>(nothingRead);
+
+    useEffect(() => {
+        // Nothing is read without a network, and what was read before it went is left on the screen rather than
+        // cleared: the last answer is still the truest thing anybody has, and saying so beside it is what the offline
+        // state is for. Coming back re-runs this, which is the whole of the automatic recovery from that direction.
+        if (baseAddress === null || authorization === null || !online) {
+            return;
+        }
+
+        // Abandoning is what says an answer is nobody's to render any more, and it is one mechanism rather than two:
+        // the signal already has to travel to the transport, so a second flag beside it would be a second thing to
+        // keep true.
+        const attempted = new AbortController();
+        const credential = { baseAddress, authorization };
+        const transport = send(attempted.signal);
+
+        // Asked through a function rather than read off the controller, so nothing decides at the first check that it
+        // can never be true at the second: what changes it is a cleanup running while a read is in flight.
+        const abandoned = (): boolean => attempted.signal.aborted;
+
+        void (async () => {
+            const session = await readDeploymentSession(credential, transport);
+
+            if (abandoned()) {
+                return;
+            }
+
+            if (session.outcome === 'failed' && session.failure.reason === 'unauthenticated') {
+                onCredentialRefused();
+
+                return;
+            }
+
+            if (session.outcome === 'failed') {
+                setAnswered({
+                    session,
+                    accounts: null,
+                    readAt: null,
+                    answering: read,
+                    presentedAt: baseAddress,
+                    presenting: authorization,
+                });
+
+                return;
+            }
+
+            setAttempts(0);
+
+            // On the screen as soon as it is known rather than once the accounts beside it are: what it decides — the
+            // spaces, the controls, the deployment's version — is answerable now, and holding it back would leave the
+            // frame saying it is still reaching a deployment that has already answered.
+            setAnswered({
+                session,
+                accounts: null,
+                readAt: null,
+                answering: read,
+                presentedAt: baseAddress,
+                presenting: authorization,
+            });
+
+            // A credential that may not read mail is never asked for it. The refusal would be the service's to give
+            // and it would arrive as a failure on a screen, where what is true is that the client is not offering
+            // something rather than that something went wrong.
+            if (!offers(session.value, 'readMail')) {
+                return;
+            }
+
+            const accounts = await readMailAccounts(credential, transport);
+
+            if (abandoned()) {
+                return;
+            }
+
+            if (accounts.outcome === 'failed' && accounts.failure.reason === 'unauthenticated') {
+                onCredentialRefused();
+
+                return;
+            }
+
+            setAnswered({
+                session,
+                accounts,
+                readAt: new Date(),
+                answering: read,
+                presentedAt: baseAddress,
+                presenting: authorization,
+            });
+        })();
+
+        return () => {
+            attempted.abort();
+        };
+    }, [baseAddress, authorization, online, read, send, onCredentialRefused]);
+
+    // An answer belonging to an earlier attempt, or to a credential this client is no longer signed in with, is not
+    // this attempt's, and nothing on the screen may be drawn from it: what a person is looking at then is a read in
+    // flight, which is what the frame says while it waits.
+    const current =
+        answered.answering === read && answered.presentedAt === baseAddress && answered.presenting === authorization;
+    const connection = current ? answered : nothingRead;
+
+    // Only a deployment that did not answer is reached for again. A credential it refused, a grant it does not hold,
+    // and an answer this client could not read each repeat identically however many times they are asked for, so the
+    // budget is spent on the one failure that passes on its own.
+    const lost =
+        connection.session?.outcome === 'failed' && connection.session.failure.reason === 'unavailable' && online;
+
+    useEffect(() => {
+        if (!lost || attempts >= mostReconnectionAttempts) {
+            return;
+        }
+
+        const waiting = setTimeout(
+            () => {
+                setAttempts((made) => made + 1);
+                setRead((token) => token + 1);
+            },
+            reconnectionDelay(attempts, Math.random()),
+        );
+
+        return () => {
+            clearTimeout(waiting);
+        };
+    }, [lost, attempts]);
+
+    return {
+        session: connection.session,
+        accounts: connection.accounts,
+        readAt: connection.readAt,
+        online,
+        attempts,
+        reread: () => {
+            setAttempts(0);
+            setRead((token) => token + 1);
+        },
+    };
+}

--- a/frontend/src/Client.Backend/src/deploymentSession.test.ts
+++ b/frontend/src/Client.Backend/src/deploymentSession.test.ts
@@ -1,0 +1,120 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import { readDeploymentSession } from './deploymentSession';
+import type { ClientRequest, ClientResponse, MailFathomTransport } from './transport';
+
+const session = { baseAddress: 'https://mail.example.invalid', authorization: 'Basic QWxhZGRpbjpvcGVu' };
+
+function answering(response: Partial<ClientResponse>): MailFathomTransport {
+    return () => Promise.resolve({ status: 200, body: '', headers: {}, ...response });
+}
+
+function sessionBody(permissions: unknown, version: unknown = '0.8.0', service: unknown = 'MailFathom'): string {
+    return JSON.stringify({ service, version, permissions });
+}
+
+describe('readDeploymentSession', () => {
+    it('presents the credential to the session route', async () => {
+        const asked: ClientRequest[] = [];
+
+        await readDeploymentSession(session, (request) => {
+            asked.push(request);
+
+            return Promise.resolve({ status: 200, body: sessionBody([]), headers: {} });
+        });
+
+        expect(asked).toEqual([
+            {
+                method: 'GET',
+                path: 'https://mail.example.invalid/api/client/session',
+                headers: { Accept: 'application/json', Authorization: session.authorization },
+            },
+        ]);
+    });
+
+    it('reads the running release and the grant the presented credential carries', async () => {
+        const result = await readDeploymentSession(
+            session,
+            answering({ body: sessionBody(['mailfathom.mail.read', 'mailfathom.mail.ask'], '0.8.1') }),
+        );
+
+        expect(result).toEqual({
+            outcome: 'read',
+            value: { version: '0.8.1', permissions: ['mailfathom.mail.read', 'mailfathom.mail.ask'] },
+        });
+    });
+
+    it('reads a credential granted nothing as one holding an empty grant rather than as a refusal', async () => {
+        const result = await readDeploymentSession(session, answering({ body: sessionBody([]) }));
+
+        expect(result).toEqual({ outcome: 'read', value: { version: '0.8.0', permissions: [] } });
+    });
+
+    it('keeps the names it knows out of an answer that also carries one it does not', async () => {
+        const result = await readDeploymentSession(
+            session,
+            answering({ body: sessionBody(['mailfathom.mail.read', 'mailfathom.mail.telepathy']) }),
+        );
+
+        expect(result).toEqual({ outcome: 'read', value: { version: '0.8.0', permissions: ['mailfathom.mail.read'] } });
+    });
+
+    it('names an administrative permission nowhere, that half being one this surface never grants', async () => {
+        const result = await readDeploymentSession(
+            session,
+            answering({ body: sessionBody(['mailfathom.admin.read']) }),
+        );
+
+        expect(result).toEqual({ outcome: 'read', value: { version: '0.8.0', permissions: [] } });
+    });
+
+    it('names a permission once however many times the answer repeated it', async () => {
+        const result = await readDeploymentSession(
+            session,
+            answering({ body: sessionBody(['mailfathom.mail.read', 'mailfathom.mail.read']) }),
+        );
+
+        expect(result).toEqual({ outcome: 'read', value: { version: '0.8.0', permissions: ['mailfathom.mail.read'] } });
+    });
+
+    it.each([
+        ['another product answering in JSON', sessionBody([], '0.8.0', 'Something else')],
+        ['an answer naming no release', sessionBody([], null)],
+        ['an answer naming an empty release', sessionBody([], '')],
+        ['an answer carrying no grant at all', JSON.stringify({ service: 'MailFathom', version: '0.8.0' })],
+        ['a grant that is not a list', sessionBody('mailfathom.mail.read')],
+        ['a grant carrying something that is not a name', sessionBody(['mailfathom.mail.read', 7])],
+        ['a grant longer than a grant is', sessionBody(Array.from({ length: 65 }, () => 'mailfathom.mail.read'))],
+        // Refused on its size before it is parsed at all, which is the order that matters: this is the one answer the
+        // client reads from an address nobody has trusted yet.
+        ['a body longer than a session answer is', sessionBody([]).padEnd(4097, ' ')],
+        ['a page rather than an answer', '<!doctype html><title>Sign in</title>'],
+        ['an array', '[]'],
+        ['nothing', ''],
+    ])('refuses %s as unreadable rather than reading a grant out of it', async (_, body) => {
+        const result = await readDeploymentSession(session, answering({ body }));
+
+        expect(result).toEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+
+    it('reads a credential the deployment has stopped accepting as one to sign in with again', async () => {
+        const result = await readDeploymentSession(session, answering({ status: 401 }));
+
+        expect(result).toEqual({ outcome: 'failed', failure: { reason: 'unauthenticated', status: 401 } });
+    });
+
+    it('reads a deployment that is failing as one to try again', async () => {
+        const result = await readDeploymentSession(session, answering({ status: 503 }));
+
+        expect(result).toEqual({ outcome: 'failed', failure: { reason: 'unavailable', status: 503 } });
+    });
+
+    it('reports a connection that never answered as one to try again, rather than throwing at the screen', async () => {
+        const result = await readDeploymentSession(session, () => Promise.reject(new TypeError('Failed to fetch')));
+
+        expect(result).toEqual({ outcome: 'failed', failure: { reason: 'unavailable', status: null } });
+    });
+});

--- a/frontend/src/Client.Backend/src/deploymentSession.ts
+++ b/frontend/src/Client.Backend/src/deploymentSession.ts
@@ -1,0 +1,150 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { failed, failureReasonForStatus, read, type ClientResult } from './failure';
+import { headersFor, routeFor, type ClientSession } from './session';
+import { send, type MailFathomTransport } from './transport';
+
+/** The route a deployment reports itself and the caller's grant at, relative to the client prefix. */
+export const deploymentSessionRoute = '/session';
+
+/** The product name the session route answers with, which is what proves an address is a deployment rather than whatever else answers a port. */
+const productName = 'MailFathom';
+
+/**
+ * The permissions a credential presented here can carry.
+ *
+ * It is the mail half of the published set and the whole of it, because that is the half this surface draws on: an
+ * administrative name is refused on this endpoint rather than reported as a grant nobody could use. The client acts on
+ * two of them today and names all eight anyway — this is the contract the deployment publishes rather than a list of
+ * what one screen happens to read, so a screen arriving later finds the name already here.
+ */
+export const mailPermissions = [
+    'mailfathom.mail.read',
+    'mailfathom.mail.ask',
+    'mailfathom.mail.flags.write',
+    'mailfathom.mail.drafts.write',
+    'mailfathom.mail.send',
+    'mailfathom.mail.accounts.write',
+    'mailfathom.mail.contacts.read',
+    'mailfathom.mail.contacts.write',
+] as const;
+
+/** One name out of the half of the published set this surface draws on. */
+export type MailFathomPermission = (typeof mailPermissions)[number];
+
+/** What a deployment answers about itself and about the credential that just reached it. */
+export interface DeploymentSession {
+    /** The release the deployment is running, which is what says which contract the client is talking to. */
+    readonly version: string;
+
+    /**
+     * What the presented credential is allowed to do here, and nothing about anybody else's.
+     *
+     * A grant carrying nothing is an empty list rather than a refusal, because that is the accurate answer for a
+     * credential narrowed to nothing — and it is what lets the client say so instead of offering an action that would
+     * be turned away.
+     */
+    readonly permissions: readonly MailFathomPermission[];
+}
+
+// The most names one answer may carry. The published set is smaller than this by a wide margin and may grow; what the
+// bound is for is the answer that is not a grant at all, which is refused before the array is walked rather than after.
+const mostPermissionsInAnswer = 64;
+
+// The longest session answer read at all. This is the one answer in the client that arrives from an address nobody has
+// trusted yet — the whole point of asking is that the client does not know what is there — so the bound is applied
+// before the body is expanded rather than to what parsing it produced. It names a product, a release, and the caller's
+// own grant out of a published set, which is a few hundred bytes; anything past this is not a session answer, whatever
+// it turns out to be. `longestResponseBody` is the transport's backstop behind it, and this is the bound that says what
+// *this* route may answer with.
+const longestSessionBody = 4096;
+
+/**
+ * Reads what the deployment says about itself and about the credential presented to it.
+ *
+ * It is what the client asks first on every start it is already signed in for: the grant decides what the application
+ * may offer, and a credential a deployment has stopped accepting is found here rather than by an action failing.
+ *
+ * @param session The address to reach and the finished header value to present.
+ * @param transport How the request goes out.
+ * @returns The deployment's version and this caller's grant, or why the answer never arrived.
+ */
+export async function readDeploymentSession(
+    session: ClientSession,
+    transport: MailFathomTransport,
+): Promise<ClientResult<DeploymentSession>> {
+    const response = await send(transport, {
+        method: 'GET',
+        path: routeFor(session, deploymentSessionRoute),
+        headers: headersFor(session),
+    });
+
+    if (response === null) {
+        return failed('unavailable', null);
+    }
+
+    if (response.status !== 200) {
+        return failed(failureReasonForStatus(response.status), response.status);
+    }
+
+    const answered = parseDeploymentSession(response.body);
+
+    return answered === null ? failed('unreadable', response.status) : read(answered);
+}
+
+/**
+ * What a session answer says, or `null` where the body is not one MailFathom writes.
+ *
+ * A name this client does not know is dropped rather than refused, which is the one deliberate leniency here: the
+ * published set grows, and a client that refused the whole answer over a name added after it was built would stop
+ * working against a deployment newer than itself. Every other departure from the shape is a refusal, because this body
+ * arrives from an address nobody has established anything about.
+ */
+export function parseDeploymentSession(body: string): DeploymentSession | null {
+    if (body.length > longestSessionBody) {
+        return null;
+    }
+
+    let parsed: unknown;
+
+    try {
+        parsed = JSON.parse(body);
+    } catch {
+        return null;
+    }
+
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        return null;
+    }
+
+    const answered = parsed as Record<string, unknown>;
+    const version = answered['version'];
+    const granted = answered['permissions'];
+
+    if (answered['service'] !== productName || typeof version !== 'string' || version.length === 0) {
+        return null;
+    }
+
+    if (!Array.isArray(granted) || granted.length > mostPermissionsInAnswer) {
+        return null;
+    }
+
+    const permissions: MailFathomPermission[] = [];
+    for (const name of granted) {
+        if (typeof name !== 'string') {
+            return null;
+        }
+
+        if (isMailPermission(name) && !permissions.includes(name)) {
+            permissions.push(name);
+        }
+    }
+
+    return { version, permissions };
+}
+
+function isMailPermission(value: string): value is MailFathomPermission {
+    return (mailPermissions as readonly string[]).includes(value);
+}

--- a/frontend/src/Client.Backend/src/index.ts
+++ b/frontend/src/Client.Backend/src/index.ts
@@ -3,6 +3,13 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 export { resolveDeploymentEntry, type DeploymentEntryRefusal, type DeploymentEntryResult } from './deployment';
+export {
+    deploymentSessionRoute,
+    mailPermissions,
+    readDeploymentSession,
+    type DeploymentSession,
+    type MailFathomPermission,
+} from './deploymentSession';
 export { failureReasonForStatus, type ClientFailure, type ClientFailureReason, type ClientResult } from './failure';
 export {
     mailBodyRoute,
@@ -41,12 +48,5 @@ export {
     type MailSynchronizationState,
 } from './mailAccounts';
 export { clientRoutePrefix, headersFor, routeFor, type ClientSession, type DeploymentAddress } from './session';
-export {
-    deploymentSessionRoute,
-    reachDeployment,
-    signIn,
-    type DeploymentGreeting,
-    type SignInOutcome,
-    type SignInRefusal,
-} from './signIn';
+export { reachDeployment, signIn, type DeploymentGreeting, type SignInOutcome, type SignInRefusal } from './signIn';
 export { longestResponseBody, type ClientRequest, type ClientResponse, type MailFathomTransport } from './transport';

--- a/frontend/src/Client.Backend/src/signIn.test.ts
+++ b/frontend/src/Client.Backend/src/signIn.test.ts
@@ -90,6 +90,9 @@ describe('signIn', () => {
         ['a page rather than an answer', '<!doctype html><title>Sign in</title>'],
         ['an array', '[]'],
         ['nothing', ''],
+        // The session answer is read through the same parser `readDeploymentSession` reads it through, so what proves
+        // an address is a deployment is the whole answer rather than the two fields sign-in happens to look at.
+        ['an answer naming no grant', JSON.stringify({ service: 'MailFathom', version: '0.8.0' })],
     ])('refuses %s as a deployment', async (_, body) => {
         const result = await signIn(session, answering({ body }));
 

--- a/frontend/src/Client.Backend/src/signIn.ts
+++ b/frontend/src/Client.Backend/src/signIn.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+import { deploymentSessionRoute, parseDeploymentSession } from './deploymentSession';
 import { failed, read, type ClientResult } from './failure';
 import { headersFor, routeFor, type ClientSession, type DeploymentAddress } from './session';
 import { send, type MailFathomTransport } from './transport';
@@ -15,14 +16,8 @@ import { send, type MailFathomTransport } from './transport';
 // there for that. What it is there for is the ordinary typo, which lands on a real host that would otherwise be sent a
 // password composed for somewhere else, and which the client cannot take back once it has.
 
-/** The route a deployment reports itself and the caller's grant at, relative to the client prefix. */
-export const deploymentSessionRoute = '/session';
-
 /** The name every MailFathom surface challenges under, which is what a refusal proves the client reached one by. */
 const protectionSpace = 'realm="MailFathom"';
-
-/** The product name the session route answers with. */
-const productName = 'MailFathom';
 
 // The scheme named as a scheme rather than as a word, so a parameter whose value happens to read as one is not mistaken
 // for a challenge. A surface accepting passwords answers with two challenges in one header — the bare bearer one every
@@ -142,28 +137,15 @@ export async function signIn(
     return failed(response.status >= 500 ? 'unavailable' : 'unreadable', response.status);
 }
 
-/** Whether the session answer is one MailFathom writes, which is what proves the address is a deployment. */
+/**
+ * Whether the session answer is one MailFathom writes, which is what proves the address is a deployment.
+ *
+ * It reads the same answer `readDeploymentSession` reads and through the same parser, because the two questions are one
+ * question asked at different moments: an address that answers as a session is a deployment, and a second reading of
+ * the same body would be a second thing to keep in step with the route.
+ */
 function answersAsMailFathom(body: string): boolean {
-    if (body.length > longestSessionBody) {
-        return false;
-    }
-
-    let parsed: unknown;
-
-    try {
-        parsed = JSON.parse(body);
-    } catch {
-        return false;
-    }
-
-    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-        return false;
-    }
-
-    const answered = parsed as Record<string, unknown>;
-    const version = answered['version'];
-
-    return answered['service'] === productName && typeof version === 'string' && version.length > 0;
+    return parseDeploymentSession(body) !== null;
 }
 
 function challengesAsMailFathom(headers: Readonly<Record<string, string>>): boolean {
@@ -173,11 +155,3 @@ function challengesAsMailFathom(headers: Readonly<Record<string, string>>): bool
 function offersBasic(headers: Readonly<Record<string, string>>): boolean {
     return offersBasicScheme.test(headers['www-authenticate']?.toLowerCase() ?? '');
 }
-
-// The longest session answer read at all. This is the one answer in the client that arrives from an address nobody has
-// trusted yet — the whole point of asking is that the client does not know what is there — so the bound is applied
-// before the body is expanded rather than to what parsing it produced. It names a product, a release, and the caller's
-// own grant out of a published set, which is a few hundred bytes; anything past this is not a session answer, whatever
-// it turns out to be. `longestResponseBody` is the transport's backstop behind it, and this is the bound that says what
-// *this* route may answer with.
-const longestSessionBody = 4096;

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -23,7 +23,14 @@ const narrowWindow = { width: 380, height: 720 };
 // What the deployment the preview server stands in for answers. It accepts any credential presented to it, because
 // what this suite proves about signing in is the composing, the sending, and the keeping — which of two passwords a
 // service accepts is the service's own decision and is proven where that decision is made.
-const sessionAnswer = { service: 'MailFathom', version: declaredVersion };
+// The grant it reports is what decides which spaces the client offers, so it names both the client acts on: a session
+// answer without them would open a frame with Discover and the intent field absent, which is a different screen from
+// the one every test below is about.
+const sessionAnswer = {
+    service: 'MailFathom',
+    version: declaredVersion,
+    permissions: ['mailfathom.mail.read', 'mailfathom.mail.ask'],
+};
 
 const mailAccounts = {
     synchronizationEnabled: true,
@@ -266,11 +273,14 @@ test('asks for the credential again after signing out, including across a reload
     await expect(page.getByRole('navigation', { name: 'Spaces' })).toHaveCount(0);
 });
 
-test('opens in Discover, under the version it was built from', async ({ page }) => {
+test('opens in Discover, under the version it was built from and the one the deployment answered', async ({ page }) => {
     await openSignedIn(page);
 
     await expect(page.getByRole('heading', { name: 'Discover', level: 1 })).toBeVisible();
-    await expect(page.getByText(declaredVersion, { exact: true })).toBeVisible();
+
+    // The client's own is substituted into the bundle at build time, which is the half only a built bundle proves; the
+    // deployment's arrives over the wire beside it.
+    await expect(page.getByText(`Client ${declaredVersion}, deployment ${declaredVersion}`)).toBeVisible();
 
     // A first load at the root is written back to the address the space is actually reached at, which is what makes
     // the next assertion — reloading it — mean anything.
@@ -351,6 +361,11 @@ test('moves a keyboard through a narrow window in the order the window shows', a
     // The narrow composition draws the navigation at the bottom of the screen, and the keyboard follows the document
     // rather than the layout — so a document that put the navigation first would hand a reader the bottom bar before
     // the header at the top of the window. Only a browser answers this: jsdom has no sequential focus navigation.
+    // The freshness line is the first thing the header holds, and it is a disclosure onto the account-by-account
+    // reading of the same sentence — so it is where a keyboard arrives before any of the controls beside it.
+    await page.keyboard.press('Tab');
+    await expect(page.getByText('Every account is up to date.')).toBeFocused();
+
     await page.keyboard.press('Tab');
     await expect(page.getByRole('combobox', { name: 'Theme' })).toBeFocused();
 


### PR DESCRIPTION
Closes #1421

The client signed in and then behaved as though every credential could do everything. It offered all three spaces to a credential granted none of them, asked for accounts it may not read, and said nothing about what it was waiting for or what it could not reach. This is the last child of #1422.

## The session as a value of its own

`Client.Backend/src/deploymentSession.ts` owns the session route, the closed set of mail permissions the surface publishes, and the parser. Sign-in now reads its own answer through that parser rather than parsing the same body a second time, which tightens its contract: an address answering the session route without a grant is no longer read as a MailFathom deployment.

The parser is a trust boundary and is bounded as one. The body length is checked before `JSON.parse` sees it, the grant length before the walk, an element that is not a string refuses the whole answer, and a permission name this client does not know is dropped rather than refusing it — so a client keeps working against a deployment that has published a newer name.

## What the shell holds

`Client.App/src/shell/useConnection.ts` is the connection state the whole application reads.

- The session is re-read on every attempt rather than kept from the sign-in that produced it, so a grant the deployment narrows while the client is open is acted on.
- Each answer is tagged with the attempt **and** the identity it answered for. Signing out and back in as somebody else changes the credential without changing the attempt, so tagging by attempt alone would put the previous owner's accounts and grants in front of the next person until their own read landed.
- A credential that may not read mail is never asked for accounts. The refusal would arrive as a failure on a screen, where what is true is that the client is not offering something.
- A deployment that stopped answering is reached for again on its own — five attempts, doubling and capped, spread so a fleet does not come back in step — with the attempt number on the screen and a `Try again` control once the budget is spent. Only `unavailable` is retried; a refused credential, a missing grant, and an unreadable answer each repeat identically.
- Going offline keeps the last answer on the screen and says so beside it; coming back re-reads on its own, with no restart.

## What the shell offers

`shell/capabilities.ts` maps each capability to the one grant it needs and each space to the capability it needs. `SpaceNavigation` renders what it was given rather than the module-level list, and `useSpace` falls back within what is offered — so a space the credential may not enter is **absent** rather than present and failing, and a fragment address naming one is replaced instead of rendering an empty screen.

`GrantNotice` says which capability is withheld and that whoever runs the deployment can grant it. A capability the *deployment* does not have is a different sentence: `accounts.notRefreshing` now names `synchronizationEnabled` as a setting on the deployment rather than a permission the caller is missing.

## Freshness

`ConnectionSummary` is a `<details>` disclosure — quiet by default, one keyboard gesture to the detail. Its summary is the freshness phrase, and behind it sit the oldest refresh and one `AccountLine` per account carrying its own state and relative age. An account that stopped synchronizing is distinguished from one merely behind, an unreachable one from a failing one, and an owner holding no account is told what would fill the screen rather than shown a failure. Ages come from `Intl.RelativeTimeFormat` against the instant the answers were read, which is handed in rather than taken off a clock.

All five states are on the screen: loading (`connection.connecting`, `accounts.reading`), empty (`connection.noAccounts`), partial (the session answered, the accounts have not), error (`connection.lost`, `connection.unreadable`, `accounts.failed`), and offline (`connection.offline`).

## Privacy

Nothing rendered, logged, or measured carries mail content, an address, or anything identifying the credential — no status code reaches a screen, and the credential is compared and never read. Every grant is read as being about the signed-in owner alone.

## Out of scope

Per the issue: no new grant or feature on the session route, no synchronization triggered from the client, and no enforcement — the service enforces, and the client only declines to offer.

## Verification

- `pnpm typecheck`, `pnpm lint --max-warnings 0` — clean
- `pnpm test` — 345 passed across 24 files
- `pnpm test:browser` — 15 passed
- `scripts/verify-full.sh` — passed, recorded 2026-09-01T10:50:21Z
