### PR TITLE
Overlap the synthetic mail tool's provider calls, and report progress while it runs

### DIFF
--- a/backend/tests/SyntheticMail.UnitTests/Commands/BatchArgumentsTests.cs
+++ b/backend/tests/SyntheticMail.UnitTests/Commands/BatchArgumentsTests.cs
@@ -486,7 +486,8 @@ public sealed class BatchArgumentsTests
         string? topic = null,
         string? aiConfigurationPath = null,
         bool conversation = false,
-        int? deliveryTimeoutSeconds = null) => BatchArguments.Parse(
+        int? deliveryTimeoutSeconds = null,
+        int? concurrency = null) => BatchArguments.Parse(
             recipient,
             seed,
             count,
@@ -503,5 +504,6 @@ public sealed class BatchArgumentsTests
             aiConfigurationPath,
             conversation,
             deliveryTimeoutSeconds,
+            concurrency,
             new FakeTimeProvider(Today));
 }

--- a/backend/tests/SyntheticMail.UnitTests/Delivery/SyntheticConversationDeliveryTests.cs
+++ b/backend/tests/SyntheticMail.UnitTests/Delivery/SyntheticConversationDeliveryTests.cs
@@ -213,12 +213,45 @@ public sealed class SyntheticConversationDeliveryTests
     }
 
     [Fact]
+    public async Task DeliverAsync_AnExchange_SaysWhichTurnItIsOnAndWhatItIsDoingWithIt()
+    {
+        // Arrange
+        await using var transport = new RecordingSyntheticMailTransport();
+        await using var mailbox = new RecordingWatchedMailbox();
+        var console = new RecordingSyntheticMailConsole();
+
+        // Act
+        await new SyntheticConversationDelivery(transport, mailbox, console, new FakeTimeProvider(Now)).DeliverAsync(
+            [Conversation(2)],
+            Account(),
+            WatchedMailbox,
+            TimeSpan.Zero,
+            TimeSpan.Zero,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        // An exchange spends most of its time waiting for a relay it cannot hurry, so what it is waiting for and how
+        // long it will wait are the two things a developer watching it needs. The two sides reach the mailbox by
+        // different routes, and the report names which one a turn took.
+        Assert.Equal(
+            [
+                "Exchange 1 of 1, turn 1 of 2: submitting to developer@example.com.",
+                "Exchange 1 of 1, turn 1 of 2: waiting up to 0 seconds for it to reach the mailbox.",
+                "Exchange 1 of 1, turn 1 of 2: delivered.",
+                "Exchange 1 of 1, turn 2 of 2: appending to Sent.",
+                "Exchange 1 of 1, turn 2 of 2: appended.",
+            ],
+            console.Diagnostics);
+        Assert.Empty(console.Output);
+    }
+
+    [Fact]
     public async Task DeliverAsync_ANullArgument_IsRefused()
     {
         // Arrange
         await using var transport = new RecordingSyntheticMailTransport();
         await using var mailbox = new RecordingWatchedMailbox();
-        var delivery = new SyntheticConversationDelivery(transport, mailbox, new FakeTimeProvider(Now));
+        var delivery = new SyntheticConversationDelivery(transport, mailbox, new RecordingSyntheticMailConsole(), new FakeTimeProvider(Now));
 
         // Act, Assert
         await Assert.ThrowsAsync<ArgumentNullException>(() => delivery.DeliverAsync(
@@ -251,7 +284,7 @@ public sealed class SyntheticConversationDeliveryTests
         IWatchedMailbox mailbox,
         IReadOnlyList<SyntheticConversation> conversations,
         SendingAccount? account = null) =>
-        new SyntheticConversationDelivery(transport, mailbox, new FakeTimeProvider(Now)).DeliverAsync(
+        new SyntheticConversationDelivery(transport, mailbox, new RecordingSyntheticMailConsole(), new FakeTimeProvider(Now)).DeliverAsync(
             conversations,
             account ?? Account(),
             WatchedMailbox,

--- a/backend/tests/SyntheticMail.UnitTests/Delivery/SyntheticMailBatchDeliveryTests.cs
+++ b/backend/tests/SyntheticMail.UnitTests/Delivery/SyntheticMailBatchDeliveryTests.cs
@@ -77,12 +77,38 @@ public sealed class SyntheticMailBatchDeliveryTests
     }
 
     [Fact]
+    public async Task DeliverAsync_ABatch_SaysWhatItIsSubmittingWhileItSubmits()
+    {
+        // Arrange
+        await using var transport = new RecordingSyntheticMailTransport();
+        var console = new RecordingSyntheticMailConsole();
+        var delivery = new SyntheticMailBatchDelivery(transport, console, new FakeTimeProvider());
+
+        // Act
+        await delivery.DeliverAsync(
+            Corpus(3),
+            Account(),
+            Recipient,
+            TimeSpan.Zero,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        // A run that submits two hundred messages over a paced connection says nothing for minutes otherwise, and a
+        // developer cannot tell that from a run that has hung. The corpus is not what carries it: progress belongs to
+        // the stream a run reports itself on.
+        Assert.Equal(
+            ["Submitting 1 of 3 to developer@example.com.", "Submitting 2 of 3 to developer@example.com.", "Submitting 3 of 3 to developer@example.com."],
+            console.Diagnostics);
+        Assert.Empty(console.Output);
+    }
+
+    [Fact]
     public async Task DeliverAsync_AnInterval_WaitsItOutBetweenTwoSubmissions()
     {
         // Arrange
         await using var transport = new RecordingSyntheticMailTransport();
         var timeProvider = new FakeTimeProvider();
-        var delivery = new SyntheticMailBatchDelivery(transport, timeProvider);
+        var delivery = new SyntheticMailBatchDelivery(transport, new RecordingSyntheticMailConsole(), timeProvider);
 
         // Act
         var run = delivery.DeliverAsync(
@@ -109,7 +135,7 @@ public sealed class SyntheticMailBatchDeliveryTests
         // Arrange
         await using var transport = new RecordingSyntheticMailTransport();
         var timeProvider = new FakeTimeProvider();
-        var delivery = new SyntheticMailBatchDelivery(transport, timeProvider);
+        var delivery = new SyntheticMailBatchDelivery(transport, new RecordingSyntheticMailConsole(), timeProvider);
 
         // Act
         var report = await delivery.DeliverAsync(
@@ -142,7 +168,7 @@ public sealed class SyntheticMailBatchDeliveryTests
     {
         // Arrange
         await using var transport = new RecordingSyntheticMailTransport();
-        var delivery = new SyntheticMailBatchDelivery(transport, TimeProvider.System);
+        var delivery = new SyntheticMailBatchDelivery(transport, new RecordingSyntheticMailConsole(), TimeProvider.System);
 
         // Act, Assert
         await Assert.ThrowsAsync<ArgumentNullException>(() => delivery.DeliverAsync(
@@ -156,7 +182,7 @@ public sealed class SyntheticMailBatchDeliveryTests
     private static Task<DeliveryReport> Deliver(
         ISyntheticMailTransport transport,
         IReadOnlyList<SyntheticEmail> corpus) =>
-        new SyntheticMailBatchDelivery(transport, new FakeTimeProvider()).DeliverAsync(
+        new SyntheticMailBatchDelivery(transport, new RecordingSyntheticMailConsole(), new FakeTimeProvider()).DeliverAsync(
             corpus,
             Account(),
             Recipient,

--- a/backend/tests/SyntheticMail.UnitTests/Generation/SyntheticEmailGeneratorAiModeTests.cs
+++ b/backend/tests/SyntheticMail.UnitTests/Generation/SyntheticEmailGeneratorAiModeTests.cs
@@ -34,8 +34,8 @@ public sealed class SyntheticEmailGeneratorAiModeTests
         var second = new ScriptedAiEmailContentSource(Answer);
 
         // Act
-        await SyntheticEmailGenerator.GenerateAsync(Plan(["en", "pl"], [SyntheticMailTopic.Business, SyntheticMailTopic.Travel]), first, CancellationToken.None);
-        await SyntheticEmailGenerator.GenerateAsync(Plan(["en", "pl"], [SyntheticMailTopic.Business, SyntheticMailTopic.Travel]), second, CancellationToken.None);
+        await SyntheticEmailGenerator.GenerateAsync(Plan(["en", "pl"], [SyntheticMailTopic.Business, SyntheticMailTopic.Travel]), first, 1, CancellationToken.None);
+        await SyntheticEmailGenerator.GenerateAsync(Plan(["en", "pl"], [SyntheticMailTopic.Business, SyntheticMailTopic.Travel]), second, 1, CancellationToken.None);
 
         // Assert
         Assert.Equal(first.Requests.Select(RequestFingerprint), second.Requests.Select(RequestFingerprint));
@@ -74,6 +74,7 @@ public sealed class SyntheticEmailGeneratorAiModeTests
         var corpus = await SyntheticEmailGenerator.GenerateAsync(
             Plan(["pl"], [SyntheticMailTopic.Travel]),
             new ScriptedAiEmailContentSource(Answer),
+            1,
             CancellationToken.None);
 
         // Assert
@@ -87,7 +88,7 @@ public sealed class SyntheticEmailGeneratorAiModeTests
         var plan = Plan(["en"], [SyntheticMailTopic.Business], count: 1);
 
         // Act
-        var corpus = await SyntheticEmailGenerator.GenerateAsync(plan, new ScriptedAiEmailContentSource(Answer), CancellationToken.None);
+        var corpus = await SyntheticEmailGenerator.GenerateAsync(plan, new ScriptedAiEmailContentSource(Answer), 1, CancellationToken.None);
 
         // Assert
         Assert.Equal(Answer.Subject, corpus.Single().Subject);
@@ -98,13 +99,15 @@ public sealed class SyntheticEmailGeneratorAiModeTests
     public async Task GenerateAsync_AReply_KeepsTheThreadSubjectAndSaysWhatItAnswers()
     {
         // Arrange
-        // One request per message, in message order, so the reply's request is the one at the reply's index.
+        // One request per message, and this run waits for one answer at a time, so the requests arrive in message
+        // order and the reply's is the one at the reply's index.
         var source = new ScriptedAiEmailContentSource(Answer);
 
         // Act
         var corpus = await SyntheticEmailGenerator.GenerateAsync(
             Plan(["en"], [SyntheticMailTopic.Business], count: 40),
             source,
+            1,
             CancellationToken.None);
         var reply = corpus.First(email => email.InReplyTo is not null);
         var replyIndex = corpus.ToList().IndexOf(reply);
@@ -122,7 +125,7 @@ public sealed class SyntheticEmailGeneratorAiModeTests
         var plan = Plan(["en"], [SyntheticMailTopic.Business], sensitivePercentage: 100);
 
         // Act
-        var corpus = await SyntheticEmailGenerator.GenerateAsync(plan, new ScriptedAiEmailContentSource(Answer), CancellationToken.None);
+        var corpus = await SyntheticEmailGenerator.GenerateAsync(plan, new ScriptedAiEmailContentSource(Answer), 1, CancellationToken.None);
 
         // Assert
         // Every message carries the answer's paragraphs and, beside them, the decoy the seed planted — recorded on
@@ -146,6 +149,7 @@ public sealed class SyntheticEmailGeneratorAiModeTests
         var corpus = await SyntheticEmailGenerator.GenerateAsync(
             Plan(["en"], [SyntheticMailTopic.Business]),
             new ScriptedAiEmailContentSource(Answer),
+            1,
             CancellationToken.None);
 
         // Assert
@@ -159,6 +163,7 @@ public sealed class SyntheticEmailGeneratorAiModeTests
         var corpus = await SyntheticEmailGenerator.GenerateAsync(
             Plan(["en"], [SyntheticMailTopic.Business], count: 60),
             new ScriptedAiEmailContentSource(Answer),
+            1,
             CancellationToken.None);
 
         // Assert
@@ -185,6 +190,7 @@ public sealed class SyntheticEmailGeneratorAiModeTests
         await Assert.ThrowsAsync<SyntheticMailFailure>(() => SyntheticEmailGenerator.GenerateAsync(
             Plan(["en"], [SyntheticMailTopic.Business]),
             new ScriptedAiEmailContentSource(failure),
+            1,
             CancellationToken.None));
     }
 
@@ -199,6 +205,7 @@ public sealed class SyntheticEmailGeneratorAiModeTests
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => SyntheticEmailGenerator.GenerateAsync(
             Plan(["en"], [SyntheticMailTopic.Business], count: 10),
             new ScriptedAiEmailContentSource(Answer),
+            1,
             cancellation.Token));
     }
 
@@ -228,6 +235,7 @@ public sealed class SyntheticEmailGeneratorAiModeTests
         await Assert.ThrowsAsync<ArgumentException>(() => SyntheticEmailGenerator.GenerateAsync(
             Plan([], [SyntheticMailTopic.Business]),
             source,
+            1,
             CancellationToken.None));
         Assert.Empty(source.Requests);
     }
@@ -239,6 +247,7 @@ public sealed class SyntheticEmailGeneratorAiModeTests
         await Assert.ThrowsAsync<ArgumentException>(() => SyntheticEmailGenerator.GenerateAsync(
             Plan(["en"], []),
             new ScriptedAiEmailContentSource(Answer),
+            1,
             CancellationToken.None));
     }
 
@@ -249,6 +258,7 @@ public sealed class SyntheticEmailGeneratorAiModeTests
         await Assert.ThrowsAsync<ArgumentException>(() => SyntheticEmailGenerator.GenerateAsync(
             Plan(["en"], [default]),
             new ScriptedAiEmailContentSource(Answer),
+            1,
             CancellationToken.None));
     }
 
@@ -259,7 +269,7 @@ public sealed class SyntheticEmailGeneratorAiModeTests
     {
         var source = new ScriptedAiEmailContentSource(Answer);
 
-        await SyntheticEmailGenerator.GenerateAsync(Plan(languages, topics, count), source, CancellationToken.None);
+        await SyntheticEmailGenerator.GenerateAsync(Plan(languages, topics, count), source, 1, CancellationToken.None);
 
         return source;
     }
@@ -272,7 +282,7 @@ public sealed class SyntheticEmailGeneratorAiModeTests
         var source = new ScriptedAiEmailContentSource(Answer);
 
         // Act
-        var corpus = await SyntheticEmailGenerator.GenerateAsync(plan, source, CancellationToken.None);
+        var corpus = await SyntheticEmailGenerator.GenerateAsync(plan, source, 1, CancellationToken.None);
 
         // Assert
         // The deterministic generator wraps its own text in one paragraph per block, which exercises the extractor
@@ -288,7 +298,7 @@ public sealed class SyntheticEmailGeneratorAiModeTests
         var source = new ScriptedAiEmailContentSource(Answer);
 
         // Act
-        var corpus = await SyntheticEmailGenerator.GenerateAsync(plan, source, CancellationToken.None);
+        var corpus = await SyntheticEmailGenerator.GenerateAsync(plan, source, 1, CancellationToken.None);
 
         // Assert
         // Which alternative a reader extracts from is the extractor's choice, so a decoy in only one of them would
@@ -310,7 +320,7 @@ public sealed class SyntheticEmailGeneratorAiModeTests
         var source = new ScriptedAiEmailContentSource(Answer);
 
         // Act
-        await SyntheticEmailGenerator.GenerateAsync(plan, source, CancellationToken.None);
+        await SyntheticEmailGenerator.GenerateAsync(plan, source, 1, CancellationToken.None);
 
         // Assert
         // A request that named the subject alone produced a second message about the same topic, which reads as a

--- a/backend/tests/SyntheticMail.UnitTests/Generation/SyntheticEmailGeneratorConversationTests.cs
+++ b/backend/tests/SyntheticMail.UnitTests/Generation/SyntheticEmailGeneratorConversationTests.cs
@@ -201,6 +201,7 @@ public sealed class SyntheticEmailGeneratorConversationTests
             plan,
             Mailbox,
             source,
+            1,
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -230,6 +231,7 @@ public sealed class SyntheticEmailGeneratorConversationTests
             plan,
             Mailbox,
             source,
+            1,
             TestContext.Current.CancellationToken);
 
         // Assert

--- a/backend/tests/SyntheticMail.UnitTests/Generation/SyntheticEmailGeneratorOverlapTests.cs
+++ b/backend/tests/SyntheticMail.UnitTests/Generation/SyntheticEmailGeneratorOverlapTests.cs
@@ -1,0 +1,148 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.SyntheticMail.Generation;
+using MailFathom.SyntheticMail.UnitTests.TestDoubles;
+
+using Xunit;
+
+namespace MailFathom.SyntheticMail.UnitTests.Generation;
+
+/// <summary>What overlapping the provider calls is allowed to change, which is how long a run takes and nothing else.</summary>
+/// <remarks>
+/// AI content mode spends almost all of its time waiting for one provider at a time, so a corpus of two hundred is an
+/// hour of a developer's day. What makes spreading those calls safe is that the seed decides the whole corpus before
+/// any of them goes out; these are the assertions that say so, and the one that says a run does not open a connection
+/// per message while it is at it.
+/// </remarks>
+public sealed class SyntheticEmailGeneratorOverlapTests
+{
+    private static readonly DateTimeOffset LatestSentAt = new(2026, 6, 1, 23, 59, 59, TimeSpan.Zero);
+
+    private static readonly SyntheticParticipant WatchedMailbox = new("Watched Mailbox", "watched@example.test");
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(3)]
+    [InlineData(16)]
+    public async Task GenerateAsync_AnyDegreeOfConcurrency_ProducesTheCorpusTheSeedDescribes(int concurrency)
+    {
+        // Arrange
+        var sequential = await SyntheticEmailGenerator.GenerateAsync(
+            Plan(count: 60),
+            new OverlappingAiEmailContentSource(),
+            1,
+            TestContext.Current.CancellationToken);
+
+        // Act
+        var overlapped = await SyntheticEmailGenerator.GenerateAsync(
+            Plan(count: 60),
+            new OverlappingAiEmailContentSource(),
+            concurrency,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        // Field by field rather than message count: what a wrong draw order moves is a date, a participant, or an
+        // attachment's bytes, and every one of those survives a count.
+        Assert.Equal(
+            sequential.Select(CorpusFingerprint.Of),
+            overlapped.Select(CorpusFingerprint.Of));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(8)]
+    public async Task GenerateConversationsAsync_AnyDegreeOfConcurrency_ProducesTheExchangesTheSeedDescribes(int concurrency)
+    {
+        // Arrange
+        var sequential = await SyntheticEmailGenerator.GenerateConversationsAsync(
+            Plan(count: 40),
+            WatchedMailbox,
+            new OverlappingAiEmailContentSource(),
+            1,
+            TestContext.Current.CancellationToken);
+
+        // Act
+        var overlapped = await SyntheticEmailGenerator.GenerateConversationsAsync(
+            Plan(count: 40),
+            WatchedMailbox,
+            new OverlappingAiEmailContentSource(),
+            concurrency,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(
+            sequential.Select(exchange => CorpusFingerprint.Of(exchange.Messages)),
+            overlapped.Select(exchange => CorpusFingerprint.Of(exchange.Messages)));
+    }
+
+    [Fact]
+    public async Task GenerateAsync_ABatch_WaitsForNoMoreAnswersAtOnceThanItWasGiven()
+    {
+        // Arrange
+        var source = new OverlappingAiEmailContentSource(holdsAnswers: true);
+
+        // Act
+        var generation = SyntheticEmailGenerator.GenerateAsync(
+            Plan(count: 60),
+            source,
+            3,
+            TestContext.Current.CancellationToken);
+
+        await source.AskedAsync(3);
+        source.Answer();
+
+        await generation;
+
+        // Assert
+        // Three held answers are what the fourth call waits behind, so a run against a provider opens the number of
+        // connections a developer asked for rather than one per message in the corpus.
+        Assert.Equal(3, source.PeakInFlight);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_AReply_IsAskedForOnlyAfterTheMessageItAnswers()
+    {
+        // Arrange
+        var source = new OverlappingAiEmailContentSource();
+
+        // Act
+        var corpus = await SyntheticEmailGenerator.GenerateAsync(
+            Plan(count: 60),
+            source,
+            16,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        // A reply's prompt carries the subject the parent was answered with, so a prompt built before that answer
+        // arrived would name a subject no message in the corpus has.
+        var answered = source.Requests.Where(request => request.ParentSubject is not null).ToArray();
+
+        Assert.NotEmpty(answered);
+        Assert.All(
+            answered,
+            request => Assert.Contains(corpus, email => email.Subject == request.ParentSubject));
+    }
+
+    [Fact]
+    public async Task GenerateAsync_AConcurrencyBelowOne_IsRefused()
+    {
+        // Arrange, Act, Assert
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => SyntheticEmailGenerator.GenerateAsync(
+            Plan(count: 4),
+            new OverlappingAiEmailContentSource(),
+            0,
+            TestContext.Current.CancellationToken));
+    }
+
+    private static SyntheticCorpusPlan Plan(int count) => new(
+        Seed: 20260902,
+        count,
+        LatestSentAt,
+        SpanDays: 90,
+        MaximumAttachmentBytes: 64 * 1024,
+        SensitivePercentage: 30,
+        ["en", "pl"],
+        [SyntheticMailTopic.Business, SyntheticMailTopic.Travel]);
+}

--- a/backend/tests/SyntheticMail.UnitTests/TestDoubles/OverlappingAiEmailContentSource.cs
+++ b/backend/tests/SyntheticMail.UnitTests/TestDoubles/OverlappingAiEmailContentSource.cs
@@ -1,0 +1,115 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Globalization;
+using MailFathom.SyntheticMail.Generation.AiContent;
+
+namespace MailFathom.SyntheticMail.UnitTests.TestDoubles;
+
+/// <summary>A source that answers asynchronously, counts how many answers were being waited for at once, and can hold them.</summary>
+/// <param name="holdsAnswers">Whether every call waits for <see cref="Answer" /> before it is answered.</param>
+/// <remarks>
+/// <para>
+/// The seam the overlapping generation is measured through. <see cref="ScriptedAiEmailContentSource" /> answers
+/// synchronously, so a generation driven by it runs to completion inside the loop that started it and proves nothing
+/// about concurrency either way; this one always yields first, which is what puts several calls in flight.
+/// </para>
+/// <para>
+/// Nothing here waits on a clock. Holding an answer is a <see cref="TaskCompletionSource" /> the test completes, and
+/// waiting for the calls to arrive is another one the source completes, so a test states an order rather than a
+/// duration and a loaded machine cannot change the result.
+/// </para>
+/// </remarks>
+internal sealed class OverlappingAiEmailContentSource(bool holdsAnswers = false) : IAiEmailContentSource
+{
+    private readonly TaskCompletionSource answering = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly Lock guard = new();
+    private readonly List<AiEmailContentRequest> requests = [];
+    private readonly Dictionary<int, TaskCompletionSource> arrivals = [];
+    private int inFlight;
+
+    /// <summary>The most answers the generation waited for at once.</summary>
+    internal int PeakInFlight { get; private set; }
+
+    /// <summary>The questions asked, in the order they arrived.</summary>
+    internal IReadOnlyList<AiEmailContentRequest> Requests
+    {
+        get
+        {
+            lock (this.guard)
+            {
+                return [.. this.requests];
+            }
+        }
+    }
+
+    /// <summary>Answers every held call, and every call that arrives after this.</summary>
+    internal void Answer() => this.answering.TrySetResult();
+
+    /// <summary>Completes once the named number of calls has arrived.</summary>
+    /// <param name="calls">How many calls to wait for.</param>
+    /// <returns>The wait.</returns>
+    internal Task AskedAsync(int calls)
+    {
+        lock (this.guard)
+        {
+            if (this.requests.Count >= calls)
+            {
+                return Task.CompletedTask;
+            }
+
+            if (!this.arrivals.TryGetValue(calls, out var arrival))
+            {
+                arrival = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                this.arrivals[calls] = arrival;
+            }
+
+            return arrival.Task;
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<AiEmailContent> GenerateAsync(AiEmailContentRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        lock (this.guard)
+        {
+            this.requests.Add(request);
+            this.inFlight++;
+            this.PeakInFlight = Math.Max(this.PeakInFlight, this.inFlight);
+
+            if (this.arrivals.TryGetValue(this.requests.Count, out var arrival))
+            {
+                arrival.SetResult();
+            }
+        }
+
+        // Always asynchronous, so the caller cannot finish a call inside the loop that started it.
+        await Task.Yield();
+
+        if (holdsAnswers)
+        {
+            await this.answering.Task.WaitAsync(cancellationToken);
+        }
+
+        lock (this.guard)
+        {
+            this.inFlight--;
+        }
+
+        // The answer is a function of the question and of nothing else, which is what makes "the same seed produces
+        // the same corpus" assertable here at all: a source answering from a call counter would answer one message
+        // differently depending on which call finished first, and the corpus would differ for the source's reason
+        // rather than the generator's.
+        var subject = string.Create(
+            CultureInfo.InvariantCulture,
+            $"{request.AuthorName} on {request.Topic} in {request.LanguageCode} answering {request.ParentSubject ?? "nobody"}");
+
+        return new AiEmailContent(
+            subject,
+            string.Create(CultureInfo.InvariantCulture, $"Hello.\n\n{subject}.\n\nRegards"),
+            string.Create(CultureInfo.InvariantCulture, $"<html><body><p>{subject}</p></body></html>"));
+    }
+}

--- a/backend/tools/SyntheticMail/Commands/BatchArguments.cs
+++ b/backend/tools/SyntheticMail/Commands/BatchArguments.cs
@@ -27,6 +27,7 @@ namespace MailFathom.SyntheticMail.Commands;
 /// <param name="AiConfigurationPath">Where the AI provider is read from, or <see langword="null" /> when the run generates without one.</param>
 /// <param name="Conversation">Whether the batch is generated and delivered as exchanges between two mailboxes rather than as a flat corpus.</param>
 /// <param name="DeliveryTimeout">How long an exchange waits for a submitted message to appear in the watched mailbox.</param>
+/// <param name="Concurrency">How many provider answers the generation waits for at once, and one when the run generates without a provider.</param>
 /// <remarks>
 /// Defaults are resolved here rather than left to the point of use, which is what makes
 /// <see cref="RepeatCommandLine" /> possible: a run that chose its own seed and its own end date can print the exact
@@ -48,7 +49,8 @@ internal sealed record BatchArguments(
     IReadOnlyList<SyntheticMailTopic> Topics,
     string? AiConfigurationPath,
     bool Conversation,
-    TimeSpan DeliveryTimeout)
+    TimeSpan DeliveryTimeout,
+    int Concurrency)
 {
     /// <summary>The fewest messages an exchange can be generated from.</summary>
     /// <remarks>Two, because a thread of one message has nothing in it that a flat corpus does not already produce.</remarks>
@@ -65,6 +67,22 @@ internal sealed record BatchArguments(
     /// <summary>How long an exchange waits for one delivered copy when the invocation says nothing, in seconds.</summary>
     /// <remarks>Two minutes, which covers an ordinary relay's queue and is short enough that a mistyped mailbox is noticed on the first turn rather than after a batch.</remarks>
     internal const int DefaultDeliveryTimeoutSeconds = 120;
+
+    /// <summary>How many provider answers a run waits for at once when the invocation says nothing.</summary>
+    /// <remarks>
+    /// Four, which turns an hour of waiting into a quarter of one and is below what any provider's ordinary key is
+    /// rate-limited at. Higher is a number a developer picks against their own key rather than one this tool can know:
+    /// what a provider answers a burst with is a refusal that says nothing about the mail.
+    /// </remarks>
+    internal const int DefaultConcurrency = 4;
+
+    /// <summary>The most provider answers a run may wait for at once.</summary>
+    /// <remarks>
+    /// A ceiling rather than none, for the reason the batch size has one: a mistyped number is otherwise a run opening
+    /// as many connections to a provider as the corpus has messages, which is answered with rate limiting rather than
+    /// with a corpus.
+    /// </remarks>
+    internal const int MaximumConcurrency = 32;
 
     /// <summary>The largest batch one invocation may ask for.</summary>
     /// <remarks>
@@ -145,6 +163,7 @@ internal sealed record BatchArguments(
     /// <param name="aiConfigurationPath">Where to read the AI provider, or <see langword="null" /> for the default.</param>
     /// <param name="conversation">Whether to generate and deliver exchanges rather than a flat corpus.</param>
     /// <param name="deliveryTimeoutSeconds">How long to wait for a submitted message to appear in the watched mailbox.</param>
+    /// <param name="concurrency">How many provider answers the generation waits for at once, or <see langword="null" /> for the default.</param>
     /// <param name="timeProvider">What today is read from.</param>
     /// <returns>The checked invocation.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="recipient" /> or <paramref name="timeProvider" /> is <see langword="null" />.</exception>
@@ -170,6 +189,7 @@ internal sealed record BatchArguments(
         string? aiConfigurationPath,
         bool conversation,
         int? deliveryTimeoutSeconds,
+        int? concurrency,
         TimeProvider timeProvider)
     {
         ArgumentNullException.ThrowIfNull(recipient);
@@ -214,7 +234,8 @@ internal sealed record BatchArguments(
             topics,
             resolvedAiConfigurationPath,
             conversation,
-            deliveryTimeout);
+            deliveryTimeout,
+            ParseConcurrency(aiContent, concurrency));
     }
 
     /// <summary>Builds the plan this invocation describes.</summary>
@@ -229,6 +250,26 @@ internal sealed record BatchArguments(
             this.SensitivePercentage,
             this.Languages,
             this.Topics);
+
+    /// <summary>Resolves how many answers the generation waits for at once, and refuses the option outside the mode that reads it.</summary>
+    /// <remarks>
+    /// Refused outside <c>--ai</c> for the reason <c>--delivery-timeout</c> is refused outside <c>--conversation</c>:
+    /// a corpus the vocabulary writes is produced in the time it takes to draw it, so there is nothing to overlap and
+    /// a number written on one decides nothing. It is absent from the repeat line deliberately — it changes what a run
+    /// costs in time and nothing about what it produces, so the line that reproduces a corpus does not carry it.
+    /// </remarks>
+    private static int ParseConcurrency(bool aiContent, int? concurrency)
+    {
+        if (!aiContent)
+        {
+            return concurrency is null
+                ? 1
+                : throw new SyntheticMailFailure(
+                    "'--concurrency' spreads the provider calls a run makes, which only '--ai' makes.");
+        }
+
+        return Bounded(concurrency ?? DefaultConcurrency, 1, MaximumConcurrency, "--concurrency");
+    }
 
     /// <summary>Resolves how long an exchange waits for a delivery, and refuses the option outside the mode that reads it.</summary>
     /// <remarks>

--- a/backend/tools/SyntheticMail/Commands/DeliverBatchCommand.cs
+++ b/backend/tools/SyntheticMail/Commands/DeliverBatchCommand.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using MailFathom.SyntheticMail.Configuration;
 using MailFathom.SyntheticMail.Delivery;
 using MailFathom.SyntheticMail.Generation;
+using MailFathom.SyntheticMail.Generation.AiContent;
 using MimeKit;
 
 namespace MailFathom.SyntheticMail.Commands;
@@ -121,6 +122,11 @@ internal static class DeliverBatchCommand
             Description = "Generate exchanges between the recipient and invented correspondents instead of a flat corpus, delivering one turn at a time and building each reply from the identifier the recipient's server assigned. Needs the 'mailbox' block in the sending account file, because both halves of a thread have to reach the mailbox.",
         };
 
+        Option<int?> concurrencyOption = new("--concurrency")
+        {
+            Description = $"How many provider answers the generation waits for at once, 1..{BatchArguments.MaximumConcurrency}. Defaults to {BatchArguments.DefaultConcurrency}, changes what the run costs in time and nothing about the corpus a seed produces, and requires --ai.",
+        };
+
         Option<int?> deliveryTimeoutOption = new("--delivery-timeout")
         {
             Description = $"Seconds to wait for a submitted message to appear in the recipient's mailbox, 1..{BatchArguments.MaximumDeliveryTimeoutSeconds}. Defaults to {BatchArguments.DefaultDeliveryTimeoutSeconds}. Requires --conversation.",
@@ -144,6 +150,7 @@ internal static class DeliverBatchCommand
             aiConfigurationOption,
             conversationOption,
             deliveryTimeoutOption,
+            concurrencyOption,
         };
 
         command.SetAction((result, cancellationToken) => RunAsync(
@@ -165,6 +172,7 @@ internal static class DeliverBatchCommand
                 result.GetValue(aiConfigurationOption),
                 result.GetValue(conversationOption),
                 result.GetValue(deliveryTimeoutOption),
+                result.GetValue(concurrencyOption),
                 context.Clock),
             cancellationToken));
 
@@ -227,7 +235,8 @@ internal static class DeliverBatchCommand
             ? await SyntheticEmailGenerator.GenerateConversationsAsync(
                 arguments.ToPlan(),
                 mailboxParticipant,
-                context.OpenAiContentSource(context.ReadAiProvider(arguments.AiConfigurationPath!)),
+                OpenReportingContentSource(context, arguments),
+                arguments.Concurrency,
                 cancellationToken)
             : SyntheticEmailGenerator.GenerateConversations(arguments.ToPlan(), mailboxParticipant);
 
@@ -283,7 +292,7 @@ internal static class DeliverBatchCommand
         await transport.OpenAsync(cancellationToken);
         await mailbox.OpenAsync(cancellationToken);
 
-        var report = await new SyntheticConversationDelivery(transport, mailbox, context.Clock).DeliverAsync(
+        var report = await new SyntheticConversationDelivery(transport, mailbox, context.Console, context.Clock).DeliverAsync(
             conversations,
             account,
             arguments.Recipient,
@@ -299,16 +308,26 @@ internal static class DeliverBatchCommand
         BatchArguments arguments,
         CancellationToken cancellationToken)
     {
-        // The provider is read before anything is generated, for the reason the account is: a run that cannot
-        // possibly generate says so immediately rather than after the corpus has been half-answered. A dry run
-        // reads it too, because the content is what a dry run lists.
-        var provider = context.ReadAiProvider(arguments.AiConfigurationPath!);
-
         return await SyntheticEmailGenerator.GenerateAsync(
             arguments.ToPlan(),
-            context.OpenAiContentSource(provider),
+            OpenReportingContentSource(context, arguments),
+            arguments.Concurrency,
             cancellationToken);
     }
+
+    /// <summary>Opens the source the run generates through, wrapped in the one that reports each answer as it lands.</summary>
+    /// <remarks>
+    /// The provider is read here, before anything is generated, for the reason the account is: a run that cannot
+    /// possibly generate says so immediately rather than after the corpus has been half-answered. A dry run reads it
+    /// too, because the content is what a dry run lists.
+    /// </remarks>
+    private static ReportingAiEmailContentSource OpenReportingContentSource(
+        SyntheticMailContext context,
+        BatchArguments arguments) =>
+        new(
+            context.OpenAiContentSource(context.ReadAiProvider(arguments.AiConfigurationPath!)),
+            context.Console,
+            arguments.Count);
 
     private static async Task<int> DeliverAsync(
         SyntheticMailContext context,
@@ -325,7 +344,7 @@ internal static class DeliverBatchCommand
 
         await transport.OpenAsync(cancellationToken);
 
-        var report = await new SyntheticMailBatchDelivery(transport, context.Clock).DeliverAsync(
+        var report = await new SyntheticMailBatchDelivery(transport, context.Console, context.Clock).DeliverAsync(
             corpus,
             account,
             arguments.Recipient,
@@ -346,7 +365,7 @@ internal static class DeliverBatchCommand
         var aiContent = arguments.AiContent
             ? string.Create(
                 CultureInfo.InvariantCulture,
-                $" AI content in {string.Join(", ", arguments.Languages)} over {string.Join(", ", arguments.Topics.Select(topic => topic.Name))}, generated by the configured provider.")
+                $" AI content in {string.Join(", ", arguments.Languages)} over {string.Join(", ", arguments.Topics.Select(topic => topic.Name))}, generated by the configured provider {arguments.Concurrency} answers at a time.")
             : string.Empty;
 
         context.Console.WriteError(string.Create(

--- a/backend/tools/SyntheticMail/Delivery/SyntheticConversationDelivery.cs
+++ b/backend/tools/SyntheticMail/Delivery/SyntheticConversationDelivery.cs
@@ -12,6 +12,7 @@ namespace MailFathom.SyntheticMail.Delivery;
 /// <summary>Delivers generated exchanges one turn at a time, so each reply answers the message that actually arrived.</summary>
 /// <param name="transport">The open submission session the correspondent's half is sent through.</param>
 /// <param name="mailbox">The open session against the mailbox MailFathom synchronizes.</param>
+/// <param name="console">Where the run reports what it is doing, which is standard error and never the corpus.</param>
 /// <param name="timeProvider">What the pacing and the delivery wait run on.</param>
 /// <remarks>
 /// <para>
@@ -31,6 +32,7 @@ namespace MailFathom.SyntheticMail.Delivery;
 internal sealed class SyntheticConversationDelivery(
     ISyntheticMailTransport transport,
     IWatchedMailbox mailbox,
+    ISyntheticMailConsole console,
     TimeProvider timeProvider)
 {
     /// <summary>How long the run waits between two looks for a delivered copy.</summary>
@@ -66,8 +68,10 @@ internal sealed class SyntheticConversationDelivery(
         var attempted = 0;
         var delivered = 0;
 
-        foreach (var conversation in conversations)
+        for (var index = 0; index < conversations.Count; index++)
         {
+            var conversation = conversations[index];
+
             var deliveredTurns = await this.DeliverConversationAsync(
                 conversation,
                 account,
@@ -76,6 +80,7 @@ internal sealed class SyntheticConversationDelivery(
                 deliveryTimeout,
                 attempted > 0,
                 failures,
+                string.Create(CultureInfo.InvariantCulture, $"Exchange {index + 1} of {conversations.Count}"),
                 cancellationToken);
 
             attempted += conversation.Messages.Count;
@@ -99,6 +104,7 @@ internal sealed class SyntheticConversationDelivery(
         TimeSpan deliveryTimeout,
         bool paceFirstTurn,
         List<DeliveryFailure> failures,
+        string exchange,
         CancellationToken cancellationToken)
     {
         var correspondent = new MailboxAddress(
@@ -136,6 +142,7 @@ internal sealed class SyntheticConversationDelivery(
                 repliedTo,
                 deliveryTimeout,
                 failures,
+                string.Create(CultureInfo.InvariantCulture, $"{exchange}, turn {turn + 1} of {conversation.Messages.Count}"),
                 cancellationToken);
 
             if (assignedMessageId is null)
@@ -161,20 +168,27 @@ internal sealed class SyntheticConversationDelivery(
         MailboxAddress repliedTo,
         TimeSpan deliveryTimeout,
         List<DeliveryFailure> failures,
+        string turn,
         CancellationToken cancellationToken)
     {
         try
         {
             if (side == SyntheticThreadSide.Mailbox)
             {
+                console.WriteError($"{turn}: appending to Sent.");
+
                 using var written = SyntheticMimeComposer.ComposeFromMailbox(email, watchedMailbox, repliedTo);
 
                 await mailbox.AppendToSentAsync(written, cancellationToken);
+
+                console.WriteError($"{turn}: appended.");
 
                 // The appended copy is the one this run composed, so nothing rewrote its identifier on the way in and
                 // there is nothing to read back.
                 return email.MessageId;
             }
+
+            console.WriteError($"{turn}: submitting to {watchedMailbox.Address}.");
 
             using var submitted = SyntheticMimeComposer.Compose(
                 email,
@@ -186,7 +200,13 @@ internal sealed class SyntheticConversationDelivery(
 
             await transport.SendAsync(submitted, watchedMailbox, cancellationToken);
 
+            console.WriteError(string.Create(
+                CultureInfo.InvariantCulture,
+                $"{turn}: waiting up to {deliveryTimeout.TotalSeconds:0} seconds for it to reach the mailbox."));
+
             var assigned = await this.AwaitDeliveredMessageIdAsync(email.MessageId, deliveryTimeout, cancellationToken);
+
+            console.WriteError(assigned is null ? $"{turn}: never arrived." : $"{turn}: delivered.");
 
             if (assigned is null)
             {
@@ -202,6 +222,7 @@ internal sealed class SyntheticConversationDelivery(
         }
         catch (SyntheticMailFailure failure)
         {
+            console.WriteError($"{turn}: failed.");
             failures.Add(new DeliveryFailure(email.MessageId, email.Subject, failure.Message));
 
             return null;

--- a/backend/tools/SyntheticMail/Delivery/SyntheticMailBatchDelivery.cs
+++ b/backend/tools/SyntheticMail/Delivery/SyntheticMailBatchDelivery.cs
@@ -2,6 +2,7 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Globalization;
 using MailFathom.SyntheticMail.Configuration;
 using MailFathom.SyntheticMail.Generation;
 using MimeKit;
@@ -10,13 +11,17 @@ namespace MailFathom.SyntheticMail.Delivery;
 
 /// <summary>Submits a generated corpus one message at a time, paced, and reports what became of it.</summary>
 /// <param name="transport">The open session to submit through.</param>
+/// <param name="console">Where the run reports what it is doing, which is standard error and never the corpus.</param>
 /// <param name="timeProvider">What the pacing waits on.</param>
 /// <remarks>
 /// A message is composed immediately before it is submitted and disposed immediately after, so a batch's peak memory
 /// is one message rather than all of them — which is what lets the attachment ceiling be raised without the count
 /// having to come down to match.
 /// </remarks>
-internal sealed class SyntheticMailBatchDelivery(ISyntheticMailTransport transport, TimeProvider timeProvider)
+internal sealed class SyntheticMailBatchDelivery(
+    ISyntheticMailTransport transport,
+    ISyntheticMailConsole console,
+    TimeProvider timeProvider)
 {
     /// <summary>Delivers the whole corpus, continuing past a message the server refuses.</summary>
     /// <param name="emails">The generated corpus, oldest first.</param>
@@ -51,6 +56,12 @@ internal sealed class SyntheticMailBatchDelivery(ISyntheticMailTransport transpo
             }
 
             var email = emails[index];
+
+            // Reported before the submission rather than after it, because the submission is the part that takes
+            // time: a run that says what it is doing is one a developer can leave alone.
+            console.WriteError(string.Create(
+                CultureInfo.InvariantCulture,
+                $"Submitting {index + 1} of {emails.Count} to {recipient.Address}."));
 
             using var message = SyntheticMimeComposer.Compose(
                 email,

--- a/backend/tools/SyntheticMail/Generation/AiContent/ReportingAiEmailContentSource.cs
+++ b/backend/tools/SyntheticMail/Generation/AiContent/ReportingAiEmailContentSource.cs
@@ -1,0 +1,48 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Globalization;
+
+namespace MailFathom.SyntheticMail.Generation.AiContent;
+
+/// <summary>Reports each answered message as it lands, and answers whatever the source it wraps answers.</summary>
+/// <param name="source">The source the run actually generates through.</param>
+/// <param name="console">Where the count is reported, which is standard error and never the corpus.</param>
+/// <param name="total">How many messages the run is generating, which is what the count is out of.</param>
+/// <remarks>
+/// <para>
+/// A decorator rather than a report the generator writes, because progress is about the run rather than about the
+/// corpus: the generator reaches nothing and says nothing, and this is the one place that knows both that a call
+/// finished and where a run reports. It counts answers rather than calls, so a message the provider refused is
+/// absent from the count rather than counted as produced.
+/// </para>
+/// <para>
+/// The count is the only thing reported. The prompt and the answer never reach a log for the reason the source
+/// itself gives — both are message content — and a run watching two hundred generations wants to know how far it
+/// has got rather than what was written.
+/// </para>
+/// </remarks>
+internal sealed class ReportingAiEmailContentSource(
+    IAiEmailContentSource source,
+    ISyntheticMailConsole console,
+    int total) : IAiEmailContentSource
+{
+    private int answered;
+
+    /// <inheritdoc />
+    public async Task<AiEmailContent> GenerateAsync(AiEmailContentRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var content = await source.GenerateAsync(request, cancellationToken);
+
+        // Several answers land at once, so the counter is incremented atomically and the line is written from
+        // whichever call finished. What a reader gets is a rising count rather than an order.
+        console.WriteError(string.Create(
+            CultureInfo.InvariantCulture,
+            $"Generated {Interlocked.Increment(ref this.answered)} of {total} messages."));
+
+        return content;
+    }
+}

--- a/backend/tools/SyntheticMail/Generation/SyntheticEmailGenerator.cs
+++ b/backend/tools/SyntheticMail/Generation/SyntheticEmailGenerator.cs
@@ -122,16 +122,20 @@ internal sealed class SyntheticEmailGenerator
     /// <summary>Produces the corpus a plan describes, reaching the named source for what the seed does not decide.</summary>
     /// <param name="plan">What the corpus is, seed included.</param>
     /// <param name="contentSource">The source the message content comes from, required when the plan names languages.</param>
+    /// <param name="concurrency">How many answers the run waits for at once, which changes what it costs in time and nothing about what it produces.</param>
     /// <param name="cancellationToken">Cancels the run.</param>
     /// <returns>The messages, oldest first.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="plan" /> is <see langword="null" />, or <paramref name="contentSource" /> is when the plan needs one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="concurrency" /> is below one.</exception>
     /// <exception cref="ArgumentException">Thrown when the plan names topics without naming languages, or when its distribution names no topic or one that is not a topic.</exception>
     internal static async Task<IReadOnlyList<SyntheticEmail>> GenerateAsync(
         SyntheticCorpusPlan plan,
         IAiEmailContentSource? contentSource,
+        int concurrency,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(plan);
+        ArgumentOutOfRangeException.ThrowIfLessThan(concurrency, 1);
 
         if (plan.Languages.Count == 0)
         {
@@ -141,7 +145,7 @@ internal sealed class SyntheticEmailGenerator
         ArgumentNullException.ThrowIfNull(contentSource);
         RequireCompleteDistribution(plan);
 
-        return await new SyntheticEmailGenerator(plan).ProduceAsync(contentSource, cancellationToken);
+        return await new SyntheticEmailGenerator(plan).ProduceAsync(contentSource, concurrency, cancellationToken);
     }
 
     /// <summary>Produces the corpus a plan describes as exchanges between the watched mailbox and invented correspondents.</summary>
@@ -173,18 +177,22 @@ internal sealed class SyntheticEmailGenerator
     /// <param name="plan">What the corpus is, seed included.</param>
     /// <param name="mailbox">The mailbox MailFathom synchronizes, which writes every second turn.</param>
     /// <param name="contentSource">The source the message content comes from, required when the plan names languages.</param>
+    /// <param name="concurrency">How many answers the run waits for at once, spread across exchanges rather than within one.</param>
     /// <param name="cancellationToken">Cancels the run.</param>
     /// <returns>The exchanges, each oldest message first.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="plan" /> or <paramref name="mailbox" /> is <see langword="null" />, or <paramref name="contentSource" /> is when the plan needs one.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="concurrency" /> is below one.</exception>
     /// <exception cref="ArgumentException">Thrown when the plan names topics without naming languages, when its distribution names no topic or one that is not a topic, or when it asks for fewer messages than one exchange holds.</exception>
     internal static async Task<IReadOnlyList<SyntheticConversation>> GenerateConversationsAsync(
         SyntheticCorpusPlan plan,
         SyntheticParticipant mailbox,
         IAiEmailContentSource? contentSource,
+        int concurrency,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(plan);
         ArgumentNullException.ThrowIfNull(mailbox);
+        ArgumentOutOfRangeException.ThrowIfLessThan(concurrency, 1);
 
         if (plan.Languages.Count == 0)
         {
@@ -195,7 +203,7 @@ internal sealed class SyntheticEmailGenerator
         RequireCompleteDistribution(plan);
         RequireRoomForOneExchange(plan);
 
-        return await new SyntheticEmailGenerator(plan).ProduceConversationsAsync(mailbox, contentSource, cancellationToken);
+        return await new SyntheticEmailGenerator(plan).ProduceConversationsAsync(mailbox, contentSource, concurrency, cancellationToken);
     }
 
     /// <summary>Refuses a plan too small to hold an exchange, before one is built that would not be one.</summary>
@@ -226,6 +234,25 @@ internal sealed class SyntheticEmailGenerator
                 nameof(plan));
         }
     }
+
+    /// <summary>Everything about one message the seed decides, drawn before any content is asked for.</summary>
+    /// <remarks>
+    /// The split an overlapping run rests on: what the seed decides is drawn for the whole corpus in one sequential
+    /// pass, and what a provider decides is asked for afterwards, so the number of calls in flight is not one of the
+    /// inputs to the sequence. <see cref="ParentIndex" /> is a position in that pass rather than a message, because
+    /// the message it names has usually not been answered yet when the envelope is drawn.
+    /// </remarks>
+    private sealed record MessageEnvelope(
+        int Index,
+        SyntheticParticipant Author,
+        IReadOnlyList<SyntheticParticipant> CarbonCopies,
+        int? ParentIndex,
+        DateTimeOffset SentAt,
+        SyntheticEmailAiOrigin Origin,
+        string MessageId,
+        SyntheticBodyShape BodyShape,
+        SensitiveDecoy? Decoy,
+        SyntheticEmailAttachment? Attachment);
 
     private static IReadOnlyList<SyntheticParticipant> BuildParticipantPool(Random source) =>
     [
@@ -289,17 +316,28 @@ internal sealed class SyntheticEmailGenerator
         return this.produced;
     }
 
-    private async Task<List<SyntheticEmail>> ProduceAsync(
+    /// <summary>Draws the whole corpus's envelopes, then answers them.</summary>
+    /// <remarks>
+    /// Every draw is made in index order before a single call goes out, so the sequence the seed produces is the one
+    /// it always produced and how many answers a run waits for at once cannot reach it.
+    /// </remarks>
+    private async Task<IReadOnlyList<SyntheticEmail>> ProduceAsync(
         IAiEmailContentSource contentSource,
+        int concurrency,
         CancellationToken cancellationToken)
     {
+        var envelopes = new List<MessageEnvelope>(this.plan.Count);
+
         for (var index = 0; index < this.plan.Count; index++)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            this.produced.Add(await this.BuildEmailAsync(index, contentSource, cancellationToken));
+            var author = this.participants[this.source.Next(this.participants.Count)];
+            var carbonCopies = this.BuildCarbonCopies(author);
+            var parent = this.PickParent(envelopes);
+
+            envelopes.Add(this.DrawEnvelope(index, author, carbonCopies, parent));
         }
 
-        return this.produced;
+        return await this.FillAsync(envelopes, contentSource, concurrency, cancellationToken);
     }
 
     private List<SyntheticConversation> ProduceConversations(SyntheticParticipant mailbox)
@@ -309,7 +347,7 @@ internal sealed class SyntheticEmailGenerator
         while (this.produced.Count < this.plan.Count)
         {
             var correspondent = this.participants[this.source.Next(this.participants.Count)];
-            var turns = this.DrawTurnCount();
+            var turns = this.DrawTurnCount(this.produced.Count);
             var messages = new List<SyntheticEmail>(turns);
 
             for (var turn = 0; turn < turns; turn++)
@@ -326,39 +364,56 @@ internal sealed class SyntheticEmailGenerator
         return conversations;
     }
 
-    private async Task<List<SyntheticConversation>> ProduceConversationsAsync(
+    /// <summary>Draws every exchange's envelopes, then answers them: the turns of one exchange in order, the exchanges beside each other.</summary>
+    /// <remarks>
+    /// A turn answers the turn before it, so its prompt carries what that one was answered with and the chain inside
+    /// an exchange is the one thing nothing overlaps. Exchanges depend on nothing but the seed, which is the axis the
+    /// calls are spread across.
+    /// </remarks>
+    private async Task<IReadOnlyList<SyntheticConversation>> ProduceConversationsAsync(
         SyntheticParticipant mailbox,
         IAiEmailContentSource contentSource,
+        int concurrency,
         CancellationToken cancellationToken)
     {
-        var conversations = new List<SyntheticConversation>();
+        var exchanges = new List<(SyntheticParticipant Correspondent, List<MessageEnvelope> Turns)>();
+        var drawn = 0;
 
-        while (this.produced.Count < this.plan.Count)
+        while (drawn < this.plan.Count)
         {
             var correspondent = this.participants[this.source.Next(this.participants.Count)];
-            var turns = this.DrawTurnCount();
-            var messages = new List<SyntheticEmail>(turns);
+            var turns = this.DrawTurnCount(drawn);
+            var envelopes = new List<MessageEnvelope>(turns);
 
             for (var turn = 0; turn < turns; turn++)
             {
-                cancellationToken.ThrowIfCancellationRequested();
+                // No carbon copies. An exchange is between two people by construction, and a third address on it
+                // would be one the envelope never carries, which reads in a client as a participant who was never
+                // written to.
+                envelopes.Add(this.DrawEnvelope(
+                    drawn,
+                    AuthorOf(turn, correspondent, mailbox),
+                    [],
+                    turn == 0 ? null : envelopes[^1]));
 
-                var message = await this.BuildConversationMessageAsync(
-                    turn,
-                    correspondent,
-                    mailbox,
-                    messages,
-                    contentSource,
-                    cancellationToken);
-
-                messages.Add(message);
-                this.produced.Add(message);
+                drawn++;
             }
 
-            conversations.Add(new SyntheticConversation(correspondent, messages));
+            exchanges.Add((correspondent, envelopes));
         }
 
-        return conversations;
+        var answered = await this.FillAsync(
+            [.. exchanges.SelectMany(exchange => exchange.Turns)],
+            contentSource,
+            concurrency,
+            cancellationToken);
+
+        return
+        [
+            .. exchanges.Select(exchange => new SyntheticConversation(
+                exchange.Correspondent,
+                [.. exchange.Turns.Select(turn => answered[turn.Index])])),
+        ];
     }
 
     /// <summary>Draws how many turns the next exchange runs to, without leaving a message that could not be one.</summary>
@@ -369,9 +424,9 @@ internal sealed class SyntheticEmailGenerator
     /// the exchange past <see cref="MostExchangeTurns" />: below that it is absorbed, and at exactly one over it the
     /// exchange gives a turn back instead, which leaves two behind rather than one and keeps the stated ceiling true.
     /// </remarks>
-    private int DrawTurnCount()
+    private int DrawTurnCount(int produced)
     {
-        var remaining = this.plan.Count - this.produced.Count;
+        var remaining = this.plan.Count - produced;
         var turns = Math.Min(this.source.Next(FewestExchangeTurns, MostExchangeTurns + 1), remaining);
 
         if (remaining - turns != 1)
@@ -391,7 +446,7 @@ internal sealed class SyntheticEmailGenerator
         var index = this.produced.Count;
         var author = AuthorOf(turn, correspondent, mailbox);
         var parent = turn == 0 ? null : messages[^1];
-        var sentAt = this.BuildSentAt(index, parent);
+        var sentAt = this.BuildSentAt(index, parent?.SentAt);
         var subject = parent is null ? this.BuildSubject() : $"Re: {StripReplyPrefix(parent.Subject)}";
 
         return new SyntheticEmail(
@@ -407,45 +462,6 @@ internal sealed class SyntheticEmailGenerator
             this.BuildBody(),
             this.BuildAttachment(),
             null);
-    }
-
-    private async Task<SyntheticEmail> BuildConversationMessageAsync(
-        int turn,
-        SyntheticParticipant correspondent,
-        SyntheticParticipant mailbox,
-        IReadOnlyList<SyntheticEmail> messages,
-        IAiEmailContentSource contentSource,
-        CancellationToken cancellationToken)
-    {
-        var index = this.produced.Count;
-        var author = AuthorOf(turn, correspondent, mailbox);
-        var parent = turn == 0 ? null : messages[^1];
-        var sentAt = this.BuildSentAt(index, parent);
-        var origin = new SyntheticEmailAiOrigin(this.DrawLanguage(), this.DrawTopic());
-        var messageId = this.BuildMessageId(index, author);
-
-        var content = await contentSource.GenerateAsync(
-            new AiEmailContentRequest(
-                origin.Language,
-                origin.Topic,
-                author.DisplayName,
-                parent?.Subject,
-                OpeningOf(parent)),
-            cancellationToken);
-
-        var subject = parent is null ? content.Subject : $"Re: {StripReplyPrefix(parent.Subject)}";
-
-        return new SyntheticEmail(
-            messageId,
-            parent?.MessageId,
-            parent is null ? [] : [.. parent.References, parent.MessageId],
-            author,
-            [],
-            subject,
-            sentAt,
-            this.BuildAiBody(content),
-            this.BuildAttachment(),
-            origin);
     }
 
     private static SyntheticParticipant AuthorOf(
@@ -469,8 +485,8 @@ internal sealed class SyntheticEmailGenerator
     {
         var author = this.participants[this.source.Next(this.participants.Count)];
         var carbonCopies = this.BuildCarbonCopies(author);
-        var parent = this.PickParent();
-        var sentAt = this.BuildSentAt(index, parent);
+        var parent = this.PickParent(this.produced);
+        var sentAt = this.BuildSentAt(index, parent?.SentAt);
         var subject = parent is null ? this.BuildSubject() : $"Re: {StripReplyPrefix(parent.Subject)}";
 
         return new SyntheticEmail(
@@ -486,45 +502,116 @@ internal sealed class SyntheticEmailGenerator
             null);
     }
 
-    private async Task<SyntheticEmail> BuildEmailAsync(
+    /// <summary>Draws everything about one message that the seed decides, which is everything but the words.</summary>
+    /// <remarks>
+    /// The draws are made in the order the sequential builder made them, including the two that used to happen after
+    /// the call — the body's MIME shape and its decoy — because neither reads the answer. Moving them in front of the
+    /// call is what lets the whole corpus be drawn before any of it is asked for, and it leaves the sequence the seed
+    /// produces unchanged.
+    /// </remarks>
+    private MessageEnvelope DrawEnvelope(
         int index,
-        IAiEmailContentSource contentSource,
-        CancellationToken cancellationToken)
+        SyntheticParticipant author,
+        IReadOnlyList<SyntheticParticipant> carbonCopies,
+        MessageEnvelope? parent)
     {
-        var author = this.participants[this.source.Next(this.participants.Count)];
-        var carbonCopies = this.BuildCarbonCopies(author);
-        var parent = this.PickParent();
-        var sentAt = this.BuildSentAt(index, parent);
+        var sentAt = this.BuildSentAt(index, parent?.SentAt);
         var origin = new SyntheticEmailAiOrigin(this.DrawLanguage(), this.DrawTopic());
         var messageId = this.BuildMessageId(index, author);
+        var bodyShape = (SyntheticBodyShape)this.source.Next(3);
+        var decoy = this.PlantDecoy();
 
-        // The envelope is decided before the call, for the reason the question is: the same plan asks the source the
-        // same questions in the same order on every run, so what differs between runs is the answer and nothing else.
-        var content = await contentSource.GenerateAsync(
-            new AiEmailContentRequest(
-                origin.Language,
-                origin.Topic,
-                author.DisplayName,
-                parent?.Subject,
-                OpeningOf(parent)),
-            cancellationToken);
-
-        // A reply keeps the thread's subject, which the deterministic layer owns: the source answers the body, and
-        // a subject it invented would break the In-Reply-To chain a corpus exists to exercise.
-        var subject = parent is null ? content.Subject : $"Re: {StripReplyPrefix(parent.Subject)}";
-
-        return new SyntheticEmail(
-            messageId,
-            parent?.MessageId,
-            parent is null ? [] : [.. parent.References, parent.MessageId],
+        return new MessageEnvelope(
+            index,
             author,
             carbonCopies,
-            subject,
+            parent?.Index,
             sentAt,
-            this.BuildAiBody(content),
-            this.BuildAttachment(),
-            origin);
+            origin,
+            messageId,
+            bodyShape,
+            decoy,
+            this.BuildAttachment());
     }
+
+    /// <summary>Asks the source for every drawn message, waiting for no more than the named number of answers at once.</summary>
+    /// <remarks>
+    /// <para>
+    /// One task per message, each awaiting the message it answers before it asks anything: a reply's prompt carries
+    /// the subject and the opening of what it replies to, so that message has to have been answered first. Everything
+    /// else in a corpus depends on nothing, which is what the calls overlap across, and the semaphore is what keeps a
+    /// batch of two hundred from opening two hundred connections to a provider at once.
+    /// </para>
+    /// <para>
+    /// The answers land in the array at the index they were drawn under, so what comes back is in corpus order however
+    /// the calls finished. That is the whole of what makes the degree of concurrency invisible in the output.
+    /// </para>
+    /// </remarks>
+    private async Task<SyntheticEmail[]> FillAsync(
+        IReadOnlyList<MessageEnvelope> envelopes,
+        IAiEmailContentSource contentSource,
+        int concurrency,
+        CancellationToken cancellationToken)
+    {
+        using var answering = new SemaphoreSlim(concurrency);
+        var filled = new Task<SyntheticEmail>[envelopes.Count];
+
+        for (var index = 0; index < envelopes.Count; index++)
+        {
+            var envelope = envelopes[index];
+
+            filled[index] = FillOneAsync(
+                envelope,
+                envelope.ParentIndex is { } parent ? filled[parent] : null);
+        }
+
+        return await Task.WhenAll(filled);
+
+        async Task<SyntheticEmail> FillOneAsync(MessageEnvelope envelope, Task<SyntheticEmail>? answeringParent)
+        {
+            var parent = answeringParent is null ? null : await answeringParent;
+
+            await answering.WaitAsync(cancellationToken);
+
+            AiEmailContent content;
+
+            try
+            {
+                content = await contentSource.GenerateAsync(
+                    new AiEmailContentRequest(
+                        envelope.Origin.Language,
+                        envelope.Origin.Topic,
+                        envelope.Author.DisplayName,
+                        parent?.Subject,
+                        OpeningOf(parent)),
+                    cancellationToken);
+            }
+            finally
+            {
+                answering.Release();
+            }
+
+            return Compose(envelope, parent, content);
+        }
+    }
+
+    /// <summary>Builds the message the envelope described around the content the source answered.</summary>
+    /// <remarks>
+    /// A reply keeps the thread's subject, which the deterministic layer owns: the source answers the body, and a
+    /// subject it invented would break the In-Reply-To chain a corpus exists to exercise.
+    /// </remarks>
+    private static SyntheticEmail Compose(MessageEnvelope envelope, SyntheticEmail? parent, AiEmailContent content) =>
+        new(
+            envelope.MessageId,
+            parent?.MessageId,
+            parent is null ? [] : [.. parent.References, parent.MessageId],
+            envelope.Author,
+            envelope.CarbonCopies,
+            parent is null ? content.Subject : $"Re: {StripReplyPrefix(parent.Subject)}",
+            envelope.SentAt,
+            ComposeAiBody(envelope, content),
+            envelope.Attachment,
+            envelope.Origin);
 
     private string DrawLanguage() => this.plan.Languages[this.source.Next(this.plan.Languages.Count)];
 
@@ -549,19 +636,26 @@ internal sealed class SyntheticEmailGenerator
         return chosen;
     }
 
-    private SyntheticEmail? PickParent()
+    /// <summary>Draws the message a new one answers, or nothing.</summary>
+    /// <remarks>
+    /// Written over what has been produced rather than over the produced messages, because the AI path draws every
+    /// envelope before a single message exists. The draws are the same two either way, which is what keeps one seed
+    /// producing one thread structure in both modes.
+    /// </remarks>
+    private TProduced? PickParent<TProduced>(IReadOnlyList<TProduced> produced)
+        where TProduced : class
     {
-        if (this.produced.Count == 0 || this.source.Next(100) >= ReplyPercentage)
+        if (produced.Count == 0 || this.source.Next(100) >= ReplyPercentage)
         {
             return null;
         }
 
-        var window = Math.Min(ThreadWindow, this.produced.Count);
+        var window = Math.Min(ThreadWindow, produced.Count);
 
-        return this.produced[this.produced.Count - 1 - this.source.Next(window)];
+        return produced[produced.Count - 1 - this.source.Next(window)];
     }
 
-    private DateTimeOffset BuildSentAt(int index, SyntheticEmail? parent)
+    private DateTimeOffset BuildSentAt(int index, DateTimeOffset? parentSentAt)
     {
         var earliest = this.plan.LatestSentAt.AddDays(-this.plan.SpanDays);
         var spanSeconds = (this.plan.LatestSentAt - earliest).TotalSeconds;
@@ -573,8 +667,8 @@ internal sealed class SyntheticEmailGenerator
 
         // One slot's worth of jitter can still put a message a little before the one it answers, which no mail client
         // would ever show. Pushing it past the parent costs one branch and keeps every thread readable.
-        return parent is not null && sentAt <= parent.SentAt
-            ? parent.SentAt.AddMinutes(this.source.Next(5, 240))
+        return parentSentAt is { } answered && sentAt <= answered
+            ? answered.AddMinutes(this.source.Next(5, 240))
             : sentAt;
     }
 
@@ -633,35 +727,33 @@ internal sealed class SyntheticEmailGenerator
             decoy);
     }
 
-    private SyntheticEmailBody BuildAiBody(AiEmailContent content)
+    /// <summary>Wraps an answered message in the body form the envelope drew for it.</summary>
+    /// <remarks>
+    /// The MIME shape is still drawn from the seed for the reason the deterministic body varies it, but the two
+    /// alternatives are no longer one text in two wrappings: the source answers the message as text and as the markup
+    /// real mail carries, so which of them an extractor chooses is a choice between genuinely different documents
+    /// rather than between a paragraph list and the same paragraph list in tags. The charset is the one axis the seed
+    /// does not draw here: a body written in the language the invocation names is one the vocabulary's three charsets
+    /// cannot be promised to hold, and utf-8 is the one that holds any of them.
+    /// </remarks>
+    private static SyntheticEmailBody ComposeAiBody(MessageEnvelope envelope, AiEmailContent content)
     {
-        var shape = (SyntheticBodyShape)this.source.Next(3);
-
-        // The MIME shape is still drawn from the seed for the reason the deterministic body varies it, but the two
-        // alternatives are no longer one text in two wrappings: the source answers the message as text and as the
-        // markup real mail carries, so which of them an extractor chooses is a choice between genuinely different
-        // documents rather than between a paragraph list and the same paragraph list in tags.
         var blocks = content.Body
             .Replace("\r\n", "\n", StringComparison.Ordinal)
             .Split(["\n\n"], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .ToList();
 
-        // The charset is the one axis the seed does not draw here: a body written in the language the invocation names
-        // is one the vocabulary's three charsets cannot be promised to hold, and utf-8 is the one that holds any of
-        // them.
-        var decoy = this.PlantDecoy();
-
-        if (decoy is not null)
+        if (envelope.Decoy is not null)
         {
-            blocks.Add(decoy.Sentence);
+            blocks.Add(envelope.Decoy.Sentence);
         }
 
         return new SyntheticEmailBody(
-            shape,
+            envelope.BodyShape,
             string.Join("\n\n", blocks),
-            PlantInHtml(content.Html, decoy),
+            PlantInHtml(content.Html, envelope.Decoy),
             SyntheticCharacterSet.Utf8,
-            decoy);
+            envelope.Decoy);
     }
 
     /// <summary>Puts the fabricated sensitive material into the answered document, where a scanner reading HTML meets it.</summary>

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -757,6 +757,31 @@ beside it shows the shape:
 }
 ```
 
+**A run overlaps its provider calls, and says how far it has got.** One message costs whatever the endpoint takes to
+write it — around twenty seconds for a rich HTML message in a language whose words cost more tokens than English does —
+so a corpus of two hundred generated one at a time is over an hour before the first submission. `--concurrency` is how
+many answers a run waits for at once, four by default and up to 32:
+
+```bash
+dotnet run --project backend/tools/SyntheticMail -- <recipient> --count 200 --ai --concurrency 8
+```
+
+It changes what the run costs in time and nothing about what it produces. The whole corpus is drawn from the seed
+before a single call goes out, and the answers land at the position they were drawn under, so the same seed produces
+the same envelope — every author, thread, date, language, topic, attachment, MIME shape, and planted decoy — whatever
+degree it was generated at. The option is absent from the repeat line for that reason, and it is refused without
+`--ai`, because a corpus the vocabulary writes is produced in the time it takes to draw it.
+
+What is not overlapped is a reply. A reply's prompt carries the subject and the opening of the message it answers, so
+it cannot be asked for until that message has been answered: in a flat batch the calls spread across everything that
+answers nothing, and in `--conversation` they spread across exchanges while the turns inside one stay in order. The
+pacing between submissions is untouched by any of it — `--interval` is what a submission server sees, and generation
+finishes before delivery starts.
+
+Both halves report what they are doing on standard error as they do it: `Generated 12 of 200 messages.` while the
+provider is being waited on, and then one line per submission, or per turn in an exchange — submitting, waiting for
+the copy to reach the mailbox, and what became of it. Standard output stays the corpus and carries none of it.
+
 `endpoint` is optional and defaults to the provider's own address; written, it must be an absolute https address,
 because the key travels in a header and there is no unsecured option. A run that finds the file missing or
 incomplete says so with the file and the key to set, before it generates anything, for the reason the sending


### PR DESCRIPTION
## The problem, measured

Every provider call in an `--ai` run happened up front and one at a time, in `SyntheticEmailGenerator`, before `SyntheticMailBatchDelivery` or `SyntheticConversationDelivery` submitted anything. A rich HTML message in Polish costs around twenty seconds, so `--count 200 --conversation --ai` spent over an hour silent — and nothing on the terminal distinguished that from a run that had hung.

## Overlapping the calls

The generation is now a **draw pass** and a **fill pass**.

- Everything the seed decides is drawn for the whole corpus in one sequential pass — author, carbon copies, parent, date, language, topic, identifier, MIME shape, planted decoy, attachment — and the provider is asked afterwards, one task per message, each answer landing at the position its message was drawn under.
- The two draws that used to happen *after* a call (the body's MIME shape and its decoy) read nothing from the answer, so moving them in front of it leaves the draw sequence unchanged.
- **A reply is not overlapped.** Its prompt carries the subject and the opening of the message it answers, so its task awaits that message first: a flat batch spreads its calls across everything that answers nothing, and `--conversation` spreads across exchanges while the turns inside one stay in order.
- `--concurrency` bounds how many answers are waited for at once. Four by default, up to 32, refused without `--ai`, and deliberately absent from the repeat line, because it changes what a run costs in time rather than what it produces.
- The SMTP side is untouched: `--interval` is still the pacing between submissions, delivery is still one message at a time, and generation still finishes before delivery starts.

## Reporting progress

Both halves report themselves on standard error while they run, through `ISyntheticMailConsole.WriteError`:

```
Generated 12 of 200 messages.
Submitting 12 of 200 to developer@example.test.
Exchange 3 of 57, turn 1 of 4: submitting to developer@example.test.
Exchange 3 of 57, turn 1 of 4: waiting up to 120 seconds for it to reach the mailbox.
Exchange 3 of 57, turn 1 of 4: delivered.
Exchange 3 of 57, turn 2 of 4: appending to Sent.
```

Generation progress is a decorator over the content source rather than a report the generator writes: the generator reaches nothing and says nothing, and the decorator is the one place that knows both that a call finished and where a run reports. Standard output stays the corpus and carries none of it.

## The determinism claim, checked rather than argued

The seed's promise is the property everything else here is subordinate to, so it was measured against the previous build rather than reasoned about:

- A dry run of `--seed 4242 --count 120` and of `--seed 99 --count 60 --conversation` is **byte-identical** to the same invocation against `main`.
- An AI-mode corpus built through a scripted source — 80 flat messages and 80 turns of exchanges, two languages, two topics, decoys planted — renders **identically** to `main`'s, both at concurrency 1 and at concurrency 8 with answers deliberately completing out of order.

Eight new unit tests hold the same ground permanently: the corpus is equal across degrees 1, 3, and 16 (and 1 and 8 for exchanges), no more answers are in flight than were asked for, a reply's prompt only ever names a subject some message in the corpus actually carries, and a degree below one is refused. Two more assert the progress lines for a batch and for an exchange.

## Verification

- `scripts/verify-fast.sh` — passed, 13347 tests, nothing rewritten.
- `dotnet test --project backend/tests/SyntheticMail.UnitTests` — 341 passed.
- The full gate was not run locally; the pipeline runs it.

## Not in scope

- **Generating while delivery is already running.** It is possible — a turn's generation depends on the previous turn's *answer*, not on its delivery — but it costs a producer/consumer pipeline across two components that currently hand over one finished list, and with the calls overlapped the generation is no longer the hour it was. Worth its own issue if the remaining wall-clock matters.
- No issue is linked: this was taken directly rather than through `$start-task`.
