### PR TITLE
[#1424] Draw the scope as a windowed message list

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -221,14 +221,39 @@ nothing configured.
 
 `src/workspace/` is what survives moving between spaces, and it is mounted above the frame for exactly that reason. It
 holds one **scope** — every mailbox at once, one role across all of them, one mailbox, or one folder of one — beside the
-question, the selection, and the rows of the folder tree somebody has folded away. It is kept in the store the web head
-keeps its credential in, so a reload returns to what was on the screen; signing out empties it, because what somebody
-was looking at and about to ask is theirs rather than the machine's.
+question, the message that is open, the messages that have been picked out, and the rows of the folder tree somebody has
+folded away. It is kept in the store the web head keeps its credential in, so a reload returns to what was on the
+screen; signing in and signing out both empty it, because what somebody was looking at and about to ask is theirs rather
+than the machine's.
 
 `src/folders/` is what writes that scope. It draws the owner's mailboxes and their folders as one tree, read from the
 folders route in a single exchange, with the roles that span every mailbox above them — so asking about every inbox at
 once is one act rather than three. A folder is placed and named by the role the deployment gave it rather than by what
 its server calls it, because a name is whatever a provider chose in whatever language.
+
+`src/messageList/` is what that scope is drawn as. It reads `/api/client/emails`, which is keyset-paged in both
+directions, and it is where the client's three hardest constraints meet: a mailbox of two hundred and fourteen thousand
+messages that has to stay smooth, a reading position that has to survive leaving the folder and reloading, and a
+multi-selection the rest of the client reads as scope for the question it is about to ask.
+
+Three bounds hold that up, and each is one module. **The document holds a window of rows rather than the folder** —
+`timelineWindow.ts` is arithmetic over four numbers, and the number of rows in the document is the same on the first
+screen as at message forty thousand. **The list holds a window of pages rather than every page it has read** —
+`heldTimeline.ts`; a page too far from the reader keeps its place and its cursor but loses its rows, so the list keeps
+its height, nothing under the reader moves, and scrolling back into it reads that page again from its own cursor rather
+than reading the folder from its leading end. **Where the reader is lives outside React** — `rememberedListings.ts`,
+keyed by the deployment and the folder, holding a cursor, a row, an order, and the filters together so a cursor cannot
+outlive the list it was issued for, and holding nothing about any message.
+
+**No package windows it, and that is a measurement rather than a preference.** Every row of this list is one height,
+because the row is a fixed two lines by design — who wrote and when, then what about and how it opens — and the browser
+suite asserts that every drawn row measures the same. What a virtualizer buys over sixty lines of arithmetic is the
+machinery for measuring rows that are _not_ one height, which this list has no use for; what it costs is a dependency,
+a licence review, and a census in
+[the third-party register](../THIRD_PARTY_LICENSES.md). So the arithmetic stays, the one height it depends on is
+measured off a rendered row rather than written down twice, and the assertion that keeps it true runs on every pull
+request. A row that ever stops being one height is the argument for reopening this, and it fails a test rather than
+degrading quietly.
 
 ## Styling, and the two themes
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -246,10 +246,10 @@ keyed by the deployment and the folder, holding a cursor, a row, an order, and t
 outlive the list it was issued for, and holding nothing about any message.
 
 **No package windows it, and that is a measurement rather than a preference.** Every row of this list is one height,
-because the row is a fixed two lines by design — who wrote and when, then what about and how it opens — and the browser
-suite asserts that every drawn row measures the same. What a virtualizer buys over sixty lines of arithmetic is the
-machinery for measuring rows that are _not_ one height, which this list has no use for; what it costs is a dependency,
-a licence review, and a census in
+because the row is a fixed three lines by design — who wrote, what about, and the line stage 3 fills with what
+MailFathom made of the message — and the browser suite asserts that every drawn row measures the same. What a
+virtualizer buys over sixty lines of arithmetic is the machinery for measuring rows that are _not_ one height, which
+this list has no use for; what it costs is a dependency, a licence review, and a census in
 [the third-party register](../THIRD_PARTY_LICENSES.md). So the arithmetic stays, the one height it depends on is
 measured off a rendered row rather than written down twice, and the assertion that keeps it true runs on every pull
 request. A row that ever stops being one height is the argument for reopening this, and it fails a test rather than

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -245,6 +245,10 @@ than reading the folder from its leading end. **Where the reader is lives outsid
 keyed by the deployment and the folder, holding a cursor, a row, an order, and the filters together so a cursor cannot
 outlive the list it was issued for, and holding nothing about any message.
 
+What a row opens is what the reading pane beside it draws. The list writes the message into the workspace and the pane
+reads it from there, so the two meet over one value rather than over each other — and nothing is open until a reader
+has opened it.
+
 **No package windows it, and that is a measurement rather than a preference.** Every row of this list is one height,
 because the row is a fixed three lines by design — who wrote, what about, and the line stage 3 fills with what
 MailFathom made of the message — and the browser suite asserts that every drawn row measures the same. What a

--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -70,6 +70,13 @@ function routesAsked(): string[] {
     return [...new Set(asked.map((request) => request.path))];
 }
 
+// The folder the message list reads once Mail is on the screen. Empty, because what these tests are about is the frame
+// rather than the list: the list has its own file, and a folder with mail in it here would be a second copy of it.
+const emptyFolder: Answer = {
+    status: 200,
+    body: JSON.stringify({ emails: [], nextCursor: null, previousCursor: null, pageSize: 100 }),
+};
+
 /** A deployment that accepts any credential and answers the session and the accounts with what a test named. */
 function deploymentAnswering(
     accounts: Answer = directory(true, [workAccount]),
@@ -77,6 +84,10 @@ function deploymentAnswering(
 ): DeploymentTransport {
     return () => (request) => {
         asked.push(request);
+
+        if (request.path.includes('/emails')) {
+            return Promise.resolve(complete(emptyFolder));
+        }
 
         return Promise.resolve(complete(request.path.endsWith('/session') ? session : accounts));
     };
@@ -1005,6 +1016,29 @@ describe('App deployment', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Point somewhere else' }));
 
         expect(document.activeElement).toBe(screen.getByRole('textbox', { name: 'Deployment address' }));
+    });
+
+    it('starts an empty workspace when somebody signs in, rather than handing them the last person’s', async () => {
+        // Written before the provider mounts, which is how a tab that was not signed out keeps what was on the screen:
+        // a second person signing into the same tab must not find the first one's question, mailbox, or reading
+        // position waiting for them.
+        window.sessionStorage.setItem(
+            'mailfathom.workspace',
+            JSON.stringify({
+                scope: { kind: 'account', accountId: 'work' },
+                collapsed: [],
+                selection: 'AAMkAD-42',
+                selected: ['AAMkAD-42'],
+                question: 'what did the last person ask',
+            }),
+        );
+
+        renderApp(servedFrom, null);
+        signIn();
+        await framed();
+
+        expect(screen.getByRole('searchbox', { name: 'Ask your mail' })).toHaveProperty('value', '');
+        expect(screen.getByRole('combobox', { name: 'Mailbox in scope' })).toHaveProperty('value', '');
     });
 
     it('signs in against the next deployment of its own, and never reads the one before it again', async () => {

--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -149,6 +149,38 @@ const describedMessage: Answer = {
     }),
 };
 
+// The folder the message the pane draws stands in, so that opening it is the act it is in the client: a reader picks a
+// row out of the list, and the pane draws what that row named.
+const folderWithOneMessage: Answer = {
+    status: 200,
+    body: JSON.stringify({
+        emails: [
+            {
+                id: '00000000-0000-4000-8000-000000000000',
+                account: 'work',
+                folder: 'INBOX',
+                threadId: null,
+                subject: 'Quarterly invoice',
+                receivedAt: '2026-08-31T09:41:10+00:00',
+                sentAt: '2026-08-31T09:41:00+00:00',
+                senderAddress: 'billing@example.invalid',
+                senderDisplayName: 'Billing',
+                toAddresses: ['owner@example.invalid'],
+                unread: true,
+                flagged: false,
+                answered: false,
+                hasAttachments: false,
+                attachmentCount: 0,
+                sizeOctets: 4_096,
+                preview: 'The invoice for August.',
+            },
+        ],
+        nextCursor: null,
+        previousCursor: null,
+        pageSize: 100,
+    }),
+};
+
 /**
  * A deployment that answers the accounts as the one above does, and both reads the reading pane in Mail makes.
  *
@@ -159,6 +191,12 @@ function deploymentDrawingAMessage(): DeploymentTransport {
     const otherwise = deploymentAnswering();
 
     return (signal) => (request) => {
+        if (request.path.includes('/emails')) {
+            asked.push(request);
+
+            return Promise.resolve(complete(folderWithOneMessage));
+        }
+
         if (!request.path.includes('/messages/')) {
             return otherwise(signal)(request);
         }
@@ -356,13 +394,27 @@ describe('App', () => {
         expect(await screen.findByRole('heading', { name: space, level: 1 })).toBeDefined();
     });
 
-    it('draws the message the reading pane read, once Mail is the space on the screen', async () => {
+    it('draws the message a row of the list opened, which is what the frame wires the two together for', async () => {
         renderApp(servedFrom, heldCredential, deploymentDrawingAMessage());
         await framed();
 
         await goTo('Mail');
 
+        const list = await screen.findByRole('listbox', { name: 'Messages' });
+        fireEvent.pointerDown(within(list).getByRole('option', { name: /Quarterly invoice/ }));
+
         expect(await screen.findByText('A drawn message.')).toBeDefined();
+    });
+
+    it('draws no message until a row of the list opens one', async () => {
+        renderApp(servedFrom, heldCredential, deploymentDrawingAMessage());
+        await framed();
+
+        await goTo('Mail');
+        await screen.findByRole('listbox', { name: 'Messages' });
+
+        expect(screen.getByText('Open a message to read it here.')).toBeDefined();
+        expect(routesAsked().some((path) => path.includes('/messages/'))).toBe(false);
     });
 
     it('reads no message while the space on the screen is not Mail', async () => {

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -9,6 +9,8 @@ import { forgetDeployment, storeDeployment, type AdoptedDeployment } from './dep
 import type { DeploymentTransport } from './deployment/sendToDeployment';
 import { FolderTree } from './folders/FolderTree';
 import { useLocalization } from './localization/useLocalization';
+import { MessageList } from './messageList/MessageList';
+import { forgetListings } from './messageList/rememberedListings';
 import { ReadingPane } from './readingPane/ReadingPane';
 import { useSpace } from './routing/useSpace';
 import { offers, spacesOffered, withheldFrom } from './shell/capabilities';
@@ -22,13 +24,8 @@ import { useConnection } from './shell/useConnection';
 import { CredentialNotices, type CredentialNotice } from './signIn/CredentialNotices';
 import type { CredentialStore } from './signIn/credentialStore';
 import { SignIn } from './signIn/SignIn';
-import { emptyWorkspace } from './workspace/useWorkspace';
-import { useWorkspace } from './workspace/useWorkspace';
-
-// Which message the reading pane draws is the message list's to decide, and that list is not built yet. Until it is,
-// the Mail space opens one message by identifier — which is what makes the pane reachable in a browser at all, and is
-// the only reason this constant is here rather than a value the screen was handed.
-const provingRead = '00000000-0000-4000-8000-000000000000';
+import { scopeKey } from './workspace/mailScope';
+import { emptyWorkspace, useWorkspace } from './workspace/useWorkspace';
 
 // The frame Discover, Mail, and Cases are held in, and the only thing in the client that survives moving between them.
 // It is one tree laid out two ways by the width it is given — a rail beside a workspace, or bottom navigation under a
@@ -53,12 +50,12 @@ export function App({
     readonly credentials: CredentialStore;
     readonly send: DeploymentTransport;
 }) {
-    const { revise } = useWorkspace();
+    const { workspace, revise } = useWorkspace();
     const [adopted, setAdopted] = useState(deployment);
     const [authorization, setAuthorization] = useState(signedInWith);
     const [notices, setNotices] = useState<readonly CredentialNotice[]>([]);
     const baseAddress = adopted === null ? null : adopted.deployment.baseAddress;
-    const workspace = useRef<HTMLDivElement>(null);
+    const workspaceRegion = useRef<HTMLDivElement>(null);
     const focusedFor = useRef(authorization);
 
     // Built once per address and credential rather than per render, because it is what the message read below depends
@@ -93,7 +90,7 @@ export function App({
         focusedFor.current = authorization;
 
         if (authorization !== null) {
-            workspace.current?.focus();
+            workspaceRegion.current?.focus();
         }
     }, [authorization]);
 
@@ -107,6 +104,7 @@ export function App({
         setNotices(['credentialNoLongerAccepted']);
         setAuthorization(null);
         revise(emptyWorkspace);
+        forgetListings();
 
         if (baseAddress === null) {
             return;
@@ -138,6 +136,12 @@ export function App({
 
         setNotices([]);
 
+        // Signing in is somebody arriving rather than somebody returning: a tab whose credential was not kept can be
+        // signed into by a second person, and what the first one was looking at and where they were reading is theirs.
+        // A reload of a signed-in client does not pass through here, so what survives a reload still survives one.
+        revise(emptyWorkspace);
+        forgetListings();
+
         // The screen has already said how long the password will be kept, so a store that refused the write says so
         // rather than leaving somebody to discover it by being asked for the password again at the next start. This
         // one is read inside the frame: signing in worked, and what failed is only the keeping.
@@ -160,6 +164,7 @@ export function App({
         setNotices([]);
         setAuthorization(null);
         revise(emptyWorkspace);
+        forgetListings();
 
         if (adopted !== null) {
             void credentials.forget(adopted.deployment).then((removed) => {
@@ -192,7 +197,7 @@ export function App({
 
     return (
         <div className="flex h-dvh flex-col bg-rail pt-safe-top pr-safe-right pb-safe-bottom pl-safe-left workspace:flex-row">
-            <div ref={workspace} tabIndex={-1} className="flex min-h-0 min-w-0 flex-1 flex-col bg-page">
+            <div ref={workspaceRegion} tabIndex={-1} className="flex min-h-0 min-w-0 flex-1 flex-col bg-page">
                 <header className="flex flex-wrap items-center gap-3 border-b border-line-soft bg-panel px-4 py-2 workspace:px-8">
                     <ConnectionSummary connection={connection} />
 
@@ -238,12 +243,27 @@ export function App({
                                 <FolderTree session={session} transport={readMail} online={connection.online} />
                             )
                         }
+                        list={
+                            session === null || !readsMail ? null : (
+                                // Keyed by the scope, so pointing at another mailbox starts a list rather than resets
+                                // one: every value the list holds belongs to one folder read one way, and there is no
+                                // correct way to carry any of it across.
+                                <MessageList
+                                    key={scopeKey(workspace.scope)}
+                                    session={session}
+                                    transport={readMail}
+                                    scope={workspace.scope}
+                                    accounts={mailAccounts}
+                                    online={connection.online}
+                                />
+                            )
+                        }
                         mail={
                             session === null ? null : (
                                 <ReadingPane
                                     session={session}
                                     transport={readMail}
-                                    storedEmailId={provingRead}
+                                    storedEmailId={workspace.selection}
                                     online={connection.online}
                                 />
                             )

--- a/frontend/src/Client.App/src/controls/CheckControl.tsx
+++ b/frontend/src/Client.App/src/controls/CheckControl.tsx
@@ -1,0 +1,40 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+// The one shape a control that is on or off has: a checkbox and its words in a box that fills while it is on. Two
+// surfaces need it — each of the list's narrowings, and the mode that picks several messages out under a finger — and
+// a second arrangement of the same utilities is how the two would stop looking like one product.
+//
+// A checkbox rather than a button that looks pressed, because whether it is on is what a reader has to be able to see
+// and what a screen reader has to be able to say, and that is what the platform's own control already answers.
+//
+// It sits here beside `SecondaryButton` rather than in the screen that needed it first, for the reason stated there: a
+// screen may reach what is shared, and what is shared reaches no screen.
+
+const checkable =
+    'flex cursor-pointer items-center gap-1.5 rounded-md border border-line bg-panel px-2 py-1 text-sm text-text-soft transition hover:bg-hover';
+
+export function CheckControl({
+    label,
+    on,
+    onChange,
+}: {
+    readonly label: string;
+    readonly on: boolean;
+    readonly onChange: (on: boolean) => void;
+}) {
+    return (
+        <label className={`${checkable} ${on ? 'bg-accent-soft text-accent-strong' : ''}`}>
+            <input
+                type="checkbox"
+                className="accent-accent"
+                checked={on}
+                onChange={(event) => {
+                    onChange(event.target.checked);
+                }}
+            />
+            {label}
+        </label>
+    );
+}

--- a/frontend/src/Client.App/src/controls/CheckControl.tsx
+++ b/frontend/src/Client.App/src/controls/CheckControl.tsx
@@ -12,8 +12,9 @@
 // It sits here beside `SecondaryButton` rather than in the screen that needed it first, for the reason stated there: a
 // screen may reach what is shared, and what is shared reaches no screen.
 
-const checkable =
-    'flex cursor-pointer items-center gap-1.5 rounded-md border border-line bg-panel px-2 py-1 text-sm text-text-soft transition hover:bg-hover';
+import { borderedControl } from './chrome';
+
+const checkable = `flex cursor-pointer items-center gap-1.5 px-2 py-1 text-sm ${borderedControl}`;
 
 export function CheckControl({
     label,

--- a/frontend/src/Client.App/src/controls/SecondaryButton.tsx
+++ b/frontend/src/Client.App/src/controls/SecondaryButton.tsx
@@ -10,6 +10,8 @@
 // It sits here rather than in `shell/` because two of the four are on the sign-in screen, which is not the frame: a
 // screen may reach what is shared, and what is shared reaches no screen.
 
+import { borderedControl } from './chrome';
+
 /**
  * How much room the button takes, which is the one thing its four callers genuinely differ on.
  *
@@ -23,8 +25,6 @@ const shapes: Readonly<Record<SecondaryButtonShape, string>> = {
     form: 'px-4 py-2 font-medium',
 };
 
-const secondary = 'rounded-md border border-line bg-panel text-text-soft transition hover:bg-hover';
-
 export function SecondaryButton({
     label,
     shape = 'compact',
@@ -35,7 +35,7 @@ export function SecondaryButton({
     readonly onActivate: () => void;
 }) {
     return (
-        <button className={`${secondary} ${shapes[shape]}`} type="button" onClick={onActivate}>
+        <button className={`${borderedControl} ${shapes[shape]}`} type="button" onClick={onActivate}>
             {label}
         </button>
     );

--- a/frontend/src/Client.App/src/controls/chrome.ts
+++ b/frontend/src/Client.App/src/controls/chrome.ts
@@ -1,0 +1,14 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+/**
+ * What every bordered control standing on a panel is drawn with: the corner, the line around it, the fill, the weight
+ * its words are set in, and what it becomes under a pointer.
+ *
+ * Stated once because three controls draw it — a secondary button, a checkbox that reads as a control, and the list's
+ * order chooser — and a restyle of that look made in one of them would leave the other two behind. What is deliberately
+ * not here is the padding and the type size: a button standing beside a submit and a checkbox on a filter line do not
+ * agree on those, so each states its own.
+ */
+export const borderedControl = 'rounded-md border border-line bg-panel text-text-soft transition hover:bg-hover';

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -113,6 +113,37 @@ export const en = {
     'folder.all': 'All mail',
     'folder.outbox': 'Outbox',
 
+    'list.label': 'Messages',
+    'list.reading': 'Reading your mail…',
+    'list.readingMore': 'Reading more…',
+    'list.rowArriving': 'Reading this message again…',
+    'list.wholeFolderRead': 'That is the whole of this folder.',
+    'list.failed': 'This folder could not be read: {reason}.',
+    'list.partiallyFailed': 'Part of this folder could not be read: {reason}.',
+    'list.emptyFolder': 'There is no mail in this folder.',
+    'list.nothingMatches': 'No message in this folder matches what the list is narrowed to.',
+    'list.notSynchronizedYet':
+        'Nothing has been taken into this deployment from this mailbox yet, so there is nothing to show. The folder is not empty — it has not been read.',
+    'list.emptyWhileFailing':
+        'This mailbox stopped synchronizing, so what is here may be less than the mail server holds.',
+
+    'list.order': 'Order',
+    'list.newestFirst': 'Newest first',
+    'list.oldestFirst': 'Oldest first',
+    'list.onlyUnread': 'Only unread',
+    'list.onlyFlagged': 'Only flagged',
+    'list.onlyWithAttachments': 'Only with attachments',
+    'list.includeJunk': 'Include junk',
+    'list.selectSeveral': 'Select several',
+    'list.selectedCount': '{count} selected',
+
+    'list.unread': 'Unread',
+    'list.flagged': 'Flagged',
+    'list.answered': 'Answered',
+    'list.attachments': '{count} attached',
+    'list.noSubject': 'No subject',
+    'list.senderUnknown': 'No sender',
+
     'connection.current': 'Every account is up to date.',
     'connection.behind': 'Some accounts are behind.',
     'connection.failing': 'Some accounts stopped synchronizing.',

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -113,6 +113,37 @@ export const pl: Catalogue = {
     'folder.all': 'Cała poczta',
     'folder.outbox': 'Do wysłania',
 
+    'list.label': 'Wiadomości',
+    'list.reading': 'Wczytywanie poczty…',
+    'list.readingMore': 'Wczytywanie dalszych wiadomości…',
+    'list.rowArriving': 'Ponowne wczytywanie tej wiadomości…',
+    'list.wholeFolderRead': 'To już cały ten folder.',
+    'list.failed': 'Nie udało się odczytać tego folderu: {reason}.',
+    'list.partiallyFailed': 'Części tego folderu nie udało się odczytać: {reason}.',
+    'list.emptyFolder': 'W tym folderze nie ma poczty.',
+    'list.nothingMatches': 'Żadna wiadomość w tym folderze nie pasuje do zawężenia listy.',
+    'list.notSynchronizedYet':
+        'Do tego wdrożenia nie pobrano jeszcze niczego z tej skrzynki, więc nie ma czego pokazać. Folder nie jest pusty — nie został odczytany.',
+    'list.emptyWhileFailing':
+        'Ta skrzynka przestała się synchronizować, więc może tu być mniej wiadomości, niż ma serwer pocztowy.',
+
+    'list.order': 'Kolejność',
+    'list.newestFirst': 'Najnowsze na górze',
+    'list.oldestFirst': 'Najstarsze na górze',
+    'list.onlyUnread': 'Tylko nieprzeczytane',
+    'list.onlyFlagged': 'Tylko oznaczone',
+    'list.onlyWithAttachments': 'Tylko z załącznikami',
+    'list.includeJunk': 'Uwzględnij spam',
+    'list.selectSeveral': 'Zaznacz wiele',
+    'list.selectedCount': 'Zaznaczono: {count}',
+
+    'list.unread': 'Nieprzeczytana',
+    'list.flagged': 'Oznaczona',
+    'list.answered': 'Odpowiedziano',
+    'list.attachments': 'Załączniki: {count}',
+    'list.noSubject': 'Bez tematu',
+    'list.senderUnknown': 'Brak nadawcy',
+
     'connection.current': 'Wszystkie konta są aktualne.',
     'connection.behind': 'Część kont ma zaległości.',
     'connection.failing': 'Część kont przestała się synchronizować.',

--- a/frontend/src/Client.App/src/messageList/ListSettings.tsx
+++ b/frontend/src/Client.App/src/messageList/ListSettings.tsx
@@ -1,0 +1,130 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { MailTimelineOrder } from '@mailfathom/client-backend';
+import type { MessageKey } from '../localization/en';
+import { useLocalization } from '../localization/useLocalization';
+import type { MailListFilters, MailListing } from './listing';
+
+// How the folder in front of the reader is being read, stated on the screen rather than held somewhere they cannot see.
+// A list narrowed by a filter nobody can see is a folder that appears to have lost mail, which is the defect this
+// exists to prevent — so every filter in force is a control that is visibly on, and turning it off is one press.
+//
+// Each filter keeps one answer or both, and never only the other: "read", "unflagged", and "without attachments" are
+// not lists anybody asks for, and offering three states per filter would triple the controls to reach one nobody wants.
+
+const orderNames: Readonly<Record<MailTimelineOrder, MessageKey>> = {
+    newestFirst: 'list.newestFirst',
+    oldestFirst: 'list.oldestFirst',
+};
+
+const orders: readonly MailTimelineOrder[] = ['newestFirst', 'oldestFirst'];
+
+const control = 'rounded-md border border-line bg-panel px-2 py-1 text-sm text-text-soft transition hover:bg-hover';
+
+export function ListSettings({
+    listing,
+    junkAskable,
+    onRead,
+}: {
+    readonly listing: MailListing;
+    readonly junkAskable: boolean;
+    readonly onRead: (listing: MailListing) => void;
+}) {
+    const { translate } = useLocalization();
+
+    function narrow(change: Partial<MailListFilters>): void {
+        onRead({ ...listing, filters: { ...listing.filters, ...change } });
+    }
+
+    return (
+        <div className="flex flex-wrap items-center gap-2 border-b border-line-soft pb-2">
+            <select
+                aria-label={translate('list.order')}
+                className={control}
+                value={listing.order}
+                onChange={(event) => {
+                    if (isOrder(event.target.value)) {
+                        onRead({ ...listing, order: event.target.value });
+                    }
+                }}
+            >
+                {orders.map((offered) => (
+                    <option key={offered} value={offered}>
+                        {translate(orderNames[offered])}
+                    </option>
+                ))}
+            </select>
+
+            <Narrowing
+                label={translate('list.onlyUnread')}
+                on={listing.filters.unread === true}
+                onChange={(on) => {
+                    narrow({ unread: on ? true : null });
+                }}
+            />
+
+            <Narrowing
+                label={translate('list.onlyFlagged')}
+                on={listing.filters.flagged === true}
+                onChange={(on) => {
+                    narrow({ flagged: on ? true : null });
+                }}
+            />
+
+            <Narrowing
+                label={translate('list.onlyWithAttachments')}
+                on={listing.filters.hasAttachments === true}
+                onChange={(on) => {
+                    narrow({ hasAttachments: on ? true : null });
+                }}
+            />
+
+            {/* Offered only where the list spans folders. A reader who has pointed at one folder is already reading
+                that folder and nothing else, so a control saying whether junk takes part would be one that changes
+                nothing — which says less about why than not offering it does. */}
+            {junkAskable ? (
+                <Narrowing
+                    label={translate('list.includeJunk')}
+                    on={listing.filters.includeJunk}
+                    onChange={(on) => {
+                        narrow({ includeJunk: on });
+                    }}
+                />
+            ) : null}
+        </div>
+    );
+}
+
+// A filter as a checkbox rather than as a button that looks pressed: whether it is on is what a reader has to be able
+// to see and what a screen reader has to be able to say, and that is what the platform's own control already answers.
+function Narrowing({
+    label,
+    on,
+    onChange,
+}: {
+    readonly label: string;
+    readonly on: boolean;
+    readonly onChange: (on: boolean) => void;
+}) {
+    return (
+        <label
+            className={`flex cursor-pointer items-center gap-1.5 ${control} ${on ? 'bg-accent-soft text-accent-strong' : ''}`}
+        >
+            <input
+                type="checkbox"
+                className="accent-accent"
+                checked={on}
+                onChange={(event) => {
+                    onChange(event.target.checked);
+                }}
+            />
+            {label}
+        </label>
+    );
+}
+
+function isOrder(value: string): value is MailTimelineOrder {
+    return value === 'newestFirst' || value === 'oldestFirst';
+}

--- a/frontend/src/Client.App/src/messageList/ListSettings.tsx
+++ b/frontend/src/Client.App/src/messageList/ListSettings.tsx
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import type { MailTimelineOrder } from '@mailfathom/client-backend';
+import { CheckControl } from '../controls/CheckControl';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
 import type { MailListFilters, MailListing } from './listing';
@@ -57,7 +58,7 @@ export function ListSettings({
                 ))}
             </select>
 
-            <Narrowing
+            <CheckControl
                 label={translate('list.onlyUnread')}
                 on={listing.filters.unread === true}
                 onChange={(on) => {
@@ -65,7 +66,7 @@ export function ListSettings({
                 }}
             />
 
-            <Narrowing
+            <CheckControl
                 label={translate('list.onlyFlagged')}
                 on={listing.filters.flagged === true}
                 onChange={(on) => {
@@ -73,7 +74,7 @@ export function ListSettings({
                 }}
             />
 
-            <Narrowing
+            <CheckControl
                 label={translate('list.onlyWithAttachments')}
                 on={listing.filters.hasAttachments === true}
                 onChange={(on) => {
@@ -85,7 +86,7 @@ export function ListSettings({
                 that folder and nothing else, so a control saying whether junk takes part would be one that changes
                 nothing — which says less about why than not offering it does. */}
             {junkAskable ? (
-                <Narrowing
+                <CheckControl
                     label={translate('list.includeJunk')}
                     on={listing.filters.includeJunk}
                     onChange={(on) => {
@@ -94,34 +95,6 @@ export function ListSettings({
                 />
             ) : null}
         </div>
-    );
-}
-
-// A filter as a checkbox rather than as a button that looks pressed: whether it is on is what a reader has to be able
-// to see and what a screen reader has to be able to say, and that is what the platform's own control already answers.
-function Narrowing({
-    label,
-    on,
-    onChange,
-}: {
-    readonly label: string;
-    readonly on: boolean;
-    readonly onChange: (on: boolean) => void;
-}) {
-    return (
-        <label
-            className={`flex cursor-pointer items-center gap-1.5 ${control} ${on ? 'bg-accent-soft text-accent-strong' : ''}`}
-        >
-            <input
-                type="checkbox"
-                className="accent-accent"
-                checked={on}
-                onChange={(event) => {
-                    onChange(event.target.checked);
-                }}
-            />
-            {label}
-        </label>
     );
 }
 

--- a/frontend/src/Client.App/src/messageList/ListSettings.tsx
+++ b/frontend/src/Client.App/src/messageList/ListSettings.tsx
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import type { MailTimelineOrder } from '@mailfathom/client-backend';
+import { borderedControl } from '../controls/chrome';
 import { CheckControl } from '../controls/CheckControl';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
@@ -22,7 +23,7 @@ const orderNames: Readonly<Record<MailTimelineOrder, MessageKey>> = {
 
 const orders: readonly MailTimelineOrder[] = ['newestFirst', 'oldestFirst'];
 
-const control = 'rounded-md border border-line bg-panel px-2 py-1 text-sm text-text-soft transition hover:bg-hover';
+const control = `px-2 py-1 text-sm ${borderedControl}`;
 
 export function ListSettings({
     listing,

--- a/frontend/src/Client.App/src/messageList/MessageList.test.tsx
+++ b/frontend/src/Client.App/src/messageList/MessageList.test.tsx
@@ -1,0 +1,509 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { ReactElement } from 'react';
+import { fireEvent, render, screen, within, type RenderResult } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { ClientRequest, ClientSession, MailAccount, MailFathomTransport } from '@mailfathom/client-backend';
+import { LocalizationProvider } from '../localization/Localization';
+import { everything, type MailScope } from '../workspace/mailScope';
+import { WorkspaceProvider } from '../workspace/Workspace';
+import { useWorkspace, type Workspace } from '../workspace/useWorkspace';
+import { rowsPerPage } from './listing';
+import { MessageList } from './MessageList';
+import { rememberedListing, rememberListing } from './rememberedListings';
+
+const session: ClientSession = { baseAddress: 'https://mail.example.invalid', authorization: 'Basic dGVzdA==' };
+
+const work: MailAccount = {
+    id: 'work',
+    displayName: 'Work',
+    synchronizationState: 'Synchronized',
+    lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
+    behind: false,
+};
+
+function message(at: number, carried: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+        id: `message-${String(at)}`,
+        account: 'work',
+        folder: 'INBOX',
+        threadId: null,
+        subject: `Message ${String(at)}`,
+        receivedAt: '2026-08-31T09:41:00+00:00',
+        sentAt: null,
+        senderAddress: `writer-${String(at)}@nordwind.example`,
+        senderDisplayName: `Writer ${String(at)}`,
+        toAddresses: ['owner@example.invalid'],
+        unread: false,
+        flagged: false,
+        answered: false,
+        hasAttachments: false,
+        attachmentCount: 0,
+        sizeOctets: 1_024,
+        preview: `The opening of message ${String(at)}.`,
+        ...carried,
+    };
+}
+
+function pageOf(rows: readonly unknown[], cursors: Record<string, unknown> = {}): string {
+    return JSON.stringify({
+        emails: rows,
+        nextCursor: null,
+        previousCursor: null,
+        pageSize: rowsPerPage,
+        ...cursors,
+    });
+}
+
+const wholeFolder = pageOf(Array.from({ length: rowsPerPage }, (_, at) => message(at)));
+
+function answering(body: string, status = 200): MailFathomTransport {
+    return () => Promise.resolve({ status, body, headers: {} });
+}
+
+function recording(body: string): { transport: MailFathomTransport; requests: ClientRequest[] } {
+    const requests: ClientRequest[] = [];
+
+    return {
+        requests,
+        transport: (request) => {
+            requests.push(request);
+
+            return Promise.resolve({ status: 200, body, headers: {} });
+        },
+    };
+}
+
+// What the list wrote, read back the way the rest of the client will read it: out of the workspace rather than out of
+// the component that wrote it.
+function SelectionProbe() {
+    const { workspace } = useWorkspace();
+
+    return <output>{JSON.stringify(workspace)}</output>;
+}
+
+function carried(): Workspace {
+    const probe = screen.getAllByRole('status').find((element) => element.textContent.startsWith('{'));
+
+    return JSON.parse(probe?.textContent ?? '') as Workspace;
+}
+
+function listUnder(
+    transport: MailFathomTransport,
+    { scope = everything, accounts = [work], online = true }: Partial<Drawn> = {},
+): ReactElement {
+    return (
+        <LocalizationProvider>
+            <WorkspaceProvider>
+                <MessageList
+                    session={session}
+                    transport={transport}
+                    scope={scope}
+                    accounts={accounts}
+                    online={online}
+                />
+                <SelectionProbe />
+            </WorkspaceProvider>
+        </LocalizationProvider>
+    );
+}
+
+interface Drawn {
+    readonly scope: MailScope;
+    readonly accounts: readonly MailAccount[];
+    readonly online: boolean;
+}
+
+function renderList(transport: MailFathomTransport, drawn: Partial<Drawn> = {}): RenderResult {
+    return render(listUnder(transport, drawn));
+}
+
+// Inside the list rather than in the document, because the order control is a `select` and its choices are options
+// too — a query across the document would answer with those first.
+async function rows(): Promise<HTMLElement[]> {
+    const list = await screen.findByRole('listbox', { name: 'Messages' });
+
+    return within(list).getAllByRole('option');
+}
+
+// By what it is about, which is the one part of a row's name nothing else abuts on both sides: the name runs its parts
+// together, so the subject is matched with the first word of the preview behind it — which is what keeps the row for
+// message one from also being the row for message ten.
+function row(at: number): HTMLElement {
+    const list = screen.getByRole('listbox', { name: 'Messages' });
+
+    return within(list).getByRole('option', { name: new RegExp(`Message ${String(at)}The opening`) });
+}
+
+afterEach(() => {
+    window.sessionStorage.clear();
+});
+
+describe('MessageList', () => {
+    it('says it is reading from the moment the read starts, where the mail will appear', () => {
+        renderList(() => new Promise(() => undefined));
+
+        expect(screen.getByText('Reading your mail…')).toBeDefined();
+    });
+
+    it('draws a row carrying who wrote, what about, when, and the opening of the message', async () => {
+        renderList(answering(wholeFolder));
+
+        const drawn = await rows();
+
+        expect(drawn[0]?.textContent).toContain('Writer 0');
+        expect(drawn[0]?.textContent).toContain('Message 0');
+        expect(drawn[0]?.textContent).toContain('The opening of message 0.');
+        expect(drawn[0]?.querySelector('time')?.getAttribute('datetime')).toBe('2026-08-31T09:41:00+00:00');
+    });
+
+    it('says what the mail server last reported about a message, in words rather than in a mark alone', async () => {
+        const marked = pageOf([
+            message(0, { unread: true, flagged: true, answered: true, hasAttachments: true, attachmentCount: 3 }),
+        ]);
+
+        renderList(answering(marked));
+
+        const drawn = await rows();
+
+        expect(drawn[0]?.textContent).toContain('Unread');
+        expect(drawn[0]?.textContent).toContain('Flagged');
+        expect(drawn[0]?.textContent).toContain('Answered');
+        expect(drawn[0]?.textContent).toContain('3 attached');
+    });
+
+    it('holds far fewer rows in the document than the page it read', async () => {
+        renderList(answering(wholeFolder));
+
+        expect((await rows()).length).toBeLessThan(rowsPerPage / 2);
+    });
+
+    it('asks for the folder the scope names rather than for every folder', async () => {
+        const { transport, requests } = recording(wholeFolder);
+
+        renderList(transport, { scope: { kind: 'folder', accountId: 'work', alias: 'ARCHIVE-2024' } });
+        await rows();
+
+        expect(requests[0]?.path).toContain('account=work');
+        expect(requests[0]?.path).toContain('folder=ARCHIVE-2024');
+    });
+
+    it('continues from the cursor the folder was left at rather than from its leading end', async () => {
+        rememberListing(session.baseAddress, everything, {
+            order: 'newestFirst',
+            filters: { unread: null, flagged: null, hasAttachments: null, includeJunk: false },
+            cursor: 'where-they-were',
+            readAs: 'forward',
+            rowInPage: 3,
+        });
+
+        const { transport, requests } = recording(wholeFolder);
+
+        renderList(transport);
+        await rows();
+
+        expect(requests[0]?.path).toContain('cursor=where-they-were');
+    });
+
+    it('says what failed and offers the way out of the one failure a second attempt answers', async () => {
+        renderList(answering('', 503));
+
+        expect(await screen.findByText('This folder could not be read: unavailable.')).toBeDefined();
+        expect(screen.getByRole('button', { name: 'Try again' })).toBeDefined();
+    });
+
+    it('offers no second attempt for a failure that repeats identically', async () => {
+        renderList(answering('', 403));
+
+        expect(await screen.findByText('This folder could not be read: unauthorized.')).toBeDefined();
+        expect(screen.queryByRole('button', { name: 'Try again' })).toBeNull();
+    });
+
+    it('says an empty folder is empty', async () => {
+        renderList(answering(pageOf([])));
+
+        expect(await screen.findByText('There is no mail in this folder.')).toBeDefined();
+    });
+
+    it('tells a folder nothing has been taken into yet apart from an empty one', async () => {
+        renderList(answering(pageOf([])), { accounts: [{ ...work, synchronizationState: 'NeverSynchronized' }] });
+
+        expect(
+            await screen.findByText(
+                'Nothing has been taken into this deployment from this mailbox yet, so there is nothing to show. The folder is not empty — it has not been read.',
+            ),
+        ).toBeDefined();
+    });
+
+    it('says a mailbox that stopped synchronizing may be holding less than the mail server does', async () => {
+        renderList(answering(pageOf([])), { accounts: [{ ...work, synchronizationState: 'Unreachable' }] });
+
+        expect(
+            await screen.findByText(
+                'This mailbox stopped synchronizing, so what is here may be less than the mail server holds.',
+            ),
+        ).toBeDefined();
+    });
+
+    it('says nothing matched where the reader narrowed the list themselves', async () => {
+        renderList(answering(pageOf([])));
+
+        await screen.findByText('There is no mail in this folder.');
+        fireEvent.click(screen.getByLabelText('Only unread'));
+
+        expect(
+            await screen.findByText('No message in this folder matches what the list is narrowed to.'),
+        ).toBeDefined();
+    });
+
+    it('says the machine is offline rather than reporting a deployment that did not answer', () => {
+        renderList(answering(wholeFolder), { online: false });
+
+        expect(
+            screen.getByText('This machine is offline. The client reconnects on its own when the network comes back.'),
+        ).toBeDefined();
+    });
+
+    it('reads the folder again under a filter the reader turned on, from its leading end', async () => {
+        const { transport, requests } = recording(wholeFolder);
+
+        renderList(transport);
+        await rows();
+        fireEvent.click(screen.getByLabelText('Only unread'));
+        await rows();
+
+        expect(requests.at(-1)?.path).toContain('unread=true');
+        expect(requests.at(-1)?.path).not.toContain('cursor=');
+    });
+
+    it('reads the folder again in the order the reader chose', async () => {
+        const { transport, requests } = recording(wholeFolder);
+
+        renderList(transport);
+        await rows();
+        fireEvent.change(screen.getByLabelText('Order'), { target: { value: 'oldestFirst' } });
+        await rows();
+
+        expect(requests.at(-1)?.path).toContain('order=oldestFirst');
+    });
+
+    it('keeps the order and the filters with the folder, so returning to it reads it the same way', async () => {
+        renderList(answering(wholeFolder));
+
+        await rows();
+        fireEvent.change(screen.getByLabelText('Order'), { target: { value: 'oldestFirst' } });
+        await rows();
+
+        expect(rememberedListing(session.baseAddress, everything).order).toBe('oldestFirst');
+    });
+
+    it('offers no junk control for a folder the reader has already pointed at', async () => {
+        renderList(answering(wholeFolder), { scope: { kind: 'folder', accountId: 'work', alias: 'Spam' } });
+
+        await rows();
+
+        expect(screen.queryByLabelText('Include junk')).toBeNull();
+    });
+
+    it('selects one message and opens it when it is pointed at', async () => {
+        renderList(answering(wholeFolder));
+
+        await rows();
+        fireEvent.pointerDown(row(2));
+
+        expect(carried().selected).toStrictEqual(['message-2']);
+        expect(carried().selection).toBe('message-2');
+    });
+
+    it('adds a message to the selection when the pointer holds the modifier key', async () => {
+        renderList(answering(wholeFolder));
+
+        await rows();
+        fireEvent.pointerDown(row(1));
+        fireEvent.pointerDown(row(3), { ctrlKey: true });
+
+        expect(carried().selected).toStrictEqual(['message-1', 'message-3']);
+    });
+
+    it('takes a message out of the selection when the modifier key picks it a second time', async () => {
+        renderList(answering(wholeFolder));
+
+        await rows();
+        fireEvent.pointerDown(row(1));
+        fireEvent.pointerDown(row(3), { ctrlKey: true });
+        fireEvent.pointerDown(row(3), { ctrlKey: true });
+
+        expect(carried().selected).toStrictEqual(['message-1']);
+    });
+
+    it('selects the run between the anchor and the message shift reached', async () => {
+        renderList(answering(wholeFolder));
+
+        await rows();
+        fireEvent.pointerDown(row(1));
+        fireEvent.pointerDown(row(4), { shiftKey: true });
+
+        expect(carried().selected).toStrictEqual(['message-1', 'message-2', 'message-3', 'message-4']);
+    });
+
+    it('selects the run a pointer dragged over', async () => {
+        renderList(answering(wholeFolder));
+
+        await rows();
+        fireEvent.pointerDown(row(1));
+        fireEvent.pointerEnter(row(3));
+
+        expect(carried().selected).toStrictEqual(['message-1', 'message-2', 'message-3']);
+    });
+
+    it('stops selecting once the pointer is let go, wherever that happened', async () => {
+        renderList(answering(wholeFolder));
+
+        await rows();
+        fireEvent.pointerDown(row(1));
+        fireEvent.pointerUp(window);
+        fireEvent.pointerEnter(row(3));
+
+        expect(carried().selected).toStrictEqual(['message-1']);
+    });
+
+    it('picks messages out one at a time under a finger, once the selection mode is on', async () => {
+        renderList(answering(wholeFolder));
+
+        await rows();
+        fireEvent.click(screen.getByLabelText('Select several'));
+        fireEvent.pointerDown(row(1));
+        fireEvent.pointerDown(row(3));
+
+        expect(carried().selected).toStrictEqual(['message-1', 'message-3']);
+    });
+
+    it('leaves what is open alone while messages are being picked out for a question', async () => {
+        renderList(answering(wholeFolder));
+
+        await rows();
+        fireEvent.click(screen.getByLabelText('Select several'));
+        fireEvent.pointerDown(row(1));
+
+        expect(carried().selection).toBeNull();
+    });
+
+    it('says how many messages are picked out', async () => {
+        renderList(answering(wholeFolder));
+
+        await rows();
+        fireEvent.pointerDown(row(1));
+        fireEvent.pointerDown(row(3), { ctrlKey: true });
+
+        expect(screen.getByText('2 selected')).toBeDefined();
+    });
+
+    it('moves through the list from the keyboard and selects what it moves onto', async () => {
+        renderList(answering(wholeFolder));
+
+        const drawn = await rows();
+
+        fireEvent.keyDown(screen.getByRole('listbox', { name: 'Messages' }), { key: 'ArrowDown' });
+
+        expect(carried().selected).toStrictEqual(['message-1']);
+        expect(drawn[1]?.getAttribute('tabindex')).toBe('0');
+    });
+
+    it('opens the message the keyboard is on', async () => {
+        renderList(answering(wholeFolder));
+
+        await rows();
+        const list = screen.getByRole('listbox', { name: 'Messages' });
+
+        fireEvent.keyDown(list, { key: 'ArrowDown' });
+        fireEvent.keyDown(list, { key: 'Enter' });
+
+        expect(carried().selection).toBe('message-1');
+    });
+
+    it('picks a message out from the keyboard without opening it', async () => {
+        renderList(answering(wholeFolder));
+
+        await rows();
+        const list = screen.getByRole('listbox', { name: 'Messages' });
+
+        fireEvent.keyDown(list, { key: 'ArrowDown', ctrlKey: true });
+        fireEvent.keyDown(list, { key: ' ' });
+
+        expect(carried().selected).toStrictEqual(['message-1']);
+        expect(carried().selection).toBeNull();
+    });
+
+    it('extends the selection when the keyboard moves with shift held', async () => {
+        renderList(answering(wholeFolder));
+
+        await rows();
+        const list = screen.getByRole('listbox', { name: 'Messages' });
+
+        fireEvent.keyDown(list, { key: 'ArrowDown' });
+        fireEvent.keyDown(list, { key: 'ArrowDown', shiftKey: true });
+
+        expect(carried().selected).toStrictEqual(['message-1', 'message-2']);
+    });
+
+    it('reports the list as one whose length no page answers, rather than as one the length of what is held', async () => {
+        renderList(answering(wholeFolder));
+
+        expect((await rows())[0]?.getAttribute('aria-setsize')).toBe('-1');
+    });
+
+    it.each([
+        ['Only flagged', 'flagged=true'],
+        ['Only with attachments', 'hasAttachments=true'],
+        ['Include junk', 'includeJunk=true'],
+    ])('reads the folder again under %s', async (control, asked) => {
+        const { transport, requests } = recording(wholeFolder);
+
+        renderList(transport);
+        await rows();
+        fireEvent.click(screen.getByLabelText(control));
+        await rows();
+
+        expect(requests.at(-1)?.path).toContain(asked);
+    });
+
+    it('draws a message carrying no subject as one with no subject rather than as a blank line', async () => {
+        renderList(answering(pageOf([message(0, { subject: null })])));
+
+        expect((await rows())[0]?.textContent).toContain('No subject');
+    });
+
+    it('draws a message whose sender could not be read as one with no sender', async () => {
+        renderList(answering(pageOf([message(0, { senderDisplayName: null, senderAddress: null, toAddresses: [] })])));
+
+        expect((await rows())[0]?.textContent).toContain('No sender');
+    });
+
+    it('falls back to who a message was written to where it carries no sender at all', async () => {
+        renderList(answering(pageOf([message(0, { senderDisplayName: null, senderAddress: null })])));
+
+        expect((await rows())[0]?.textContent).toContain('owner@example.invalid');
+    });
+
+    it('draws no time for a message no header carried a usable date on', async () => {
+        renderList(answering(pageOf([message(0, { receivedAt: null })])));
+
+        expect((await rows())[0]?.querySelector('time')).toBeNull();
+    });
+
+    it('draws no time where the date is one no clock produced, rather than the words for an invalid one', async () => {
+        renderList(answering(pageOf([message(0, { receivedAt: 'the day before yesterday' })])));
+
+        expect((await rows())[0]?.querySelector('time')).toBeNull();
+    });
+
+    it('says the whole of a folder has been read once both its cursors are spent', async () => {
+        renderList(answering(wholeFolder));
+
+        await rows();
+
+        expect(screen.getByText('That is the whole of this folder.')).toBeDefined();
+    });
+});

--- a/frontend/src/Client.App/src/messageList/MessageList.tsx
+++ b/frontend/src/Client.App/src/messageList/MessageList.tsx
@@ -19,6 +19,7 @@ import {
     type MailAccount,
     type MailFathomTransport,
 } from '@mailfathom/client-backend';
+import { CheckControl } from '../controls/CheckControl';
 import { SecondaryButton } from '../controls/SecondaryButton';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
@@ -41,7 +42,7 @@ import {
 import { ListSettings } from './ListSettings';
 import { narrowed, queryFor, type MailListing } from './listing';
 import { MessageRow } from './MessageRow';
-import { inReadingOrder, onlySelected, rangeBetween, withToggled } from './messageSelection';
+import { extendedTo, inReadingOrder, onlySelected, withToggled } from './messageSelection';
 import { rememberedListing, rememberListing } from './rememberedListings';
 import { estimatedRowHeight, leadingRow, offsetOfRow, windowOf } from './timelineWindow';
 
@@ -111,6 +112,11 @@ export function MessageList({
     const drawn = windowOf(rowCount, rowHeight, scrollTop, viewport);
     const lastDrawn = drawn.first + drawn.count - 1;
     const rows = heldRows(held);
+
+    // Whether the row the keyboard is on is a row rather than the space one is arriving into. The effect below waits on
+    // it: a keyboard that reached a dropped page has nothing to put focus on until that page answers, and refilling one
+    // changes neither the row count nor the window — so this is what says the row is there now.
+    const focusedIsDrawn = rowAt(held, focusedRow) !== null;
 
     // Which page is wanted is worked out during render rather than kept beside what is held, because it is a function
     // of what is held and where the window is: two pieces of state that have to agree are one piece of state and a
@@ -217,7 +223,7 @@ export function MessageList({
             element.scrollTop = offsetOfRow(opening.rowInPage, measured > 0 ? measured : rowHeight);
         }
 
-        if (wantsFocus.current) {
+        if (wantsFocus.current && focusedIsDrawn) {
             const row = elements.current.get(focusedRow);
 
             if (row !== undefined) {
@@ -225,7 +231,7 @@ export function MessageList({
                 wantsFocus.current = false;
             }
         }
-    }, [viewport, rowHeight, rowCount, drawn.first, opening.rowInPage, focusedRow]);
+    }, [viewport, rowHeight, rowCount, drawn.first, opening.rowInPage, focusedRow, focusedIsDrawn]);
 
     // A window resized changes how many rows the list draws, and a resize is not a commit. The scroller's own size is
     // read on the commit that follows, which is what this asks for.
@@ -323,7 +329,7 @@ export function MessageList({
         }
 
         if (extending && anchor !== null) {
-            select(rangeBetween(rows.map(identityOf), anchor, email.id));
+            select(extendedTo(workspace.selected, rows.map(identityOf), anchor, email.id));
         } else {
             setAnchor(email.id);
             select(onlySelected(email.id));
@@ -358,7 +364,7 @@ export function MessageList({
         }
 
         if (event.shiftKey && anchor !== null) {
-            select(rangeBetween(rows.map(identityOf), anchor, email.id));
+            select(extendedTo(workspace.selected, rows.map(identityOf), anchor, email.id));
 
             return;
         }
@@ -376,7 +382,7 @@ export function MessageList({
             return;
         }
 
-        select(rangeBetween(rows.map(identityOf), anchor, email.id));
+        select(extendedTo(workspace.selected, rows.map(identityOf), anchor, email.id));
     }
 
     function onKeyDown(event: KeyboardEvent<HTMLUListElement>): void {
@@ -443,7 +449,11 @@ export function MessageList({
             />
 
             <div className="flex flex-wrap items-center gap-2">
-                <SelectionMode
+                {/* Under a finger there is no modifier key, so picking out several messages is a mode rather than a
+                    chord. It is offered at every width and to every pointer, because a mode a reader can see is easier
+                    than a chord they have to know — and because nothing in this tree asks which head it runs on. */}
+                <CheckControl
+                    label={translate('list.selectSeveral')}
                     on={selecting}
                     onChange={(on) => {
                         setSelecting(on);
@@ -589,31 +599,6 @@ function ArrivingRow({ position }: { readonly position: number }) {
         >
             {translate('list.rowArriving')}
         </li>
-    );
-}
-
-// Under a finger there is no modifier key, so picking out several messages is a mode rather than a chord. It is offered
-// at every width and to every pointer, because a mode a reader can see is easier than a chord they have to know — and
-// because nothing in this tree asks which head it is running on.
-function SelectionMode({ on, onChange }: { readonly on: boolean; readonly onChange: (on: boolean) => void }) {
-    const { translate } = useLocalization();
-
-    return (
-        <label
-            className={`flex cursor-pointer items-center gap-1.5 rounded-md border border-line bg-panel px-2 py-1 text-sm text-text-soft transition hover:bg-hover ${
-                on ? 'bg-accent-soft text-accent-strong' : ''
-            }`}
-        >
-            <input
-                type="checkbox"
-                className="accent-accent"
-                checked={on}
-                onChange={(event) => {
-                    onChange(event.target.checked);
-                }}
-            />
-            {translate('list.selectSeveral')}
-        </label>
     );
 }
 

--- a/frontend/src/Client.App/src/messageList/MessageList.tsx
+++ b/frontend/src/Client.App/src/messageList/MessageList.tsx
@@ -297,6 +297,12 @@ export function MessageList({
         setHeld(nothingHeld);
         setFailure(null);
         setFocusedRow(0);
+
+        // The position goes back with them. Emptying the list unmounts the scroller, so the one that comes back is at
+        // the top whatever this state says — and a window computed from where the reader was in the old listing draws
+        // the new one's last row under a screen of blank space, with no scroll left to fire the event that would
+        // correct it.
+        setScrollTop(0);
     }
 
     function reveal(row: number): void {

--- a/frontend/src/Client.App/src/messageList/MessageList.tsx
+++ b/frontend/src/Client.App/src/messageList/MessageList.tsx
@@ -1,0 +1,626 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import {
+    useEffect,
+    useLayoutEffect,
+    useRef,
+    useState,
+    type KeyboardEvent,
+    type PointerEvent,
+    type ReactNode,
+} from 'react';
+import {
+    readMailTimeline,
+    type ClientFailure,
+    type ClientFailureReason,
+    type ClientSession,
+    type MailAccount,
+    type MailFathomTransport,
+} from '@mailfathom/client-backend';
+import { SecondaryButton } from '../controls/SecondaryButton';
+import type { MessageKey } from '../localization/en';
+import { useLocalization } from '../localization/useLocalization';
+import { needsAttention } from '../synchronization/synchronizationState';
+import { accountInScope, type MailScope } from '../workspace/mailScope';
+import { useWorkspace } from '../workspace/useWorkspace';
+import {
+    answered,
+    cursorAfter,
+    heldRows,
+    nothingHeld,
+    positionOfRow,
+    rowAt,
+    rowCountOf,
+    trimmedAround,
+    wantedFor,
+    type HeldTimeline,
+    type TimelineRead,
+} from './heldTimeline';
+import { ListSettings } from './ListSettings';
+import { narrowed, queryFor, type MailListing } from './listing';
+import { MessageRow } from './MessageRow';
+import { inReadingOrder, onlySelected, rangeBetween, withToggled } from './messageSelection';
+import { rememberedListing, rememberListing } from './rememberedListings';
+import { estimatedRowHeight, leadingRow, offsetOfRow, windowOf } from './timelineWindow';
+
+// The client's message list, which is where a mail client is judged: it stays smooth at message forty thousand, it puts
+// a returning reader back where they were, and it lets somebody pick out four messages for the question they are about
+// to ask.
+//
+// Three bounds hold that up and none of them is optional. The document holds a window of rows rather than the folder —
+// `timelineWindow.ts`. The list holds a window of pages rather than every page it has read — `heldTimeline.ts`. And
+// where the reader is survives outside React rather than in it — `rememberedListings.ts`, because a scroll offset in
+// state re-renders everything under the workspace provider on the one interaction this screen exists to keep smooth.
+//
+// The component is mounted with the scope as its key, so pointing at another mailbox starts a list rather than resets
+// one: every piece of state below belongs to one folder read one way, and there is no correct way to carry any of it
+// across.
+
+const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
+    unauthenticated: 'failure.unauthenticated',
+    unauthorized: 'failure.unauthorized',
+    unavailable: 'failure.unavailable',
+    unreadable: 'failure.unreadable',
+};
+
+// How long after scrolling stops before where the reader is is written down. Long enough that a flick through a folder
+// writes once rather than per frame, short enough that leaving immediately afterwards keeps the position.
+const restingBeforeRemembered = 400;
+
+export function MessageList({
+    session,
+    transport,
+    scope,
+    accounts,
+    online,
+}: {
+    readonly session: ClientSession;
+    readonly transport: MailFathomTransport;
+    readonly scope: MailScope;
+    readonly accounts: readonly MailAccount[];
+    readonly online: boolean;
+}) {
+    const { translate } = useLocalization();
+    const { workspace, revise } = useWorkspace();
+    // Where this list opens: how the folder was last read and where in it the reader was. State rather than a value
+    // computed each render, because it is read back once the first page has arrived and because changing the order or
+    // a filter replaces it with the leading end of the list the change asks for.
+    const [opening, setOpening] = useState(() => rememberedListing(session.baseAddress, scope));
+
+    const [listing, setListing] = useState<MailListing>(opening);
+    const [held, setHeld] = useState<HeldTimeline>(nothingHeld);
+    const [failure, setFailure] = useState<ClientFailure | null>(null);
+
+    const [scrollTop, setScrollTop] = useState(0);
+    const [viewport, setViewport] = useState(0);
+    const [rowHeight, setRowHeight] = useState(estimatedRowHeight);
+
+    const [focusedRow, setFocusedRow] = useState(0);
+    const [anchor, setAnchor] = useState<string | null>(null);
+    const [selecting, setSelecting] = useState(false);
+
+    const scroller = useRef<HTMLDivElement>(null);
+    const elements = useRef(new Map<number, HTMLLIElement>());
+    const dragging = useRef(false);
+    const restored = useRef(false);
+    const wantsFocus = useRef(false);
+
+    const rowCount = rowCountOf(held);
+    const drawn = windowOf(rowCount, rowHeight, scrollTop, viewport);
+    const lastDrawn = drawn.first + drawn.count - 1;
+    const rows = heldRows(held);
+
+    // Which page is wanted is worked out during render rather than kept beside what is held, because it is a function
+    // of what is held and where the window is: two pieces of state that have to agree are one piece of state and a
+    // function, and the pair that disagrees here would be a list reading a page it already has.
+    //
+    // It is `null` for a list that wants nothing, which is also how a read in flight reads: the answer is what changes
+    // it, so nothing has to be kept saying whether one is out. A network gap and a failure both make it `null`, which
+    // ends the read they interrupted rather than letting it outlive them.
+    const wanted =
+        !online || failure !== null
+            ? null
+            : held.slots.length === 0
+              ? { cursor: opening.cursor, direction: opening.readAs, refilling: null }
+              : wantedFor(held, drawn.first, lastDrawn);
+
+    // Named apart so the effect below depends on what the request *is* rather than on the object naming it. A fresh
+    // object every render would put a request on the wire every render; these three change only when the page wanted
+    // changes, which is what starts one read per page and abandons one the reader has scrolled away from.
+    const wantedCursor = wanted?.cursor ?? null;
+    const wantedDirection = wanted?.direction ?? null;
+    const wantedRefilling = wanted?.refilling ?? null;
+
+    // The one effect that puts a request on the wire, which is what an effect is for. What it asked for travels with
+    // the answer, so a page knows where it belongs and an answer to a read this list has moved on from is discarded.
+    useEffect(() => {
+        if (wantedDirection === null) {
+            return;
+        }
+
+        const asked: TimelineRead = {
+            cursor: wantedCursor,
+            direction: wantedDirection,
+            refilling: wantedRefilling,
+        };
+
+        let listening = true;
+
+        void readMailTimeline(session, transport, queryFor(scope, listing, asked.cursor, asked.direction)).then(
+            (result) => {
+                if (!listening) {
+                    return;
+                }
+
+                if (result.outcome === 'failed') {
+                    setFailure(result.failure);
+                } else {
+                    setHeld((current) => answered(current, result.value, asked));
+                }
+            },
+        );
+
+        return () => {
+            listening = false;
+        };
+    }, [session, transport, scope, listing, wantedCursor, wantedDirection, wantedRefilling]);
+
+    // Where the reader is, written down once they have stopped moving, and again the moment the page goes away —
+    // whichever comes first. The second is what makes a reload a continuation rather than a race with the first: a
+    // reader who reloads, closes the tab, or is sent to another page mid-scroll keeps where they were. Outside React
+    // both times, so nothing here re-renders.
+    useEffect(() => {
+        function keep(): void {
+            const position = positionOfRow(held, leadingRow(scrollTop, rowHeight));
+
+            if (position !== null) {
+                rememberListing(session.baseAddress, scope, { ...listing, ...position });
+            }
+        }
+
+        const timer = window.setTimeout(keep, restingBeforeRemembered);
+        window.addEventListener('pagehide', keep);
+
+        return () => {
+            window.clearTimeout(timer);
+            window.removeEventListener('pagehide', keep);
+        };
+    }, [held, scrollTop, rowHeight, listing, scope, session.baseAddress]);
+
+    // The two measurements the window is arithmetic over, taken after the browser has laid the list out rather than
+    // written down as numbers here. One element each, on a commit that has already happened: the row height is a token
+    // decision this must not hold a second copy of, and the scroller's height is whatever the composition gave it.
+    useLayoutEffect(() => {
+        const element = scroller.current;
+
+        if (element === null) {
+            return;
+        }
+
+        if (element.clientHeight !== viewport) {
+            setViewport(element.clientHeight);
+        }
+
+        const measured = elements.current.get(drawn.first)?.offsetHeight ?? 0;
+
+        if (measured > 0 && measured !== rowHeight) {
+            setRowHeight(measured);
+        }
+
+        // The reader is put back where they were once there is something to put them back into, and once only: every
+        // later scroll is theirs. The measured height rather than the one in state, because both happen on this commit
+        // and the one in state is a render behind.
+        if (!restored.current && rowCount > 0) {
+            restored.current = true;
+            element.scrollTop = offsetOfRow(opening.rowInPage, measured > 0 ? measured : rowHeight);
+        }
+
+        if (wantsFocus.current) {
+            const row = elements.current.get(focusedRow);
+
+            if (row !== undefined) {
+                row.focus();
+                wantsFocus.current = false;
+            }
+        }
+    }, [viewport, rowHeight, rowCount, drawn.first, opening.rowInPage, focusedRow]);
+
+    // A window resized changes how many rows the list draws, and a resize is not a commit. The scroller's own size is
+    // read on the commit that follows, which is what this asks for.
+    useEffect(() => {
+        function remeasure(): void {
+            setViewport(scroller.current?.clientHeight ?? 0);
+        }
+
+        window.addEventListener('resize', remeasure);
+
+        return () => {
+            window.removeEventListener('resize', remeasure);
+        };
+    }, []);
+
+    // A drag selects while the pointer is down and stops wherever it is let go, including outside the list — a drag
+    // that ended over the header would otherwise still be selecting when the pointer came back.
+    useEffect(() => {
+        function release(): void {
+            dragging.current = false;
+        }
+
+        window.addEventListener('pointerup', release);
+        window.addEventListener('pointercancel', release);
+
+        return () => {
+            window.removeEventListener('pointerup', release);
+            window.removeEventListener('pointercancel', release);
+        };
+    }, []);
+
+    // Scrolling is where the list stops holding what the reader has moved away from. Here rather than in an effect
+    // watching the window, because dropping rows is what a scroll did rather than something to reconcile afterwards —
+    // and `trimmedAround` answers with the list it was given where nothing was far enough to drop, so the ordinary
+    // scroll that changes nothing renders nothing.
+    function scrolledTo(top: number): void {
+        setScrollTop(top);
+
+        const moved = windowOf(rowCount, rowHeight, top, viewport);
+
+        setHeld((current) => trimmedAround(current, moved.first, moved.first + moved.count - 1));
+    }
+
+    function tryAgain(): void {
+        setFailure(null);
+    }
+
+    function select(selected: readonly string[]): void {
+        revise({ selected: inReadingOrder(selected, rows.map(identityOf)) });
+    }
+
+    function readWith(chosen: MailListing): void {
+        // The cursor belongs to the order and the filters it was issued under, so changing either starts the list at
+        // its leading end rather than continuing from a cursor the deployment would refuse.
+        const restarted = { ...chosen, cursor: null, readAs: 'forward' as const, rowInPage: 0 };
+
+        // Written down here rather than left to the effect below, because how a folder is read is a choice somebody
+        // made rather than a position they drifted to: leaving the moment after making it keeps it.
+        rememberListing(session.baseAddress, scope, restarted);
+        setOpening(restarted);
+        restored.current = false;
+        setListing(chosen);
+        setHeld(nothingHeld);
+        setFailure(null);
+        setFocusedRow(0);
+    }
+
+    function reveal(row: number): void {
+        const element = scroller.current;
+
+        if (element === null) {
+            return;
+        }
+
+        const top = offsetOfRow(row, rowHeight);
+
+        if (top < element.scrollTop) {
+            element.scrollTop = top;
+        } else if (top + rowHeight > element.scrollTop + element.clientHeight) {
+            element.scrollTop = top + rowHeight - element.clientHeight;
+        }
+    }
+
+    function moveTo(row: number, extending: boolean, keepingSelection: boolean): void {
+        const reached = Math.min(Math.max(row, 0), Math.max(rowCount - 1, 0));
+
+        reveal(reached);
+        setFocusedRow(reached);
+        wantsFocus.current = true;
+
+        const email = rowAt(held, reached);
+
+        if (email === null || keepingSelection) {
+            return;
+        }
+
+        if (extending && anchor !== null) {
+            select(rangeBetween(rows.map(identityOf), anchor, email.id));
+        } else {
+            setAnchor(email.id);
+            select(onlySelected(email.id));
+        }
+    }
+
+    function open(row: number): void {
+        const email = rowAt(held, row);
+
+        if (email !== null) {
+            revise({ selection: email.id });
+        }
+    }
+
+    function point(event: PointerEvent<HTMLLIElement>, row: number): void {
+        const email = rowAt(held, row);
+
+        if (email === null) {
+            return;
+        }
+
+        setFocusedRow(row);
+
+        // Adding one at a time, which is what the modifier key does under a pointer and what the selection mode does
+        // under a finger. The mode exists because a touch screen has no modifier, and it is a control rather than a
+        // gesture so that its state is something a reader can see and a screen reader can say.
+        if (selecting || event.ctrlKey || event.metaKey) {
+            setAnchor(email.id);
+            select(withToggled(workspace.selected, email.id));
+
+            return;
+        }
+
+        if (event.shiftKey && anchor !== null) {
+            select(rangeBetween(rows.map(identityOf), anchor, email.id));
+
+            return;
+        }
+
+        dragging.current = true;
+        setAnchor(email.id);
+        select(onlySelected(email.id));
+        revise({ selection: email.id });
+    }
+
+    function dragOver(row: number): void {
+        const email = rowAt(held, row);
+
+        if (!dragging.current || email === null || anchor === null) {
+            return;
+        }
+
+        select(rangeBetween(rows.map(identityOf), anchor, email.id));
+    }
+
+    function onKeyDown(event: KeyboardEvent<HTMLUListElement>): void {
+        switch (event.key) {
+            case 'ArrowDown':
+                moveTo(focusedRow + 1, event.shiftKey, event.ctrlKey || event.metaKey);
+                break;
+            case 'ArrowUp':
+                moveTo(focusedRow - 1, event.shiftKey, event.ctrlKey || event.metaKey);
+                break;
+            case 'Home':
+                moveTo(0, event.shiftKey, event.ctrlKey || event.metaKey);
+                break;
+            case ' ': {
+                const email = rowAt(held, focusedRow);
+
+                if (email !== null) {
+                    setAnchor(email.id);
+                    select(withToggled(workspace.selected, email.id));
+                }
+
+                break;
+            }
+            case 'Enter':
+                open(focusedRow);
+                break;
+            default:
+                return;
+        }
+
+        event.preventDefault();
+    }
+
+    if (!online) {
+        return <Note>{translate('connection.offline')}</Note>;
+    }
+
+    if (rowCount === 0 && failure !== null) {
+        return (
+            <div className="flex flex-col items-start gap-2">
+                <p className="text-sm text-warning">
+                    {translate('list.failed', { reason: translate(failureLabels[failure.reason]) })}
+                </p>
+
+                {/* Reading again is the way out of exactly one of the four failures, for the reason
+                    `shell/ConnectionSummary.tsx` gives: the other three repeat identically on a second attempt. */}
+                {failure.reason === 'unavailable' ? (
+                    <SecondaryButton label={translate('connection.retry')} onActivate={tryAgain} />
+                ) : null}
+            </div>
+        );
+    }
+
+    if (rowCount === 0 && wanted !== null) {
+        return <Note announced>{translate('list.reading')}</Note>;
+    }
+
+    return (
+        <div className="flex min-h-0 flex-col gap-2">
+            <ListSettings
+                listing={listing}
+                junkAskable={scope.kind !== 'folder' && scope.kind !== 'role'}
+                onRead={readWith}
+            />
+
+            <div className="flex flex-wrap items-center gap-2">
+                <SelectionMode
+                    on={selecting}
+                    onChange={(on) => {
+                        setSelecting(on);
+                    }}
+                />
+
+                {workspace.selected.length === 0 ? null : (
+                    <p className="text-sm text-muted" role="status">
+                        {translate('list.selectedCount', { count: String(workspace.selected.length) })}
+                    </p>
+                )}
+
+                {/* A read that failed with rows already drawn is the partial state: what is on the screen stays, and
+                    what is missing is said above it rather than replacing it. */}
+                {failure === null ? null : (
+                    <p className="text-sm text-warning">
+                        {translate('list.partiallyFailed', { reason: translate(failureLabels[failure.reason]) })}
+                    </p>
+                )}
+
+                {failure?.reason === 'unavailable' ? (
+                    <SecondaryButton label={translate('connection.retry')} onActivate={tryAgain} />
+                ) : null}
+            </div>
+
+            {rowCount === 0 ? (
+                <Note>{translate(emptyReason(accounts, scope, listing))}</Note>
+            ) : (
+                <div
+                    ref={scroller}
+                    className="h-message-list min-h-0 overflow-y-auto overscroll-contain"
+                    onScroll={(event) => {
+                        scrolledTo(event.currentTarget.scrollTop);
+                    }}
+                >
+                    {/* The rows that are not in the document, as the space they take. Outside the list rather than in
+                        it, because a listbox holds options and nothing else — a spacer inside it would be announced as
+                        one more thing in the list. */}
+                    <div aria-hidden="true" style={{ height: `${String(drawn.above)}px` }} />
+
+                    {/* Rows sit flush against each other, and that is arithmetic rather than taste: the spacers above
+                        and below are whole rows of the token height, so a gap between drawn rows would put every row a
+                        fraction lower than the space the list drew for it, and the drift would grow with how far down
+                        the folder the reader is. What separates them is the line each row carries. */}
+                    <ul
+                        aria-label={translate('list.label')}
+                        aria-busy={wanted !== null}
+                        aria-multiselectable="true"
+                        role="listbox"
+                        className="flex flex-col"
+                        onKeyDown={onKeyDown}
+                    >
+                        {Array.from({ length: drawn.count }, (_, at) => drawn.first + at).map((row) => {
+                            const email = rowAt(held, row);
+
+                            return email === null ? (
+                                <ArrivingRow key={`arriving-${String(row)}`} position={row + 1} />
+                            ) : (
+                                <MessageRow
+                                    key={email.id}
+                                    email={email}
+                                    position={row + 1}
+                                    open={workspace.selection === email.id}
+                                    selected={workspace.selected.includes(email.id)}
+                                    focusable={row === focusedRow}
+                                    onOpen={() => {
+                                        open(row);
+                                    }}
+                                    onPoint={(event) => {
+                                        point(event, row);
+                                    }}
+                                    onPointerEnter={() => {
+                                        dragOver(row);
+                                    }}
+                                    onElement={(element) => {
+                                        if (element === null) {
+                                            elements.current.delete(row);
+                                        } else {
+                                            elements.current.set(row, element);
+                                        }
+                                    }}
+                                />
+                            );
+                        })}
+                    </ul>
+
+                    <div aria-hidden="true" style={{ height: `${String(drawn.below)}px` }} />
+
+                    {wanted !== null ? (
+                        <p className="px-3 py-2 text-sm text-muted" role="status">
+                            {translate('list.readingMore')}
+                        </p>
+                    ) : null}
+
+                    {cursorAfter(held) === null ? (
+                        <p className="px-3 py-2 text-sm text-faint">{translate('list.wholeFolderRead')}</p>
+                    ) : null}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function identityOf(email: { readonly id: string }): string {
+    return email.id;
+}
+
+/**
+ * Why a folder is showing nothing, which is four different sentences rather than one.
+ *
+ * A folder nothing has been taken into yet is the one a reader would otherwise read as empty and act on — so it is told
+ * apart from a folder that genuinely holds nothing, from one whose account stopped synchronizing, and from a list the
+ * reader has narrowed to nothing themselves.
+ */
+function emptyReason(accounts: readonly MailAccount[], scope: MailScope, listing: MailListing): MessageKey {
+    const named = accountInScope(scope);
+    const inScope = named === null ? accounts : accounts.filter((account) => account.id === named);
+
+    if (inScope.length > 0 && inScope.every((account) => account.synchronizationState === 'NeverSynchronized')) {
+        return 'list.notSynchronizedYet';
+    }
+
+    if (inScope.some((account) => needsAttention(account.synchronizationState))) {
+        return 'list.emptyWhileFailing';
+    }
+
+    return narrowed(listing.filters) ? 'list.nothingMatches' : 'list.emptyFolder';
+}
+
+// A row standing where a page the list dropped used to be. It is drawn rather than left blank so that the space is
+// visibly a message on its way rather than a hole, and it takes exactly the room the row it stands for will.
+function ArrivingRow({ position }: { readonly position: number }) {
+    const { translate } = useLocalization();
+
+    return (
+        <li
+            role="option"
+            aria-selected={false}
+            aria-disabled="true"
+            aria-posinset={position}
+            aria-setsize={-1}
+            className="flex h-message-row items-center px-3 text-sm text-faint"
+        >
+            {translate('list.rowArriving')}
+        </li>
+    );
+}
+
+// Under a finger there is no modifier key, so picking out several messages is a mode rather than a chord. It is offered
+// at every width and to every pointer, because a mode a reader can see is easier than a chord they have to know — and
+// because nothing in this tree asks which head it is running on.
+function SelectionMode({ on, onChange }: { readonly on: boolean; readonly onChange: (on: boolean) => void }) {
+    const { translate } = useLocalization();
+
+    return (
+        <label
+            className={`flex cursor-pointer items-center gap-1.5 rounded-md border border-line bg-panel px-2 py-1 text-sm text-text-soft transition hover:bg-hover ${
+                on ? 'bg-accent-soft text-accent-strong' : ''
+            }`}
+        >
+            <input
+                type="checkbox"
+                className="accent-accent"
+                checked={on}
+                onChange={(event) => {
+                    onChange(event.target.checked);
+                }}
+            />
+            {translate('list.selectSeveral')}
+        </label>
+    );
+}
+
+function Note({ announced = false, children }: { readonly announced?: boolean; readonly children: ReactNode }) {
+    return (
+        <p className="text-sm text-muted" role={announced ? 'status' : undefined}>
+            {children}
+        </p>
+    );
+}

--- a/frontend/src/Client.App/src/messageList/MessageList.tsx
+++ b/frontend/src/Client.App/src/messageList/MessageList.tsx
@@ -423,7 +423,10 @@ export function MessageList({
     if (rowCount === 0 && failure !== null) {
         return (
             <div className="flex flex-col items-start gap-2">
-                <p className="text-sm text-warning">
+                {/* Announced rather than merely drawn, for the reason the reading pane's failure is: a reader who
+                    heard the list say it was reading hears nothing at all when it stops, and the way out sits under a
+                    sentence they were never told about. */}
+                <p className="text-sm text-warning" role="alert">
                     {translate('list.failed', { reason: translate(failureLabels[failure.reason]) })}
                 </p>
 
@@ -469,7 +472,7 @@ export function MessageList({
                 {/* A read that failed with rows already drawn is the partial state: what is on the screen stays, and
                     what is missing is said above it rather than replacing it. */}
                 {failure === null ? null : (
-                    <p className="text-sm text-warning">
+                    <p className="text-sm text-warning" role="alert">
                         {translate('list.partiallyFailed', { reason: translate(failureLabels[failure.reason]) })}
                     </p>
                 )}

--- a/frontend/src/Client.App/src/messageList/MessageRow.tsx
+++ b/frontend/src/Client.App/src/messageList/MessageRow.tsx
@@ -12,11 +12,9 @@ import { useLocalization } from '../localization/useLocalization';
 //
 // Its height is fixed by the token rather than by its contents, and that is load-bearing rather than cosmetic: the
 // window above it is arithmetic over one height, and a row that grew with a long subject would put every row below it
-// somewhere other than where the list drew the space for it.
-//
-// Everything on it competes for one column narrower than a reading measure, so what it carries is what a person scans
-// by: who wrote, when, what about, and how it opens. The sender's host was on the first line and is not, because at
-// this width it took the room the name needed and left both of them ellipsised.
+// somewhere other than where the list drew the space for it. The third line is empty on purpose — it is the room stage
+// 3 fills with what MailFathom makes of the message, and leaving it now is what keeps that from being a redesign every
+// screen has to be re-read against.
 
 export function MessageRow({
     email,
@@ -68,9 +66,16 @@ export function MessageRow({
                     </span>
                 ) : null}
 
-                <span className={`truncate text-sm ${email.unread ? 'font-semibold text-text' : ''}`}>
+                {/* Who wrote is read before where they wrote from, so the name keeps up to half the line and the host
+                    is what gives way. Half rather than more because the marks and the time hold their own width: a
+                    name allowed past it would push the time out of a row that clips rather than wraps. */}
+                <span
+                    className={`max-w-1/2 shrink-0 truncate text-sm ${email.unread ? 'font-semibold text-text' : ''}`}
+                >
                     {correspondent(email) ?? translate('list.senderUnknown')}
                 </span>
+
+                <Organisation address={email.senderAddress} />
 
                 <Markers email={email} />
 
@@ -86,6 +91,10 @@ export function MessageRow({
 
                 {email.preview === null ? null : <span className="truncate text-faint">{email.preview}</span>}
             </div>
+
+            {/* The room stage 3 draws what MailFathom made of this message in. It is reserved rather than filled, so
+                the row that gains that line is this row rather than a taller one. */}
+            <div aria-hidden="true" className="h-4" />
         </li>
     );
 }
@@ -93,6 +102,19 @@ export function MessageRow({
 /** Who the row is about: the sender, else the address it came from, else who it was written to. */
 function correspondent(email: MailTimelineEntry): string | undefined {
     return email.senderDisplayName ?? email.senderAddress ?? email.toAddresses[0];
+}
+
+// The host the message came from, which is what the reader recognises when the display name is somebody's first name
+// and the address is not shown. Absent where the sender wrote no address, rather than drawn as an empty parenthesis.
+// It gives way before the name does: a column this narrow cannot hold both in full, and the name is what is scanned.
+function Organisation({ address }: { readonly address: string | null }) {
+    const at = address?.lastIndexOf('@') ?? -1;
+
+    if (address === null || at < 0 || at === address.length - 1) {
+        return null;
+    }
+
+    return <span className="hidden truncate text-xs text-faint workspace:inline">{address.slice(at + 1)}</span>;
 }
 
 // What the mail server said about the message, in the order a reader scans for it. Each carries its own words, because

--- a/frontend/src/Client.App/src/messageList/MessageRow.tsx
+++ b/frontend/src/Client.App/src/messageList/MessageRow.tsx
@@ -1,0 +1,158 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { PointerEvent, ReactNode } from 'react';
+import type { MailTimelineEntry } from '@mailfathom/client-backend';
+import { useLocalization } from '../localization/useLocalization';
+
+// One row of the list, which is its own component for the reason a tree's row is: it is what carries state, a keyboard
+// path, and a test. What it draws is what the page answered with — nothing here reads anything of its own, so a row
+// costs one request for the whole page it is in.
+//
+// Its height is fixed by the token rather than by its contents, and that is load-bearing rather than cosmetic: the
+// window above it is arithmetic over one height, and a row that grew with a long subject would put every row below it
+// somewhere other than where the list drew the space for it.
+//
+// Everything on it competes for one column narrower than a reading measure, so what it carries is what a person scans
+// by: who wrote, when, what about, and how it opens. The sender's host was on the first line and is not, because at
+// this width it took the room the name needed and left both of them ellipsised.
+
+export function MessageRow({
+    email,
+    position,
+    open,
+    selected,
+    focusable,
+    onOpen,
+    onPoint,
+    onPointerEnter,
+    onElement,
+}: {
+    readonly email: MailTimelineEntry;
+    readonly position: number;
+    readonly open: boolean;
+    readonly selected: boolean;
+    readonly focusable: boolean;
+    readonly onOpen: () => void;
+    readonly onPoint: (event: PointerEvent<HTMLLIElement>) => void;
+    readonly onPointerEnter: () => void;
+    readonly onElement: (element: HTMLLIElement | null) => void;
+}) {
+    const { locale, translate } = useLocalization();
+
+    return (
+        <li
+            ref={onElement}
+            role="option"
+            aria-selected={selected}
+            aria-posinset={position}
+            // The list is keyset-paged, so how many rows the folder holds is not something any page answers. That is
+            // what ARIA's unknown size names, and it is the accurate answer rather than the number of rows held.
+            aria-setsize={-1}
+            aria-current={open ? 'true' : undefined}
+            tabIndex={focusable ? 0 : -1}
+            onPointerDown={onPoint}
+            onPointerEnter={onPointerEnter}
+            onDoubleClick={onOpen}
+            // Flush and square rather than a card: the rows are one continuous list, each separated from the next by
+            // the line it carries, which is what the window's arithmetic needs them to be as well.
+            className={`flex h-message-row cursor-pointer flex-col justify-center gap-0.5 overflow-hidden border-b border-line-soft px-3 transition ${
+                selected ? 'bg-accent-soft text-accent-strong' : 'text-text-soft hover:bg-hover'
+            } ${open ? 'ring-1 ring-inset ring-accent' : ''}`}
+        >
+            <div className="flex items-baseline gap-2">
+                {email.unread ? (
+                    <span className="size-2 shrink-0 rounded-full bg-accent">
+                        <span className="sr-only">{translate('list.unread')}</span>
+                    </span>
+                ) : null}
+
+                <span className={`truncate text-sm ${email.unread ? 'font-semibold text-text' : ''}`}>
+                    {correspondent(email) ?? translate('list.senderUnknown')}
+                </span>
+
+                <Markers email={email} />
+
+                <ReceivedAt at={email.receivedAt} locale={locale} />
+            </div>
+
+            <div className="flex items-baseline gap-2 text-sm">
+                {/* What the message is about is read before how it opens, so it keeps up to half the line whatever
+                    the preview behind it is long enough to ask for, and the preview is what gives way. */}
+                <span className={`max-w-1/2 shrink-0 truncate ${email.unread ? 'font-medium text-text' : ''}`}>
+                    {email.subject ?? translate('list.noSubject')}
+                </span>
+
+                {email.preview === null ? null : <span className="truncate text-faint">{email.preview}</span>}
+            </div>
+        </li>
+    );
+}
+
+/** Who the row is about: the sender, else the address it came from, else who it was written to. */
+function correspondent(email: MailTimelineEntry): string | undefined {
+    return email.senderDisplayName ?? email.senderAddress ?? email.toAddresses[0];
+}
+
+// What the mail server said about the message, in the order a reader scans for it. Each carries its own words, because
+// a mark with no name is a mark nobody using a screen reader can see at all.
+function Markers({ email }: { readonly email: MailTimelineEntry }) {
+    const { translate } = useLocalization();
+
+    return (
+        <span className="ms-auto flex shrink-0 items-center gap-1">
+            {email.answered ? (
+                <Marker label={translate('list.answered')}>
+                    <path d="M10 9V5l-7 7 7 7v-4.1c5 0 8.5 1.6 11 5.1-1-5-4-10-11-11Z" />
+                </Marker>
+            ) : null}
+
+            {email.hasAttachments ? (
+                <Marker label={translate('list.attachments', { count: String(email.attachmentCount) })}>
+                    <path d="M16.5 6.5v9a4.5 4.5 0 1 1-9 0V5.5a3 3 0 1 1 6 0v9a1.5 1.5 0 1 1-3 0v-8H9v8a3 3 0 1 0 6 0v-9a4.5 4.5 0 1 0-9 0v10a6 6 0 0 0 12 0v-9h-1.5Z" />
+                </Marker>
+            ) : null}
+
+            {email.flagged ? (
+                <Marker label={translate('list.flagged')}>
+                    <path d="m12 17.3-6.2 3.7 1.7-7L2 9.2l7.2-.6L12 2l2.8 6.6 7.2.6-5.5 4.8 1.7 7L12 17.3Z" />
+                </Marker>
+            ) : null}
+        </span>
+    );
+}
+
+function Marker({ label, children }: { readonly label: string; readonly children: ReactNode }) {
+    return (
+        <span className="text-muted">
+            <svg viewBox="0 0 24 24" aria-hidden="true" className="size-3.5 fill-current">
+                {children}
+            </svg>
+            <span className="sr-only">{label}</span>
+        </span>
+    );
+}
+
+// When the last receiving hop recorded the message, formatted by `Intl` under the active locale rather than assembled
+// here. The machine-readable form stays on the element beside it, which is what lets anything reading the document work
+// with the instant rather than with somebody's local spelling of it.
+function ReceivedAt({ at, locale }: { readonly at: string | null; readonly locale: string }) {
+    if (at === null) {
+        return null;
+    }
+
+    const received = new Date(at);
+
+    if (Number.isNaN(received.getTime())) {
+        return null;
+    }
+
+    const when = new Intl.DateTimeFormat(locale, { dateStyle: 'short', timeStyle: 'short' });
+
+    return (
+        <time dateTime={at} className="shrink-0 text-xs tabular-nums text-faint">
+            {when.format(received)}
+        </time>
+    );
+}

--- a/frontend/src/Client.App/src/messageList/heldTimeline.test.ts
+++ b/frontend/src/Client.App/src/messageList/heldTimeline.test.ts
@@ -1,0 +1,246 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import type { MailTimelineEntry, MailTimelinePage } from '@mailfathom/client-backend';
+import {
+    answered,
+    cursorAfter,
+    cursorBefore,
+    heldRows,
+    nothingHeld,
+    pagesKeptEitherSide,
+    positionOfRow,
+    rowAt,
+    rowCountOf,
+    rowOfSlot,
+    trimmedAround,
+    wantedFor,
+    type HeldTimeline,
+    type TimelineRead,
+} from './heldTimeline';
+
+const rowsPerPage = 4;
+
+function message(at: number): MailTimelineEntry {
+    return {
+        id: `message-${String(at)}`,
+        account: 'work',
+        folder: 'INBOX',
+        threadId: null,
+        subject: `Message ${String(at)}`,
+        receivedAt: '2026-08-31T09:41:00+00:00',
+        sentAt: null,
+        senderAddress: 'auditor@example.invalid',
+        senderDisplayName: null,
+        toAddresses: [],
+        unread: false,
+        flagged: false,
+        answered: false,
+        hasAttachments: false,
+        attachmentCount: 0,
+        sizeOctets: 1_024,
+        preview: null,
+    };
+}
+
+// One page of four, numbered from where it starts, so a row identity says which page it came from.
+function page(from: number, cursors: Partial<MailTimelinePage> = {}): MailTimelinePage {
+    return {
+        emails: Array.from({ length: rowsPerPage }, (_, at) => message(from + at)),
+        nextCursor: `after-${String(from + rowsPerPage)}`,
+        previousCursor: from === 0 ? null : `before-${String(from)}`,
+        pageSize: rowsPerPage,
+        ...cursors,
+    };
+}
+
+const forward: TimelineRead = { cursor: null, direction: 'forward', refilling: null };
+
+function extending(cursor: string): TimelineRead {
+    return { cursor, direction: 'forward', refilling: null };
+}
+
+/** A list read forward from its leading end, one page at a time, which is what scrolling down produces. */
+function readForward(pages: number): HeldTimeline {
+    let held = answered(nothingHeld, page(0), forward);
+
+    for (let at = 1; at < pages; at += 1) {
+        held = answered(held, page(at * rowsPerPage), extending(`after-${String(at * rowsPerPage)}`));
+    }
+
+    return held;
+}
+
+describe('answered', () => {
+    it('stands a list on the first page it read', () => {
+        const held = answered(nothingHeld, page(0), forward);
+
+        expect(rowCountOf(held)).toBe(rowsPerPage);
+        expect(rowAt(held, 0)?.id).toBe('message-0');
+    });
+
+    it('records a folder holding no mail rather than reading it again', () => {
+        const empty = { emails: [], nextCursor: null, previousCursor: null, pageSize: rowsPerPage };
+        const held = answered(nothingHeld, empty, forward);
+
+        expect(held.slots).toHaveLength(1);
+        expect(rowCountOf(held)).toBe(0);
+        expect(wantedFor(held, 0, 0)).toBeNull();
+    });
+
+    it('joins a page read forward to the end of the list', () => {
+        const held = readForward(2);
+
+        expect(rowCountOf(held)).toBe(8);
+        expect(rowAt(held, 7)?.id).toBe('message-7');
+    });
+
+    it('joins a page read backward to the beginning of the list', () => {
+        const opened = answered(nothingHeld, page(4), forward);
+        const held = answered(opened, page(0), { cursor: 'before-4', direction: 'backward', refilling: null });
+
+        expect(rowAt(held, 0)?.id).toBe('message-0');
+        expect(rowAt(held, 4)?.id).toBe('message-4');
+    });
+
+    it('retires the cursor at an end that answered with nothing, so the list stops asking there', () => {
+        const opened = answered(nothingHeld, page(0), forward);
+        const empty = { emails: [], nextCursor: null, previousCursor: null, pageSize: rowsPerPage };
+        const held = answered(opened, empty, extending('after-4'));
+
+        expect(rowCountOf(held)).toBe(rowsPerPage);
+        expect(cursorAfter(held)).toBeNull();
+    });
+
+    it('puts a page read again back where its rows stood, rather than at an end', () => {
+        const held = readForward(3);
+        const dropped = trimmedAround(held, 8, 11);
+        const refilled = answered(dropped, page(0), { cursor: null, direction: 'forward', refilling: 0 });
+
+        expect(rowCountOf(refilled)).toBe(rowCountOf(held));
+        expect(rowAt(refilled, 0)?.id).toBe('message-0');
+    });
+});
+
+describe('trimmedAround', () => {
+    it('drops the rows of a page far from the reader and keeps the space they stood in', () => {
+        const held = readForward(2 + pagesKeptEitherSide * 2);
+        const trimmed = trimmedAround(held, 0, 3);
+
+        expect(rowCountOf(trimmed)).toBe(rowCountOf(held));
+        expect(rowAt(trimmed, rowCountOf(held) - 1)).toBeNull();
+    });
+
+    it('keeps the pages either side of the one being read', () => {
+        const held = readForward(6);
+        const trimmed = trimmedAround(held, 8, 11);
+
+        expect(rowAt(trimmed, 0)?.id).toBe('message-0');
+        expect(rowAt(trimmed, 19)?.id).toBe('message-19');
+    });
+
+    it('answers with the list it was given where nothing was far enough to drop', () => {
+        const held = readForward(2);
+
+        expect(trimmedAround(held, 0, 7)).toBe(held);
+    });
+
+    it('leaves a page it already dropped alone rather than reporting a change', () => {
+        const held = trimmedAround(readForward(6), 0, 3);
+
+        expect(trimmedAround(held, 0, 3)).toBe(held);
+    });
+});
+
+describe('wantedFor', () => {
+    it('wants nothing while the window is inside rows the list is holding', () => {
+        expect(wantedFor(readForward(3), 4, 7)).toBeNull();
+    });
+
+    it('wants the page after the end once the window reaches it', () => {
+        expect(wantedFor(readForward(2), 4, 7)).toStrictEqual({
+            cursor: 'after-8',
+            direction: 'forward',
+            refilling: null,
+        });
+    });
+
+    it('wants the page before the beginning once the window reaches it', () => {
+        const held = answered(nothingHeld, page(4, { nextCursor: null }), forward);
+
+        expect(wantedFor(held, 0, 3)).toStrictEqual({
+            cursor: 'before-4',
+            direction: 'backward',
+            refilling: null,
+        });
+    });
+
+    it('reads onward before it reads back, where a short list has both of its ends on the screen', () => {
+        const held = answered(nothingHeld, page(4), forward);
+
+        expect(wantedFor(held, 0, 3)?.direction).toBe('forward');
+    });
+
+    it('wants a dropped page back through the cursor it was read under, not the leading end of the list', () => {
+        const held = trimmedAround(readForward(6), 20, 23);
+
+        expect(wantedFor(held, 0, 3)).toStrictEqual({ cursor: null, direction: 'forward', refilling: 0 });
+    });
+
+    it('wants a dropped page before either end, so a hole on the screen is filled before the list grows', () => {
+        const held = trimmedAround(readForward(6), 20, 23);
+
+        expect(wantedFor(held, 0, 23)?.refilling).toBe(0);
+    });
+
+    it('wants nothing at an end the list has reached', () => {
+        const held = answered(nothingHeld, page(0, { nextCursor: null, previousCursor: null }), forward);
+
+        expect(wantedFor(held, 0, 3)).toBeNull();
+    });
+});
+
+describe('positionOfRow', () => {
+    it('answers the page a row is in and where in it, so a returning visit reads that page', () => {
+        expect(positionOfRow(readForward(3), 9)).toStrictEqual({
+            cursor: 'after-8',
+            readAs: 'forward',
+            rowInPage: 1,
+        });
+    });
+
+    it('answers the leading page for a row in it', () => {
+        expect(positionOfRow(readForward(2), 1)).toStrictEqual({ cursor: null, readAs: 'forward', rowInPage: 1 });
+    });
+
+    it('answers nothing for a row past the end of the list', () => {
+        expect(positionOfRow(readForward(1), 99)).toBeNull();
+    });
+});
+
+describe('rowOfSlot', () => {
+    it('answers where a page starts', () => {
+        expect(rowOfSlot(readForward(3), 2)).toBe(8);
+    });
+
+    it('answers nothing for a page the list does not know', () => {
+        expect(rowOfSlot(readForward(1), 4)).toBeNull();
+    });
+});
+
+describe('heldRows', () => {
+    it('answers only the rows the list is holding, in reading order', () => {
+        const held = trimmedAround(readForward(6), 20, 23);
+
+        expect(heldRows(held).map((email) => email.id)).not.toContain('message-0');
+        expect(heldRows(held)[0]?.id).toBe(`message-${String(rowsPerPage * (6 - 1 - pagesKeptEitherSide))}`);
+    });
+});
+
+describe('cursorBefore', () => {
+    it('answers nothing at the beginning of a list read from its leading end', () => {
+        expect(cursorBefore(readForward(2))).toBeNull();
+    });
+});

--- a/frontend/src/Client.App/src/messageList/heldTimeline.ts
+++ b/frontend/src/Client.App/src/messageList/heldTimeline.ts
@@ -1,0 +1,251 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { MailTimelineEntry, MailTimelinePage, MailTimelinePageDirection } from '@mailfathom/client-backend';
+
+// What the list is holding, which is bounded as well as what it is drawing. Windowing alone bounds the document; this
+// bounds the memory behind it, because a reader who has scrolled past forty thousand messages has read four hundred
+// pages, and holding them would be the same defect one level down.
+//
+// A page whose rows are dropped keeps its place rather than leaving the list. It becomes a slot that still knows how
+// many rows stood there and the cursor they were read under, so the list keeps its height, nothing the reader is
+// looking at moves, and scrolling back into it reads that page again from its own cursor rather than reading the folder
+// from its leading end. The alternative — dropping the slot too — would shrink the list under the reader on a scroll
+// they did not make, which is the defect windowing exists to avoid one level up.
+
+/** One page's worth of the list: its rows where they are held, and where they are read from where they are not. */
+export interface TimelineSlot {
+    /** The cursor this page was asked with, or `null` where it was read from the leading end of the list. */
+    readonly askedWith: string | null;
+
+    /** Which way it was read from that cursor, which is the other half of how it is read again. */
+    readonly readAs: MailTimelinePageDirection;
+
+    /** How many rows stand here, which the list keeps whether or not it is holding them. */
+    readonly rowCount: number;
+
+    /** The rows, or `null` where they have been dropped and the cursor above is how they come back. */
+    readonly emails: readonly MailTimelineEntry[] | null;
+
+    readonly nextCursor: string | null;
+    readonly previousCursor: string | null;
+}
+
+/**
+ * How many pages either side of what is being read keep their rows.
+ *
+ * Two pages of a hundred either side is a few screenfuls in both directions, which is further than ordinary scrolling
+ * reaches between frames — so a reader moving at any speed a person moves at finds rows rather than the space they
+ * stood in. Everything beyond it is dropped, so the list costs the same after an hour of scrolling as on the first
+ * screen.
+ */
+export const pagesKeptEitherSide = 2;
+
+/** The pages the list knows about, in the order the list is read in. */
+export interface HeldTimeline {
+    readonly slots: readonly TimelineSlot[];
+}
+
+/** A list that knows about nothing, which is where every scope and every change of filter starts. */
+export const nothingHeld: HeldTimeline = { slots: [] };
+
+/** How many rows the list stands for, held or dropped. */
+export function rowCountOf(held: HeldTimeline): number {
+    return held.slots.reduce((rows, slot) => rows + slot.rowCount, 0);
+}
+
+/** The message at a row, or `null` where the page holding it has been dropped. */
+export function rowAt(held: HeldTimeline, row: number): MailTimelineEntry | null {
+    let passed = 0;
+
+    for (const slot of held.slots) {
+        if (row < passed + slot.rowCount) {
+            return slot.emails?.[row - passed] ?? null;
+        }
+
+        passed += slot.rowCount;
+    }
+
+    return null;
+}
+
+/** Every message the list is holding, in reading order, which is what the selection is ordered against. */
+export function heldRows(held: HeldTimeline): readonly MailTimelineEntry[] {
+    return held.slots.flatMap((slot) => slot.emails ?? []);
+}
+
+/** The cursor the page after the end of the list is asked with, or `null` where the end has been reached. */
+export function cursorAfter(held: HeldTimeline): string | null {
+    return held.slots.at(-1)?.nextCursor ?? null;
+}
+
+/** The cursor the page before the beginning of the list is asked with, or `null` where the beginning has been reached. */
+export function cursorBefore(held: HeldTimeline): string | null {
+    return held.slots.at(0)?.previousCursor ?? null;
+}
+
+/** Where in the list a row is, as the page holding it, how that page is read, and the row's place inside it. */
+export interface HeldPosition {
+    readonly cursor: string | null;
+    readonly readAs: MailTimelinePageDirection;
+    readonly rowInPage: number;
+}
+
+/**
+ * Which page holds a row and where in it, which is what a returning visit is read back from.
+ *
+ * The direction travels with the cursor because the pair is what names a page: the same cursor read the other way
+ * answers with the page on the other side of it, which would put a returning reader a page from where they left.
+ */
+export function positionOfRow(held: HeldTimeline, row: number): HeldPosition | null {
+    let passed = 0;
+
+    for (const slot of held.slots) {
+        if (row < passed + slot.rowCount) {
+            return { cursor: slot.askedWith, readAs: slot.readAs, rowInPage: row - passed };
+        }
+
+        passed += slot.rowCount;
+    }
+
+    return null;
+}
+
+/** The row the first row of a page stands at, or `null` where the list knows no such page. */
+export function rowOfSlot(held: HeldTimeline, slot: number): number | null {
+    if (slot < 0 || slot >= held.slots.length) {
+        return null;
+    }
+
+    return held.slots.slice(0, slot).reduce((rows, passed) => rows + passed.rowCount, 0);
+}
+
+/** What one read asked for, which is what says where its answer belongs. */
+export interface TimelineRead {
+    readonly cursor: string | null;
+    readonly direction: MailTimelinePageDirection;
+
+    /** The page whose dropped rows this read is fetching again, or `null` where it extends one end of the list. */
+    readonly refilling: number | null;
+}
+
+/** The page a read the list has not made yet would ask for, or `null` where what is on the screen is all held. */
+export function wantedFor(held: HeldTimeline, firstRow: number, lastRow: number): TimelineRead | null {
+    let passed = 0;
+
+    for (const [at, slot] of held.slots.entries()) {
+        const beyond = passed + slot.rowCount;
+
+        if (slot.emails === null && passed <= lastRow && beyond > firstRow) {
+            return { cursor: slot.askedWith, direction: slot.readAs, refilling: at };
+        }
+
+        passed += slot.rowCount;
+    }
+
+    const after = cursorAfter(held);
+    if (after !== null && lastRow >= passed - 1) {
+        return { cursor: after, direction: 'forward', refilling: null };
+    }
+
+    const before = cursorBefore(held);
+    if (before !== null && firstRow <= 0) {
+        return { cursor: before, direction: 'backward', refilling: null };
+    }
+
+    return null;
+}
+
+/** The page a read answered with, as a slot the list stands on. */
+function slotFor(page: MailTimelinePage, read: TimelineRead): TimelineSlot {
+    return {
+        askedWith: read.cursor,
+        readAs: read.direction,
+        rowCount: page.emails.length,
+        emails: page.emails,
+        nextCursor: page.nextCursor,
+        previousCursor: page.previousCursor,
+    };
+}
+
+/**
+ * What the list knows once a page has answered.
+ *
+ * A page that was asked for to refill a dropped one goes back where it stood; one that extends the list joins the end
+ * it was read from.
+ *
+ * @param held What the list knows now.
+ * @param page The page that answered.
+ * @param read What was asked for, which says where the answer belongs.
+ * @returns What the list knows.
+ */
+export function answered(held: HeldTimeline, page: MailTimelinePage, read: TimelineRead): HeldTimeline {
+    if (read.refilling !== null) {
+        return {
+            slots: held.slots.map((slot, at) => (at === read.refilling ? slotFor(page, read) : slot)),
+        };
+    }
+
+    // A page with no rows is the end of the list having been reached between two reads, and it joins nothing rather
+    // than standing as a row of nowhere. The first page is the exception: a folder holding no mail answers with one,
+    // and a list that recorded nothing would ask for it again on every render.
+    if (page.emails.length === 0 && held.slots.length > 0) {
+        return endReached(held, read.direction);
+    }
+
+    const slot = slotFor(page, read);
+
+    return { slots: read.direction === 'forward' ? [...held.slots, slot] : [slot, ...held.slots] };
+}
+
+// An end that answered with no rows is an end reached, and the cursor pointing at it is retired so the list does not
+// ask again on the next scroll. Nothing else about the slot changes: its rows and its other cursor are still what they
+// were.
+function endReached(held: HeldTimeline, direction: MailTimelinePageDirection): HeldTimeline {
+    const at = direction === 'forward' ? held.slots.length - 1 : 0;
+
+    return {
+        slots: held.slots.map((slot, passed) =>
+            passed === at
+                ? { ...slot, ...(direction === 'forward' ? { nextCursor: null } : { previousCursor: null }) }
+                : slot,
+        ),
+    };
+}
+
+/**
+ * The list with the rows of every page too far from the reader dropped.
+ *
+ * The slots stay: each keeps its height and the cursor its rows are read back with, so dropping costs the reader
+ * nothing until they scroll back into one, and costs them one page read when they do.
+ *
+ * @param held What the list knows.
+ * @param firstRow The first row on the screen.
+ * @param lastRow The last row on the screen.
+ * @returns The list with distant rows dropped, or the same list where nothing was far enough to drop.
+ */
+export function trimmedAround(held: HeldTimeline, firstRow: number, lastRow: number): HeldTimeline {
+    const reached: number[] = [];
+    let passed = 0;
+
+    for (const [at, slot] of held.slots.entries()) {
+        if (passed <= lastRow && passed + slot.rowCount > firstRow) {
+            reached.push(at);
+        }
+
+        passed += slot.rowCount;
+    }
+
+    const nearest = reached[0] ?? 0;
+    const furthest = reached.at(-1) ?? held.slots.length - 1;
+    const keptFrom = nearest - pagesKeptEitherSide;
+    const keptTo = furthest + pagesKeptEitherSide;
+
+    const slots = held.slots.map((slot, at) =>
+        slot.emails === null || (at >= keptFrom && at <= keptTo) ? slot : { ...slot, emails: null },
+    );
+
+    // The list it was given where nothing was far enough to drop, so a scroll that changes nothing renders nothing.
+    return slots.some((slot, at) => slot !== held.slots[at]) ? { slots } : held;
+}

--- a/frontend/src/Client.App/src/messageList/listing.test.ts
+++ b/frontend/src/Client.App/src/messageList/listing.test.ts
@@ -50,6 +50,13 @@ describe('queryFor', () => {
         expect(queryFor({ kind: 'role', role: 'Junk' }, openingListing, null, 'forward').includeJunk).toBe(true);
     });
 
+    it.each(['Inbox', 'Sent', 'Archive', 'Trash'] as const)(
+        'leaves junk out of the %s role, which spans folders the reader did not point at',
+        (role) => {
+            expect(queryFor({ kind: 'role', role }, openingListing, null, 'forward').includeJunk).toBe(false);
+        },
+    );
+
     it('carries the reader’s own narrowing', () => {
         const listing = { ...openingListing, filters: { ...openingListing.filters, unread: true, flagged: true } };
         const query = queryFor(everything, listing, null, 'forward');

--- a/frontend/src/Client.App/src/messageList/listing.test.ts
+++ b/frontend/src/Client.App/src/messageList/listing.test.ts
@@ -1,0 +1,89 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import { everything, type MailScope } from '../workspace/mailScope';
+import { narrowed, openingListing, queryFor, rowsPerPage } from './listing';
+
+describe('queryFor', () => {
+    it('names neither an account nor a folder for every folder of every mailbox', () => {
+        const query = queryFor(everything, openingListing, null, 'forward');
+
+        expect(query.account).toBeNull();
+        expect(query.folder).toBeNull();
+    });
+
+    it('names the role a scope spanning every mailbox stands for', () => {
+        const query = queryFor({ kind: 'role', role: 'Inbox' }, openingListing, null, 'forward');
+
+        expect(query.account).toBeNull();
+        expect(query.folder).toBe('role:Inbox');
+    });
+
+    it('names the account a scope of one whole mailbox stands for', () => {
+        const query = queryFor({ kind: 'account', accountId: 'work' }, openingListing, null, 'forward');
+
+        expect(query.account).toBe('work');
+        expect(query.folder).toBeNull();
+    });
+
+    it('names both for one folder of one mailbox', () => {
+        const scope: MailScope = { kind: 'folder', accountId: 'work', alias: 'ARCHIVE-2024' };
+        const query = queryFor(scope, openingListing, null, 'forward');
+
+        expect(query.account).toBe('work');
+        expect(query.folder).toBe('ARCHIVE-2024');
+    });
+
+    it('leaves junk out of a list spanning folders unless the reader asked for it', () => {
+        expect(queryFor(everything, openingListing, null, 'forward').includeJunk).toBe(false);
+    });
+
+    it('asks for junk where a scope points at one folder, so the folder somebody opened is not shown empty', () => {
+        const scope: MailScope = { kind: 'folder', accountId: 'work', alias: 'Spam' };
+
+        expect(queryFor(scope, openingListing, null, 'forward').includeJunk).toBe(true);
+    });
+
+    it('asks for junk where the scope is the junk role, which the deployment withholds from anything wider', () => {
+        expect(queryFor({ kind: 'role', role: 'Junk' }, openingListing, null, 'forward').includeJunk).toBe(true);
+    });
+
+    it('carries the reader’s own narrowing', () => {
+        const listing = { ...openingListing, filters: { ...openingListing.filters, unread: true, flagged: true } };
+        const query = queryFor(everything, listing, null, 'forward');
+
+        expect(query.unread).toBe(true);
+        expect(query.flagged).toBe(true);
+        expect(query.hasAttachments).toBeNull();
+    });
+
+    it('carries the cursor and the direction the page continues from', () => {
+        const query = queryFor(everything, openingListing, 'held', 'backward');
+
+        expect(query.cursor).toBe('held');
+        expect(query.direction).toBe('backward');
+    });
+
+    it('asks for the largest page the deployment serves, because a page is one exchange', () => {
+        expect(queryFor(everything, openingListing, null, 'forward').pageSize).toBe(rowsPerPage);
+    });
+});
+
+describe('narrowed', () => {
+    it('reports a list nobody has narrowed', () => {
+        expect(narrowed(openingListing.filters)).toBe(false);
+    });
+
+    it.each([{ unread: true }, { flagged: true }, { hasAttachments: false }])(
+        'reports a list narrowed by %o',
+        (filter) => {
+            expect(narrowed({ ...openingListing.filters, ...filter })).toBe(true);
+        },
+    );
+
+    it('does not read reaching into junk as a narrowing, because it widens the list rather than narrowing it', () => {
+        expect(narrowed({ ...openingListing.filters, includeJunk: true })).toBe(false);
+    });
+});

--- a/frontend/src/Client.App/src/messageList/listing.ts
+++ b/frontend/src/Client.App/src/messageList/listing.ts
@@ -1,0 +1,104 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import {
+    longestTimelinePage,
+    type MailTimelineOrder,
+    type MailTimelinePageDirection,
+    type MailTimelineQuery,
+} from '@mailfathom/client-backend';
+import type { MailScope } from '../workspace/mailScope';
+
+// What the reader has asked of one folder: which way round it is read, and what is kept out of it. It is the list's own
+// state rather than the workspace's, because it belongs to a folder rather than to the person — moving to another
+// mailbox is not a reason to inherit the last one's filters, and coming back to this one is a reason to find them.
+//
+// It is also half of what a cursor means. The deployment refuses a cursor presented under different filters or a
+// different order, which is why `rememberedListings.ts` keeps the cursor inside the same record as the two of them:
+// changing either replaces the record, and there is nowhere for a cursor issued under the old one to survive.
+
+/** What the list is keeping out, where each of the three keeps both answers unless the reader narrowed it. */
+export interface MailListFilters {
+    readonly unread: boolean | null;
+    readonly flagged: boolean | null;
+    readonly hasAttachments: boolean | null;
+
+    /** Whether the junk folder takes part in a list spanning folders, which it does not unless the reader asks. */
+    readonly includeJunk: boolean;
+}
+
+/** How one folder is being read. */
+export interface MailListing {
+    readonly order: MailTimelineOrder;
+    readonly filters: MailListFilters;
+}
+
+/** What a folder nobody has narrowed is read as: newest first, nothing kept out, and no junk swept in. */
+export const openingListing: MailListing = {
+    order: 'newestFirst',
+    filters: { unread: null, flagged: null, hasAttachments: null, includeJunk: false },
+};
+
+/**
+ * How many rows one page holds.
+ *
+ * The largest the deployment serves, because a page is one exchange and the list holds a bounded number of them: a
+ * smaller page would cost the reader more round trips for the same rows and would bound the list's memory no further.
+ */
+export const rowsPerPage = longestTimelinePage;
+
+/** The account and the folder a scope names on the client surface, where it names either. */
+function askedOf(scope: MailScope): { readonly account: string | null; readonly folder: string | null } {
+    switch (scope.kind) {
+        case 'everything':
+            return { account: null, folder: null };
+        case 'role':
+            return { account: null, folder: `role:${scope.role}` };
+        case 'account':
+            return { account: scope.accountId, folder: null };
+        case 'folder':
+            return { account: scope.accountId, folder: scope.alias };
+    }
+}
+
+/**
+ * The request one page of a scope is read with.
+ *
+ * A scope that names a folder asks for the junk folder whatever the reader's filter says, and that is narrowing rather
+ * than widening: the deployment withholds junk from a read that spans folders, so a reader who has pointed at their
+ * junk folder would otherwise be shown an empty one. A folder scope has already excluded every folder but the one
+ * named, so asking cannot reach anything the reader did not point at.
+ *
+ * @param scope What the client is looking at.
+ * @param listing How the reader has asked for it to be read.
+ * @param cursor The cursor the page is asked from, or `null` for the leading end of the list.
+ * @param direction Which way the page continues from that cursor.
+ * @returns The request the client surface is asked with.
+ */
+export function queryFor(
+    scope: MailScope,
+    listing: MailListing,
+    cursor: string | null,
+    direction: MailTimelinePageDirection,
+): MailTimelineQuery {
+    const { account, folder } = askedOf(scope);
+
+    return {
+        account,
+        folder,
+        includeJunk: listing.filters.includeJunk || folder !== null,
+        unread: listing.filters.unread,
+        flagged: listing.filters.flagged,
+        hasAttachments: listing.filters.hasAttachments,
+        order: listing.order,
+        direction,
+        pageSize: rowsPerPage,
+        cursor,
+    };
+}
+
+/** Whether the reader has narrowed the list at all, which is what says a folder is empty rather than filtered to nothing. */
+export function narrowed(filters: MailListFilters): boolean {
+    return filters.unread !== null || filters.flagged !== null || filters.hasAttachments !== null;
+}

--- a/frontend/src/Client.App/src/messageList/listing.ts
+++ b/frontend/src/Client.App/src/messageList/listing.ts
@@ -63,12 +63,22 @@ function askedOf(scope: MailScope): { readonly account: string | null; readonly 
 }
 
 /**
+ * Whether the scope is junk the reader pointed at, which is the one case a read asks for junk without being told to.
+ *
+ * The deployment withholds junk from a read spanning folders, so a reader who has opened their junk folder — or the
+ * role that is every account's junk folder at once — would be shown an empty one. Both of those have already excluded
+ * everything but junk, so asking cannot reach anything the reader did not point at. Every other role spans many
+ * folders across many accounts and is exactly the list junk is withheld from, so it is left out there.
+ */
+function pointsAtJunk(scope: MailScope): boolean {
+    return scope.kind === 'folder' || (scope.kind === 'role' && scope.role === 'Junk');
+}
+
+/**
  * The request one page of a scope is read with.
  *
- * A scope that names a folder asks for the junk folder whatever the reader's filter says, and that is narrowing rather
- * than widening: the deployment withholds junk from a read that spans folders, so a reader who has pointed at their
- * junk folder would otherwise be shown an empty one. A folder scope has already excluded every folder but the one
- * named, so asking cannot reach anything the reader did not point at.
+ * A scope pointing at junk asks for it whatever the reader's filter says, and that is narrowing rather than widening —
+ * {@link pointsAtJunk} holds the reasoning.
  *
  * @param scope What the client is looking at.
  * @param listing How the reader has asked for it to be read.
@@ -87,7 +97,7 @@ export function queryFor(
     return {
         account,
         folder,
-        includeJunk: listing.filters.includeJunk || folder !== null,
+        includeJunk: listing.filters.includeJunk || pointsAtJunk(scope),
         unread: listing.filters.unread,
         flagged: listing.filters.flagged,
         hasAttachments: listing.filters.hasAttachments,

--- a/frontend/src/Client.App/src/messageList/messageSelection.test.ts
+++ b/frontend/src/Client.App/src/messageList/messageSelection.test.ts
@@ -1,0 +1,52 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import { inReadingOrder, onlySelected, rangeBetween, withToggled } from './messageSelection';
+
+const drawn = ['one', 'two', 'three', 'four', 'five'];
+
+describe('onlySelected', () => {
+    it('selects the one message a plain click picked out', () => {
+        expect(onlySelected('three')).toStrictEqual(['three']);
+    });
+});
+
+describe('withToggled', () => {
+    it('adds a message the selection does not hold', () => {
+        expect(withToggled(['one'], 'three')).toStrictEqual(['one', 'three']);
+    });
+
+    it('takes out a message the selection holds', () => {
+        expect(withToggled(['one', 'three'], 'one')).toStrictEqual(['three']);
+    });
+});
+
+describe('rangeBetween', () => {
+    it('selects every message from the anchor to the one reached', () => {
+        expect(rangeBetween(drawn, 'two', 'four')).toStrictEqual(['two', 'three', 'four']);
+    });
+
+    it('selects the same run whichever end the reader started from', () => {
+        expect(rangeBetween(drawn, 'four', 'two')).toStrictEqual(rangeBetween(drawn, 'two', 'four'));
+    });
+
+    it('selects one message where both ends are the same', () => {
+        expect(rangeBetween(drawn, 'two', 'two')).toStrictEqual(['two']);
+    });
+
+    it('selects nothing where an end is no longer drawn', () => {
+        expect(rangeBetween(drawn, 'dropped', 'four')).toStrictEqual([]);
+    });
+});
+
+describe('inReadingOrder', () => {
+    it('orders a selection the way the list draws it, whichever order it was picked in', () => {
+        expect(inReadingOrder(['four', 'one'], drawn)).toStrictEqual(['one', 'four']);
+    });
+
+    it('keeps a message the list has scrolled past, so a question about four does not lose one', () => {
+        expect(inReadingOrder(['scrolled-past', 'two'], drawn)).toStrictEqual(['two', 'scrolled-past']);
+    });
+});

--- a/frontend/src/Client.App/src/messageList/messageSelection.test.ts
+++ b/frontend/src/Client.App/src/messageList/messageSelection.test.ts
@@ -3,7 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { describe, expect, it } from 'vitest';
-import { inReadingOrder, onlySelected, rangeBetween, withToggled } from './messageSelection';
+import { extendedTo, inReadingOrder, onlySelected, rangeBetween, withToggled } from './messageSelection';
 
 const drawn = ['one', 'two', 'three', 'four', 'five'];
 
@@ -38,6 +38,24 @@ describe('rangeBetween', () => {
 
     it('selects nothing where an end is no longer drawn', () => {
         expect(rangeBetween(drawn, 'dropped', 'four')).toStrictEqual([]);
+    });
+});
+
+describe('extendedTo', () => {
+    it('selects the run where the list still holds both ends of it', () => {
+        expect(extendedTo(['two'], drawn, 'two', 'four')).toStrictEqual(['two', 'three', 'four']);
+    });
+
+    it('keeps what was picked out where the anchor’s page has been dropped, rather than selecting nothing', () => {
+        expect(extendedTo(['scrolled-past', 'two'], drawn, 'dropped', 'four')).toStrictEqual([
+            'scrolled-past',
+            'two',
+            'four',
+        ]);
+    });
+
+    it('leaves a selection alone where the message reached is already in it', () => {
+        expect(extendedTo(['four'], drawn, 'dropped', 'four')).toStrictEqual(['four']);
     });
 });
 

--- a/frontend/src/Client.App/src/messageList/messageSelection.ts
+++ b/frontend/src/Client.App/src/messageList/messageSelection.ts
@@ -44,6 +44,35 @@ export function rangeBetween(rows: readonly string[], anchor: string, reached: s
 }
 
 /**
+ * The selection a gesture that runs from the anchor leaves behind.
+ *
+ * The run where both ends are held, and otherwise what was already selected with the message reached added to it. That
+ * fallback is the whole point of this function: the anchor's page is dropped once the reader has scrolled far enough
+ * from it, and a run that cannot be worked out must not be written back as the empty selection it computes to — the
+ * pages behind the reader go, and what they picked out of them does not.
+ *
+ * @param selected What is selected.
+ * @param rows The identities the list is holding, in the order it draws them.
+ * @param anchor Where the run started.
+ * @param reached Where the run has got to.
+ * @returns The selection after the gesture.
+ */
+export function extendedTo(
+    selected: readonly string[],
+    rows: readonly string[],
+    anchor: string,
+    reached: string,
+): readonly string[] {
+    const run = rangeBetween(rows, anchor, reached);
+
+    if (run.length > 0) {
+        return run;
+    }
+
+    return selected.includes(reached) ? selected : [...selected, reached];
+}
+
+/**
  * The selection ordered as the list draws it, and with anything the list no longer holds left in place.
  *
  * A message scrolled past is still selected — the pages behind the reader are dropped and the selection is not, because

--- a/frontend/src/Client.App/src/messageList/messageSelection.ts
+++ b/frontend/src/Client.App/src/messageList/messageSelection.ts
@@ -1,0 +1,62 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+// What several messages at once means, as an operation on identities rather than as something the list draws. The
+// selection itself is the workspace's, because *select and ask* is the client's most-used gesture and the question is
+// asked somewhere the list is not — a selection only the list knew about would be a visual state that the rest of the
+// client could not read as scope.
+//
+// Order matters and is the list's rather than the click's: a selection read back as a question about four messages
+// should name them in the order the reader sees them, whichever one they happened to point at first.
+
+/** The one message a plain click selects. */
+export function onlySelected(id: string): readonly string[] {
+    return [id];
+}
+
+/** The selection with one message added or taken out of it, which is what a click holding the modifier key does. */
+export function withToggled(selected: readonly string[], id: string): readonly string[] {
+    return selected.includes(id) ? selected.filter((chosen) => chosen !== id) : [...selected, id];
+}
+
+/**
+ * Every message from the anchor to the one reached, in the order the list draws them.
+ *
+ * Replacing rather than adding, which is what a click holding shift does everywhere a list is selected: the anchor
+ * stays where it was, so dragging or shifting again from the same anchor grows and shrinks one run rather than leaving
+ * the runs it passed over behind.
+ *
+ * @param rows The identities the list is holding, in the order it draws them.
+ * @param anchor Where the run started, which is the last message selected without shift.
+ * @param reached Where the run has got to.
+ * @returns The run, or nothing where either end is no longer held.
+ */
+export function rangeBetween(rows: readonly string[], anchor: string, reached: string): readonly string[] {
+    const from = rows.indexOf(anchor);
+    const to = rows.indexOf(reached);
+
+    if (from < 0 || to < 0) {
+        return [];
+    }
+
+    return rows.slice(Math.min(from, to), Math.max(from, to) + 1);
+}
+
+/**
+ * The selection ordered as the list draws it, and with anything the list no longer holds left in place.
+ *
+ * A message scrolled past is still selected — the pages behind the reader are dropped and the selection is not, because
+ * a question about four messages must not lose one of them to the list having been scrolled. So this orders what it can
+ * find and appends what it cannot, rather than filtering.
+ *
+ * @param selected What is selected.
+ * @param rows The identities the list is holding, in the order it draws them.
+ * @returns The selection in reading order.
+ */
+export function inReadingOrder(selected: readonly string[], rows: readonly string[]): readonly string[] {
+    const held = rows.filter((id) => selected.includes(id));
+    const beyond = selected.filter((id) => !rows.includes(id));
+
+    return [...held, ...beyond];
+}

--- a/frontend/src/Client.App/src/messageList/rememberedListings.test.ts
+++ b/frontend/src/Client.App/src/messageList/rememberedListings.test.ts
@@ -9,7 +9,7 @@ import {
     forgetListings,
     rememberedListing,
     rememberListing,
-    unreadListing,
+    neverOpenedListing,
     type RememberedListing,
 } from './rememberedListings';
 
@@ -48,13 +48,13 @@ describe('rememberListing', () => {
     it('keeps a folder of one deployment apart from the same folder of another', () => {
         rememberListing(deployment, inbox, kept);
 
-        expect(rememberedListing('https://other.example.invalid', inbox)).toStrictEqual(unreadListing);
+        expect(rememberedListing('https://other.example.invalid', inbox)).toStrictEqual(neverOpenedListing);
     });
 
     it('keeps one folder apart from another of the same deployment', () => {
         rememberListing(deployment, inbox, kept);
 
-        expect(rememberedListing(deployment, everything)).toStrictEqual(unreadListing);
+        expect(rememberedListing(deployment, everything)).toStrictEqual(neverOpenedListing);
     });
 
     it('drops the folder read longest ago once it is holding as many as it keeps', () => {
@@ -62,7 +62,9 @@ describe('rememberListing', () => {
             rememberListing(deployment, { kind: 'account', accountId: `account-${String(at)}` }, kept);
         }
 
-        expect(rememberedListing(deployment, { kind: 'account', accountId: 'account-0' })).toStrictEqual(unreadListing);
+        expect(rememberedListing(deployment, { kind: 'account', accountId: 'account-0' })).toStrictEqual(
+            neverOpenedListing,
+        );
         expect(rememberedListing(deployment, { kind: 'account', accountId: 'account-64' })).toStrictEqual(kept);
     });
 
@@ -96,7 +98,7 @@ describe('rememberedListing', () => {
     ])('opens at the leading end for %s', (_, written) => {
         window.sessionStorage.setItem(storageKey, written);
 
-        expect(rememberedListing(deployment, inbox)).toStrictEqual(unreadListing);
+        expect(rememberedListing(deployment, inbox)).toStrictEqual(neverOpenedListing);
     });
 
     it.each([
@@ -114,7 +116,7 @@ describe('rememberedListing', () => {
     ])('opens at the leading end for a record carrying %s', (_, written) => {
         stored({ [keyFor(inbox)]: written });
 
-        expect(rememberedListing(deployment, inbox)).toStrictEqual(unreadListing);
+        expect(rememberedListing(deployment, inbox)).toStrictEqual(neverOpenedListing);
     });
 
     it('refuses a store holding more folders than it keeps rather than reading part of it', () => {
@@ -124,7 +126,7 @@ describe('rememberedListing', () => {
 
         stored(crowd);
 
-        expect(rememberedListing(deployment, { kind: 'account', accountId: '1' })).toStrictEqual(unreadListing);
+        expect(rememberedListing(deployment, { kind: 'account', accountId: '1' })).toStrictEqual(neverOpenedListing);
     });
 });
 
@@ -134,6 +136,6 @@ describe('forgetListings', () => {
 
         forgetListings();
 
-        expect(rememberedListing(deployment, inbox)).toStrictEqual(unreadListing);
+        expect(rememberedListing(deployment, inbox)).toStrictEqual(neverOpenedListing);
     });
 });

--- a/frontend/src/Client.App/src/messageList/rememberedListings.test.ts
+++ b/frontend/src/Client.App/src/messageList/rememberedListings.test.ts
@@ -1,0 +1,139 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { everything, type MailScope } from '../workspace/mailScope';
+import { openingListing } from './listing';
+import {
+    forgetListings,
+    rememberedListing,
+    rememberListing,
+    unreadListing,
+    type RememberedListing,
+} from './rememberedListings';
+
+const storageKey = 'mailfathom.listings';
+const deployment = 'https://mail.example.invalid';
+const inbox: MailScope = { kind: 'folder', accountId: 'work', alias: 'INBOX' };
+
+const kept: RememberedListing = {
+    order: 'oldestFirst',
+    filters: { unread: true, flagged: null, hasAttachments: null, includeJunk: false },
+    cursor: 'the-cursor-that-page-was-read-with',
+    readAs: 'backward',
+    rowInPage: 17,
+};
+
+function stored(value: unknown): void {
+    window.sessionStorage.setItem(storageKey, JSON.stringify(value));
+}
+
+function keyFor(scope: MailScope, address = deployment): string {
+    return `${address}\n${scope.kind === 'folder' ? `folder:${scope.accountId}:${scope.alias}` : scope.kind}`;
+}
+
+// The store is one per file rather than one per test, so what one test kept would be what the next one read back.
+afterEach(() => {
+    window.sessionStorage.clear();
+});
+
+describe('rememberListing', () => {
+    it('keeps a folder’s position and how it was being read, and reads it back whole', () => {
+        rememberListing(deployment, inbox, kept);
+
+        expect(rememberedListing(deployment, inbox)).toStrictEqual(kept);
+    });
+
+    it('keeps a folder of one deployment apart from the same folder of another', () => {
+        rememberListing(deployment, inbox, kept);
+
+        expect(rememberedListing('https://other.example.invalid', inbox)).toStrictEqual(unreadListing);
+    });
+
+    it('keeps one folder apart from another of the same deployment', () => {
+        rememberListing(deployment, inbox, kept);
+
+        expect(rememberedListing(deployment, everything)).toStrictEqual(unreadListing);
+    });
+
+    it('drops the folder read longest ago once it is holding as many as it keeps', () => {
+        for (let at = 0; at < 65; at += 1) {
+            rememberListing(deployment, { kind: 'account', accountId: `account-${String(at)}` }, kept);
+        }
+
+        expect(rememberedListing(deployment, { kind: 'account', accountId: 'account-0' })).toStrictEqual(unreadListing);
+        expect(rememberedListing(deployment, { kind: 'account', accountId: 'account-64' })).toStrictEqual(kept);
+    });
+
+    it('keeps a folder read again rather than dropping it as the oldest', () => {
+        rememberListing(deployment, inbox, kept);
+
+        for (let at = 0; at < 63; at += 1) {
+            rememberListing(deployment, { kind: 'account', accountId: `account-${String(at)}` }, kept);
+        }
+
+        rememberListing(deployment, inbox, kept);
+        rememberListing(deployment, { kind: 'account', accountId: 'one-more' }, kept);
+
+        expect(rememberedListing(deployment, inbox)).toStrictEqual(kept);
+    });
+});
+
+describe('rememberedListing', () => {
+    it('opens a folder nobody has read at its leading end, newest first', () => {
+        expect(rememberedListing(deployment, inbox)).toStrictEqual({
+            ...openingListing,
+            cursor: null,
+            readAs: 'forward',
+            rowInPage: 0,
+        });
+    });
+
+    it.each([
+        ['a store holding something that is not JSON', 'not json'],
+        ['a store holding an array', JSON.stringify([])],
+    ])('opens at the leading end for %s', (_, written) => {
+        window.sessionStorage.setItem(storageKey, written);
+
+        expect(rememberedListing(deployment, inbox)).toStrictEqual(unreadListing);
+    });
+
+    it.each([
+        ['an order this client never wrote', { ...kept, order: 'bySender' }],
+        ['a direction this client never wrote', { ...kept, readAs: 'sideways' }],
+        ['a cursor that is not text', { ...kept, cursor: 7 }],
+        ['a cursor with nothing in it', { ...kept, cursor: '' }],
+        ['a row that is not whole', { ...kept, rowInPage: 1.5 }],
+        ['a row before the first', { ...kept, rowInPage: -1 }],
+        ['a row past the page it names', { ...kept, rowInPage: 100 }],
+        ['a filter that is neither answer nor both', { ...kept, filters: { ...kept.filters, unread: 'yes' } }],
+        ['no junk answer at all', { ...kept, filters: { unread: null, flagged: null, hasAttachments: null } }],
+        ['filters that are not a record', { ...kept, filters: [] }],
+        ['a listing that is not a record', 'the inbox'],
+    ])('opens at the leading end for a record carrying %s', (_, written) => {
+        stored({ [keyFor(inbox)]: written });
+
+        expect(rememberedListing(deployment, inbox)).toStrictEqual(unreadListing);
+    });
+
+    it('refuses a store holding more folders than it keeps rather than reading part of it', () => {
+        const crowd = Object.fromEntries(
+            Array.from({ length: 65 }, (_, at) => [keyFor({ kind: 'account', accountId: String(at) }), kept]),
+        );
+
+        stored(crowd);
+
+        expect(rememberedListing(deployment, { kind: 'account', accountId: '1' })).toStrictEqual(unreadListing);
+    });
+});
+
+describe('forgetListings', () => {
+    it('drops every position, so where somebody was reading does not outlive their credential', () => {
+        rememberListing(deployment, inbox, kept);
+
+        forgetListings();
+
+        expect(rememberedListing(deployment, inbox)).toStrictEqual(unreadListing);
+    });
+});

--- a/frontend/src/Client.App/src/messageList/rememberedListings.ts
+++ b/frontend/src/Client.App/src/messageList/rememberedListings.ts
@@ -1,0 +1,198 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { MailTimelineOrder, MailTimelinePageDirection } from '@mailfathom/client-backend';
+import { scopeKey, type MailScope } from '../workspace/mailScope';
+import { openingListing, rowsPerPage, type MailListFilters, type MailListing } from './listing';
+
+// Where a folder's reading position survives leaving it and reloading. Outside React deliberately: the position moves
+// while somebody scrolls, and holding it in state would re-render everything under the workspace provider on the one
+// interaction the whole of this screen exists to keep smooth.
+//
+// What is kept is where the reader was and how they were reading, and nothing about any message: a cursor the
+// deployment issued, a row number inside the page it names, the order, and the filters. No subject, no sender, and no
+// identity of anything in the folder — a store is a place a screen's contents must not accumulate in.
+//
+// Four of the five things the position is keyed by are in the key itself: the deployment's address and the scope, which
+// names the account and the folder. The fifth pair — the order and the filters — is inside the record rather than in
+// the key, which is the stronger arrangement: a cursor and the two values it was issued under are written and replaced
+// together, so a cursor cannot outlive them and there is no composite key to get wrong. The owner is the credential,
+// and `forgetListings` is called wherever the client lets one go.
+//
+// The session's store rather than the machine's, and reached as `window.sessionStorage` rather than as the bare global,
+// both for the reasons `workspace/rememberedWorkspace.ts` gives.
+const storageKey = 'mailfathom.listings';
+
+// How many folders keep a position before the oldest is dropped. A reader moves between a handful of mailboxes in a
+// session; this is far above that and bounds what one tab can accumulate.
+const mostRememberedListings = 64;
+
+// The longest cursor read back. The client surface's own bound is smaller; this is what a store may hold before what is
+// in it is read as somebody's writing rather than as this client's.
+const longestCursor = 4_096;
+
+/** Where a folder was left, and how it was being read at the time. */
+export interface RememberedListing extends MailListing {
+    /** The cursor of the page the reader's leading row was in, or `null` where it was the leading page. */
+    readonly cursor: string | null;
+
+    /** Which way that page was read from the cursor, which is the other half of reading it again. */
+    readonly readAs: MailTimelinePageDirection;
+
+    /** Which row of that page was under the top of the scroller. */
+    readonly rowInPage: number;
+}
+
+/** A folder nobody has read yet: the opening listing, at the leading end of it. */
+export const unreadListing: RememberedListing = { ...openingListing, cursor: null, readAs: 'forward', rowInPage: 0 };
+
+/** How a folder of one deployment was last read, or the opening listing where it has not been. */
+export function rememberedListing(baseAddress: string, scope: MailScope): RememberedListing {
+    return listingsIn(stored())[keyFor(baseAddress, scope)] ?? unreadListing;
+}
+
+/** Keeps how a folder is being read and where in it the reader is, so leaving and returning is a continuation. */
+export function rememberListing(baseAddress: string, scope: MailScope, listing: RememberedListing): void {
+    const key = keyFor(baseAddress, scope);
+
+    // Written back last so that it is the newest entry, which is what makes the oldest the one dropped: object key
+    // order is insertion order for string keys, and re-reading a folder therefore keeps it.
+    const entries = Object.entries(listingsIn(stored()))
+        .filter(([held]) => held !== key)
+        .slice(-(mostRememberedListings - 1));
+
+    write(Object.fromEntries([...entries, [key, listing]]));
+}
+
+/**
+ * Drops every remembered position.
+ *
+ * Called wherever the client lets a credential or a deployment go, which is what keeps a position from outliving the
+ * person it belonged to. A cursor is not mail, but where somebody was reading is theirs.
+ */
+export function forgetListings(): void {
+    try {
+        window.sessionStorage.removeItem(storageKey);
+    } catch {
+        // A browser refusing storage has nothing kept to remove.
+    }
+}
+
+function keyFor(baseAddress: string, scope: MailScope): string {
+    return `${baseAddress}\n${scopeKey(scope)}`;
+}
+
+function stored(): unknown {
+    let kept: string | null;
+
+    try {
+        kept = window.sessionStorage.getItem(storageKey);
+    } catch {
+        return null;
+    }
+
+    if (kept === null) {
+        return null;
+    }
+
+    try {
+        return JSON.parse(kept);
+    } catch {
+        return null;
+    }
+}
+
+function write(listings: Readonly<Record<string, RememberedListing>>): void {
+    try {
+        window.sessionStorage.setItem(storageKey, JSON.stringify(listings));
+    } catch {
+        // A browser refusing storage still runs the client; a folder then opens at its leading end, which is a smaller
+        // loss than a client that fails over a convenience.
+    }
+}
+
+// Read back as untrusted input, because a store is a place a person can write. A record with anything wrong in it is
+// answered as nothing kept, so a cursor this client did not issue never reaches the deployment.
+function listingsIn(value: unknown): Readonly<Record<string, RememberedListing>> {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        return {};
+    }
+
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length > mostRememberedListings) {
+        return {};
+    }
+
+    const listings: Record<string, RememberedListing> = {};
+    for (const [key, kept] of entries) {
+        const listing = listingIn(kept);
+
+        if (listing === null) {
+            return {};
+        }
+
+        listings[key] = listing;
+    }
+
+    return listings;
+}
+
+function listingIn(value: unknown): RememberedListing | null {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        return null;
+    }
+
+    const record = value as Record<string, unknown>;
+    const order = record['order'];
+    const filters = filtersIn(record['filters']);
+    const cursor = record['cursor'] ?? null;
+    const readAs = record['readAs'];
+    const rowInPage = record['rowInPage'];
+
+    if (!isOrder(order) || filters === null || !isDirection(readAs)) {
+        return null;
+    }
+
+    if (cursor !== null && (typeof cursor !== 'string' || cursor.length === 0 || cursor.length > longestCursor)) {
+        return null;
+    }
+
+    if (typeof rowInPage !== 'number' || !Number.isSafeInteger(rowInPage) || rowInPage < 0) {
+        return null;
+    }
+
+    // A row past the page it names is a record this client never wrote: the page it would be read back into cannot
+    // hold it, and scrolling to it would leave the reader below every row there is.
+    return rowInPage >= rowsPerPage ? null : { order, filters, cursor, readAs, rowInPage };
+}
+
+function filtersIn(value: unknown): MailListFilters | null {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        return null;
+    }
+
+    const record = value as Record<string, unknown>;
+    const unread = record['unread'] ?? null;
+    const flagged = record['flagged'] ?? null;
+    const hasAttachments = record['hasAttachments'] ?? null;
+    const includeJunk = record['includeJunk'];
+
+    if (!isWanted(unread) || !isWanted(flagged) || !isWanted(hasAttachments) || typeof includeJunk !== 'boolean') {
+        return null;
+    }
+
+    return { unread, flagged, hasAttachments, includeJunk };
+}
+
+function isWanted(value: unknown): value is boolean | null {
+    return value === null || typeof value === 'boolean';
+}
+
+function isOrder(value: unknown): value is MailTimelineOrder {
+    return value === 'newestFirst' || value === 'oldestFirst';
+}
+
+function isDirection(value: unknown): value is MailTimelinePageDirection {
+    return value === 'forward' || value === 'backward';
+}

--- a/frontend/src/Client.App/src/messageList/rememberedListings.ts
+++ b/frontend/src/Client.App/src/messageList/rememberedListings.ts
@@ -44,12 +44,22 @@ export interface RememberedListing extends MailListing {
     readonly rowInPage: number;
 }
 
-/** A folder nobody has read yet: the opening listing, at the leading end of it. */
-export const unreadListing: RememberedListing = { ...openingListing, cursor: null, readAs: 'forward', rowInPage: 0 };
+/**
+ * Where a folder nobody has opened yet is read from: the opening listing, at the leading end of it.
+ *
+ * Named for the reading position rather than for a message state, because `unread` is this client's word for a message
+ * nobody has read and is a filter three controls away from here.
+ */
+export const neverOpenedListing: RememberedListing = {
+    ...openingListing,
+    cursor: null,
+    readAs: 'forward',
+    rowInPage: 0,
+};
 
 /** How a folder of one deployment was last read, or the opening listing where it has not been. */
 export function rememberedListing(baseAddress: string, scope: MailScope): RememberedListing {
-    return listingsIn(stored())[keyFor(baseAddress, scope)] ?? unreadListing;
+    return listingsIn(stored())[keyFor(baseAddress, scope)] ?? neverOpenedListing;
 }
 
 /** Keeps how a folder is being read and where in it the reader is, so leaving and returning is a continuation. */

--- a/frontend/src/Client.App/src/messageList/timelineWindow.test.ts
+++ b/frontend/src/Client.App/src/messageList/timelineWindow.test.ts
@@ -1,0 +1,88 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import { leadingRow, offsetOfRow, overscanRows, windowOf } from './timelineWindow';
+
+// Ten rows of a hundred pixels each, so a number in an expectation reads as the row it stands for.
+const rowHeight = 100;
+const viewport = 1_000;
+
+describe('windowOf', () => {
+    it('draws nothing for a list holding nothing', () => {
+        expect(windowOf(0, rowHeight, 0, viewport)).toStrictEqual({ first: 0, count: 0, above: 0, below: 0 });
+    });
+
+    it('draws the rows a screenful shows and the overscan after them, at the top of a long list', () => {
+        const drawn = windowOf(10_000, rowHeight, 0, viewport);
+
+        expect(drawn.first).toBe(0);
+        expect(drawn.count).toBe(10 + overscanRows * 2);
+        expect(drawn.above).toBe(0);
+    });
+
+    it('keeps the number of rows in the document the same however far down the list it is', () => {
+        const near = windowOf(214_000, rowHeight, 0, viewport);
+        const far = windowOf(214_000, rowHeight, 21_000_000, viewport);
+
+        expect(far.count).toBe(near.count);
+    });
+
+    it('starts the overscan before the row the reader is on, so scrolling does not reach the end of the document', () => {
+        const drawn = windowOf(10_000, rowHeight, 5_000, viewport);
+
+        expect(drawn.first).toBe(50 - overscanRows);
+    });
+
+    it('reserves the space the rows above and below the window would take', () => {
+        const drawn = windowOf(10_000, rowHeight, 5_000, viewport);
+
+        expect(drawn.above).toBe(drawn.first * rowHeight);
+        expect(drawn.above + drawn.count * rowHeight + drawn.below).toBe(10_000 * rowHeight);
+    });
+
+    it('draws to the end of a list rather than past it', () => {
+        const drawn = windowOf(12, rowHeight, 0, viewport);
+
+        expect(drawn.first).toBe(0);
+        expect(drawn.count).toBe(12);
+        expect(drawn.below).toBe(0);
+    });
+
+    it('draws the last rows for a scroller left below every row there is', () => {
+        const drawn = windowOf(12, rowHeight, 99_000, viewport);
+
+        expect(drawn.first).toBe(11);
+        expect(drawn.count).toBe(1);
+        expect(drawn.below).toBe(0);
+    });
+
+    it('reads a scroller pulled above its own top as being at the top', () => {
+        expect(windowOf(100, rowHeight, -400, viewport)).toStrictEqual(windowOf(100, rowHeight, 0, viewport));
+    });
+
+    it('draws nothing before a row has been measured', () => {
+        expect(windowOf(100, 0, 0, viewport).count).toBe(0);
+    });
+});
+
+describe('offsetOfRow', () => {
+    it('answers where a row stands in a list of rows one height each', () => {
+        expect(offsetOfRow(42, rowHeight)).toBe(4_200);
+    });
+
+    it('answers the top of the list for a row before the first', () => {
+        expect(offsetOfRow(-3, rowHeight)).toBe(0);
+    });
+});
+
+describe('leadingRow', () => {
+    it('answers the row under the top of the scroller rather than the first one drawn', () => {
+        expect(leadingRow(4_250, rowHeight)).toBe(42);
+    });
+
+    it('answers the first row before anything has been measured', () => {
+        expect(leadingRow(4_250, 0)).toBe(0);
+    });
+});

--- a/frontend/src/Client.App/src/messageList/timelineWindow.ts
+++ b/frontend/src/Client.App/src/messageList/timelineWindow.ts
@@ -1,0 +1,81 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+// Which rows of a list are in the document, which is the whole of what keeps a mailbox of two hundred thousand
+// messages costing what a screenful costs. It is arithmetic over four numbers rather than a package, and the
+// measurement that decided it is in `frontend/README.md`: every row of this list is one height, so the only thing a
+// virtualizer would add over this file is the machinery for measuring rows that are not.
+//
+// The height itself is measured from a rendered row rather than written here, because the row's height is a token
+// decision and a number repeated in JavaScript is a second copy of it that drifts on the first change of the type
+// scale, of the reader's font size, or of the browser's zoom.
+
+/** How many rows outside the viewport are drawn either side of it, so scrolling does not reach the end of the document. */
+export const overscanRows = 6;
+
+/**
+ * The estimate a list draws its first frame under, before a row has been rendered to measure.
+ *
+ * It only has to be close: a wrong estimate draws too many or too few rows for one frame, and the measurement that
+ * arrives with that frame replaces it. It is deliberately not the row's real height, so nothing here can quietly become
+ * the value the list works to.
+ */
+export const estimatedRowHeight = 72;
+
+/** Which rows are drawn, and the space standing in for the ones that are not. */
+export interface RowWindow {
+    /** The index of the first row in the document. */
+    readonly first: number;
+
+    /** How many rows are in the document. */
+    readonly count: number;
+
+    /** The height, in pixels, reserved above them for the rows before. */
+    readonly above: number;
+
+    /** The height, in pixels, reserved below them for the rows after. */
+    readonly below: number;
+}
+
+/**
+ * The rows a scroller of this size shows at this offset, with the overscan either side of them.
+ *
+ * @param rowCount How many rows the list holds.
+ * @param rowHeight What one row measures, in pixels.
+ * @param scrollTop How far the scroller has been scrolled, in pixels.
+ * @param viewportHeight How tall the scroller is, in pixels.
+ * @returns The window of rows to draw and the space standing in for the rest.
+ */
+export function windowOf(rowCount: number, rowHeight: number, scrollTop: number, viewportHeight: number): RowWindow {
+    if (rowCount <= 0 || rowHeight <= 0) {
+        return { first: 0, count: 0, above: 0, below: 0 };
+    }
+
+    const drawn = Math.ceil(viewportHeight / rowHeight) + overscanRows * 2;
+    const reached = Math.floor(Math.max(scrollTop, 0) / rowHeight);
+    const first = Math.min(Math.max(reached - overscanRows, 0), Math.max(rowCount - 1, 0));
+    const count = Math.min(drawn, rowCount - first);
+
+    return {
+        first,
+        count,
+        above: first * rowHeight,
+        below: (rowCount - first - count) * rowHeight,
+    };
+}
+
+/** How far a list has to be scrolled for a row to be the first one under the top of the scroller. */
+export function offsetOfRow(row: number, rowHeight: number): number {
+    return Math.max(row, 0) * rowHeight;
+}
+
+/**
+ * The row the reader is looking at, which is what a returning visit is put back to.
+ *
+ * The first row under the top of the scroller rather than the first one drawn: the overscan is not on the screen, and
+ * returning somebody to it would put them a screenful above where they left off.
+ */
+export function leadingRow(scrollTop: number, rowHeight: number): number {
+    return rowHeight <= 0 ? 0 : Math.floor(Math.max(scrollTop, 0) / rowHeight);
+}

--- a/frontend/src/Client.App/src/shell/Space.test.tsx
+++ b/frontend/src/Client.App/src/shell/Space.test.tsx
@@ -9,9 +9,10 @@ import { LocalizationProvider } from '../localization/Localization';
 import type { Space as SpaceName } from '../routing/spaces';
 import { Space } from './Space';
 
-// Not catalogue entries: each stands for whatever the frame composes for Mail, which is the point of the two props.
+// Not catalogue entries: each stands for whatever the frame composes for Mail, which is the point of the three props.
 const handedToMail = 'The mail this space was handed.';
 const handedTheFolders = 'The folder tree this space was handed.';
+const handedTheList = 'The message list this space was handed.';
 
 // Every case here renders under `StrictMode`, which is what `main.tsx` mounts and what makes React invoke an effect
 // twice on the first mount. A focus rule written against "has this effect run before" passes without it and moves
@@ -20,7 +21,12 @@ function inStrictMode(space: SpaceName): ReactNode {
     return (
         <StrictMode>
             <LocalizationProvider>
-                <Space space={space} folders={<p>{handedTheFolders}</p>} mail={<p>{handedToMail}</p>} />
+                <Space
+                    space={space}
+                    folders={<p>{handedTheFolders}</p>}
+                    list={<p>{handedTheList}</p>}
+                    mail={<p>{handedToMail}</p>}
+                />
             </LocalizationProvider>
         </StrictMode>
     );
@@ -57,6 +63,12 @@ describe('Space', () => {
         render(inStrictMode('mail'));
 
         expect(screen.getByText(handedTheFolders)).toBeDefined();
+    });
+
+    it('does not call the Mail space unbuilt, which is what it stopped being when it started reading mail', () => {
+        render(inStrictMode('mail'));
+
+        expect(screen.queryByText(/This space is not built yet\./)).toBeNull();
     });
 
     it('shows the pending note rather than the mail in a space nothing has been built for yet', () => {

--- a/frontend/src/Client.App/src/shell/Space.tsx
+++ b/frontend/src/Client.App/src/shell/Space.tsx
@@ -57,10 +57,20 @@ export function Space({
                     narrow window and side by side at the width the workspace opens out at, out of one tree at one
                     breakpoint rather than one composition per head. */}
                 {space === 'mail' ? (
-                    <div className="flex flex-col gap-6 workspace:flex-row workspace:items-start">
+                    <div className="flex flex-col gap-6 workspace:flex-row workspace:flex-wrap workspace:items-start">
                         <div className="workspace:w-64 workspace:shrink-0">{folders}</div>
-                        <div className="min-w-0 workspace:w-96 workspace:shrink-0">{list}</div>
-                        <div className="min-w-0 flex-1">{mail}</div>
+                        {/* Wider than the folder tree beside it because a row carries four things on one line — who
+                            wrote, where from, what the server marked it with, and when — and a column that cannot
+                            hold them ellipsises the two that are read first. It is the column that gives way where
+                            the three of them do not fit, which is what keeps a window just wide enough for this
+                            composition from scrolling sideways. */}
+                        <div className="min-w-0 workspace:w-112">{list}</div>
+                        {/* The message asks for a width of its own rather than for whatever is left: three columns do
+                            not fit a window barely wider than the point they open out at, and a pane squeezed to
+                            nothing there would push the space sideways instead of standing under the other two. So it
+                            states the width it needs, takes everything beyond that, and wraps below them where the
+                            window cannot give it. */}
+                        <div className="min-w-0 grow basis-0 workspace:basis-80">{mail}</div>
                     </div>
                 ) : null}
             </div>

--- a/frontend/src/Client.App/src/shell/Space.tsx
+++ b/frontend/src/Client.App/src/shell/Space.tsx
@@ -12,10 +12,12 @@ import { spaceLabels, type Space as SpaceName } from '../routing/spaces';
 export function Space({
     space,
     folders,
+    list,
     mail,
 }: {
     readonly space: SpaceName;
     readonly folders: ReactNode;
+    readonly list: ReactNode;
     readonly mail: ReactNode;
 }) {
     const { translate } = useLocalization();
@@ -37,22 +39,27 @@ export function Space({
 
     return (
         <main ref={region} tabIndex={-1} className="flex-1 overflow-y-auto px-4 py-6 workspace:px-8">
-            <div className="flex max-w-3xl flex-col gap-3">
+            {/* Mail is the one space laid out in columns, so it is the one that is not held to a reading width: a
+                measure that keeps prose readable is the wrong bound for a scope selector beside a list beside a
+                message. */}
+            <div className={`flex flex-col gap-3 ${space === 'mail' ? '' : 'max-w-3xl'}`}>
                 <h1 className="text-2xl font-semibold tracking-tight">{translate(spaceLabels[space])}</h1>
 
-                {/* The note stands above whatever a space has so far rather than instead of it: none of the three is
-                    built, and Mail is the one that has anything at all — the reading pane the messages a list has not
-                    been written yet would be opened in. What it holds is composed above rather than reached for here,
-                    because this region owns where a space is drawn and what happens to focus, and a space that read
-                    something of its own would make that true of one of the three and not the others. */}
-                <p className="text-sm text-muted">{translate('space.pending')}</p>
+                {/* The note belongs to a space that holds nothing, which Mail no longer is: it reads its own mail now,
+                    and a sentence saying otherwise above a working list is a screen contradicting itself. What Mail
+                    holds is composed above rather than reached for here, because this region owns where a space is
+                    drawn and what happens to focus, and a space that read something of its own would make that true of
+                    one of the three and not the others. */}
+                {space === 'mail' ? null : <p className="text-sm text-muted">{translate('space.pending')}</p>}
 
-                {/* Mail is the one space with anything in it, and what it has is the scope selector beside what the
-                    scope is about: a column under a narrow window and beside the reading pane at the width the
-                    workspace opens out at. The list that will stand between them is #1424's. */}
+                {/* Mail is the one space with anything in it, and what it has is the three regions a mail client is:
+                    the scope selector, the list of what is in that scope, and the message being read. Stacked under a
+                    narrow window and side by side at the width the workspace opens out at, out of one tree at one
+                    breakpoint rather than one composition per head. */}
                 {space === 'mail' ? (
                     <div className="flex flex-col gap-6 workspace:flex-row workspace:items-start">
                         <div className="workspace:w-64 workspace:shrink-0">{folders}</div>
+                        <div className="min-w-0 workspace:w-96 workspace:shrink-0">{list}</div>
                         <div className="min-w-0 flex-1">{mail}</div>
                     </div>
                 ) : null}

--- a/frontend/src/Client.App/src/shell/Space.tsx
+++ b/frontend/src/Client.App/src/shell/Space.tsx
@@ -61,7 +61,7 @@ export function Space({
                         <div className="workspace:w-64 workspace:shrink-0">{folders}</div>
                         {/* Wider than the folder tree beside it because a row carries four things on one line — who
                             wrote, where from, what the server marked it with, and when — and a column that cannot
-                            hold them ellipsises the two that are read first. It is the column that gives way where
+                            hold them cuts short the two that are read first. It is the column that gives way where
                             the three of them do not fit, which is what keeps a window just wide enough for this
                             composition from scrolling sideways. */}
                         <div className="min-w-0 workspace:w-112">{list}</div>

--- a/frontend/src/Client.App/src/styles.css
+++ b/frontend/src/Client.App/src/styles.css
@@ -68,6 +68,14 @@
        than one per screen. The number is the prototype's, and it is a width rather than a device. */
     --breakpoint-workspace: 48.75rem;
 
+    /* One row of the message list, and the room the list itself takes. The row height is declared here rather than in
+       the list because it is a density decision like any other — and because the list is arithmetic over it: the
+       window that keeps a mailbox of two hundred thousand messages costing what a screenful costs measures this value
+       off a rendered row rather than holding a second copy of it. It is two lines and the space around them: who
+       wrote and when, then what about and how it opens. */
+    --spacing-message-row: 3.5rem;
+    --spacing-message-list: 70dvh;
+
     /* What a notch, a rounded corner, or a system bar takes out of the viewport. Zero everywhere a window has none,
        which is every head this repository builds today; declaring it as a token is what keeps a screen from reaching
        for a fixed padding the day one of them has one. */

--- a/frontend/src/Client.App/src/styles.css
+++ b/frontend/src/Client.App/src/styles.css
@@ -71,9 +71,9 @@
     /* One row of the message list, and the room the list itself takes. The row height is declared here rather than in
        the list because it is a density decision like any other — and because the list is arithmetic over it: the
        window that keeps a mailbox of two hundred thousand messages costing what a screenful costs measures this value
-       off a rendered row rather than holding a second copy of it. It is two lines and the space around them: who
-       wrote and when, then what about and how it opens. */
-    --spacing-message-row: 3.5rem;
+       off a rendered row rather than holding a second copy of it. It is three lines and the space around them: who
+       wrote, what about, and the line stage 3 fills with what MailFathom made of the message. */
+    --spacing-message-row: 4.75rem;
     --spacing-message-list: 70dvh;
 
     /* What a notch, a rounded corner, or a system bar takes out of the viewport. Zero everywhere a window has none,

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
@@ -13,6 +13,7 @@ const kept: Workspace = {
     collapsed: ['account:personal'],
     selection: 'AAMkAD-42',
     fragment: null,
+    selected: ['AAMkAD-42', 'AAMkAD-43'],
     question: 'what did Nordwind send',
 };
 

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
@@ -109,6 +109,25 @@ describe('rememberedWorkspace', () => {
             shape: 'a selection longer than any identifier the client wrote there',
             value: JSON.stringify({ ...emptyWorkspace, selection: 'a'.repeat(257) }),
         },
+        {
+            shape: 'messages picked out as something other than a list of them',
+            value: JSON.stringify({ ...emptyWorkspace, selected: 'message-1' }),
+        },
+        {
+            shape: 'a message picked out that is not an identifier',
+            value: JSON.stringify({ ...emptyWorkspace, selected: [7] }),
+        },
+        {
+            shape: 'a picked-out identifier longer than any the client wrote there',
+            value: JSON.stringify({ ...emptyWorkspace, selected: ['a'.repeat(257)] }),
+        },
+        {
+            shape: 'more messages picked out than one question may be asked about',
+            value: JSON.stringify({
+                ...emptyWorkspace,
+                selected: Array.from({ length: 1_025 }, (_, at) => `message-${String(at)}`),
+            }),
+        },
     ])('opens on nothing rather than on $shape', ({ value }) => {
         window.sessionStorage.setItem(storageKey, value);
 

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.ts
@@ -25,6 +25,10 @@ const mostCollapsedRows = 512;
 const longestQuestion = 4_096;
 const longestIdentifier = 256;
 
+// What a selection may hold before it is read as somebody's edit. The list keeps a bounded number of pages, so a reader
+// who selects every row it is holding selects a few hundred; this is above that and bounds what one tab writes here.
+const mostSelectedMessages = 1_024;
+
 // A folded row is keyed by the scope it stands for, so at its longest it names an account and a folder's whole place on
 // its mail server rather than one identifier.
 const longestRow = 1_024;
@@ -82,9 +86,10 @@ function workspaceIn(value: unknown): Workspace | null {
     const scope = scopeIn(record['scope']);
     const collapsed = collapsedIn(record['collapsed']);
     const selection = record['selection'] ?? null;
+    const selected = selectedIn(record['selected']);
     const question = record['question'];
 
-    if (scope === null || collapsed === null) {
+    if (scope === null || collapsed === null || selected === null) {
         return null;
     }
 
@@ -96,7 +101,24 @@ function workspaceIn(value: unknown): Workspace | null {
         return null;
     }
 
-    return { scope, collapsed, selection, fragment: null, question };
+    return { scope, collapsed, selection, fragment: null, selected, question };
+}
+
+function selectedIn(value: unknown): readonly string[] | null {
+    if (!Array.isArray(value) || value.length > mostSelectedMessages) {
+        return null;
+    }
+
+    const messages: string[] = [];
+    for (const message of value) {
+        if (!isIdentifier(message)) {
+            return null;
+        }
+
+        messages.push(message);
+    }
+
+    return messages;
 }
 
 function scopeIn(value: unknown): MailScope | null {

--- a/frontend/src/Client.App/src/workspace/useWorkspace.ts
+++ b/frontend/src/Client.App/src/workspace/useWorkspace.ts
@@ -36,6 +36,15 @@ export interface Workspace {
      */
     readonly fragment: string | null;
 
+    /**
+     * The messages the person has picked out, in the order the list draws them.
+     *
+     * Here rather than inside the list because *select and ask* is what it is for: the question asked of a selection is
+     * composed somewhere the list is not, so a selection the list kept to itself would be a visual state nothing else
+     * could read as scope.
+     */
+    readonly selected: readonly string[];
+
     /** What has been typed into the intent field, which the next question would be asked with. */
     readonly question: string;
 }
@@ -52,6 +61,7 @@ export const emptyWorkspace: Workspace = {
     collapsed: [],
     selection: null,
     fragment: null,
+    selected: [],
     question: '',
 };
 

--- a/frontend/src/Client.Backend/src/index.ts
+++ b/frontend/src/Client.Backend/src/index.ts
@@ -75,6 +75,17 @@ export {
     type MailParticipantRole,
     type MailSenderVerdict,
 } from './mailMessage';
+export {
+    longestTimelinePage,
+    mailTimelineRoute,
+    readMailTimeline,
+    timelineQueryString,
+    type MailTimelineEntry,
+    type MailTimelineOrder,
+    type MailTimelinePage,
+    type MailTimelinePageDirection,
+    type MailTimelineQuery,
+} from './mailTimeline';
 export { clientRoutePrefix, headersFor, routeFor, type ClientSession, type DeploymentAddress } from './session';
 export { reachDeployment, signIn, type DeploymentGreeting, type SignInOutcome, type SignInRefusal } from './signIn';
 export { longestResponseBody, type ClientRequest, type ClientResponse, type MailFathomTransport } from './transport';

--- a/frontend/src/Client.Backend/src/mailTimeline.test.ts
+++ b/frontend/src/Client.Backend/src/mailTimeline.test.ts
@@ -1,0 +1,242 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import { readMailTimeline, timelineQueryString, type MailTimelineQuery } from './mailTimeline';
+import type { ClientSession } from './session';
+import type { ClientRequest, ClientResponse, MailFathomTransport } from './transport';
+
+const session: ClientSession = {
+    baseAddress: 'https://mail.example.invalid',
+    authorization: 'Basic dGVzdA==',
+};
+
+const leadingPage: MailTimelineQuery = {
+    account: null,
+    folder: null,
+    includeJunk: false,
+    unread: null,
+    flagged: null,
+    hasAttachments: null,
+    order: 'newestFirst',
+    direction: 'forward',
+    pageSize: 50,
+    cursor: null,
+};
+
+const message = {
+    id: '2f7d4f2a-6c1e-4e0a-9a2f-1b0c9d8e7f60',
+    account: 'work',
+    folder: 'INBOX',
+    threadId: null,
+    subject: 'The quarterly figures',
+    receivedAt: '2026-08-31T09:41:00+00:00',
+    sentAt: '2026-08-31T09:40:00+00:00',
+    senderAddress: 'auditor@example.invalid',
+    senderDisplayName: 'The auditor',
+    toAddresses: ['owner@example.invalid'],
+    unread: true,
+    flagged: false,
+    answered: false,
+    hasAttachments: true,
+    attachmentCount: 2,
+    sizeOctets: 84_213,
+    preview: 'The figures you asked for are attached.',
+};
+
+function bodyOf(emails: readonly unknown[], cursors: Readonly<Record<string, unknown>> = {}): string {
+    return JSON.stringify({ emails, nextCursor: null, previousCursor: null, pageSize: 50, ...cursors });
+}
+
+type Answer = Omit<ClientResponse, 'headers'>;
+
+function answering(response: Answer): MailFathomTransport {
+    return () => Promise.resolve({ ...response, headers: {} });
+}
+
+function recording(response: Answer): { transport: MailFathomTransport; requests: ClientRequest[] } {
+    const requests: ClientRequest[] = [];
+
+    return {
+        requests,
+        transport: (request) => {
+            requests.push(request);
+
+            return Promise.resolve({ ...response, headers: {} });
+        },
+    };
+}
+
+describe('timelineQueryString', () => {
+    it('states the sort, the order, the direction, and the page size even where the route would default them', () => {
+        expect(timelineQueryString(leadingPage)).toBe(
+            '?sort=receivedAt&order=newestFirst&direction=forward&pageSize=50',
+        );
+    });
+
+    it('names the folder a role scope stands for', () => {
+        expect(timelineQueryString({ ...leadingPage, folder: 'role:Inbox' })).toContain('folder=role%3AInbox');
+    });
+
+    it('escapes an account name a mail server chose', () => {
+        expect(timelineQueryString({ ...leadingPage, account: 'work & home' })).toContain('account=work%20%26%20home');
+    });
+
+    it('asks for the junk folder only where the list includes it', () => {
+        expect(timelineQueryString(leadingPage)).not.toContain('includeJunk');
+        expect(timelineQueryString({ ...leadingPage, includeJunk: true })).toContain('includeJunk=true');
+    });
+
+    it.each([
+        [{ unread: true }, 'unread=true'],
+        [{ unread: false }, 'unread=false'],
+        [{ flagged: true }, 'flagged=true'],
+        [{ hasAttachments: false }, 'hasAttachments=false'],
+    ])('states %o as %s', (filter, expected) => {
+        expect(timelineQueryString({ ...leadingPage, ...filter })).toContain(expected);
+    });
+
+    it('leaves out a filter that keeps both answers', () => {
+        const asked = timelineQueryString(leadingPage);
+
+        expect(asked).not.toContain('unread');
+        expect(asked).not.toContain('flagged');
+        expect(asked).not.toContain('hasAttachments');
+    });
+
+    it('escapes the cursor a previous page answered with', () => {
+        expect(timelineQueryString({ ...leadingPage, cursor: 'a+b/c=' })).toContain('cursor=a%2Bb%2Fc%3D');
+    });
+});
+
+describe('readMailTimeline', () => {
+    it('asks for the timeline route on the client surface with the session it was given', async () => {
+        const { transport, requests } = recording({ status: 200, body: bodyOf([message]) });
+
+        await readMailTimeline(session, transport, leadingPage);
+
+        expect(requests[0]?.method).toBe('GET');
+        expect(requests[0]?.path).toBe(
+            'https://mail.example.invalid/api/client/emails?sort=receivedAt&order=newestFirst&direction=forward&pageSize=50',
+        );
+        expect(requests[0]?.headers['Authorization']).toBe('Basic dGVzdA==');
+    });
+
+    it('bounds the answer it will read below the transport backstop', async () => {
+        const { transport, requests } = recording({ status: 200, body: bodyOf([]) });
+
+        await readMailTimeline(session, transport, leadingPage);
+
+        expect(requests[0]?.longestAnswer).toBe(262_144);
+    });
+
+    it('reads a page and the two cursors the pages either side of it are asked with', async () => {
+        const transport = answering({
+            status: 200,
+            body: bodyOf([message], { nextCursor: 'after', previousCursor: 'before' }),
+        });
+
+        const result = await readMailTimeline(session, transport, leadingPage);
+
+        expect(result).toStrictEqual({
+            outcome: 'read',
+            value: { emails: [message], nextCursor: 'after', previousCursor: 'before', pageSize: 50 },
+        });
+    });
+
+    it('reads the end of a list as no cursor rather than as a hint to ask again', async () => {
+        const transport = answering({ status: 200, body: bodyOf([]) });
+
+        const result = await readMailTimeline(session, transport, leadingPage);
+
+        expect(result.outcome === 'read' && result.value.nextCursor).toBeNull();
+    });
+
+    it('reads a message this deployment has stored but not extracted as one with no preview', async () => {
+        const transport = answering({ status: 200, body: bodyOf([{ ...message, preview: null }]) });
+
+        const result = await readMailTimeline(session, transport, leadingPage);
+
+        expect(result.outcome === 'read' && result.value.emails[0]?.preview).toBeNull();
+    });
+
+    it.each([
+        [401, 'unauthenticated'],
+        [403, 'unauthorized'],
+        [400, 'unavailable'],
+        [500, 'unavailable'],
+    ])('reports %i as %s', async (status, reason) => {
+        const result = await readMailTimeline(session, answering({ status, body: '' }), leadingPage);
+
+        expect(result).toStrictEqual({ outcome: 'failed', failure: { reason, status } });
+    });
+
+    it('reports a deployment that did not answer at all as unavailable', async () => {
+        const result = await readMailTimeline(
+            session,
+            () => Promise.reject(new Error('the name does not resolve')),
+            leadingPage,
+        );
+
+        expect(result).toStrictEqual({ outcome: 'failed', failure: { reason: 'unavailable', status: null } });
+    });
+
+    it('refuses a page carrying more rows than the request admits', async () => {
+        const crowded = bodyOf([message, message, message]);
+
+        const result = await readMailTimeline(session, answering({ status: 200, body: crowded }), {
+            ...leadingPage,
+            pageSize: 2,
+        });
+
+        expect(result).toStrictEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+
+    it.each([
+        ['a body that is not JSON', 'not json'],
+        ['a body that is not an object', JSON.stringify([])],
+        ['rows that are not an array', JSON.stringify({ emails: {}, pageSize: 50 })],
+        ['a page size that is not a number', bodyOf([], { pageSize: 'fifty' })],
+        ['a page size below one', bodyOf([], { pageSize: 0 })],
+        ['a cursor that is not text', bodyOf([], { nextCursor: 7 })],
+        ['a cursor with nothing in it', bodyOf([], { previousCursor: '' })],
+        ['a row that is not an object', bodyOf(['message'])],
+        ['a row with no identity', bodyOf([{ ...message, id: '' }])],
+        ['a row naming no account', bodyOf([{ ...message, account: null }])],
+        ['a row naming no folder', bodyOf([{ ...message, folder: 7 }])],
+        ['a conversation that is not an identity', bodyOf([{ ...message, threadId: 7 }])],
+        ['a subject that is not text', bodyOf([{ ...message, subject: 7 }])],
+        ['a received time that is not text', bodyOf([{ ...message, receivedAt: 1_756_632_060 }])],
+        ['recipients that are not an array', bodyOf([{ ...message, toAddresses: 'owner@example.invalid' }])],
+        ['a recipient that is not text', bodyOf([{ ...message, toAddresses: [null] }])],
+        ['an unread state that is not a boolean', bodyOf([{ ...message, unread: 'yes' }])],
+        ['a flagged state that is not a boolean', bodyOf([{ ...message, flagged: null }])],
+        ['an attachment count that is not whole', bodyOf([{ ...message, attachmentCount: 1.5 }])],
+        ['a negative size', bodyOf([{ ...message, sizeOctets: -1 }])],
+    ])('refuses %s rather than reading a page with a hole in it', async (_, body) => {
+        const result = await readMailTimeline(session, answering({ status: 200, body }), leadingPage);
+
+        expect(result).toStrictEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+
+    it('refuses a row carrying more recipients than a message has', async () => {
+        const crowd = Array.from({ length: 257 }, (_, at) => `person-${String(at)}@example.invalid`);
+
+        const result = await readMailTimeline(
+            session,
+            answering({ status: 200, body: bodyOf([{ ...message, toAddresses: crowd }]) }),
+            leadingPage,
+        );
+
+        expect(result).toStrictEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+
+    it('reads a message nothing has placed in a conversation as one with no thread', async () => {
+        const transport = answering({ status: 200, body: bodyOf([{ ...message, threadId: undefined }]) });
+
+        const result = await readMailTimeline(session, transport, leadingPage);
+
+        expect(result.outcome === 'read' && result.value.emails[0]?.threadId).toBeNull();
+    });
+});

--- a/frontend/src/Client.Backend/src/mailTimeline.ts
+++ b/frontend/src/Client.Backend/src/mailTimeline.ts
@@ -1,0 +1,365 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { failed, failureReasonForStatus, read, type ClientResult } from './failure';
+import { asRecord } from './json';
+import { headersFor, routeFor, type ClientSession } from './session';
+import { send, type MailFathomTransport } from './transport';
+
+// One page of the owner's mail, keyset-paged in both directions. The route is the one a mail screen spends its time
+// in, so what this package owes it is a request that says exactly which list is being read and a parser that refuses a
+// page rather than handing a screen a row with a hole in it.
+//
+// The two cursors are opaque and holdable: each names a row together with the list it was read under, and nothing on
+// the deployment remembers one. That is what lets a screen keep one while it is closed and continue from it — and it
+// is why the filters and the order are part of the request rather than something the deployment recalls, because a
+// cursor presented under different ones is refused rather than silently reinterpreted.
+
+/** The route one page of the owner's mail is served at, relative to the client prefix. */
+export const mailTimelineRoute = '/emails';
+
+/** Which end of the received order leads. */
+export type MailTimelineOrder = 'newestFirst' | 'oldestFirst';
+
+/** Whether the page asked for lies after the cursor or before it. */
+export type MailTimelinePageDirection = 'forward' | 'backward';
+
+/**
+ * Which list is being read, in full.
+ *
+ * Every field is stated rather than defaulted, because the whole of it is what a cursor was issued under: a request
+ * that left one out would be asking for a different list than the one the cursor names, which the deployment refuses.
+ */
+export interface MailTimelineQuery {
+    /** The account to draw from, or `null` for every account the owner owns. */
+    readonly account: string | null;
+
+    /** The folder to draw from, by its alias or as `role:Inbox`, or `null` for every folder. */
+    readonly folder: string | null;
+
+    /** Whether the junk folder takes part, which it does not unless the request asks. */
+    readonly includeJunk: boolean;
+
+    /** Keep only unread mail, only read mail, or `null` for both. */
+    readonly unread: boolean | null;
+
+    /** Keep only flagged mail, only unflagged mail, or `null` for both. */
+    readonly flagged: boolean | null;
+
+    /** Keep only mail with attachments, only mail without, or `null` for both. */
+    readonly hasAttachments: boolean | null;
+
+    readonly order: MailTimelineOrder;
+    readonly direction: MailTimelinePageDirection;
+
+    /** How many rows the page may hold, between one and {@link longestTimelinePage}. */
+    readonly pageSize: number;
+
+    /** The cursor a previous page answered with, or `null` for the leading end of the list. */
+    readonly cursor: string | null;
+}
+
+/** One row of the list, carrying what a screen draws and nothing it does not. */
+export interface MailTimelineEntry {
+    /** The stable local identity of the message, which is what a row is keyed by and what every later request names it by. */
+    readonly id: string;
+
+    readonly account: string;
+    readonly folder: string;
+    readonly threadId: string | null;
+    readonly subject: string | null;
+
+    /** When the last receiving hop recorded the message, which is what the list is ordered by. */
+    readonly receivedAt: string | null;
+    readonly sentAt: string | null;
+
+    readonly senderAddress: string | null;
+    readonly senderDisplayName: string | null;
+
+    /** The `To` addresses in header order, which is what a sent-mail row draws instead of a sender. */
+    readonly toAddresses: readonly string[];
+
+    readonly unread: boolean;
+    readonly flagged: boolean;
+    readonly answered: boolean;
+    readonly hasAttachments: boolean;
+    readonly attachmentCount: number;
+    readonly sizeOctets: number;
+
+    /** The opening of the message's own text, or `null` for a message this deployment has stored but not extracted. */
+    readonly preview: string | null;
+}
+
+/** One page of the list, and the two cursors the pages either side of it are asked with. */
+export interface MailTimelinePage {
+    readonly emails: readonly MailTimelineEntry[];
+
+    /** The cursor the following page is asked with, or `null` at the end of the list. */
+    readonly nextCursor: string | null;
+
+    /** The cursor the preceding page is asked with, or `null` at the beginning of the list. */
+    readonly previousCursor: string | null;
+
+    /** How many rows the read ran under, which is what the request asked for. */
+    readonly pageSize: number;
+}
+
+/**
+ * The largest page this surface serves, which is the deployment's bound rather than a preference.
+ *
+ * A screen asking for more would be refused with a `400`, so the client holds the same number and asks within it.
+ */
+export const longestTimelinePage = 100;
+
+// The most of one page this client reads. A row carries a subject, a bounded preview, and a handful of addresses, so a
+// full page is on the order of a hundred kilobytes; this is well above that and well below the transport's backstop,
+// which is written for an address nobody has trusted yet rather than for a route the client has already signed in to.
+const longestTimelineAnswer = 256 * 1024;
+
+// What one row may carry before the page is refused unread. Each is far above anything a mail server produces and
+// exists for the answer that is not a page at all — checked while the rows are walked rather than after.
+const longestIdentity = 256;
+const longestCursor = 4_096;
+const longestText = 4_096;
+const mostRecipients = 256;
+
+/**
+ * Reads one page of the signed-in owner's mail, answering an expected failure as a value rather than by throwing.
+ *
+ * @param session The address to reach and the finished header value to present.
+ * @param transport How the request goes out.
+ * @param query Which list is being read, and where in it.
+ * @returns The page, or why it never arrived.
+ */
+export async function readMailTimeline(
+    session: ClientSession,
+    transport: MailFathomTransport,
+    query: MailTimelineQuery,
+): Promise<ClientResult<MailTimelinePage>> {
+    const response = await send(transport, {
+        method: 'GET',
+        path: routeFor(session, mailTimelineRoute) + timelineQueryString(query),
+        headers: headersFor(session),
+        longestAnswer: longestTimelineAnswer,
+    });
+
+    if (response === null) {
+        return failed('unavailable', null);
+    }
+
+    if (response.status !== 200) {
+        return failed(failureReasonForStatus(response.status), response.status);
+    }
+
+    const page = parsePage(response.body, query.pageSize);
+
+    return page === null ? failed('unreadable', response.status) : read(page);
+}
+
+/**
+ * The query string one page is asked with, including the two values the route would default anyway.
+ *
+ * They are written out because the request is the statement of which list the cursor belongs to: a screen that stopped
+ * naming its order would be asking for a different list with a cursor issued for the one before it, and the difference
+ * between the two spellings would only appear once somebody had scrolled.
+ */
+export function timelineQueryString(query: MailTimelineQuery): string {
+    const asked: string[] = [
+        `sort=receivedAt`,
+        `order=${query.order}`,
+        `direction=${query.direction}`,
+        `pageSize=${String(query.pageSize)}`,
+    ];
+
+    if (query.account !== null) {
+        asked.push(`account=${encodeURIComponent(query.account)}`);
+    }
+
+    if (query.folder !== null) {
+        asked.push(`folder=${encodeURIComponent(query.folder)}`);
+    }
+
+    if (query.includeJunk) {
+        asked.push('includeJunk=true');
+    }
+
+    for (const [name, wanted] of [
+        ['unread', query.unread],
+        ['flagged', query.flagged],
+        ['hasAttachments', query.hasAttachments],
+    ] as const) {
+        if (wanted !== null) {
+            asked.push(`${name}=${wanted ? 'true' : 'false'}`);
+        }
+    }
+
+    if (query.cursor !== null) {
+        asked.push(`cursor=${encodeURIComponent(query.cursor)}`);
+    }
+
+    return `?${asked.join('&')}`;
+}
+
+// The page is held against what was asked for as well as against its own shape: a deployment answering with more rows
+// than the request admits is one this client refuses to render rather than one it draws, which is the bound the root
+// instructions place at every remote boundary.
+function parsePage(body: string, asked: number): MailTimelinePage | null {
+    let parsed: unknown;
+
+    try {
+        parsed = JSON.parse(body);
+    } catch {
+        return null;
+    }
+
+    const record = asRecord(parsed);
+    if (record === null) {
+        return null;
+    }
+
+    const rows = record['emails'];
+    const pageSize = record['pageSize'];
+    const nextCursor = record['nextCursor'] ?? null;
+    const previousCursor = record['previousCursor'] ?? null;
+
+    if (!Array.isArray(rows) || rows.length > asked) {
+        return null;
+    }
+
+    if (typeof pageSize !== 'number' || !Number.isSafeInteger(pageSize) || pageSize < 1) {
+        return null;
+    }
+
+    if (!isCursor(nextCursor) || !isCursor(previousCursor)) {
+        return null;
+    }
+
+    const emails: MailTimelineEntry[] = [];
+    for (const row of rows) {
+        const entry = parseEntry(row);
+        if (entry === null) {
+            return null;
+        }
+
+        emails.push(entry);
+    }
+
+    return { emails, nextCursor, previousCursor, pageSize };
+}
+
+function parseEntry(value: unknown): MailTimelineEntry | null {
+    const record = asRecord(value);
+    if (record === null) {
+        return null;
+    }
+
+    const id = record['id'];
+    const account = record['account'];
+    const folder = record['folder'];
+    const threadId = record['threadId'] ?? null;
+    const subject = record['subject'] ?? null;
+    const receivedAt = record['receivedAt'] ?? null;
+    const sentAt = record['sentAt'] ?? null;
+    const senderAddress = record['senderAddress'] ?? null;
+    const senderDisplayName = record['senderDisplayName'] ?? null;
+    const preview = record['preview'] ?? null;
+
+    if (!isIdentity(id) || !isIdentity(account) || !isIdentity(folder)) {
+        return null;
+    }
+
+    if (threadId !== null && !isIdentity(threadId)) {
+        return null;
+    }
+
+    if (!isOptionalText(subject) || !isOptionalText(senderAddress) || !isOptionalText(senderDisplayName)) {
+        return null;
+    }
+
+    if (!isOptionalText(preview) || !isOptionalText(receivedAt) || !isOptionalText(sentAt)) {
+        return null;
+    }
+
+    const toAddresses = parseRecipients(record['toAddresses']);
+    if (toAddresses === null) {
+        return null;
+    }
+
+    const unread = record['unread'];
+    const flagged = record['flagged'];
+    const answered = record['answered'];
+    const hasAttachments = record['hasAttachments'];
+
+    if (
+        typeof unread !== 'boolean' ||
+        typeof flagged !== 'boolean' ||
+        typeof answered !== 'boolean' ||
+        typeof hasAttachments !== 'boolean'
+    ) {
+        return null;
+    }
+
+    const attachmentCount = record['attachmentCount'];
+    const sizeOctets = record['sizeOctets'];
+
+    if (!isCount(attachmentCount) || !isCount(sizeOctets)) {
+        return null;
+    }
+
+    return {
+        id,
+        account,
+        folder,
+        threadId,
+        subject,
+        receivedAt,
+        sentAt,
+        senderAddress,
+        senderDisplayName,
+        toAddresses,
+        unread,
+        flagged,
+        answered,
+        hasAttachments,
+        attachmentCount,
+        sizeOctets,
+        preview,
+    };
+}
+
+function parseRecipients(value: unknown): readonly string[] | null {
+    if (!Array.isArray(value) || value.length > mostRecipients) {
+        return null;
+    }
+
+    const addresses: string[] = [];
+    for (const address of value) {
+        if (typeof address !== 'string' || address.length > longestText) {
+            return null;
+        }
+
+        addresses.push(address);
+    }
+
+    return addresses;
+}
+
+// A name the deployment assigned, which is what a row is keyed by and what a later request names the message with.
+function isIdentity(value: unknown): value is string {
+    return typeof value === 'string' && value.length > 0 && value.length <= longestIdentity;
+}
+
+function isOptionalText(value: unknown): value is string | null {
+    return value === null || (typeof value === 'string' && value.length <= longestText);
+}
+
+function isCursor(value: unknown): value is string | null {
+    return value === null || (typeof value === 'string' && value.length > 0 && value.length <= longestCursor);
+}
+
+// A count is a whole number, so a fraction, a negative, and a value past what arithmetic here stays exact for are each
+// an answer no mailbox produced.
+function isCount(value: unknown): value is number {
+    return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+}

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -341,6 +341,34 @@ function timelinePage(url: URL): string {
  * own, and this suite is compiled without a DOM declaration on purpose — `tsconfig.json` says why — so a closure
  * naming an element would be the one thing that changes. A gesture needs neither.
  */
+/**
+ * The row at the top of the list once it has stopped moving.
+ *
+ * A wheel gesture goes on arriving after the row under it has changed, and where the reader is is written down only
+ * once the list has rested — so the row read the instant it changes is not the row the client will remember. Two reads
+ * that agree across longer than that rest is what says the list has settled on one.
+ */
+async function restingFirstRow(list: Locator): Promise<string> {
+    const row = list.getByRole('option').first();
+    let previous = '';
+
+    await expect
+        .poll(
+            async () => {
+                const now = (await row.textContent()) ?? '';
+                const rested = now !== '' && now === previous;
+
+                previous = now;
+
+                return rested;
+            },
+            { intervals: [600, 600, 600, 600] },
+        )
+        .toBe(true);
+
+    return (await row.textContent()) ?? '';
+}
+
 async function readOnward(page: Page, list: Locator): Promise<void> {
     const before = await list.getByRole('option').first().textContent();
 
@@ -890,7 +918,7 @@ test('puts a reader back where they were reading, across a reload', async ({ pag
         await readOnward(page, list);
     }
 
-    const before = await list.getByRole('option').first().textContent();
+    const before = await restingFirstRow(list);
 
     // A reload is a cold start, so where somebody was reading is kept where the credential is kept and read back the
     // same way. Only a real document reloaded proves it was written rather than held.

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -630,6 +630,14 @@ test('keeps the folder tree as it was left, across a reload', async ({ page }) =
     await expect(tree.getByRole('treeitem', { name: /^2024/ })).toHaveAttribute('aria-selected', 'true');
 });
 
+// Opening a message is an act rather than a state the client lands in: the reading pane draws what a row of the list
+// was opened, so every check about it starts by opening one.
+async function openTheFirstMessage(page: Page): Promise<void> {
+    await openSignedIn(page, '/#/mail');
+
+    await page.getByRole('listbox', { name: 'Messages' }).getByRole('option').first().click();
+}
+
 test('issues every request to the origin it was served from and to no other', async ({ page }) => {
     const origins = new Set<string>();
 
@@ -639,7 +647,7 @@ test('issues every request to the origin it was served from and to no other', as
 
     // Mail rather than the root, because drawing a message is where a request to somebody else's server would come
     // from: reading mail must not be what tells a sender it was read.
-    await openSignedIn(page, '/#/mail');
+    await openTheFirstMessage(page);
     await expect(page.getByRole('heading', messageHeading)).toBeVisible();
 
     // A client of one person's own mail reaches the deployment serving it and nothing else, so a font, an analytics
@@ -651,7 +659,7 @@ test('issues every request to the origin it was served from and to no other', as
 // parser makes, every block, and every sentence — is jsdom's and lives in the unit suite beside the source.
 
 test('draws the message as this document own elements, with nothing a sender wrote becoming one', async ({ page }) => {
-    await openSignedIn(page, '/#/mail');
+    await openTheFirstMessage(page);
 
     const message = page.getByRole('article', messageRegion);
     await expect(message.getByRole('heading', messageHeading)).toBeVisible();
@@ -668,7 +676,7 @@ test('draws the message as this document own elements, with nothing a sender wro
 });
 
 test('shows where a link goes, and says so when its words name somewhere else', async ({ page }) => {
-    await openSignedIn(page, '/#/mail');
+    await openTheFirstMessage(page);
 
     const message = page.getByRole('article', messageRegion);
 
@@ -679,7 +687,7 @@ test('shows where a link goes, and says so when its words name somewhere else', 
 });
 
 test('leaves the application when a link is followed rather than navigating it', async ({ page }) => {
-    await openSignedIn(page, '/#/mail');
+    await openTheFirstMessage(page);
     await expect(page.getByRole('heading', messageHeading)).toBeVisible();
 
     const openedHere = page.url();
@@ -710,7 +718,7 @@ test('describes an attached file before it is fetched, and fetches it only when 
         }
     });
 
-    await openSignedIn(page, '/#/mail');
+    await openTheFirstMessage(page);
 
     const download = page.getByRole('button', { name: 'Download orders.csv' });
     await expect(download).toBeVisible();
@@ -732,7 +740,7 @@ test('describes an attached file before it is fetched, and fetches it only when 
 test('presents the credential the bundle composed when it fetches an attached file', async ({ page }) => {
     const presented: (string | undefined)[] = [];
 
-    await openSignedIn(page, '/#/mail');
+    await openTheFirstMessage(page);
 
     // Registered after the deployment's own routes so this one wins for the attachment, which is what lets the header
     // the built bundle actually sent be read rather than inferred from the source.
@@ -756,7 +764,7 @@ test('fetches nothing from the sender until the reader asks, and asks again next
         hosts.add(new URL(request.url()).hostname);
     });
 
-    await openSignedIn(page, '/#/mail');
+    await openTheFirstMessage(page);
 
     const askForPictures = page.getByRole('button', { name: 'Load pictures from the sender' });
     await expect(askForPictures).toBeVisible();

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -271,6 +271,14 @@ async function servedByADeployment(page: Page): Promise<void> {
         route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mailFolders) }),
     );
 
+    await page.route('**/api/client/emails*', (route) =>
+        route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: timelinePage(new URL(route.request().url())),
+        }),
+    );
+
     // The one route whose answer depends on what the client asked for: the reader's ask for the sender's pictures is
     // in the query and nowhere else, so answering it here is what lets this suite watch a request leave for the
     // sender's host — and watch it not leave before the ask.
@@ -281,6 +289,65 @@ async function servedByADeployment(page: Page): Promise<void> {
             body: messageBody(new URL(route.request().url()).searchParams.get('remoteImages') === 'true'),
         }),
     );
+}
+
+// How many messages the mailbox behind the routing holds, which is the number `frontend/src/AGENTS.md` names as the
+// one the client actually has to render. Nothing here is anybody's mail: every row is generated from its own number.
+const mailboxSize = 214_000;
+const rowsPerPage = 100;
+
+/**
+ * One page of the mailbox, keyset-paged the way the client surface pages it.
+ *
+ * The cursor is the row the page starts at, written as text, because what this suite proves about a cursor is that the
+ * client holds one and continues from it — what a deployment encodes in one is the deployment's own business.
+ */
+function timelinePage(url: URL): string {
+    const asked = Number(url.searchParams.get('cursor') ?? '0');
+    const backward = url.searchParams.get('direction') === 'backward';
+    const from = Math.max(backward ? asked - rowsPerPage : asked, 0);
+    const rows = Math.min(rowsPerPage, mailboxSize - from);
+
+    return JSON.stringify({
+        emails: Array.from({ length: rows }, (_, at) => ({
+            id: `message-${String(from + at)}`,
+            account: 'work',
+            folder: 'INBOX',
+            threadId: null,
+            subject: `Message ${String(from + at)}`,
+            receivedAt: '2026-08-31T09:41:00+00:00',
+            sentAt: null,
+            senderAddress: `writer-${String(from + at)}@nordwind.example`,
+            senderDisplayName: `Writer ${String(from + at)}`,
+            toAddresses: ['owner@example.invalid'],
+            unread: at % 3 === 0,
+            flagged: false,
+            answered: false,
+            hasAttachments: at % 5 === 0,
+            attachmentCount: at % 5 === 0 ? 1 : 0,
+            sizeOctets: 4_096,
+            preview: `The opening of message ${String(from + at)}.`,
+        })),
+        nextCursor: from + rows >= mailboxSize ? null : String(from + rows),
+        previousCursor: from === 0 ? null : String(from),
+        pageSize: rowsPerPage,
+    });
+}
+
+/**
+ * Reads onward the way a reader does, and answers once the list has moved.
+ *
+ * A wheel over the rows rather than a scroll offset written into the scroller: the scroller carries no role of its
+ * own, and this suite is compiled without a DOM declaration on purpose — `tsconfig.json` says why — so a closure
+ * naming an element would be the one thing that changes. A gesture needs neither.
+ */
+async function readOnward(page: Page, list: Locator): Promise<void> {
+    const before = await list.getByRole('option').first().textContent();
+
+    await list.getByRole('option').first().hover();
+    await page.mouse.wheel(0, 6_000);
+
+    await expect.poll(() => list.getByRole('option').first().textContent()).not.toBe(before);
 }
 
 async function signIn(page: Page): Promise<void> {
@@ -708,4 +775,72 @@ test('fetches nothing from the sender until the reader asks, and asks again next
     // Nothing on either side wrote the ask down, so the message opens asking again. Only a real document reloaded
     // proves that: browser storage is what a durable answer would have been kept in.
     await expect(page.getByRole('button', { name: 'Load pictures from the sender' })).toBeVisible();
+});
+
+// What only a browser can say about the message list: every row is one height, the document holds a window of rows
+// rather than the folder, and a reader who leaves and comes back is put back where they were. Everything else about
+// it — the paging arithmetic, the states, the selection, and every sentence — is jsdom's and lives in the unit suite
+// beside the source.
+
+test('draws every row of the list at one height, which is what the window is arithmetic over', async ({ page }) => {
+    await openSignedIn(page, '/#/mail');
+
+    const list = page.getByRole('listbox', { name: 'Messages' });
+    await expect(list.getByRole('option').first()).toBeVisible();
+
+    const heights = await Promise.all(
+        (await list.getByRole('option').all()).map(async (row) => (await row.boundingBox())?.height),
+    );
+
+    // The measurement the choice of windowing was made against, kept as an assertion rather than as a number in a
+    // pull request: a row whose height varied with its subject, its preview, or its marks would put every row below it
+    // somewhere other than where the list drew the space for it — and would be the argument for a virtualizer that
+    // measures rows, which this list deliberately does not carry.
+    expect(new Set(heights).size).toBe(1);
+    expect(heights[0]).toBeGreaterThan(0);
+});
+
+test('holds a window of rows in the document however far down the folder it is scrolled', async ({ page }) => {
+    await openSignedIn(page, '/#/mail');
+
+    const list = page.getByRole('listbox', { name: 'Messages' });
+    await expect(list.getByRole('option').first()).toBeVisible();
+
+    const drawnAtTheTop = await list.getByRole('option').count();
+
+    for (let read = 1; read <= 6; read += 1) {
+        await readOnward(page, list);
+    }
+
+    // Hundreds of rows further down a folder of two hundred and fourteen thousand, reached a screenful at a time the
+    // way somebody scrolls — and the document holds no more rows than it did on the first screen. That is the whole
+    // claim windowing makes, and only a browser laying the list out can answer it.
+    await expect(list.getByRole('option').first()).toContainText(/Message [1-9]\d\d/);
+    expect(await list.getByRole('option').count()).toBeLessThanOrEqual(drawnAtTheTop);
+    await expect(list.getByRole('option', { name: /^Writer 0\D/ })).toHaveCount(0);
+});
+
+test('puts a reader back where they were reading, across a reload', async ({ page }) => {
+    await openSignedIn(page, '/#/mail');
+
+    const list = page.getByRole('listbox', { name: 'Messages' });
+    await expect(list.getByRole('option').first()).toBeVisible();
+
+    // Far enough that the row the reader is on is in a page the client had to ask for with a cursor, which is the
+    // whole of what returning to a position means: a client that read the folder again from its leading end would land
+    // on message zero and look identical to one that had never scrolled.
+    for (let read = 1; read <= 3; read += 1) {
+        await readOnward(page, list);
+    }
+
+    const before = await list.getByRole('option').first().textContent();
+
+    // A reload is a cold start, so where somebody was reading is kept where the credential is kept and read back the
+    // same way. Only a real document reloaded proves it was written rather than held.
+    await page.reload();
+
+    const after = page.getByRole('listbox', { name: 'Messages' });
+    await expect(after.getByRole('option').first()).toBeVisible();
+
+    expect(await after.getByRole('option').first().textContent()).toBe(before);
 });

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -800,6 +800,27 @@ test('draws every row of the list at one height, which is what the window is ari
     expect(heights[0]).toBeGreaterThan(0);
 });
 
+test('draws the three columns of the Mail space without the page scrolling sideways', async ({ page }) => {
+    // The width the composition opens out at, which is where the three columns have the least room they will ever
+    // have: any narrower and they are a stack instead. A column that held its width here rather than giving way is
+    // what would push the page wider than the window, and only a browser answers that — jsdom computes no geometry.
+    await page.setViewportSize({ width: 780, height: 800 });
+    await openSignedIn(page, '/#/mail');
+
+    await expect(page.getByRole('tree', { name: 'Mailboxes and folders' })).toBeVisible();
+    await expect(page.getByRole('listbox', { name: 'Messages' })).toBeVisible();
+
+    // The space's own box rather than the document's: the region that holds the three columns scrolls its own
+    // overflow, so a column too wide for the window makes that region scroll sideways while the document stays
+    // exactly as wide as the window. Asked of the landmark by its element name, because what is being measured is a
+    // box rather than something a reader would look for — and as an expression rather than a closure, for the reason
+    // the sign-in test above gives.
+    const scrollingSideways = await page.evaluate<boolean>(
+        'document.querySelector("main").scrollWidth > document.querySelector("main").clientWidth',
+    );
+    expect(scrollingSideways).toBe(false);
+});
+
 test('holds a window of rows in the document however far down the folder it is scrolled', async ({ page }) => {
     await openSignedIn(page, '/#/mail');
 

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -813,20 +813,26 @@ test('draws the three columns of the Mail space without the page scrolling sidew
     // have: any narrower and they are a stack instead. A column that held its width here rather than giving way is
     // what would push the page wider than the window, and only a browser answers that — jsdom computes no geometry.
     await page.setViewportSize({ width: 780, height: 800 });
-    await openSignedIn(page, '/#/mail');
 
-    await expect(page.getByRole('tree', { name: 'Mailboxes and folders' })).toBeVisible();
-    await expect(page.getByRole('listbox', { name: 'Messages' })).toBeVisible();
+    // With a message open, so the third column is the pane a reader actually gets rather than the note standing in
+    // for it: the pane is the column that has to give way, and an empty one proves nothing about a filled one.
+    await openTheFirstMessage(page);
+    await expect(page.getByRole('article', messageRegion)).toBeVisible();
 
-    // The space's own box rather than the document's: the region that holds the three columns scrolls its own
-    // overflow, so a column too wide for the window makes that region scroll sideways while the document stays
-    // exactly as wide as the window. Asked of the landmark by its element name, because what is being measured is a
-    // box rather than something a reader would look for — and as an expression rather than a closure, for the reason
-    // the sign-in test above gives.
-    const scrollingSideways = await page.evaluate<boolean>(
-        'document.querySelector("main").scrollWidth > document.querySelector("main").clientWidth',
-    );
-    expect(scrollingSideways).toBe(false);
+    // Each column against the space it stands in, reached by its role like everything else here. A column that held
+    // its width rather than giving way lays out past that space's right edge, which is what makes the region scroll
+    // sideways while the document stays exactly as wide as the window.
+    const room = await boxOf(page.getByRole('main'));
+    const columns = [
+        await boxOf(page.getByRole('tree', { name: 'Mailboxes and folders' })),
+        await boxOf(page.getByRole('listbox', { name: 'Messages' })),
+        await boxOf(page.getByRole('article', messageRegion)),
+    ];
+
+    for (const column of columns) {
+        expect(column.x).toBeGreaterThanOrEqual(room.x);
+        expect(column.x + column.width).toBeLessThanOrEqual(room.x + room.width);
+    }
 });
 
 test('holds a window of rows in the document however far down the folder it is scrolled', async ({ page }) => {
@@ -847,6 +853,28 @@ test('holds a window of rows in the document however far down the folder it is s
     await expect(list.getByRole('option').first()).toContainText(/Message [1-9]\d\d/);
     expect(await list.getByRole('option').count()).toBeLessThanOrEqual(drawnAtTheTop);
     await expect(list.getByRole('option', { name: /^Writer 0\D/ })).toHaveCount(0);
+});
+
+test('starts the list at its leading end when the order changes under a reader who had scrolled', async ({ page }) => {
+    await openSignedIn(page, '/#/mail');
+
+    const list = page.getByRole('listbox', { name: 'Messages' });
+    await expect(list.getByRole('option').first()).toBeVisible();
+
+    const drawnAtTheTop = await list.getByRole('option').count();
+
+    for (let read = 1; read <= 3; read += 1) {
+        await readOnward(page, list);
+    }
+
+    await page.getByLabel('Order').selectOption('oldestFirst');
+
+    // Changing the order empties the list, which takes the scroller out of the document, so the one that comes back is
+    // at the top however far down the reader had been. A window still computed from where they were draws the far end
+    // of the first page under a screen of blank space, and no scroll is left to fire the event that would correct it —
+    // which only a browser laying the list out can answer.
+    await expect(list.getByRole('option').first()).toContainText('Message 0');
+    expect(await list.getByRole('option').count()).toBeGreaterThanOrEqual(drawnAtTheTop);
 });
 
 test('puts a reader back where they were reading, across a reload', async ({ page }) => {

--- a/scripts/test-agent-workflow.sh
+++ b/scripts/test-agent-workflow.sh
@@ -8563,9 +8563,14 @@ no_tracked_text_file_carries_a_nul_byte() {
 # extension is also what keeps `Cargo.lock` beside `Cargo.toml` out of the answer: those spell their
 # shared stem identically, and only a stem spelled two ways is a collision. A leading dot is not an
 # extension, so `.npmrc` keeps its whole name.
+#
+# The sort collates by byte, because a locale collation orders one pair two ways: `theme` before
+# `Theme` under a UTF-8 locale and after it under `C`, so which half of a collision the answer names
+# first would follow the machine the sweep ran on. It also stops `sort -u` from dropping one of a
+# pair a locale collates as equal, which would hide the collision the sweep exists to find.
 paths_differing_only_by_case() {
   sed -E 's#(/|^)([^/]+)\.[^/.]+$#\1\2#' |
-    sort -u |
+    LC_ALL=C sort -u |
     awk '{ key = tolower($0); if (key in seen) { print seen[key] " and " $0 } else { seen[key] = $0 } }'
 }
 
@@ -8590,7 +8595,7 @@ no_two_tracked_paths_differ_only_by_case() {
 
   # And the sweep itself, against the pair the nightly of 2026-09-01 found and against the two shapes
   # it must leave alone.
-  if [[ "$(printf 'a/theme.ts\na/Theme.tsx\n' | paths_differing_only_by_case)" != 'a/theme and a/Theme' ]]; then
+  if [[ "$(printf 'a/theme.ts\na/Theme.tsx\n' | paths_differing_only_by_case)" != 'a/Theme and a/theme' ]]; then
     printf 'the sweep does not report one stem spelled two ways in a directory\n' >&2
     failures=$(( failures + 1 ))
   fi


### PR DESCRIPTION
Closes #1424

The Mail space stopped being a frame. It reads `/api/client/emails` and draws the folder in scope as a list the owner's
mailbox of two hundred and fourteen thousand messages can actually be read in — scrolled through, returned to, and
picked from for the question the client is about to ask.

## What it does

**The document holds a window of rows rather than the folder.** `timelineWindow.ts` is arithmetic over four numbers —
row count, row height, scroll offset, viewport — so the number of rows in the document is the same on the first screen
as at message forty thousand. The one height it depends on is measured off a rendered row rather than written down a
second time in JavaScript, and the rows sit flush so a row lands exactly where the list drew the space for it.

**The list holds a window of pages rather than every page it has read.** `heldTimeline.ts` keeps two pages either side
of the reader. A page beyond that keeps its place, its row count, and the cursor it was read under, and loses only its
rows — so the list keeps its height, nothing under the reader moves, and scrolling back into it reads that page again
from its own cursor rather than reading the folder from its leading end.

**Where the reader is lives outside React.** `rememberedListings.ts` keeps the cursor, the row inside its page, the
order, and the filters together in one record, keyed by the deployment and the folder, so a cursor cannot outlive the
list it was issued for. It is read back as untrusted input with bounds on every field, it holds nothing about any
message, and it is dropped wherever the client lets a credential go.

**A selection the rest of the client can read.** A pointer, a modifier, a drag, and the keyboard each pick rows out, and
a selection mode gives a finger what a modifier key gives a pointer — no branch on a head, and a mode a screen reader
can announce. What is picked out is kept in the workspace in reading order, including rows scrolled past, which is the
scope the question field will ask against.

**The wire.** `Client.Backend` gains `mailTimeline.ts`: a request that states the whole of which list is being read —
sort, order, direction, and page size written out even where the route would default them, because the request is what
the cursor belongs to — and a parser that refuses a page rather than handing a screen a row with a hole in it. Every
field is checked, every collection is bounded during the walk, and a page carrying more rows than the request admits is
refused.

**Its five states are designed rather than defaulted.** Offline, reading, four different empty sentences — a folder
nothing has synchronized yet, an account that stopped synchronizing, a narrowing that matches nothing, and a folder
that genuinely holds nothing — a failure carrying the way out of the one failure that has one, and a partial state
where a later read failed with rows already on the screen.

## Two things it changes beyond the list

- No package windows the list, and that is a measurement rather than a preference: the row is a fixed two lines, so the
  only thing a virtualizer buys — measuring rows that are *not* one height — has no use here. The browser suite asserts
  that every drawn row measures the same, so a row that ever stops being one height fails a test rather than degrading
  quietly. `frontend/README.md` carries the argument.
- The Mail space no longer says it is not built yet. That sentence stands above a space that holds nothing, which Mail
  stopped being.

## Verification

- `pnpm typecheck`, `pnpm lint` — clean.
- `pnpm test` — 51 files, 913 tests. `pnpm test:browser` — 27 specs, including five new ones: every drawn row is one
  height, the three columns stand inside the space they are drawn in at the width they open out at, the document holds
  a bounded number of rows however far the folder is scrolled, the list starts at its leading end when the order
  changes under a reader who had scrolled, and a reader is put back where they were across a reload.
- `scripts/verify-full.sh` — 286 passed, 0 failed.
- The screens were looked at in a real browser at 1440 and 380 CSS pixels, in both themes, against a routed mailbox.

## Since the first review round

- The five findings are answered in `017841a6`, each in its own thread: a range gesture whose anchor has been trimmed
  keeps the selection instead of emptying it, the focus effect waits on whether the focused row is drawn so a refilled
  page completes a pending focus, only a scope that points at junk asks for it, the workspace store's refusal table
  covers `selected`, and the checkbox both the narrowings and the selection mode draw is one component in `controls/`.
- Looking at the screen found three more: the three columns pushed the space sideways at the width they open out at,
  the list column was too narrow for what a row carries, and rows separated by a gap put every row a fraction below the
  space the list drew for it. The browser suite now asserts the first of those.
- Rebased onto #1426, which landed the reading pane. That pane opened one message by identifier because the list that
  would decide did not exist yet; it does, so `7ff538ec` deletes the identifier and the pane draws what a row opened.
  Both suites follow — the frame's test picks a row out of the list the way a reader does, and what the pane says with
  nothing open is a test of its own.


## Since the second review round

- The three findings are answered in `1e2732c3`: both failure paragraphs carry `role="alert"`, so a reader who heard
  the list say it was reading hears it stop; the opening listing is named `neverOpenedListing`, for the reading
  position rather than for a message state three controls away; and the bordered control's look is stated once in
  `controls/chrome.ts` for the three controls that draw it.

## Since the third review round

- The two findings are answered in `9b8873ab`. Changing the order or a filter now puts the list back at its leading end
  rather than leaving the window computed from where the reader had scrolled to, which drew the far end of the new
  first page under a screen of blank space with no scroll left to correct it; the browser suite covers it. And the
  three columns are measured against the space they stand in by the role each is reached by, rather than through a
  selector reaching for the landmark — the thread records why neither form of `Locator.evaluate` could be used here.

## One commit that is not this issue's

`a85f13fb` fixes the case-collision sweep #1456 added to the contract suite: `sort` collates by the ambient locale, so
the sweep's own assertion passed on a developer's machine and failed on the runner, and `main` had been red since that
merge. It rides here because this branch could not go green without it, and it is called out rather than folded into
the work above.
