### PR TITLE
[#1423] Show accounts and folders as one tree, and make it the client's scope selector

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -219,7 +219,16 @@ a path because a path would have to be reloadable, and the service serves the bu
 unmatched path onto the entry document; a fragment never reaches a server, so every address reloads on both heads with
 nothing configured.
 
-`src/workspace/` is what survives moving between spaces, and it is mounted above the frame for exactly that reason.
+`src/workspace/` is what survives moving between spaces, and it is mounted above the frame for exactly that reason. It
+holds one **scope** — every mailbox at once, one role across all of them, one mailbox, or one folder of one — beside the
+question, the selection, and the rows of the folder tree somebody has folded away. It is kept in the store the web head
+keeps its credential in, so a reload returns to what was on the screen; signing out empties it, because what somebody
+was looking at and about to ask is theirs rather than the machine's.
+
+`src/folders/` is what writes that scope. It draws the owner's mailboxes and their folders as one tree, read from the
+folders route in a single exchange, with the roles that span every mailbox above them — so asking about every inbox at
+once is one act rather than three. A folder is placed and named by the role the deployment gave it rather than by what
+its server calls it, because a name is whatever a provider chose in whatever language.
 
 ## Styling, and the two themes
 

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -7,6 +7,7 @@ import type { DeploymentAddress } from '@mailfathom/client-backend';
 import { SecondaryButton } from './controls/SecondaryButton';
 import { forgetDeployment, storeDeployment, type AdoptedDeployment } from './deployment/adoptedDeployment';
 import type { DeploymentTransport } from './deployment/sendToDeployment';
+import { FolderTree } from './folders/FolderTree';
 import { useLocalization } from './localization/useLocalization';
 import { Message } from './messageBody/Message';
 import { useSpace } from './routing/useSpace';
@@ -67,10 +68,10 @@ export function App({
         [baseAddress, authorization],
     );
 
-    // The transport that read is made through, built once for the same reason. It carries a signal nothing ever fires:
-    // `Message` discards the answer to a read it stopped listening for rather than cancelling it, and the pane that
-    // will own a read outliving the message it was started for is #1426's.
-    const readMessage = useMemo(() => send(new AbortController().signal), [send]);
+    // The transport those reads are made through, built once for the same reason. It carries a signal nothing ever
+    // fires: both the tree and the message discard the answer to a read they stopped listening for rather than
+    // cancelling it, and the pane that will own a read outliving the message it was started for is #1426's.
+    const readMail = useMemo(() => send(new AbortController().signal), [send]);
 
     // The view changed, so focus goes to the start of what replaced it rather than staying on a control that is no
     // longer there. Only in this direction: the sign-in screen places focus itself, on the field it is asking to have
@@ -125,6 +126,7 @@ export function App({
     const space = useSpace(offeredSpaces);
     const withheld = deploymentSession === null ? [] : withheldFrom(deploymentSession);
     const mailAccounts = connection.accounts?.outcome === 'read' ? connection.accounts.value.accounts : [];
+    const readsMail = deploymentSession !== null && offers(deploymentSession, 'readMail');
 
     function signedIn(reached: DeploymentAddress, presented: string): void {
         if (adopted === null) {
@@ -229,9 +231,14 @@ export function App({
                 ) : (
                     <Space
                         space={space}
+                        folders={
+                            session === null || !readsMail ? null : (
+                                <FolderTree session={session} transport={readMail} online={connection.online} />
+                            )
+                        }
                         mail={
                             session === null ? null : (
-                                <Message session={session} transport={readMessage} storedEmailId={provingRead} />
+                                <Message session={session} transport={readMail} storedEmailId={provingRead} />
                             )
                         }
                     />

--- a/frontend/src/Client.App/src/folders/FolderRow.tsx
+++ b/frontend/src/Client.App/src/folders/FolderRow.tsx
@@ -1,0 +1,172 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { KeyboardEvent } from 'react';
+import type { MailFolderRole } from '@mailfathom/client-backend';
+import type { MessageKey } from '../localization/en';
+import { useLocalization } from '../localization/useLocalization';
+import { isCurrent, needsAttention, synchronizationStateLabel } from '../synchronization/synchronizationState';
+import type { FolderTreeRow } from './folderTree';
+
+// One row of the tree, which is its own component because it is the row of a list and because it carries everything a
+// tree asks of a row: where it sits, whether it is open, whether it is what the client is scoped to, and whether it is
+// the one the keyboard is on.
+//
+// What names it is decided here rather than by the service. A folder playing a role is called by the role — an inbox
+// is an inbox whatever the provider named the folder and in whatever language — and everything else is called what its
+// mail server calls it.
+
+const roleLabels: Readonly<Record<MailFolderRole, MessageKey>> = {
+    Inbox: 'folder.inbox',
+    Drafts: 'folder.drafts',
+    Sent: 'folder.sent',
+    Archive: 'folder.archive',
+    Junk: 'folder.junk',
+    Trash: 'folder.trash',
+    Flagged: 'folder.flagged',
+    Important: 'folder.important',
+    All: 'folder.all',
+    Outbox: 'folder.outbox',
+};
+
+// How far in each level sits. Stated as one list rather than as a width worked out from the level, because a computed
+// indentation is a value written outside the token layer however it is arrived at. Anything deeper than the list sits
+// where its last entry does: a mailbox nested six deep is rare, and a row indented off the side of a narrow column is
+// worse than one that stops moving.
+const levelIndents: readonly string[] = ['ps-2', 'ps-6', 'ps-10', 'ps-14', 'ps-16'];
+
+export function FolderRow({
+    row,
+    position,
+    setSize,
+    expanded,
+    selected,
+    focusable,
+    onSelect,
+    onToggle,
+    onKeyDown,
+    onElement,
+}: {
+    readonly row: FolderTreeRow;
+    readonly position: number;
+    readonly setSize: number;
+    readonly expanded: boolean | null;
+    readonly selected: boolean;
+    readonly focusable: boolean;
+    readonly onSelect: () => void;
+    readonly onToggle: () => void;
+    readonly onKeyDown: (event: KeyboardEvent<HTMLLIElement>) => void;
+    readonly onElement: (element: HTMLLIElement | null) => void;
+}) {
+    const { translate } = useLocalization();
+    const indent = levelIndents[Math.min(Math.max(row.level, 1), levelIndents.length) - 1] ?? '';
+
+    return (
+        <li
+            ref={onElement}
+            role="treeitem"
+            aria-level={row.level}
+            aria-posinset={position}
+            aria-setsize={setSize}
+            aria-expanded={expanded ?? undefined}
+            aria-selected={row.scope === null ? undefined : selected}
+            tabIndex={focusable ? 0 : -1}
+            onClick={onSelect}
+            onKeyDown={onKeyDown}
+            className={`flex items-center gap-2 rounded-md py-1 pe-2 text-sm transition ${indent} ${
+                row.scope === null ? '' : 'cursor-pointer'
+            } ${selected ? 'bg-accent-soft text-accent-strong' : 'text-text-soft hover:bg-hover'}`}
+        >
+            <Twist
+                expanded={expanded}
+                onToggle={() => {
+                    onToggle();
+                }}
+            />
+
+            <span className="truncate">{nameOf(row, translate)}</span>
+
+            <State row={row} />
+            <Counts unread={row.unreadEmailCount} stored={row.storedEmailCount} />
+        </li>
+    );
+}
+
+function nameOf(row: FolderTreeRow, translate: (key: MessageKey) => string): string {
+    if (row.scope?.kind === 'everything') {
+        return translate('scope.allMailboxes');
+    }
+
+    return row.role === null ? row.name : translate(roleLabels[row.role]);
+}
+
+// The control that opens a row, and the room it takes when there is nothing to open, so every name on one level starts
+// at the same place. It is hidden from the accessibility tree because a tree already says whether a row is open and
+// opens one from the keyboard: an extra control here would be a second way to do what arrow keys already do, announced
+// on every row.
+function Twist({ expanded, onToggle }: { readonly expanded: boolean | null; readonly onToggle: () => void }) {
+    if (expanded === null) {
+        return <span aria-hidden="true" className="size-4 shrink-0" />;
+    }
+
+    return (
+        <span
+            aria-hidden="true"
+            className="shrink-0 rounded p-0.5 hover:bg-hover"
+            onClick={(event) => {
+                event.stopPropagation();
+                onToggle();
+            }}
+        >
+            <svg viewBox="0 0 24 24" className={`size-3 fill-current transition ${expanded ? 'rotate-90' : ''}`}>
+                <path d="M9 5l7 7-7 7V5Z" />
+            </svg>
+        </span>
+    );
+}
+
+// Said in words rather than in a colour, and only where there is something to say: a row whose last attempt succeeded
+// and left nothing behind carries nothing, so the two rows that do are the ones a reader's eye lands on.
+function State({ row }: { readonly row: FolderTreeRow }) {
+    const { translate } = useLocalization();
+
+    if (row.state === null || isCurrent(row.state, row.behind)) {
+        return null;
+    }
+
+    return (
+        <span className={`shrink-0 text-xs ${needsAttention(row.state) ? 'text-warning' : 'text-muted'}`}>
+            {translate(synchronizationStateLabel(row.state, row.behind))}
+        </span>
+    );
+}
+
+// What is unread here, and what is held here at all. Both are of the deployment's own copy rather than of the mailbox,
+// which is what the state beside them says; the words a reader hears are carried for both, because a bare number on a
+// row is a number of nothing to somebody who cannot see the column it is in.
+function Counts({ unread, stored }: { readonly unread: number | null; readonly stored: number | null }) {
+    const { locale, translate } = useLocalization();
+
+    if (unread === null || stored === null) {
+        return null;
+    }
+
+    const numbers = new Intl.NumberFormat(locale);
+
+    return (
+        <span className="ms-auto flex shrink-0 items-baseline gap-2 text-xs tabular-nums">
+            {unread === 0 ? null : (
+                <span className="font-semibold text-accent-strong">
+                    <span aria-hidden="true">{numbers.format(unread)}</span>
+                    <span className="sr-only">{translate('folders.unread', { count: numbers.format(unread) })}</span>
+                </span>
+            )}
+
+            <span className="text-faint">
+                <span aria-hidden="true">{numbers.format(stored)}</span>
+                <span className="sr-only">{translate('folders.stored', { count: numbers.format(stored) })}</span>
+            </span>
+        </span>
+    );
+}

--- a/frontend/src/Client.App/src/folders/FolderTree.test.tsx
+++ b/frontend/src/Client.App/src/folders/FolderTree.test.tsx
@@ -2,7 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { fireEvent, render, screen, type RenderResult } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ClientSession, MailFathomTransport } from '@mailfathom/client-backend';
 import { LocalizationProvider } from '../localization/Localization';
@@ -93,15 +94,19 @@ function carried(): Workspace {
     return JSON.parse(probe?.textContent ?? '') as Workspace;
 }
 
-function renderTree(transport: MailFathomTransport, online = true): void {
-    render(
+function treeUnder(transport: MailFathomTransport, online: boolean): ReactElement {
+    return (
         <LocalizationProvider>
             <WorkspaceProvider>
                 <FolderTree session={session} transport={transport} online={online} />
                 <ScopeProbe />
             </WorkspaceProvider>
-        </LocalizationProvider>,
+        </LocalizationProvider>
     );
+}
+
+function renderTree(transport: MailFathomTransport, online = true): RenderResult {
+    return render(treeUnder(transport, online));
 }
 
 function row(name: RegExp): HTMLElement {
@@ -121,6 +126,29 @@ describe('FolderTree', () => {
         renderTree(() => new Promise(() => undefined));
 
         expect(screen.getByText('Reading mailboxes and folders…')).toBeDefined();
+    });
+
+    it('says it is reading again when the network comes back, rather than swapping the tree in silence', async () => {
+        let reads = 0;
+
+        // One transport across all three renders, so what starts the second read is the network coming back rather
+        // than a changed dependency, and that read never answers — which is the wait the note has to report.
+        const transport: MailFathomTransport = () => {
+            reads += 1;
+
+            return reads === 1
+                ? Promise.resolve({ status: 200, body: JSON.stringify(tree), headers: {} })
+                : new Promise<never>(() => undefined);
+        };
+
+        const view = renderTree(transport);
+
+        await drawn();
+        view.rerender(treeUnder(transport, false));
+        view.rerender(treeUnder(transport, true));
+
+        expect(screen.getByText('Reading mailboxes and folders…')).toBeDefined();
+        expect(screen.queryByRole('tree')).toBeNull();
     });
 
     it('draws the mailboxes and their folders as one tree', async () => {

--- a/frontend/src/Client.App/src/folders/FolderTree.test.tsx
+++ b/frontend/src/Client.App/src/folders/FolderTree.test.tsx
@@ -305,6 +305,16 @@ describe('FolderTree', () => {
         expect(carried().scope).toEqual({ kind: 'everything' });
     });
 
+    it('leaves the tab stop on the row the pointer opened, so tabbing out leaves the tree from it', async () => {
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+
+        fireEvent.click(row(/^Work/).firstElementChild as HTMLElement);
+
+        expect(row(/^Work/).getAttribute('tabindex')).toBe('0');
+    });
+
     it('keeps what has been folded away in the workspace, so it survives moving between the spaces', async () => {
         renderTree(answering(JSON.stringify(tree)));
 

--- a/frontend/src/Client.App/src/folders/FolderTree.test.tsx
+++ b/frontend/src/Client.App/src/folders/FolderTree.test.tsx
@@ -1,0 +1,354 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ClientSession, MailFathomTransport } from '@mailfathom/client-backend';
+import { LocalizationProvider } from '../localization/Localization';
+import { WorkspaceProvider } from '../workspace/Workspace';
+import { useWorkspace, type Workspace } from '../workspace/useWorkspace';
+import { FolderTree } from './FolderTree';
+
+const session: ClientSession = { baseAddress: 'https://mail.example.invalid', authorization: 'Basic dGVzdA==' };
+
+// Two mailboxes, one of them nesting a folder its server nests and one of them unreachable, which is what the rows
+// below are read against. The counts differ per row deliberately: two mailboxes both have an inbox, so what tells the
+// row spanning them apart from either of theirs is what it says it holds.
+const tree = {
+    synchronizationEnabled: true,
+    accounts: [
+        {
+            account: {
+                id: 'work',
+                displayName: 'Work',
+                synchronizationState: 'Synchronized',
+                lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
+                behind: false,
+            },
+            folders: [
+                {
+                    alias: 'INBOX',
+                    role: 'Inbox',
+                    path: ['Odebrane'],
+                    storedEmailCount: 4213,
+                    unreadEmailCount: 12,
+                    synchronizationState: 'Synchronized',
+                    lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
+                    behind: false,
+                },
+                {
+                    alias: 'ARCHIVE-2024',
+                    role: null,
+                    path: ['Archiwum', '2024'],
+                    storedEmailCount: 980,
+                    unreadEmailCount: 0,
+                    synchronizationState: 'Synchronized',
+                    lastSynchronizedAt: '2026-08-31T09:00:00+00:00',
+                    behind: true,
+                },
+            ],
+        },
+        {
+            account: {
+                id: 'personal',
+                displayName: 'Personal',
+                synchronizationState: 'Unreachable',
+                lastSynchronizedAt: '2026-08-30T21:00:00+00:00',
+                behind: false,
+            },
+            folders: [
+                {
+                    alias: 'INBOX',
+                    role: 'Inbox',
+                    path: ['INBOX'],
+                    storedEmailCount: 50,
+                    unreadEmailCount: 3,
+                    synchronizationState: 'Unreachable',
+                    lastSynchronizedAt: '2026-08-30T21:00:00+00:00',
+                    behind: false,
+                },
+            ],
+        },
+    ],
+};
+
+function answering(body: string, status = 200): MailFathomTransport {
+    return () => Promise.resolve({ status, body, headers: {} });
+}
+
+// What the tree wrote, read back the way every other screen will read it: out of the workspace rather than out of the
+// component that wrote it.
+function ScopeProbe() {
+    const { workspace } = useWorkspace();
+
+    return <output>{JSON.stringify(workspace)}</output>;
+}
+
+// An `output` reports itself as a status region, exactly as the tree's own waiting line does, so the probe is picked
+// out by being the one carrying a workspace rather than a sentence.
+function carried(): Workspace {
+    const probe = screen.getAllByRole('status').find((element) => element.textContent.startsWith('{'));
+
+    return JSON.parse(probe?.textContent ?? '') as Workspace;
+}
+
+function renderTree(transport: MailFathomTransport, online = true): void {
+    render(
+        <LocalizationProvider>
+            <WorkspaceProvider>
+                <FolderTree session={session} transport={transport} online={online} />
+                <ScopeProbe />
+            </WorkspaceProvider>
+        </LocalizationProvider>,
+    );
+}
+
+function row(name: RegExp): HTMLElement {
+    return screen.getByRole('treeitem', { name });
+}
+
+async function drawn(): Promise<HTMLElement> {
+    return screen.findByRole('tree', { name: 'Mailboxes and folders' });
+}
+
+afterEach(() => {
+    window.sessionStorage.clear();
+});
+
+describe('FolderTree', () => {
+    it('says it is reading from the moment the read starts, where the tree will appear', () => {
+        renderTree(() => new Promise(() => undefined));
+
+        expect(screen.getByText('Reading mailboxes and folders…')).toBeDefined();
+    });
+
+    it('draws the mailboxes and their folders as one tree', async () => {
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+
+        expect(row(/^All mailboxes/)).toBeDefined();
+        expect(row(/^Work/)).toBeDefined();
+        expect(row(/^Personal/)).toBeDefined();
+        expect(row(/^Archiwum/).getAttribute('aria-level')).toBe('2');
+        expect(row(/^2024/).getAttribute('aria-level')).toBe('3');
+    });
+
+    it('names a folder by the role the deployment gave it rather than by what its server calls the folder', async () => {
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+
+        expect(row(/^Inbox12 unread/)).toBeDefined();
+        expect(screen.queryByRole('treeitem', { name: /Odebrane/ })).toBeNull();
+    });
+
+    it('reports what is unread and what is held, in the words a reader hears rather than as bare numbers', async () => {
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+
+        expect(row(/^Inbox12 unread/).textContent).toContain('12 unread');
+        expect(row(/^Inbox12 unread/).textContent).toContain('4,213 held here');
+    });
+
+    it('offers every mailbox at once as the scope everything else is read under', async () => {
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+        fireEvent.click(row(/^All mailboxes/));
+
+        expect(carried().scope).toEqual({ kind: 'everything' });
+        expect(row(/^All mailboxes/).getAttribute('aria-selected')).toBe('true');
+    });
+
+    it('offers a special-use folder across every mailbox playing that role, counting all of them', async () => {
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+        const acrossMailboxes = row(/^Inbox15 unread/);
+
+        expect(acrossMailboxes.textContent).toContain('4,263 held here');
+
+        fireEvent.click(acrossMailboxes);
+
+        expect(carried().scope).toEqual({ kind: 'role', role: 'Inbox' });
+    });
+
+    it('scopes to one folder of one mailbox, named by what the client surface names it by', async () => {
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+        fireEvent.click(row(/^Inbox12 unread/));
+
+        expect(carried().scope).toEqual({ kind: 'folder', accountId: 'work', alias: 'INBOX' });
+    });
+
+    it('says which folder is behind and which one nothing could reach, rather than showing either as waiting', async () => {
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+
+        expect(row(/^2024/).textContent).toContain('Catching up');
+        expect(row(/^InboxThe mail server did not answer/)).toBeDefined();
+        expect(screen.queryByRole('progressbar')).toBeNull();
+    });
+
+    it('moves through the rows a reader can see from the keyboard', async () => {
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+        const first = row(/^All mailboxes/);
+
+        first.focus();
+        fireEvent.keyDown(first, { key: 'ArrowDown' });
+
+        expect(document.activeElement).toBe(row(/^Inbox15 unread/));
+
+        fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'ArrowUp' });
+
+        expect(document.activeElement).toBe(first);
+    });
+
+    it('folds a mailbox away from the keyboard, and everything under it with it', async () => {
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+        const work = row(/^Work/);
+
+        work.focus();
+        fireEvent.keyDown(work, { key: 'ArrowLeft' });
+
+        expect(screen.queryByRole('treeitem', { name: /^Archiwum/ })).toBeNull();
+        expect(row(/^Work/).getAttribute('aria-expanded')).toBe('false');
+
+        fireEvent.keyDown(row(/^Work/), { key: 'ArrowRight' });
+
+        expect(row(/^Work/).getAttribute('aria-expanded')).toBe('true');
+    });
+
+    it('chooses the row the keyboard is on, so a tree is usable without a pointer at all', async () => {
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+        const inbox = row(/^Inbox12 unread/);
+
+        inbox.focus();
+        fireEvent.keyDown(inbox, { key: 'Enter' });
+
+        expect(carried().scope).toEqual({ kind: 'folder', accountId: 'work', alias: 'INBOX' });
+    });
+
+    it('steps into what a row holds where it is already open, rather than opening it twice', async () => {
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+        const work = row(/^Work/);
+
+        work.focus();
+        fireEvent.keyDown(work, { key: 'ArrowRight' });
+
+        expect(document.activeElement).toBe(row(/^Inbox12 unread/));
+    });
+
+    it('leaves a key it has no answer for to the browser', async () => {
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+        const first = row(/^All mailboxes/);
+
+        first.focus();
+        fireEvent.keyDown(first, { key: 'a' });
+
+        expect(document.activeElement).toBe(first);
+    });
+
+    it('moves to the first and the last row a reader can see', async () => {
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+        const first = row(/^All mailboxes/);
+
+        first.focus();
+        fireEvent.keyDown(first, { key: 'End' });
+
+        expect(document.activeElement).toBe(row(/^InboxThe mail server did not answer/));
+
+        fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'Home' });
+
+        expect(document.activeElement).toBe(first);
+    });
+
+    it('moves out to what a folder sits in, where there is nothing under it to shut', async () => {
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+        const nested = row(/^2024/);
+
+        nested.focus();
+        fireEvent.keyDown(nested, { key: 'ArrowLeft' });
+
+        expect(document.activeElement).toBe(row(/^Archiwum/));
+    });
+
+    it('opens and shuts a row with the pointer as well', async () => {
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+
+        // The control that opens a row is hidden from the accessibility tree deliberately — a tree says whether a row
+        // is open and opens one from the keyboard — so this is the one thing here that cannot be found by its role.
+        fireEvent.click(row(/^Work/).firstElementChild as HTMLElement);
+
+        expect(row(/^Work/).getAttribute('aria-expanded')).toBe('false');
+        expect(carried().scope).toEqual({ kind: 'everything' });
+    });
+
+    it('keeps what has been folded away in the workspace, so it survives moving between the spaces', async () => {
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+        const work = row(/^Work/);
+
+        work.focus();
+        fireEvent.keyDown(work, { key: 'ArrowLeft' });
+
+        expect(carried().collapsed).toEqual(['account:work']);
+    });
+
+    it('says an owner with no mailbox has none, and what would give them one', async () => {
+        renderTree(answering(JSON.stringify({ synchronizationEnabled: false, accounts: [] })));
+
+        expect(await screen.findByText(/No mail account is configured for this owner yet\./)).toBeDefined();
+        expect(screen.getByText(/none is declared yet\./)).toBeDefined();
+    });
+
+    it('says a deployment that did not answer did not answer, and offers the one way out of it', async () => {
+        const transport = vi.fn(answering('', 503));
+
+        renderTree(transport);
+
+        expect(await screen.findByText('The mailboxes and folders could not be read: unavailable.')).toBeDefined();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+
+        expect(transport).toHaveBeenCalledTimes(2);
+    });
+
+    it('offers no second attempt at a failure a second attempt would repeat', async () => {
+        renderTree(answering('', 403));
+
+        expect(await screen.findByText('The mailboxes and folders could not be read: unauthorized.')).toBeDefined();
+        expect(screen.queryByRole('button', { name: 'Try again' })).toBeNull();
+    });
+
+    it('reads nothing without a network, and says so rather than waiting in silence', () => {
+        const transport = vi.fn(answering(JSON.stringify(tree)));
+
+        renderTree(transport, false);
+
+        expect(screen.getByText(/This machine is offline\./)).toBeDefined();
+        expect(transport).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/src/Client.App/src/folders/FolderTree.tsx
+++ b/frontend/src/Client.App/src/folders/FolderTree.tsx
@@ -243,6 +243,10 @@ export function FolderTree({
                             }
                         }}
                         onToggle={() => {
+                            // The tab stop follows the row a pointer just acted on, exactly as selecting one moves it:
+                            // the browser has already put DOM focus on this row, and a tab stop left on another is a
+                            // reader tabbing out of the tree from somewhere they never were.
+                            setFocused(visibleRow.row.key);
                             fold(visibleRow.row.key, visibleRow.expanded === true);
                         }}
                         onKeyDown={(event) => {

--- a/frontend/src/Client.App/src/folders/FolderTree.tsx
+++ b/frontend/src/Client.App/src/folders/FolderTree.tsx
@@ -1,0 +1,271 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { useEffect, useRef, useState, type KeyboardEvent, type ReactNode } from 'react';
+import {
+    readMailFolders,
+    type ClientFailureReason,
+    type ClientResult,
+    type ClientSession,
+    type MailFathomTransport,
+    type MailFolderDirectory,
+} from '@mailfathom/client-backend';
+import { SecondaryButton } from '../controls/SecondaryButton';
+import type { MessageKey } from '../localization/en';
+import { useLocalization } from '../localization/useLocalization';
+import { scopeKey } from '../workspace/mailScope';
+import { useWorkspace } from '../workspace/useWorkspace';
+import { FolderRow } from './FolderRow';
+import { folderTreeOf, visibleRows, type VisibleRow } from './folderTree';
+
+// The client's scope selector: which mailbox and which folder everything else is about. It is a tree because the
+// mailboxes are a tree, and it is one tree rather than one per account because several mailboxes are one workspace —
+// the row above them all, and the roles under it, are what make asking about every inbox at once a single act.
+//
+// It reads the folders route rather than the accounts route the frame polls, because that route is the tree: it costs
+// what counting a folder's mail costs, and it answers the mailboxes and their folders in one exchange so that a screen
+// never draws one picture out of two answers.
+//
+// What it does not do is decide anything about the mail itself. Selecting a row writes the scope into the workspace,
+// and the list, the search, and the next question read it from there.
+
+const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
+    unauthenticated: 'failure.unauthenticated',
+    unauthorized: 'failure.unauthorized',
+    unavailable: 'failure.unavailable',
+    unreadable: 'failure.unreadable',
+};
+
+/** What one attempt answered, tagged with the attempt, so whether a read is in flight is worked out rather than kept. */
+interface Answered {
+    readonly attempt: number;
+    readonly result: ClientResult<MailFolderDirectory>;
+}
+
+export function FolderTree({
+    session,
+    transport,
+    online,
+}: {
+    readonly session: ClientSession;
+    readonly transport: MailFathomTransport;
+    readonly online: boolean;
+}) {
+    const { translate } = useLocalization();
+    const { workspace, revise } = useWorkspace();
+    const [attempt, setAttempt] = useState(0);
+    const [answered, setAnswered] = useState<Answered | null>(null);
+    const [focused, setFocused] = useState<string | null>(null);
+    const elements = useRef(new Map<string, HTMLLIElement>());
+
+    // Nothing is read without a network, and coming back re-runs this — which is the whole of the recovery from that
+    // direction, exactly as it is for the accounts the frame reads.
+    useEffect(() => {
+        if (!online) {
+            return;
+        }
+
+        let listening = true;
+
+        void readMailFolders(session, transport).then((result) => {
+            if (listening) {
+                setAnswered({ attempt, result });
+            }
+        });
+
+        return () => {
+            listening = false;
+        };
+    }, [session, transport, attempt, online]);
+
+    if (!online) {
+        return <Note>{translate('connection.offline')}</Note>;
+    }
+
+    const reading = answered?.attempt !== attempt;
+
+    // A tree already drawn stays on the screen while a re-read runs, but a failure has nothing worth keeping — so a
+    // read started from one says it started rather than leaving the sentence about the last attempt under the button
+    // that started this one.
+    if (answered === null || (reading && answered.result.outcome === 'failed')) {
+        return <Note announced>{translate('folders.reading')}</Note>;
+    }
+
+    if (answered.result.outcome === 'failed') {
+        const reason = answered.result.failure.reason;
+
+        return (
+            <div className="flex flex-col items-start gap-2">
+                <p className="text-sm text-warning">
+                    {translate('folders.failed', { reason: translate(failureLabels[reason]) })}
+                </p>
+
+                {/* Reading again is the way out of exactly one of the four failures, for the reason
+                    `shell/ConnectionSummary.tsx` gives: the other three repeat identically on a second attempt. */}
+                {reason === 'unavailable' ? (
+                    <SecondaryButton
+                        label={translate('connection.retry')}
+                        onActivate={() => {
+                            setAttempt(attempt + 1);
+                        }}
+                    />
+                ) : null}
+            </div>
+        );
+    }
+
+    const directory = answered.result.value;
+
+    // An owner holding no account is told so and told what would fill it, rather than being handed an empty tree.
+    if (directory.accounts.length === 0) {
+        return (
+            <Note>
+                {translate('connection.noAccounts')} {translate('accounts.noneDeclared')}
+            </Note>
+        );
+    }
+
+    const collapsed = new Set(workspace.collapsed);
+    const visible = visibleRows(folderTreeOf(directory), collapsed);
+
+    // A row is what the client is scoped to when it stands for that scope, which is a comparison of one string because
+    // a row is keyed by the scope selecting it writes.
+    const inScope = scopeKey(workspace.scope);
+
+    // The row the keyboard is on, which is the first one until somebody moves it, and the first one again whenever the
+    // row it was on has been folded away with its parent.
+    const carryingFocus = visible.find((visibleRow) => visibleRow.row.key === focused) ?? visible[0];
+
+    function focusRow(at: number): void {
+        const moved = visible[Math.min(Math.max(at, 0), visible.length - 1)];
+
+        if (moved !== undefined) {
+            setFocused(moved.row.key);
+            elements.current.get(moved.row.key)?.focus();
+        }
+    }
+
+    function fold(key: string, away: boolean): void {
+        const folded = new Set(collapsed);
+
+        if (away) {
+            folded.add(key);
+        } else {
+            folded.delete(key);
+        }
+
+        revise({ collapsed: [...folded] });
+    }
+
+    // The parent of a row is the nearest row above it sitting one level out, which is what a flat list of rows that
+    // each state their own level makes answerable without a second structure to walk.
+    function parentOf(at: number): number {
+        const level = visible[at]?.row.level ?? 1;
+
+        for (let above = at - 1; above >= 0; above -= 1) {
+            const candidate = visible[above];
+
+            if (candidate !== undefined && candidate.row.level < level) {
+                return above;
+            }
+        }
+
+        return at;
+    }
+
+    function onKeyDown(event: KeyboardEvent<HTMLLIElement>, at: number, visibleRow: VisibleRow): void {
+        switch (event.key) {
+            case 'ArrowDown':
+                focusRow(at + 1);
+                break;
+            case 'ArrowUp':
+                focusRow(at - 1);
+                break;
+            case 'Home':
+                focusRow(0);
+                break;
+            case 'End':
+                focusRow(visible.length - 1);
+                break;
+            case 'ArrowRight':
+                if (visibleRow.expanded === false) {
+                    fold(visibleRow.row.key, false);
+                } else if (visibleRow.expanded === true) {
+                    focusRow(at + 1);
+                }
+
+                break;
+            case 'ArrowLeft':
+                if (visibleRow.expanded === true) {
+                    fold(visibleRow.row.key, true);
+                } else {
+                    focusRow(parentOf(at));
+                }
+
+                break;
+            case 'Enter':
+            case ' ':
+                if (visibleRow.row.scope !== null) {
+                    revise({ scope: visibleRow.row.scope });
+                }
+
+                break;
+            default:
+                return;
+        }
+
+        event.preventDefault();
+    }
+
+    return (
+        <div className="flex flex-col gap-2">
+            {/* A tree already on the screen stays on it while a re-read runs, and what is waiting is said beside it
+                rather than in place of it: replacing the tree with one line would move everything under a reader's
+                cursor and drop the focus of whoever asked. */}
+            {reading ? <Note announced>{translate('folders.reading')}</Note> : null}
+
+            <ul aria-label={translate('folders.label')} className="flex flex-col gap-0.5" role="tree">
+                {visible.map((visibleRow, at) => (
+                    <FolderRow
+                        key={visibleRow.row.key}
+                        row={visibleRow.row}
+                        position={visibleRow.position}
+                        setSize={visibleRow.setSize}
+                        expanded={visibleRow.expanded}
+                        selected={visibleRow.row.key === inScope}
+                        focusable={visibleRow.row.key === carryingFocus?.row.key}
+                        onSelect={() => {
+                            setFocused(visibleRow.row.key);
+
+                            if (visibleRow.row.scope !== null) {
+                                revise({ scope: visibleRow.row.scope });
+                            }
+                        }}
+                        onToggle={() => {
+                            fold(visibleRow.row.key, visibleRow.expanded === true);
+                        }}
+                        onKeyDown={(event) => {
+                            onKeyDown(event, at, visibleRow);
+                        }}
+                        onElement={(element) => {
+                            if (element === null) {
+                                elements.current.delete(visibleRow.row.key);
+                            } else {
+                                elements.current.set(visibleRow.row.key, element);
+                            }
+                        }}
+                    />
+                ))}
+            </ul>
+        </div>
+    );
+}
+
+function Note({ announced = false, children }: { readonly announced?: boolean; readonly children: ReactNode }) {
+    return (
+        <p className="text-sm text-muted" role={announced ? 'status' : undefined}>
+            {children}
+        </p>
+    );
+}

--- a/frontend/src/Client.App/src/folders/FolderTree.tsx
+++ b/frontend/src/Client.App/src/folders/FolderTree.tsx
@@ -97,12 +97,11 @@ export function FolderTree({
         return <Note>{translate('connection.offline')}</Note>;
     }
 
-    const reading = answered?.attempt !== attempt;
-
-    // A tree already drawn stays on the screen while a re-read runs, but a failure has nothing worth keeping — so a
-    // read started from one says it started rather than leaving the sentence about the last attempt under the button
-    // that started this one.
-    if (answered === null || (reading && answered.result.outcome === 'failed')) {
+    // Every read this tree starts is one with nothing worth keeping on the screen behind it: the first, one a retry
+    // started from a failure, and one the network coming back started after the offline note had already replaced the
+    // tree. So a read in flight is the whole of what the screen says, rather than a line beside a drawing that would
+    // otherwise be a sentence about the attempt before it.
+    if (answered?.attempt !== attempt) {
         return <Note announced>{translate('folders.reading')}</Note>;
     }
 
@@ -233,50 +232,43 @@ export function FolderTree({
     }
 
     return (
-        <div className="flex flex-col gap-2">
-            {/* A tree already on the screen stays on it while a re-read runs, and what is waiting is said beside it
-                rather than in place of it: replacing the tree with one line would move everything under a reader's
-                cursor and drop the focus of whoever asked. */}
-            {reading ? <Note announced>{translate('folders.reading')}</Note> : null}
+        <ul aria-label={translate('folders.label')} className="flex flex-col gap-0.5" role="tree">
+            {visible.map((visibleRow, at) => (
+                <FolderRow
+                    key={visibleRow.row.key}
+                    row={visibleRow.row}
+                    position={visibleRow.position}
+                    setSize={visibleRow.setSize}
+                    expanded={visibleRow.expanded}
+                    selected={visibleRow.row.key === inScope}
+                    focusable={visibleRow.row.key === carryingFocus?.row.key}
+                    onSelect={() => {
+                        setFocused(visibleRow.row.key);
 
-            <ul aria-label={translate('folders.label')} className="flex flex-col gap-0.5" role="tree">
-                {visible.map((visibleRow, at) => (
-                    <FolderRow
-                        key={visibleRow.row.key}
-                        row={visibleRow.row}
-                        position={visibleRow.position}
-                        setSize={visibleRow.setSize}
-                        expanded={visibleRow.expanded}
-                        selected={visibleRow.row.key === inScope}
-                        focusable={visibleRow.row.key === carryingFocus?.row.key}
-                        onSelect={() => {
-                            setFocused(visibleRow.row.key);
-
-                            if (visibleRow.row.scope !== null) {
-                                revise({ scope: visibleRow.row.scope });
-                            }
-                        }}
-                        onToggle={() => {
-                            // The tab stop follows the row a pointer just acted on, exactly as selecting one moves it:
-                            // the browser has already put DOM focus on this row, and a tab stop left on another is a
-                            // reader tabbing out of the tree from somewhere they never were.
-                            setFocused(visibleRow.row.key);
-                            fold(visibleRow.row.key, visibleRow.expanded === true);
-                        }}
-                        onKeyDown={(event) => {
-                            onKeyDown(event, at, visibleRow);
-                        }}
-                        onElement={(element) => {
-                            if (element === null) {
-                                elements.current.delete(visibleRow.row.key);
-                            } else {
-                                elements.current.set(visibleRow.row.key, element);
-                            }
-                        }}
-                    />
-                ))}
-            </ul>
-        </div>
+                        if (visibleRow.row.scope !== null) {
+                            revise({ scope: visibleRow.row.scope });
+                        }
+                    }}
+                    onToggle={() => {
+                        // The tab stop follows the row a pointer just acted on, exactly as selecting one moves it:
+                        // the browser has already put DOM focus on this row, and a tab stop left on another is a
+                        // reader tabbing out of the tree from somewhere they never were.
+                        setFocused(visibleRow.row.key);
+                        fold(visibleRow.row.key, visibleRow.expanded === true);
+                    }}
+                    onKeyDown={(event) => {
+                        onKeyDown(event, at, visibleRow);
+                    }}
+                    onElement={(element) => {
+                        if (element === null) {
+                            elements.current.delete(visibleRow.row.key);
+                        } else {
+                            elements.current.set(visibleRow.row.key, element);
+                        }
+                    }}
+                />
+            ))}
+        </ul>
     );
 }
 

--- a/frontend/src/Client.App/src/folders/FolderTree.tsx
+++ b/frontend/src/Client.App/src/folders/FolderTree.tsx
@@ -57,7 +57,21 @@ export function FolderTree({
     const [attempt, setAttempt] = useState(0);
     const [answered, setAnswered] = useState<Answered | null>(null);
     const [focused, setFocused] = useState<string | null>(null);
+    const [connected, setConnected] = useState(online);
     const elements = useRef(new Map<string, HTMLLIElement>());
+
+    // A network gap ends the answer it interrupted rather than outliving it. Coming back re-reads with the attempt
+    // unchanged, so an answer kept across the gap would report a read that is over while the new one is still running,
+    // and the tree would swap under a reader with nothing having said one was in flight. Adjusted during render, which
+    // is where React answers a changed prop: an effect would set it a rendered frame too late, which is the frame the
+    // stale tree would be drawn in.
+    if (connected !== online) {
+        setConnected(online);
+
+        if (!online) {
+            setAnswered(null);
+        }
+    }
 
     // Nothing is read without a network, and coming back re-runs this — which is the whole of the recovery from that
     // direction, exactly as it is for the accounts the frame reads.

--- a/frontend/src/Client.App/src/folders/folderTree.test.ts
+++ b/frontend/src/Client.App/src/folders/folderTree.test.ts
@@ -1,0 +1,167 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import type { MailAccount, MailFolder, MailFolderDirectory } from '@mailfathom/client-backend';
+import { folderTreeOf, visibleRows, type FolderTreeRow } from './folderTree';
+
+function account(id: string, displayName: string): MailAccount {
+    return {
+        id,
+        displayName,
+        synchronizationState: 'Synchronized',
+        lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
+        behind: false,
+    };
+}
+
+function folder(folder: Partial<MailFolder> & Pick<MailFolder, 'alias'>): MailFolder {
+    return {
+        role: null,
+        path: [folder.alias],
+        storedEmailCount: 0,
+        unreadEmailCount: 0,
+        synchronizationState: 'Synchronized',
+        lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
+        behind: false,
+        ...folder,
+    };
+}
+
+const directory: MailFolderDirectory = {
+    synchronizationEnabled: true,
+    accounts: [
+        {
+            account: account('work', 'Work'),
+            folders: [
+                folder({
+                    alias: 'INBOX',
+                    role: 'Inbox',
+                    path: ['INBOX'],
+                    unreadEmailCount: 12,
+                    storedEmailCount: 4213,
+                }),
+                folder({ alias: 'SENT', role: 'Sent', path: ['Wysłane'], storedEmailCount: 300 }),
+                folder({ alias: 'ARCHIVE-2024', path: ['Archiwum', '2024'], storedEmailCount: 980 }),
+            ],
+        },
+        {
+            account: account('personal', 'Personal'),
+            folders: [
+                folder({ alias: 'INBOX', role: 'Inbox', path: ['INBOX'], unreadEmailCount: 3, storedEmailCount: 50 }),
+                folder({ alias: 'NEWS', path: [], synchronizationState: 'NeverSynchronized' }),
+            ],
+        },
+    ],
+};
+
+function keysOf(rows: readonly FolderTreeRow[]): readonly string[] {
+    return rows.map((row) => row.key);
+}
+
+function find(rows: readonly FolderTreeRow[], key: string): FolderTreeRow | undefined {
+    for (const row of rows) {
+        const found = row.key === key ? row : find(row.children, key);
+
+        if (found !== undefined) {
+            return found;
+        }
+    }
+
+    return undefined;
+}
+
+describe('folderTreeOf', () => {
+    it('opens with every mailbox at once, and then each of them', () => {
+        expect(keysOf(folderTreeOf(directory))).toEqual(['everything', 'account:work', 'account:personal']);
+    });
+
+    it('offers the roles the owner’s mailboxes play as scopes spanning all of them', () => {
+        const rows = folderTreeOf(directory);
+
+        expect(keysOf(find(rows, 'everything')?.children ?? [])).toEqual(['role:Inbox', 'role:Sent']);
+    });
+
+    it('counts a role across every mailbox playing it, because that is what selecting it would show', () => {
+        const inbox = find(folderTreeOf(directory), 'role:Inbox');
+
+        expect(inbox?.unreadEmailCount).toBe(15);
+        expect(inbox?.storedEmailCount).toBe(4263);
+    });
+
+    it('names a folder by the role its deployment gave it rather than by what its server calls the folder', () => {
+        const sent = find(folderTreeOf(directory), 'folder:work:SENT');
+
+        expect(sent?.role).toBe('Sent');
+        expect(sent?.name).toBe('Wysłane');
+    });
+
+    it('places the folders playing a role before the ones playing none, in the order they are offered in', () => {
+        const work = find(folderTreeOf(directory), 'account:work');
+
+        expect(keysOf(work?.children ?? [])).toEqual(['folder:work:INBOX', 'folder:work:SENT', 'level:work:Archiwum']);
+    });
+
+    it('nests a folder where its mail server nests it', () => {
+        const archive = find(folderTreeOf(directory), 'level:work:Archiwum');
+        const nested = archive?.children[0];
+
+        expect(archive?.scope).toBeNull();
+        expect(archive?.level).toBe(2);
+        expect(nested?.key).toBe('folder:work:ARCHIVE-2024');
+        expect(nested?.name).toBe('2024');
+        expect(nested?.level).toBe(3);
+    });
+
+    it('shows a folder nothing has bound to a remote folder under the name MailFathom knows it by', () => {
+        const news = find(folderTreeOf(directory), 'folder:personal:NEWS');
+
+        expect(news?.name).toBe('NEWS');
+        expect(news?.state).toBe('NeverSynchronized');
+    });
+
+    it('reads an owner with no mailbox as a tree with no rows rather than as a row with nothing under it', () => {
+        expect(folderTreeOf({ synchronizationEnabled: true, accounts: [] })).toEqual([]);
+    });
+});
+
+describe('visibleRows', () => {
+    it('draws every row of an unfolded tree, each knowing where it sits among its siblings', () => {
+        const visible = visibleRows(folderTreeOf(directory), new Set());
+
+        expect(visible.map((row) => row.row.key)).toEqual([
+            'everything',
+            'role:Inbox',
+            'role:Sent',
+            'account:work',
+            'folder:work:INBOX',
+            'folder:work:SENT',
+            'level:work:Archiwum',
+            'folder:work:ARCHIVE-2024',
+            'account:personal',
+            'folder:personal:INBOX',
+            'folder:personal:NEWS',
+        ]);
+
+        expect(visible[0]).toEqual(expect.objectContaining({ position: 1, setSize: 3, expanded: true }));
+    });
+
+    it('leaves out what is folded away, and everything under it', () => {
+        const visible = visibleRows(folderTreeOf(directory), new Set(['everything', 'account:work']));
+
+        expect(visible.map((row) => row.row.key)).toEqual([
+            'everything',
+            'account:work',
+            'account:personal',
+            'folder:personal:INBOX',
+            'folder:personal:NEWS',
+        ]);
+    });
+
+    it('says a row with nothing under it has nothing to open, rather than saying it is shut', () => {
+        const visible = visibleRows(folderTreeOf(directory), new Set());
+
+        expect(visible.find((row) => row.row.key === 'folder:personal:NEWS')?.expanded).toBeNull();
+    });
+});

--- a/frontend/src/Client.App/src/folders/folderTree.ts
+++ b/frontend/src/Client.App/src/folders/folderTree.ts
@@ -1,0 +1,292 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type {
+    MailAccountFolders,
+    MailFolder,
+    MailFolderDirectory,
+    MailFolderRole,
+    MailSynchronizationState,
+} from '@mailfathom/client-backend';
+import { everything, roleRank, scopeKey, type MailScope } from '../workspace/mailScope';
+
+// What the service answered, turned into the rows a tree draws. It is a function over values rather than anything a
+// component does while rendering: the shape of the tree is the interesting decision here, and a decision that can be
+// read as a value can be tested as one.
+//
+// Three things it decides. The owner's mailboxes are one workspace rather than four applications, so the tree opens
+// with every account at once and the roles that span them — the inbox of all three accounts is a thing somebody wants
+// as often as the inbox of one. Below that each account carries its own folders, nested the way its mail server nests
+// them, which is what the levels of a folder's path are for. And a folder that plays a role is placed by that role
+// rather than by its name, because a name is whatever a provider chose in whatever language.
+
+/** One row of the tree, whatever it stands for: the whole workspace, a role across it, an account, or a folder. */
+export interface FolderTreeRow {
+    /** What identifies the row — what is folded, what is focused, and what is compared against the current scope. */
+    readonly key: string;
+
+    /** What selecting the row scopes the client to, or `null` for a level of a path the service named no folder for. */
+    readonly scope: MailScope | null;
+
+    /** The name whatever this row stands for has: a mailbox's display name, a level of a path, or a folder's alias. */
+    readonly name: string;
+
+    /** The role this row stands for, where it has one — in which case the role names it rather than `name` does. */
+    readonly role: MailFolderRole | null;
+
+    /** How deep the row sits, counted from one, which is what a tree reports as its level. */
+    readonly level: number;
+
+    /** How current the local copy is, or `null` for a row that stands for more than one thing. */
+    readonly state: MailSynchronizationState | null;
+
+    /** Whether the last attempt ended with mail it had not yet taken in. */
+    readonly behind: boolean;
+
+    /** How many unread messages the deployment holds here, or `null` where nothing counted any. */
+    readonly unreadEmailCount: number | null;
+
+    /** How many messages in total the deployment holds here, or `null` where nothing counted any. */
+    readonly storedEmailCount: number | null;
+
+    readonly children: readonly FolderTreeRow[];
+}
+
+/** One row as it is drawn, with what a tree has to say about where it sits among the rows a reader can see. */
+export interface VisibleRow {
+    readonly row: FolderTreeRow;
+
+    /** Where the row falls among its siblings, counted from one. */
+    readonly position: number;
+
+    /** How many siblings it has, itself included. */
+    readonly setSize: number;
+
+    /** Whether it is open, or `null` where it has nothing to open. */
+    readonly expanded: boolean | null;
+}
+
+// A level of a folder's path while the tree is being built: the folder bound to exactly that path where there is one,
+// and whatever is nested under it. A level with no folder of its own is a path the service named a deeper folder for
+// without naming this one — a mapping bound to `Archive/2024` where nothing is bound to `Archive`.
+interface PathLevel {
+    readonly name: string;
+    folder: MailFolder | null;
+    readonly children: Map<string, PathLevel>;
+}
+
+/** The whole tree, as the rows drawing it top to bottom. */
+export function folderTreeOf(directory: MailFolderDirectory): readonly FolderTreeRow[] {
+    if (directory.accounts.length === 0) {
+        return [];
+    }
+
+    return [everythingRow(directory), ...directory.accounts.map(accountRow)];
+}
+
+/**
+ * The rows a reader can see, with each row's place among its siblings.
+ *
+ * Flattened rather than nested, because both things reading this want it flat: the keyboard moves from one visible row
+ * to the next one whatever their depth, and a row states its own level rather than being nested inside its parent's
+ * list. A tree that draws its rows as a flat list with the level on each is what lets the two agree by construction.
+ */
+export function visibleRows(rows: readonly FolderTreeRow[], collapsed: ReadonlySet<string>): readonly VisibleRow[] {
+    const visible: VisibleRow[] = [];
+
+    gather(rows, collapsed, visible);
+
+    return visible;
+}
+
+function gather(siblings: readonly FolderTreeRow[], collapsed: ReadonlySet<string>, into: VisibleRow[]): void {
+    siblings.forEach((row, index) => {
+        const opens = row.children.length > 0;
+        const expanded = opens && !collapsed.has(row.key);
+
+        into.push({ row, position: index + 1, setSize: siblings.length, expanded: opens ? expanded : null });
+
+        if (expanded) {
+            gather(row.children, collapsed, into);
+        }
+    });
+}
+
+// Every mailbox at once, and under it the roles at least one of them plays. The counts are summed rather than reported
+// because that is what the row stands for: an inbox row spanning three accounts holds what the three inboxes hold.
+function everythingRow(directory: MailFolderDirectory): FolderTreeRow {
+    const roles = rolesAcross(directory);
+
+    return {
+        key: scopeKey(everything),
+        scope: everything,
+        name: '',
+        role: null,
+        level: 1,
+        state: null,
+        behind: false,
+        unreadEmailCount: totalOf(directory, (folder) => folder.unreadEmailCount),
+        storedEmailCount: totalOf(directory, (folder) => folder.storedEmailCount),
+        children: [...roles.entries()]
+            .sort(([one], [other]) => roleRank(one) - roleRank(other))
+            .map(([role, folders]) => roleRow(role, folders)),
+    };
+}
+
+function roleRow(role: MailFolderRole, folders: readonly MailFolder[]): FolderTreeRow {
+    const scope: MailScope = { kind: 'role', role };
+
+    return {
+        key: scopeKey(scope),
+        scope,
+        name: '',
+        role,
+        level: 2,
+        state: null,
+        behind: false,
+        unreadEmailCount: sumOf(folders, (folder) => folder.unreadEmailCount),
+        storedEmailCount: sumOf(folders, (folder) => folder.storedEmailCount),
+        children: [],
+    };
+}
+
+function accountRow(entry: MailAccountFolders): FolderTreeRow {
+    const scope: MailScope = { kind: 'account', accountId: entry.account.id };
+
+    return {
+        key: scopeKey(scope),
+        scope,
+        name: entry.account.displayName,
+        role: null,
+        level: 1,
+        state: entry.account.synchronizationState,
+        behind: entry.account.behind,
+        unreadEmailCount: sumOf(entry.folders, (folder) => folder.unreadEmailCount),
+        storedEmailCount: sumOf(entry.folders, (folder) => folder.storedEmailCount),
+        children: folderRows(entry),
+    };
+}
+
+function folderRows(entry: MailAccountFolders): readonly FolderTreeRow[] {
+    const levels = new Map<string, PathLevel>();
+    const unbound: MailFolder[] = [];
+
+    for (const folder of entry.folders) {
+        const [outermost, ...rest] = folder.path;
+
+        if (outermost === undefined) {
+            unbound.push(folder);
+        } else {
+            place(levels, outermost, rest, folder);
+        }
+    }
+
+    const rows = [
+        ...[...levels.values()].map((level) => rowOfLevel(level, entry.account.id, [], 2)),
+        ...unbound.map((folder) => folderRow(folder, folder.alias, entry.account.id, 2, [])),
+    ];
+
+    return rows.sort(bySiblingOrder);
+}
+
+// Walks a folder's path down the levels built so far, adding what is missing, and binds the folder to the last of
+// them. Recursive rather than iterative so nothing has to assert that the level it ended on exists.
+function place(levels: Map<string, PathLevel>, name: string, rest: readonly string[], folder: MailFolder): void {
+    const level = levels.get(name) ?? { name, folder: null, children: new Map<string, PathLevel>() };
+
+    levels.set(name, level);
+
+    const [next, ...deeper] = rest;
+
+    if (next === undefined) {
+        level.folder = folder;
+    } else {
+        place(level.children, next, deeper, folder);
+    }
+}
+
+function rowOfLevel(level: PathLevel, accountId: string, above: readonly string[], depth: number): FolderTreeRow {
+    const path = [...above, level.name];
+    const children = [...level.children.values()]
+        .map((nested) => rowOfLevel(nested, accountId, path, depth + 1))
+        .sort(bySiblingOrder);
+
+    if (level.folder === null) {
+        return {
+            // Keyed by where it sits rather than by what it is called, because two mailboxes nest folders of the same
+            // name and a key that collided would fold both of them away together.
+            key: `level:${accountId}:${path.join('/')}`,
+            scope: null,
+            name: level.name,
+            role: null,
+            level: depth,
+            state: null,
+            behind: false,
+            unreadEmailCount: null,
+            storedEmailCount: null,
+            children,
+        };
+    }
+
+    return folderRow(level.folder, level.name, accountId, depth, children);
+}
+
+function folderRow(
+    folder: MailFolder,
+    name: string,
+    accountId: string,
+    depth: number,
+    children: readonly FolderTreeRow[],
+): FolderTreeRow {
+    const scope: MailScope = { kind: 'folder', accountId, alias: folder.alias };
+
+    return {
+        key: scopeKey(scope),
+        scope,
+        name,
+        role: folder.role,
+        level: depth,
+        state: folder.synchronizationState,
+        behind: folder.behind,
+        unreadEmailCount: folder.unreadEmailCount,
+        storedEmailCount: folder.storedEmailCount,
+        children,
+    };
+}
+
+// A folder playing a role comes before one that plays none, in the order roles are offered in; the rest read as a
+// mailbox reads, by the name on the row. Sorting by name is the client's decision rather than the service's, which
+// orders by an alias no screen shows.
+function bySiblingOrder(one: FolderTreeRow, other: FolderTreeRow): number {
+    const byRole = roleRank(one.role) - roleRank(other.role);
+
+    return byRole === 0 ? one.name.localeCompare(other.name) : byRole;
+}
+
+function rolesAcross(directory: MailFolderDirectory): ReadonlyMap<MailFolderRole, readonly MailFolder[]> {
+    const roles = new Map<MailFolderRole, MailFolder[]>();
+
+    for (const entry of directory.accounts) {
+        for (const folder of entry.folders) {
+            if (folder.role === null) {
+                continue;
+            }
+
+            const carrying = roles.get(folder.role) ?? [];
+
+            carrying.push(folder);
+            roles.set(folder.role, carrying);
+        }
+    }
+
+    return roles;
+}
+
+function sumOf(folders: readonly MailFolder[], count: (folder: MailFolder) => number): number {
+    return folders.reduce((total, folder) => total + count(folder), 0);
+}
+
+function totalOf(directory: MailFolderDirectory, count: (folder: MailFolder) => number): number {
+    return directory.accounts.reduce((total, entry) => total + sumOf(entry.folders, count), 0);
+}

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -96,6 +96,23 @@ export const en = {
     'account.lastRefreshed': 'Last refreshed {age}',
     'account.neverRefreshed': 'Never refreshed',
 
+    'folders.label': 'Mailboxes and folders',
+    'folders.reading': 'Reading mailboxes and folders…',
+    'folders.failed': 'The mailboxes and folders could not be read: {reason}.',
+    'folders.unread': '{count} unread',
+    'folders.stored': '{count} held here',
+
+    'folder.inbox': 'Inbox',
+    'folder.drafts': 'Drafts',
+    'folder.sent': 'Sent',
+    'folder.archive': 'Archive',
+    'folder.junk': 'Junk',
+    'folder.trash': 'Trash',
+    'folder.flagged': 'Flagged',
+    'folder.important': 'Important',
+    'folder.all': 'All mail',
+    'folder.outbox': 'Outbox',
+
     'connection.current': 'Every account is up to date.',
     'connection.behind': 'Some accounts are behind.',
     'connection.failing': 'Some accounts stopped synchronizing.',

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -96,6 +96,23 @@ export const pl: Catalogue = {
     'account.lastRefreshed': 'Ostatnio odświeżono {age}',
     'account.neverRefreshed': 'Nigdy nie odświeżono',
 
+    'folders.label': 'Skrzynki i foldery',
+    'folders.reading': 'Odczytywanie skrzynek i folderów…',
+    'folders.failed': 'Nie udało się odczytać skrzynek i folderów: {reason}.',
+    'folders.unread': 'nieprzeczytane: {count}',
+    'folders.stored': 'przechowywane tutaj: {count}',
+
+    'folder.inbox': 'Odebrane',
+    'folder.drafts': 'Kopie robocze',
+    'folder.sent': 'Wysłane',
+    'folder.archive': 'Archiwum',
+    'folder.junk': 'Spam',
+    'folder.trash': 'Kosz',
+    'folder.flagged': 'Oznaczone',
+    'folder.important': 'Ważne',
+    'folder.all': 'Cała poczta',
+    'folder.outbox': 'Do wysłania',
+
     'connection.current': 'Wszystkie konta są aktualne.',
     'connection.behind': 'Część kont ma zaległości.',
     'connection.failing': 'Część kont przestała się synchronizować.',

--- a/frontend/src/Client.App/src/shell/AccountLine.tsx
+++ b/frontend/src/Client.App/src/shell/AccountLine.tsx
@@ -2,29 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import type { MailAccount, MailSynchronizationState } from '@mailfathom/client-backend';
-import type { MessageKey } from '../localization/en';
+import type { MailAccount } from '@mailfathom/client-backend';
 import { useLocalization } from '../localization/useLocalization';
+import { synchronizationStateLabel } from '../synchronization/synchronizationState';
 import { ageOf } from './synchronizationAge';
 
 // One account, and how current the deployment's copy of it is. It is its own component because it is the row of a list
 // and because the three facts on it answer different questions: what the last finished attempt did, whether mail was
 // left behind by it, and when anything was last taken in.
-
-const stateLabels: Readonly<Record<MailSynchronizationState, MessageKey>> = {
-    Synchronized: 'account.synchronized',
-    Failing: 'account.failing',
-    Unreachable: 'account.unreachable',
-    NeverSynchronized: 'account.neverSynchronized',
-};
-
-// An account nothing is fixing is read before one that is merely catching up, for the reason the summary above the
-// list reads them in that order: "behind" would let a mailbox nobody is refreshing wait unnoticed.
-function stateOf(account: MailAccount): MessageKey {
-    return account.synchronizationState === 'Synchronized' && account.behind
-        ? 'account.behind'
-        : stateLabels[account.synchronizationState];
-}
 
 export function AccountLine({ account, readAt }: { readonly account: MailAccount; readonly readAt: Date }) {
     const { locale, translate } = useLocalization();
@@ -33,7 +18,9 @@ export function AccountLine({ account, readAt }: { readonly account: MailAccount
     return (
         <li className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
             <span className="font-medium text-text">{account.displayName}</span>
-            <span className="text-muted">{translate(stateOf(account))}</span>
+            <span className="text-muted">
+                {translate(synchronizationStateLabel(account.synchronizationState, account.behind))}
+            </span>
             <span className="text-faint">
                 {age === null ? translate('account.neverRefreshed') : translate('account.lastRefreshed', { age })}
             </span>

--- a/frontend/src/Client.App/src/shell/ConnectionSummary.tsx
+++ b/frontend/src/Client.App/src/shell/ConnectionSummary.tsx
@@ -3,10 +3,11 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import type { ReactNode } from 'react';
-import type { ClientFailureReason, MailAccountDirectory, MailSynchronizationState } from '@mailfathom/client-backend';
+import type { ClientFailureReason, MailAccountDirectory } from '@mailfathom/client-backend';
 import { SecondaryButton } from '../controls/SecondaryButton';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
+import { needsAttention } from '../synchronization/synchronizationState';
 import { AccountLine } from './AccountLine';
 import { offers } from './capabilities';
 import { ageOf } from './synchronizationAge';
@@ -35,10 +36,6 @@ const toneColours: Readonly<Record<Tone, string>> = {
     quiet: 'bg-faint',
 };
 
-// The two states in which an account is not going to catch up on its own. They are read before the lag below, because
-// an account nothing is fixing says something a lagging one does not, and "behind" would let it wait unnoticed.
-const brokenStates: readonly MailSynchronizationState[] = ['Failing', 'Unreachable'];
-
 interface Freshness {
     readonly message: MessageKey;
     readonly tone: Tone;
@@ -53,7 +50,8 @@ function freshnessOf(directory: MailAccountDirectory): Freshness {
         return { message: 'accounts.notRefreshing', tone: 'quiet' };
     }
 
-    if (directory.accounts.some((account) => brokenStates.includes(account.synchronizationState))) {
+    // An account nothing is fixing is read before the lag below, because it says something a lagging one does not.
+    if (directory.accounts.some((account) => needsAttention(account.synchronizationState))) {
         return { message: 'connection.failing', tone: 'attention' };
     }
 

--- a/frontend/src/Client.App/src/shell/IntentField.tsx
+++ b/frontend/src/Client.App/src/shell/IntentField.tsx
@@ -5,11 +5,16 @@
 import type { MailAccount } from '@mailfathom/client-backend';
 import { useLocalization } from '../localization/useLocalization';
 import { goToSpace } from '../routing/useSpace';
+import { accountInScope, scopeOfAccount } from '../workspace/mailScope';
 import { useWorkspace } from '../workspace/useWorkspace';
 
 // What the product puts at the centre of the application, above whichever space is open. It asks nothing here: running
 // a question is Discover's work, so submitting goes to the space that will answer and carries the question there in the
 // workspace rather than starting anything. The scope beside it always says what that question would be asked against.
+//
+// It reads and writes the one scope the folder tree writes, rather than holding a mailbox of its own: the two controls
+// are two ways to say one thing, and this one is present in every space where the tree is Mail's. Choosing a mailbox
+// here scopes to the whole of it, which is what somebody who has not opened a folder means by naming one.
 
 export function IntentField({ accounts }: { readonly accounts: readonly MailAccount[] }) {
     const { translate } = useLocalization();
@@ -39,9 +44,9 @@ export function IntentField({ accounts }: { readonly accounts: readonly MailAcco
 
             <select
                 aria-label={translate('scope.mailbox')}
-                value={workspace.accountId ?? ''}
+                value={accountInScope(workspace.scope) ?? ''}
                 onChange={(event) => {
-                    revise({ accountId: event.target.value === '' ? null : event.target.value });
+                    revise({ scope: scopeOfAccount(event.target.value === '' ? null : event.target.value) });
                 }}
                 className="rounded-full border border-line bg-sunken px-3 py-1.5 text-sm text-text-soft"
             >

--- a/frontend/src/Client.App/src/shell/Space.test.tsx
+++ b/frontend/src/Client.App/src/shell/Space.test.tsx
@@ -9,8 +9,9 @@ import { LocalizationProvider } from '../localization/Localization';
 import type { Space as SpaceName } from '../routing/spaces';
 import { Space } from './Space';
 
-// Not a catalogue entry: it stands for whatever the frame composes for Mail, which is the point of the prop.
+// Not catalogue entries: each stands for whatever the frame composes for Mail, which is the point of the two props.
 const handedToMail = 'The mail this space was handed.';
+const handedTheFolders = 'The folder tree this space was handed.';
 
 // Every case here renders under `StrictMode`, which is what `main.tsx` mounts and what makes React invoke an effect
 // twice on the first mount. A focus rule written against "has this effect run before" passes without it and moves
@@ -19,7 +20,7 @@ function inStrictMode(space: SpaceName): ReactNode {
     return (
         <StrictMode>
             <LocalizationProvider>
-                <Space space={space} mail={<p>{handedToMail}</p>} />
+                <Space space={space} folders={<p>{handedTheFolders}</p>} mail={<p>{handedToMail}</p>} />
             </LocalizationProvider>
         </StrictMode>
     );
@@ -52,10 +53,17 @@ describe('Space', () => {
         expect(screen.getByText(handedToMail)).toBeDefined();
     });
 
+    it('shows the scope the Mail space is drawn against beside what it is drawn from', () => {
+        render(inStrictMode('mail'));
+
+        expect(screen.getByText(handedTheFolders)).toBeDefined();
+    });
+
     it('shows the pending note rather than the mail in a space nothing has been built for yet', () => {
         render(inStrictMode('cases'));
 
         expect(screen.queryByText(handedToMail)).toBeNull();
+        expect(screen.queryByText(handedTheFolders)).toBeNull();
         expect(screen.getByText(/This space is not built yet\./)).toBeDefined();
     });
 });

--- a/frontend/src/Client.App/src/shell/Space.tsx
+++ b/frontend/src/Client.App/src/shell/Space.tsx
@@ -9,7 +9,15 @@ import { spaceLabels, type Space as SpaceName } from '../routing/spaces';
 // The region the address decides the contents of. What each of the three spaces actually holds is built by its own
 // issue; what this owns permanently is where a space is rendered and what happens to focus when the address changes.
 
-export function Space({ space, mail }: { readonly space: SpaceName; readonly mail: ReactNode }) {
+export function Space({
+    space,
+    folders,
+    mail,
+}: {
+    readonly space: SpaceName;
+    readonly folders: ReactNode;
+    readonly mail: ReactNode;
+}) {
     const { translate } = useLocalization();
     const region = useRef<HTMLElement>(null);
     const shown = useRef(space);
@@ -39,7 +47,15 @@ export function Space({ space, mail }: { readonly space: SpaceName; readonly mai
                     something of its own would make that true of one of the three and not the others. */}
                 <p className="text-sm text-muted">{translate('space.pending')}</p>
 
-                {space === 'mail' ? mail : null}
+                {/* Mail is the one space with anything in it, and what it has is the scope selector beside what the
+                    scope is about: a column under a narrow window and beside the reading pane at the width the
+                    workspace opens out at. The list that will stand between them is #1424's. */}
+                {space === 'mail' ? (
+                    <div className="flex flex-col gap-6 workspace:flex-row workspace:items-start">
+                        <div className="workspace:w-64 workspace:shrink-0">{folders}</div>
+                        <div className="min-w-0 flex-1">{mail}</div>
+                    </div>
+                ) : null}
             </div>
         </main>
     );

--- a/frontend/src/Client.App/src/synchronization/synchronizationState.ts
+++ b/frontend/src/Client.App/src/synchronization/synchronizationState.ts
@@ -1,0 +1,36 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { MailSynchronizationState } from '@mailfathom/client-backend';
+import type { MessageKey } from '../localization/en';
+
+// What a local copy's freshness is called, and which readings ask somebody to do something. It says the same thing
+// about an account and about one folder of one, because the service answers both with the same four states — and two
+// screens saying it in two vocabularies would be two answers to one question.
+
+const stateLabels: Readonly<Record<MailSynchronizationState, MessageKey>> = {
+    Synchronized: 'account.synchronized',
+    Failing: 'account.failing',
+    Unreachable: 'account.unreachable',
+    NeverSynchronized: 'account.neverSynchronized',
+};
+
+// The two states in which a copy is not going to catch up on its own. They are read before the lag below, because
+// something nothing is fixing says what a merely lagging one does not, and "behind" would let it wait unnoticed.
+const brokenStates: readonly MailSynchronizationState[] = ['Failing', 'Unreachable'];
+
+/** What to call the state of a local copy: what its last finished attempt did, unless it left mail behind. */
+export function synchronizationStateLabel(state: MailSynchronizationState, behind: boolean): MessageKey {
+    return state === 'Synchronized' && behind ? 'account.behind' : stateLabels[state];
+}
+
+/** Whether the state is one nothing is going to resolve on its own, which is what a screen says out loud. */
+export function needsAttention(state: MailSynchronizationState): boolean {
+    return brokenStates.includes(state);
+}
+
+/** Whether there is nothing to say about the copy: its last attempt succeeded and it left nothing behind. */
+export function isCurrent(state: MailSynchronizationState, behind: boolean): boolean {
+    return state === 'Synchronized' && !behind;
+}

--- a/frontend/src/Client.App/src/workspace/Workspace.test.tsx
+++ b/frontend/src/Client.App/src/workspace/Workspace.test.tsx
@@ -3,13 +3,14 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { WorkspaceProvider } from './Workspace';
-import { useWorkspace, type Workspace } from './useWorkspace';
+import { emptyWorkspace, useWorkspace, type Workspace } from './useWorkspace';
 
 // A space writes what it owns and reads what the others left, so what is proven here is that one part of the workspace
-// can be revised without any other part of it being lost. Which spaces write which part is decided by the space:
-// today the frame writes the question and the mailbox in scope, and the folder and the selection arrive with Mail.
+// can be revised without any other part of it being lost, and that what it holds survives the reload a single-page
+// application makes a cold start. Which spaces write which part is decided by the space: today the frame writes the
+// question, the folder tree writes the scope and what it has folded away, and the selection arrives with the list.
 
 function Probe({ change }: { readonly change: Partial<Workspace> }) {
     const { workspace, revise } = useWorkspace();
@@ -29,28 +30,44 @@ function Probe({ change }: { readonly change: Partial<Workspace> }) {
     );
 }
 
-function renderProbe(change: Partial<Workspace>): void {
-    render(
+function renderProbe(change: Partial<Workspace>): { rerender: () => void } {
+    const rendered = render(
         <WorkspaceProvider>
             <Probe change={change} />
         </WorkspaceProvider>,
     );
+
+    return {
+        rerender: () => {
+            rendered.unmount();
+            render(
+                <WorkspaceProvider>
+                    <Probe change={change} />
+                </WorkspaceProvider>,
+            );
+        },
+    };
 }
 
 function carried(): Workspace {
     return JSON.parse(screen.getByRole('status').textContent) as Workspace;
 }
 
+// The store outlives a test rather than a file, so what one test kept would be what the next one opened with.
+afterEach(() => {
+    window.sessionStorage.clear();
+});
+
 describe('WorkspaceProvider', () => {
     it('carries nothing until a space puts something in it', () => {
         renderProbe({});
 
-        expect(carried()).toEqual({ accountId: null, folder: null, selection: null, question: '' });
+        expect(carried()).toEqual(emptyWorkspace);
     });
 
-    it.each([
-        { accountId: 'work' },
-        { folder: 'Archive/2026' },
+    it.each<Partial<Workspace>>([
+        { scope: { kind: 'account', accountId: 'work' } },
+        { collapsed: ['account:work'] },
         { selection: 'AAMkAD-42' },
         { question: 'what did Nordwind send' },
     ])('changes %o and leaves the rest of the workspace as it was', (change) => {
@@ -58,7 +75,28 @@ describe('WorkspaceProvider', () => {
 
         fireEvent.click(screen.getByRole('button'));
 
-        expect(carried()).toEqual({ accountId: null, folder: null, selection: null, question: '', ...change });
+        expect(carried()).toEqual({ ...emptyWorkspace, ...change });
+    });
+
+    it('opens on what the last run of this tab was looking at, so a reload returns to it', () => {
+        const change: Partial<Workspace> = {
+            scope: { kind: 'folder', accountId: 'work', alias: 'INBOX' },
+            collapsed: ['account:personal'],
+        };
+        const { rerender } = renderProbe(change);
+
+        fireEvent.click(screen.getByRole('button'));
+        rerender();
+
+        expect(carried()).toEqual({ ...emptyWorkspace, ...change });
+    });
+
+    it('opens on nothing where what was kept is not a workspace this client wrote', () => {
+        window.sessionStorage.setItem('mailfathom.workspace', '{"scope":{"kind":"everywhere"}}');
+
+        renderProbe({});
+
+        expect(carried()).toEqual(emptyWorkspace);
     });
 });
 

--- a/frontend/src/Client.App/src/workspace/Workspace.tsx
+++ b/frontend/src/Client.App/src/workspace/Workspace.tsx
@@ -2,18 +2,29 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import { useCallback, useMemo, useState, type ReactNode } from 'react';
-import { emptyWorkspace, WorkspaceContext, type Workspace, type WorkspaceRevision } from './useWorkspace';
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { rememberedWorkspace, rememberWorkspace } from './rememberedWorkspace';
+import { WorkspaceContext, type Workspace, type WorkspaceRevision } from './useWorkspace';
 
 // Mounted above the frame rather than inside a space, which is the whole mechanism: a space is what the address
 // changes, and this is not below the address.
+//
+// What it opens with is what this tab was last looking at, and what it holds is written back where the next start
+// reads it from. Keeping it is a browser store being synchronized rather than a value being computed, which is what an
+// effect is for; the alternative — writing inside the revision — would either put a side effect in an updater React
+// invokes twice under StrictMode, or make `revise` a new function on every render, which is a read restarted on every
+// render for everything holding it.
 
 export function WorkspaceProvider({ children }: { readonly children: ReactNode }) {
-    const [workspace, setWorkspace] = useState<Workspace>(emptyWorkspace);
+    const [workspace, setWorkspace] = useState<Workspace>(rememberedWorkspace);
 
     const revise = useCallback((change: Partial<Workspace>) => {
         setWorkspace((current) => ({ ...current, ...change }));
     }, []);
+
+    useEffect(() => {
+        rememberWorkspace(workspace);
+    }, [workspace]);
 
     const revision = useMemo<WorkspaceRevision>(() => ({ workspace, revise }), [workspace, revise]);
 

--- a/frontend/src/Client.App/src/workspace/mailScope.test.ts
+++ b/frontend/src/Client.App/src/workspace/mailScope.test.ts
@@ -1,0 +1,94 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import {
+    accountInScope,
+    everything,
+    isMailFolderRole,
+    roleRank,
+    sameScope,
+    scopeKey,
+    scopeOfAccount,
+    type MailScope,
+} from './mailScope';
+
+const workInbox: MailScope = { kind: 'folder', accountId: 'work', alias: 'INBOX' };
+
+describe('scopeKey', () => {
+    it.each<{ scope: MailScope; key: string }>([
+        { scope: everything, key: 'everything' },
+        { scope: { kind: 'role', role: 'Sent' }, key: 'role:Sent' },
+        { scope: { kind: 'account', accountId: 'work' }, key: 'account:work' },
+        { scope: workInbox, key: 'folder:work:INBOX' },
+    ])('identifies $key', ({ scope, key }) => {
+        expect(scopeKey(scope)).toBe(key);
+    });
+});
+
+describe('sameScope', () => {
+    it('reads two scopes pointing at one folder as the same one', () => {
+        expect(sameScope(workInbox, { kind: 'folder', accountId: 'work', alias: 'INBOX' })).toBe(true);
+    });
+
+    it('tells one mailbox’s inbox apart from another’s', () => {
+        expect(sameScope(workInbox, { kind: 'folder', accountId: 'personal', alias: 'INBOX' })).toBe(false);
+    });
+
+    it('tells a whole mailbox apart from one folder of it', () => {
+        expect(sameScope(workInbox, { kind: 'account', accountId: 'work' })).toBe(false);
+    });
+});
+
+describe('accountInScope', () => {
+    it.each<{ scope: MailScope; accountId: string }>([
+        { scope: workInbox, accountId: 'work' },
+        { scope: { kind: 'account', accountId: 'personal' }, accountId: 'personal' },
+    ])('answers the mailbox $accountId a scope names', ({ scope, accountId }) => {
+        expect(accountInScope(scope)).toBe(accountId);
+    });
+
+    it.each<{ scope: MailScope }>([{ scope: everything }, { scope: { kind: 'role', role: 'Inbox' } }])(
+        'answers no mailbox for a scope spanning every one of them',
+        ({ scope }) => {
+            expect(accountInScope(scope)).toBeNull();
+        },
+    );
+});
+
+describe('scopeOfAccount', () => {
+    it('scopes to the whole of a mailbox somebody named', () => {
+        expect(scopeOfAccount('work')).toEqual({ kind: 'account', accountId: 'work' });
+    });
+
+    it('scopes to everything where nobody named one', () => {
+        expect(scopeOfAccount(null)).toEqual(everything);
+    });
+});
+
+describe('isMailFolderRole', () => {
+    it.each(['Inbox', 'Archive', 'Drafts', 'Sent', 'Junk', 'Trash', 'All', 'Flagged', 'Important', 'Outbox'])(
+        'reads %s as a role this surface publishes',
+        (role) => {
+            expect(isMailFolderRole(role)).toBe(true);
+        },
+    );
+
+    it.each([{ value: 'Spam' }, { value: 'inbox' }, { value: 7 }, { value: null }])(
+        'refuses $value, which is not one of them',
+        ({ value }) => {
+            expect(isMailFolderRole(value)).toBe(false);
+        },
+    );
+});
+
+describe('roleRank', () => {
+    it('offers the inbox before everything else', () => {
+        expect(roleRank('Inbox')).toBeLessThan(roleRank('Sent'));
+    });
+
+    it('offers a folder playing no role after every folder that plays one', () => {
+        expect(roleRank(null)).toBeGreaterThan(roleRank('Outbox'));
+    });
+});

--- a/frontend/src/Client.App/src/workspace/mailScope.ts
+++ b/frontend/src/Client.App/src/workspace/mailScope.ts
@@ -1,0 +1,90 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { MailFolderRole } from '@mailfathom/client-backend';
+
+// What the client is looking at, which the list, the search, and the next question are all asked against. It is one
+// value rather than an account beside a folder, because the four things somebody can point at are not a pair: an
+// account with no folder and a folder with no account are both meaningless, and the role scopes — one mailbox's worth
+// of inbox is one thing, every mailbox's inbox at once is another — have no account to name at all.
+//
+// The last of those is what several mailboxes in one workspace actually means. Somebody with a work account and two
+// personal ones wants the inbox of all three as often as they want one, and wants sent to mean sent from any of them.
+
+/** What every read and every question is scoped to. */
+export type MailScope =
+    /** Every folder of every account the owner has. */
+    | { readonly kind: 'everything' }
+
+    /** The folders playing one role, across every account that has one — every inbox at once, every sent folder at once. */
+    | { readonly kind: 'role'; readonly role: MailFolderRole }
+
+    /** Every folder of one account. */
+    | { readonly kind: 'account'; readonly accountId: string }
+
+    /** One folder of one account, named by the alias everything on the client surface names a folder by. */
+    | { readonly kind: 'folder'; readonly accountId: string; readonly alias: string };
+
+/** Where the client opens: everything the owner has, which is the widest scope rather than an unset one. */
+export const everything: MailScope = { kind: 'everything' };
+
+// The order the roles are offered in, which is the order a mail client has shown them in for thirty years rather than
+// the order the service happens to declare them. Exhaustive by its own type, so a role added to the client surface
+// fails to compile here until somebody has decided where it belongs.
+const roleOrder: Readonly<Record<MailFolderRole, number>> = {
+    Inbox: 0,
+    Drafts: 1,
+    Sent: 2,
+    Archive: 3,
+    Junk: 4,
+    Trash: 5,
+    Flagged: 6,
+    Important: 7,
+    All: 8,
+    Outbox: 9,
+};
+
+/** Whether the value is one of the roles this surface publishes. */
+export function isMailFolderRole(value: unknown): value is MailFolderRole {
+    return typeof value === 'string' && Object.hasOwn(roleOrder, value);
+}
+
+/** Where a role falls in the order they are offered in; a folder carrying none falls after every one that does. */
+export function roleRank(role: MailFolderRole | null): number {
+    return role === null ? Object.keys(roleOrder).length : roleOrder[role];
+}
+
+/**
+ * The scope's identity as one string.
+ *
+ * It is what a row of the tree is keyed and compared by, so nothing has to write a comparison per scope shape and a
+ * fifth shape cannot be forgotten by one of them.
+ */
+export function scopeKey(scope: MailScope): string {
+    switch (scope.kind) {
+        case 'everything':
+            return 'everything';
+        case 'role':
+            return `role:${scope.role}`;
+        case 'account':
+            return `account:${scope.accountId}`;
+        case 'folder':
+            return `folder:${scope.accountId}:${scope.alias}`;
+    }
+}
+
+/** Whether two scopes point at the same thing. */
+export function sameScope(one: MailScope, other: MailScope): boolean {
+    return scopeKey(one) === scopeKey(other);
+}
+
+/** The account a scope names, or `null` where it spans every account the owner has. */
+export function accountInScope(scope: MailScope): string | null {
+    return scope.kind === 'account' || scope.kind === 'folder' ? scope.accountId : null;
+}
+
+/** The scope naming one whole account, or everything where no account was named. */
+export function scopeOfAccount(accountId: string | null): MailScope {
+    return accountId === null ? everything : { kind: 'account', accountId };
+}

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
@@ -1,0 +1,92 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { rememberedWorkspace, rememberWorkspace } from './rememberedWorkspace';
+import { emptyWorkspace, type Workspace } from './useWorkspace';
+
+const storageKey = 'mailfathom.workspace';
+
+const kept: Workspace = {
+    scope: { kind: 'folder', accountId: 'work', alias: 'INBOX' },
+    collapsed: ['account:personal'],
+    selection: 'AAMkAD-42',
+    question: 'what did Nordwind send',
+};
+
+function stored(value: unknown): void {
+    window.sessionStorage.setItem(storageKey, JSON.stringify(value));
+}
+
+// The store is one per file rather than one per test, so what one test kept would be what the next one read back.
+afterEach(() => {
+    window.sessionStorage.clear();
+});
+
+describe('rememberWorkspace', () => {
+    it('keeps a workspace the next start reads back whole', () => {
+        rememberWorkspace(kept);
+
+        expect(rememberedWorkspace()).toEqual(kept);
+    });
+});
+
+describe('rememberedWorkspace', () => {
+    it('answers an empty workspace where nothing was kept', () => {
+        expect(rememberedWorkspace()).toEqual(emptyWorkspace);
+    });
+
+    it.each([
+        { kind: 'everything' },
+        { kind: 'role', role: 'Sent' },
+        { kind: 'account', accountId: 'work' },
+        { kind: 'folder', accountId: 'work', alias: 'ARCHIVE-2024' },
+    ])('reads back the scope %o a person had chosen', (scope) => {
+        stored({ ...emptyWorkspace, scope });
+
+        expect(rememberedWorkspace().scope).toEqual(scope);
+    });
+
+    it.each([
+        { shape: 'something that is not JSON at all', value: 'workspace' },
+        { shape: 'a workspace that is not an object', value: JSON.stringify([]) },
+        { shape: 'a scope naming something this client cannot show', value: JSON.stringify({ scope: 'INBOX' }) },
+        {
+            shape: 'a scope of a kind this client does not have',
+            value: JSON.stringify({ ...emptyWorkspace, scope: { kind: 'everywhere' } }),
+        },
+        {
+            shape: 'a role this surface does not publish',
+            value: JSON.stringify({ ...emptyWorkspace, scope: { kind: 'role', role: 'Spam' } }),
+        },
+        {
+            shape: 'a folder scope naming no account',
+            value: JSON.stringify({ ...emptyWorkspace, scope: { kind: 'folder', alias: 'INBOX' } }),
+        },
+        {
+            shape: 'folded rows that are not rows',
+            value: JSON.stringify({ ...emptyWorkspace, collapsed: [42] }),
+        },
+        {
+            shape: 'more folded rows than a tree has',
+            value: JSON.stringify({ ...emptyWorkspace, collapsed: Array.from({ length: 513 }, () => 'account:work') }),
+        },
+        {
+            shape: 'a question longer than anybody typed',
+            value: JSON.stringify({ ...emptyWorkspace, question: 'a'.repeat(4_097) }),
+        },
+        {
+            shape: 'a selection that is not an identifier',
+            value: JSON.stringify({ ...emptyWorkspace, selection: 7 }),
+        },
+        {
+            shape: 'a selection longer than any identifier the client wrote there',
+            value: JSON.stringify({ ...emptyWorkspace, selection: 'a'.repeat(257) }),
+        },
+    ])('opens on nothing rather than on $shape', ({ value }) => {
+        window.sessionStorage.setItem(storageKey, value);
+
+        expect(rememberedWorkspace()).toEqual(emptyWorkspace);
+    });
+});

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
@@ -65,6 +65,17 @@ describe('rememberedWorkspace', () => {
             value: JSON.stringify({ ...emptyWorkspace, scope: { kind: 'folder', alias: 'INBOX' } }),
         },
         {
+            shape: 'an account identifier longer than any the service assigned',
+            value: JSON.stringify({ ...emptyWorkspace, scope: { kind: 'account', accountId: 'a'.repeat(257) } }),
+        },
+        {
+            shape: 'a folder alias longer than any the service assigned',
+            value: JSON.stringify({
+                ...emptyWorkspace,
+                scope: { kind: 'folder', accountId: 'work', alias: 'a'.repeat(257) },
+            }),
+        },
+        {
             shape: 'folded rows that are not rows',
             value: JSON.stringify({ ...emptyWorkspace, collapsed: [42] }),
         },

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
@@ -80,6 +80,10 @@ describe('rememberedWorkspace', () => {
             value: JSON.stringify({ ...emptyWorkspace, collapsed: [42] }),
         },
         {
+            shape: 'a folded row longer than any key this client writes',
+            value: JSON.stringify({ ...emptyWorkspace, collapsed: ['a'.repeat(1_025)] }),
+        },
+        {
             shape: 'more folded rows than a tree has',
             value: JSON.stringify({ ...emptyWorkspace, collapsed: Array.from({ length: 513 }, () => 'account:work') }),
         },

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.ts
@@ -19,11 +19,11 @@ import { emptyWorkspace, type Workspace } from './useWorkspace';
 const storageKey = 'mailfathom.workspace';
 
 // What a stored workspace may carry before it is read as somebody's edit rather than as this client's own writing. A
-// tree holds tens of rows, a question is a sentence, and a selection is an identifier, so each of the three is far
-// above anything the client itself writes there.
+// tree holds tens of rows, a question is a sentence, and an identifier — a message, an account, a folder alias — is a
+// name the service assigned, so each of the three is far above anything the client itself writes there.
 const mostCollapsedRows = 512;
 const longestQuestion = 4_096;
-const longestSelection = 256;
+const longestIdentifier = 256;
 
 /** What this tab was last looking at, or an empty workspace where nothing was kept or what was kept is not one. */
 export function rememberedWorkspace(): Workspace {
@@ -78,7 +78,7 @@ function workspaceIn(value: unknown): Workspace | null {
         return null;
     }
 
-    if (selection !== null && (typeof selection !== 'string' || selection.length > longestSelection)) {
+    if (selection !== null && !isIdentifier(selection)) {
         return null;
     }
 
@@ -104,14 +104,18 @@ function scopeIn(value: unknown): MailScope | null {
         case 'role':
             return isMailFolderRole(record['role']) ? { kind: 'role', role: record['role'] } : null;
         case 'account':
-            return typeof accountId === 'string' ? { kind: 'account', accountId } : null;
+            return isIdentifier(accountId) ? { kind: 'account', accountId } : null;
         case 'folder':
-            return typeof accountId === 'string' && typeof alias === 'string'
-                ? { kind: 'folder', accountId, alias }
-                : null;
+            return isIdentifier(accountId) && isIdentifier(alias) ? { kind: 'folder', accountId, alias } : null;
         default:
             return null;
     }
+}
+
+// A name the service assigned rather than free text, so it is bounded here for the same reason every other stored value
+// is: what is read back is held in state and written out again on every revision.
+function isIdentifier(value: unknown): value is string {
+    return typeof value === 'string' && value.length <= longestIdentifier;
 }
 
 function collapsedIn(value: unknown): readonly string[] | null {

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.ts
@@ -1,0 +1,132 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { everything, isMailFolderRole, type MailScope } from './mailScope';
+import { emptyWorkspace, type Workspace } from './useWorkspace';
+
+// Where the workspace survives a reload, which a single-page application makes a cold start rather than a way out:
+// reloading already returns to the same deployment and the same signed-in person, so returning them to a folder tree
+// they had folded shut and a mailbox they had chosen is the same promise kept one level further in.
+//
+// The session's store rather than the machine's, deliberately. What a person is looking at and what they were about to
+// ask are theirs rather than the machine's — the frame already empties the workspace when the credential goes, and a
+// store that dies with the tab is what makes that true of a tab somebody closed without signing out. It is the same
+// bound the web head keeps its credential under, for the same reason.
+//
+// Reached as `window.sessionStorage` rather than as the bare global for the reason `localization/locale.ts` gives:
+// Node publishes stores of its own that win over the document's under the test runner.
+const storageKey = 'mailfathom.workspace';
+
+// What a stored workspace may carry before it is read as somebody's edit rather than as this client's own writing. A
+// tree holds tens of rows, a question is a sentence, and a selection is an identifier, so each of the three is far
+// above anything the client itself writes there.
+const mostCollapsedRows = 512;
+const longestQuestion = 4_096;
+const longestSelection = 256;
+
+/** What this tab was last looking at, or an empty workspace where nothing was kept or what was kept is not one. */
+export function rememberedWorkspace(): Workspace {
+    let stored: string | null;
+
+    try {
+        stored = window.sessionStorage.getItem(storageKey);
+    } catch {
+        return emptyWorkspace;
+    }
+
+    if (stored === null) {
+        return emptyWorkspace;
+    }
+
+    let parsed: unknown;
+
+    try {
+        parsed = JSON.parse(stored);
+    } catch {
+        return emptyWorkspace;
+    }
+
+    return workspaceIn(parsed) ?? emptyWorkspace;
+}
+
+/** Keeps what this tab is looking at, so a reload returns to it. */
+export function rememberWorkspace(workspace: Workspace): void {
+    try {
+        window.sessionStorage.setItem(storageKey, JSON.stringify(workspace));
+    } catch {
+        // A browser refusing storage still runs the client; what a person was looking at then lasts the run rather
+        // than outliving it, which is a smaller loss than a client that fails over a preference.
+    }
+}
+
+// Read back as untrusted input, because a store is a place a person can write. Anything this client did not write is
+// answered as nothing kept rather than as a workspace with a hole in it, which is what would otherwise reach a screen
+// as a scope naming a mailbox that does not exist.
+function workspaceIn(value: unknown): Workspace | null {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        return null;
+    }
+
+    const record = value as Record<string, unknown>;
+    const scope = scopeIn(record['scope']);
+    const collapsed = collapsedIn(record['collapsed']);
+    const selection = record['selection'] ?? null;
+    const question = record['question'];
+
+    if (scope === null || collapsed === null) {
+        return null;
+    }
+
+    if (selection !== null && (typeof selection !== 'string' || selection.length > longestSelection)) {
+        return null;
+    }
+
+    if (typeof question !== 'string' || question.length > longestQuestion) {
+        return null;
+    }
+
+    return { scope, collapsed, selection, question };
+}
+
+function scopeIn(value: unknown): MailScope | null {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        return null;
+    }
+
+    const record = value as Record<string, unknown>;
+    const accountId = record['accountId'];
+    const alias = record['alias'];
+
+    switch (record['kind']) {
+        case 'everything':
+            return everything;
+        case 'role':
+            return isMailFolderRole(record['role']) ? { kind: 'role', role: record['role'] } : null;
+        case 'account':
+            return typeof accountId === 'string' ? { kind: 'account', accountId } : null;
+        case 'folder':
+            return typeof accountId === 'string' && typeof alias === 'string'
+                ? { kind: 'folder', accountId, alias }
+                : null;
+        default:
+            return null;
+    }
+}
+
+function collapsedIn(value: unknown): readonly string[] | null {
+    if (!Array.isArray(value) || value.length > mostCollapsedRows) {
+        return null;
+    }
+
+    const rows: string[] = [];
+    for (const row of value) {
+        if (typeof row !== 'string') {
+            return null;
+        }
+
+        rows.push(row);
+    }
+
+    return rows;
+}

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.ts
@@ -25,6 +25,10 @@ const mostCollapsedRows = 512;
 const longestQuestion = 4_096;
 const longestIdentifier = 256;
 
+// A folded row is keyed by the scope it stands for, so at its longest it names an account and a folder's whole place on
+// its mail server rather than one identifier.
+const longestRow = 1_024;
+
 /** What this tab was last looking at, or an empty workspace where nothing was kept or what was kept is not one. */
 export function rememberedWorkspace(): Workspace {
     let stored: string | null;
@@ -125,7 +129,7 @@ function collapsedIn(value: unknown): readonly string[] | null {
 
     const rows: string[] = [];
     for (const row of value) {
-        if (typeof row !== 'string') {
+        if (typeof row !== 'string' || row.length > longestRow) {
             return null;
         }
 

--- a/frontend/src/Client.App/src/workspace/useWorkspace.ts
+++ b/frontend/src/Client.App/src/workspace/useWorkspace.ts
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { createContext, useContext } from 'react';
+import { everything, type MailScope } from './mailScope';
 
 // What a person carries between the spaces. Discover, Mail, and Cases are one application rather than three, and this
 // is what makes them one: the frame owns it, so moving to another space re-renders what is under the frame and leaves
@@ -12,11 +13,16 @@ import { createContext, useContext } from 'react';
 // gives: a module Vite hot-reloads may export components alone.
 
 export interface Workspace {
-    /** The account every question is asked against, or `null` for all of the owner's accounts at once. */
-    readonly accountId: string | null;
+    /** What the list, the search, and the next question are all asked against, owned here rather than per screen. */
+    readonly scope: MailScope;
 
-    /** The folder within that account, once a space offers one to choose. */
-    readonly folder: string | null;
+    /**
+     * The rows of the folder tree somebody has folded away, by the key each row is identified with.
+     *
+     * Folded rather than unfolded, so a tree nobody has touched shows what is in it: an owner who opens the client and
+     * sees a column of closed mailboxes has to open every one of them before the client says anything.
+     */
+    readonly collapsed: readonly string[];
 
     /** What the person has open, once a space offers something to open. */
     readonly selection: string | null;
@@ -33,8 +39,8 @@ export interface WorkspaceRevision {
 }
 
 export const emptyWorkspace: Workspace = {
-    accountId: null,
-    folder: null,
+    scope: everything,
+    collapsed: [],
     selection: null,
     question: '',
 };

--- a/frontend/src/Client.Backend/src/index.ts
+++ b/frontend/src/Client.Backend/src/index.ts
@@ -47,6 +47,14 @@ export {
     type MailAccountDirectory,
     type MailSynchronizationState,
 } from './mailAccounts';
+export {
+    mailFoldersRoute,
+    readMailFolders,
+    type MailAccountFolders,
+    type MailFolder,
+    type MailFolderDirectory,
+    type MailFolderRole,
+} from './mailFolders';
 export { clientRoutePrefix, headersFor, routeFor, type ClientSession, type DeploymentAddress } from './session';
 export { reachDeployment, signIn, type DeploymentGreeting, type SignInOutcome, type SignInRefusal } from './signIn';
 export { longestResponseBody, type ClientRequest, type ClientResponse, type MailFathomTransport } from './transport';

--- a/frontend/src/Client.Backend/src/json.ts
+++ b/frontend/src/Client.Backend/src/json.ts
@@ -1,0 +1,20 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+// The one shape every parser in this package starts from. A response body is untrusted input, so nothing here reads a
+// field off a value before that value has been established to be an object with fields at all — and `typeof null` and
+// `typeof []` both answer `'object'`, which is the whole reason this is a function rather than a check written inline.
+//
+// It is stated once for the package rather than per operation: three parsers needed it, and three copies of the same
+// two lines is three places for one of them to stop refusing an array.
+
+/** Whether the value is an object with fields, which an array and `null` are not. */
+export function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** The value read as a record of fields, or `null` where it is anything else. */
+export function asRecord(value: unknown): Readonly<Record<string, unknown>> | null {
+    return isRecord(value) ? value : null;
+}

--- a/frontend/src/Client.Backend/src/mailAccounts.ts
+++ b/frontend/src/Client.Backend/src/mailAccounts.ts
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { failed, failureReasonForStatus, read, type ClientResult } from './failure';
+import { asRecord } from './json';
 import { headersFor, routeFor, type ClientSession } from './session';
 import { send, type MailFathomTransport } from './transport';
 
@@ -30,7 +31,10 @@ export interface MailAccountDirectory {
 // The most accounts a directory answer may carry before it is refused unread. One owner holds a handful in practice,
 // so the ceiling is far above anything real and exists for the case the answer is not: the array is walked and
 // validated element by element, and a bound applied after that walk is not a bound.
-const maximumAccountsInDirectory = 256;
+//
+// The folders route nests this same account shape, so the bound and the parser below are that route's as well: two
+// copies of either would be two answers to what an account is, and the surface publishes one.
+export const maximumAccountsInDirectory = 256;
 
 const synchronizationStates: readonly MailSynchronizationState[] = [
     'NeverSynchronized',
@@ -89,7 +93,7 @@ function parseDirectory(body: string): MailAccountDirectory | null {
 
     const accounts: MailAccount[] = [];
     for (const entry of entries) {
-        const account = parseAccount(entry);
+        const account = parseMailAccount(entry);
         if (account === null) {
             return null;
         }
@@ -100,7 +104,8 @@ function parseDirectory(body: string): MailAccountDirectory | null {
     return { synchronizationEnabled, accounts };
 }
 
-function parseAccount(value: unknown): MailAccount | null {
+/** Reads one account off a response body, or answers `null` where any field of it is missing or of the wrong shape. */
+export function parseMailAccount(value: unknown): MailAccount | null {
     const record = asRecord(value);
     if (record === null) {
         return null;
@@ -133,12 +138,7 @@ function parseAccount(value: unknown): MailAccount | null {
     };
 }
 
-function asRecord(value: unknown): Readonly<Record<string, unknown>> | null {
-    return typeof value === 'object' && value !== null && !Array.isArray(value)
-        ? (value as Record<string, unknown>)
-        : null;
-}
-
-function isSynchronizationState(value: unknown): value is MailSynchronizationState {
+/** Whether the value is one of the four states this surface publishes, which the folders route answers with as well. */
+export function isSynchronizationState(value: unknown): value is MailSynchronizationState {
     return typeof value === 'string' && synchronizationStates.includes(value as MailSynchronizationState);
 }

--- a/frontend/src/Client.Backend/src/mailBody.ts
+++ b/frontend/src/Client.Backend/src/mailBody.ts
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { failed, failureReasonForStatus, read, type ClientResult } from './failure';
+import { asRecord, isRecord } from './json';
 import { headersFor, routeFor, type ClientSession } from './session';
 import { send, type MailFathomTransport } from './transport';
 
@@ -875,14 +876,6 @@ function parsed(body: string): unknown {
     } catch {
         return null;
     }
-}
-
-function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
-    return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function asRecord(value: unknown): Readonly<Record<string, unknown>> | null {
-    return isRecord(value) ? value : null;
 }
 
 function isCount(value: unknown): value is number {

--- a/frontend/src/Client.Backend/src/mailFolders.test.ts
+++ b/frontend/src/Client.Backend/src/mailFolders.test.ts
@@ -1,0 +1,226 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import { readMailFolders } from './mailFolders';
+import type { ClientSession } from './session';
+import type { ClientRequest, ClientResponse, MailFathomTransport } from './transport';
+
+const session: ClientSession = {
+    baseAddress: 'https://mail.example.invalid',
+    authorization: 'Basic dGVzdA==',
+};
+
+const workAccount = {
+    id: 'work',
+    displayName: 'Work',
+    synchronizationState: 'Synchronized',
+    lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
+    behind: false,
+};
+
+const inbox = {
+    alias: 'INBOX',
+    role: 'Inbox',
+    path: ['INBOX'],
+    storedEmailCount: 4213,
+    unreadEmailCount: 12,
+    synchronizationState: 'Synchronized',
+    lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
+    behind: false,
+};
+
+function bodyOf(folders: readonly unknown[]): string {
+    return JSON.stringify({ synchronizationEnabled: true, accounts: [{ account: workAccount, folders }] });
+}
+
+const treeBody = bodyOf([inbox]);
+
+type Answer = Omit<ClientResponse, 'headers'>;
+
+function answering(response: Answer): MailFathomTransport {
+    return () => Promise.resolve({ ...response, headers: {} });
+}
+
+function recording(response: Answer): { transport: MailFathomTransport; requests: ClientRequest[] } {
+    const requests: ClientRequest[] = [];
+
+    return {
+        requests,
+        transport: (request) => {
+            requests.push(request);
+
+            return Promise.resolve({ ...response, headers: {} });
+        },
+    };
+}
+
+describe('readMailFolders', () => {
+    it('asks for the folders route on the client surface with the session it was given', async () => {
+        const { transport, requests } = recording({ status: 200, body: treeBody });
+
+        await readMailFolders(session, transport);
+
+        expect(requests).toEqual([
+            {
+                method: 'GET',
+                path: 'https://mail.example.invalid/api/client/folders',
+                headers: { Accept: 'application/json', Authorization: 'Basic dGVzdA==' },
+            },
+        ]);
+    });
+
+    it('reads the tree a well-formed answer describes', async () => {
+        const result = await readMailFolders(session, answering({ status: 200, body: treeBody }));
+
+        expect(result).toEqual({
+            outcome: 'read',
+            value: {
+                synchronizationEnabled: true,
+                accounts: [
+                    {
+                        account: {
+                            id: 'work',
+                            displayName: 'Work',
+                            synchronizationState: 'Synchronized',
+                            lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
+                            behind: false,
+                        },
+                        folders: [
+                            {
+                                alias: 'INBOX',
+                                role: 'Inbox',
+                                path: ['INBOX'],
+                                storedEmailCount: 4213,
+                                unreadEmailCount: 12,
+                                synchronizationState: 'Synchronized',
+                                lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
+                                behind: false,
+                            },
+                        ],
+                    },
+                ],
+            },
+        });
+    });
+
+    it('reads a folder the deployment has not bound to a remote folder as one with no place on its server', async () => {
+        const unbound = {
+            ...inbox,
+            role: null,
+            path: [],
+            synchronizationState: 'NeverSynchronized',
+            lastSynchronizedAt: null,
+            storedEmailCount: 0,
+            unreadEmailCount: 0,
+        };
+
+        const result = await readMailFolders(session, answering({ status: 200, body: bodyOf([unbound]) }));
+
+        expect(result.outcome === 'read' ? result.value.accounts[0]?.folders : null).toEqual([
+            {
+                alias: 'INBOX',
+                role: null,
+                path: [],
+                storedEmailCount: 0,
+                unreadEmailCount: 0,
+                synchronizationState: 'NeverSynchronized',
+                lastSynchronizedAt: null,
+                behind: false,
+            },
+        ]);
+    });
+
+    it('reads an owner with no mail account as a tree with nothing in it', async () => {
+        const empty = JSON.stringify({ synchronizationEnabled: false, accounts: [] });
+
+        const result = await readMailFolders(session, answering({ status: 200, body: empty }));
+
+        expect(result).toEqual({ outcome: 'read', value: { synchronizationEnabled: false, accounts: [] } });
+    });
+
+    it.each([
+        { status: 401, reason: 'unauthenticated' },
+        { status: 403, reason: 'unauthorized' },
+        { status: 500, reason: 'unavailable' },
+        { status: 503, reason: 'unavailable' },
+    ])('reports $status as $reason rather than as a tree', async ({ status, reason }) => {
+        const result = await readMailFolders(session, answering({ status, body: '' }));
+
+        expect(result).toEqual({ outcome: 'failed', failure: { reason, status } });
+    });
+
+    it('reports a connection that never answered as one to try again, rather than throwing at the screen', async () => {
+        const result = await readMailFolders(session, () => Promise.reject(new TypeError('Failed to fetch')));
+
+        expect(result).toEqual({ outcome: 'failed', failure: { reason: 'unavailable', status: null } });
+    });
+
+    it.each([
+        { shape: 'a body that is not JSON', body: 'folders' },
+        { shape: 'a body that is not an object', body: '[]' },
+        { shape: 'an answer carrying no accounts array', body: JSON.stringify({ synchronizationEnabled: true }) },
+        {
+            shape: 'an account entry that is not an object',
+            body: JSON.stringify({ synchronizationEnabled: true, accounts: ['work'] }),
+        },
+        {
+            shape: 'an account entry carrying no account',
+            body: JSON.stringify({ synchronizationEnabled: true, accounts: [{ folders: [] }] }),
+        },
+        { shape: 'a folder that is not an object', body: bodyOf(['INBOX']) },
+        {
+            shape: 'an account entry carrying no folders array',
+            body: JSON.stringify({ synchronizationEnabled: true, accounts: [{ account: workAccount }] }),
+        },
+        { shape: 'a folder with no alias', body: bodyOf([{ ...inbox, alias: 42 }]) },
+        { shape: 'a folder carrying a role this client does not know', body: bodyOf([{ ...inbox, role: 'Spam' }]) },
+        { shape: 'a folder whose path is not levels', body: bodyOf([{ ...inbox, path: 'INBOX/2026' }]) },
+        { shape: 'a folder whose path holds something other than a name', body: bodyOf([{ ...inbox, path: [7] }]) },
+        { shape: 'a folder counting a fraction of a message', body: bodyOf([{ ...inbox, unreadEmailCount: 1.5 }]) },
+        { shape: 'a folder counting fewer than none', body: bodyOf([{ ...inbox, storedEmailCount: -1 }]) },
+        {
+            shape: 'a folder in a state this client does not know',
+            body: bodyOf([{ ...inbox, synchronizationState: 'Paused' }]),
+        },
+        {
+            shape: 'a folder timed by something other than an instant',
+            body: bodyOf([{ ...inbox, lastSynchronizedAt: 0 }]),
+        },
+    ])('refuses $shape rather than drawing a tree with a hole in it', async ({ body }) => {
+        const result = await readMailFolders(session, answering({ status: 200, body }));
+
+        expect(result).toEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+
+    it('refuses an answer carrying more accounts than this surface serves one owner', async () => {
+        const accounts = Array.from({ length: 257 }, (_, index) => ({
+            account: { ...workAccount, id: `account-${String(index)}` },
+            folders: [],
+        }));
+
+        const result = await readMailFolders(
+            session,
+            answering({ status: 200, body: JSON.stringify({ synchronizationEnabled: true, accounts }) }),
+        );
+
+        expect(result).toEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+
+    it('refuses an account carrying more folders than a mailbox has', async () => {
+        const folders = Array.from({ length: 1025 }, (_, index) => ({ ...inbox, alias: `FOLDER-${String(index)}` }));
+
+        const result = await readMailFolders(session, answering({ status: 200, body: bodyOf(folders) }));
+
+        expect(result).toEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+
+    it('refuses a folder nested deeper than a mail server nests one', async () => {
+        const deep = { ...inbox, path: Array.from({ length: 33 }, (_, index) => `level-${String(index)}`) };
+
+        const result = await readMailFolders(session, answering({ status: 200, body: bodyOf([deep]) }));
+
+        expect(result).toEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+});

--- a/frontend/src/Client.Backend/src/mailFolders.ts
+++ b/frontend/src/Client.Backend/src/mailFolders.ts
@@ -1,0 +1,252 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { failed, failureReasonForStatus, read, type ClientResult } from './failure';
+import { asRecord } from './json';
+import {
+    isSynchronizationState,
+    maximumAccountsInDirectory,
+    parseMailAccount,
+    type MailAccount,
+    type MailSynchronizationState,
+} from './mailAccounts';
+import { headersFor, routeFor, type ClientSession } from './session';
+import { send, type MailFathomTransport } from './transport';
+
+// The owner's mailboxes and the folders in them, which the service answers in one exchange because they are one tree
+// on screen. The account inside each entry is the accounts route's own shape, parsed by the accounts route's own
+// parser, so the two reads cannot come to disagree about what a mailbox is.
+
+/** The route the owner's folders are served at, relative to the client prefix. */
+export const mailFoldersRoute = '/folders';
+
+/**
+ * The role a folder plays for its account, independently of what its server calls it.
+ *
+ * It is what a client cannot work out for itself: special-use folders are advertised by server attribute rather than
+ * by name, and the names differ per provider and per language. A folder configuration labelled with none carries
+ * `null` here, and nothing in this package guesses one from a name.
+ */
+export type MailFolderRole =
+    'Inbox' | 'Archive' | 'Drafts' | 'Sent' | 'Junk' | 'Trash' | 'All' | 'Flagged' | 'Important' | 'Outbox';
+
+/** One folder of one account, as a screen drawing a tree reads it. */
+export interface MailFolder {
+    /** MailFathom's own name for the folder, which is what every other route on this surface names it by. */
+    readonly alias: string;
+
+    /** The role the folder plays, or `null` where configuration labels it with none. */
+    readonly role: MailFolderRole | null;
+
+    /** The folder's place on its mail server, outermost level first, and empty where nothing has bound the alias yet. */
+    readonly path: readonly string[];
+
+    /** How many of the folder's emails this deployment holds, which is not how many the mailbox has. */
+    readonly storedEmailCount: number;
+
+    /** How many of those the mail server last reported without the seen flag. */
+    readonly unreadEmailCount: number;
+
+    readonly synchronizationState: MailSynchronizationState;
+    readonly lastSynchronizedAt: string | null;
+    readonly behind: boolean;
+}
+
+/** One of the owner's accounts and the folders beneath it. */
+export interface MailAccountFolders {
+    readonly account: MailAccount;
+    readonly folders: readonly MailFolder[];
+}
+
+/** The owner's whole tree, beside the deployment-wide switch saying whether any of it is being refreshed at all. */
+export interface MailFolderDirectory {
+    readonly synchronizationEnabled: boolean;
+    readonly accounts: readonly MailAccountFolders[];
+}
+
+// What one account may answer with before the tree is refused unread. A mailbox holds tens of folders in practice and
+// the service bounds them by what configuration admits, so this is far above anything real and exists for the answer
+// that is not — checked during the walk rather than after it, because a bound applied afterwards is not a bound.
+const maximumFoldersInAccount = 1_024;
+
+// How deep a folder's place on its server may be. Servers nest a handful of levels; a path longer than this is an
+// answer no mailbox produced, and drawing it would indent a tree past anything a screen can show.
+const maximumHierarchyLevels = 32;
+
+const roles: readonly MailFolderRole[] = [
+    'Inbox',
+    'Archive',
+    'Drafts',
+    'Sent',
+    'Junk',
+    'Trash',
+    'All',
+    'Flagged',
+    'Important',
+    'Outbox',
+];
+
+/** Reads the signed-in owner's mailboxes and folders, answering an expected failure as a value rather than by throwing. */
+export async function readMailFolders(
+    session: ClientSession,
+    transport: MailFathomTransport,
+): Promise<ClientResult<MailFolderDirectory>> {
+    const response = await send(transport, {
+        method: 'GET',
+        path: routeFor(session, mailFoldersRoute),
+        headers: headersFor(session),
+    });
+
+    if (response === null) {
+        return failed('unavailable', null);
+    }
+
+    if (response.status !== 200) {
+        return failed(failureReasonForStatus(response.status), response.status);
+    }
+
+    const directory = parseDirectory(response.body);
+
+    return directory === null ? failed('unreadable', response.status) : read(directory);
+}
+
+function parseDirectory(body: string): MailFolderDirectory | null {
+    let parsed: unknown;
+
+    try {
+        parsed = JSON.parse(body);
+    } catch {
+        return null;
+    }
+
+    const record = asRecord(parsed);
+    if (record === null) {
+        return null;
+    }
+
+    const synchronizationEnabled = record['synchronizationEnabled'];
+    const entries = record['accounts'];
+    if (typeof synchronizationEnabled !== 'boolean' || !Array.isArray(entries)) {
+        return null;
+    }
+
+    if (entries.length > maximumAccountsInDirectory) {
+        return null;
+    }
+
+    const accounts: MailAccountFolders[] = [];
+    for (const entry of entries) {
+        const account = parseAccountFolders(entry);
+        if (account === null) {
+            return null;
+        }
+
+        accounts.push(account);
+    }
+
+    return { synchronizationEnabled, accounts };
+}
+
+function parseAccountFolders(value: unknown): MailAccountFolders | null {
+    const record = asRecord(value);
+    if (record === null) {
+        return null;
+    }
+
+    const account = parseMailAccount(record['account']);
+    const entries = record['folders'];
+    if (account === null || !Array.isArray(entries) || entries.length > maximumFoldersInAccount) {
+        return null;
+    }
+
+    const folders: MailFolder[] = [];
+    for (const entry of entries) {
+        const folder = parseFolder(entry);
+        if (folder === null) {
+            return null;
+        }
+
+        folders.push(folder);
+    }
+
+    return { account, folders };
+}
+
+function parseFolder(value: unknown): MailFolder | null {
+    const record = asRecord(value);
+    if (record === null) {
+        return null;
+    }
+
+    const alias = record['alias'];
+    const role = record['role'] ?? null;
+    const storedEmailCount = record['storedEmailCount'];
+    const unreadEmailCount = record['unreadEmailCount'];
+    const synchronizationState = record['synchronizationState'];
+    const lastSynchronizedAt = record['lastSynchronizedAt'] ?? null;
+    const behind = record['behind'];
+
+    if (typeof alias !== 'string' || typeof behind !== 'boolean') {
+        return null;
+    }
+
+    if (role !== null && !isFolderRole(role)) {
+        return null;
+    }
+
+    const path = parsePath(record['path']);
+    if (path === null) {
+        return null;
+    }
+
+    if (!isCount(storedEmailCount) || !isCount(unreadEmailCount)) {
+        return null;
+    }
+
+    if (!isSynchronizationState(synchronizationState)) {
+        return null;
+    }
+
+    if (lastSynchronizedAt !== null && typeof lastSynchronizedAt !== 'string') {
+        return null;
+    }
+
+    return {
+        alias,
+        role,
+        path,
+        storedEmailCount,
+        unreadEmailCount,
+        synchronizationState,
+        lastSynchronizedAt,
+        behind,
+    };
+}
+
+function parsePath(value: unknown): readonly string[] | null {
+    if (!Array.isArray(value) || value.length > maximumHierarchyLevels) {
+        return null;
+    }
+
+    const levels: string[] = [];
+    for (const level of value) {
+        if (typeof level !== 'string') {
+            return null;
+        }
+
+        levels.push(level);
+    }
+
+    return levels;
+}
+
+function isFolderRole(value: unknown): value is MailFolderRole {
+    return typeof value === 'string' && roles.includes(value as MailFolderRole);
+}
+
+// A count is a whole number of messages this deployment holds, so a fraction, a negative, and a value past what
+// arithmetic here stays exact for are each an answer no mailbox produced.
+function isCount(value: unknown): value is number {
+    return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+}

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -45,6 +45,39 @@ const mailAccounts = {
     ],
 };
 
+// The tree the Mail space is scoped by, standing in for what the folders route answers. One mailbox with an inbox and
+// a folder nested where a mail server nests one, which is what the reload below is read against.
+const mailFolders = {
+    synchronizationEnabled: true,
+    accounts: [
+        {
+            account: mailAccounts.accounts[0],
+            folders: [
+                {
+                    alias: 'INBOX',
+                    role: 'Inbox',
+                    path: ['INBOX'],
+                    storedEmailCount: 4213,
+                    unreadEmailCount: 12,
+                    synchronizationState: 'Synchronized',
+                    lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
+                    behind: false,
+                },
+                {
+                    alias: 'ARCHIVE-2024',
+                    role: null,
+                    path: ['Archive', '2024'],
+                    storedEmailCount: 980,
+                    unreadEmailCount: 0,
+                    synchronizationState: 'Synchronized',
+                    lastSynchronizedAt: '2026-08-31T09:00:00+00:00',
+                    behind: false,
+                },
+            ],
+        },
+    ],
+};
+
 // The password this suite signs in with, and the RFC 7617 value the client is expected to compose out of it. Neither
 // belongs to anybody: the deployment is the preview server, and nothing here reaches a machine holding real mail.
 const userName = 'owner';
@@ -161,7 +194,7 @@ async function boxOf(element: Locator): Promise<Box> {
 }
 
 /**
- * Answers the two routes the client reaches on the origin it was served from, as the deployment behind it would.
+ * Answers the routes the client reaches on the origin it was served from, as the deployment behind it would.
  *
  * The preview server serves the bundle and nothing else, so without this the client meets a deployment that is not
  * there — and every screen past the sign-in would be unreachable. It is the browser's own routing rather than a
@@ -175,6 +208,10 @@ async function servedByADeployment(page: Page): Promise<void> {
 
     await page.route('**/api/client/accounts', (route) =>
         route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mailAccounts) }),
+    );
+
+    await page.route('**/api/client/folders', (route) =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mailFolders) }),
     );
 
     // The one route whose answer depends on what the client asked for: the reader's ask for the sender's pictures is
@@ -444,6 +481,29 @@ test('opens again in the language that was chosen, after the page is loaded afre
     // object to.
     await expect(discover).toHaveCount(0);
     await expect(page.locator('html')).toHaveAttribute('lang', 'pl');
+});
+
+test('keeps the folder tree as it was left, across a reload', async ({ page }) => {
+    await openSignedIn(page, '/#/mail');
+
+    const tree = page.getByRole('tree', { name: 'Mailboxes and folders' });
+    const everyMailbox = tree.getByRole('treeitem', { name: /^All mailboxes/ });
+
+    await everyMailbox.click();
+    await page.keyboard.press('ArrowLeft');
+    await expect(everyMailbox).toHaveAttribute('aria-expanded', 'false');
+
+    const nested = tree.getByRole('treeitem', { name: /^2024/ });
+    await nested.click();
+    await expect(nested).toHaveAttribute('aria-selected', 'true');
+
+    await page.reload();
+
+    // A reload is a cold start, so what somebody was looking at is kept where the credential is kept and read back the
+    // same way. Only a real document reloaded proves it was written rather than held: a remount in jsdom re-reads the
+    // same process's storage, and what this asks is that a browser wrote it.
+    await expect(tree.getByRole('treeitem', { name: /^All mailboxes/ })).toHaveAttribute('aria-expanded', 'false');
+    await expect(tree.getByRole('treeitem', { name: /^2024/ })).toHaveAttribute('aria-selected', 'true');
 });
 
 test('issues every request to the origin it was served from and to no other', async ({ page }) => {


### PR DESCRIPTION
Closes #1423.

The Mail space draws the owner's mailboxes and their folders as one tree, and that tree is what scopes the client.

## What it does

- **`Client.Backend/src/mailFolders.ts`** reads `GET /api/client/folders`: the accounts and every folder beneath them in one exchange, with the role, the path levels, the two counts, and the freshness each folder carries. It parses the way `readMailAccounts` does — every field checked before it becomes a value a screen may render, every collection bounded during the walk rather than after it (256 accounts, 1 024 folders per account, 32 path levels, counts as safe non-negative integers) — and it reuses that module's account parser rather than writing a second answer to what a mailbox is.
- **`Client.App/src/folders/`** turns that answer into rows (`folderTree.ts`, a function over values) and draws them (`FolderTree.tsx`, `FolderRow.tsx`). The tree opens with every mailbox at once and the roles that span them, then each account with its folders nested where its server nests them.
- **`Client.App/src/workspace/mailScope.ts`** is the scope every other screen reads.

## The decisions worth reviewing

**The scope is one value rather than an account beside a folder.** The four things somebody can point at are `everything`, a role across every mailbox, one mailbox, or one folder of one — and the third acceptance item ("a special-use folder can be selected across accounts") has no account to name at all, so a pair would have been two fields that must agree. Every row of the tree is keyed by the scope selecting it writes, which is also what "is this row the current scope" compares.

**The intent field stopped holding a mailbox of its own.** It reads and writes the same scope, so the two controls are two ways to say one thing; choosing a mailbox there scopes to the whole of it.

**The workspace survives a reload, in the session store.** Acceptance asks the tree to keep its expansion and selection across a reload and across moving between spaces; the second is the workspace context, and the first is `sessionStorage` — the store the web head already keeps its credential in, so what somebody was looking at dies with the tab exactly as the credential does, and signing out empties it as it already did. It is read back as untrusted input, because a store is a place a person can write. What is stored is the *folded* rows rather than the unfolded ones, so a tree nobody has touched shows what is in it.

**A folder is placed and named by its role.** The row for a folder the deployment labelled `Sent` reads *Sent* whatever its server calls the folder and in whatever language, which is the answer a client cannot work out for itself.

**Nothing is a spinner.** A row whose last attempt succeeded and left nothing behind says nothing; one that is behind or unreachable says which, in words, in the same vocabulary the account lines above already use — that naming moved into `synchronization/synchronizationState.ts` so the shell and the tree cannot drift apart.

**It is a real tree.** `role="tree"` with levels, set positions, `aria-expanded`, and `aria-selected`; a roving tab stop; arrows, `Home`, `End`, `Enter`, and `Space`. The counts carry the words a reader hears rather than arriving as bare numbers.

## Two edits beyond the folder tree

- `json.ts` — three parsers in `Client.Backend` had their own copy of the same `asRecord` guard, and this change needed a fourth. It is one module now, which is a deletion rather than an addition.
- `frontend/README.md` — the paragraph about `src/workspace/` said what it held before this change; it now names the scope, the folded rows, and where they are kept, with `src/folders/` beside it.

## Verification

`scripts/verify-full.sh` — passed, 284 workflow contract checks included. `pnpm test` — 623 unit tests. `pnpm test:browser` — 20 specs against the built bundle, including the new one: the tree is folded and a folder chosen, the page is reloaded, and both come back.

## Not in this change

The message list, the thread, and search are #1424, #1425, and #1429. The Mail space still draws the one proving message beside the tree until #1426 owns the reading pane, and the tree does not re-read on its own when a deployment comes back — the frame reconnects and the tree offers the way out a failed read has.
