### PR TITLE
[#1426] Read a message in the client: headers, body, files, and who actually sent it

### DIFF
--- a/backend/src/Host/Api/ClientMailMessageEndpoint.cs
+++ b/backend/src/Host/Api/ClientMailMessageEndpoint.cs
@@ -146,7 +146,7 @@ internal sealed record ClientMailMessageResponse(
             message.SizeOctets,
             ClientMailMessageHeadersResponse.For(message.Headers),
             ClientMailMessageBodyResponse.For(message.Body),
-            ClientMailSenderVerdictResponse.For(message.SenderVerification),
+            ClientMailSenderVerdictResponse.For(message.SenderVerification, message.SenderAuthenticationEvidence),
             [.. message.Attachments.Select((attachment, position) =>
                 ClientMailAttachmentResponse.For(attachment, position))],
             message.AttachmentSummary is { } carried ? ClientMailCarriedResponse.For(carried) : null,
@@ -232,28 +232,51 @@ internal sealed record ClientMailMessageBodyResponse(string Availability, bool P
 /// <summary>What this deployment established about the author one message displays.</summary>
 /// <param name="AuthorAuthentication">What the receiving mail server established about the displayed author, as the outcome's own name.</param>
 /// <param name="DeploymentTrust">Whether this deployment recognizes that author, as the level's own name.</param>
+/// <param name="AuthenticatedDomain">The domain that actually authenticated, or <see langword="null" /> where none did.</param>
 /// <remarks>
 /// <para>
-/// The two are published side by side and are never collapsed into one value, because a screen drawing a single badge
-/// from them would have to invent the rule that combines them. One is a fact a receiving server established about the
-/// message, and the other is this deployment's own classification of the author it established; an authenticated author
-/// nobody has named is the ordinary state of legitimate mail and carries the same trust value as one whose
+/// The two outcomes are published side by side and are never collapsed into one value, because a screen drawing a single
+/// badge from them would have to invent the rule that combines them. One is a fact a receiving server established about
+/// the message, and the other is this deployment's own classification of the author it established; an authenticated
+/// author nobody has named is the ordinary state of legitimate mail and carries the same trust value as one whose
 /// authentication failed outright.
+/// </para>
+/// <para>
+/// The domain travels with them so that a reading pane can name who actually sent a message rather than repeating the
+/// <c>From</c> value the message displays, which is the one thing an impersonation gets wrong. It is stated and never
+/// judged: whether it differs from the displayed domain says nothing on its own — a provider that signs as itself while
+/// the author's own domain passes SPF is authenticated exactly as it appears — so what a reader acts on stays
+/// <paramref name="AuthorAuthentication" />, and a client comparing the two would be evaluating a policy this deployment
+/// deliberately does not.
 /// </para>
 /// <para>
 /// It is read back as it was stored rather than derived here. Nothing on this path re-reads a header, resolves DNS, or
 /// evaluates a policy, so what a reader is shown is what extraction concluded about the authenticated author — never a
-/// reading of the <c>From</c> header the message displays.
+/// reading of the <c>From</c> header the message displays. The domain is personal data like the rest of this response.
 /// </para>
 /// </remarks>
-internal sealed record ClientMailSenderVerdictResponse(string AuthorAuthentication, string DeploymentTrust)
+internal sealed record ClientMailSenderVerdictResponse(
+    string AuthorAuthentication,
+    string DeploymentTrust,
+    string? AuthenticatedDomain)
 {
     /// <summary>Describes one message's sender verdict for the wire.</summary>
     /// <param name="verification">The verdict the read carried.</param>
+    /// <param name="evidence">What that verdict was reached from, of which only the authenticated domain is published.</param>
     /// <returns>The response body.</returns>
-    internal static ClientMailSenderVerdictResponse For(SenderVerification verification) => new(
-        verification.AuthorAuthentication.ToString(),
-        verification.DeploymentTrust.ToString());
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    internal static ClientMailSenderVerdictResponse For(
+        SenderVerification verification,
+        SenderAuthenticationEvidence evidence)
+    {
+        ArgumentNullException.ThrowIfNull(verification);
+        ArgumentNullException.ThrowIfNull(evidence);
+
+        return new ClientMailSenderVerdictResponse(
+            verification.AuthorAuthentication.ToString(),
+            verification.DeploymentTrust.ToString(),
+            evidence.AuthenticatedDomain?.Value);
+    }
 }
 
 /// <summary>One file a message carries, described and carrying none of what it holds.</summary>

--- a/backend/tests/Host.UnitTests/Api/ClientMailMessageEndpointTests.cs
+++ b/backend/tests/Host.UnitTests/Api/ClientMailMessageEndpointTests.cs
@@ -191,6 +191,40 @@ public sealed class ClientMailMessageEndpointTests
         Assert.Equal("Trusted", response.Sender.DeploymentTrust);
     }
 
+    /// <summary>
+    /// The domain that authenticated travels beside the verdict, so a reading pane can name who actually sent a message
+    /// rather than repeating the <c>From</c> value it displays — which is the one thing an impersonation gets wrong.
+    /// </summary>
+    [Fact]
+    public void For_AMessageWhoseAuthorAuthenticated_NamesTheDomainThatDidSo()
+    {
+        // Arrange
+        var evidence = new SenderAuthenticationEvidence
+        {
+            AuthenticatedDomain = SenderDomain.TryCreate("mail.example.test", out var domain) ? domain : default,
+            AuthenticatedBy = SenderAuthenticationMethod.DomainKeysIdentifiedMail,
+            Dmarc = DmarcOutcome.Pass,
+            Source = SenderAuthenticationSource.ReceivingServer,
+        };
+
+        // Act
+        var response = ClientMailMessageResponse.For(MessageWith(evidence));
+
+        // Assert
+        Assert.Equal("mail.example.test", response.Sender.AuthenticatedDomain);
+    }
+
+    /// <summary>A message nothing authenticated names no domain, which is an ordinary outcome rather than missing data.</summary>
+    [Fact]
+    public void For_AMessageNothingAuthenticated_NamesNoDomain()
+    {
+        // Act
+        var response = ClientMailMessageResponse.For(MessageWith());
+
+        // Assert
+        Assert.Null(response.Sender.AuthenticatedDomain);
+    }
+
     /// <summary>The flags a pane draws are the ones the mail server last showed, and unread is the absence of the seen flag.</summary>
     [Fact]
     public void For_AReadMessage_CarriesTheFlagsTheServerLastShowed()
@@ -204,7 +238,7 @@ public sealed class ClientMailMessageEndpointTests
         Assert.False(response.Answered);
     }
 
-    private static ReadEmailContent MessageWith() => new()
+    private static ReadEmailContent MessageWith(SenderAuthenticationEvidence? evidence = null) => new()
     {
         StoredEmailId = StoredEmailId.Create(Message),
         AccountId = MailAccountId.Create("primary"),
@@ -242,7 +276,7 @@ public sealed class ClientMailMessageEndpointTests
             AuthorAuthentication = AuthorAuthenticationOutcome.Authenticated,
             DeploymentTrust = SenderTrustLevel.Trusted,
         },
-        SenderAuthenticationEvidence = SenderAuthenticationEvidence.None,
+        SenderAuthenticationEvidence = evidence ?? SenderAuthenticationEvidence.None,
         MachineAuthorship = MachineAuthorshipAssessment.NotAssessed,
         Thread = new ReadEmailThread
         {

--- a/backend/tests/PublicSurfaces.UnitTests/http-api-contract.json
+++ b/backend/tests/PublicSurfaces.UnitTests/http-api-contract.json
@@ -662,6 +662,12 @@
       },
       "ClientMailSenderVerdictResponse": {
         "properties": {
+          "authenticatedDomain": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
           "authorAuthentication": {
             "type": "string"
           },
@@ -671,7 +677,8 @@
         },
         "required": [
           "authorAuthentication",
-          "deploymentTrust"
+          "deploymentTrust",
+          "authenticatedDomain"
         ],
         "type": "object"
       },

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -664,7 +664,11 @@ of its body exist to be asked for:
     "references": []
   },
   "body": { "availability": "Readable", "plainText": true, "html": true },
-  "sender": { "authorAuthentication": "Authenticated", "deploymentTrust": "Trusted" },
+  "sender": {
+    "authorAuthentication": "Authenticated",
+    "deploymentTrust": "Trusted",
+    "authenticatedDomain": "example.test"
+  },
   "attachments": [
     {
       "position": 0,
@@ -711,6 +715,12 @@ would mean inventing the rule that combines them: an authenticated author nobody
 legitimate mail and carries the same trust value as one whose authentication failed outright. Both are read back as they
 were stored; nothing on this path re-reads a header, resolves DNS, or evaluates a policy, so what a reader is shown is
 what was concluded about the authenticated author rather than a reading of the `From` header.
+
+**`authenticatedDomain` is who the authentication was established for**, which is the fact a reader needs when the
+name a message displays is not it. It is the domain the receiving mail server authenticated and nothing wider: it is
+`null` for a message nothing authenticated a sender for, and it is published beside the two states rather than
+compared against the `From` address, because judging whether the two agree is the policy this path deliberately does
+not evaluate.
 
 **No octet of a file is here, at any size and in any encoding.** Each entry says what the file is called, what it
 declares itself to be, and how large it decodes to — which is what a reader decides against — and `position` is what its

--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ClientRequest, ClientResponse } from '@mailfathom/client-backend';
 import { App } from './App';
 import type { AdoptedDeployment } from './deployment/adoptedDeployment';
+import type { AttachmentDelivery } from './deployment/attachmentDelivery';
 import type { DeploymentTransport } from './deployment/sendToDeployment';
 import { LocalizationProvider } from './localization/Localization';
 import { localeNames, locales, readStoredLocale } from './localization/locale';
@@ -109,7 +110,40 @@ const drawnMessage: Answer = {
     }),
 };
 
-/** A deployment that answers the accounts as the one above does, and the body the reading pane in Mail asks it for. */
+/** What the message route answers with, which is everything the pane draws around a body it never carries. */
+const describedMessage: Answer = {
+    status: 200,
+    body: JSON.stringify({
+        storedEmailId: '00000000-0000-4000-8000-000000000000',
+        account: 'work',
+        folder: 'INBOX',
+        threadId: null,
+        sizeOctets: 4_096,
+        headers: {
+            subject: 'Quarterly invoice',
+            sentAt: '2026-08-31T09:41:00+00:00',
+            receivedAt: '2026-08-31T09:41:10+00:00',
+            participants: [{ role: 'From', address: 'billing@example.invalid', displayName: 'Billing' }],
+            messageId: 'abc@example.invalid',
+            inReplyTo: null,
+            references: [],
+        },
+        body: { availability: 'Readable', plainText: true, html: true },
+        sender: { authorAuthentication: 'Authenticated', deploymentTrust: 'Unknown', authenticatedDomain: null },
+        attachments: [],
+        carried: null,
+        unread: true,
+        flagged: false,
+        answered: false,
+    }),
+};
+
+/**
+ * A deployment that answers the accounts as the one above does, and both reads the reading pane in Mail makes.
+ *
+ * The two are separate routes because they are separately expensive, so the double answers them separately as well —
+ * a description that also served a body would prove the pane against an exchange the service does not have.
+ */
 function deploymentDrawingAMessage(): DeploymentTransport {
     const otherwise = deploymentAnswering();
 
@@ -120,9 +154,12 @@ function deploymentDrawingAMessage(): DeploymentTransport {
 
         asked.push(request);
 
-        return Promise.resolve(complete(drawnMessage));
+        return Promise.resolve(complete(request.path.includes('/body') ? drawnMessage : describedMessage));
     };
 }
+
+/** A delivery nobody in these tests asks for, supplied because the frame hands one down rather than reaching for it. */
+const deliversNothing: AttachmentDelivery = () => Promise.resolve('delivered');
 
 /** A deployment answering every route the same way, which is how a refusal to sign anybody in is stated. */
 function deploymentRefusing(answer: Answer): DeploymentTransport {
@@ -202,6 +239,7 @@ function renderApp(
                         <LinkOpenerContext value={() => Promise.resolve()}>
                             <App
                                 credentials={credentials}
+                                deliver={deliversNothing}
                                 deployment={deployment}
                                 send={send}
                                 signedInWith={signedInWith}

--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ClientRequest, ClientResponse } from '@mailfathom/client-backend';
 import { App } from './App';
 import type { AdoptedDeployment } from './deployment/adoptedDeployment';
-import type { AttachmentDelivery } from './deployment/attachmentDelivery';
+import { AttachmentDeliveryContext, type AttachmentDelivery } from './deployment/attachmentDelivery';
 import type { DeploymentTransport } from './deployment/sendToDeployment';
 import { LocalizationProvider } from './localization/Localization';
 import { localeNames, locales, readStoredLocale } from './localization/locale';
@@ -158,7 +158,7 @@ function deploymentDrawingAMessage(): DeploymentTransport {
     };
 }
 
-/** A delivery nobody in these tests asks for, supplied because the frame hands one down rather than reaching for it. */
+/** A delivery nobody in these tests asks for, supplied because a row below the frame reads one from the context. */
 const deliversNothing: AttachmentDelivery = () => Promise.resolve('delivered');
 
 /** A deployment answering every route the same way, which is how a refusal to sign anybody in is stated. */
@@ -237,13 +237,14 @@ function renderApp(
                 <ThemeProvider>
                     <WorkspaceProvider>
                         <LinkOpenerContext value={() => Promise.resolve()}>
-                            <App
-                                credentials={credentials}
-                                deliver={deliversNothing}
-                                deployment={deployment}
-                                send={send}
-                                signedInWith={signedInWith}
-                            />
+                            <AttachmentDeliveryContext value={deliversNothing}>
+                                <App
+                                    credentials={credentials}
+                                    deployment={deployment}
+                                    send={send}
+                                    signedInWith={signedInWith}
+                                />
+                            </AttachmentDeliveryContext>
                         </LinkOpenerContext>
                     </WorkspaceProvider>
                 </ThemeProvider>

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -6,10 +6,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { DeploymentAddress } from '@mailfathom/client-backend';
 import { SecondaryButton } from './controls/SecondaryButton';
 import { forgetDeployment, storeDeployment, type AdoptedDeployment } from './deployment/adoptedDeployment';
+import type { AttachmentDelivery } from './deployment/attachmentDelivery';
 import type { DeploymentTransport } from './deployment/sendToDeployment';
 import { FolderTree } from './folders/FolderTree';
 import { useLocalization } from './localization/useLocalization';
-import { Message } from './messageBody/Message';
+import { ReadingPane } from './readingPane/ReadingPane';
 import { useSpace } from './routing/useSpace';
 import { offers, spacesOffered, withheldFrom } from './shell/capabilities';
 import { ConnectionSummary } from './shell/ConnectionSummary';
@@ -25,9 +26,9 @@ import { SignIn } from './signIn/SignIn';
 import { emptyWorkspace } from './workspace/useWorkspace';
 import { useWorkspace } from './workspace/useWorkspace';
 
-// Which message the Mail space draws is the reading pane's to decide, and that pane is #1426's. Until it exists, the
-// space draws one message by identifier — which is what makes the renderer reachable in a browser at all, and is the
-// only reason this constant is here rather than a value the screen was handed.
+// Which message the reading pane draws is the message list's to decide, and that list is not built yet. Until it is,
+// the Mail space opens one message by identifier — which is what makes the pane reachable in a browser at all, and is
+// the only reason this constant is here rather than a value the screen was handed.
 const provingRead = '00000000-0000-4000-8000-000000000000';
 
 // The frame Discover, Mail, and Cases are held in, and the only thing in the client that survives moving between them.
@@ -47,11 +48,13 @@ export function App({
     signedInWith,
     credentials,
     send,
+    deliver,
 }: {
     readonly deployment: AdoptedDeployment | null;
     readonly signedInWith: string | null;
     readonly credentials: CredentialStore;
     readonly send: DeploymentTransport;
+    readonly deliver: AttachmentDelivery;
 }) {
     const { revise } = useWorkspace();
     const [adopted, setAdopted] = useState(deployment);
@@ -69,8 +72,10 @@ export function App({
     );
 
     // The transport those reads are made through, built once for the same reason. It carries a signal nothing ever
-    // fires: both the tree and the message discard the answer to a read they stopped listening for rather than
-    // cancelling it, and the pane that will own a read outliving the message it was started for is #1426's.
+    // fires: the tree, the reading pane, and the body renderer each discard the answer to a read they stopped listening
+    // for rather than cancelling it, which is what a screen that may be looking at another message by then actually
+    // needs. A download is the one read here that is genuinely abandoned, and it carries a signal of its own from the
+    // row that started it.
     const readMail = useMemo(() => send(new AbortController().signal), [send]);
 
     // The view changed, so focus goes to the start of what replaced it rather than staying on a control that is no
@@ -238,7 +243,13 @@ export function App({
                         }
                         mail={
                             session === null ? null : (
-                                <Message session={session} transport={readMail} storedEmailId={provingRead} />
+                                <ReadingPane
+                                    session={session}
+                                    transport={readMail}
+                                    storedEmailId={provingRead}
+                                    online={connection.online}
+                                    deliver={deliver}
+                                />
                             )
                         }
                     />

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -6,7 +6,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { DeploymentAddress } from '@mailfathom/client-backend';
 import { SecondaryButton } from './controls/SecondaryButton';
 import { forgetDeployment, storeDeployment, type AdoptedDeployment } from './deployment/adoptedDeployment';
-import type { AttachmentDelivery } from './deployment/attachmentDelivery';
 import type { DeploymentTransport } from './deployment/sendToDeployment';
 import { FolderTree } from './folders/FolderTree';
 import { useLocalization } from './localization/useLocalization';
@@ -48,13 +47,11 @@ export function App({
     signedInWith,
     credentials,
     send,
-    deliver,
 }: {
     readonly deployment: AdoptedDeployment | null;
     readonly signedInWith: string | null;
     readonly credentials: CredentialStore;
     readonly send: DeploymentTransport;
-    readonly deliver: AttachmentDelivery;
 }) {
     const { revise } = useWorkspace();
     const [adopted, setAdopted] = useState(deployment);
@@ -248,7 +245,6 @@ export function App({
                                     transport={readMail}
                                     storedEmailId={provingRead}
                                     online={connection.online}
-                                    deliver={deliver}
                                 />
                             )
                         }

--- a/frontend/src/Client.App/src/deployment/attachmentDelivery.ts
+++ b/frontend/src/Client.App/src/deployment/attachmentDelivery.ts
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+import { createContext, useContext } from 'react';
 import { attachmentRefusalForStatus, longestResponseBody, type ClientRequest } from '@mailfathom/client-backend';
 
 // Fetching one file a message carries and handing it to the person, which is one operation rather than two: nothing
@@ -31,6 +32,24 @@ export type AttachmentDelivery = (
     arrived: (octets: number) => void,
     abandoned: AbortSignal,
 ) => Promise<AttachmentDeliveryOutcome>;
+
+// Reached through a context rather than handed down, for the reason `shellOperations/linkOpener.ts` gives about
+// the operation it carries: which implementation satisfies it is the composition root's decision, and the row
+// that calls it is several components below the screen that owns the message — none of which has a reason to
+// name a download it never makes.
+export const AttachmentDeliveryContext = createContext<AttachmentDelivery | null>(null);
+
+export function useAttachmentDelivery(): AttachmentDelivery {
+    const delivery = useContext(AttachmentDeliveryContext);
+
+    if (delivery === null) {
+        throw new Error(
+            'A component asked for an attachment outside the AttachmentDeliveryContext that main.tsx supplies.',
+        );
+    }
+
+    return delivery;
+}
 
 export const deliverAttachment: AttachmentDelivery = async (request, fileName, arrived, abandoned) => {
     let response: Response;

--- a/frontend/src/Client.App/src/deployment/attachmentDelivery.ts
+++ b/frontend/src/Client.App/src/deployment/attachmentDelivery.ts
@@ -1,0 +1,141 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { attachmentRefusalForStatus, longestResponseBody, type ClientRequest } from '@mailfathom/client-backend';
+
+// Fetching one file a message carries and handing it to the person, which is one operation rather than two: nothing
+// above this module ever holds the octets, so no screen and no component in the client has a reason to.
+//
+// It sits beside `sendToDeployment.ts` because the two are the whole of what calls `fetch` here — `Client.Backend`
+// declares no DOM, so a `ReadableStream`, an `AbortSignal`, and a `Blob` can only be named on this side of the boundary.
+// What that package still owns is the part that is the contract: the route, the credential, the header the answer is
+// asked in, and the bound it is read under all arrive as the composed `ClientRequest`.
+
+/** What happened to a download, where an expected failure is a value rather than an exception. */
+export type AttachmentDeliveryOutcome =
+    'delivered' | 'abandoned' | 'unauthenticated' | 'unauthorized' | 'unavailable' | 'largerThanDescribed';
+
+/**
+ * Downloads one file and hands it to the person as a file to keep.
+ *
+ * @param request What `mailAttachmentRequest` composed, which carries the route, the credential, and the bound.
+ * @param fileName What to offer the file under, already reduced to a name this client is willing to write.
+ * @param arrived How many octets have been read so far, reported as they arrive so a screen can say so.
+ * @param abandoned Abandons the download when the person waiting on it gives up.
+ * @returns What happened, which is `delivered` only where the whole file arrived within its stated size.
+ */
+export type AttachmentDelivery = (
+    request: ClientRequest,
+    fileName: string,
+    arrived: (octets: number) => void,
+    abandoned: AbortSignal,
+) => Promise<AttachmentDeliveryOutcome>;
+
+export const deliverAttachment: AttachmentDelivery = async (request, fileName, arrived, abandoned) => {
+    let response: Response;
+
+    try {
+        response = await fetch(request.path, {
+            method: request.method,
+            headers: { ...request.headers },
+            signal: abandoned,
+        });
+    } catch {
+        // A connection refused, a name that does not resolve, and a person pressing the way out all arrive here as one
+        // rejected promise, so which of them it was is asked of the signal rather than of the error.
+        return abandoned.aborted ? 'abandoned' : 'unavailable';
+    }
+
+    if (response.status !== 200) {
+        return attachmentRefusalForStatus(response.status);
+    }
+
+    const octets = await readBoundedContent(response, request.longestAnswer ?? longestResponseBody, arrived);
+
+    if (typeof octets === 'string') {
+        return abandoned.aborted ? 'abandoned' : octets;
+    }
+
+    keepAsFile(octets, fileName);
+
+    return 'delivered';
+};
+
+/**
+ * Reads the octets up to the size the message said the file holds, and stops there.
+ *
+ * `response.blob()` would buffer whatever arrives before anything got to look at it, which is the wrong order for a
+ * download a person is waiting on: they are told a size before they ask, so an answer larger than that is refused
+ * rather than written to their machine, and reading in chunks is also what makes the progress they are shown real
+ * rather than a guess.
+ *
+ * The two ways it can end without a file are kept apart rather than collapsed into an absence, because they are two
+ * different sentences to a reader: an answer larger than the message described is a defect worth reporting, and a
+ * connection that stopped partway through is the ordinary one to try again.
+ */
+async function readBoundedContent(
+    response: Response,
+    longest: number,
+    arrived: (octets: number) => void,
+): Promise<readonly Uint8Array<ArrayBuffer>[] | 'largerThanDescribed' | 'unavailable'> {
+    const reading = response.body?.getReader();
+
+    if (reading === undefined) {
+        return 'unavailable';
+    }
+
+    const chunks: Uint8Array<ArrayBuffer>[] = [];
+    let octets = 0;
+
+    for (;;) {
+        let chunk: ReadableStreamReadResult<Uint8Array>;
+
+        try {
+            chunk = await reading.read();
+        } catch {
+            return 'unavailable';
+        }
+
+        if (chunk.done) {
+            return chunks;
+        }
+
+        octets += chunk.value.byteLength;
+
+        if (octets > longest) {
+            await reading.cancel();
+
+            return 'largerThanDescribed';
+        }
+
+        // Copied out of the chunk the stream handed over rather than kept as it stands, because a stream's own buffer
+        // may be a shared one and a `Blob` is composed from unshared memory. The copy replaces the chunk rather than
+        // standing beside it, so what is held at once is the file and one chunk rather than the file twice.
+        chunks.push(chunk.value.slice());
+        arrived(octets);
+    }
+}
+
+/**
+ * Hands the octets to the person as a file to keep, and lets go of them.
+ *
+ * The type is always the general binary one rather than what the sender declared the part to be. A blob URL carries its
+ * own origin, so a message whose attachment claims to be markup would otherwise be a scripted page a browser could be
+ * talked into opening rather than saving — which is the same reason the service serves every download as an attachment
+ * with sniffing turned off. What names the file is its extension, which the sender's own name already carries.
+ *
+ * The URL is released in the same turn. A blob URL keeps its octets alive for as long as the document holds it, so a
+ * reader who downloads several large files in one sitting would otherwise be holding all of them in memory until they
+ * navigated away.
+ */
+function keepAsFile(octets: readonly Uint8Array<ArrayBuffer>[], fileName: string): void {
+    const address = URL.createObjectURL(new Blob([...octets], { type: 'application/octet-stream' }));
+    const offered = document.createElement('a');
+
+    offered.href = address;
+    offered.download = fileName;
+    offered.click();
+
+    URL.revokeObjectURL(address);
+}

--- a/frontend/src/Client.App/src/deployment/sendToDeployment.ts
+++ b/frontend/src/Client.App/src/deployment/sendToDeployment.ts
@@ -4,9 +4,10 @@
 
 import { longestResponseBody, type MailFathomTransport } from '@mailfathom/client-backend';
 
-// The adapter `Client.Backend` asks its caller for. That package declares no DOM, so the one call to `fetch` in the
-// client is here — which is what makes the boundary a resolution error rather than a convention, and it is the whole
-// of what this module is.
+// The adapter `Client.Backend` asks its caller for. That package declares no DOM, so `fetch` is called in this
+// directory and nowhere else in the client — which is what makes the boundary a resolution error rather than a
+// convention. This module is the whole of the transport that answers with text; `attachmentDelivery.ts` beside it is
+// the one operation that answers with octets instead, which is why it is a second module rather than a second export.
 
 /**
  * The transport for one attempt, which the signal abandons when the person waiting on it gives up.

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -169,6 +169,57 @@ export const en = {
     'body.remotePicturesShownCount': 'Pictures loaded from the sender: {count}',
     'body.undrawnPicturesCount': 'Pictures too large to draw: {count}',
 
+    'message.nothingOpen': 'Open a message to read it here.',
+    'message.reading': 'Reading this message…',
+    'message.offline':
+        'This machine is offline, so this message cannot be opened. It opens on its own once the network comes back.',
+    'message.failed': 'This message could not be opened: {reason}.',
+    'message.noSubject': 'No subject',
+    'message.noAuthor': 'This message names nobody as its author.',
+    'message.sentAt': 'Sent {when}',
+    'message.sentAtUnknown': 'The sender wrote no date this client can read.',
+    'message.otherParticipants': 'Everybody else this message names ({count})',
+
+    'participant.from': 'From',
+    'participant.sender': 'Submitted by',
+    'participant.replyTo': 'Reply to',
+    'participant.to': 'To',
+    'participant.cc': 'Copy to',
+    'participant.bcc': 'Blind copy to',
+
+    'sender.failed':
+        'A receiving mail server checked who actually sent this message and reported that the author it displays did not hold.',
+    'sender.recognized': 'This deployment recognizes the sender of this message.',
+    'sender.authenticatedBy': 'Authenticated by {domain}, which is who actually sent it rather than the name above.',
+    'sender.authenticatedByNobody': 'Nothing authenticated a sender for this message.',
+
+    'attachments.heading': 'Files this message carries',
+    'attachment.unnamed': 'Unnamed file',
+    'attachment.download': 'Download {name}',
+    'attachment.nameWasRewritten':
+        'The sender wrote a file name this deployment would not use, so what is shown is the name it was given instead.',
+    'attachment.arriving': 'How much of the file has arrived',
+    'attachment.arrivingOf': '{arrived} of {whole}',
+    'attachment.stop': 'Stop downloading',
+    'attachment.saved': '{name} was downloaded.',
+    'attachment.abandoned': 'The download was stopped, so nothing was saved.',
+    'attachment.refusedUnauthenticated':
+        'This deployment no longer accepts the credential, so the file was not downloaded. Sign in again.',
+    'attachment.refusedUnauthorized':
+        'This credential may not read mail on this deployment, so the file was not downloaded.',
+    'attachment.refusedUnavailable': 'The deployment did not answer, so the file was not downloaded. Try again.',
+    'attachment.refusedLargerThanDescribed':
+        'The deployment sent more than this message said the file holds, so nothing was saved. Report this as a defect.',
+
+    'carried.total': 'Everything attached comes to {size}.',
+    'carried.encrypted': 'This message carries encrypted content somewhere.',
+    'carried.unverifiedSignature': 'This message carries a signature, and nothing here has verified it.',
+    'carried.unexpandedTnefPart':
+        'This message carries a winmail.dat part, which was recorded without being opened, so whatever it holds is not listed above.',
+
+    'scope.fragment': 'Asking about the part of this message you selected: “{fragment}”',
+    'scope.wholeMessage': 'Ask about the whole message instead',
+
     'link.goesTo': 'goes to {host}',
     'link.warningDisplayedHostDiffers': 'This link does not go where its words say. It goes to {host}.',
     'link.warningAsciiHost': 'This link goes to {host}, which is written {asciiHost}.',

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -180,7 +180,6 @@ export const en = {
     'message.sentAtUnknown': 'The sender wrote no date this client can read.',
     'message.otherParticipants': 'Everybody else this message names ({count})',
 
-    'participant.from': 'From',
     'participant.sender': 'Submitted by',
     'participant.replyTo': 'Reply to',
     'participant.to': 'To',

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -172,6 +172,58 @@ export const pl: Catalogue = {
     'body.remotePicturesShownCount': 'Obrazów pobranych od nadawcy: {count}',
     'body.undrawnPicturesCount': 'Obrazów zbyt dużych, by je narysować: {count}',
 
+    'message.nothingOpen': 'Otwórz wiadomość, aby ją tutaj przeczytać.',
+    'message.reading': 'Trwa otwieranie tej wiadomości…',
+    'message.offline':
+        'Ta maszyna jest bez sieci, więc nie można otworzyć tej wiadomości. Otworzy się sama, gdy sieć wróci.',
+    'message.failed': 'Nie udało się otworzyć tej wiadomości: {reason}.',
+    'message.noSubject': 'Bez tematu',
+    'message.noAuthor': 'Ta wiadomość nie wskazuje nikogo jako autora.',
+    'message.sentAt': 'Wysłano {when}',
+    'message.sentAtUnknown': 'Nadawca nie zapisał daty, którą ten klient potrafi odczytać.',
+    'message.otherParticipants': 'Pozostałe osoby wskazane w tej wiadomości ({count})',
+
+    'participant.from': 'Od',
+    'participant.sender': 'Nadane przez',
+    'participant.replyTo': 'Odpowiedź do',
+    'participant.to': 'Do',
+    'participant.cc': 'Kopia do',
+    'participant.bcc': 'Ukryta kopia do',
+
+    'sender.failed':
+        'Odbierający serwer pocztowy sprawdził, kto naprawdę wysłał tę wiadomość, i stwierdził, że wskazany w niej autor się nie potwierdził.',
+    'sender.recognized': 'To wdrożenie rozpoznaje nadawcę tej wiadomości.',
+    'sender.authenticatedBy':
+        'Uwierzytelniona przez {domain} — to ona naprawdę ją wysłała, a nie nazwa widoczna powyżej.',
+    'sender.authenticatedByNobody': 'Nic nie uwierzytelniło nadawcy tej wiadomości.',
+
+    'attachments.heading': 'Pliki dołączone do tej wiadomości',
+    'attachment.unnamed': 'Plik bez nazwy',
+    'attachment.download': 'Pobierz {name}',
+    'attachment.nameWasRewritten':
+        'Nadawca zapisał nazwę pliku, której to wdrożenie by nie użyło, więc widoczna jest nazwa nadana w jej miejsce.',
+    'attachment.arriving': 'Jaka część pliku już dotarła',
+    'attachment.arrivingOf': '{arrived} z {whole}',
+    'attachment.stop': 'Przerwij pobieranie',
+    'attachment.saved': 'Pobrano {name}.',
+    'attachment.abandoned': 'Pobieranie zostało przerwane, więc nic nie zostało zapisane.',
+    'attachment.refusedUnauthenticated':
+        'To wdrożenie nie przyjmuje już tych danych logowania, więc plik nie został pobrany. Zaloguj się ponownie.',
+    'attachment.refusedUnauthorized':
+        'Te dane logowania nie pozwalają czytać poczty w tym wdrożeniu, więc plik nie został pobrany.',
+    'attachment.refusedUnavailable': 'Wdrożenie nie odpowiedziało, więc plik nie został pobrany. Spróbuj ponownie.',
+    'attachment.refusedLargerThanDescribed':
+        'Wdrożenie przysłało więcej, niż ta wiadomość deklaruje dla tego pliku, więc nic nie zostało zapisane. Zgłoś to jako usterkę.',
+
+    'carried.total': 'Wszystkie załączniki razem to {size}.',
+    'carried.encrypted': 'Ta wiadomość zawiera gdzieś zaszyfrowaną treść.',
+    'carried.unverifiedSignature': 'Ta wiadomość zawiera podpis, którego nic tutaj nie zweryfikowało.',
+    'carried.unexpandedTnefPart':
+        'Ta wiadomość zawiera część winmail.dat, którą zapisano bez otwierania, więc to, co się w niej znajduje, nie jest wymienione powyżej.',
+
+    'scope.fragment': 'Pytanie dotyczy zaznaczonego fragmentu tej wiadomości: „{fragment}”',
+    'scope.wholeMessage': 'Pytaj o całą wiadomość',
+
     'link.goesTo': 'prowadzi do {host}',
     'link.warningDisplayedHostDiffers': 'Ten odnośnik nie prowadzi tam, gdzie mówią jego słowa. Prowadzi do {host}.',
     'link.warningAsciiHost': 'Ten odnośnik prowadzi do {host}, zapisanego jako {asciiHost}.',

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -183,7 +183,6 @@ export const pl: Catalogue = {
     'message.sentAtUnknown': 'Nadawca nie zapisał daty, którą ten klient potrafi odczytać.',
     'message.otherParticipants': 'Pozostałe osoby wskazane w tej wiadomości ({count})',
 
-    'participant.from': 'Od',
     'participant.sender': 'Nadane przez',
     'participant.replyTo': 'Odpowiedź do',
     'participant.to': 'Do',

--- a/frontend/src/Client.App/src/main.tsx
+++ b/frontend/src/Client.App/src/main.tsx
@@ -6,7 +6,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
 import { adoptedDeployment } from './deployment/adoptedDeployment';
-import { deliverAttachment } from './deployment/attachmentDelivery';
+import { AttachmentDeliveryContext, deliverAttachment } from './deployment/attachmentDelivery';
 import { sendToDeployment } from './deployment/sendToDeployment';
 import { LocalizationProvider } from './localization/Localization';
 import { LinkOpenerContext, linkOpenerForThisApplication } from './shellOperations/linkOpener';
@@ -51,13 +51,14 @@ async function open(root: HTMLElement): Promise<void> {
                 <ThemeProvider>
                     <WorkspaceProvider>
                         <LinkOpenerContext value={openLink}>
-                            <App
-                                credentials={credentials}
-                                deliver={deliverAttachment}
-                                deployment={deployment}
-                                send={sendToDeployment}
-                                signedInWith={signedInWith}
-                            />
+                            <AttachmentDeliveryContext value={deliverAttachment}>
+                                <App
+                                    credentials={credentials}
+                                    deployment={deployment}
+                                    send={sendToDeployment}
+                                    signedInWith={signedInWith}
+                                />
+                            </AttachmentDeliveryContext>
                         </LinkOpenerContext>
                     </WorkspaceProvider>
                 </ThemeProvider>

--- a/frontend/src/Client.App/src/main.tsx
+++ b/frontend/src/Client.App/src/main.tsx
@@ -6,6 +6,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
 import { adoptedDeployment } from './deployment/adoptedDeployment';
+import { deliverAttachment } from './deployment/attachmentDelivery';
 import { sendToDeployment } from './deployment/sendToDeployment';
 import { LocalizationProvider } from './localization/Localization';
 import { LinkOpenerContext, linkOpenerForThisApplication } from './shellOperations/linkOpener';
@@ -52,6 +53,7 @@ async function open(root: HTMLElement): Promise<void> {
                         <LinkOpenerContext value={openLink}>
                             <App
                                 credentials={credentials}
+                                deliver={deliverAttachment}
                                 deployment={deployment}
                                 send={sendToDeployment}
                                 signedInWith={signedInWith}

--- a/frontend/src/Client.App/src/messageBody/Message.tsx
+++ b/frontend/src/Client.App/src/messageBody/Message.tsx
@@ -16,9 +16,9 @@ import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
 import { MessageBody } from './MessageBody';
 
-// One message, read and drawn. The pane that will choose which message and lay the space out around it is #1426's;
-// what this owns is the read itself, the reader's own ask for pictures from the sender, and the five states a surface
-// that waits owes somebody.
+// One message's body, read and drawn. Which message that is, and everything the reading pane lays out around it, is
+// `readingPane/ReadingPane.tsx`'s; what this owns is the body read itself, the reader's own ask for pictures from the
+// sender, and the five states a surface that waits owes somebody.
 //
 // Asking for pictures re-reads that one message with the ask in the query, and neither this component nor anything
 // beneath it writes the answer down: leaving the message and coming back asks again, which is the whole of what

--- a/frontend/src/Client.App/src/messageBody/MessageBlocks.test.tsx
+++ b/frontend/src/Client.App/src/messageBody/MessageBlocks.test.tsx
@@ -10,8 +10,8 @@ import { MessageBlocks } from './MessageBlocks';
 import { LinkOpenerContext } from '../shellOperations/linkOpener';
 
 // Written as attacks rather than as examples, because a message is written by a stranger: what is asserted below is
-// that markup written into a message stays characters, that a heading a sender wrote cannot claim the level the
-// application's own title holds, and that a block this build does not know costs the reader that block and no more.
+// that markup written into a message stays characters, that a heading a sender wrote cannot claim a level the screen
+// around the message already holds, and that a block this build does not know costs the reader that block and no more.
 
 const noEmphasis = {
     bold: false,
@@ -56,11 +56,12 @@ describe('MessageBlocks', () => {
         expect(screen.queryByRole('img')).toBeNull();
     });
 
-    it('never lets a heading a sender wrote claim the level the application own title holds', () => {
+    it('never lets a heading a sender wrote claim a level the screen around the message already holds', () => {
         drawing([{ type: 'heading', level: 1, content: [run('A masthead')], alignment: 'Start' }]);
 
-        expect(screen.getByRole('heading', { level: 2, name: 'A masthead' })).toBeDefined();
+        expect(screen.getByRole('heading', { level: 3, name: 'A masthead' })).toBeDefined();
         expect(screen.queryByRole('heading', { level: 1 })).toBeNull();
+        expect(screen.queryByRole('heading', { level: 2 })).toBeNull();
     });
 
     it('draws the deepest heading a message may carry without running past the levels there are', () => {

--- a/frontend/src/Client.App/src/messageBody/MessageBlocks.tsx
+++ b/frontend/src/Client.App/src/messageBody/MessageBlocks.tsx
@@ -34,9 +34,11 @@ const alignments: Readonly<Record<MailBlockAlignment, string>> = {
     Justify: 'text-justify',
 };
 
-// A message never claims the level the application's own title holds, so every heading it wrote is drawn one level
-// deeper. The reading order stays a real heading order, which is what a screen reader navigates by.
-const headingElements = ['h2', 'h3', 'h4', 'h5', 'h6', 'h6'] as const;
+// A message never claims a level the screen around it already holds, so every heading it wrote is drawn two levels
+// deeper: the space's own title is the first, and the reading pane draws the message's subject as the second. What a
+// sender wrote therefore starts below the subject it belongs to, which is what makes the reading order a real heading
+// order rather than a message whose own headings read as siblings of its subject.
+const headingElements = ['h3', 'h4', 'h5', 'h6', 'h6', 'h6'] as const;
 
 export function MessageBlocks({ blocks }: { readonly blocks: readonly MailDocumentBlock[] }) {
     return (

--- a/frontend/src/Client.App/src/readingPane/Attachment.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/Attachment.test.tsx
@@ -5,7 +5,11 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import type { ClientRequest, ClientSession, MailAttachment } from '@mailfathom/client-backend';
-import type { AttachmentDelivery, AttachmentDeliveryOutcome } from '../deployment/attachmentDelivery';
+import {
+    AttachmentDeliveryContext,
+    type AttachmentDelivery,
+    type AttachmentDeliveryOutcome,
+} from '../deployment/attachmentDelivery';
 import { LocalizationProvider } from '../localization/Localization';
 import { Attachment } from './Attachment';
 
@@ -59,9 +63,11 @@ function deliveryHeldOpen(): {
 function drawing(attachment: MailAttachment, deliver: AttachmentDelivery): void {
     render(
         <LocalizationProvider>
-            <ul>
-                <Attachment session={session} storedEmailId={messageId} attachment={attachment} deliver={deliver} />
-            </ul>
+            <AttachmentDeliveryContext value={deliver}>
+                <ul>
+                    <Attachment session={session} storedEmailId={messageId} attachment={attachment} />
+                </ul>
+            </AttachmentDeliveryContext>
         </LocalizationProvider>,
     );
 }

--- a/frontend/src/Client.App/src/readingPane/Attachment.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/Attachment.test.tsx
@@ -1,0 +1,190 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { ClientRequest, ClientSession, MailAttachment } from '@mailfathom/client-backend';
+import type { AttachmentDelivery, AttachmentDeliveryOutcome } from '../deployment/attachmentDelivery';
+import { LocalizationProvider } from '../localization/Localization';
+import { Attachment } from './Attachment';
+
+const session: ClientSession = {
+    baseAddress: 'https://mail.example.invalid',
+    authorization: 'Basic dGVzdA==',
+};
+
+const messageId = '00000000-0000-4000-8000-000000000000';
+
+const invoice: MailAttachment = {
+    position: 1,
+    fileName: 'invoice.pdf',
+    wasFileNameNormalized: false,
+    mediaType: 'application/pdf',
+    sizeOctets: 2_048,
+};
+
+/** What a download was asked to do, so a test asserts on the request and the name rather than on a call being made. */
+interface Asked {
+    readonly request: ClientRequest;
+    readonly fileName: string;
+    readonly arrived: (octets: number) => void;
+    readonly abandoned: AbortSignal;
+}
+
+/** A delivery that records what it was asked and answers when the test says so, never on its own. */
+function deliveryHeldOpen(): {
+    deliver: AttachmentDelivery;
+    asked: Asked[];
+    answer: (outcome: AttachmentDeliveryOutcome) => void;
+} {
+    const asked: Asked[] = [];
+    let settle: ((outcome: AttachmentDeliveryOutcome) => void) | null = null;
+
+    return {
+        asked,
+        answer: (outcome) => {
+            settle?.(outcome);
+        },
+        deliver: (request, fileName, arrived, abandoned) => {
+            asked.push({ request, fileName, arrived, abandoned });
+
+            return new Promise<AttachmentDeliveryOutcome>((resolve) => {
+                settle = resolve;
+            });
+        },
+    };
+}
+
+function drawing(attachment: MailAttachment, deliver: AttachmentDelivery): void {
+    render(
+        <LocalizationProvider>
+            <ul>
+                <Attachment session={session} storedEmailId={messageId} attachment={attachment} deliver={deliver} />
+            </ul>
+        </LocalizationProvider>,
+    );
+}
+
+describe('Attachment', () => {
+    it('describes the file before anything is fetched, so a reader decides before it arrives', () => {
+        drawing(invoice, () => Promise.resolve('delivered'));
+
+        expect(screen.getByText('invoice.pdf')).toBeDefined();
+        expect(screen.getByText('application/pdf')).toBeDefined();
+        expect(screen.getByText(sizeReadAs(2_048))).toBeDefined();
+    });
+
+    it('names an unnamed part rather than offering a control with nothing to say', () => {
+        drawing({ ...invoice, fileName: null }, () => Promise.resolve('delivered'));
+
+        expect(screen.getByRole('button', { name: 'Download Unnamed file' })).toBeDefined();
+    });
+
+    it('says where the sender wrote a file name the deployment would not use', () => {
+        drawing({ ...invoice, wasFileNameNormalized: true }, () => Promise.resolve('delivered'));
+
+        expect(
+            screen.getByText(
+                'The sender wrote a file name this deployment would not use, so what is shown is the name it was given instead.',
+            ),
+        ).toBeDefined();
+    });
+
+    it('fetches nothing until the download is asked for', () => {
+        const held = deliveryHeldOpen();
+        drawing(invoice, held.deliver);
+
+        expect(held.asked).toEqual([]);
+    });
+
+    it('asks for the file at the position the message described it at, under the size it stated', () => {
+        const held = deliveryHeldOpen();
+        drawing(invoice, held.deliver);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Download invoice.pdf' }));
+
+        expect(held.asked[0]?.request).toEqual({
+            method: 'GET',
+            path: `https://mail.example.invalid/api/client/messages/${messageId}/attachments/1`,
+            headers: { Accept: 'application/octet-stream', Authorization: 'Basic dGVzdA==' },
+            longestAnswer: 2_048,
+        });
+    });
+
+    it('says how much has arrived while the file is still arriving', async () => {
+        const held = deliveryHeldOpen();
+        drawing(invoice, held.deliver);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Download invoice.pdf' }));
+
+        act(() => {
+            held.asked[0]?.arrived(1_024);
+        });
+
+        expect(await screen.findByText(`${sizeReadAs(1_024)} of ${sizeReadAs(2_048)}`)).toBeDefined();
+    });
+
+    it('starts one download however often the control is pressed while that one is arriving', () => {
+        const held = deliveryHeldOpen();
+        drawing(invoice, held.deliver);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Download invoice.pdf' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Download invoice.pdf' }));
+
+        expect(held.asked.length).toBe(1);
+    });
+
+    it('offers a way out of a download in flight, and abandons it when that is taken', () => {
+        const held = deliveryHeldOpen();
+        drawing(invoice, held.deliver);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Download invoice.pdf' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Stop downloading' }));
+
+        expect(held.asked[0]?.abandoned.aborted).toBe(true);
+    });
+
+    it('says the file was downloaded once it has been', async () => {
+        const held = deliveryHeldOpen();
+        drawing(invoice, held.deliver);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Download invoice.pdf' }));
+        held.answer('delivered');
+
+        expect(await screen.findByText('invoice.pdf was downloaded.')).toBeDefined();
+    });
+
+    it.each([
+        [
+            'unauthenticated',
+            'This deployment no longer accepts the credential, so the file was not downloaded. Sign in again.',
+        ],
+        ['unauthorized', 'This credential may not read mail on this deployment, so the file was not downloaded.'],
+        ['unavailable', 'The deployment did not answer, so the file was not downloaded. Try again.'],
+        [
+            'largerThanDescribed',
+            'The deployment sent more than this message said the file holds, so nothing was saved. Report this as a defect.',
+        ],
+        ['abandoned', 'The download was stopped, so nothing was saved.'],
+    ] as const)('says what became of a download that answered %s', async (outcome, said) => {
+        const held = deliveryHeldOpen();
+        drawing(invoice, held.deliver);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Download invoice.pdf' }));
+        held.answer(outcome);
+
+        expect(await screen.findByText(said)).toBeDefined();
+    });
+});
+
+// The size is `Intl`'s under the active language, so a test asks it the same question the screen asked rather than
+// spelling out an answer that would be about this machine.
+function sizeReadAs(octets: number): string {
+    return new Intl.NumberFormat('en', {
+        style: 'unit',
+        unit: 'kilobyte',
+        unitDisplay: 'short',
+        maximumFractionDigits: 1,
+    }).format(octets / 1_000);
+}

--- a/frontend/src/Client.App/src/readingPane/Attachment.tsx
+++ b/frontend/src/Client.App/src/readingPane/Attachment.tsx
@@ -1,0 +1,167 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { useEffect, useRef, useState } from 'react';
+import { mailAttachmentRequest, type ClientSession, type MailAttachment } from '@mailfathom/client-backend';
+import type { MessageKey } from '../localization/en';
+import { useLocalization } from '../localization/useLocalization';
+import type { AttachmentDelivery, AttachmentDeliveryOutcome } from '../deployment/attachmentDelivery';
+import { sizeOf } from './octets';
+import { savedAs } from './savedFileName';
+
+// One file a message carries. It is described before anything is fetched — what it is called, what it declares itself to
+// be, and how large it is — so that opening a message costs the same whether the sender attached a note or a video, and
+// so that a reader decides whether a file is worth having before it starts arriving.
+//
+// The row is its own component because it is what gains state: a download in flight, how much of it has arrived, a way
+// to stop it, and what became of it.
+
+const refusalMessages: Readonly<Record<Exclude<AttachmentDeliveryOutcome, 'delivered'>, MessageKey>> = {
+    abandoned: 'attachment.abandoned',
+    unauthenticated: 'attachment.refusedUnauthenticated',
+    unauthorized: 'attachment.refusedUnauthorized',
+    unavailable: 'attachment.refusedUnavailable',
+    largerThanDescribed: 'attachment.refusedLargerThanDescribed',
+};
+
+/** What the row is doing, which is one piece of state rather than a flag beside a count that has to agree with it. */
+type Downloading =
+    | { readonly stage: 'described' }
+    | { readonly stage: 'arriving'; readonly octets: number }
+    | { readonly stage: 'finished'; readonly outcome: AttachmentDeliveryOutcome };
+
+export function Attachment({
+    session,
+    storedEmailId,
+    attachment,
+    deliver,
+}: {
+    readonly session: ClientSession;
+    readonly storedEmailId: string;
+    readonly attachment: MailAttachment;
+    readonly deliver: AttachmentDelivery;
+}) {
+    const { locale, translate } = useLocalization();
+    const [downloading, setDownloading] = useState<Downloading>({ stage: 'described' });
+
+    // The one thing a render does not own: a download in flight outlives the render that started it, and the way out of
+    // it has to be reachable from the button that stops it and from the cleanup below alike.
+    const running = useRef<AbortController | null>(null);
+
+    // A download whose row has gone is a download nobody is waiting for, and letting it finish would write a file to
+    // somebody's machine after they left the message it belongs to.
+    useEffect(
+        () => () => {
+            running.current?.abort();
+        },
+        [],
+    );
+
+    const shown = attachment.fileName ?? translate('attachment.unnamed');
+    const arriving = downloading.stage === 'arriving';
+
+    function start(): void {
+        if (arriving) {
+            return;
+        }
+
+        const abandoning = new AbortController();
+        running.current = abandoning;
+        setDownloading({ stage: 'arriving', octets: 0 });
+
+        void deliver(
+            mailAttachmentRequest(session, storedEmailId, attachment.position, attachment.sizeOctets),
+            savedAs(attachment.fileName, attachment.position),
+            (octets) => {
+                setDownloading({ stage: 'arriving', octets });
+            },
+            abandoning.signal,
+        ).then((outcome) => {
+            running.current = null;
+            setDownloading({ stage: 'finished', outcome });
+        });
+    }
+
+    return (
+        <li className="flex flex-col gap-1 rounded-md border border-line bg-sunken px-3 py-2 text-sm">
+            <div className="flex flex-wrap items-center gap-2">
+                <span className="font-medium break-all text-text">{shown}</span>
+                <span className="text-muted">{attachment.mediaType}</span>
+                <span className="text-muted">{sizeOf(attachment.sizeOctets, locale)}</span>
+
+                {/* `aria-disabled` rather than `disabled` while a download runs, for the reason the body's own button
+                    gives: a disabled control is not focusable, so disabling the one somebody has just pressed drops
+                    their focus to the top of the document. The handler is what refuses the second press. */}
+                <button
+                    aria-disabled={arriving}
+                    className="ms-auto rounded-md bg-accent px-3 py-1 font-medium text-on-accent aria-disabled:opacity-60"
+                    type="button"
+                    onClick={start}
+                >
+                    {translate('attachment.download', { name: shown })}
+                </button>
+            </div>
+
+            {/* Said where a sender wrote a name this client would not use. It is the case worth drawing carefully
+                rather than one to hide: what is on the screen is not what the message wrote. */}
+            {attachment.wasFileNameNormalized ? (
+                <p className="text-muted">{translate('attachment.nameWasRewritten')}</p>
+            ) : null}
+
+            {downloading.stage === 'arriving' ? (
+                <Arriving
+                    octets={downloading.octets}
+                    of={attachment.sizeOctets}
+                    onStop={() => {
+                        running.current?.abort();
+                    }}
+                />
+            ) : null}
+
+            {downloading.stage === 'finished' ? (
+                <p
+                    className={downloading.outcome === 'delivered' ? 'text-muted' : 'text-warning'}
+                    role={downloading.outcome === 'delivered' ? undefined : 'alert'}
+                >
+                    {downloading.outcome === 'delivered'
+                        ? translate('attachment.saved', { name: shown })
+                        : translate(refusalMessages[downloading.outcome])}
+                </p>
+            ) : null}
+        </li>
+    );
+}
+
+// How much has arrived and the way to stop it, said in the place the file will appear. `progress` is the element the
+// platform already has for this: it announces itself, it needs no role, and a reader on a screen reader is told a
+// proportion rather than a number of octets they would have to divide themselves.
+function Arriving({
+    octets,
+    of,
+    onStop,
+}: {
+    readonly octets: number;
+    readonly of: number;
+    readonly onStop: () => void;
+}) {
+    const { locale, translate } = useLocalization();
+
+    return (
+        <div className="flex flex-wrap items-center gap-2">
+            <progress aria-label={translate('attachment.arriving')} className="h-1 flex-1" max={of} value={octets} />
+
+            <span className="text-muted">
+                {translate('attachment.arrivingOf', { arrived: sizeOf(octets, locale), whole: sizeOf(of, locale) })}
+            </span>
+
+            <button
+                className="rounded-md border border-line bg-panel px-2 py-0.5 text-text-soft"
+                type="button"
+                onClick={onStop}
+            >
+                {translate('attachment.stop')}
+            </button>
+        </div>
+    );
+}

--- a/frontend/src/Client.App/src/readingPane/Attachment.tsx
+++ b/frontend/src/Client.App/src/readingPane/Attachment.tsx
@@ -6,7 +6,7 @@ import { useEffect, useRef, useState } from 'react';
 import { mailAttachmentRequest, type ClientSession, type MailAttachment } from '@mailfathom/client-backend';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
-import type { AttachmentDelivery, AttachmentDeliveryOutcome } from '../deployment/attachmentDelivery';
+import { useAttachmentDelivery, type AttachmentDeliveryOutcome } from '../deployment/attachmentDelivery';
 import { sizeOf } from './octets';
 import { savedAs } from './savedFileName';
 
@@ -35,14 +35,13 @@ export function Attachment({
     session,
     storedEmailId,
     attachment,
-    deliver,
 }: {
     readonly session: ClientSession;
     readonly storedEmailId: string;
     readonly attachment: MailAttachment;
-    readonly deliver: AttachmentDelivery;
 }) {
     const { locale, translate } = useLocalization();
+    const deliver = useAttachmentDelivery();
     const [downloading, setDownloading] = useState<Downloading>({ stage: 'described' });
 
     // The one thing a render does not own: a download in flight outlives the render that started it, and the way out of

--- a/frontend/src/Client.App/src/readingPane/MessageHeaders.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/MessageHeaders.test.tsx
@@ -1,0 +1,118 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { MailMessageHeaders } from '@mailfathom/client-backend';
+import { LocalizationProvider } from '../localization/Localization';
+import { MessageHeaders } from './MessageHeaders';
+
+const headers: MailMessageHeaders = {
+    subject: 'Quarterly invoice',
+    sentAt: '2026-08-31T09:41:00+00:00',
+    receivedAt: '2026-08-31T09:41:10+00:00',
+    participants: [
+        { role: 'From', address: 'billing@example.invalid', displayName: 'Billing' },
+        { role: 'To', address: 'reader@example.invalid', displayName: null },
+        { role: 'Cc', address: 'archive@example.invalid', displayName: 'Archive' },
+    ],
+    messageId: 'abc@example.invalid',
+    inReplyTo: null,
+    references: [],
+};
+
+// Found by the words a person reads and then read as the element it is, because whether a disclosure is open is a
+// property of that element rather than something jsdom expresses by hiding what is inside it.
+function disclosure(): HTMLDetailsElement {
+    const opened = screen.getByText(/^Everybody else this message names/u).closest('details');
+
+    if (opened === null) {
+        throw new Error('The summary naming the other participants is not inside a disclosure.');
+    }
+
+    return opened;
+}
+
+function drawing(written: Partial<MailMessageHeaders> = {}): void {
+    render(
+        <LocalizationProvider>
+            <MessageHeaders headers={{ ...headers, ...written }} />
+        </LocalizationProvider>,
+    );
+}
+
+describe('MessageHeaders', () => {
+    it('draws the subject as the heading of the message', () => {
+        drawing();
+
+        expect(screen.getByRole('heading', { name: 'Quarterly invoice', level: 2 })).toBeDefined();
+    });
+
+    it('says a message carries no subject rather than heading it with nothing', () => {
+        drawing({ subject: null });
+
+        expect(screen.getByRole('heading', { name: 'No subject', level: 2 })).toBeDefined();
+    });
+
+    it('draws the author with the address beside the name the sender wrote', () => {
+        drawing();
+
+        expect(screen.getByText('Billing <billing@example.invalid>')).toBeDefined();
+    });
+
+    it('draws an author who wrote no name as the address alone', () => {
+        drawing({ participants: [{ role: 'From', address: 'billing@example.invalid', displayName: null }] });
+
+        expect(screen.getByText('billing@example.invalid')).toBeDefined();
+    });
+
+    it('says a message names nobody as its author rather than drawing an empty line', () => {
+        drawing({ participants: [] });
+
+        expect(screen.getByText('This message names nobody as its author.')).toBeDefined();
+    });
+
+    it('words the date the platform way under the active language rather than out of a catalogue', () => {
+        drawing();
+
+        const worded = new Intl.DateTimeFormat('en', { dateStyle: 'long', timeStyle: 'short' }).format(
+            Date.parse('2026-08-31T09:41:00+00:00'),
+        );
+
+        expect(screen.getByText(`Sent ${worded}`)).toBeDefined();
+    });
+
+    it('says the sender wrote no readable date rather than drawing a broken one', () => {
+        drawing({ sentAt: 'the day before yesterday' });
+
+        expect(screen.getByText('The sender wrote no date this client can read.')).toBeDefined();
+    });
+
+    it('keeps everybody else behind a disclosure, so a message to two hundred people is not a screen of addresses', () => {
+        drawing();
+
+        expect(disclosure().open).toBe(false);
+    });
+
+    it('names everybody else under the header each address appeared in, once the disclosure is opened', () => {
+        drawing();
+
+        fireEvent.click(screen.getByText('Everybody else this message names (2)'));
+
+        expect(disclosure().open).toBe(true);
+        expect(screen.getByText('To')).toBeDefined();
+        expect(screen.getByText('reader@example.invalid')).toBeDefined();
+        expect(screen.getByText('Archive <archive@example.invalid>')).toBeDefined();
+    });
+
+    it('draws a display name written to look like markup as the characters the sender wrote', () => {
+        drawing({
+            participants: [
+                { role: 'From', address: 'billing@example.invalid', displayName: '<script>alert(1)</script>' },
+            ],
+        });
+
+        expect(screen.getByText('<script>alert(1)</script> <billing@example.invalid>')).toBeDefined();
+    });
+});

--- a/frontend/src/Client.App/src/readingPane/MessageHeaders.tsx
+++ b/frontend/src/Client.App/src/readingPane/MessageHeaders.tsx
@@ -15,11 +15,14 @@ import { useLocalization } from '../localization/useLocalization';
 // Every value here is text a sender chose. It is drawn as text and never as markup, so a display name written to look
 // like an address, a heading, or a control arrives as the characters it is.
 
-// Every role the service publishes, in the order a reader reads them rather than the order the wire lists them.
-const roleOrder: readonly MailParticipantRole[] = ['From', 'Sender', 'ReplyTo', 'To', 'Cc', 'Bcc'];
+// Every role the disclosure shows, in the order a reader reads them rather than the order the wire lists them.
+// `From` is not one of them: the author stands on its own line above, so the disclosure is given everybody else
+// and a `From` row here could never be drawn.
+type DisclosedRole = Exclude<MailParticipantRole, 'From'>;
 
-const roleLabels: Readonly<Record<MailParticipantRole, MessageKey>> = {
-    From: 'participant.from',
+const roleOrder: readonly DisclosedRole[] = ['Sender', 'ReplyTo', 'To', 'Cc', 'Bcc'];
+
+const roleLabels: Readonly<Record<DisclosedRole, MessageKey>> = {
     Sender: 'participant.sender',
     ReplyTo: 'participant.replyTo',
     To: 'participant.to',
@@ -70,7 +73,10 @@ function OtherParticipants({ participants }: { readonly participants: readonly M
 
             <dl className="mt-2 flex flex-col gap-1">
                 {roleOrder
-                    .map((role) => ({ role, addressed: participants.filter((one) => one.role === role) }))
+                    .map((role) => ({
+                        role,
+                        addressed: participants.filter((one) => one.role === role),
+                    }))
                     .filter((group) => group.addressed.length > 0)
                     .map((group) => (
                         <div key={group.role} className="flex flex-wrap gap-2">

--- a/frontend/src/Client.App/src/readingPane/MessageHeaders.tsx
+++ b/frontend/src/Client.App/src/readingPane/MessageHeaders.tsx
@@ -1,0 +1,106 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { MailMessageHeaders, MailParticipant, MailParticipantRole } from '@mailfathom/client-backend';
+import type { MessageKey } from '../localization/en';
+import type { Locale } from '../localization/locale';
+import { useLocalization } from '../localization/useLocalization';
+
+// What a message displays above its body: what it is called, who wrote it, when, and everybody else it names. The
+// author stands on its own line because it is what a reader checks first, and the rest is a disclosure the platform
+// already has an element for — a message addressed to two hundred people would otherwise be a screen of addresses in
+// front of the words somebody opened it to read.
+//
+// Every value here is text a sender chose. It is drawn as text and never as markup, so a display name written to look
+// like an address, a heading, or a control arrives as the characters it is.
+
+// Every role the service publishes, in the order a reader reads them rather than the order the wire lists them.
+const roleOrder: readonly MailParticipantRole[] = ['From', 'Sender', 'ReplyTo', 'To', 'Cc', 'Bcc'];
+
+const roleLabels: Readonly<Record<MailParticipantRole, MessageKey>> = {
+    From: 'participant.from',
+    Sender: 'participant.sender',
+    ReplyTo: 'participant.replyTo',
+    To: 'participant.to',
+    Cc: 'participant.cc',
+    Bcc: 'participant.bcc',
+};
+
+export function MessageHeaders({ headers }: { readonly headers: MailMessageHeaders }) {
+    const { locale, translate } = useLocalization();
+
+    const authors = headers.participants.filter((participant) => participant.role === 'From');
+    const others = headers.participants.filter((participant) => participant.role !== 'From');
+    const sentAt = instantOf(headers.sentAt, locale);
+
+    return (
+        <header className="flex flex-col gap-2 border-b border-line-soft pb-4">
+            <h2 className="text-xl font-semibold tracking-tight">
+                {headers.subject ?? translate('message.noSubject')}
+            </h2>
+
+            <p className="text-sm text-text-soft">
+                {authors.length === 0
+                    ? translate('message.noAuthor')
+                    : authors.map((author) => named(author)).join(', ')}
+            </p>
+
+            <p className="text-sm text-muted">
+                {sentAt === null ? translate('message.sentAtUnknown') : translate('message.sentAt', { when: sentAt })}
+            </p>
+
+            {others.length === 0 ? null : <OtherParticipants participants={others} />}
+        </header>
+    );
+}
+
+// A disclosure rather than a list that is always open, and the browser's own rather than one built out of a button and
+// a piece of state: it is operable from the keyboard, it announces whether it is open, and it costs no code to be so.
+function OtherParticipants({ participants }: { readonly participants: readonly MailParticipant[] }) {
+    const { locale, translate } = useLocalization();
+
+    return (
+        <details className="text-sm">
+            <summary className="cursor-pointer text-muted">
+                {translate('message.otherParticipants', {
+                    count: new Intl.NumberFormat(locale).format(participants.length),
+                })}
+            </summary>
+
+            <dl className="mt-2 flex flex-col gap-1">
+                {roleOrder
+                    .map((role) => ({ role, addressed: participants.filter((one) => one.role === role) }))
+                    .filter((group) => group.addressed.length > 0)
+                    .map((group) => (
+                        <div key={group.role} className="flex flex-wrap gap-2">
+                            <dt className="text-muted">{translate(roleLabels[group.role])}</dt>
+                            <dd className="text-text-soft">{group.addressed.map((one) => named(one)).join(', ')}</dd>
+                        </div>
+                    ))}
+            </dl>
+        </details>
+    );
+}
+
+// One address as a person reads it: the name the sender wrote beside the address, and the address itself, because a
+// display name is chosen by whoever sent the message and reading only that is how the wrong sender goes unnoticed.
+function named(participant: MailParticipant): string {
+    return participant.displayName === null
+        ? participant.address
+        : `${participant.displayName} <${participant.address}>`;
+}
+
+// The instant as the platform words it under the active language, rather than as anything a catalogue holds. A date the
+// sender wrote that this client cannot read is an absence rather than a value to repair.
+function instantOf(instant: string | null, locale: Locale): string | null {
+    if (instant === null) {
+        return null;
+    }
+
+    const at = Date.parse(instant);
+
+    return Number.isNaN(at)
+        ? null
+        : new Intl.DateTimeFormat(locale, { dateStyle: 'long', timeStyle: 'short' }).format(at);
+}

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
@@ -5,7 +5,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import type { ClientRequest, ClientResponse, ClientSession, MailFathomTransport } from '@mailfathom/client-backend';
-import type { AttachmentDelivery } from '../deployment/attachmentDelivery';
+import { AttachmentDeliveryContext, type AttachmentDelivery } from '../deployment/attachmentDelivery';
 import { LocalizationProvider } from '../localization/Localization';
 import { IntentField } from '../shell/IntentField';
 import { LinkOpenerContext } from '../shellOperations/linkOpener';
@@ -87,13 +87,14 @@ function drawing(
         <LocalizationProvider>
             <WorkspaceProvider>
                 <LinkOpenerContext value={() => Promise.resolve()}>
-                    <ReadingPane
-                        session={session}
-                        transport={transport}
-                        storedEmailId={storedEmailId}
-                        online={online}
-                        deliver={deliver}
-                    />
+                    <AttachmentDeliveryContext value={deliver}>
+                        <ReadingPane
+                            session={session}
+                            transport={transport}
+                            storedEmailId={storedEmailId}
+                            online={online}
+                        />
+                    </AttachmentDeliveryContext>
                 </LinkOpenerContext>
             </WorkspaceProvider>
         </LocalizationProvider>,
@@ -123,6 +124,20 @@ describe('ReadingPane', () => {
                 'This machine is offline, so this message cannot be opened. It opens on its own once the network comes back.',
             ),
         ).toBeDefined();
+    });
+
+    // The sentence above promises the message opens on its own, so the network coming back is what has to make
+    // that true — and asking for nothing while there is none is what leaves a read to come back to.
+    it('asks for nothing without a network, and reads on its own once one is back', async () => {
+        asked.length = 0;
+        const transport = deploymentDescribing();
+        const { rerender } = render(paneReading(transport, false));
+
+        expect(asked).toEqual([]);
+
+        rerender(paneReading(transport, true));
+
+        expect(await screen.findByRole('heading', { name: 'Quarterly invoice', level: 2 })).toBeDefined();
     });
 
     it('draws the headers and the body of the message it read', async () => {
@@ -234,6 +249,25 @@ const photograph = {
     sizeOctets: 100_000,
 };
 
+// The same pane across a network gap, which is a thing only a rerender with another `online` produces.
+function paneReading(transport: MailFathomTransport, online: boolean) {
+    return (
+        <LocalizationProvider>
+            <WorkspaceProvider>
+                <LinkOpenerContext value={() => Promise.resolve()}>
+                    <AttachmentDeliveryContext value={deliversNothing}>
+                        <ReadingPane
+                            session={session}
+                            transport={transport}
+                            storedEmailId={messageId}
+                            online={online}
+                        />
+                    </AttachmentDeliveryContext>
+                </LinkOpenerContext>
+            </WorkspaceProvider>
+        </LocalizationProvider>
+    );
+}
 // A second message opening is a view change, which is a thing only a rerender with another identifier produces — the
 // first render is a landing rather than a navigation and deliberately moves focus nowhere.
 function paneFor(storedEmailId: string) {
@@ -241,13 +275,14 @@ function paneFor(storedEmailId: string) {
         <LocalizationProvider>
             <WorkspaceProvider>
                 <LinkOpenerContext value={() => Promise.resolve()}>
-                    <ReadingPane
-                        session={session}
-                        transport={deploymentDescribing()}
-                        storedEmailId={storedEmailId}
-                        online
-                        deliver={deliversNothing}
-                    />
+                    <AttachmentDeliveryContext value={deliversNothing}>
+                        <ReadingPane
+                            session={session}
+                            transport={deploymentDescribing()}
+                            storedEmailId={storedEmailId}
+                            online
+                        />
+                    </AttachmentDeliveryContext>
                 </LinkOpenerContext>
             </WorkspaceProvider>
         </LocalizationProvider>
@@ -262,14 +297,15 @@ describe('ReadingPane selection', () => {
             <LocalizationProvider>
                 <WorkspaceProvider>
                     <LinkOpenerContext value={() => Promise.resolve()}>
-                        <IntentField accounts={[]} />
-                        <ReadingPane
-                            session={session}
-                            transport={deploymentDescribing()}
-                            storedEmailId={messageId}
-                            online
-                            deliver={deliversNothing}
-                        />
+                        <AttachmentDeliveryContext value={deliversNothing}>
+                            <IntentField accounts={[]} />
+                            <ReadingPane
+                                session={session}
+                                transport={deploymentDescribing()}
+                                storedEmailId={messageId}
+                                online
+                            />
+                        </AttachmentDeliveryContext>
                     </LinkOpenerContext>
                 </WorkspaceProvider>
             </LocalizationProvider>,

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
@@ -113,7 +113,7 @@ describe('ReadingPane', () => {
     it('says it is reading while the deployment has answered nothing', () => {
         drawing(answersNothing);
 
-        expect(screen.getByText('Reading this message…')).toBeDefined();
+        expect(screen.getByRole('status')).toHaveProperty('textContent', 'Reading this message…');
     });
 
     it('says the machine is offline rather than reporting the deployment as unreachable', () => {

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
@@ -1,0 +1,321 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { ClientRequest, ClientResponse, ClientSession, MailFathomTransport } from '@mailfathom/client-backend';
+import type { AttachmentDelivery } from '../deployment/attachmentDelivery';
+import { LocalizationProvider } from '../localization/Localization';
+import { IntentField } from '../shell/IntentField';
+import { LinkOpenerContext } from '../shellOperations/linkOpener';
+import { WorkspaceProvider } from '../workspace/Workspace';
+import { ReadingPane } from './ReadingPane';
+
+// The network boundary is the transport and it is the whole of what these tests fake, so the routes the pane asks for,
+// the parsing that reads the answers, and the failure mapping are all under test rather than replaced.
+
+const session: ClientSession = {
+    baseAddress: 'https://mail.example.invalid',
+    authorization: 'Basic dGVzdA==',
+};
+
+const messageId = '00000000-0000-4000-8000-000000000000';
+
+const deliversNothing: AttachmentDelivery = () => Promise.resolve('delivered');
+
+function description(overrides: Readonly<Record<string, unknown>> = {}): string {
+    return JSON.stringify({
+        storedEmailId: messageId,
+        account: 'work',
+        folder: 'INBOX',
+        threadId: null,
+        sizeOctets: 40_960,
+        headers: {
+            subject: 'Quarterly invoice',
+            sentAt: '2026-08-31T09:41:00+00:00',
+            receivedAt: '2026-08-31T09:41:10+00:00',
+            participants: [{ role: 'From', address: 'billing@example.invalid', displayName: 'Billing' }],
+            messageId: 'abc@example.invalid',
+            inReplyTo: null,
+            references: [],
+        },
+        body: { availability: 'Readable', plainText: true, html: true },
+        sender: { authorAuthentication: 'Authenticated', deploymentTrust: 'Unknown', authenticatedDomain: null },
+        attachments: [],
+        carried: null,
+        unread: true,
+        flagged: false,
+        answered: false,
+        ...overrides,
+    });
+}
+
+const bodyAsWords = JSON.stringify({
+    storedEmailId: messageId,
+    availability: 'Readable',
+    plainText: { text: 'The invoice is attached.', originalCharacterCount: 24, truncation: 'None' },
+    document: null,
+    remoteImagesRequested: false,
+});
+
+const asked: ClientRequest[] = [];
+
+/** A deployment answering both reads the pane makes, with the description a test named and a body it always sends. */
+function deploymentDescribing(described = description(), status = 200): MailFathomTransport {
+    return (request) => {
+        asked.push(request);
+
+        const answer: ClientResponse = request.path.includes('/body')
+            ? { status: 200, body: bodyAsWords, headers: {} }
+            : { status, body: described, headers: {} };
+
+        return Promise.resolve(answer);
+    };
+}
+
+/** A deployment that has taken the request and not answered it, which is what a surface that waits is proven against. */
+const answersNothing: MailFathomTransport = () => new Promise<ClientResponse>(() => undefined);
+
+function drawing(
+    transport: MailFathomTransport,
+    storedEmailId: string | null = messageId,
+    online = true,
+    deliver: AttachmentDelivery = deliversNothing,
+): void {
+    render(
+        <LocalizationProvider>
+            <WorkspaceProvider>
+                <LinkOpenerContext value={() => Promise.resolve()}>
+                    <ReadingPane
+                        session={session}
+                        transport={transport}
+                        storedEmailId={storedEmailId}
+                        online={online}
+                        deliver={deliver}
+                    />
+                </LinkOpenerContext>
+            </WorkspaceProvider>
+        </LocalizationProvider>,
+    );
+}
+
+describe('ReadingPane', () => {
+    it('says nothing is open rather than drawing an empty message', () => {
+        asked.length = 0;
+        drawing(deploymentDescribing(), null);
+
+        expect(screen.getByText('Open a message to read it here.')).toBeDefined();
+        expect(asked).toEqual([]);
+    });
+
+    it('says it is reading while the deployment has answered nothing', () => {
+        drawing(answersNothing);
+
+        expect(screen.getByText('Reading this message…')).toBeDefined();
+    });
+
+    it('says the machine is offline rather than reporting the deployment as unreachable', () => {
+        drawing(answersNothing, messageId, false);
+
+        expect(
+            screen.getByText(
+                'This machine is offline, so this message cannot be opened. It opens on its own once the network comes back.',
+            ),
+        ).toBeDefined();
+    });
+
+    it('draws the headers and the body of the message it read', async () => {
+        drawing(deploymentDescribing());
+
+        expect(await screen.findByRole('heading', { name: 'Quarterly invoice', level: 2 })).toBeDefined();
+        expect(await screen.findByText('The invoice is attached.')).toBeDefined();
+    });
+
+    // Nothing here writes to a mailbox, and the strongest statement of that a test can make is which routes were
+    // reached: the request type admits no verb but `GET`, so an assertion on the verb would be an assertion about the
+    // compiler rather than about the pane.
+    it('asks for the description and for the body, and reaches no other route on the deployment', async () => {
+        asked.length = 0;
+        drawing(deploymentDescribing());
+        await screen.findByRole('heading', { name: 'Quarterly invoice', level: 2 });
+
+        expect([...new Set(asked.map((request) => request.path))]).toEqual([
+            `https://mail.example.invalid/api/client/messages/${messageId}`,
+            `https://mail.example.invalid/api/client/messages/${messageId}/body`,
+        ]);
+    });
+
+    it('says what failed and offers the way out where reading again is one', async () => {
+        drawing(deploymentDescribing(description(), 503));
+
+        expect(await screen.findByText('This message could not be opened: unavailable.')).toBeDefined();
+        expect(screen.getByRole('button', { name: 'Try again' })).toBeDefined();
+    });
+
+    it('offers no way out of a refusal that would repeat identically on a second attempt', async () => {
+        drawing(deploymentDescribing(description(), 403));
+
+        expect(await screen.findByText('This message could not be opened: unauthorized.')).toBeDefined();
+        expect(screen.queryByRole('button', { name: 'Try again' })).toBeNull();
+    });
+
+    it('names no file where the message carries none', async () => {
+        drawing(deploymentDescribing());
+        await screen.findByRole('heading', { name: 'Quarterly invoice', level: 2 });
+
+        expect(screen.queryByText('Files this message carries')).toBeNull();
+    });
+
+    it('describes every file the message carries before any of them is fetched', async () => {
+        drawing(deploymentDescribing(description({ attachments: [invoice, photograph] })));
+
+        expect(await screen.findByRole('button', { name: 'Download invoice.pdf' })).toBeDefined();
+        expect(screen.getByRole('button', { name: 'Download photo.jpg' })).toBeDefined();
+    });
+
+    it('says what a message carries besides its files, where any of it is true', async () => {
+        drawing(
+            deploymentDescribing(
+                description({
+                    carried: {
+                        attachmentCount: 0,
+                        totalSizeOctets: 0,
+                        inlineResourceCount: 0,
+                        encrypted: false,
+                        unverifiedSignature: true,
+                        unexpandedTnefPart: true,
+                    },
+                }),
+            ),
+        );
+
+        expect(
+            await screen.findByText('This message carries a signature, and nothing here has verified it.'),
+        ).toBeDefined();
+        expect(
+            screen.getByText(
+                'This message carries a winmail.dat part, which was recorded without being opened, so whatever it holds is not listed above.',
+            ),
+        ).toBeDefined();
+    });
+
+    it('leaves focus where it was when the pane opens, because landing on a message is not a navigation', async () => {
+        render(paneFor(messageId));
+
+        expect(await screen.findByRole('article', { name: 'Quarterly invoice' })).not.toBe(document.activeElement);
+    });
+
+    it('places focus on the message opened next, rather than leaving it on whatever opened it', async () => {
+        const { rerender } = render(paneFor(messageId));
+        await screen.findByRole('article', { name: 'Quarterly invoice' });
+
+        rerender(paneFor('11111111-1111-4111-8111-111111111111'));
+
+        await waitFor(() => {
+            expect(screen.getByRole('article', { name: 'Quarterly invoice' })).toBe(document.activeElement);
+        });
+    });
+});
+
+const invoice = {
+    position: 0,
+    fileName: 'invoice.pdf',
+    wasFileNameNormalized: false,
+    mediaType: 'application/pdf',
+    sizeOctets: 2_048,
+};
+
+const photograph = {
+    position: 1,
+    fileName: 'photo.jpg',
+    wasFileNameNormalized: false,
+    mediaType: 'image/jpeg',
+    sizeOctets: 100_000,
+};
+
+// A second message opening is a view change, which is a thing only a rerender with another identifier produces — the
+// first render is a landing rather than a navigation and deliberately moves focus nowhere.
+function paneFor(storedEmailId: string) {
+    return (
+        <LocalizationProvider>
+            <WorkspaceProvider>
+                <LinkOpenerContext value={() => Promise.resolve()}>
+                    <ReadingPane
+                        session={session}
+                        transport={deploymentDescribing()}
+                        storedEmailId={storedEmailId}
+                        online
+                        deliver={deliversNothing}
+                    />
+                </LinkOpenerContext>
+            </WorkspaceProvider>
+        </LocalizationProvider>
+    );
+}
+
+// A selection is a gesture over a real range, and what it is worth is what the intent field then says about it — so the
+// field is mounted beside the pane, in the one workspace both read, and the assertion is the sentence a person sees.
+describe('ReadingPane selection', () => {
+    function readingBeside(): void {
+        render(
+            <LocalizationProvider>
+                <WorkspaceProvider>
+                    <LinkOpenerContext value={() => Promise.resolve()}>
+                        <IntentField accounts={[]} />
+                        <ReadingPane
+                            session={session}
+                            transport={deploymentDescribing()}
+                            storedEmailId={messageId}
+                            online
+                            deliver={deliversNothing}
+                        />
+                    </LinkOpenerContext>
+                </WorkspaceProvider>
+            </LocalizationProvider>,
+        );
+    }
+
+    it('scopes the next question to nothing while nobody has selected anything', async () => {
+        readingBeside();
+        await screen.findByText('The invoice is attached.');
+
+        expect(
+            screen.queryByText('Asking about the part of this message you selected: “The invoice is attached.”'),
+        ).toBeNull();
+    });
+
+    it('carries the words somebody selected into the scope the next question is asked under', async () => {
+        readingBeside();
+        const words = await screen.findByText('The invoice is attached.');
+
+        select(words);
+        fireEvent.mouseUp(words);
+
+        expect(
+            await screen.findByText('Asking about the part of this message you selected: “The invoice is attached.”'),
+        ).toBeDefined();
+    });
+
+    it('gives back the whole message as the scope when that is asked for', async () => {
+        readingBeside();
+        const words = await screen.findByText('The invoice is attached.');
+
+        select(words);
+        fireEvent.mouseUp(words);
+        fireEvent.click(await screen.findByRole('button', { name: 'Ask about the whole message instead' }));
+
+        expect(
+            screen.queryByText('Asking about the part of this message you selected: “The invoice is attached.”'),
+        ).toBeNull();
+    });
+});
+
+function select(within: Element): void {
+    const range = document.createRange();
+    range.selectNodeContents(within);
+
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+}

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
@@ -1,0 +1,291 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { useEffect, useRef, useState } from 'react';
+import {
+    readMailMessage,
+    type ClientFailureReason,
+    type ClientResult,
+    type ClientSession,
+    type MailCarried,
+    type MailFathomTransport,
+    type MailMessage,
+} from '@mailfathom/client-backend';
+import { SecondaryButton } from '../controls/SecondaryButton';
+import type { AttachmentDelivery } from '../deployment/attachmentDelivery';
+import type { MessageKey } from '../localization/en';
+import { useLocalization } from '../localization/useLocalization';
+import { useWorkspace } from '../workspace/useWorkspace';
+import { Message } from '../messageBody/Message';
+import { Attachment } from './Attachment';
+import { MessageHeaders } from './MessageHeaders';
+import { sizeOf } from './octets';
+import { SenderVerdict } from './SenderVerdict';
+
+// Reading one message, which is the act everything else in this client exists to support and where the most is on screen
+// at once. What this component owns is the composition and the honesty of it: the headers, what the deployment
+// established about who actually sent the message, the body beneath them, and the files it carries — each drawn from
+// what the service answered rather than from anything worked out here.
+//
+// Two reads stand behind it and that is deliberate rather than incidental. The description and the body are separately
+// expensive, so the header block is drawn the moment the first answers and the body says it is still reading underneath
+// it; that is this screen's partial state rather than a gap in it.
+//
+// Nothing here writes to a mailbox. Both reads are `GET`s against the local copy, so opening a message sets no remote
+// flag and tells no mail server that anybody read anything.
+
+const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
+    unauthenticated: 'failure.unauthenticated',
+    unauthorized: 'failure.unauthorized',
+    unavailable: 'failure.unavailable',
+    unreadable: 'failure.unreadable',
+};
+
+// The most of a selected passage the workspace carries. A question is asked about a fragment somebody pointed at, so a
+// select-all is a gesture rather than a scope, and a whole message in the workspace would travel into every later screen
+// that reads it.
+const longestFragment = 2000;
+
+/** What is being read: which message, and which attempt at it. A change to either reads again. */
+interface Read {
+    readonly storedEmailId: string;
+    readonly attempt: number;
+}
+
+interface Answered {
+    readonly read: Read;
+    readonly result: ClientResult<MailMessage>;
+}
+
+export function ReadingPane({
+    session,
+    transport,
+    storedEmailId,
+    online,
+    deliver,
+}: {
+    readonly session: ClientSession;
+    readonly transport: MailFathomTransport;
+    readonly storedEmailId: string | null;
+    readonly online: boolean;
+    readonly deliver: AttachmentDelivery;
+}) {
+    const { translate } = useLocalization();
+
+    return (
+        <section className="flex flex-col gap-4">
+            {storedEmailId === null ? (
+                <p className="text-sm text-muted">{translate('message.nothingOpen')}</p>
+            ) : (
+                <OpenMessage
+                    session={session}
+                    transport={transport}
+                    storedEmailId={storedEmailId}
+                    online={online}
+                    deliver={deliver}
+                />
+            )}
+        </section>
+    );
+}
+
+// The message that is actually open, split out so that opening the first one mounts it rather than changing what an
+// already-mounted component is reading: everything below holds state about one message, and none of it is the empty
+// pane's.
+function OpenMessage({
+    session,
+    transport,
+    storedEmailId,
+    online,
+    deliver,
+}: {
+    readonly session: ClientSession;
+    readonly transport: MailFathomTransport;
+    readonly storedEmailId: string;
+    readonly online: boolean;
+    readonly deliver: AttachmentDelivery;
+}) {
+    const { translate } = useLocalization();
+    const { revise } = useWorkspace();
+    const [read, setRead] = useState<Read>({ storedEmailId, attempt: 0 });
+    const [answer, setAnswer] = useState<Answered | null>(null);
+
+    const opened = useRef<HTMLElement>(null);
+    const body = useRef<HTMLDivElement>(null);
+    const focusedOn = useRef(storedEmailId);
+
+    // A message changing under this component invalidates what is being read, which React answers by adjusting state
+    // during the render rather than in an effect that would draw the previous message's answer once first.
+    if (read.storedEmailId !== storedEmailId) {
+        setRead({ storedEmailId, attempt: 0 });
+    }
+
+    useEffect(() => {
+        let listening = true;
+
+        void readMailMessage(session, transport, read.storedEmailId).then((answered) => {
+            if (listening) {
+                setAnswer({ read, result: answered });
+            }
+        });
+
+        return () => {
+            listening = false;
+        };
+    }, [session, transport, read]);
+
+    // The fragment somebody selected belonged to the message they were reading, so it goes when the message does:
+    // carrying it into the next one would scope a question to words that are no longer on the screen. It happens as the
+    // message changes rather than once the next one has been read, because the words are already gone by then.
+    useEffect(() => {
+        revise({ fragment: null });
+    }, [storedEmailId, revise]);
+
+    // What a person selected becomes the scope the intent field asks its next question under. It is read from the
+    // gesture that produced it rather than from an effect watching the document, and it is bounded, trimmed, and
+    // confined to this message's own words: a selection that started outside the body is not part of the message.
+    function capture(): void {
+        const selected = window.getSelection();
+        const region = body.current;
+
+        if (selected === null || region === null) {
+            return;
+        }
+
+        if (!region.contains(selected.anchorNode) || !region.contains(selected.focusNode)) {
+            return;
+        }
+
+        const fragment = selected.toString().trim().slice(0, longestFragment);
+
+        revise({ fragment: fragment === '' ? null : fragment });
+    }
+
+    const held = answer?.read === read ? answer : null;
+    const drawable = held?.result.outcome === 'read';
+
+    // A message opening is a view change, so focus goes to the start of it rather than staying on whatever opened it —
+    // which for a list is a row that is still on the screen and for a keyboard reader is where reading silently stops.
+    // It waits for the message to be drawable, because the element focus is placed on does not exist while the read is
+    // still in flight and a focus call before then would silently move nothing.
+    //
+    // Not for the message this pane opened with, for the reason `shell/Space.tsx` gives: landing on a message is not a
+    // navigation, and a ref holding the message last focused survives StrictMode's second invocation where a flag would
+    // not.
+    useEffect(() => {
+        if (drawable && focusedOn.current !== storedEmailId) {
+            focusedOn.current = storedEmailId;
+            opened.current?.focus();
+        }
+    }, [drawable, storedEmailId]);
+
+    // Offline is its own sentence rather than a failure worded politely, and it is said only where there is nothing to
+    // draw instead: a message already on the screen is the truest thing anybody has, and the frame above already says
+    // the machine has no network.
+    if (!online && held?.result.outcome !== 'read') {
+        return (
+            <p className="text-sm text-muted" role="status">
+                {translate('message.offline')}
+            </p>
+        );
+    }
+
+    if (held === null) {
+        return <p className="text-sm text-muted">{translate('message.reading')}</p>;
+    }
+
+    if (held.result.outcome === 'failed') {
+        return (
+            <div className="flex flex-col items-start gap-2">
+                <p className="text-sm text-warning" role="alert">
+                    {translate('message.failed', { reason: translate(failureLabels[held.result.failure.reason]) })}
+                </p>
+
+                {/* Reading again is the way out of exactly one of the four failures, for the reason
+                    `shell/ConnectionSummary.tsx` gives: the other three repeat identically on a second attempt. */}
+                {held.result.failure.reason === 'unavailable' ? (
+                    <SecondaryButton
+                        label={translate('connection.retry')}
+                        onActivate={() => {
+                            setRead({ storedEmailId, attempt: read.attempt + 1 });
+                        }}
+                    />
+                ) : null}
+            </div>
+        );
+    }
+
+    const message = held.result.value;
+
+    // Named by its own subject, which is what a reader arriving in the region needs to hear and what tells one message's
+    // region from the body's inside it. The heading below says the same words on the screen; this is what the region
+    // itself is called.
+    return (
+        <article
+            ref={opened}
+            tabIndex={-1}
+            aria-label={message.headers.subject ?? translate('message.noSubject')}
+            className="flex flex-col gap-4"
+        >
+            <MessageHeaders headers={message.headers} />
+            <SenderVerdict verdict={message.sender} />
+
+            {/* The gestures a selection ends on rather than a document-wide subscription: a selection made with the
+                pointer settles on the release and one made with the keyboard on the key coming back up, and both of
+                them are events this region already receives. */}
+            <div ref={body} onKeyUp={capture} onMouseUp={capture}>
+                <Message session={session} transport={transport} storedEmailId={storedEmailId} />
+            </div>
+
+            {message.attachments.length === 0 ? null : (
+                <section className="flex flex-col gap-2">
+                    <h3 className="text-sm font-medium text-text-soft">{translate('attachments.heading')}</h3>
+
+                    <ul className="flex flex-col gap-2">
+                        {message.attachments.map((attachment) => (
+                            <Attachment
+                                key={attachment.position}
+                                session={session}
+                                storedEmailId={storedEmailId}
+                                attachment={attachment}
+                                deliver={deliver}
+                            />
+                        ))}
+                    </ul>
+                </section>
+            )}
+
+            {message.carried === null ? null : <Carried carried={message.carried} />}
+        </article>
+    );
+}
+
+// What a message carries besides its files, where any of it is true. Each of the three is a fact about the message
+// rather than about a part, which is why they are said here and not on a row: a signature and an unopened `winmail.dat`
+// are not files a reader can open, and drawing them as ones would offer a download that answers with nothing.
+function Carried({ carried }: { readonly carried: MailCarried }) {
+    const { locale, translate } = useLocalization();
+
+    const notes: readonly MessageKey[] = [
+        ...(carried.encrypted ? (['carried.encrypted'] as const) : []),
+        ...(carried.unverifiedSignature ? (['carried.unverifiedSignature'] as const) : []),
+        ...(carried.unexpandedTnefPart ? (['carried.unexpandedTnefPart'] as const) : []),
+    ];
+
+    if (notes.length === 0 && carried.attachmentCount === 0) {
+        return null;
+    }
+
+    return (
+        <aside className="flex flex-col gap-1 text-sm text-muted">
+            {carried.attachmentCount === 0 ? null : (
+                <p>{translate('carried.total', { size: sizeOf(carried.totalSizeOctets, locale) })}</p>
+            )}
+
+            {notes.map((note) => (
+                <p key={note}>{translate(note)}</p>
+            ))}
+        </aside>
+    );
+}

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
@@ -201,7 +201,11 @@ function OpenMessage({
     }
 
     if (held === null) {
-        return <p className="text-sm text-muted">{translate('message.reading')}</p>;
+        return (
+            <p className="text-sm text-muted" role="status">
+                {translate('message.reading')}
+            </p>
+        );
     }
 
     if (held.result.outcome === 'failed') {

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
@@ -13,7 +13,6 @@ import {
     type MailMessage,
 } from '@mailfathom/client-backend';
 import { SecondaryButton } from '../controls/SecondaryButton';
-import type { AttachmentDelivery } from '../deployment/attachmentDelivery';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
 import { useWorkspace } from '../workspace/useWorkspace';
@@ -63,13 +62,11 @@ export function ReadingPane({
     transport,
     storedEmailId,
     online,
-    deliver,
 }: {
     readonly session: ClientSession;
     readonly transport: MailFathomTransport;
     readonly storedEmailId: string | null;
     readonly online: boolean;
-    readonly deliver: AttachmentDelivery;
 }) {
     const { translate } = useLocalization();
 
@@ -78,13 +75,7 @@ export function ReadingPane({
             {storedEmailId === null ? (
                 <p className="text-sm text-muted">{translate('message.nothingOpen')}</p>
             ) : (
-                <OpenMessage
-                    session={session}
-                    transport={transport}
-                    storedEmailId={storedEmailId}
-                    online={online}
-                    deliver={deliver}
-                />
+                <OpenMessage session={session} transport={transport} storedEmailId={storedEmailId} online={online} />
             )}
         </section>
     );
@@ -98,18 +89,17 @@ function OpenMessage({
     transport,
     storedEmailId,
     online,
-    deliver,
 }: {
     readonly session: ClientSession;
     readonly transport: MailFathomTransport;
     readonly storedEmailId: string;
     readonly online: boolean;
-    readonly deliver: AttachmentDelivery;
 }) {
     const { translate } = useLocalization();
     const { revise } = useWorkspace();
     const [read, setRead] = useState<Read>({ storedEmailId, attempt: 0 });
     const [answer, setAnswer] = useState<Answered | null>(null);
+    const [connected, setConnected] = useState(online);
 
     const opened = useRef<HTMLElement>(null);
     const body = useRef<HTMLDivElement>(null);
@@ -121,7 +111,26 @@ function OpenMessage({
         setRead({ storedEmailId, attempt: 0 });
     }
 
+    // A failure the network gap itself caused goes with the gap, so what stands while there is no network is the
+    // sentence below rather than a refusal to try again that a reader would have to press through. A message already
+    // drawn stays where it is: nothing about it stopped being true, and it is the truest thing anybody has offline.
+    // Adjusted during render, which is where React answers a changed prop, for the reason `folders/FolderTree.tsx`
+    // gives about the frame this would otherwise be drawn one late in.
+    if (connected !== online) {
+        setConnected(online);
+
+        if (!online && answer?.result.outcome === 'failed') {
+            setAnswer(null);
+        }
+    }
+
+    // Nothing is read without a network, and coming back re-runs this — which is the whole of the recovery from that
+    // direction, and what makes the offline sentence's promise that the message opens on its own a true one.
     useEffect(() => {
+        if (!online) {
+            return;
+        }
+
         let listening = true;
 
         void readMailMessage(session, transport, read.storedEmailId).then((answered) => {
@@ -133,7 +142,7 @@ function OpenMessage({
         return () => {
             listening = false;
         };
-    }, [session, transport, read]);
+    }, [session, transport, read, online]);
 
     // The fragment somebody selected belonged to the message they were reading, so it goes when the message does:
     // carrying it into the next one would scope a question to words that are no longer on the screen. It happens as the
@@ -249,7 +258,6 @@ function OpenMessage({
                                 session={session}
                                 storedEmailId={storedEmailId}
                                 attachment={attachment}
-                                deliver={deliver}
                             />
                         ))}
                     </ul>

--- a/frontend/src/Client.App/src/readingPane/SenderVerdict.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/SenderVerdict.test.tsx
@@ -1,0 +1,66 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { MailAuthorAuthentication, MailDeploymentTrust } from '@mailfathom/client-backend';
+import { LocalizationProvider } from '../localization/Localization';
+import { SenderVerdict } from './SenderVerdict';
+
+function drawing(
+    authorAuthentication: MailAuthorAuthentication,
+    deploymentTrust: MailDeploymentTrust,
+    authenticatedDomain: string | null = null,
+): void {
+    render(
+        <LocalizationProvider>
+            <SenderVerdict verdict={{ authorAuthentication, deploymentTrust, authenticatedDomain }} />
+        </LocalizationProvider>,
+    );
+}
+
+const failed =
+    'A receiving mail server checked who actually sent this message and reported that the author it displays did not hold.';
+
+const recognized = 'This deployment recognizes the sender of this message.';
+
+describe('SenderVerdict', () => {
+    it.each([
+        ['a message whose author authenticated and whom nobody has named', 'Authenticated'],
+        ['a message nothing established an author for', 'NotEstablished'],
+    ] as const)('says nothing about %s, which is the ordinary state of legitimate mail', (_case, outcome) => {
+        drawing(outcome, 'Unknown');
+
+        expect(screen.queryByText(failed)).toBeNull();
+        expect(screen.queryByText(recognized)).toBeNull();
+    });
+
+    it('says so where the receiving server reported that the displayed author did not hold', () => {
+        drawing('Failed', 'Unknown');
+
+        expect(screen.getByText(failed)).toBeDefined();
+    });
+
+    it('says so where this deployment recognizes the sender', () => {
+        drawing('Authenticated', 'Trusted');
+
+        expect(screen.getByText(recognized)).toBeDefined();
+    });
+
+    it('names the domain that actually authenticated rather than the address the message displays', () => {
+        drawing('Failed', 'Unknown', 'mail.example.invalid');
+
+        expect(
+            screen.getByText(
+                'Authenticated by mail.example.invalid, which is who actually sent it rather than the name above.',
+            ),
+        ).toBeDefined();
+    });
+
+    it('says nothing authenticated a sender where the deployment named no domain', () => {
+        drawing('Failed', 'Unknown');
+
+        expect(screen.getByText('Nothing authenticated a sender for this message.')).toBeDefined();
+    });
+});

--- a/frontend/src/Client.App/src/readingPane/SenderVerdict.tsx
+++ b/frontend/src/Client.App/src/readingPane/SenderVerdict.tsx
@@ -1,0 +1,42 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { MailSenderVerdict } from '@mailfathom/client-backend';
+import { useLocalization } from '../localization/useLocalization';
+
+// What the deployment established about who actually sent a message, drawn where it says something and drawn nowhere
+// otherwise. A badge on every message is a badge nobody reads, and the mail this pane mostly shows is legitimate mail
+// whose author authenticated and whom nobody has named — which is the state the service calls ordinary and which is
+// therefore silent here.
+//
+// Nothing on this side combines the two outcomes or compares the authenticated domain against the displayed one. Both
+// would be rules, and a rule is the service's: a provider that signs as itself while the author's own domain passes is
+// authenticated exactly as it appears, and a client that decided otherwise would warn about ordinary mail.
+
+export function SenderVerdict({ verdict }: { readonly verdict: MailSenderVerdict }) {
+    const { translate } = useLocalization();
+
+    const failed = verdict.authorAuthentication === 'Failed';
+    const recognized = verdict.deploymentTrust === 'Trusted';
+
+    if (!failed && !recognized) {
+        return null;
+    }
+
+    return (
+        <aside
+            className={`flex flex-col gap-1 rounded-md border px-4 py-3 text-sm ${
+                failed ? 'border-warning bg-warning-soft text-warning' : 'border-line-soft bg-healthy-soft text-healthy'
+            }`}
+        >
+            <p className="font-medium">{translate(failed ? 'sender.failed' : 'sender.recognized')}</p>
+
+            <p>
+                {verdict.authenticatedDomain === null
+                    ? translate('sender.authenticatedByNobody')
+                    : translate('sender.authenticatedBy', { domain: verdict.authenticatedDomain })}
+            </p>
+        </aside>
+    );
+}

--- a/frontend/src/Client.App/src/readingPane/octets.test.ts
+++ b/frontend/src/Client.App/src/readingPane/octets.test.ts
@@ -1,0 +1,50 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import { sizeOf } from './octets';
+
+// The wording is `Intl`'s, so an expectation spelled out by hand would be an expectation about this machine rather than
+// about the unit reaching the formatter. Each test therefore asks `Intl` the same question the module asked it.
+function worded(value: number, unit: 'byte' | 'kilobyte' | 'megabyte' | 'gigabyte', fractionDigits: number): string {
+    return new Intl.NumberFormat('en', {
+        style: 'unit',
+        unit,
+        unitDisplay: 'short',
+        maximumFractionDigits: fractionDigits,
+    }).format(value);
+}
+
+describe('sizeOf', () => {
+    it('counts a small file in whole octets, because half an octet says nothing', () => {
+        expect(sizeOf(512, 'en')).toBe(worded(512, 'byte', 0));
+    });
+
+    it('reads nothing at all as no octets rather than as the smallest unit above them', () => {
+        expect(sizeOf(0, 'en')).toBe(worded(0, 'byte', 0));
+    });
+
+    it('moves to the largest unit that leaves a number a person reads at a glance', () => {
+        expect(sizeOf(2_048, 'en')).toBe(worded(2.048, 'kilobyte', 1));
+    });
+
+    it('stays in a unit until the next one holds at least one of what is being measured', () => {
+        expect(sizeOf(999_999, 'en')).toBe(worded(999.999, 'kilobyte', 1));
+    });
+
+    it('words the unit under the language it was asked in rather than out of a catalogue', () => {
+        expect(sizeOf(3_000_000, 'pl')).toBe(
+            new Intl.NumberFormat('pl', {
+                style: 'unit',
+                unit: 'megabyte',
+                unitDisplay: 'short',
+                maximumFractionDigits: 1,
+            }).format(3),
+        );
+    });
+
+    it('reaches the largest unit it names rather than reporting an enormous number of the one below', () => {
+        expect(sizeOf(4_000_000_000, 'en')).toBe(worded(4, 'gigabyte', 1));
+    });
+});

--- a/frontend/src/Client.App/src/readingPane/octets.ts
+++ b/frontend/src/Client.App/src/readingPane/octets.ts
@@ -1,0 +1,39 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { Locale } from '../localization/locale';
+
+// How large a file is, worded rather than counted out. The unit names are `Intl`'s under the active language, so no
+// catalogue holds an abbreviation for a kilobyte and neither language's form has to be maintained beside the other's.
+
+// The units a size is expressed in, smallest first, each with how many octets one of them holds. They are the sanctioned
+// unit identifiers `Intl.NumberFormat` accepts, which is why the list stops where it does rather than at a round number.
+const units = [
+    { unit: 'byte', octets: 1 },
+    { unit: 'kilobyte', octets: 1_000 },
+    { unit: 'megabyte', octets: 1_000_000 },
+    { unit: 'gigabyte', octets: 1_000_000_000 },
+    { unit: 'terabyte', octets: 1_000_000_000_000 },
+] as const;
+
+/**
+ * How large something is, in the largest unit that leaves a number a person reads at a glance.
+ *
+ * @param octets How many octets it holds, as the deployment reported it.
+ * @param locale The language the wording is asked for in.
+ * @returns The size as a person reads it.
+ */
+export function sizeOf(octets: number, locale: Locale): string {
+    const chosen = units.findLast((candidate) => octets >= candidate.octets) ?? units[0];
+
+    return new Intl.NumberFormat(locale, {
+        style: 'unit',
+        unit: chosen.unit,
+        unitDisplay: 'short',
+
+        // Whole octets and one place above them: half a kilobyte is worth saying and half an octet is not, and a file
+        // reported to three decimal places reads as a measurement rather than as a size.
+        maximumFractionDigits: chosen.unit === 'byte' ? 0 : 1,
+    }).format(octets / chosen.octets);
+}

--- a/frontend/src/Client.App/src/readingPane/savedFileName.test.ts
+++ b/frontend/src/Client.App/src/readingPane/savedFileName.test.ts
@@ -16,6 +16,10 @@ describe('savedAs', () => {
         ['a drive letter', 'C:notes.txt', 'Cnotes.txt'],
         ['a name that would be hidden by leading dots', '...secret.key', 'secret.key'],
         ['a name a file system would not keep the end of', 'summary.doc.', 'summary.doc'],
+        ['an override reversing what a listing draws after it', 'invoice\u202Efdp.exe', 'invoicefdp.exe'],
+        ['an isolate a sender wrapped an extension in', 'photo\u2066.jpg\u2069', 'photo.jpg'],
+        ['a mark that would reorder what is drawn', 'report\u200F.pdf', 'report.pdf'],
+        ['a control character nothing draws', 'notes\u0085.txt', 'notes.txt'],
     ])('reduces %s to something this client is willing to write', (_case, written, offered) => {
         expect(savedAs(written, 0)).toBe(offered);
     });
@@ -30,5 +34,10 @@ describe('savedAs', () => {
 
     it('keeps a sender from naming a file longer than this client will write', () => {
         expect(savedAs('a'.repeat(500), 0).length).toBe(128);
+    });
+
+    // Cutting to length is what can put back the character the trim removed, so the order of the two is the behaviour.
+    it('keeps a name cut to length from ending in what a file system would drop', () => {
+        expect(savedAs(`${'a'.repeat(127)}..pdf`, 0)).toBe('a'.repeat(127));
     });
 });

--- a/frontend/src/Client.App/src/readingPane/savedFileName.test.ts
+++ b/frontend/src/Client.App/src/readingPane/savedFileName.test.ts
@@ -1,0 +1,34 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import { savedAs } from './savedFileName';
+
+describe('savedAs', () => {
+    it('keeps the name the message gave the file, extension and all', () => {
+        expect(savedAs('invoice.pdf', 0)).toBe('invoice.pdf');
+    });
+
+    it.each([
+        ['a path a sender wrote into a name', '../../etc/passwd', 'etcpasswd'],
+        ['a separator either operating system acts on', 'reports\\2026\\q3.csv', 'reports2026q3.csv'],
+        ['a drive letter', 'C:notes.txt', 'Cnotes.txt'],
+        ['a name that would be hidden by leading dots', '...secret.key', 'secret.key'],
+        ['a name a file system would not keep the end of', 'summary.doc.', 'summary.doc'],
+    ])('reduces %s to something this client is willing to write', (_case, written, offered) => {
+        expect(savedAs(written, 0)).toBe(offered);
+    });
+
+    it('answers a part with no usable name at all by the position the message gave it', () => {
+        expect(savedAs('///', 3)).toBe('attachment-3');
+    });
+
+    it('answers a part the message named nothing by the position as well', () => {
+        expect(savedAs(null, 0)).toBe('attachment-0');
+    });
+
+    it('keeps a sender from naming a file longer than this client will write', () => {
+        expect(savedAs('a'.repeat(500), 0).length).toBe(128);
+    });
+});

--- a/frontend/src/Client.App/src/readingPane/savedFileName.ts
+++ b/frontend/src/Client.App/src/readingPane/savedFileName.ts
@@ -1,0 +1,31 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+// What a downloaded file is named on somebody's machine. It sits apart from the row that offers the download because a
+// module Vite hot-reloads may export components alone, which is the same reason `localization/useLocalization.ts` sits
+// apart from the provider that fills it.
+
+// The most of a sender's own file name this client will write to somebody's machine.
+const longestSavedName = 128;
+
+/**
+ * The name a downloaded file is offered under, reduced to something this client is willing to write.
+ *
+ * The service normalizes the name already, and this normalizes it again, because a file name is text a sender chose and
+ * a value crossing into a `download` attribute is crossing into a place the operating system acts on. A separator, a
+ * traversal segment, a control character, or a leading dot each mean something to a file system that they do not mean in
+ * a message, so none of them survives — and a name reduced to nothing is answered by the position the message gave the
+ * part rather than by a name invented for it.
+ */
+export function savedAs(fileName: string | null, position: number): string {
+    const reduced = (fileName ?? '')
+        // A control character in a file name is exactly what has to go, so naming that range is the point of the
+        // pattern rather than an accident of it.
+        // eslint-disable-next-line no-control-regex
+        .replaceAll(/[\u0000-\u001F\u007F/\\:*?"<>|]/gu, '')
+        .replaceAll(/^[.\s]+|[.\s]+$/gu, '')
+        .slice(0, longestSavedName);
+
+    return reduced === '' ? `attachment-${position.toFixed(0)}` : reduced;
+}

--- a/frontend/src/Client.App/src/readingPane/savedFileName.ts
+++ b/frontend/src/Client.App/src/readingPane/savedFileName.ts
@@ -9,23 +9,37 @@
 // The most of a sender's own file name this client will write to somebody's machine.
 const longestSavedName = 128;
 
+// What no file name may carry: the characters nothing draws — C0, then DEL with C1 behind it, then the bidirectional
+// controls, which occupy no width while reordering everything around them — beside the separators and the reserved
+// characters a file system acts on. Naming each range by number is the point of the pattern rather than an accident
+// of it, which is what the suppression below says.
+// eslint-disable-next-line no-control-regex
+const refusedInAFileName = /[\u0000-\u001F\u007F-\u009F\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069/\\:*?"<>|]/gu;
+
+// A leading dot hides a file and a trailing dot or space is dropped by a file system rather than kept, so a name
+// ending in either is a name that is not the one anybody agreed to.
+const hiddenOrDropped = /^[.\s]+|[.\s]+$/gu;
+
 /**
  * The name a downloaded file is offered under, reduced to something this client is willing to write.
  *
  * The service normalizes the name already, and this normalizes it again, because a file name is text a sender chose and
  * a value crossing into a `download` attribute is crossing into a place the operating system acts on. A separator, a
- * traversal segment, a control character, or a leading dot each mean something to a file system that they do not mean in
- * a message, so none of them survives — and a name reduced to nothing is answered by the position the message gave the
- * part rather than by a name invented for it.
+ * traversal segment, a control character, a bidirectional override, or a leading dot each mean something to a file
+ * system or to whatever draws its listing that they do not mean in a message, so none of them survives — and a name
+ * reduced to nothing is answered by the position the message gave the part rather than by a name invented for it.
+ *
+ * The override is the one worth naming. A sender who writes `invoice`, U+202E, then `fdp.exe` has written an
+ * executable whose name a file listing draws as `invoiceexe.pdf`, because the override reverses everything after it —
+ * so a reader deciding from what they can see decides about a file that is not the one they will open. Removing the
+ * character is what keeps the drawn name and the real name one name.
  */
 export function savedAs(fileName: string | null, position: number): string {
     const reduced = (fileName ?? '')
-        // A control character in a file name is exactly what has to go, so naming that range is the point of the
-        // pattern rather than an accident of it.
-        // eslint-disable-next-line no-control-regex
-        .replaceAll(/[\u0000-\u001F\u007F/\\:*?"<>|]/gu, '')
-        .replaceAll(/^[.\s]+|[.\s]+$/gu, '')
-        .slice(0, longestSavedName);
+        .replaceAll(refusedInAFileName, '')
+        .slice(0, longestSavedName)
+        // Last, so that cutting a long name to length cannot put back the trailing dot or space the trim removes.
+        .replaceAll(hiddenOrDropped, '');
 
     return reduced === '' ? `attachment-${position.toFixed(0)}` : reduced;
 }

--- a/frontend/src/Client.App/src/shell/IntentField.test.tsx
+++ b/frontend/src/Client.App/src/shell/IntentField.test.tsx
@@ -2,11 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+import { useEffect } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import type { MailAccount } from '@mailfathom/client-backend';
 import { LocalizationProvider } from '../localization/Localization';
 import { WorkspaceProvider } from '../workspace/Workspace';
+import { useWorkspace } from '../workspace/useWorkspace';
 import { IntentField } from './IntentField';
 
 const workAccount: MailAccount = {
@@ -63,5 +65,55 @@ describe('IntentField', () => {
 
         expect(screen.getByRole('combobox', { name: 'Mailbox in scope' })).toHaveProperty('value', '');
         expect(screen.getByRole('option', { name: 'All mailboxes' })).toBeDefined();
+    });
+});
+
+// A fragment reaches the workspace from a gesture over a message, which is the reading pane's own act rather than
+// anything this field can do — so what stands in for that here is the same write made on mount, and everything
+// asserted below is the field's own behaviour once the value is there.
+function Selecting({ words }: { readonly words: string }) {
+    const { revise } = useWorkspace();
+
+    useEffect(() => {
+        revise({ fragment: words });
+    }, [revise, words]);
+
+    return null;
+}
+
+function fieldBesideASelection(words: string): void {
+    render(
+        <LocalizationProvider>
+            <WorkspaceProvider>
+                <Selecting words={words} />
+                <IntentField accounts={[workAccount]} />
+            </WorkspaceProvider>
+        </LocalizationProvider>,
+    );
+}
+
+describe('IntentField scope', () => {
+    it('says nothing about a fragment while the whole message is the scope', () => {
+        renderField();
+
+        expect(screen.queryByRole('button', { name: 'Ask about the whole message instead' })).toBeNull();
+    });
+
+    it('quotes the words a question would be asked about, rather than saying a fragment exists', () => {
+        fieldBesideASelection('the part of the message somebody pointed at');
+
+        expect(
+            screen.getByText(
+                'Asking about the part of this message you selected: “the part of the message somebody pointed at”',
+            ),
+        ).toBeDefined();
+    });
+
+    it('gives the whole message back as the scope when that is asked for', () => {
+        fieldBesideASelection('the part of the message somebody pointed at');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Ask about the whole message instead' }));
+
+        expect(screen.queryByRole('button', { name: 'Ask about the whole message instead' })).toBeNull();
     });
 });

--- a/frontend/src/Client.App/src/shell/IntentField.test.tsx
+++ b/frontend/src/Client.App/src/shell/IntentField.test.tsx
@@ -116,4 +116,14 @@ describe('IntentField scope', () => {
 
         expect(screen.queryByRole('button', { name: 'Ask about the whole message instead' })).toBeNull();
     });
+
+    // Widening the scope takes the control that did it off the screen, so where focus lands is the behaviour:
+    // left to the browser it falls to the document, which is where reading from a keyboard silently stops.
+    it('puts focus on the question when the control that widened the scope goes', () => {
+        fieldBesideASelection('the part of the message somebody pointed at');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Ask about the whole message instead' }));
+
+        expect(screen.getByRole('searchbox', { name: 'Ask your mail' })).toBe(document.activeElement);
+    });
 });

--- a/frontend/src/Client.App/src/shell/IntentField.tsx
+++ b/frontend/src/Client.App/src/shell/IntentField.tsx
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import type { MailAccount } from '@mailfathom/client-backend';
+import { SecondaryButton } from '../controls/SecondaryButton';
 import { useLocalization } from '../localization/useLocalization';
 import { goToSpace } from '../routing/useSpace';
 import { accountInScope, scopeOfAccount } from '../workspace/mailScope';
@@ -57,6 +58,22 @@ export function IntentField({ accounts }: { readonly accounts: readonly MailAcco
                     </option>
                 ))}
             </select>
+
+            {/* The other half of the scope, and the one a person set by pointing at something rather than by choosing
+                from a list. It is shown rather than assumed, because a question silently narrowed to words somebody
+                selected minutes ago is a question answered about the wrong thing — and it says the words themselves
+                rather than that a fragment exists, so what the next question is about is readable before it is asked. */}
+            {workspace.fragment === null ? null : (
+                <p className="flex w-full items-center gap-2 text-sm text-muted">
+                    <span className="truncate">{translate('scope.fragment', { fragment: workspace.fragment })}</span>
+                    <SecondaryButton
+                        label={translate('scope.wholeMessage')}
+                        onActivate={() => {
+                            revise({ fragment: null });
+                        }}
+                    />
+                </p>
+            )}
         </form>
     );
 }

--- a/frontend/src/Client.App/src/shell/IntentField.tsx
+++ b/frontend/src/Client.App/src/shell/IntentField.tsx
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+import { useRef } from 'react';
 import type { MailAccount } from '@mailfathom/client-backend';
 import { SecondaryButton } from '../controls/SecondaryButton';
 import { useLocalization } from '../localization/useLocalization';
@@ -20,6 +21,7 @@ import { useWorkspace } from '../workspace/useWorkspace';
 export function IntentField({ accounts }: { readonly accounts: readonly MailAccount[] }) {
     const { translate } = useLocalization();
     const { workspace, revise } = useWorkspace();
+    const question = useRef<HTMLInputElement>(null);
 
     return (
         <form
@@ -33,6 +35,7 @@ export function IntentField({ accounts }: { readonly accounts: readonly MailAcco
             }}
         >
             <input
+                ref={question}
                 type="search"
                 aria-label={translate('intent.label')}
                 placeholder={translate('intent.placeholder')}
@@ -66,10 +69,14 @@ export function IntentField({ accounts }: { readonly accounts: readonly MailAcco
             {workspace.fragment === null ? null : (
                 <p className="flex w-full items-center gap-2 text-sm text-muted">
                     <span className="truncate">{translate('scope.fragment', { fragment: workspace.fragment })}</span>
+                    {/* Giving the scope back takes this line off the screen, and the control somebody pressed with
+                        it, so focus is placed rather than left to fall to the document: it goes to the question
+                        itself, which is what widening the scope was in aid of asking. */}
                     <SecondaryButton
                         label={translate('scope.wholeMessage')}
                         onActivate={() => {
                             revise({ fragment: null });
+                            question.current?.focus();
                         }}
                     />
                 </p>

--- a/frontend/src/Client.App/src/workspace/Workspace.test.tsx
+++ b/frontend/src/Client.App/src/workspace/Workspace.test.tsx
@@ -69,6 +69,7 @@ describe('WorkspaceProvider', () => {
         { scope: { kind: 'account', accountId: 'work' } },
         { collapsed: ['account:work'] },
         { selection: 'AAMkAD-42' },
+        { fragment: 'the part of the message somebody pointed at' },
         { question: 'what did Nordwind send' },
     ])('changes %o and leaves the rest of the workspace as it was', (change) => {
         renderProbe(change);

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
@@ -12,6 +12,7 @@ const kept: Workspace = {
     scope: { kind: 'folder', accountId: 'work', alias: 'INBOX' },
     collapsed: ['account:personal'],
     selection: 'AAMkAD-42',
+    fragment: null,
     question: 'what did Nordwind send',
 };
 
@@ -29,6 +30,14 @@ describe('rememberWorkspace', () => {
         rememberWorkspace(kept);
 
         expect(rememberedWorkspace()).toEqual(kept);
+    });
+
+    // The one part of the workspace that is mail rather than a name for one, so it is the one part a store never sees.
+    it('keeps no part of the message somebody had selected', () => {
+        rememberWorkspace({ ...kept, fragment: 'the part of the message somebody pointed at' });
+
+        expect(window.sessionStorage.getItem(storageKey)).not.toContain('somebody pointed at');
+        expect(rememberedWorkspace().fragment).toBeNull();
     });
 });
 

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.ts
@@ -54,10 +54,16 @@ export function rememberedWorkspace(): Workspace {
     return workspaceIn(parsed) ?? emptyWorkspace;
 }
 
-/** Keeps what this tab is looking at, so a reload returns to it. */
+/**
+ * Keeps what this tab is looking at, so a reload returns to it.
+ *
+ * Everything but the selected fragment, which is a passage of somebody's mail rather than a name the service assigned:
+ * keeping it would put mail content in a browser store for nothing, since the reading pane drops the fragment as the
+ * message it belongs to opens and a reload is that message opening again.
+ */
 export function rememberWorkspace(workspace: Workspace): void {
     try {
-        window.sessionStorage.setItem(storageKey, JSON.stringify(workspace));
+        window.sessionStorage.setItem(storageKey, JSON.stringify({ ...workspace, fragment: null }));
     } catch {
         // A browser refusing storage still runs the client; what a person was looking at then lasts the run rather
         // than outliving it, which is a smaller loss than a client that fails over a preference.
@@ -90,7 +96,7 @@ function workspaceIn(value: unknown): Workspace | null {
         return null;
     }
 
-    return { scope, collapsed, selection, question };
+    return { scope, collapsed, selection, fragment: null, question };
 }
 
 function scopeIn(value: unknown): MailScope | null {

--- a/frontend/src/Client.App/src/workspace/useWorkspace.ts
+++ b/frontend/src/Client.App/src/workspace/useWorkspace.ts
@@ -27,6 +27,15 @@ export interface Workspace {
     /** What the person has open, once a space offers something to open. */
     readonly selection: string | null;
 
+    /**
+     * The part of what is open that a question would be asked about, or `null` where the whole of it is.
+     *
+     * It is the words a person selected rather than a position in anything, because what the intent field does with it
+     * is quote it: a range would have to be resolved against a document that is drawn again on every read, and against
+     * the same message read a second time under a different ask.
+     */
+    readonly fragment: string | null;
+
     /** What has been typed into the intent field, which the next question would be asked with. */
     readonly question: string;
 }
@@ -42,6 +51,7 @@ export const emptyWorkspace: Workspace = {
     scope: everything,
     collapsed: [],
     selection: null,
+    fragment: null,
     question: '',
 };
 

--- a/frontend/src/Client.Backend/src/index.ts
+++ b/frontend/src/Client.Backend/src/index.ts
@@ -55,6 +55,26 @@ export {
     type MailFolderDirectory,
     type MailFolderRole,
 } from './mailFolders';
+export {
+    attachmentRefusalForStatus,
+    mailAttachmentRequest,
+    mailAttachmentRoute,
+    type MailAttachmentRefusal,
+} from './mailAttachment';
+export {
+    mailMessageRoute,
+    readMailMessage,
+    type MailAttachment,
+    type MailAuthorAuthentication,
+    type MailCarried,
+    type MailDeploymentTrust,
+    type MailMessage,
+    type MailMessageBodyForms,
+    type MailMessageHeaders,
+    type MailParticipant,
+    type MailParticipantRole,
+    type MailSenderVerdict,
+} from './mailMessage';
 export { clientRoutePrefix, headersFor, routeFor, type ClientSession, type DeploymentAddress } from './session';
 export { reachDeployment, signIn, type DeploymentGreeting, type SignInOutcome, type SignInRefusal } from './signIn';
 export { longestResponseBody, type ClientRequest, type ClientResponse, type MailFathomTransport } from './transport';

--- a/frontend/src/Client.Backend/src/mailAttachment.test.ts
+++ b/frontend/src/Client.Backend/src/mailAttachment.test.ts
@@ -1,0 +1,51 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import { attachmentRefusalForStatus, mailAttachmentRequest, mailAttachmentRoute } from './mailAttachment';
+import type { ClientSession } from './session';
+
+const session: ClientSession = {
+    baseAddress: 'https://mail.example.invalid',
+    authorization: 'Basic dGVzdA==',
+};
+
+const messageId = '00000000-0000-4000-8000-000000000000';
+
+describe('mailAttachmentRoute', () => {
+    it('names the file by the position the message described it at', () => {
+        expect(mailAttachmentRoute(messageId, 2)).toBe(`/messages/${messageId}/attachments/2`);
+    });
+
+    it('encodes the identifier it is given rather than writing it into the path as it stands', () => {
+        expect(mailAttachmentRoute('a/../b', 0)).toBe('/messages/a%2F..%2Fb/attachments/0');
+    });
+});
+
+describe('mailAttachmentRequest', () => {
+    it('asks for octets rather than for JSON, and presents the credential the session holds', () => {
+        expect(mailAttachmentRequest(session, messageId, 1, 2_048)).toEqual({
+            method: 'GET',
+            path: `https://mail.example.invalid/api/client/messages/${messageId}/attachments/1`,
+            headers: { Accept: 'application/octet-stream', Authorization: 'Basic dGVzdA==' },
+            longestAnswer: 2_048,
+        });
+    });
+
+    it('reads the answer under the size the message said the file holds, so a larger one is refusable', () => {
+        expect(mailAttachmentRequest(session, messageId, 0, 17).longestAnswer).toBe(17);
+    });
+});
+
+describe('attachmentRefusalForStatus', () => {
+    it.each([
+        [401, 'unauthenticated'],
+        [403, 'unauthorized'],
+        [404, 'unavailable'],
+        [500, 'unavailable'],
+        [503, 'unavailable'],
+    ])('reads a status of %i as %s', (status, refusal) => {
+        expect(attachmentRefusalForStatus(status)).toBe(refusal);
+    });
+});

--- a/frontend/src/Client.Backend/src/mailAttachment.ts
+++ b/frontend/src/Client.Backend/src/mailAttachment.ts
@@ -1,0 +1,67 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { headersFor, routeFor, type ClientSession } from './session';
+import type { ClientRequest } from './transport';
+
+// The one operation on this surface that is not read through a transport, because what it answers with is octets and a
+// `MailFathomTransport` answers with text. So this module composes the request and stops there: putting it on the wire
+// with a progress report and a way to abandon it is the application's adapter, exactly as calling `fetch` at all is.
+//
+// What stays here is everything the boundary owns — the route, the credential, the header the answer is asked in, and
+// the bound the answer is read under — so no screen and no adapter above learns a path or a header name.
+
+/** The route one file a message carries is served at, relative to the client prefix. */
+export function mailAttachmentRoute(storedEmailId: string, position: number): string {
+    return `/messages/${encodeURIComponent(storedEmailId)}/attachments/${position.toFixed(0)}`;
+}
+
+/**
+ * Composes the request that downloads one file a message carries.
+ *
+ * @param session Who is asking, and where.
+ * @param storedEmailId The message the file belongs to, as a read of that message published it.
+ * @param position The file's place in the order that read listed the message's attachments in.
+ * @param describedSizeOctets How many octets that read said the file holds, which becomes the bound the answer is read
+ * under: a response larger than the description is refused rather than saved, so a deployment cannot hand a reader more
+ * than the screen told them they were asking for.
+ * @returns The request an adapter puts on the wire.
+ */
+export function mailAttachmentRequest(
+    session: ClientSession,
+    storedEmailId: string,
+    position: number,
+    describedSizeOctets: number,
+): ClientRequest {
+    return {
+        method: 'GET',
+        path: routeFor(session, mailAttachmentRoute(storedEmailId, position)),
+
+        // Octets rather than JSON, which is the one place a request on this surface asks for something else. The
+        // credential is unchanged: it is the access control this route applies, and no second capability is minted.
+        headers: { ...headersFor(session), Accept: 'application/octet-stream' },
+        longestAnswer: describedSizeOctets,
+    };
+}
+
+/**
+ * Why a download did not answer with a file.
+ *
+ * It reuses nothing from `ClientFailureReason` deliberately: three of those four are about a read of a description and
+ * the fourth says a body could not be parsed, while what can go wrong here is a refusal, an unreachable deployment, or
+ * an answer that did not hold what the message said it would.
+ */
+export type MailAttachmentRefusal = 'unauthenticated' | 'unauthorized' | 'unavailable' | 'largerThanDescribed';
+
+/** The refusal an HTTP status stands for, for a status this package did not expect to succeed. */
+export function attachmentRefusalForStatus(status: number): MailAttachmentRefusal {
+    switch (status) {
+        case 401:
+            return 'unauthenticated';
+        case 403:
+            return 'unauthorized';
+        default:
+            return 'unavailable';
+    }
+}

--- a/frontend/src/Client.Backend/src/mailMessage.test.ts
+++ b/frontend/src/Client.Backend/src/mailMessage.test.ts
@@ -1,0 +1,256 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import { mailMessageRoute, readMailMessage, type MailMessage } from './mailMessage';
+import type { ClientSession } from './session';
+import type { ClientRequest, ClientResponse, MailFathomTransport } from './transport';
+
+const session: ClientSession = {
+    baseAddress: 'https://mail.example.invalid',
+    authorization: 'Basic dGVzdA==',
+};
+
+const messageId = '00000000-0000-4000-8000-000000000000';
+
+/** The whole of what the message route answers with, which every test below narrows or breaks one field of. */
+function described(overrides: Readonly<Record<string, unknown>> = {}): string {
+    return JSON.stringify({
+        storedEmailId: messageId,
+        account: 'work',
+        folder: 'INBOX',
+        threadId: null,
+        sizeOctets: 40_960,
+        headers: {
+            subject: 'Quarterly invoice',
+            sentAt: '2026-08-31T09:41:00+00:00',
+            receivedAt: '2026-08-31T09:41:10+00:00',
+            participants: [
+                { role: 'From', address: 'billing@example.invalid', displayName: 'Billing' },
+                { role: 'To', address: 'reader@example.invalid', displayName: null },
+            ],
+            messageId: 'abc@example.invalid',
+            inReplyTo: null,
+            references: [],
+        },
+        body: { availability: 'Readable', plainText: true, html: true },
+        sender: {
+            authorAuthentication: 'Authenticated',
+            deploymentTrust: 'Trusted',
+            authenticatedDomain: 'mail.example.invalid',
+        },
+        attachments: [
+            {
+                position: 0,
+                fileName: 'invoice.pdf',
+                wasFileNameNormalized: false,
+                mediaType: 'application/pdf',
+                sizeOctets: 2_048,
+            },
+        ],
+        carried: {
+            attachmentCount: 1,
+            totalSizeOctets: 2_048,
+            inlineResourceCount: 3,
+            encrypted: false,
+            unverifiedSignature: true,
+            unexpandedTnefPart: false,
+        },
+        unread: true,
+        flagged: false,
+        answered: false,
+        ...overrides,
+    });
+}
+
+type Answer = Omit<ClientResponse, 'headers'>;
+
+function answering(response: Answer): MailFathomTransport {
+    return () => Promise.resolve({ ...response, headers: {} });
+}
+
+function recording(response: Answer): { transport: MailFathomTransport; requests: ClientRequest[] } {
+    const requests: ClientRequest[] = [];
+
+    return {
+        requests,
+        transport: (request) => {
+            requests.push(request);
+
+            return Promise.resolve({ ...response, headers: {} });
+        },
+    };
+}
+
+async function readingOf(body: string): Promise<MailMessage | null> {
+    const result = await readMailMessage(session, answering({ status: 200, body }), messageId);
+
+    return result.outcome === 'read' ? result.value : null;
+}
+
+describe('mailMessageRoute', () => {
+    it('encodes the identifier it is given rather than writing it into the path as it stands', () => {
+        expect(mailMessageRoute('a/../b')).toBe('/messages/a%2F..%2Fb');
+    });
+});
+
+describe('readMailMessage', () => {
+    it('asks for the message route on the client surface with the session it was given', async () => {
+        const { transport, requests } = recording({ status: 200, body: described() });
+
+        await readMailMessage(session, transport, messageId);
+
+        expect(requests).toEqual([
+            {
+                method: 'GET',
+                path: `https://mail.example.invalid/api/client/messages/${messageId}`,
+                headers: { Accept: 'application/json', Authorization: 'Basic dGVzdA==' },
+                longestAnswer: 4 * 1024 * 1024,
+            },
+        ]);
+    });
+
+    it('reads the message a well-formed answer describes', async () => {
+        const message = await readingOf(described());
+
+        expect(message?.headers.subject).toBe('Quarterly invoice');
+        expect(message?.headers.participants).toEqual([
+            { role: 'From', address: 'billing@example.invalid', displayName: 'Billing' },
+            { role: 'To', address: 'reader@example.invalid', displayName: null },
+        ]);
+        expect(message?.attachments).toEqual([
+            {
+                position: 0,
+                fileName: 'invoice.pdf',
+                wasFileNameNormalized: false,
+                mediaType: 'application/pdf',
+                sizeOctets: 2_048,
+            },
+        ]);
+    });
+
+    it('reads the domain that authenticated beside the two outcomes it is published with', async () => {
+        const message = await readingOf(described());
+
+        expect(message?.sender).toEqual({
+            authorAuthentication: 'Authenticated',
+            deploymentTrust: 'Trusted',
+            authenticatedDomain: 'mail.example.invalid',
+        });
+    });
+
+    it('reads a message nothing authenticated as one naming no domain', async () => {
+        const message = await readingOf(
+            described({
+                sender: {
+                    authorAuthentication: 'NotEstablished',
+                    deploymentTrust: 'Unknown',
+                    authenticatedDomain: null,
+                },
+            }),
+        );
+
+        expect(message?.sender.authenticatedDomain).toBeNull();
+    });
+
+    it('reads a message whose parts nothing has ever read as one carrying no counts', async () => {
+        const message = await readingOf(described({ carried: null }));
+
+        expect(message?.carried).toBeNull();
+    });
+
+    it.each([401, 403, 404, 500, 503])(
+        'reports a status of %i as a failure rather than reading the answer',
+        async (status) => {
+            const result = await readMailMessage(session, answering({ status, body: '' }), messageId);
+
+            expect(result.outcome).toBe('failed');
+        },
+    );
+
+    it('reports a deployment that answered nothing at all as unavailable', async () => {
+        const result = await readMailMessage(
+            session,
+            () => Promise.reject(new Error('the connection was refused')),
+            messageId,
+        );
+
+        expect(result).toEqual({ outcome: 'failed', failure: { reason: 'unavailable', status: null } });
+    });
+
+    it.each([
+        ['a body that is not JSON at all', 'not json'],
+        ['a body that is an array rather than a message', '[]'],
+        ['a message with no headers block', described({ headers: undefined })],
+        ['a subject that is not text', described({ headers: { subject: 7 } })],
+        ['a participant in a role this build does not publish', headersNaming({ role: 'Approver' })],
+        ['a participant with no address', headersNaming({ role: 'To', displayName: 'Nobody' })],
+        [
+            'an authentication outcome this build does not publish',
+            described({
+                sender: { authorAuthentication: 'Probably', deploymentTrust: 'Unknown', authenticatedDomain: null },
+            }),
+        ],
+        [
+            'a trust level this build does not publish',
+            described({
+                sender: { authorAuthentication: 'Failed', deploymentTrust: 'Suspect', authenticatedDomain: null },
+            }),
+        ],
+        ['an attachment at a negative position', attachmentOf({ position: -1 })],
+        ['an attachment with a fractional size', attachmentOf({ sizeOctets: 1.5 })],
+        ['an attachment declaring no media type', attachmentOf({ mediaType: null })],
+        ['a carried block with a count that is not a number', described({ carried: { attachmentCount: 'two' } })],
+        ['more attachments than a message may carry', tooManyAttachments()],
+    ])('refuses %s rather than reading part of it', async (_shape, body) => {
+        const result = await readMailMessage(session, answering({ status: 200, body }), messageId);
+
+        expect(result).toEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+});
+
+/** A message whose only participant is the one named, which is how a malformed address is put in front of the parser. */
+function headersNaming(participant: Readonly<Record<string, unknown>>): string {
+    return described({
+        headers: {
+            subject: 'Quarterly invoice',
+            sentAt: null,
+            receivedAt: null,
+            participants: [participant],
+            messageId: null,
+            inReplyTo: null,
+            references: [],
+        },
+    });
+}
+
+/** A message whose only attachment is the one named, with the rest of a well-formed description around it. */
+function attachmentOf(attachment: Readonly<Record<string, unknown>>): string {
+    return described({
+        attachments: [
+            {
+                position: 0,
+                fileName: 'invoice.pdf',
+                wasFileNameNormalized: false,
+                mediaType: 'application/pdf',
+                sizeOctets: 2_048,
+                ...attachment,
+            },
+        ],
+    });
+}
+
+// The bound is checked while the list is walked rather than after it, so the case worth proving is an answer larger than
+// anything the service composes rather than one merely longer than a reader would open.
+function tooManyAttachments(): string {
+    return described({
+        attachments: Array.from({ length: 1_025 }, (_unused, position) => ({
+            position,
+            fileName: 'invoice.pdf',
+            wasFileNameNormalized: false,
+            mediaType: 'application/pdf',
+            sizeOctets: 2_048,
+        })),
+    });
+}

--- a/frontend/src/Client.Backend/src/mailMessage.ts
+++ b/frontend/src/Client.Backend/src/mailMessage.ts
@@ -1,0 +1,455 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { failed, failureReasonForStatus, read, type ClientResult } from './failure';
+import { headersFor, routeFor, type ClientSession } from './session';
+import { send, type MailFathomTransport } from './transport';
+
+// Everything a reading pane draws around a message, which is the other half of the body route. What the service serves
+// here is a description rather than any of the message's content beyond its headers: no octet of a file, and no picture
+// the body embeds. This is the client's trust boundary for that description, so every field is checked before it becomes
+// a value a screen may draw, and every collection carries a bound checked during the walk rather than after it.
+
+/** The route one message is served at, relative to the client prefix. */
+export function mailMessageRoute(storedEmailId: string): string {
+    return `/messages/${encodeURIComponent(storedEmailId)}`;
+}
+
+/** The header one address appeared in, which is what decides where a screen draws it. */
+export type MailParticipantRole = 'Sender' | 'From' | 'ReplyTo' | 'To' | 'Cc' | 'Bcc';
+
+/** What the receiving mail server established about the author the message displays. */
+export type MailAuthorAuthentication = 'NotEstablished' | 'Failed' | 'Authenticated';
+
+/** Whether this deployment recognizes that author. */
+export type MailDeploymentTrust = 'Unknown' | 'Trusted';
+
+/** One address a message wrote, and the header it wrote it in. */
+export interface MailParticipant {
+    readonly role: MailParticipantRole;
+    readonly address: string;
+    readonly displayName: string | null;
+}
+
+/** What a message displays above its body. */
+export interface MailMessageHeaders {
+    readonly subject: string | null;
+    readonly sentAt: string | null;
+    readonly receivedAt: string | null;
+    readonly participants: readonly MailParticipant[];
+    readonly messageId: string | null;
+    readonly inReplyTo: string | null;
+    readonly references: readonly string[];
+}
+
+/** Whether a message has a body to draw, and which forms of it the sender wrote. */
+export interface MailMessageBodyForms {
+    readonly availability: string;
+    readonly plainText: boolean;
+    readonly html: boolean;
+}
+
+/**
+ * What this deployment established about the author a message displays.
+ *
+ * The two outcomes are held side by side and never collapsed into one value, for the reason the service publishes them
+ * that way: one is a fact a receiving server established about the message, the other is this deployment's own
+ * classification of the author it established, and a client that combined them would be inventing the rule that does so.
+ *
+ * `authenticatedDomain` is who actually sent the message, which is what a screen names instead of the `From` value the
+ * message displays. It is stated and never judged: comparing it against the displayed domain would be evaluating a
+ * policy the service deliberately does not, so what a reader acts on stays `authorAuthentication`.
+ */
+export interface MailSenderVerdict {
+    readonly authorAuthentication: MailAuthorAuthentication;
+    readonly deploymentTrust: MailDeploymentTrust;
+    readonly authenticatedDomain: string | null;
+}
+
+/**
+ * One file a message carries, described and carrying none of what it holds.
+ *
+ * The position is the identity because it is the only stable one a message's parts have, and it is what the download
+ * route is asked with. The file name is text a sender chose: it arrives normalized to a bare name, and
+ * `wasFileNameNormalized` says whether that rewrote anything — which is the case worth drawing carefully rather than a
+ * detail to hide.
+ */
+export interface MailAttachment {
+    readonly position: number;
+    readonly fileName: string | null;
+    readonly wasFileNameNormalized: boolean;
+    readonly mediaType: string;
+    readonly sizeOctets: number;
+}
+
+/** The counts for everything a message carries besides its body, or `null` where nothing has read its parts. */
+export interface MailCarried {
+    readonly attachmentCount: number;
+    readonly totalSizeOctets: number;
+    readonly inlineResourceCount: number;
+    readonly encrypted: boolean;
+    readonly unverifiedSignature: boolean;
+    readonly unexpandedTnefPart: boolean;
+}
+
+/** One message as the reading pane draws it, without its body and without any file it carries. */
+export interface MailMessage {
+    readonly storedEmailId: string;
+    readonly account: string;
+    readonly folder: string;
+    readonly threadId: string | null;
+    readonly sizeOctets: number;
+    readonly headers: MailMessageHeaders;
+    readonly body: MailMessageBodyForms;
+    readonly sender: MailSenderVerdict;
+    readonly attachments: readonly MailAttachment[];
+    readonly carried: MailCarried | null;
+    readonly unread: boolean;
+    readonly flagged: boolean;
+    readonly answered: boolean;
+}
+
+// A description composes to a stated size, so the backstop written for a stranger is far looser than this answer ever
+// needs. It is generous against the bounds below rather than tight against them: the point of failing here is to stop a
+// body being buffered whole, and the point of failing there is to refuse a description this client would not draw.
+const longestMessageAnswer = 4 * 1024 * 1024;
+
+// What the service will compose at most, mirrored so a description larger than that is refused rather than drawn. The
+// part count is the ceiling `MaxMimePartCount` defaults to, rounded up, because every part of a message can be an
+// attachment; the address count is far above any real header set and exists for the case the answer is not one. Each is
+// checked during the walk, because a bound applied after a walk that completed has already paid for what it read.
+const bounds = {
+    maximumAttachments: 1024,
+    maximumParticipants: 2048,
+    maximumReferences: 512,
+    maximumTextLength: 4096,
+    maximumFileNameLength: 1024,
+    maximumMediaTypeLength: 256,
+} as const;
+
+const participantRoles: readonly MailParticipantRole[] = ['Sender', 'From', 'ReplyTo', 'To', 'Cc', 'Bcc'];
+
+const authorAuthentications: readonly MailAuthorAuthentication[] = ['NotEstablished', 'Failed', 'Authenticated'];
+
+const deploymentTrusts: readonly MailDeploymentTrust[] = ['Unknown', 'Trusted'];
+
+/** Reads one message's description, answering an expected failure as a value rather than by throwing. */
+export async function readMailMessage(
+    session: ClientSession,
+    transport: MailFathomTransport,
+    storedEmailId: string,
+): Promise<ClientResult<MailMessage>> {
+    const response = await send(transport, {
+        method: 'GET',
+        path: routeFor(session, mailMessageRoute(storedEmailId)),
+        headers: headersFor(session),
+        longestAnswer: longestMessageAnswer,
+    });
+
+    if (response === null) {
+        return failed('unavailable', null);
+    }
+
+    if (response.status !== 200) {
+        return failed(failureReasonForStatus(response.status), response.status);
+    }
+
+    const message = parseMessage(response.body);
+
+    return message === null ? failed('unreadable', response.status) : read(message);
+}
+
+function parseMessage(body: string): MailMessage | null {
+    let parsed: unknown;
+
+    try {
+        parsed = JSON.parse(body);
+    } catch {
+        return null;
+    }
+
+    const record = asRecord(parsed);
+    if (record === null) {
+        return null;
+    }
+
+    const storedEmailId = record['storedEmailId'];
+    const account = record['account'];
+    const folder = record['folder'];
+    const threadId = record['threadId'] ?? null;
+    const sizeOctets = record['sizeOctets'];
+
+    if (!isText(storedEmailId) || !isText(account) || !isText(folder)) {
+        return null;
+    }
+
+    if (threadId !== null && !isText(threadId)) {
+        return null;
+    }
+
+    if (!isCount(sizeOctets)) {
+        return null;
+    }
+
+    const headers = parseHeaders(record['headers']);
+    const forms = parseBodyForms(record['body']);
+    const sender = parseSenderVerdict(record['sender']);
+    const attachments = parseAttachments(record['attachments']);
+    const carried = parseCarried(record['carried'] ?? null);
+    const unread = record['unread'];
+    const flagged = record['flagged'];
+    const answered = record['answered'];
+
+    if (headers === null || forms === null || sender === null || attachments === null || carried === undefined) {
+        return null;
+    }
+
+    if (typeof unread !== 'boolean' || typeof flagged !== 'boolean' || typeof answered !== 'boolean') {
+        return null;
+    }
+
+    return {
+        storedEmailId,
+        account,
+        folder,
+        threadId,
+        sizeOctets,
+        headers,
+        body: forms,
+        sender,
+        attachments,
+        carried,
+        unread,
+        flagged,
+        answered,
+    };
+}
+
+function parseHeaders(value: unknown): MailMessageHeaders | null {
+    const record = asRecord(value);
+    if (record === null) {
+        return null;
+    }
+
+    const subject = record['subject'] ?? null;
+    const sentAt = record['sentAt'] ?? null;
+    const receivedAt = record['receivedAt'] ?? null;
+    const messageId = record['messageId'] ?? null;
+    const inReplyTo = record['inReplyTo'] ?? null;
+
+    if (!isOptionalText(subject) || !isOptionalText(sentAt) || !isOptionalText(receivedAt)) {
+        return null;
+    }
+
+    if (!isOptionalText(messageId) || !isOptionalText(inReplyTo)) {
+        return null;
+    }
+
+    const participants = parseParticipants(record['participants']);
+    const references = parseReferences(record['references']);
+
+    if (participants === null || references === null) {
+        return null;
+    }
+
+    return { subject, sentAt, receivedAt, participants, messageId, inReplyTo, references };
+}
+
+function parseParticipants(value: unknown): readonly MailParticipant[] | null {
+    if (!Array.isArray(value) || value.length > bounds.maximumParticipants) {
+        return null;
+    }
+
+    const participants: MailParticipant[] = [];
+    for (const entry of value) {
+        const participant = parseParticipant(entry);
+        if (participant === null) {
+            return null;
+        }
+
+        participants.push(participant);
+    }
+
+    return participants;
+}
+
+function parseParticipant(value: unknown): MailParticipant | null {
+    const record = asRecord(value);
+    if (record === null) {
+        return null;
+    }
+
+    const role = record['role'];
+    const address = record['address'];
+    const displayName = record['displayName'] ?? null;
+
+    if (!isOneOf(role, participantRoles) || !isText(address) || !isOptionalText(displayName)) {
+        return null;
+    }
+
+    return { role, address, displayName };
+}
+
+function parseReferences(value: unknown): readonly string[] | null {
+    if (!Array.isArray(value) || value.length > bounds.maximumReferences) {
+        return null;
+    }
+
+    const references: string[] = [];
+    for (const entry of value) {
+        if (!isText(entry)) {
+            return null;
+        }
+
+        references.push(entry);
+    }
+
+    return references;
+}
+
+function parseBodyForms(value: unknown): MailMessageBodyForms | null {
+    const record = asRecord(value);
+    if (record === null) {
+        return null;
+    }
+
+    const availability = record['availability'];
+    const plainText = record['plainText'];
+    const html = record['html'];
+
+    if (!isText(availability) || typeof plainText !== 'boolean' || typeof html !== 'boolean') {
+        return null;
+    }
+
+    return { availability, plainText, html };
+}
+
+function parseSenderVerdict(value: unknown): MailSenderVerdict | null {
+    const record = asRecord(value);
+    if (record === null) {
+        return null;
+    }
+
+    const authorAuthentication = record['authorAuthentication'];
+    const deploymentTrust = record['deploymentTrust'];
+    const authenticatedDomain = record['authenticatedDomain'] ?? null;
+
+    if (!isOneOf(authorAuthentication, authorAuthentications) || !isOneOf(deploymentTrust, deploymentTrusts)) {
+        return null;
+    }
+
+    if (!isOptionalText(authenticatedDomain)) {
+        return null;
+    }
+
+    return { authorAuthentication, deploymentTrust, authenticatedDomain };
+}
+
+function parseAttachments(value: unknown): readonly MailAttachment[] | null {
+    if (!Array.isArray(value) || value.length > bounds.maximumAttachments) {
+        return null;
+    }
+
+    const attachments: MailAttachment[] = [];
+    for (const entry of value) {
+        const attachment = parseAttachment(entry);
+        if (attachment === null) {
+            return null;
+        }
+
+        attachments.push(attachment);
+    }
+
+    return attachments;
+}
+
+function parseAttachment(value: unknown): MailAttachment | null {
+    const record = asRecord(value);
+    if (record === null) {
+        return null;
+    }
+
+    const position = record['position'];
+    const fileName = record['fileName'] ?? null;
+    const wasFileNameNormalized = record['wasFileNameNormalized'];
+    const mediaType = record['mediaType'];
+    const sizeOctets = record['sizeOctets'];
+
+    if (!isCount(position) || typeof wasFileNameNormalized !== 'boolean' || !isCount(sizeOctets)) {
+        return null;
+    }
+
+    if (fileName !== null && (!isText(fileName) || fileName.length > bounds.maximumFileNameLength)) {
+        return null;
+    }
+
+    if (!isText(mediaType) || mediaType.length > bounds.maximumMediaTypeLength) {
+        return null;
+    }
+
+    return { position, fileName, wasFileNameNormalized, mediaType, sizeOctets };
+}
+
+// Answers `undefined` for a shape it refuses, because `null` is one of the two answers the service legitimately gives:
+// a message whose parts nothing has ever read carries no counts at all.
+function parseCarried(value: unknown): MailCarried | null | undefined {
+    if (value === null) {
+        return null;
+    }
+
+    const record = asRecord(value);
+    if (record === null) {
+        return undefined;
+    }
+
+    const attachmentCount = record['attachmentCount'];
+    const totalSizeOctets = record['totalSizeOctets'];
+    const inlineResourceCount = record['inlineResourceCount'];
+    const encrypted = record['encrypted'];
+    const unverifiedSignature = record['unverifiedSignature'];
+    const unexpandedTnefPart = record['unexpandedTnefPart'];
+
+    if (!isCount(attachmentCount) || !isCount(totalSizeOctets) || !isCount(inlineResourceCount)) {
+        return undefined;
+    }
+
+    if (
+        typeof encrypted !== 'boolean' ||
+        typeof unverifiedSignature !== 'boolean' ||
+        typeof unexpandedTnefPart !== 'boolean'
+    ) {
+        return undefined;
+    }
+
+    return {
+        attachmentCount,
+        totalSizeOctets,
+        inlineResourceCount,
+        encrypted,
+        unverifiedSignature,
+        unexpandedTnefPart,
+    };
+}
+
+function asRecord(value: unknown): Readonly<Record<string, unknown>> | null {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+        ? (value as Record<string, unknown>)
+        : null;
+}
+
+function isText(value: unknown): value is string {
+    return typeof value === 'string' && value.length <= bounds.maximumTextLength;
+}
+
+function isOptionalText(value: unknown): value is string | null {
+    return value === null || isText(value);
+}
+
+function isCount(value: unknown): value is number {
+    return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+}
+
+function isOneOf<TValue extends string>(value: unknown, members: readonly TValue[]): value is TValue {
+    return typeof value === 'string' && members.includes(value as TValue);
+}

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -169,10 +169,52 @@ function messageBody(remoteImages: boolean): string {
     });
 }
 
-// The heading the message below carries. The sender wrote it as their own first-level heading and the space it is
-// drawn in already holds the only first-level heading on the screen, so the pane draws it one deeper — which is the
-// assertion in the level rather than an accident of the fixture.
-const messageHeading = { name: 'This week at Example', level: 2 } as const;
+// The heading the message below carries. The sender wrote it as their own first-level heading, and two levels above it
+// are already taken — the space's own title and the subject the reading pane draws — so the pane draws it two deeper,
+// which is the assertion in the level rather than an accident of the fixture.
+const messageHeading = { name: 'This week at Example', level: 3 } as const;
+
+/** The subject the message below carries, which is what names the region the pane draws it in. */
+const messageRegion = { name: 'A newsletter from Example' } as const;
+
+/** What the attachment below holds, small enough to state here and large enough to arrive in more than nothing. */
+const attachedOctets = 'order,quantity\nkettle,1\n';
+
+/** What the message route answers with: everything the pane draws around a body it never carries. */
+const messageDescription = JSON.stringify({
+    storedEmailId: '00000000-0000-4000-8000-000000000000',
+    account: 'work',
+    folder: 'INBOX',
+    threadId: null,
+    sizeOctets: 40_960,
+    headers: {
+        subject: messageRegion.name,
+        sentAt: '2026-08-31T09:41:00+00:00',
+        receivedAt: '2026-08-31T09:41:10+00:00',
+        participants: [
+            { role: 'From', address: 'news@example.invalid', displayName: 'Example' },
+            { role: 'To', address: 'reader@example.invalid', displayName: null },
+        ],
+        messageId: 'abc@example.invalid',
+        inReplyTo: null,
+        references: [],
+    },
+    body: { availability: 'Readable', plainText: true, html: true },
+    sender: { authorAuthentication: 'Authenticated', deploymentTrust: 'Unknown', authenticatedDomain: null },
+    attachments: [
+        {
+            position: 0,
+            fileName: 'orders.csv',
+            wasFileNameNormalized: false,
+            mediaType: 'text/csv',
+            sizeOctets: attachedOctets.length,
+        },
+    ],
+    carried: null,
+    unread: true,
+    flagged: false,
+    answered: false,
+});
 
 interface Box {
     readonly x: number;
@@ -202,6 +244,21 @@ async function boxOf(element: Locator): Promise<Box> {
  * bundle exactly as it would be against a service.
  */
 async function servedByADeployment(page: Page): Promise<void> {
+    await page.route('**/api/client/messages/*', (route) =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: messageDescription }),
+    );
+
+    // The one route that answers with octets rather than with JSON, which is what makes a real download something this
+    // suite can watch: the built bundle composes the request, sends it with the credential it holds, reads the stream,
+    // and hands the browser a file — none of which jsdom has any of.
+    await page.route('**/api/client/messages/*/attachments/*', (route) =>
+        route.fulfill({
+            status: 200,
+            contentType: 'text/csv',
+            body: attachedOctets,
+        }),
+    );
+
     await page.route('**/api/client/session', (route) =>
         route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(sessionAnswer) }),
     );
@@ -529,7 +586,7 @@ test('issues every request to the origin it was served from and to no other', as
 test('draws the message as this document own elements, with nothing a sender wrote becoming one', async ({ page }) => {
     await openSignedIn(page, '/#/mail');
 
-    const message = page.getByRole('article');
+    const message = page.getByRole('article', messageRegion);
     await expect(message.getByRole('heading', messageHeading)).toBeVisible();
 
     // The isolation statement is an absence, so it is asserted as one. A frame, a script, an embedded object, or a
@@ -546,7 +603,7 @@ test('draws the message as this document own elements, with nothing a sender wro
 test('shows where a link goes, and says so when its words name somewhere else', async ({ page }) => {
     await openSignedIn(page, '/#/mail');
 
-    const message = page.getByRole('article');
+    const message = page.getByRole('article', messageRegion);
 
     await expect(message.getByText('goes to offers.invalid', { exact: true })).toBeVisible();
     await expect(
@@ -575,6 +632,54 @@ test('leaves the application when a link is followed rather than navigating it',
     // nothing whenever `noopener` was asked for, so a client reading that answer as a refusal would put this sentence
     // under every link that worked — and every unit test of it would still pass.
     await expect(page.getByText('This link could not be opened.')).toHaveCount(0);
+});
+
+test('describes an attached file before it is fetched, and fetches it only when it is asked for', async ({ page }) => {
+    const downloads: string[] = [];
+
+    page.on('request', (request) => {
+        if (request.url().includes('/attachments/')) {
+            downloads.push(request.url());
+        }
+    });
+
+    await openSignedIn(page, '/#/mail');
+
+    const download = page.getByRole('button', { name: 'Download orders.csv' });
+    await expect(download).toBeVisible();
+    await expect(page.getByText('text/csv')).toBeVisible();
+
+    // Nothing about the file has been fetched at this point, which is what keeps opening a message the same cost
+    // whether the sender attached a note or a video. Only a browser can say so: the source says what the pane intends
+    // and this says what the built bundle actually put on the wire.
+    expect(downloads).toStrictEqual([]);
+
+    const offered = page.waitForEvent('download');
+    await download.click();
+
+    // The file reaches the person as a file rather than as a page, which is a browser event and nothing jsdom has.
+    expect((await offered).suggestedFilename()).toBe('orders.csv');
+    await expect(page.getByText('orders.csv was downloaded.')).toBeVisible();
+});
+
+test('presents the credential the bundle composed when it fetches an attached file', async ({ page }) => {
+    const presented: (string | undefined)[] = [];
+
+    await openSignedIn(page, '/#/mail');
+
+    // Registered after the deployment's own routes so this one wins for the attachment, which is what lets the header
+    // the built bundle actually sent be read rather than inferred from the source.
+    await page.route('**/api/client/messages/*/attachments/*', async (route) => {
+        presented.push(route.request().headers()['authorization']);
+
+        await route.fulfill({ status: 200, contentType: 'text/csv', body: attachedOctets });
+    });
+
+    const offered = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Download orders.csv' }).click();
+    await offered;
+
+    expect(presented).toStrictEqual([expectedAuthorization]);
 });
 
 test('fetches nothing from the sender until the reader asks, and asks again next time', async ({ page }) => {


### PR DESCRIPTION
Closes #1426

The reading pane is what the rest of the client existed to reach. It draws one message out of two reads that answer separately — the description above, the body beneath it — so the header block is on the screen whatever the body costs, and that partial state is designed rather than a gap. Both reads are `GET`s against the local copy: opening a message sets no remote flag, and nothing here writes to a mailbox.

## What is on the screen

- **Headers.** Subject, the author on its own line as `Name <address>` because a display name alone is how the wrong sender goes unnoticed, the sent instant through `Intl.DateTimeFormat`, and everybody else the message names inside a native `<details>` grouped by role — a message addressed to two hundred people is not a screen of addresses in front of the words somebody opened it to read. Every value is drawn as text, never as markup.
- **The sender verdict**, drawn only where it says something: an authentication that failed, or an author this deployment recognizes. Authenticated-and-unnamed is the ordinary state of legitimate mail and is therefore silent. It names the domain that actually authenticated rather than the `From` value the message displays.
- **The body**, which is `messageBody/`'s existing work, now mounted inside the pane. Its headings start at `h3` so a sender's own heading sits under the pane's subject rather than beside it.
- **The files a message carries** — name, media type, size — described before an octet is fetched, so opening a message costs the same whether the sender attached a note or a video. Downloading is per file, with progress, a way to stop, and a sentence for each way it can end.
- **A selection** in the body becomes the scope the intent field asks its next question under, quoted so what the question is about is readable before it is asked, with the way back to the whole message beside it. It is bounded, trimmed, and dropped when the message changes.

## The break

`ClientMailSenderVerdictResponse` on `GET /api/client/messages/{storedEmailId}` gains a third field, `authenticatedDomain` — the domain the receiving mail server authenticated, `null` where nothing authenticated a sender. Without it the client could not satisfy the issue's requirement to name the authenticated author rather than the raw `From` value: the two enums say *that* something was established, never *for whom*.

It is **additive**, so an existing reader of that route is unaffected and no operator action follows. `backend/tests/PublicSurfaces.UnitTests/http-api-contract.json` moved with it. The value is read back as it was stored — nothing on that path re-reads a header, resolves DNS, or evaluates a policy — and the client states it and never compares it against the displayed address, because that comparison is exactly the policy the service deliberately does not evaluate.

## Where the octets are read

`MailFathomTransport` answers with text, so it cannot carry a file. The contract half stays in `Client.Backend` — `mailAttachmentRequest` composes the route, the credential, the `Accept` header, and the bound — and the streaming half is `Client.App/src/deployment/attachmentDelivery.ts`, beside `sendToDeployment.ts`, which is now the whole of what calls `fetch` in this client. It reads in chunks so the progress a reader watches is real rather than a guess, refuses an answer larger than the message described, tells an interrupted connection apart from an oversized one, abandons on request, and offers the file as `application/octet-stream` so a blob URL cannot become a scripted page on its own origin — the same reason the service serves every download with `Content-Disposition: attachment` and `nosniff`. The delivery is an operation the composition root resolves and every row below receives through `AttachmentDeliveryContext`, in the shape `shellOperations/linkOpener.ts` already holds — which is also what lets the suite prove the behaviour without patching `fetch` or `URL.createObjectURL`.

## The acceptance criteria

Headers, body, inline parts resolved by the service, and the attachment list are drawn; the verdict names the authenticated author and is quiet where it says nothing; a file is described before it is fetched and downloaded only on request, with progress and cancellation; a file name is reduced to something safe to write and displayed values are drawn as text; plain text is complete in its own right; a selection is application state the intent field reads; the five states are distinct; every control has a name and a keyboard path; focus goes to the opened message on a view change and nowhere on the first landing; nothing writes to a mailbox; and no mail content, subject, or address reaches a log, an error message, or telemetry.

## Verification

- `scripts/verify-full.sh` — passed, recorded 2026-09-01T13:35:12Z, 284 workflow assertions.
- `pnpm test` — 39 files, 613 tests. `pnpm test:browser` — 21 tests, including a real Chromium download asserted through `waitForEvent('download')` and its suggested file name, and the credential the bundle presents when it fetches one.
- `backend/tests/Host.UnitTests` and `backend/tests/PublicSurfaces.UnitTests` pass with the regenerated contract.

`attachmentDelivery.ts` carries no unit coverage by design: it is the `fetch` adapter, which the client's test contract forbids faking, so the browser suite is what proves it.

