### PR TITLE
Read the synthetic mail tool's configuration from dotnet user-secrets

### DIFF
--- a/backend/tests/SyntheticMail.UnitTests/Configuration/ConfigurationSourceTests.cs
+++ b/backend/tests/SyntheticMail.UnitTests/Configuration/ConfigurationSourceTests.cs
@@ -1,0 +1,101 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text;
+using MailFathom.SyntheticMail.Configuration;
+
+using Xunit;
+
+namespace MailFathom.SyntheticMail.UnitTests.Configuration;
+
+/// <summary>What a run reads out of the <c>dotnet user-secrets</c> store, which writes flat keys and string values.</summary>
+public sealed class ConfigurationSourceTests
+{
+    private const string Origin = "user secrets";
+
+    [Fact]
+    public void Nest_AStoreWrittenByTheTooling_ReadsAsACompleteAccount()
+    {
+        // Arrange
+        const string secrets = """
+            {
+              "host": "smtp.example.test",
+              "port": "2525",
+              "security": "ImplicitTls",
+              "address": "throwaway@example.test",
+              "password": "not-a-real-password"
+            }
+            """;
+
+        // Act
+        var account = Nested(secrets, SendingAccountFile.ReadFrom);
+
+        // Assert
+        Assert.Equal("smtp.example.test", account.Host);
+        Assert.Equal(2525, account.Port);
+        Assert.Equal(MailTransportSecurity.ImplicitTls, account.Security);
+        Assert.Equal("not-a-real-password", account.Password);
+    }
+
+    [Fact]
+    public void Nest_ColonSeparatedKeys_BecomeTheBlockTheyName()
+    {
+        // Arrange
+        const string secrets = """
+            {
+              "mailbox:host": "imap.example.test",
+              "mailbox:port": "1143",
+              "mailbox:security": "StartTls",
+              "mailbox:address": "watched@example.test",
+              "mailbox:password": "not-a-real-password"
+            }
+            """;
+
+        // Act
+        var mailbox = Nested(secrets, SendingAccountFile.ReadWatchedMailboxFrom);
+
+        // Assert
+        Assert.Equal("imap.example.test", mailbox.Host);
+        Assert.Equal(1143, mailbox.Port);
+        Assert.Equal("watched@example.test", mailbox.Address.Address);
+    }
+
+    [Fact]
+    public void Nest_AHandWrittenNestedBlock_IsLeftAsItIs()
+    {
+        // Arrange
+        const string secrets = """
+            {
+              "mailbox": { "host": "imap.example.test", "address": "watched@example.test", "password": "not-a-real-password" }
+            }
+            """;
+
+        // Act
+        var mailbox = Nested(secrets, SendingAccountFile.ReadWatchedMailboxFrom);
+
+        // Assert
+        Assert.Equal("imap.example.test", mailbox.Host);
+    }
+
+    [Fact]
+    public void Nest_ContentsThatAreNotAnObject_AreRefused()
+    {
+        // Arrange
+        using var flattened = new MemoryStream("[]"u8.ToArray());
+
+        // Act
+        var failure = Assert.Throws<SyntheticMailFailure>(() => ConfigurationSource.Nest(flattened));
+
+        // Assert
+        Assert.Contains("is not a JSON object", failure.Message, StringComparison.Ordinal);
+    }
+
+    private static TConfigured Nested<TConfigured>(string secrets, Func<Stream, string, TConfigured> read)
+    {
+        using var flattened = new MemoryStream(Encoding.UTF8.GetBytes(secrets));
+        using var nested = ConfigurationSource.Nest(flattened);
+
+        return read(nested, Origin);
+    }
+}

--- a/backend/tests/SyntheticMail.UnitTests/Generation/AiContent/OpenAiEmailContentSourceTests.cs
+++ b/backend/tests/SyntheticMail.UnitTests/Generation/AiContent/OpenAiEmailContentSourceTests.cs
@@ -145,6 +145,26 @@ public sealed class OpenAiEmailContentSourceTests
     }
 
     [Fact]
+    public void ParseContent_AnObjectWrappedInAFencedBlock_IsReadAsTheAnswerItCarries()
+    {
+        // Arrange
+        const string answer = """
+            Here is the email:
+
+            ```json
+            { "subject": "Figures", "body": "Hello.", "html": "<p>Hello.</p>" }
+            ```
+            """;
+
+        // Act
+        var content = OpenAiEmailContentSource.ParseContent(answer);
+
+        // Assert
+        Assert.Equal("Figures", content.Subject);
+        Assert.Equal("<p>Hello.</p>", content.Html);
+    }
+
+    [Fact]
     public void ParseContent_AnAnswerCarryingControlCharacters_IsReducedToWhatItsDestinationsCarry()
     {
         // Arrange, Act

--- a/backend/tools/SyntheticMail/Configuration/ConfigurationSource.cs
+++ b/backend/tools/SyntheticMail/Configuration/ConfigurationSource.cs
@@ -1,0 +1,149 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace MailFathom.SyntheticMail.Configuration;
+
+/// <summary>Where a run's configuration is read from: the named local file, or the machine's <c>dotnet user-secrets</c> store.</summary>
+/// <remarks>
+/// <para>
+/// A developer who already keeps development credentials in the user-secrets store should not have to write a second
+/// copy of one into the checkout, so a run whose local file is absent reads the store instead. The store is a plain
+/// JSON file at a path derived from this project's <c>UserSecretsId</c>, which is why no configuration package is
+/// referenced for it: reading it is opening that file, and the two readers beside this type already know how to turn
+/// one into an account or a provider.
+/// </para>
+/// <para>
+/// <c>dotnet user-secrets set</c> writes a key exactly as it was typed, so <c>mailbox:host</c> arrives as a key with a
+/// colon in it rather than as a member of a <c>mailbox</c> object, and every value it writes is a string.
+/// <see cref="Nest" /> turns the first back into the document the readers expect and leaves a hand-written nested
+/// object alone; the second is why the serialization contract reads a number from a string.
+/// </para>
+/// </remarks>
+internal static class ConfigurationSource
+{
+    /// <summary>The identifier the store is kept under.</summary>
+    /// <remarks>
+    /// Stated here as well as in <c>SyntheticMail.csproj</c>, which is what the <c>dotnet user-secrets</c> command
+    /// itself reads. Recovering it from the generated assembly attribute instead would mean referencing a
+    /// configuration package for one constant string.
+    /// </remarks>
+    internal const string UserSecretsId = "mailfathom-synthetic-mail-5c4b9288-c758-4871-8c58-d869809d8808";
+
+    /// <summary>What a message about the store names, so a refusal points at something a developer can act on.</summary>
+    internal static string UserSecretsOrigin => $"the user secrets of '{UserSecretsId}'";
+
+    /// <summary>Reports where <c>dotnet user-secrets</c> keeps this project's store.</summary>
+    /// <returns>The absolute path of the store's file, whether or not anything has been set in it.</returns>
+    /// <remarks>Resolved the way the tooling resolves it: under <c>%APPDATA%</c> on Windows and under the home directory anywhere else.</remarks>
+    internal static string UserSecretsPath()
+    {
+        var root = Environment.GetEnvironmentVariable("APPDATA") is { Length: > 0 } roaming
+            ? Path.Combine(roaming, "Microsoft", "UserSecrets")
+            : Path.Combine(Environment.GetEnvironmentVariable("HOME") ?? AppContext.BaseDirectory, ".microsoft", "usersecrets");
+
+        return Path.Combine(root, UserSecretsId, "secrets.json");
+    }
+
+    /// <summary>Opens what the run reads, preferring the named file and falling back to the store.</summary>
+    /// <param name="path">The local file the command was pointed at.</param>
+    /// <returns>The contents and what a failure about them names, or <see langword="null" /> when neither exists.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="path" /> is <see langword="null" />.</exception>
+    /// <exception cref="SyntheticMailFailure">Thrown when what exists could not be opened or is not a JSON object.</exception>
+    /// <remarks>
+    /// The file wins, because it is the one a developer pointed the command at; the store is what a checkout that has
+    /// never written one falls back to. Nothing is merged across the two: a half-configured run refuses with a message
+    /// naming one origin rather than reporting keys from two.
+    /// </remarks>
+    internal static (Stream Contents, string Origin)? Open(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+
+        if (File.Exists(path))
+        {
+            return (OpenFile(path), path);
+        }
+
+        var store = UserSecretsPath();
+
+        return File.Exists(store) ? (NestFile(store), UserSecretsOrigin) : null;
+    }
+
+    /// <summary>Turns the flat keys the user-secrets tooling writes into the nested document the readers deserialize.</summary>
+    /// <param name="flattened">The store's contents.</param>
+    /// <returns>The same values with every colon-separated key expanded into a block.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="flattened" /> is <see langword="null" />.</exception>
+    /// <exception cref="SyntheticMailFailure">Thrown when the contents are not a JSON object.</exception>
+    internal static Stream Nest(Stream flattened)
+    {
+        ArgumentNullException.ThrowIfNull(flattened);
+
+        JsonObject? document;
+
+        try
+        {
+            document = JsonNode.Parse(flattened) as JsonObject;
+        }
+        catch (Exception failure) when (failure is JsonException or IOException)
+        {
+            throw new SyntheticMailFailure($"{UserSecretsOrigin} could not be read as JSON: {failure.Message}", failure);
+        }
+
+        if (document is null)
+        {
+            throw new SyntheticMailFailure($"{UserSecretsOrigin} is not a JSON object.");
+        }
+
+        var nested = new JsonObject();
+
+        foreach (var (key, value) in document)
+        {
+            var segments = key.Split(':', StringSplitOptions.RemoveEmptyEntries);
+
+            if (segments.Length == 0)
+            {
+                continue;
+            }
+
+            var block = nested;
+
+            for (var depth = 0; depth < segments.Length - 1; depth++)
+            {
+                if (block[segments[depth]] is not JsonObject inner)
+                {
+                    inner = [];
+                    block[segments[depth]] = inner;
+                }
+
+                block = inner;
+            }
+
+            block[segments[^1]] = value?.DeepClone();
+        }
+
+        return new MemoryStream(Encoding.UTF8.GetBytes(nested.ToJsonString()));
+    }
+
+    private static Stream NestFile(string path)
+    {
+        using var contents = OpenFile(path);
+
+        return Nest(contents);
+    }
+
+    private static FileStream OpenFile(string path)
+    {
+        try
+        {
+            return File.OpenRead(path);
+        }
+        catch (Exception failure) when (failure is IOException or UnauthorizedAccessException)
+        {
+            throw new SyntheticMailFailure($"'{path}' could not be opened: {failure.Message}", failure);
+        }
+    }
+}

--- a/backend/tools/SyntheticMail/Configuration/SendingAccountFile.cs
+++ b/backend/tools/SyntheticMail/Configuration/SendingAccountFile.cs
@@ -16,7 +16,8 @@ namespace MailFathom.SyntheticMail.Configuration;
 /// address and its password come from a local file that <c>.gitignore</c> covers as <c>*.local.json</c>, while the
 /// recipient stays an argument, because the recipient is the part that changes per invocation. The file carries two
 /// accounts: the sending one every batch submits as, and — for a run generating exchanges — the mailbox MailFathom
-/// synchronizes, which that run reads over IMAP and appends to.
+/// synchronizes, which that run reads over IMAP and appends to. A checkout that wrote no such file reads the same
+/// keys out of the machine's user-secrets store instead, which <see cref="ConfigurationSource" /> is about.
 /// </para>
 /// <para>
 /// Every refusal here names the file and the key to set. A tool nobody has configured yet is the ordinary first
@@ -58,15 +59,13 @@ internal static class SendingAccountFile
     {
         ArgumentNullException.ThrowIfNull(path);
 
-        if (!File.Exists(path))
-        {
-            throw new SyntheticMailFailure(
-                $"No sending account is configured. Write '{path}' as {{ \"host\": \"…\", \"port\": 587, \"security\": \"StartTls\", \"address\": \"…\", \"password\": \"…\" }} and use a throwaway account: this tool fabricates mail and must never hold a credential that reaches anything else. The file is git-ignored.");
-        }
+        var configured = ConfigurationSource.Open(path)
+            ?? throw new SyntheticMailFailure(
+                $"No sending account is configured. Write '{path}' as {{ \"host\": \"…\", \"port\": 587, \"security\": \"StartTls\", \"address\": \"…\", \"password\": \"…\" }}, or set the same keys with `dotnet user-secrets set --project backend/tools/SyntheticMail`, and use a throwaway account: this tool fabricates mail and must never hold a credential that reaches anything else. The file is git-ignored.");
 
-        using var contents = OpenFile(path);
+        using var contents = configured.Contents;
 
-        return ReadFrom(contents, path);
+        return ReadFrom(contents, configured.Origin);
     }
 
     /// <summary>Reads the account from an already-open file, which is where every check on its contents happens.</summary>
@@ -108,15 +107,13 @@ internal static class SendingAccountFile
     {
         ArgumentNullException.ThrowIfNull(path);
 
-        if (!File.Exists(path))
-        {
-            throw new SyntheticMailFailure(
-                $"No sending account is configured. Write '{path}' as {{ \"host\": \"…\", \"port\": 587, \"security\": \"StartTls\", \"address\": \"…\", \"password\": \"…\", \"mailbox\": {{ \"host\": \"…\", \"address\": \"…\", \"password\": \"…\" }} }} and use throwaway accounts for both: this tool fabricates mail and must never hold a credential that reaches anything else. The file is git-ignored.");
-        }
+        var configured = ConfigurationSource.Open(path)
+            ?? throw new SyntheticMailFailure(
+                $"No sending account is configured. Write '{path}' as {{ \"host\": \"…\", \"port\": 587, \"security\": \"StartTls\", \"address\": \"…\", \"password\": \"…\", \"mailbox\": {{ \"host\": \"…\", \"address\": \"…\", \"password\": \"…\" }} }}, or set the same keys with `dotnet user-secrets set --project backend/tools/SyntheticMail`, and use throwaway accounts for both: this tool fabricates mail and must never hold a credential that reaches anything else. The file is git-ignored.");
 
-        using var contents = OpenFile(path);
+        using var contents = configured.Contents;
 
-        return ReadWatchedMailboxFrom(contents, path);
+        return ReadWatchedMailboxFrom(contents, configured.Origin);
     }
 
     /// <summary>Reads the watched mailbox from an already-open file, which is where every check on that block happens.</summary>
@@ -148,18 +145,6 @@ internal static class SendingAccountFile
             string.IsNullOrWhiteSpace(document.UserName) ? address.Address : document.UserName,
             password,
             string.IsNullOrWhiteSpace(document.SentFolder) ? null : document.SentFolder);
-    }
-
-    private static FileStream OpenFile(string path)
-    {
-        try
-        {
-            return File.OpenRead(path);
-        }
-        catch (Exception failure) when (failure is IOException or UnauthorizedAccessException)
-        {
-            throw new SyntheticMailFailure($"'{path}' could not be opened: {failure.Message}", failure);
-        }
     }
 
     private static SendingAccountDocument Deserialize(Stream contents, string origin)

--- a/backend/tools/SyntheticMail/Configuration/SyntheticAiProviderFile.cs
+++ b/backend/tools/SyntheticMail/Configuration/SyntheticAiProviderFile.cs
@@ -12,7 +12,8 @@ namespace MailFathom.SyntheticMail.Configuration;
 /// The key never reaches an argument. A key typed on a command line lands in the shell history and in the process
 /// list of a shared machine, and this repository is public enough that the pattern would be copied — so the key, the
 /// model, and the endpoint come from a local file that <c>.gitignore</c> covers as <c>*.local.json</c>, beside the
-/// sending account file and on the same terms.
+/// sending account file and on the same terms — including the fall back to the machine's user-secrets store that
+/// <see cref="ConfigurationSource" /> is about.
 /// </para>
 /// <para>
 /// Every refusal here names the file and the key to set, for the reason <see cref="SendingAccountFile" /> gives: a
@@ -42,15 +43,13 @@ internal static class SyntheticAiProviderFile
     {
         ArgumentNullException.ThrowIfNull(path);
 
-        if (!File.Exists(path))
-        {
-            throw new SyntheticMailFailure(
-                $"No AI provider is configured. Write '{path}' as {{ \"apiKey\": \"…\", \"model\": \"…\" }} and treat the key as one that reaches a third party: this mode sends the generation prompt to the endpoint and reads the message content back. The file is git-ignored.");
-        }
+        var configured = ConfigurationSource.Open(path)
+            ?? throw new SyntheticMailFailure(
+                $"No AI provider is configured. Write '{path}' as {{ \"apiKey\": \"…\", \"model\": \"…\" }}, or set the same keys with `dotnet user-secrets set --project backend/tools/SyntheticMail`, and treat the key as one that reaches a third party: this mode sends the generation prompt to the endpoint and reads the message content back. The file is git-ignored.");
 
-        using var contents = OpenFile(path);
+        using var contents = configured.Contents;
 
-        return ReadFrom(contents, path);
+        return ReadFrom(contents, configured.Origin);
     }
 
     /// <summary>Reads the provider configuration from an already-open file, which is where every check on its contents happens.</summary>
@@ -71,18 +70,6 @@ internal static class SyntheticAiProviderFile
             Required(document.ApiKey, "apiKey", origin),
             Required(document.Model, "model", origin),
             ParseEndpoint(document.Endpoint, origin));
-    }
-
-    private static FileStream OpenFile(string path)
-    {
-        try
-        {
-            return File.OpenRead(path);
-        }
-        catch (Exception failure) when (failure is IOException or UnauthorizedAccessException)
-        {
-            throw new SyntheticMailFailure($"'{path}' could not be opened: {failure.Message}", failure);
-        }
     }
 
     private static AiProviderConfigurationDocument Deserialize(Stream contents, string origin)

--- a/backend/tools/SyntheticMail/Configuration/SyntheticMailJsonContext.cs
+++ b/backend/tools/SyntheticMail/Configuration/SyntheticMailJsonContext.cs
@@ -13,13 +13,15 @@ namespace MailFathom.SyntheticMail.Configuration;
 /// Source-generated for the reason <c>mfctl</c>'s context is: <c>.config/BannedSymbols.txt</c> refuses the reflective
 /// overloads outright, so stating the contract is the only way to read the file at all. Names are matched without
 /// regard to case, because a developer writing their own credential file should not have a run refused over a capital
-/// letter.
+/// letter. A number is read from a string as well, because the <c>dotnet user-secrets</c> store
+/// <see cref="ConfigurationSource" /> falls back to writes every value as one.
 /// </remarks>
 [JsonSourceGenerationOptions(
     PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
     PropertyNameCaseInsensitive = true,
     ReadCommentHandling = JsonCommentHandling.Skip,
-    AllowTrailingCommas = true)]
+    AllowTrailingCommas = true,
+    NumberHandling = JsonNumberHandling.AllowReadingFromString)]
 [JsonSerializable(typeof(SendingAccountDocument))]
 [JsonSerializable(typeof(WatchedMailboxDocument))]
 [JsonSerializable(typeof(AiProviderConfigurationDocument))]

--- a/backend/tools/SyntheticMail/Generation/AiContent/OpenAiEmailContentSource.cs
+++ b/backend/tools/SyntheticMail/Generation/AiContent/OpenAiEmailContentSource.cs
@@ -37,12 +37,14 @@ internal sealed partial class OpenAiEmailContentSource : IAiEmailContentSource
 {
     /// <summary>The most a single email's content may cost in output tokens.</summary>
     /// <remarks>
-    /// A ceiling rather than an expectation: an email body is a few hundred tokens, and the bound is what keeps one
-    /// stuck generation from pricing a whole batch like a document. It is high enough to carry the message twice,
-    /// because an answer holds the body as text and as the markup around the same content, and a bound that truncated
-    /// the second form would produce an unclosed document rather than a shorter one.
+    /// A ceiling rather than an expectation: the bound is what keeps one stuck generation from pricing a whole batch
+    /// like a document. It has to carry the message twice over, because an answer holds the body as text and the same
+    /// content again as the markup real mail carries, and a message in a language whose words cost more tokens than
+    /// English pays that twice as well. Measured against real answers, a rich HTML message runs to about two thousand
+    /// output tokens, so the earlier bound cut one in the middle — and a cut answer arrives as an incomplete JSON
+    /// object, which reads as a model that cannot write the answer rather than as a ceiling that stopped it.
     /// </remarks>
-    private const int MaximumOutputTokens = 2500;
+    private const int MaximumOutputTokens = 6000;
 
     /// <summary>The constructs an answered document is refused for carrying.</summary>
     /// <remarks>
@@ -132,6 +134,14 @@ internal sealed partial class OpenAiEmailContentSource : IAiEmailContentSource
                 throw new SyntheticMailFailure("The model refused to write the message. Retry, or name a different topic or language.");
             }
 
+            // A truncated answer is an incomplete JSON object, and reporting it as a malformed one sends a developer
+            // to the model when the ceiling above is what cut it: the same prompt reaches it again on every retry.
+            if (completion.FinishReason == ChatFinishReason.Length)
+            {
+                throw new SyntheticMailFailure(
+                    $"The model's answer was cut off at the {MaximumOutputTokens}-token output ceiling, so it is not a complete message. Retry, or name a model that writes a shorter one.");
+            }
+
             var text = string.Concat(completion.Content.Select(part => part.Text));
 
             return string.IsNullOrWhiteSpace(text)
@@ -196,7 +206,7 @@ internal sealed partial class OpenAiEmailContentSource : IAiEmailContentSource
 
         try
         {
-            content = JsonSerializer.Deserialize(text, SyntheticMailJsonContext.Default.AiEmailContent);
+            content = JsonSerializer.Deserialize(JsonObjectIn(text), SyntheticMailJsonContext.Default.AiEmailContent);
         }
         catch (JsonException)
         {
@@ -234,6 +244,22 @@ internal sealed partial class OpenAiEmailContentSource : IAiEmailContentSource
         }
 
         return new AiEmailContent(subject, body, html);
+    }
+
+    /// <summary>Reduces an answer to the JSON object in it, which is the whole of it unless the model wrapped one.</summary>
+    /// <remarks>
+    /// The request asks for a single JSON object and states the response format, and a model that honours both answers
+    /// with one and nothing else. An endpoint a developer named is not required to: a fenced code block or a sentence
+    /// in front of the object is the common way one is spelled instead, and refusing that reports a formatting habit
+    /// as a model that cannot write the answer. An answer carrying no object at all is left as it was, so what is
+    /// refused is refused for the reason it deserves.
+    /// </remarks>
+    private static string JsonObjectIn(string text)
+    {
+        var opening = text.IndexOf('{');
+        var closing = text.LastIndexOf('}');
+
+        return opening >= 0 && closing > opening ? text[opening..(closing + 1)] : text;
     }
 
     /// <summary>Reduces the answered subject to what a composed header can carry.</summary>

--- a/backend/tools/SyntheticMail/SyntheticMail.csproj
+++ b/backend/tools/SyntheticMail/SyntheticMail.csproj
@@ -3,6 +3,12 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>MailFathom.SyntheticMail</RootNamespace>
 
+    <!-- What the `dotnet user-secrets` command writes this project's store under, and what ConfigurationSource falls
+         back to when no local credential file was written. The identifier is repeated in that type, because recovering
+         it from the generated assembly attribute would mean referencing a configuration package for one constant
+         string. -->
+    <UserSecretsId>mailfathom-synthetic-mail-5c4b9288-c758-4871-8c58-d869809d8808</UserSecretsId>
+
     <!-- A run must produce the same corpus on every machine, and a machine's locale is the one input nothing here
          passes explicitly: the dates the command parses and the ones it prints would otherwise follow whatever culture
          the shell was started under. Turning globalization off pins both to the invariant culture, which is what the

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -529,9 +529,24 @@ shell history and in the process list of a shared machine. `.gitignore` covers t
 }
 ```
 
+**Or keep it in `dotnet user-secrets`.** A checkout that has never written the file reads the machine's user-secrets
+store for this project instead, so a developer who already keeps development credentials there writes no second copy
+into the tree:
+
+```bash
+dotnet user-secrets --project backend/tools/SyntheticMail set host smtp.example.test
+dotnet user-secrets --project backend/tools/SyntheticMail set address throwaway@example.test
+dotnet user-secrets --project backend/tools/SyntheticMail set password "the throwaway account's password"
+dotnet user-secrets --project backend/tools/SyntheticMail set mailbox:host imap.example.test
+```
+
+The keys are the file's keys, and a block is reached through the `:` the command already separates a key with. Nothing
+is merged across the two: the file wins wherever one exists, and the store is what a run falls back to rather than an
+overlay on it. Every value the store holds is a string, including `port`, which is read as the number it spells.
+
 **Use a throwaway account.** The command authenticates as whatever this file names and submits a few hundred messages
 under it; nothing about that belongs to an account that reaches anything else. Startup refuses a missing or incomplete
-file with a message naming the key to set.
+configuration with a message naming the key to set.
 
 `security` is `StartTls` or `ImplicitTls`, and there is no third value: the run authenticates with a password, so an
 endpoint that cannot secure the connection is refused rather than downgraded to. `port` defaults to 587 or 465 to match,
@@ -745,7 +760,8 @@ beside it shows the shape:
 `endpoint` is optional and defaults to the provider's own address; written, it must be an absolute https address,
 because the key travels in a header and there is no unsecured option. A run that finds the file missing or
 incomplete says so with the file and the key to set, before it generates anything, for the reason the sending
-account does.
+account does. The same keys are read from the project's `dotnet user-secrets` store when no file was written, on the
+terms the sending account's are.
 
 **What the seed still decides, and what it no longer does.** The envelope is still the seed's: author, participants,
 threading, dates, attachments, and the fabricated sensitive material are drawn exactly as in the default mode, and


### PR DESCRIPTION
## What this changes

`backend/tools/SyntheticMail` read its sending account, its watched mailbox, and its AI provider from two git-ignored files beside the built command and from nothing else. A developer who already keeps development credentials in the machine's `dotnet user-secrets` store had to write a second copy of one into the checkout.

A run whose named file is absent now reads this project's user-secrets store instead:

```bash
dotnet user-secrets --project backend/tools/SyntheticMail set password "the throwaway account's password"
dotnet user-secrets --project backend/tools/SyntheticMail set mailbox:host imap.example.test
```

- `ConfigurationSource` opens whichever of the two exists and the readers beside it turn the contents into an account or a provider exactly as they already did. No configuration package is referenced: the store is a plain JSON file at a path derived from the project's `UserSecretsId`.
- The file wins where one exists, and nothing is merged across the two, so a refusal names one origin rather than reporting keys from both.
- `dotnet user-secrets set` keeps a key exactly as it was typed, so `mailbox:host` arrives with a colon in it rather than as a member of a `mailbox` object, and every value it writes is a string. The colon-separated keys are nested before the deserializer sees them, a hand-written nested object is left alone, and the serialization contract reads a number from a string.

## Two AI-mode failures corrected on the way

- The output ceiling was 2500 tokens. A rich HTML answer in a language whose words cost more than English does ran past it, and the cut answer reached a developer as *"The model's answer was not the JSON object it was asked for"* — advice that sends them to the model when the ceiling is what stopped it. The ceiling is 6000, and a truncated answer now says so by name.
- An answer that wraps the object in a fenced block or a sentence is read for the object it carries rather than refused for the wrapping.

## Verification

- `dotnet test --project backend/tests/SyntheticMail.UnitTests` — 331 passed, including four new tests for the store's flat keys, its string values, a hand-written nested block, and a wrapped answer.
- Driven end to end against a throwaway store: the sending account, the port written as a string, and the flattened `mailbox:*` keys all reached the run.
- The full gate was not run locally; the pipeline runs it.

## Still coming on this branch

Overlapping the provider calls under a bounded concurrency option and reporting generation and delivery progress on standard error, which is the rest of what this branch was asked for.

## Not in scope

No issue is linked: this was taken directly rather than through `$start-task`.
