### PR TITLE
[#1228] Relay a signed-in person's OTLP out of the client endpoint, under the owner this deployment authenticated

### DIFF
--- a/backend/src/Host/Api/ClientApiEndpoints.cs
+++ b/backend/src/Host/Api/ClientApiEndpoints.cs
@@ -38,6 +38,12 @@ namespace MailFathom.Host.Api;
 /// an administrator maintains writes there while writing nothing to the record.
 /// </para>
 /// <para>
+/// The telemetry routes, which <see cref="ClientTelemetryEndpoint" /> describes, are the one family here that is not
+/// about mail: they take the client's own OTLP export and forward it to the collector this deployment already exports
+/// to, because the collector's address and its credential belong to the deployment and a browser bundle holding either
+/// would be publishing them. They exist only where a destination is configured.
+/// </para>
+/// <para>
 /// Every route is mapped into one group so the requirement the endpoint attaches covers everything the surface serves,
 /// including a route added later, and so the one filter that reads each route's published grant covers them all too.
 /// </para>
@@ -83,6 +89,7 @@ internal static class ClientApiEndpoints
         api.MapClientMailAttachment();
         api.MapClientDrafts();
         api.MapClientOutbox();
+        api.MapClientTelemetry();
 
         return api;
     }

--- a/backend/src/Host/Api/ClientTelemetryEndpoint.cs
+++ b/backend/src/Host/Api/ClientTelemetryEndpoint.cs
@@ -24,8 +24,18 @@ namespace MailFathom.Host.Api;
 /// <b>Identity is settled here rather than taken from the payload.</b> A client says what it likes about the browser,
 /// the release, and the screen, and none of that is this deployment's business; whose telemetry it is, is. The owner
 /// comes off the credential that authenticated, and it is written over whatever arrived under that name rather than
-/// merged with it — a client cannot export as somebody else, because there is no argument or attribute in which it
-/// could say so and be believed.
+/// merged with it — there is no argument and no resource attribute in which a client could name an owner of its own
+/// and be believed.
+/// </para>
+/// <para>
+/// The guarantee is about the <b>resource</b>, which is where OpenTelemetry puts the identity of what produced a
+/// signal and where a backend reads it from. A client remains free to write anything it likes into a span, a log
+/// record, or a metric data point, including a key spelled like this one, exactly as it is free to write anything into
+/// the text of a span name — those are the client's own words about its own work rather than an attribution this
+/// deployment made, and nothing here reads them. Stripping them would mean walking every record of all three signals
+/// against their schemas, which is the decoding this proxy deliberately does not do and which would make it a
+/// processor. So the rule to read telemetry by is the resource's own attribution, and it is the one thing in a
+/// forwarded batch a client cannot influence.
 /// </para>
 /// <para>
 /// <b>The routes exist only where the deployment named a destination.</b> Enabling the export is the whole switch and it

--- a/backend/src/Host/Api/ClientTelemetryEndpoint.cs
+++ b/backend/src/Host/Api/ClientTelemetryEndpoint.cs
@@ -142,8 +142,9 @@ internal static class ClientTelemetryEndpoint
     /// <exception cref="ArgumentNullException">Thrown when any resolved dependency is <see langword="null" />.</exception>
     /// <remarks>
     /// The order is deliberate. The credential is resolved to an owner first, because an export nobody can be
-    /// attributed to must not be read at all; the quota is spent next, so a client past its rate costs this process one
-    /// refusal rather than a parse; and only then is the batch read, bounded, and rewritten.
+    /// attributed to must not be read at all; the media type is read next, which costs one header and settles whether
+    /// this is an export request at all; the quota is spent after that, so a client past its rate costs this process
+    /// one refusal rather than a parse; and only then is the batch read, bounded, and rewritten.
     /// </remarks>
     internal static async Task<IResult> AcceptAsync(
         ClientTelemetrySignal signal,

--- a/backend/src/Host/Api/ClientTelemetryEndpoint.cs
+++ b/backend/src/Host/Api/ClientTelemetryEndpoint.cs
@@ -73,8 +73,12 @@ internal static class ClientTelemetryEndpoint
     /// </remarks>
     internal const int MaxRequestBytes = 4 * 1024 * 1024;
 
-    /// <summary>The most records one batch may carry.</summary>
-    /// <remarks>Bounded beside the byte count rather than instead of it, because the two are different costs: the octets are what this process buffers, and the records are what the destination is charged for.</remarks>
+    /// <summary>The most records one batch may carry, a record being a span, a log record, or a single metric data point.</summary>
+    /// <remarks>
+    /// Bounded beside the byte count rather than instead of it, because the two are different costs: the octets are
+    /// what this process buffers, and the records are what the destination is charged for. A metric counts as its data
+    /// points rather than as one definition for exactly that reason — a collector bills the measurements.
+    /// </remarks>
     internal const int MaxRecordsPerBatch = 10_000;
 
     private const int InvalidArgumentStatus = 3;
@@ -193,7 +197,12 @@ internal static class ClientTelemetryEndpoint
                 $"An export batch is at most {MaxRequestBytes} bytes.");
         }
 
-        var rewritten = OtlpExportPayload.Rewrite(batch, OwnerTagName, owner.ToString(), MaxRecordsPerBatch);
+        var rewritten = OtlpExportPayload.Rewrite(
+            batch,
+            signal,
+            OwnerTagName,
+            owner.ToString(),
+            MaxRecordsPerBatch);
 
         if (rewritten.Refusal != OtlpPayloadRefusal.None)
         {

--- a/backend/src/Host/Api/ClientTelemetryEndpoint.cs
+++ b/backend/src/Host/Api/ClientTelemetryEndpoint.cs
@@ -1,0 +1,327 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Globalization;
+using MailFathom.Application.Access;
+using MailFathom.Host.Observability.ClientTelemetry;
+using MailFathom.Host.Security.Endpoints;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Net.Http.Headers;
+
+namespace MailFathom.Host.Api;
+
+/// <summary>Takes the client's own telemetry and forwards it to the collector this deployment already exports to.</summary>
+/// <remarks>
+/// <para>
+/// It is the one route family on this surface that is not about mail. A browser head cannot hold the collector's
+/// address or its credential — both belong to the deployment, they travel in <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> and
+/// <c>OTEL_EXPORTER_OTLP_HEADERS</c>, and a bundle carrying either would be publishing them to whoever opened the
+/// developer tools. So the client exports to MailFathom with the token it signed in with, and MailFathom forwards. One
+/// collector, one credential, both stacks, and a client span and the service spans it caused end up in one place.
+/// </para>
+/// <para>
+/// <b>Identity is settled here rather than taken from the payload.</b> A client says what it likes about the browser,
+/// the release, and the screen, and none of that is this deployment's business; whose telemetry it is, is. The owner
+/// comes off the credential that authenticated, and it is written over whatever arrived under that name rather than
+/// merged with it — a client cannot export as somebody else, because there is no argument or attribute in which it
+/// could say so and be believed.
+/// </para>
+/// <para>
+/// <b>The routes exist only where the deployment named a destination.</b> Enabling the export is the whole switch and it
+/// is the variable the service's own exporter already reads, so there is no second key and no way for the two to
+/// disagree. A deployment that named none serves nothing here, which a client learns from the same <c>404</c> the rest
+/// of the surface answers with where something is not served — a non-retryable answer, which is what stops a client
+/// exporting into a deployment that will never forward it.
+/// </para>
+/// <para>
+/// Everything an unauthenticated shape could push through is bounded before anything leaves: the body, the number of
+/// records in one batch, and how often one owner may export. Each refusal is answered with the status the OTLP
+/// specification names and a status document rather than a truncation, so the client can tell a batch that will never
+/// be accepted from one worth holding.
+/// </para>
+/// </remarks>
+internal static class ClientTelemetryEndpoint
+{
+    /// <summary>The prefix the OTLP routes are served beneath, relative to the client prefix.</summary>
+    /// <remarks>
+    /// A prefix of its own because the paths under it are not this repository's to choose: the specification fixes
+    /// <c>/v1/traces</c> and its two siblings relative to whatever endpoint a client is configured with, so a client
+    /// points its exporter at this prefix and appends nothing itself.
+    /// </remarks>
+    internal const string TelemetryRoutePrefix = "/telemetry";
+
+    /// <summary>The resource attribute naming whose telemetry a forwarded batch is.</summary>
+    /// <remarks>The same key the guarded-egress span carries the same identifier under, because one dimension keeps one key wherever it is published.</remarks>
+    internal const string OwnerTagName = "mailfathom.owner";
+
+    /// <summary>The largest export body this endpoint reads.</summary>
+    /// <remarks>
+    /// Far below the ceiling the specification names a receiver must enforce, because the sender here is a browser
+    /// exporting every few seconds rather than a collector shipping an aggregation: a batch anywhere near this is a
+    /// client that has stopped exporting and started accumulating, and refusing it is the honest answer.
+    /// </remarks>
+    internal const int MaxRequestBytes = 4 * 1024 * 1024;
+
+    /// <summary>The most records one batch may carry.</summary>
+    /// <remarks>Bounded beside the byte count rather than instead of it, because the two are different costs: the octets are what this process buffers, and the records are what the destination is charged for.</remarks>
+    internal const int MaxRecordsPerBatch = 10_000;
+
+    private const int InvalidArgumentStatus = 3;
+    private const int ResourceExhaustedStatus = 8;
+    private const int UnavailableStatus = 14;
+
+    /// <summary>Maps the three OTLP routes into the client group, where the deployment named somewhere to forward to.</summary>
+    /// <param name="api">The client route group.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="api" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The destination being registered is what says the deployment configured one, so the switch is read where
+    /// composition read it rather than a second time here. Nothing is mapped without it, which is what makes "not
+    /// configured" answer as nothing served rather than as a route that always fails.
+    /// </remarks>
+    internal static void MapClientTelemetry(this RouteGroupBuilder api)
+    {
+        ArgumentNullException.ThrowIfNull(api);
+
+        if (((IEndpointRouteBuilder)api).ServiceProvider.GetService<ClientTelemetryDestination>() is null)
+        {
+            return;
+        }
+
+        foreach (var signal in ClientTelemetrySignal.All)
+        {
+            api.MapPost(
+                    $"{TelemetryRoutePrefix}{signal.Route}",
+                    (HttpContext context,
+                        [FromServices] AccessAuthorization authorization,
+                        [FromServices] ClientTelemetryQuota quota,
+                        [FromServices] ClientTelemetryForwarder forwarder,
+                        [FromServices] ClientTelemetryProxyTelemetry telemetry,
+                        CancellationToken cancellationToken) => AcceptAsync(
+                        signal,
+                        context,
+                        authorization,
+                        quota,
+                        forwarder,
+                        telemetry,
+                        cancellationToken))
+
+                // The attribute is reached for its metadata rather than as an MVC filter, exactly as the record routes
+                // reach it: it implements IRequestSizeLimitMetadata, so a body over the bound is stopped by the request
+                // body feature instead of being buffered here first.
+                .WithMetadata(new RequestSizeLimitAttribute(MaxRequestBytes))
+                .Accepts<Stream>(ClientTelemetryForwarder.ProtobufMediaType)
+                .Produces<Stream>(StatusCodes.Status200OK, ClientTelemetryForwarder.ProtobufMediaType)
+                .RequireNoPermission();
+        }
+    }
+
+    /// <summary>Accepts one export batch, attributes it, and forwards it.</summary>
+    /// <param name="signal">The signal the route serves.</param>
+    /// <param name="context">The request being answered, whose body carries the batch.</param>
+    /// <param name="authorization">Answers whose telemetry this is, and refuses a caller acting for nobody.</param>
+    /// <param name="quota">Bounds how often one owner may export.</param>
+    /// <param name="forwarder">Sends the batch to the deployment's own collector.</param>
+    /// <param name="telemetry">Reports what was accepted, refused, forwarded, and not forwarded.</param>
+    /// <param name="cancellationToken">Cancels the forward when the client disconnects.</param>
+    /// <returns>The destination's own answer, or the refusal that stopped the batch, as the specification's own protocol buffers documents.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when any resolved dependency is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The order is deliberate. The credential is resolved to an owner first, because an export nobody can be
+    /// attributed to must not be read at all; the quota is spent next, so a client past its rate costs this process one
+    /// refusal rather than a parse; and only then is the batch read, bounded, and rewritten.
+    /// </remarks>
+    internal static async Task<IResult> AcceptAsync(
+        ClientTelemetrySignal signal,
+        HttpContext context,
+        AccessAuthorization authorization,
+        ClientTelemetryQuota quota,
+        ClientTelemetryForwarder forwarder,
+        ClientTelemetryProxyTelemetry telemetry,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(signal);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(authorization);
+        ArgumentNullException.ThrowIfNull(quota);
+        ArgumentNullException.ThrowIfNull(forwarder);
+        ArgumentNullException.ThrowIfNull(telemetry);
+
+        var owner = authorization.RequireOwner();
+
+        if (!SpeaksProtobuf(context.Request.ContentType))
+        {
+            return Refused(
+                telemetry,
+                signal,
+                "unsupported_media_type",
+                StatusCodes.Status415UnsupportedMediaType,
+                InvalidArgumentStatus,
+                $"This endpoint accepts '{ClientTelemetryForwarder.ProtobufMediaType}' alone.");
+        }
+
+        if (!quota.TryAdmit(owner.ToString()))
+        {
+            return Refused(
+                telemetry,
+                signal,
+                "rate_limited",
+                StatusCodes.Status429TooManyRequests,
+                ResourceExhaustedStatus,
+                "This deployment accepts telemetry from one credential at a bounded rate. Hold what has not been exported and send it with the next batch.",
+                ClientTelemetryQuota.RetryAfter);
+        }
+
+        if (await ReadBatchAsync(context, cancellationToken) is not { } batch)
+        {
+            return Refused(
+                telemetry,
+                signal,
+                "too_large",
+                StatusCodes.Status413PayloadTooLarge,
+                InvalidArgumentStatus,
+                $"An export batch is at most {MaxRequestBytes} bytes.");
+        }
+
+        var rewritten = OtlpExportPayload.Rewrite(batch, OwnerTagName, owner.ToString(), MaxRecordsPerBatch);
+
+        if (rewritten.Refusal != OtlpPayloadRefusal.None)
+        {
+            return RefusedPayload(telemetry, signal, rewritten.Refusal);
+        }
+
+        telemetry.RecordAccepted(signal, rewritten.RecordCount);
+
+        var forwarding = await forwarder.ForwardAsync(signal, rewritten.Body, cancellationToken);
+        telemetry.RecordForwarding(signal, forwarding);
+
+        return Answered(forwarding);
+    }
+
+    /// <summary>Answers the client with what the destination said, or with what its silence means for the batch.</summary>
+    /// <remarks>
+    /// A destination's own answer is relayed where the batch arrived, because a partial success lives in it and a bare
+    /// success would hide a rejection the client is entitled to read. A refusal is answered in this endpoint's own
+    /// words instead: what a collector says about a batch it would not take is about this deployment's export rather
+    /// than about the client, and it is not a document to publish to a browser. Everything transient answers as unavailability,
+    /// which the specification defines as retryable — the client holds what it has not exported, and nothing is queued
+    /// on this side.
+    /// </remarks>
+    private static OtlpProtobufResult Answered(ClientTelemetryForwarding forwarding) => forwarding.Failure switch
+    {
+        ClientTelemetryFailure.None => new OtlpProtobufResult(StatusCodes.Status200OK, forwarding.Body),
+        ClientTelemetryFailure.Refused => new OtlpProtobufResult(
+            StatusCodes.Status400BadRequest,
+            OtlpExportPayload.Status(InvalidArgumentStatus, "The configured destination refused the batch.")),
+        ClientTelemetryFailure.Throttled => new OtlpProtobufResult(
+            StatusCodes.Status429TooManyRequests,
+            OtlpExportPayload.Status(ResourceExhaustedStatus, "The configured destination is being sent too much."),
+            forwarding.RetryAfter),
+        _ => new OtlpProtobufResult(
+            StatusCodes.Status503ServiceUnavailable,
+            OtlpExportPayload.Status(UnavailableStatus, "The configured destination did not take the batch.")),
+    };
+
+    /// <summary>Answers a batch this endpoint would not read, counting it and saying why.</summary>
+    private static OtlpProtobufResult RefusedPayload(
+        ClientTelemetryProxyTelemetry telemetry,
+        ClientTelemetrySignal signal,
+        OtlpPayloadRefusal refusal) => refusal == OtlpPayloadRefusal.TooManyRecords
+        ? Refused(
+            telemetry,
+            signal,
+            "too_many_records",
+            StatusCodes.Status413PayloadTooLarge,
+            InvalidArgumentStatus,
+            $"An export batch carries at most {MaxRecordsPerBatch} records.")
+        : Refused(
+            telemetry,
+            signal,
+            "malformed",
+            StatusCodes.Status400BadRequest,
+            InvalidArgumentStatus,
+            "The body is not an OTLP export request this endpoint can read.");
+
+    /// <summary>Counts one refusal and writes the answer that goes with it.</summary>
+    /// <remarks>The refusal word and the status travel together so a counter and an answer cannot come to disagree about what happened.</remarks>
+    private static OtlpProtobufResult Refused(
+        ClientTelemetryProxyTelemetry telemetry,
+        ClientTelemetrySignal signal,
+        string refusal,
+        int httpStatus,
+        int statusCode,
+        string message,
+        TimeSpan? retryAfter = null)
+    {
+        telemetry.RecordRefused(signal, refusal);
+
+        return new OtlpProtobufResult(httpStatus, OtlpExportPayload.Status(statusCode, message), retryAfter);
+    }
+
+    /// <summary>Reads the batch out of the request body, or reports that it is past what this endpoint accepts.</summary>
+    /// <remarks>
+    /// The bound is enforced twice by construction rather than by care: the request size metadata stops a declared
+    /// length before the handler runs and raises during the read where the sender declared none, and the length is read
+    /// back afterwards so nothing depends on which of the two fired.
+    /// </remarks>
+    private static async Task<byte[]?> ReadBatchAsync(HttpContext context, CancellationToken cancellationToken)
+    {
+        if (context.Request.ContentLength > MaxRequestBytes)
+        {
+            return null;
+        }
+
+        using var batch = new MemoryStream(
+            context.Request.ContentLength is { } declared and > 0 and <= MaxRequestBytes ? (int)declared : 0);
+
+        try
+        {
+            await context.Request.Body.CopyToAsync(batch, cancellationToken);
+        }
+        catch (BadHttpRequestException)
+        {
+            return null;
+        }
+
+        return batch.Length > MaxRequestBytes ? null : batch.ToArray();
+    }
+
+    /// <summary>Reports whether the request declares the one media type this endpoint reads.</summary>
+    /// <remarks>JSON is deliberately not accepted. The specification permits a receiver to take either, and one encoding is one parser, one bound, and one thing to get right.</remarks>
+    private static bool SpeaksProtobuf(string? contentType) =>
+        MediaTypeHeaderValue.TryParse(contentType, out var declared)
+        && string.Equals(
+            declared.MediaType.Value,
+            ClientTelemetryForwarder.ProtobufMediaType,
+            StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Writes one protocol buffers document back to the client, under the status the specification names.</summary>
+    /// <param name="StatusCode">The response status.</param>
+    /// <param name="Body">The encoded document, which is empty for a destination that answered nothing.</param>
+    /// <param name="RetryAfter">How long the client is asked to hold for, where there is an answer to that.</param>
+    /// <remarks>
+    /// A result of its own rather than one of the typed helpers, because every one of them fixes the status, the media
+    /// type, or both, and this endpoint answers four statuses with the same media type on all of them — the
+    /// specification requires the document whether the news is good or not.
+    /// </remarks>
+    private sealed record OtlpProtobufResult(int StatusCode, byte[] Body, TimeSpan? RetryAfter = null) : IResult
+    {
+        /// <inheritdoc />
+        public Task ExecuteAsync(HttpContext httpContext)
+        {
+            ArgumentNullException.ThrowIfNull(httpContext);
+
+            httpContext.Response.StatusCode = this.StatusCode;
+            httpContext.Response.ContentType = ClientTelemetryForwarder.ProtobufMediaType;
+            httpContext.Response.ContentLength = this.Body.Length;
+
+            if (this.RetryAfter is { } delay)
+            {
+                httpContext.Response.Headers.RetryAfter = ((int)Math.Ceiling(delay.TotalSeconds))
+                    .ToString(CultureInfo.InvariantCulture);
+            }
+
+            return httpContext.Response.Body.WriteAsync(this.Body, 0, this.Body.Length, httpContext.RequestAborted);
+        }
+    }
+}

--- a/backend/src/Host/HostComposition.cs
+++ b/backend/src/Host/HostComposition.cs
@@ -67,6 +67,7 @@ using MailFathom.Host.Hosting;
 using MailFathom.Host.Hosting.Startup;
 using MailFathom.Host.Hosting.Warnings;
 using MailFathom.Host.Hosting.Workers;
+using MailFathom.Host.Observability.ClientTelemetry;
 using MailFathom.Host.Security.Endpoints;
 using MailFathom.Host.Security.Mcp;
 using MailFathom.Host.Security.Transport;
@@ -81,6 +82,7 @@ using MailFathom.Infrastructure.Rules;
 using MailFathom.Infrastructure.Secrets.Resolution;
 using MailFathom.Mcp;
 using Microsoft.Extensions.Options;
+using OpenTelemetry.Exporter;
 
 namespace MailFathom.Host;
 
@@ -1293,6 +1295,7 @@ internal static class HostComposition
         if (clientEndpointSettings.Enabled)
         {
             builder.Services.AddClientTransportSecurity(clientEndpointSettings);
+            AddClientTelemetryProxy(builder);
         }
 
         // A separate callback from the listener binding below, and outside its condition, because the two decide different
@@ -1352,5 +1355,41 @@ internal static class HostComposition
             mcpRequestTimeout,
             adminRequestTimeout,
             clientRequestTimeout);
+    }
+
+    /// <summary>Registers what forwards a signed-in client's own telemetry, where this deployment named somewhere to forward it.</summary>
+    /// <remarks>
+    /// <para>
+    /// The destination variable is the whole switch. There is no key of its own, so a deployment cannot end up
+    /// forwarding a client's telemetry somewhere its own signals do not go — and where nothing is registered here,
+    /// <see cref="ClientTelemetryEndpoint.MapClientTelemetry" /> maps no route, which is how a deployment that
+    /// configured no collector answers a client that tried.
+    /// </para>
+    /// <para>
+    /// The destination is read once, through the same options type the SDK's own exporter is configured from, because
+    /// the exporter reads its configuration while the host is being built and a proxy re-reading it per request could
+    /// come to disagree with where this process's own signals are going.
+    /// </para>
+    /// <para>
+    /// The forwarding client keeps the standard resilience handler the service defaults give every client, and refuses
+    /// redirects: a collector answering a redirect would move somebody's telemetry and the deployment's own collector
+    /// credential to whatever host the answer named. Its ceiling is not set here, because the one that applies is the
+    /// exporter's own configured timeout and the forwarder holds it.
+    /// </para>
+    /// </remarks>
+    private static void AddClientTelemetryProxy(IHostApplicationBuilder builder)
+    {
+        if (!ServiceDefaultsExtensions.ExportsOverOtlp(builder.Configuration))
+        {
+            return;
+        }
+
+        builder.Services.AddSingleton(ClientTelemetryDestination.From(new OtlpExporterOptions()));
+        builder.Services.AddSingleton<ClientTelemetryQuota>();
+        builder.Services.AddSingleton<ClientTelemetryProxyTelemetry>();
+        builder.Services.AddSingleton<ClientTelemetryForwarder>();
+
+        builder.Services.AddHttpClient(ClientTelemetryForwarder.HttpClientName)
+            .ConfigurePrimaryHttpMessageHandler(static () => new SocketsHttpHandler { AllowAutoRedirect = false });
     }
 }

--- a/backend/src/Host/Observability/ClientTelemetry/ClientTelemetryDestination.cs
+++ b/backend/src/Host/Observability/ClientTelemetry/ClientTelemetryDestination.cs
@@ -1,0 +1,94 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using OpenTelemetry.Exporter;
+
+namespace MailFathom.Host.Observability.ClientTelemetry;
+
+/// <summary>Where the proxy forwards a client's telemetry, which is wherever this process exports its own.</summary>
+/// <remarks>
+/// <para>
+/// There is no second destination and no key of its own. The collector's address and its credential belong to the
+/// deployment — they travel in <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> and <c>OTEL_EXPORTER_OTLP_HEADERS</c>, which
+/// <see cref="Configuration.EnvironmentOnlySettings" /> already refuses from every source but the process environment —
+/// and a client holding either would be publishing them to whoever opened the developer tools. One collector, one
+/// credential, both stacks.
+/// </para>
+/// <para>
+/// The values are read through <see cref="OtlpExporterOptions" /> rather than out of the environment a second time.
+/// That is the type the SDK's own exporter is configured from, so the endpoint, the protocol, the headers, and the
+/// timeout this forwards under are the ones the deployment's own telemetry already leaves by, including every
+/// precedence rule about which variable outranks which. A reading of its own would be a second answer to a question
+/// with one.
+/// </para>
+/// <para>
+/// It is resolved once, while the host is being composed, because the exporter reads its own configuration then and a
+/// destination the proxy re-read per request could come to disagree with where the service's own signals are going.
+/// </para>
+/// </remarks>
+/// <param name="Endpoint">The collector's address, as the exporter resolved it.</param>
+/// <param name="Protocol">Which OTLP transport the deployment's exporter speaks, which is the one a batch is forwarded over.</param>
+/// <param name="Headers">What the collector requires on a request, which is where its credential travels.</param>
+/// <param name="Timeout">The ceiling on one forwarded request.</param>
+internal sealed record ClientTelemetryDestination(
+    Uri Endpoint,
+    OtlpExportProtocol Protocol,
+    IReadOnlyList<KeyValuePair<string, string>> Headers,
+    TimeSpan Timeout)
+{
+    /// <summary>Reads the destination the deployment's own exporter is configured with.</summary>
+    /// <param name="exporterSettings">The exporter settings, which read the standard variables when they are constructed.</param>
+    /// <returns>The destination one batch is forwarded to.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="exporterSettings" /> is <see langword="null" />.</exception>
+    internal static ClientTelemetryDestination From(OtlpExporterOptions exporterSettings)
+    {
+        ArgumentNullException.ThrowIfNull(exporterSettings);
+
+        return new ClientTelemetryDestination(
+            exporterSettings.Endpoint,
+            exporterSettings.Protocol,
+            ParseHeaders(exporterSettings.Headers),
+            TimeSpan.FromMilliseconds(exporterSettings.TimeoutMilliseconds));
+    }
+
+    /// <summary>Names the address one signal's batch is posted to.</summary>
+    /// <param name="signal">The signal being forwarded.</param>
+    /// <returns>The address the request is sent to.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="signal" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The signal's own path is appended under both protocols, because under both the address names a server rather
+    /// than a signal: over gRPC the method is part of the address, and over HTTP the specification fixes the path a
+    /// receiver serves each signal at. What it is appended to is always the base endpoint, because that is the variable
+    /// this destination is read from and a deployment that set only the per-signal ones serves no route here at all.
+    /// </remarks>
+    internal Uri AddressFor(ClientTelemetrySignal signal)
+    {
+        ArgumentNullException.ThrowIfNull(signal);
+
+        return Append(
+            this.Endpoint,
+            this.Protocol == OtlpExportProtocol.Grpc ? signal.ServiceMethod : signal.Route);
+    }
+
+    /// <summary>Reads the header list the OpenTelemetry specification defines for the standard variable.</summary>
+    /// <remarks>
+    /// A pair whose value carries a comma or an equals sign arrives percent-encoded, which is the encoding the
+    /// specification names and the one the exporter's own reader undoes. A malformed pair is dropped rather than
+    /// refused: the exporter reading the same string drops it too, and failing startup here over a value the exporter
+    /// accepted would refuse a deployment whose own telemetry works.
+    /// </remarks>
+    private static IReadOnlyList<KeyValuePair<string, string>> ParseHeaders(string? headers) =>
+    [
+        .. (headers ?? string.Empty)
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(pair => pair.Split('=', 2))
+            .Where(pair => pair.Length == 2 && pair[0].Length > 0)
+            .Select(pair => new KeyValuePair<string, string>(
+                pair[0].Trim(),
+                Uri.UnescapeDataString(pair[1].Trim()))),
+    ];
+
+    private static Uri Append(Uri endpoint, string path) =>
+        new UriBuilder(endpoint) { Path = endpoint.AbsolutePath.TrimEnd('/') + path }.Uri;
+}

--- a/backend/src/Host/Observability/ClientTelemetry/ClientTelemetryForwarder.cs
+++ b/backend/src/Host/Observability/ClientTelemetry/ClientTelemetryForwarder.cs
@@ -1,0 +1,235 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Buffers.Binary;
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using OpenTelemetry.Exporter;
+
+namespace MailFathom.Host.Observability.ClientTelemetry;
+
+/// <summary>Sends one batch of a client's telemetry on to the collector this deployment already exports to.</summary>
+/// <remarks>
+/// <para>
+/// It speaks whichever OTLP transport the deployment's own exporter speaks, because the destination is the same
+/// destination and a collector configured for one of them is not necessarily listening for the other. Over HTTP that is
+/// the batch posted verbatim under the specification's media type; over gRPC it is the same octets inside the
+/// length-prefixed frame that protocol wraps a unary message in, which is the whole of the difference — the message on
+/// the wire is identical, so nothing here decodes or re-encodes a payload to change protocol.
+/// </para>
+/// <para>
+/// Nothing is buffered and nothing is retried in this process beyond what the shared resilience handler already does.
+/// A batch that cannot be forwarded is dropped and the caller is told so, because the client is the one holding what it
+/// has not exported and it will send it again — a queue here would be a second copy of somebody's telemetry, kept in a
+/// process that never promised to keep it.
+/// </para>
+/// <para>
+/// A rejection and a failure are answered differently, which is the distinction the OTLP specification draws between a
+/// request a receiver will never accept and one it could accept later. A collector refusing the payload is relayed as
+/// the refusal it is, so the client stops rather than retrying forever; anything transient is answered as
+/// unavailability, which is what tells the client to hold.
+/// </para>
+/// </remarks>
+internal sealed class ClientTelemetryForwarder
+{
+    /// <summary>The name the forwarding client is registered under, which is the only way to obtain one with these bounds.</summary>
+    internal const string HttpClientName = "MailFathom.ClientTelemetryProxy";
+
+    /// <summary>The media type the OTLP specification fixes for a protocol buffers payload over HTTP.</summary>
+    internal const string ProtobufMediaType = "application/x-protobuf";
+
+    private const string GrpcMediaType = "application/grpc";
+    private const string GrpcStatusHeader = "grpc-status";
+    private const int GrpcFrameHeaderLength = 5;
+
+    private readonly IHttpClientFactory clients;
+    private readonly ClientTelemetryDestination destination;
+
+    /// <summary>Initializes the forwarder over the destination composition resolved.</summary>
+    /// <param name="clients">Builds the bounded client one forward is sent on.</param>
+    /// <param name="destination">Where the deployment's own telemetry goes, which is where this goes.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="clients" /> or <paramref name="destination" /> is <see langword="null" />.</exception>
+    public ClientTelemetryForwarder(IHttpClientFactory clients, ClientTelemetryDestination destination)
+    {
+        ArgumentNullException.ThrowIfNull(clients);
+        ArgumentNullException.ThrowIfNull(destination);
+
+        this.clients = clients;
+        this.destination = destination;
+    }
+
+    /// <summary>Forwards one batch and reports what the caller should be answered.</summary>
+    /// <param name="signal">The signal the batch belongs to.</param>
+    /// <param name="batch">The batch, already rewritten to name the owner it belongs to.</param>
+    /// <param name="cancellationToken">Cancels the forward when the client disconnects.</param>
+    /// <returns>What to answer the client, and the condition to report where the batch did not arrive.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="signal" /> or <paramref name="batch" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The ceiling is the exporter's own configured timeout, applied here rather than left to the client's registration
+    /// so that a deployment changing <c>OTEL_EXPORTER_OTLP_TIMEOUT</c> moves both this and its own exports together.
+    /// </remarks>
+    internal async Task<ClientTelemetryForwarding> ForwardAsync(
+        ClientTelemetrySignal signal,
+        byte[] batch,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(signal);
+        ArgumentNullException.ThrowIfNull(batch);
+
+        using var deadline = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        deadline.CancelAfter(this.destination.Timeout);
+
+        try
+        {
+            using var client = this.clients.CreateClient(HttpClientName);
+            using var request = this.Compose(signal, batch);
+            using var response = await client.SendAsync(request, deadline.Token);
+
+            return this.destination.Protocol == OtlpExportProtocol.Grpc
+                ? await ReadGrpcAsync(response, deadline.Token)
+                : await ReadHttpAsync(response, deadline.Token);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return ClientTelemetryForwarding.Failed(ClientTelemetryFailure.Cancelled);
+        }
+        catch (OperationCanceledException)
+        {
+            return ClientTelemetryForwarding.Failed(ClientTelemetryFailure.TimedOut);
+        }
+        catch (HttpRequestException)
+        {
+            return ClientTelemetryForwarding.Failed(ClientTelemetryFailure.Unreachable);
+        }
+    }
+
+    /// <summary>Composes the request one batch travels in, under whichever transport the destination speaks.</summary>
+    private HttpRequestMessage Compose(ClientTelemetrySignal signal, byte[] batch)
+    {
+        var overGrpc = this.destination.Protocol == OtlpExportProtocol.Grpc;
+
+        var request = new HttpRequestMessage(HttpMethod.Post, this.destination.AddressFor(signal))
+        {
+            Content = new ByteArrayContent(overGrpc ? GrpcFrame(batch) : batch),
+        };
+
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue(overGrpc ? GrpcMediaType : ProtobufMediaType);
+
+        if (overGrpc)
+        {
+            // gRPC is defined over HTTP/2 alone, and an exact version is what makes a clear-text destination negotiate
+            // it rather than fall back to HTTP/1.1 and answer a protocol error the collector never saw.
+            request.Version = HttpVersion.Version20;
+            request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
+            request.Headers.TryAddWithoutValidation("grpc-encoding", "identity");
+            request.Headers.TryAddWithoutValidation("te", "trailers");
+        }
+
+        foreach (var header in this.destination.Headers)
+        {
+            request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
+
+        return request;
+    }
+
+    /// <summary>Reads what the collector answered an OTLP/HTTP export with.</summary>
+    /// <remarks>
+    /// A success is relayed body and all, because that body is where a partial success lives: a collector that accepted
+    /// eight records of ten says so in it, and answering the client a bare success instead would hide a rejection it is
+    /// entitled to read.
+    /// </remarks>
+    private static async Task<ClientTelemetryForwarding> ReadHttpAsync(
+        HttpResponseMessage response,
+        CancellationToken cancellationToken)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            return ClientTelemetryForwarding.Forwarded(
+                await response.Content.ReadAsByteArrayAsync(cancellationToken));
+        }
+
+        if (response.StatusCode is HttpStatusCode.TooManyRequests)
+        {
+            return ClientTelemetryForwarding.Throttled(response.Headers.RetryAfter?.Delta);
+        }
+
+        return (int)response.StatusCode >= StatusCodes.Status500InternalServerError
+            ? ClientTelemetryForwarding.Failed(ClientTelemetryFailure.Unavailable)
+            : ClientTelemetryForwarding.Refused();
+    }
+
+    /// <summary>Reads what the collector answered a gRPC export with, which is a status rather than a response code.</summary>
+    /// <remarks>
+    /// The status arrives in the trailers of an ordinary answer and in the headers of a trailers-only one, so both are
+    /// consulted; an answer carrying neither is treated as a failure rather than as a success, because a success is the
+    /// one thing a gRPC server states explicitly.
+    /// </remarks>
+    private static async Task<ClientTelemetryForwarding> ReadGrpcAsync(
+        HttpResponseMessage response,
+        CancellationToken cancellationToken)
+    {
+        var body = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+
+        if (GrpcStatusOf(response) is not { } status)
+        {
+            return ClientTelemetryForwarding.Failed(ClientTelemetryFailure.Unavailable);
+        }
+
+        return status switch
+        {
+            GrpcStatus.Ok => ClientTelemetryForwarding.Forwarded(Unframe(body)),
+            GrpcStatus.InvalidArgument or GrpcStatus.NotFound or GrpcStatus.Unimplemented =>
+                ClientTelemetryForwarding.Refused(),
+            GrpcStatus.ResourceExhausted => ClientTelemetryForwarding.Throttled(retryAfter: null),
+            _ => ClientTelemetryForwarding.Failed(ClientTelemetryFailure.Unavailable),
+        };
+    }
+
+    /// <summary>Reads the gRPC status out of whichever half of the answer carries it.</summary>
+    private static int? GrpcStatusOf(HttpResponseMessage response)
+    {
+        if (!response.IsSuccessStatusCode)
+        {
+            return null;
+        }
+
+        var stated = Stated(response.TrailingHeaders) ?? Stated(response.Headers);
+
+        return int.TryParse(stated, NumberStyles.Integer, CultureInfo.InvariantCulture, out var status)
+            ? status
+            : null;
+
+        static string? Stated(HttpHeaders headers) =>
+            headers.TryGetValues(GrpcStatusHeader, out var values) ? values.FirstOrDefault() : null;
+    }
+
+    /// <summary>Wraps one message in the frame a gRPC unary call carries it in.</summary>
+    /// <remarks>The leading octet says the message is not compressed, and the four after it are its length, most significant octet first.</remarks>
+    private static byte[] GrpcFrame(byte[] message)
+    {
+        var framed = new byte[GrpcFrameHeaderLength + message.Length];
+        framed[0] = 0;
+        BinaryPrimitives.WriteUInt32BigEndian(framed.AsSpan(1, 4), (uint)message.Length);
+        message.CopyTo(framed, GrpcFrameHeaderLength);
+
+        return framed;
+    }
+
+    /// <summary>Takes one message back out of the frame a gRPC answer carries it in.</summary>
+    /// <remarks>A compressed frame is answered as an empty success rather than relayed, because the client is owed the specification's own encoding and this endpoint asked for none.</remarks>
+    private static byte[] Unframe(byte[] framed) =>
+        framed.Length > GrpcFrameHeaderLength && framed[0] == 0 ? framed[GrpcFrameHeaderLength..] : [];
+
+    /// <summary>The gRPC status codes this forwarder tells apart, which is every one it answers differently.</summary>
+    private static class GrpcStatus
+    {
+        internal const int Ok = 0;
+        internal const int InvalidArgument = 3;
+        internal const int NotFound = 5;
+        internal const int ResourceExhausted = 8;
+        internal const int Unimplemented = 12;
+    }
+}

--- a/backend/src/Host/Observability/ClientTelemetry/ClientTelemetryForwarder.cs
+++ b/backend/src/Host/Observability/ClientTelemetry/ClientTelemetryForwarder.cs
@@ -54,18 +54,25 @@ internal sealed class ClientTelemetryForwarder
 
     private readonly IHttpClientFactory clients;
     private readonly ClientTelemetryDestination destination;
+    private readonly TimeProvider clock;
 
     /// <summary>Initializes the forwarder over the destination composition resolved.</summary>
     /// <param name="clients">Builds the bounded client one forward is sent on.</param>
     /// <param name="destination">Where the deployment's own telemetry goes, which is where this goes.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="clients" /> or <paramref name="destination" /> is <see langword="null" />.</exception>
-    public ClientTelemetryForwarder(IHttpClientFactory clients, ClientTelemetryDestination destination)
+    /// <param name="clock">Times the deadline one forward is given, so a suite can reach it without waiting it out.</param>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    public ClientTelemetryForwarder(
+        IHttpClientFactory clients,
+        ClientTelemetryDestination destination,
+        TimeProvider clock)
     {
         ArgumentNullException.ThrowIfNull(clients);
         ArgumentNullException.ThrowIfNull(destination);
+        ArgumentNullException.ThrowIfNull(clock);
 
         this.clients = clients;
         this.destination = destination;
+        this.clock = clock;
     }
 
     /// <summary>Forwards one batch and reports what the caller should be answered.</summary>
@@ -86,18 +93,21 @@ internal sealed class ClientTelemetryForwarder
         ArgumentNullException.ThrowIfNull(signal);
         ArgumentNullException.ThrowIfNull(batch);
 
-        using var deadline = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        deadline.CancelAfter(this.destination.Timeout);
+        // Two sources rather than one: the deadline is the exporter's own and is timed by the injected clock, and the
+        // caller's token is what a disconnected client cancels through. Linking them keeps the two apart at the catch
+        // below, which is what tells a timeout from a client that hung up.
+        using var deadline = new CancellationTokenSource(this.destination.Timeout, this.clock);
+        using var forwarding = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, deadline.Token);
 
         try
         {
             using var client = this.clients.CreateClient(HttpClientName);
             using var request = this.Compose(signal, batch);
-            using var response = await client.SendAsync(request, deadline.Token);
+            using var response = await client.SendAsync(request, forwarding.Token);
 
             return this.destination.Protocol == OtlpExportProtocol.Grpc
-                ? await ReadGrpcAsync(response, deadline.Token)
-                : await ReadHttpAsync(response, deadline.Token);
+                ? await ReadGrpcAsync(response, forwarding.Token)
+                : await ReadHttpAsync(response, forwarding.Token);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {

--- a/backend/src/Host/Observability/ClientTelemetry/ClientTelemetryForwarder.cs
+++ b/backend/src/Host/Observability/ClientTelemetry/ClientTelemetryForwarder.cs
@@ -31,6 +31,14 @@ namespace MailFathom.Host.Observability.ClientTelemetry;
 /// the refusal it is, so the client stops rather than retrying forever; anything transient is answered as
 /// unavailability, which is what tells the client to hold.
 /// </para>
+/// <para>
+/// A destination that will not take <b>this deployment's own credential</b> is neither of those, and both transports
+/// sort it into a condition of its own. It is not the client's batch that was wrong, so answering the refusal would
+/// have a browser drop telemetry over a credential nobody there can repair, and it is not a collector that is down, so
+/// folding it into unavailability would leave the one condition an operator has to act on indistinguishable from the
+/// one they wait out. The client is therefore told to hold, exactly as it is for anything else transient, and the
+/// condition is named for the deployment on the counter and in the line the proxy writes.
+/// </para>
 /// </remarks>
 internal sealed class ClientTelemetryForwarder
 {
@@ -156,6 +164,11 @@ internal sealed class ClientTelemetryForwarder
             return ClientTelemetryForwarding.Throttled(response.Headers.RetryAfter?.Delta);
         }
 
+        if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+        {
+            return ClientTelemetryForwarding.Failed(ClientTelemetryFailure.Unauthorized);
+        }
+
         return (int)response.StatusCode >= StatusCodes.Status500InternalServerError
             ? ClientTelemetryForwarding.Failed(ClientTelemetryFailure.Unavailable)
             : ClientTelemetryForwarding.Refused();
@@ -183,6 +196,8 @@ internal sealed class ClientTelemetryForwarder
             GrpcStatus.Ok => ClientTelemetryForwarding.Forwarded(Unframe(body)),
             GrpcStatus.InvalidArgument or GrpcStatus.NotFound or GrpcStatus.Unimplemented =>
                 ClientTelemetryForwarding.Refused(),
+            GrpcStatus.PermissionDenied or GrpcStatus.Unauthenticated =>
+                ClientTelemetryForwarding.Failed(ClientTelemetryFailure.Unauthorized),
             GrpcStatus.ResourceExhausted => ClientTelemetryForwarding.Throttled(retryAfter: null),
             _ => ClientTelemetryForwarding.Failed(ClientTelemetryFailure.Unavailable),
         };
@@ -229,7 +244,9 @@ internal sealed class ClientTelemetryForwarder
         internal const int Ok = 0;
         internal const int InvalidArgument = 3;
         internal const int NotFound = 5;
+        internal const int PermissionDenied = 7;
         internal const int ResourceExhausted = 8;
         internal const int Unimplemented = 12;
+        internal const int Unauthenticated = 16;
     }
 }

--- a/backend/src/Host/Observability/ClientTelemetry/ClientTelemetryForwarding.cs
+++ b/backend/src/Host/Observability/ClientTelemetry/ClientTelemetryForwarding.cs
@@ -1,0 +1,81 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Host.Observability.ClientTelemetry;
+
+/// <summary>What became of one batch the proxy sent on, and what the client is owed as a result.</summary>
+/// <param name="Failure">The condition that stopped the batch, or <see cref="ClientTelemetryFailure.None" /> where it arrived.</param>
+/// <param name="Body">What the destination answered, relayed to the client so a partial success is not hidden behind a success.</param>
+/// <param name="RetryAfter">How long the destination asked to be left alone for, where it said.</param>
+/// <remarks>
+/// One type covers arrival, refusal, and failure because the caller answers all three from the same place and the
+/// difference between them is exactly one value. Splitting it would put the question of which case a result is into the
+/// type system and the question of what to answer for it somewhere else.
+/// </remarks>
+internal readonly record struct ClientTelemetryForwarding(
+    ClientTelemetryFailure Failure,
+    byte[] Body,
+    TimeSpan? RetryAfter)
+{
+    /// <summary>Gets whether the batch reached the destination.</summary>
+    internal bool Arrived => this.Failure == ClientTelemetryFailure.None;
+
+    /// <summary>Reports a batch the destination accepted, carrying whatever it answered.</summary>
+    /// <param name="body">The destination's own answer, which is where a partial success lives.</param>
+    /// <returns>The forwarding.</returns>
+    internal static ClientTelemetryForwarding Forwarded(byte[] body) =>
+        new(ClientTelemetryFailure.None, body, RetryAfter: null);
+
+    /// <summary>Reports a batch the destination will never accept.</summary>
+    /// <returns>The forwarding.</returns>
+    /// <remarks>
+    /// What the destination said about it is deliberately not carried. A refusal from a collector is about this
+    /// deployment's own export — a credential it would not take, a version it does not speak — and relaying that
+    /// document to a browser would publish the deployment's infrastructure to whoever is signed in. A partial success
+    /// is the one answer a client is owed verbatim, and that arrives as an arrival rather than as this.
+    /// </remarks>
+    internal static ClientTelemetryForwarding Refused() =>
+        new(ClientTelemetryFailure.Refused, [], RetryAfter: null);
+
+    /// <summary>Reports a destination asking to be sent less.</summary>
+    /// <param name="retryAfter">How long it asked for, where it said.</param>
+    /// <returns>The forwarding.</returns>
+    internal static ClientTelemetryForwarding Throttled(TimeSpan? retryAfter) =>
+        new(ClientTelemetryFailure.Throttled, [], retryAfter);
+
+    /// <summary>Reports a batch that did not arrive and may arrive later.</summary>
+    /// <param name="failure">Which condition stopped it.</param>
+    /// <returns>The forwarding.</returns>
+    internal static ClientTelemetryForwarding Failed(ClientTelemetryFailure failure) => new(failure, [], RetryAfter: null);
+}
+
+/// <summary>Why a batch did not reach the destination, at the level a deployment acts on.</summary>
+/// <remarks>
+/// These are conditions rather than incidents, which is what makes the proxy quiet: a collector that has been down for
+/// an hour is one of these repeating, and the log line the deployment reads is written per condition rather than per
+/// batch.
+/// </remarks>
+internal enum ClientTelemetryFailure
+{
+    /// <summary>The batch arrived.</summary>
+    None = 0,
+
+    /// <summary>The destination will never accept the batch, and said so.</summary>
+    Refused = 1,
+
+    /// <summary>The destination asked to be sent less.</summary>
+    Throttled = 2,
+
+    /// <summary>The destination answered that it could not take the batch now.</summary>
+    Unavailable = 3,
+
+    /// <summary>The destination did not answer inside the exporter's own configured timeout.</summary>
+    TimedOut = 4,
+
+    /// <summary>Nothing answered at the destination's address at all.</summary>
+    Unreachable = 5,
+
+    /// <summary>The client that sent the batch disconnected before the destination answered.</summary>
+    Cancelled = 6,
+}

--- a/backend/src/Host/Observability/ClientTelemetry/ClientTelemetryForwarding.cs
+++ b/backend/src/Host/Observability/ClientTelemetry/ClientTelemetryForwarding.cs
@@ -78,4 +78,13 @@ internal enum ClientTelemetryFailure
 
     /// <summary>The client that sent the batch disconnected before the destination answered.</summary>
     Cancelled = 6,
+
+    /// <summary>The destination would not take this deployment's own credential.</summary>
+    /// <remarks>
+    /// Its own condition rather than one of the two it sits between, because it is the one forwarding failure an
+    /// operator repairs rather than waits out, and neither neighbour would say so: folded into
+    /// <see cref="Unavailable" /> it reads as a collector that is down, and folded into <see cref="Refused" /> it would
+    /// tell a client to drop a batch that is not what was wrong.
+    /// </remarks>
+    Unauthorized = 7,
 }

--- a/backend/src/Host/Observability/ClientTelemetry/ClientTelemetryProxyTelemetry.cs
+++ b/backend/src/Host/Observability/ClientTelemetry/ClientTelemetryProxyTelemetry.cs
@@ -166,6 +166,7 @@ internal sealed partial class ClientTelemetryProxyTelemetry
         ClientTelemetryFailure.Unavailable => "unavailable",
         ClientTelemetryFailure.TimedOut => "timed_out",
         ClientTelemetryFailure.Unreachable => "unreachable",
+        ClientTelemetryFailure.Unauthorized => "unauthorized",
         _ => "cancelled",
     };
 

--- a/backend/src/Host/Observability/ClientTelemetry/ClientTelemetryProxyTelemetry.cs
+++ b/backend/src/Host/Observability/ClientTelemetry/ClientTelemetryProxyTelemetry.cs
@@ -1,0 +1,215 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using MailFathom.Common.Observability;
+
+namespace MailFathom.Host.Observability.ClientTelemetry;
+
+/// <summary>Reports what the proxy accepted, refused, forwarded, and failed to forward.</summary>
+/// <remarks>
+/// <para>
+/// The proxy is silent while it works, and that is a constraint rather than a preference. A signed-in client exports
+/// every few seconds for as long as it is open, so a record per accepted batch would be the largest thing in a
+/// deployment's own logs within a day while saying nothing that was not already true — an operator reading their logs
+/// would be reading the bookkeeping rather than the deployment. So accepting and forwarding writes nothing at all, at
+/// any level, and the numbers live here instead.
+/// </para>
+/// <para>
+/// A failure does write a line, and it is written <b>per condition rather than per batch</b>. A collector that has been
+/// unreachable for an hour is one condition, not two thousand incidents, so the first batch to meet it says so and the
+/// next line comes when the condition has held for long enough to be worth repeating — carrying how many batches went
+/// with it, which is the part a rate cannot tell an operator reading a log. The line carries the signal, the condition,
+/// and a count, and no part of any payload: what was in a batch is somebody's telemetry, and none of it is this
+/// process's to write down.
+/// </para>
+/// <para>
+/// Every instrument's dimensions are closed sets of this process's own words — three signal names, six refusals, six
+/// conditions — so nothing here opens a series per person, per batch, or per collector. The owner a batch was
+/// attributed to is deliberately on no instrument, for the reason
+/// <see cref="Infrastructure.Observability.SensitiveContentEgressTelemetry" /> states about the same identifier: a
+/// counter incremented once per export would be a time series per person.
+/// </para>
+/// </remarks>
+internal sealed partial class ClientTelemetryProxyTelemetry
+{
+    /// <summary>Which of the three signals a batch belonged to.</summary>
+    internal const string SignalTagName = "mailfathom.client_telemetry.signal";
+
+    /// <summary>Why this endpoint refused a batch before anything was forwarded.</summary>
+    internal const string RefusalTagName = "mailfathom.client_telemetry.refusal";
+
+    /// <summary>What stopped a batch from reaching the destination.</summary>
+    internal const string ConditionTagName = "mailfathom.client_telemetry.condition";
+
+    /// <summary>How long one condition holds before a second line is written about it.</summary>
+    /// <remarks>
+    /// Long enough that an outage is a handful of lines an hour rather than a stream, and short enough that an operator
+    /// watching a deployment sees the condition is still true. It is a constant rather than a setting because it
+    /// decides nothing an operator configures around: what they act on is the condition, and the counter beside it
+    /// already reports the rate at whatever resolution their collector keeps.
+    /// </remarks>
+    private static readonly TimeSpan QuietPeriodPerCondition = TimeSpan.FromMinutes(5);
+
+    private readonly ConcurrentDictionary<string, ReportedCondition> reportedConditions = new(StringComparer.Ordinal);
+    private readonly ILogger<ClientTelemetryProxyTelemetry> logger;
+    private readonly TimeProvider clock;
+    private readonly Counter<long> acceptedBatchCount;
+    private readonly Counter<long> acceptedRecordCount;
+    private readonly Counter<long> refusedBatchCount;
+    private readonly Counter<long> forwardedBatchCount;
+    private readonly Counter<long> failedBatchCount;
+
+    /// <summary>Initializes the instruments every forwarded batch reports through.</summary>
+    /// <param name="logger">Where a forwarding condition is written, and nothing else is.</param>
+    /// <param name="clock">Decides when a condition has held long enough to be written about again.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="logger" /> or <paramref name="clock" /> is <see langword="null" />.</exception>
+    public ClientTelemetryProxyTelemetry(ILogger<ClientTelemetryProxyTelemetry> logger, TimeProvider clock)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(clock);
+
+        this.logger = logger;
+        this.clock = clock;
+
+        this.acceptedBatchCount = Telemetry.Meter.CreateCounter<long>(
+            "mailfathom.client_telemetry.accepted",
+            unit: "{batch}",
+            description: "Client telemetry batches this endpoint read, bounded, and attributed, by signal.");
+        this.acceptedRecordCount = Telemetry.Meter.CreateCounter<long>(
+            "mailfathom.client_telemetry.records",
+            unit: "{record}",
+            description: "Records carried by the accepted batches, by signal, which is what their volume is read against.");
+        this.refusedBatchCount = Telemetry.Meter.CreateCounter<long>(
+            "mailfathom.client_telemetry.refused",
+            unit: "{batch}",
+            description: "Client telemetry batches this endpoint refused before forwarding anything, by signal and refusal.");
+        this.forwardedBatchCount = Telemetry.Meter.CreateCounter<long>(
+            "mailfathom.client_telemetry.forwarded",
+            unit: "{batch}",
+            description: "Client telemetry batches the configured destination accepted, by signal.");
+        this.failedBatchCount = Telemetry.Meter.CreateCounter<long>(
+            "mailfathom.client_telemetry.failed",
+            unit: "{batch}",
+            description: "Client telemetry batches that did not reach the destination, by signal and condition.");
+    }
+
+    /// <summary>Records a batch this endpoint read and is about to forward.</summary>
+    /// <param name="signal">The signal the batch belongs to.</param>
+    /// <param name="records">How many records it carries.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="signal" /> is <see langword="null" />.</exception>
+    internal void RecordAccepted(ClientTelemetrySignal signal, int records)
+    {
+        ArgumentNullException.ThrowIfNull(signal);
+
+        var tags = new TagList { { SignalTagName, signal.Name } };
+
+        this.acceptedBatchCount.Add(1, tags);
+        this.acceptedRecordCount.Add(records, tags);
+    }
+
+    /// <summary>Records a batch this endpoint refused, which reached no destination and was never counted as accepted.</summary>
+    /// <param name="signal">The signal the batch claimed to belong to.</param>
+    /// <param name="refusal">Why it was refused, in this endpoint's own closed vocabulary.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="signal" /> or <paramref name="refusal" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// No line is written for one. A refusal is the endpoint working — a client sending what this deployment will not
+    /// take is answered, and an answer is not an incident — and the counter is what makes a client suddenly being
+    /// refused visible without a log entry per attempt.
+    /// </remarks>
+    internal void RecordRefused(ClientTelemetrySignal signal, string refusal)
+    {
+        ArgumentNullException.ThrowIfNull(signal);
+        ArgumentNullException.ThrowIfNull(refusal);
+
+        this.refusedBatchCount.Add(
+            1,
+            new TagList { { SignalTagName, signal.Name }, { RefusalTagName, refusal } });
+    }
+
+    /// <summary>Records what became of a batch that was sent on.</summary>
+    /// <param name="signal">The signal the batch belongs to.</param>
+    /// <param name="forwarding">What the destination did with it.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="signal" /> is <see langword="null" />.</exception>
+    internal void RecordForwarding(ClientTelemetrySignal signal, ClientTelemetryForwarding forwarding)
+    {
+        ArgumentNullException.ThrowIfNull(signal);
+
+        if (forwarding.Arrived)
+        {
+            this.forwardedBatchCount.Add(1, new TagList { { SignalTagName, signal.Name } });
+
+            return;
+        }
+
+        var condition = ConditionOf(forwarding.Failure);
+
+        this.failedBatchCount.Add(
+            1,
+            new TagList { { SignalTagName, signal.Name }, { ConditionTagName, condition } });
+
+        this.ReportCondition(signal, condition);
+    }
+
+    /// <summary>Names one forwarding condition in the vocabulary the log and the counter share.</summary>
+    /// <param name="failure">The condition being named.</param>
+    /// <returns>The word the dimension carries.</returns>
+    /// <remarks>Past participles, as every other outcome in this repository is written, so a panel splitting on this reads the same way as one splitting on any other family's.</remarks>
+    internal static string ConditionOf(ClientTelemetryFailure failure) => failure switch
+    {
+        ClientTelemetryFailure.None => "forwarded",
+        ClientTelemetryFailure.Refused => "refused",
+        ClientTelemetryFailure.Throttled => "throttled",
+        ClientTelemetryFailure.Unavailable => "unavailable",
+        ClientTelemetryFailure.TimedOut => "timed_out",
+        ClientTelemetryFailure.Unreachable => "unreachable",
+        _ => "cancelled",
+    };
+
+    /// <summary>Writes a line about one condition, or counts this batch against the line already written for it.</summary>
+    /// <remarks>
+    /// The count reported is the batches that met the condition since the previous line, so a reader sees both that the
+    /// condition holds and how much traffic it is costing. The dictionary is keyed by the condition rather than by the
+    /// signal beside it, because a collector that is unreachable is unreachable for all three and three identical lines
+    /// would be the noise this exists to avoid.
+    /// </remarks>
+    private void ReportCondition(ClientTelemetrySignal signal, string condition)
+    {
+        var now = this.clock.GetUtcNow();
+        var reported = this.reportedConditions.AddOrUpdate(
+            condition,
+            _ => new ReportedCondition(now, Unreported: 0, Due: 1),
+            (_, previous) => previous.WithAnother(now, QuietPeriodPerCondition));
+
+        if (reported.Due > 0)
+        {
+            this.LogForwardingCondition(condition, signal.Name, reported.Due);
+        }
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Client telemetry could not be forwarded to the configured OTLP destination [{Condition}], most "
+            + "recently a {Signal} batch, and {Batches} batch(es) have been dropped under this condition since it was "
+            + "last reported. The clients hold what they have not exported; nothing is queued here.")]
+    private partial void LogForwardingCondition(string condition, string signal, long batches);
+
+    /// <summary>When one condition was last written about, and how many batches have met it silently since.</summary>
+    /// <param name="ReportedAt">When the last line about this condition was written.</param>
+    /// <param name="Unreported">How many batches have met it since that line, none of which produced one.</param>
+    /// <param name="Due">How many batches this line reports, or zero where no line is owed.</param>
+    private readonly record struct ReportedCondition(DateTimeOffset ReportedAt, long Unreported, long Due)
+    {
+        /// <summary>Counts one more batch against this condition, writing it off as a line once the quiet period has passed.</summary>
+        /// <param name="now">The instant the batch failed at.</param>
+        /// <param name="quietPeriod">How long a condition holds before it is worth writing about again.</param>
+        /// <returns>The condition as it now stands, whose <see cref="Due" /> is what the line owed reports.</returns>
+        internal ReportedCondition WithAnother(DateTimeOffset now, TimeSpan quietPeriod) =>
+            now - this.ReportedAt >= quietPeriod
+                ? new ReportedCondition(now, Unreported: 0, Due: this.Unreported + 1)
+                : new ReportedCondition(this.ReportedAt, this.Unreported + 1, Due: 0);
+    }
+}

--- a/backend/src/Host/Observability/ClientTelemetry/ClientTelemetryQuota.cs
+++ b/backend/src/Host/Observability/ClientTelemetry/ClientTelemetryQuota.cs
@@ -1,0 +1,76 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Threading.RateLimiting;
+
+namespace MailFathom.Host.Observability.ClientTelemetry;
+
+/// <summary>Bounds how often one signed-in person's client may export through this deployment.</summary>
+/// <remarks>
+/// <para>
+/// A bucket of its own rather than the surface's, and the reason is where each of the two runs. The client endpoint's
+/// limiter runs ahead of the authorization middleware, so every caller shares one partition until a credential has been
+/// judged — which is the stronger bound for unbounded key guessing and exactly the wrong shape here, because the
+/// callers are all authenticated and one of them exporting continuously would spend the capacity a person reading their
+/// mail needs. This runs behind authentication, where there is an owner to count against.
+/// </para>
+/// <para>
+/// The numbers are constants rather than settings. What an operator configures is whether telemetry is forwarded at
+/// all, which is the destination variable; how fast one browser may push is a property of what a client exports rather
+/// than of a deployment, and a knob here would be one nobody could set correctly without reading this file anyway. The
+/// capacity is a minute's worth of exports at the rate an OpenTelemetry pipeline's default interval produces them
+/// across three signals, with room for a client that has just come back from being offline.
+/// </para>
+/// <para>
+/// Refusing costs a batch rather than a client. A refused export is answered with the status the OTLP specification
+/// names for throttling, so the client holds what it has not exported and sends it with the next one.
+/// </para>
+/// </remarks>
+internal sealed class ClientTelemetryQuota : IDisposable
+{
+    /// <summary>The most exports one owner may have outstanding capacity for at any instant.</summary>
+    internal const int BurstCapacity = 120;
+
+    /// <summary>How much capacity one owner regains each period.</summary>
+    internal const int ExportsPerPeriod = 120;
+
+    /// <summary>How long a refused client is asked to hold for, which is one replenishment away from having capacity again.</summary>
+    internal static readonly TimeSpan RetryAfter = TimeSpan.FromMinutes(1);
+
+    private static readonly TimeSpan ReplenishmentPeriod = RetryAfter;
+
+    private readonly PartitionedRateLimiter<string> exports = PartitionedRateLimiter.Create<string, string>(
+        owner => RateLimitPartition.GetTokenBucketLimiter(
+            owner,
+            _ => new TokenBucketRateLimiterOptions
+            {
+                AutoReplenishment = true,
+                TokenLimit = BurstCapacity,
+                TokensPerPeriod = ExportsPerPeriod,
+                ReplenishmentPeriod = ReplenishmentPeriod,
+
+                // Nothing waits. A client holding what it could not export is the contract this endpoint already
+                // works to, so queuing a batch here would hold a request open to deliver what the client is
+                // perfectly able to send again.
+                QueueLimit = 0,
+            }),
+        StringComparer.Ordinal);
+
+    /// <summary>Spends one export's capacity for one owner, or reports that there is none left.</summary>
+    /// <param name="owner">The owner the export was attributed to.</param>
+    /// <returns><see langword="true" /> when the export may proceed.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="owner" /> is <see langword="null" />.</exception>
+    /// <remarks>The lease is released immediately, which returns nothing to a token bucket: what it holds is permission that has already been spent.</remarks>
+    internal bool TryAdmit(string owner)
+    {
+        ArgumentNullException.ThrowIfNull(owner);
+
+        using var lease = this.exports.AttemptAcquire(owner);
+
+        return lease.IsAcquired;
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => this.exports.Dispose();
+}

--- a/backend/src/Host/Observability/ClientTelemetry/ClientTelemetrySignal.cs
+++ b/backend/src/Host/Observability/ClientTelemetry/ClientTelemetrySignal.cs
@@ -15,8 +15,11 @@ namespace MailFathom.Host.Observability.ClientTelemetry;
 /// <para>
 /// The three request messages are shaped identically for everything the proxy does with them — a repeated resource
 /// envelope at field 1, a resource at field 1 within it, repeated scopes at field 2, and repeated records at field 2
-/// within those — so nothing here says how a payload is read. <see cref="OtlpExportPayload" /> reads all three the same
-/// way, which is why a signal is a name and two strings rather than a parser of its own.
+/// within those — so nothing here says how a payload is read. <see cref="OtlpExportPayload" /> rewrites all three the
+/// same way and is told which signal it holds for one purpose alone: a metric's measurements sit one level below the
+/// metric, so counting them against the batch bound is the one thing that is not the same in all three. That is still
+/// a decision the walker takes from the member rather than from a parser here, which is why a signal is a name and two
+/// strings.
 /// </para>
 /// </remarks>
 internal sealed record ClientTelemetrySignal

--- a/backend/src/Host/Observability/ClientTelemetry/ClientTelemetrySignal.cs
+++ b/backend/src/Host/Observability/ClientTelemetry/ClientTelemetrySignal.cs
@@ -1,0 +1,60 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Host.Observability.ClientTelemetry;
+
+/// <summary>One of the three OTLP signals the client endpoint accepts and forwards.</summary>
+/// <remarks>
+/// <para>
+/// A closed set of three rather than an enumeration, because each member carries strings the proxy composes a request
+/// from: the path the OTLP specification fixes for it, and the gRPC method the same payload is exported to when the
+/// deployment's own exporter speaks that protocol. Neither is derivable from an ordinal, and both are wire contracts
+/// this repository does not get to choose.
+/// </para>
+/// <para>
+/// The three request messages are shaped identically for everything the proxy does with them — a repeated resource
+/// envelope at field 1, a resource at field 1 within it, repeated scopes at field 2, and repeated records at field 2
+/// within those — so nothing here says how a payload is read. <see cref="OtlpExportPayload" /> reads all three the same
+/// way, which is why a signal is a name and two strings rather than a parser of its own.
+/// </para>
+/// </remarks>
+internal sealed record ClientTelemetrySignal
+{
+    private ClientTelemetrySignal(string name, string route, string serviceMethod)
+    {
+        this.Name = name;
+        this.Route = route;
+        this.ServiceMethod = serviceMethod;
+    }
+
+    /// <summary>Gets the traces signal.</summary>
+    public static ClientTelemetrySignal Traces { get; } = new(
+        "traces",
+        "/v1/traces",
+        "/opentelemetry.proto.collector.trace.v1.TraceService/Export");
+
+    /// <summary>Gets the metrics signal.</summary>
+    public static ClientTelemetrySignal Metrics { get; } = new(
+        "metrics",
+        "/v1/metrics",
+        "/opentelemetry.proto.collector.metrics.v1.MetricsService/Export");
+
+    /// <summary>Gets the logs signal.</summary>
+    public static ClientTelemetrySignal Logs { get; } = new(
+        "logs",
+        "/v1/logs",
+        "/opentelemetry.proto.collector.logs.v1.LogsService/Export");
+
+    /// <summary>Gets the three signals, in the order the proxy publishes them.</summary>
+    public static IReadOnlyList<ClientTelemetrySignal> All { get; } = [Traces, Metrics, Logs];
+
+    /// <summary>Gets the word this signal is written with wherever the proxy reports one of them apart from the others.</summary>
+    public string Name { get; }
+
+    /// <summary>Gets the path the OTLP specification fixes for this signal, beneath whatever prefix serves it.</summary>
+    public string Route { get; }
+
+    /// <summary>Gets the gRPC method the same payload is exported to where the deployment's exporter speaks that protocol.</summary>
+    public string ServiceMethod { get; }
+}

--- a/backend/src/Host/Observability/ClientTelemetry/OtlpExportPayload.cs
+++ b/backend/src/Host/Observability/ClientTelemetry/OtlpExportPayload.cs
@@ -1,0 +1,469 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Buffers;
+using System.Text;
+
+namespace MailFathom.Host.Observability.ClientTelemetry;
+
+/// <summary>Reads an OTLP export request far enough to count what it carries and to write who it belongs to.</summary>
+/// <remarks>
+/// <para>
+/// The proxy is not a processor, so this is deliberately not a decoder of the OTLP schema. It walks the protocol
+/// buffers wire format, which needs no schema at all: every field announces its own number and its own length, so a
+/// field this repository has no opinion about is copied octet for octet without ever being understood. What is
+/// understood is the one path to the resource attributes and the two levels of nesting a record sits at, and those are
+/// the same three field numbers in all three signals — a repeated resource envelope at field 1, the resource itself at
+/// field 1 within it, repeated scopes at field 2, and repeated records at field 2 within those.
+/// </para>
+/// <para>
+/// Copying rather than re-encoding is what makes that safe as the schema grows. A field OpenTelemetry adds after this
+/// was written travels through untouched, in the order it arrived and with its own bytes, so a collector reads exactly
+/// what the client sent apart from the one attribute this deployment overwrites. Nothing here allocates per record: the
+/// walk is over spans, and the only bytes written are the envelope's own length prefixes and the attribute added.
+/// </para>
+/// <para>
+/// A payload that does not parse is refused rather than forwarded. That is a bound as much as a correctness rule — a
+/// receiver that forwards whatever arrives is a receiver an unauthenticated shape can push arbitrary octets through,
+/// and the specification answers a request it cannot decode rather than passing it on.
+/// </para>
+/// </remarks>
+internal static class OtlpExportPayload
+{
+    private const int VarintWireType = 0;
+    private const int Fixed64WireType = 1;
+    private const int LengthDelimitedWireType = 2;
+    private const int Fixed32WireType = 5;
+
+    /// <summary>The field number the resource envelope, the resource, and a key-value entry all sit at.</summary>
+    private const int FirstField = 1;
+
+    /// <summary>The field number the scopes within an envelope and the records within a scope both sit at.</summary>
+    private const int SecondField = 2;
+
+    /// <summary>Rewrites one export request so it names the owner this deployment authenticated, and counts what it carries.</summary>
+    /// <param name="request">The export request exactly as the client sent it.</param>
+    /// <param name="attributeKey">The resource attribute naming whose telemetry this is.</param>
+    /// <param name="attributeValue">What this deployment resolved that owner to.</param>
+    /// <param name="maxRecords">The most records one batch may carry before it is refused whole.</param>
+    /// <returns>The rewritten request and what it carries, or the refusal that stopped it.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="attributeKey" /> or <paramref name="attributeValue" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The owner attribute is written onto every resource in the batch rather than onto the first, because a batch may
+    /// carry several and a resource left unwritten would be the one path by which a client's own claim survived.
+    /// </remarks>
+    internal static OtlpExportRewrite Rewrite(
+        ReadOnlySpan<byte> request,
+        string attributeKey,
+        string attributeValue,
+        int maxRecords)
+    {
+        ArgumentNullException.ThrowIfNull(attributeKey);
+        ArgumentNullException.ThrowIfNull(attributeValue);
+
+        var owner = OwnerAttribute(attributeKey, attributeValue);
+        var output = new ArrayBufferWriter<byte>(request.Length + owner.Length + 16);
+        var records = 0;
+        var at = 0;
+
+        while (at < request.Length)
+        {
+            if (!TryReadField(request, ref at, out var field, out var wireType, out var start, out var length))
+            {
+                return OtlpExportRewrite.Malformed;
+            }
+
+            if (field != FirstField || wireType != LengthDelimitedWireType)
+            {
+                CopyField(output, request, field, wireType, start, length);
+
+                continue;
+            }
+
+            var envelope = RewriteEnvelope(request.Slice(start, length), owner, maxRecords, ref records);
+
+            if (envelope.Refusal != OtlpPayloadRefusal.None)
+            {
+                return envelope;
+            }
+
+            WriteLengthDelimited(output, FirstField, envelope.Body);
+        }
+
+        return new OtlpExportRewrite(output.WrittenSpan.ToArray(), records, OtlpPayloadRefusal.None);
+    }
+
+    /// <summary>Rewrites one resource envelope, replacing its resource and counting the records beneath it.</summary>
+    /// <remarks>
+    /// An envelope carrying no resource at all is given one rather than left alone. The client is not obliged to send a
+    /// resource, and telemetry arriving under none would be the one batch this deployment forwarded without saying
+    /// whose it was.
+    /// </remarks>
+    private static OtlpExportRewrite RewriteEnvelope(
+        ReadOnlySpan<byte> envelope,
+        ReadOnlySpan<byte> owner,
+        int maxRecords,
+        ref int records)
+    {
+        var output = new ArrayBufferWriter<byte>(envelope.Length + owner.Length + 8);
+        var carriedResource = false;
+        var at = 0;
+
+        while (at < envelope.Length)
+        {
+            if (!TryReadField(envelope, ref at, out var field, out var wireType, out var start, out var length))
+            {
+                return OtlpExportRewrite.Malformed;
+            }
+
+            if (wireType != LengthDelimitedWireType)
+            {
+                CopyField(output, envelope, field, wireType, start, length);
+
+                continue;
+            }
+
+            switch (field)
+            {
+                case FirstField:
+                    carriedResource = true;
+
+                    if (!TryWriteResource(output, envelope.Slice(start, length), owner))
+                    {
+                        return OtlpExportRewrite.Malformed;
+                    }
+
+                    break;
+
+                case SecondField:
+                    if (!TryCountRecords(envelope.Slice(start, length), maxRecords, ref records))
+                    {
+                        return records > maxRecords ? OtlpExportRewrite.TooManyRecords : OtlpExportRewrite.Malformed;
+                    }
+
+                    CopyField(output, envelope, field, wireType, start, length);
+
+                    break;
+
+                default:
+                    CopyField(output, envelope, field, wireType, start, length);
+
+                    break;
+            }
+        }
+
+        if (!carriedResource)
+        {
+            var resource = new ArrayBufferWriter<byte>(owner.Length + 8);
+            WriteLengthDelimited(resource, FirstField, owner);
+            WriteLengthDelimited(output, FirstField, resource.WrittenSpan);
+        }
+
+        return new OtlpExportRewrite(output.WrittenSpan.ToArray(), records, OtlpPayloadRefusal.None);
+    }
+
+    /// <summary>Writes the resource with the owner attribute replacing whatever the client claimed under that name.</summary>
+    /// <returns><see langword="true" /> when the resource parsed, otherwise <see langword="false" />.</returns>
+    /// <remarks>
+    /// Replaced rather than merged: an entry the client sent under this key is dropped as it is read, and this
+    /// deployment's own is appended once. Every other attribute survives, because what the resource says about the
+    /// browser, the release, or the screen is the client's to report.
+    /// </remarks>
+    private static bool TryWriteResource(
+        ArrayBufferWriter<byte> output,
+        ReadOnlySpan<byte> resource,
+        ReadOnlySpan<byte> owner)
+    {
+        var attributes = new ArrayBufferWriter<byte>(resource.Length + owner.Length);
+        var claimedKey = OwnerAttributeKey(owner);
+        var at = 0;
+
+        while (at < resource.Length)
+        {
+            if (!TryReadField(resource, ref at, out var field, out var wireType, out var start, out var length))
+            {
+                return false;
+            }
+
+            if (field == FirstField
+                && wireType == LengthDelimitedWireType
+                && NamesTheOwner(resource.Slice(start, length), claimedKey))
+            {
+                continue;
+            }
+
+            CopyField(attributes, resource, field, wireType, start, length);
+        }
+
+        WriteLengthDelimited(attributes, FirstField, owner);
+        WriteLengthDelimited(output, FirstField, attributes.WrittenSpan);
+
+        return true;
+    }
+
+    /// <summary>Counts the records one scope carries, refusing once the batch is past what this endpoint accepts.</summary>
+    /// <returns><see langword="true" /> when the scope parsed and the batch is still within its bound.</returns>
+    private static bool TryCountRecords(ReadOnlySpan<byte> scope, int maxRecords, ref int records)
+    {
+        var at = 0;
+
+        while (at < scope.Length)
+        {
+            if (!TryReadField(scope, ref at, out var field, out var wireType, out _, out _))
+            {
+                return false;
+            }
+
+            if (field != SecondField || wireType != LengthDelimitedWireType)
+            {
+                continue;
+            }
+
+            records++;
+
+            if (records > maxRecords)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>Reports whether one key-value entry is written under the key this deployment owns.</summary>
+    private static bool NamesTheOwner(ReadOnlySpan<byte> entry, ReadOnlySpan<byte> key)
+    {
+        var at = 0;
+
+        while (at < entry.Length)
+        {
+            if (!TryReadField(entry, ref at, out var field, out var wireType, out var start, out var length))
+            {
+                return false;
+            }
+
+            if (field == FirstField && wireType == LengthDelimitedWireType)
+            {
+                return entry.Slice(start, length).SequenceEqual(key);
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Encodes the status document the OTLP specification requires a refusal to carry.</summary>
+    /// <param name="code">The canonical status code naming what kind of refusal this is.</param>
+    /// <param name="message">What an operator or a client developer reads, which never carries any part of the payload.</param>
+    /// <returns>The encoded status.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="message" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The specification is explicit that a refused export answers with a status document rather than with an empty
+    /// body or a shape of this repository's own, because the client reading it is an exporter rather than a person.
+    /// Two fields is the whole of what one needs, so it is written here beside the wire primitives rather than pulling
+    /// a schema and a code generator in for a message with a code and a sentence in it.
+    /// </remarks>
+    internal static byte[] Status(int code, string message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        var output = new ArrayBufferWriter<byte>(Encoding.UTF8.GetByteCount(message) + 8);
+        WriteVarint(output, ((ulong)FirstField << 3) | VarintWireType);
+        WriteVarint(output, (ulong)code);
+        WriteLengthDelimited(output, SecondField, Encoding.UTF8.GetBytes(message));
+
+        return output.WrittenSpan.ToArray();
+    }
+
+    /// <summary>Encodes the one key-value entry this deployment writes onto every resource it forwards.</summary>
+    private static byte[] OwnerAttribute(string key, string value)
+    {
+        var anyValue = new ArrayBufferWriter<byte>(Encoding.UTF8.GetByteCount(value) + 8);
+        WriteLengthDelimited(anyValue, FirstField, Encoding.UTF8.GetBytes(value));
+
+        var attribute = new ArrayBufferWriter<byte>(anyValue.WrittenCount + Encoding.UTF8.GetByteCount(key) + 8);
+        WriteLengthDelimited(attribute, FirstField, Encoding.UTF8.GetBytes(key));
+        WriteLengthDelimited(attribute, SecondField, anyValue.WrittenSpan);
+
+        return attribute.WrittenSpan.ToArray();
+    }
+
+    /// <summary>Reads back the key out of the encoded attribute, so the name exists once rather than twice.</summary>
+    private static ReadOnlySpan<byte> OwnerAttributeKey(ReadOnlySpan<byte> owner)
+    {
+        var at = 0;
+
+        return TryReadField(owner, ref at, out _, out _, out var start, out var length)
+            ? owner.Slice(start, length)
+            : [];
+    }
+
+    /// <summary>Reads one field, leaving the cursor past it and reporting where its payload sits.</summary>
+    /// <returns><see langword="false" /> for a field that is truncated, carries an unknown wire type, or is numbered zero.</returns>
+    /// <remarks>
+    /// The two group wire types are refused rather than skipped. They were removed from the language in proto3, no
+    /// OpenTelemetry message uses one, and skipping a group correctly means matching its end marker — so a payload
+    /// carrying one is refused as the thing it is, which is not an OTLP request.
+    /// </remarks>
+    private static bool TryReadField(
+        ReadOnlySpan<byte> body,
+        ref int at,
+        out int field,
+        out int wireType,
+        out int payloadStart,
+        out int payloadLength)
+    {
+        field = 0;
+        wireType = 0;
+        payloadStart = 0;
+        payloadLength = 0;
+
+        if (!TryReadVarint(body, ref at, out var tag))
+        {
+            return false;
+        }
+
+        field = (int)(tag >> 3);
+        wireType = (int)(tag & 0x7);
+
+        if (field == 0)
+        {
+            return false;
+        }
+
+        switch (wireType)
+        {
+            case VarintWireType:
+                payloadStart = at;
+
+                if (!TryReadVarint(body, ref at, out _))
+                {
+                    return false;
+                }
+
+                payloadLength = at - payloadStart;
+
+                return true;
+
+            case Fixed64WireType:
+            case Fixed32WireType:
+                payloadLength = wireType == Fixed64WireType ? 8 : 4;
+
+                if (body.Length - at < payloadLength)
+                {
+                    return false;
+                }
+
+                payloadStart = at;
+                at += payloadLength;
+
+                return true;
+
+            case LengthDelimitedWireType:
+                if (!TryReadVarint(body, ref at, out var length) || length > (ulong)(body.Length - at))
+                {
+                    return false;
+                }
+
+                payloadStart = at;
+                payloadLength = (int)length;
+                at += payloadLength;
+
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    private static bool TryReadVarint(ReadOnlySpan<byte> body, ref int at, out ulong value)
+    {
+        value = 0;
+
+        for (var shift = 0; shift < 64; shift += 7)
+        {
+            if (at >= body.Length)
+            {
+                return false;
+            }
+
+            var octet = body[at++];
+            value |= (ulong)(octet & 0x7F) << shift;
+
+            if ((octet & 0x80) == 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Copies one field back out exactly as it arrived, tag included.</summary>
+    private static void CopyField(
+        ArrayBufferWriter<byte> output,
+        ReadOnlySpan<byte> body,
+        int field,
+        int wireType,
+        int payloadStart,
+        int payloadLength)
+    {
+        WriteVarint(output, ((ulong)field << 3) | (uint)wireType);
+
+        if (wireType == LengthDelimitedWireType)
+        {
+            WriteVarint(output, (ulong)payloadLength);
+        }
+
+        output.Write(body.Slice(payloadStart, payloadLength));
+    }
+
+    private static void WriteLengthDelimited(ArrayBufferWriter<byte> output, int field, ReadOnlySpan<byte> payload)
+    {
+        WriteVarint(output, ((ulong)field << 3) | LengthDelimitedWireType);
+        WriteVarint(output, (ulong)payload.Length);
+        output.Write(payload);
+    }
+
+    private static void WriteVarint(ArrayBufferWriter<byte> output, ulong value)
+    {
+        Span<byte> encoded = stackalloc byte[10];
+        var written = 0;
+
+        do
+        {
+            var octet = (byte)(value & 0x7F);
+            value >>= 7;
+            encoded[written++] = value == 0 ? octet : (byte)(octet | 0x80);
+        }
+        while (value != 0);
+
+        output.Write(encoded[..written]);
+    }
+}
+
+/// <summary>Why an export request was refused before anything was forwarded.</summary>
+internal enum OtlpPayloadRefusal
+{
+    /// <summary>The request parsed and is forwardable.</summary>
+    None = 0,
+
+    /// <summary>The octets are not a protocol buffers message this endpoint can read.</summary>
+    Malformed = 1,
+
+    /// <summary>The batch carries more records than one request may.</summary>
+    TooManyRecords = 2,
+}
+
+/// <summary>What reading one export request produced.</summary>
+/// <param name="Body">The request as it will be forwarded, empty where it was refused.</param>
+/// <param name="RecordCount">How many records the batch carries, as far as reading it got.</param>
+/// <param name="Refusal">Why the request was refused, or <see cref="OtlpPayloadRefusal.None" /> where it was not.</param>
+internal readonly record struct OtlpExportRewrite(byte[] Body, int RecordCount, OtlpPayloadRefusal Refusal)
+{
+    /// <summary>Gets the reading of a request that is not a protocol buffers message.</summary>
+    internal static OtlpExportRewrite Malformed { get; } = new([], 0, OtlpPayloadRefusal.Malformed);
+
+    /// <summary>Gets the reading of a batch carrying more records than one request may.</summary>
+    internal static OtlpExportRewrite TooManyRecords { get; } = new([], 0, OtlpPayloadRefusal.TooManyRecords);
+}

--- a/backend/src/Host/Observability/ClientTelemetry/OtlpExportPayload.cs
+++ b/backend/src/Host/Observability/ClientTelemetry/OtlpExportPayload.cs
@@ -15,7 +15,9 @@ namespace MailFathom.Host.Observability.ClientTelemetry;
 /// field this repository has no opinion about is copied octet for octet without ever being understood. What is
 /// understood is the one path to the resource attributes and the two levels of nesting a record sits at, and those are
 /// the same three field numbers in all three signals — a repeated resource envelope at field 1, the resource itself at
-/// field 1 within it, repeated scopes at field 2, and repeated records at field 2 within those.
+/// field 1 within it, repeated scopes at field 2, and repeated records at field 2 within those. One thing beyond that
+/// is understood, and only for counting: a metric holds its measurements one level further down, so the record bound
+/// reaches them rather than stopping at the metric definitions that carry them.
 /// </para>
 /// <para>
 /// Copying rather than re-encoding is what makes that safe as the schema grows. A field OpenTelemetry adds after this
@@ -44,11 +46,12 @@ internal static class OtlpExportPayload
 
     /// <summary>Rewrites one export request so it names the owner this deployment authenticated, and counts what it carries.</summary>
     /// <param name="request">The export request exactly as the client sent it.</param>
+    /// <param name="signal">Which signal the request carries, which is what decides what one record is.</param>
     /// <param name="attributeKey">The resource attribute naming whose telemetry this is.</param>
     /// <param name="attributeValue">What this deployment resolved that owner to.</param>
     /// <param name="maxRecords">The most records one batch may carry before it is refused whole.</param>
     /// <returns>The rewritten request and what it carries, or the refusal that stopped it.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="attributeKey" /> or <paramref name="attributeValue" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="signal" />, <paramref name="attributeKey" /> or <paramref name="attributeValue" /> is <see langword="null" />.</exception>
     /// <remarks>
     /// The owner attribute is written onto every resource in the batch rather than onto the first, because a batch may
     /// carry several and a resource left unwritten would be the one path by which a client's own claim survived at the
@@ -58,10 +61,12 @@ internal static class OtlpExportPayload
     /// </remarks>
     internal static OtlpExportRewrite Rewrite(
         ReadOnlySpan<byte> request,
+        ClientTelemetrySignal signal,
         string attributeKey,
         string attributeValue,
         int maxRecords)
     {
+        ArgumentNullException.ThrowIfNull(signal);
         ArgumentNullException.ThrowIfNull(attributeKey);
         ArgumentNullException.ThrowIfNull(attributeValue);
 
@@ -84,7 +89,7 @@ internal static class OtlpExportPayload
                 continue;
             }
 
-            var envelope = RewriteEnvelope(request.Slice(start, length), owner, maxRecords, ref records);
+            var envelope = RewriteEnvelope(request.Slice(start, length), signal, owner, maxRecords, ref records);
 
             if (envelope.Refusal != OtlpPayloadRefusal.None)
             {
@@ -105,6 +110,7 @@ internal static class OtlpExportPayload
     /// </remarks>
     private static OtlpExportRewrite RewriteEnvelope(
         ReadOnlySpan<byte> envelope,
+        ClientTelemetrySignal signal,
         ReadOnlySpan<byte> owner,
         int maxRecords,
         ref int records)
@@ -140,7 +146,7 @@ internal static class OtlpExportPayload
                     break;
 
                 case SecondField:
-                    if (!TryCountRecords(envelope.Slice(start, length), maxRecords, ref records))
+                    if (!TryCountRecords(envelope.Slice(start, length), signal, maxRecords, ref records))
                     {
                         return records > maxRecords ? OtlpExportRewrite.TooManyRecords : OtlpExportRewrite.Malformed;
                     }
@@ -207,13 +213,24 @@ internal static class OtlpExportPayload
 
     /// <summary>Counts the records one scope carries, refusing once the batch is past what this endpoint accepts.</summary>
     /// <returns><see langword="true" /> when the scope parsed and the batch is still within its bound.</returns>
-    private static bool TryCountRecords(ReadOnlySpan<byte> scope, int maxRecords, ref int records)
+    /// <remarks>
+    /// A span and a log record are one record each, and a metric is as many as it carries data points. That is the one
+    /// place a signal is told apart here, and it is told apart because a bound counted in metric definitions is no
+    /// bound at all: a handful of them carry as many measurements as a client cares to put in, so counting the
+    /// definitions would leave the batch bounded by its size alone.
+    /// </remarks>
+    private static bool TryCountRecords(
+        ReadOnlySpan<byte> scope,
+        ClientTelemetrySignal signal,
+        int maxRecords,
+        ref int records)
     {
+        var countsDataPoints = signal == ClientTelemetrySignal.Metrics;
         var at = 0;
 
         while (at < scope.Length)
         {
-            if (!TryReadField(scope, ref at, out var field, out var wireType, out _, out _))
+            if (!TryReadField(scope, ref at, out var field, out var wireType, out var start, out var length))
             {
                 return false;
             }
@@ -223,7 +240,18 @@ internal static class OtlpExportPayload
                 continue;
             }
 
-            records++;
+            if (!countsDataPoints)
+            {
+                records++;
+            }
+            else if (TryCountDataPoints(scope.Slice(start, length), out var points))
+            {
+                records += points;
+            }
+            else
+            {
+                return false;
+            }
 
             if (records > maxRecords)
             {
@@ -233,6 +261,57 @@ internal static class OtlpExportPayload
 
         return true;
     }
+
+    /// <summary>Counts the data points one metric carries, across whichever payload shape it was reported in.</summary>
+    /// <returns><see langword="true" /> when the metric parsed, otherwise <see langword="false" />.</returns>
+    /// <remarks>
+    /// Every shape a metric's measurements arrive in — a gauge, a sum, either histogram, or a summary — is a message
+    /// holding its points at its own first field, so the count is the same walk in all five and needs nothing of what
+    /// a point contains. A metric reported in none of them counts as one rather than as none, which is what keeps a
+    /// shape OpenTelemetry adds later from arriving uncounted at a bound that exists to be unavoidable.
+    /// </remarks>
+    private static bool TryCountDataPoints(ReadOnlySpan<byte> metric, out int points)
+    {
+        points = 0;
+        var at = 0;
+
+        while (at < metric.Length)
+        {
+            if (!TryReadField(metric, ref at, out var field, out var wireType, out var start, out var length))
+            {
+                return false;
+            }
+
+            if (wireType != LengthDelimitedWireType || !CarriesDataPoints(field))
+            {
+                continue;
+            }
+
+            var payload = metric.Slice(start, length);
+            var within = 0;
+
+            while (within < payload.Length)
+            {
+                if (!TryReadField(payload, ref within, out var pointField, out var pointWireType, out _, out _))
+                {
+                    return false;
+                }
+
+                if (pointField == FirstField && pointWireType == LengthDelimitedWireType)
+                {
+                    points++;
+                }
+            }
+        }
+
+        points = Math.Max(points, 1);
+
+        return true;
+    }
+
+    /// <summary>Reports whether a metric's field is one of the payload shapes measurements are reported in.</summary>
+    /// <remarks>The five are the arms of the one-of a metric's data sits in: a gauge, a sum, a histogram, an exponential histogram, and a summary.</remarks>
+    private static bool CarriesDataPoints(int field) => field is 5 or 7 or 9 or 10 or 11;
 
     /// <summary>Reports whether one key-value entry is written under the key this deployment owns.</summary>
     private static bool NamesTheOwner(ReadOnlySpan<byte> entry, ReadOnlySpan<byte> key)

--- a/backend/src/Host/Observability/ClientTelemetry/OtlpExportPayload.cs
+++ b/backend/src/Host/Observability/ClientTelemetry/OtlpExportPayload.cs
@@ -51,7 +51,10 @@ internal static class OtlpExportPayload
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="attributeKey" /> or <paramref name="attributeValue" /> is <see langword="null" />.</exception>
     /// <remarks>
     /// The owner attribute is written onto every resource in the batch rather than onto the first, because a batch may
-    /// carry several and a resource left unwritten would be the one path by which a client's own claim survived.
+    /// carry several and a resource left unwritten would be the one path by which a client's own claim survived at the
+    /// level attribution is read from. It reaches the resource and nothing below it: an attribute a client writes on a
+    /// scope, a span, a log record, or a metric data point is copied through like every other field it sends, since
+    /// reaching those means walking each signal's own schema, which is the decoding this file exists not to do.
     /// </remarks>
     internal static OtlpExportRewrite Rewrite(
         ReadOnlySpan<byte> request,

--- a/backend/src/Host/Security/Endpoints/ClientTransportSecurityExtensions.cs
+++ b/backend/src/Host/Security/Endpoints/ClientTransportSecurityExtensions.cs
@@ -127,9 +127,16 @@ internal static class ClientTransportSecurityExtensions
     /// CORS specification forbids outright.
     /// </para>
     /// <para>
-    /// The methods and headers are what this surface serves rather than what an HTTP API might: one read, one
-    /// <c>Authorization</c> header, and JSON. A route added later adds its method here, which is the direction that
-    /// fails visibly — a policy written wide in advance is a policy nobody narrows afterwards.
+    /// The methods and headers are what this surface serves rather than what an HTTP API might: the two verbs its
+    /// routes are mapped under, one <c>Authorization</c> header, and a declared content type. A route added later adds
+    /// its method here, which is the direction that fails visibly — a policy written wide in advance is a policy nobody
+    /// narrows afterwards.
+    /// </para>
+    /// <para>
+    /// Two response headers are exposed rather than one. A browser cannot read a header the policy does not name, so
+    /// without <c>WWW-Authenticate</c> the one answer telling a page how to proceed is the one it cannot see, and
+    /// without <c>Retry-After</c> a client told to hold cannot read for how long — which on the telemetry routes is the
+    /// difference between a client that backs off and one that keeps exporting into a refusal.
     /// </para>
     /// </remarks>
     private static void ConfigureCorsPolicy(CorsPolicyBuilder policy, BrowserOriginPolicy originPolicy)
@@ -144,12 +151,8 @@ internal static class ClientTransportSecurityExtensions
         }
 
         policy
-            .WithMethods(HttpMethods.Get)
+            .WithMethods(HttpMethods.Get, HttpMethods.Post)
             .WithHeaders(HeaderNames.Authorization, HeaderNames.ContentType, HeaderNames.Accept)
-
-            // A refusal says where to authorize, and a browser cannot read a response header the policy does not name.
-            // Without this the one answer that tells a page how to proceed is the one it cannot see, and a client that
-            // could have started discovery only learns that something failed.
-            .WithExposedHeaders(HeaderNames.WWWAuthenticate);
+            .WithExposedHeaders(HeaderNames.WWWAuthenticate, HeaderNames.RetryAfter);
     }
 }

--- a/backend/tests/Host.UnitTests/Api/ClientApiEndpointsTests.cs
+++ b/backend/tests/Host.UnitTests/Api/ClientApiEndpointsTests.cs
@@ -13,6 +13,7 @@ using MailFathom.Domain.Access;
 using MailFathom.Host.Api;
 using MailFathom.Host.Configuration.Endpoints;
 using MailFathom.Host.Configuration.Mail;
+using MailFathom.Host.Observability.ClientTelemetry;
 using MailFathom.Host.Security.Endpoints;
 using MailFathom.Host.Security.Transport;
 using MailFathom.Host.UnitTests.TestDoubles;
@@ -26,6 +27,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
+using OpenTelemetry.Exporter;
 using Xunit;
 
 namespace MailFathom.Host.UnitTests.Api;
@@ -152,6 +154,10 @@ public sealed class ClientApiEndpointsTests
                 $"{ClientEndpointOptions.RoutePrefix}{ClientOwnerRecordEndpoint.MailAccountsRoute}",
                 $"{ClientEndpointOptions.RoutePrefix}{ClientOwnerRecordEndpoint.MailAccountRemovalRoute}",
                 $"{ClientEndpointOptions.RoutePrefix}{ClientApiEndpoints.SessionRoute}",
+                .. ClientTelemetrySignal.All
+                    .Select(signal =>
+                        $"{ClientEndpointOptions.RoutePrefix}{ClientTelemetryEndpoint.TelemetryRoutePrefix}{signal.Route}")
+                    .Order(StringComparer.Ordinal),
                 $"{ClientEndpointOptions.RoutePrefix}{ClientMailThreadEndpoint.MailThreadRoute}",
             ],
             routes);
@@ -220,6 +226,10 @@ public sealed class ClientApiEndpointsTests
                 $"POST {prefix}{ClientOwnerRecordEndpoint.RecordRoute} -> {MailFathomPermission.MailAccountsWrite.Name}",
                 $"POST {prefix}{ClientOwnerRecordEndpoint.MailAccountsRoute} -> {MailFathomPermission.MailAccountsWrite.Name}",
                 $"POST {prefix}{ClientOwnerRecordEndpoint.MailAccountRemovalRoute} -> {MailFathomPermission.MailAccountsWrite.Name}",
+                .. ClientTelemetrySignal.All
+                    .Select(signal =>
+                        $"POST {prefix}{ClientTelemetryEndpoint.TelemetryRoutePrefix}{signal.Route} -> none")
+                    .Order(StringComparer.Ordinal),
                 $"PUT {prefix}{ClientDraftEndpoints.DraftRoute} -> {MailFathomPermission.MailDraftsWrite.Name}",
             ],
             PublishedAllocation(endpoints).Order(StringComparer.Ordinal));
@@ -248,11 +258,12 @@ public sealed class ClientApiEndpointsTests
     }
 
     /// <summary>
-    /// A read under the reading grant, and every write under a grant that says what it writes, save the one write of
-    /// the caller's own client preferences. Reading mail, changing the caller's own record, composing a draft, filing
-    /// one on their server, and sending are five separately provisioned powers, so a route that changes anything under
-    /// <c>mailfathom.mail.read</c> is one somebody added without deciding what it costs — and a credential provisioned
-    /// to read a mailbox would then send from it.
+    /// A read under the reading grant, and every write under a grant that says what it writes, save the two a grant
+    /// could not tell apart: the caller's own client preferences, and the client handing over its own telemetry.
+    /// Reading mail, changing the caller's own record, composing a draft, filing one on their server, and sending are
+    /// five separately provisioned powers, so a route that changes anything under <c>mailfathom.mail.read</c> is one
+    /// somebody added without deciding what it costs — and a credential provisioned to read a mailbox would then send
+    /// from it.
     /// </summary>
     [Fact]
     public void MapClientApi_Always_PublishesEveryWriteUnderAGrantThatSaysWhatItWrites()
@@ -279,7 +290,8 @@ public sealed class ClientApiEndpointsTests
                     method => Assert.True(
                         method == "GET"
                         || IsPublishedAsAWrite(endpoint)
-                        || WritesTheCallersOwnPreferences(endpoint),
+                        || WritesTheCallersOwnPreferences(endpoint)
+                        || HandsOverTheClientsOwnTelemetry(endpoint),
                         $"{method} {endpoint} changes something under a grant that does not say so."));
             });
     }
@@ -305,6 +317,14 @@ public sealed class ClientApiEndpointsTests
         endpoint is RouteEndpoint route
         && $"/{route.RoutePattern.RawText?.TrimStart('/')}"
             == $"{ClientEndpointOptions.RoutePrefix}{ClientPreferencesEndpoint.PreferencesRoute}";
+
+    /// <summary>Reports whether a route is the client posting its own telemetry, which changes nothing this deployment holds.</summary>
+    /// <remarks>The path rather than the grant here, because these are published under none by design — the caller is handing over what it recorded about itself, and no permission in the mailbox half names that act.</remarks>
+    private static bool HandsOverTheClientsOwnTelemetry(Endpoint endpoint) =>
+        endpoint is RouteEndpoint { RoutePattern.RawText: { } path }
+        && path.Contains(
+            $"{ClientEndpointOptions.RoutePrefix}{ClientTelemetryEndpoint.TelemetryRoutePrefix}/",
+            StringComparison.Ordinal);
 
     /// <summary>
     /// The bound on each record-route body, which the routes carry as metadata the routing pipeline reads. This surface
@@ -430,6 +450,15 @@ public sealed class ClientApiEndpointsTests
             UnreachedScopeResolver(),
             Substitute.For<IStoredMailFolderReader>(),
             Substitute.For<IMailFolderMappingReader>()));
+
+        // A destination is registered so the telemetry routes are mapped, because every surface-wide claim in this
+        // file — the group's requirement, the CORS policy, the prefix, the published decision — has to hold over them
+        // too. Which deployment maps them at all is ClientTelemetryEndpointTests' subject rather than this file's.
+        services.AddSingleton(new ClientTelemetryDestination(
+            new Uri("https://collector.example.test"),
+            OtlpExportProtocol.HttpProtobuf,
+            [],
+            TimeSpan.FromSeconds(10)));
 
         return new TestEndpointRouteBuilder(services.BuildServiceProvider());
     }

--- a/backend/tests/Host.UnitTests/Api/ClientTelemetryEndpointTests.cs
+++ b/backend/tests/Host.UnitTests/Api/ClientTelemetryEndpointTests.cs
@@ -2,7 +2,9 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Globalization;
 using System.Net;
+using System.Text;
 using MailFathom.Application.Access;
 using MailFathom.Domain.Access;
 using MailFathom.Host.Api;
@@ -124,6 +126,67 @@ public sealed class ClientTelemetryEndpointTests
         // Assert
         Assert.Equal(StatusCodes.Status400BadRequest, answered);
         Assert.Empty(collector.RecordedRequests);
+    }
+
+    /// <summary>The byte bound, refused whether the client declared the size or only sent it.</summary>
+    /// <remarks>
+    /// Both arrangements are the same behaviour and both are arranged, because the two arrive at the bound by
+    /// different routes: a declared length is refused before the body is read at all, and an undeclared one is refused
+    /// by what was actually copied — which is the one an oversized body without a header takes.
+    /// </remarks>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task AcceptAsync_ABodyPastTheByteBound_RefusesWithoutForwardingAnything(bool declaresItsLength)
+    {
+        // Arrange
+        using var collector = AcceptingCollector();
+        var request = Requesting(new byte[ClientTelemetryEndpoint.MaxRequestBytes + 1]);
+        var body = new MemoryStream();
+        request.Response.Body = body;
+
+        if (!declaresItsLength)
+        {
+            request.Request.ContentLength = null;
+        }
+
+        // Act
+        var answered = await AcceptAsync(request, collector);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status413PayloadTooLarge, answered);
+        Assert.Empty(collector.RecordedRequests);
+        Assert.Contains(
+            ClientTelemetryEndpoint.MaxRequestBytes.ToString(CultureInfo.InvariantCulture),
+            Encoding.UTF8.GetString(body.ToArray()),
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>The record bound is the other ceiling, and it answers for itself rather than as the byte one.</summary>
+    /// <remarks>
+    /// The batch is refused whole rather than truncated, and the answer names the bound it met — which is what a
+    /// client acts on, and what tells this refusal from the one above given both are answered <c>413</c>.
+    /// </remarks>
+    [Fact]
+    public async Task AcceptAsync_ABatchPastTheRecordBound_RefusesWithoutForwardingAnything()
+    {
+        // Arrange
+        using var collector = AcceptingCollector();
+        var request = Requesting(
+            OtlpExportRequests.Batch([], ClientTelemetryEndpoint.MaxRecordsPerBatch + 1));
+        var body = new MemoryStream();
+        request.Response.Body = body;
+
+        // Act
+        var answered = await AcceptAsync(request, collector);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status413PayloadTooLarge, answered);
+        Assert.Empty(collector.RecordedRequests);
+        Assert.Contains(
+            ClientTelemetryEndpoint.MaxRecordsPerBatch.ToString(CultureInfo.InvariantCulture),
+            Encoding.UTF8.GetString(body.ToArray()),
+            StringComparison.Ordinal);
     }
 
     /// <summary>The rate bound, and the answer that tells a client to hold rather than to stop.</summary>

--- a/backend/tests/Host.UnitTests/Api/ClientTelemetryEndpointTests.cs
+++ b/backend/tests/Host.UnitTests/Api/ClientTelemetryEndpointTests.cs
@@ -194,7 +194,7 @@ public sealed class ClientTelemetryEndpointTests
         // Arrange
         byte[] collectorReason = [0x0A, 0x02, 0x08, 0x10];
         using var collector = FakeHttpMessageHandler.AlwaysResponding(
-            () => new HttpResponseMessage(HttpStatusCode.Unauthorized) { Content = new ByteArrayContent(collectorReason) });
+            () => new HttpResponseMessage(HttpStatusCode.BadRequest) { Content = new ByteArrayContent(collectorReason) });
         var request = Requesting(OtlpExportRequests.Batch([], records: 1));
         var body = new MemoryStream();
         request.Response.Body = body;
@@ -206,6 +206,27 @@ public sealed class ClientTelemetryEndpointTests
         Assert.Equal(StatusCodes.Status400BadRequest, answered);
         Assert.NotEqual(collectorReason, body.ToArray());
         Assert.NotEmpty(body.ToArray());
+    }
+
+    /// <summary>A collector that will not take this deployment's credential is not the client's batch being wrong.</summary>
+    /// <remarks>
+    /// Answered as retryable rather than as a refusal, because a browser told to stop would drop telemetry over a
+    /// header only an operator can correct — and the operator is told which condition it is, on the counter and in the
+    /// line the proxy writes, rather than through this answer.
+    /// </remarks>
+    [Fact]
+    public async Task AcceptAsync_ACollectorRefusingThisDeploymentsCredential_TellsTheClientToHold()
+    {
+        // Arrange
+        using var collector = FakeHttpMessageHandler.AlwaysResponding(
+            () => new HttpResponseMessage(HttpStatusCode.Unauthorized) { Content = new ByteArrayContent([]) });
+        var request = Requesting(OtlpExportRequests.Batch([], records: 1));
+
+        // Act
+        var answered = await AcceptAsync(request, collector);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, answered);
     }
 
     /// <summary>Nobody exports on somebody's behalf without a person to attribute it to.</summary>

--- a/backend/tests/Host.UnitTests/Api/ClientTelemetryEndpointTests.cs
+++ b/backend/tests/Host.UnitTests/Api/ClientTelemetryEndpointTests.cs
@@ -301,7 +301,8 @@ public sealed class ClientTelemetryEndpointTests
                 new Uri("https://collector.example.test"),
                 OtlpExportProtocol.HttpProtobuf,
                 [],
-                TimeSpan.FromSeconds(10)));
+                TimeSpan.FromSeconds(10)),
+            TimeProvider.System);
     }
 
     private static TestEndpointRouteBuilder BuildRouteBuilder()

--- a/backend/tests/Host.UnitTests/Api/ClientTelemetryEndpointTests.cs
+++ b/backend/tests/Host.UnitTests/Api/ClientTelemetryEndpointTests.cs
@@ -1,0 +1,298 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Net;
+using MailFathom.Application.Access;
+using MailFathom.Domain.Access;
+using MailFathom.Host.Api;
+using MailFathom.Host.Configuration.Endpoints;
+using MailFathom.Host.Observability.ClientTelemetry;
+using MailFathom.Host.UnitTests.TestDoubles;
+using MailFathom.TestSupport;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using OpenTelemetry.Exporter;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Api;
+
+/// <summary>Covers what the OTLP routes accept, what they refuse, and what leaves under whose name.</summary>
+/// <remarks>
+/// The forwarder is real here rather than substituted, over the suite's HTTP double, because the claim worth asserting
+/// is what arrived at the collector: that the batch carries the owner this deployment authenticated and not the one the
+/// client claimed. A substitute between the handler and the wire would let the attribution be asserted against the
+/// argument the test itself arranged.
+/// </remarks>
+public sealed class ClientTelemetryEndpointTests
+{
+    private static readonly MailOwnerId AuthenticatedOwner =
+        MailOwnerId.Create(new Guid("9f2a1c64-0000-4000-8000-000000000001"));
+
+    /// <summary>A deployment that named no collector serves nothing, which is what "the endpoint is off" looks like here.</summary>
+    [Fact]
+    public void MapClientTelemetry_WithNoDestinationConfigured_MapsNoRoute()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddRouting();
+        var endpoints = new TestEndpointRouteBuilder(services.BuildServiceProvider());
+
+        // Act
+        endpoints.MapGroup(ClientEndpointOptions.RoutePrefix).MapClientTelemetry();
+
+        // Assert
+        Assert.Empty(endpoints.Materialize());
+    }
+
+    /// <summary>The paths are the specification's, so a client points its exporter at the prefix and appends nothing.</summary>
+    [Fact]
+    public void MapClientTelemetry_WithADestinationConfigured_ServesTheThreeSignalPathsBeneathTheTelemetryPrefix()
+    {
+        // Arrange
+        var endpoints = BuildRouteBuilder();
+
+        // Act
+        endpoints.MapGroup(ClientEndpointOptions.RoutePrefix).MapClientTelemetry();
+
+        // Assert
+        Assert.Equal(
+            [
+                $"{ClientEndpointOptions.RoutePrefix}/telemetry/v1/logs",
+                $"{ClientEndpointOptions.RoutePrefix}/telemetry/v1/metrics",
+                $"{ClientEndpointOptions.RoutePrefix}/telemetry/v1/traces",
+            ],
+            endpoints.Materialize()
+                .OfType<RouteEndpoint>()
+                .Select(endpoint => endpoint.RoutePattern.RawText)
+                .Order(StringComparer.Ordinal));
+    }
+
+    /// <summary>The claim the whole feature rests on, asserted at the wire rather than at the argument.</summary>
+    [Fact]
+    public async Task AcceptAsync_ABatchClaimingAnOwnerOfItsOwn_ForwardsItNamingTheAuthenticatedOne()
+    {
+        // Arrange
+        using var collector = AcceptingCollector();
+        var request = Requesting(OtlpExportRequests.Batch(
+            [new KeyValuePair<string, string>(ClientTelemetryEndpoint.OwnerTagName, "somebody-else")],
+            records: 3));
+
+        // Act
+        var answered = await AcceptAsync(request, collector);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, answered);
+        var forwarded = Assert.Single(collector.RecordedRequests).Content.ToArray();
+        Assert.Equal(
+            [new KeyValuePair<string, string>(ClientTelemetryEndpoint.OwnerTagName, AuthenticatedOwner.ToString())],
+            OtlpExportRequests.ResourceAttributes(forwarded));
+    }
+
+    /// <summary>One encoding, one parser, one bound: anything else is refused with the status that says so.</summary>
+    [Fact]
+    public async Task AcceptAsync_ABodyThatIsNotProtocolBuffers_RefusesWithoutForwardingAnything()
+    {
+        // Arrange
+        using var collector = AcceptingCollector();
+        var request = Requesting(OtlpExportRequests.Batch([], records: 1));
+        request.Request.ContentType = "application/json";
+
+        // Act
+        var answered = await AcceptAsync(request, collector);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status415UnsupportedMediaType, answered);
+        Assert.Empty(collector.RecordedRequests);
+    }
+
+    /// <summary>A batch this endpoint cannot read is one it must not pass on to somebody's collector.</summary>
+    [Fact]
+    public async Task AcceptAsync_ABodyThatIsNotAnExportRequest_RefusesWithoutForwardingAnything()
+    {
+        // Arrange
+        using var collector = AcceptingCollector();
+        var request = Requesting([0xFF, 0xFF, 0xFF]);
+
+        // Act
+        var answered = await AcceptAsync(request, collector);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, answered);
+        Assert.Empty(collector.RecordedRequests);
+    }
+
+    /// <summary>The rate bound, and the answer that tells a client to hold rather than to stop.</summary>
+    [Fact]
+    public async Task AcceptAsync_PastTheOwnersRate_RefusesWithTooManyRequestsAndSaysHowLongToHold()
+    {
+        // Arrange
+        using var collector = AcceptingCollector();
+        using var quota = new ClientTelemetryQuota();
+
+        foreach (var _ in Enumerable.Range(0, ClientTelemetryQuota.BurstCapacity))
+        {
+            quota.TryAdmit(AuthenticatedOwner.ToString());
+        }
+
+        var request = Requesting(OtlpExportRequests.Batch([], records: 1));
+
+        // Act
+        var answered = await AcceptAsync(request, collector, quota);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status429TooManyRequests, answered);
+        Assert.Equal("60", request.Response.Headers.RetryAfter.ToString());
+        Assert.Empty(collector.RecordedRequests);
+    }
+
+    /// <summary>A batch that did not arrive is answered as retryable, because the client is the one holding it.</summary>
+    [Fact]
+    public async Task AcceptAsync_ACollectorThatDidNotTakeTheBatch_AnswersServiceUnavailable()
+    {
+        // Arrange
+        using var collector = FakeHttpMessageHandler.AlwaysResponding(
+            () => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable) { Content = new ByteArrayContent([]) });
+        var request = Requesting(OtlpExportRequests.Batch([], records: 1));
+
+        // Act
+        var answered = await AcceptAsync(request, collector);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, answered);
+    }
+
+    /// <summary>A partial success reaches the client, because a bare success would hide a rejection it is owed.</summary>
+    [Fact]
+    public async Task AcceptAsync_ACollectorReportingAPartialSuccess_RelaysItRatherThanAnsweringABareSuccess()
+    {
+        // Arrange
+        byte[] partialSuccess = [0x0A, 0x02, 0x08, 0x03];
+        using var collector = FakeHttpMessageHandler.AlwaysResponding(
+            () => new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(partialSuccess) });
+        var request = Requesting(OtlpExportRequests.Batch([], records: 1));
+        var body = new MemoryStream();
+        request.Response.Body = body;
+
+        // Act
+        var answered = await AcceptAsync(request, collector);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, answered);
+        Assert.Equal(partialSuccess, body.ToArray());
+        Assert.Equal(ClientTelemetryForwarder.ProtobufMediaType, request.Response.ContentType);
+    }
+
+    /// <summary>What a collector says about a batch it would not take is about this deployment, not about the client.</summary>
+    [Fact]
+    public async Task AcceptAsync_ACollectorThatRefusedTheBatch_AnswersWithoutRelayingWhatItSaid()
+    {
+        // Arrange
+        byte[] collectorReason = [0x0A, 0x02, 0x08, 0x10];
+        using var collector = FakeHttpMessageHandler.AlwaysResponding(
+            () => new HttpResponseMessage(HttpStatusCode.Unauthorized) { Content = new ByteArrayContent(collectorReason) });
+        var request = Requesting(OtlpExportRequests.Batch([], records: 1));
+        var body = new MemoryStream();
+        request.Response.Body = body;
+
+        // Act
+        var answered = await AcceptAsync(request, collector);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, answered);
+        Assert.NotEqual(collectorReason, body.ToArray());
+        Assert.NotEmpty(body.ToArray());
+    }
+
+    /// <summary>Nobody exports on somebody's behalf without a person to attribute it to.</summary>
+    [Fact]
+    public async Task AcceptAsync_ACallerActingForNoOwner_RefusesBeforeReadingTheBody()
+    {
+        // Arrange
+        using var collector = AcceptingCollector();
+        var request = Requesting(OtlpExportRequests.Batch([], records: 1));
+
+        // Act
+        await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(async () => await AcceptAsync(
+            request,
+            collector,
+            quota: null,
+            authorization: AccessAuthorizations.ForAdministratorGranted()));
+
+        // Assert
+        Assert.Empty(collector.RecordedRequests);
+    }
+
+    /// <summary>Runs one request through the handler and reports the status it answered with.</summary>
+    private static async Task<int> AcceptAsync(
+        DefaultHttpContext request,
+        FakeHttpMessageHandler collector,
+        ClientTelemetryQuota? quota = null,
+        AccessAuthorization? authorization = null)
+    {
+        using var owned = quota is null ? new ClientTelemetryQuota() : null;
+
+        var answered = await ClientTelemetryEndpoint.AcceptAsync(
+            ClientTelemetrySignal.Traces,
+            request,
+            authorization ?? AccessAuthorizations.ForOwnerGranted(AuthenticatedOwner),
+            quota ?? owned!,
+            ForwarderOver(collector),
+            new ClientTelemetryProxyTelemetry(
+                new RecordingLogger<ClientTelemetryProxyTelemetry>(),
+                new FakeTimeProvider()),
+            TestContext.Current.CancellationToken);
+
+        await answered.ExecuteAsync(request);
+
+        return request.Response.StatusCode;
+    }
+
+    /// <summary>Composes the request one export arrives as.</summary>
+    private static DefaultHttpContext Requesting(byte[] batch)
+    {
+        var request = new DefaultHttpContext();
+        request.Request.Method = HttpMethods.Post;
+        request.Request.ContentType = ClientTelemetryForwarder.ProtobufMediaType;
+        request.Request.ContentLength = batch.Length;
+        request.Request.Body = new MemoryStream(batch);
+        request.Response.Body = new MemoryStream();
+
+        return request;
+    }
+
+    private static FakeHttpMessageHandler AcceptingCollector() => FakeHttpMessageHandler.AlwaysResponding(
+        () => new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent([]) });
+
+    private static ClientTelemetryForwarder ForwarderOver(HttpMessageHandler collector)
+    {
+        var clients = Substitute.For<IHttpClientFactory>();
+        clients.CreateClient(ClientTelemetryForwarder.HttpClientName)
+            .Returns(_ => new HttpClient(collector, disposeHandler: false));
+
+        return new ClientTelemetryForwarder(
+            clients,
+            new ClientTelemetryDestination(
+                new Uri("https://collector.example.test"),
+                OtlpExportProtocol.HttpProtobuf,
+                [],
+                TimeSpan.FromSeconds(10)));
+    }
+
+    private static TestEndpointRouteBuilder BuildRouteBuilder()
+    {
+        var services = new ServiceCollection();
+        services.AddRouting();
+        services.AddSingleton(new ClientTelemetryDestination(
+            new Uri("https://collector.example.test"),
+            OtlpExportProtocol.HttpProtobuf,
+            [],
+            TimeSpan.FromSeconds(10)));
+
+        return new TestEndpointRouteBuilder(services.BuildServiceProvider());
+    }
+}

--- a/backend/tests/Host.UnitTests/Host.UnitTests.csproj
+++ b/backend/tests/Host.UnitTests/Host.UnitTests.csproj
@@ -48,6 +48,11 @@
     <!-- The redaction contract is stated once and asserted in every project that has a telemetry name to hold against
          it. This one holds the names every assembly declares, so it needs the rules and not the recorder. -->
     <Compile Include="..\shared\TelemetryRedactionContract.cs" Link="TelemetryRedactionContract.cs" />
+
+    <!-- The client telemetry proxy is the one thing this composition root speaks HTTP from, so it is tested through
+         the suite's one HTTP double rather than through a second one written here. -->
+    <Compile Include="..\shared\FakeHttpMessageHandler.cs" Link="FakeHttpMessageHandler.cs" />
+    <Compile Include="..\shared\RecordedHttpRequest.cs" Link="RecordedHttpRequest.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/tests/Host.UnitTests/Observability/ClientTelemetry/ClientTelemetryDestinationTests.cs
+++ b/backend/tests/Host.UnitTests/Observability/ClientTelemetry/ClientTelemetryDestinationTests.cs
@@ -1,0 +1,134 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Host.Observability.ClientTelemetry;
+using OpenTelemetry.Exporter;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Observability.ClientTelemetry;
+
+/// <summary>Covers where a forwarded batch is addressed and what it carries with it.</summary>
+/// <remarks>
+/// The settings are stated rather than read from the process environment, which is what the exporter's own constructor
+/// does: a test that let the ambient environment decide would pass or fail on whatever the machine running it exports
+/// to. What is asserted here is the composition of an address and the reading of a header list, which is all this type
+/// decides.
+/// </remarks>
+public sealed class ClientTelemetryDestinationTests
+{
+    /// <summary>The path is the specification's, so a collector serving OTLP over HTTP is reached where it listens.</summary>
+    [Fact]
+    public void AddressFor_OverHttp_AppendsThePathTheSpecificationFixesForTheSignal()
+    {
+        // Arrange
+        var destination = DestinationAt("https://collector.example.test:4318", OtlpExportProtocol.HttpProtobuf);
+
+        // Act
+        var addresses = ClientTelemetrySignal.All.Select(destination.AddressFor).ToArray();
+
+        // Assert
+        Assert.Equal(
+            [
+                new Uri("https://collector.example.test:4318/v1/traces"),
+                new Uri("https://collector.example.test:4318/v1/metrics"),
+                new Uri("https://collector.example.test:4318/v1/logs"),
+            ],
+            addresses);
+    }
+
+    /// <summary>A gRPC endpoint names a server, so the service and the method are what make it an export.</summary>
+    [Fact]
+    public void AddressFor_OverGrpc_AppendsTheSignalsOwnServiceMethod()
+    {
+        // Arrange
+        var destination = DestinationAt("http://localhost:4317", OtlpExportProtocol.Grpc);
+
+        // Act
+        var address = destination.AddressFor(ClientTelemetrySignal.Traces);
+
+        // Assert
+        Assert.Equal(
+            new Uri("http://localhost:4317/opentelemetry.proto.collector.trace.v1.TraceService/Export"),
+            address);
+    }
+
+    /// <summary>An endpoint an operator wrote with a trailing slash addresses the same collector as one without.</summary>
+    [Fact]
+    public void AddressFor_AnEndpointWrittenWithATrailingSlash_ComposesTheSameAddress()
+    {
+        // Arrange
+        var destination = DestinationAt("https://collector.example.test/otlp/", OtlpExportProtocol.HttpProtobuf);
+
+        // Act
+        var address = destination.AddressFor(ClientTelemetrySignal.Logs);
+
+        // Assert
+        Assert.Equal(new Uri("https://collector.example.test/otlp/v1/logs"), address);
+    }
+
+    /// <summary>The collector's credential travels in this list, so a pair the exporter would send is a pair this sends.</summary>
+    [Fact]
+    public void From_HeadersInTheStandardForm_ReadsEachPairWithItsValueDecoded()
+    {
+        // Arrange
+        var exporterSettings = new OtlpExporterOptions
+        {
+            Endpoint = new Uri("https://collector.example.test"),
+            Headers = "api-key=abc123, x-scope=team%2Cmail",
+        };
+
+        // Act
+        var destination = ClientTelemetryDestination.From(exporterSettings);
+
+        // Assert
+        Assert.Equal(
+            [
+                new KeyValuePair<string, string>("api-key", "abc123"),
+                new KeyValuePair<string, string>("x-scope", "team,mail"),
+            ],
+            destination.Headers);
+    }
+
+    /// <summary>The control for the reading above, which would otherwise pass over a parser that found nothing.</summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("nothing-that-is-a-pair")]
+    public void From_NoHeaderPairs_ReadsNone(string? headers)
+    {
+        // Arrange
+        var exporterSettings = new OtlpExporterOptions
+        {
+            Endpoint = new Uri("https://collector.example.test"),
+            Headers = headers,
+        };
+
+        // Act
+        var destination = ClientTelemetryDestination.From(exporterSettings);
+
+        // Assert
+        Assert.Empty(destination.Headers);
+    }
+
+    /// <summary>The ceiling on one forward is the exporter's own, so both move together.</summary>
+    [Fact]
+    public void From_TheExportersConfiguredTimeout_IsWhatOneForwardRunsUnder()
+    {
+        // Arrange
+        var exporterSettings = new OtlpExporterOptions
+        {
+            Endpoint = new Uri("https://collector.example.test"),
+            TimeoutMilliseconds = 2500,
+        };
+
+        // Act
+        var destination = ClientTelemetryDestination.From(exporterSettings);
+
+        // Assert
+        Assert.Equal(TimeSpan.FromMilliseconds(2500), destination.Timeout);
+    }
+
+    private static ClientTelemetryDestination DestinationAt(string endpoint, OtlpExportProtocol protocol) =>
+        new(new Uri(endpoint), protocol, [], TimeSpan.FromSeconds(10));
+}

--- a/backend/tests/Host.UnitTests/Observability/ClientTelemetry/ClientTelemetryForwarderTests.cs
+++ b/backend/tests/Host.UnitTests/Observability/ClientTelemetry/ClientTelemetryForwarderTests.cs
@@ -1,0 +1,267 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Globalization;
+using System.Net;
+using MailFathom.Host.Observability.ClientTelemetry;
+using MailFathom.TestSupport;
+using NSubstitute;
+using OpenTelemetry.Exporter;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Observability.ClientTelemetry;
+
+/// <summary>Covers what reaches the collector and what the client is told about it.</summary>
+/// <remarks>
+/// Both transports are exercised, because a deployment's exporter picks one and the proxy has to reach the same
+/// collector the same way: over HTTP that is the batch posted verbatim, and over gRPC the same octets inside the frame
+/// that protocol wraps a unary message in. The distinction the answers turn on is the specification's own — a rejection
+/// the destination will never take back is relayed as one, and anything transient is answered as unavailability so the
+/// client holds what it has not exported.
+/// </remarks>
+public sealed class ClientTelemetryForwarderTests
+{
+    private static readonly byte[] Batch = [0x0A, 0x02, 0x12, 0x00];
+
+    /// <summary>The batch reaches the collector unchanged, at the path the specification serves the signal at.</summary>
+    [Fact]
+    public async Task ForwardAsync_OverHttp_PostsTheBatchVerbatimToTheSignalsOwnPath()
+    {
+        // Arrange
+        using var collector = FakeHttpMessageHandler.AlwaysResponding(
+            () => new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent([]) });
+        var forwarder = ForwarderOver(collector, OtlpExportProtocol.HttpProtobuf);
+
+        // Act
+        var forwarding = await forwarder.ForwardAsync(
+            ClientTelemetrySignal.Metrics,
+            Batch,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var sent = Assert.Single(collector.RecordedRequests);
+        Assert.Equal(HttpMethod.Post, sent.Method);
+        Assert.Equal(new Uri("https://collector.example.test/v1/metrics"), sent.RequestUri);
+        Assert.Equal(Batch, sent.Content.ToArray());
+        Assert.True(forwarding.Arrived);
+    }
+
+    /// <summary>The collector's credential travels on the request, which is what keeps it out of the client bundle.</summary>
+    [Fact]
+    public async Task ForwardAsync_ADestinationWithConfiguredHeaders_SendsEachOfThem()
+    {
+        // Arrange
+        using var collector = FakeHttpMessageHandler.AlwaysResponding(
+            () => new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent([]) });
+        var forwarder = ForwarderOver(
+            collector,
+            OtlpExportProtocol.HttpProtobuf,
+            [new KeyValuePair<string, string>("api-key", "abc123")]);
+
+        // Act
+        await forwarder.ForwardAsync(ClientTelemetrySignal.Logs, Batch, TestContext.Current.CancellationToken);
+
+        // Assert
+        var sent = Assert.Single(collector.RecordedRequests);
+        Assert.Equal("abc123", Assert.Single(sent.Headers["api-key"]));
+    }
+
+    /// <summary>A partial success lives in the destination's own body, so answering a bare success would hide a rejection.</summary>
+    [Fact]
+    public async Task ForwardAsync_ADestinationReportingAPartialSuccess_RelaysWhatItAnswered()
+    {
+        // Arrange
+        byte[] partialSuccess = [0x0A, 0x02, 0x08, 0x03];
+        using var collector = FakeHttpMessageHandler.AlwaysResponding(
+            () => new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(partialSuccess) });
+        var forwarder = ForwarderOver(collector, OtlpExportProtocol.HttpProtobuf);
+
+        // Act
+        var forwarding = await forwarder.ForwardAsync(
+            ClientTelemetrySignal.Traces,
+            Batch,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(forwarding.Arrived);
+        Assert.Equal(partialSuccess, forwarding.Body);
+    }
+
+    /// <summary>The two halves of the specification's own split: what a client should stop sending, and what it should hold.</summary>
+    [Theory]
+    [InlineData(HttpStatusCode.BadRequest, nameof(ClientTelemetryFailure.Refused))]
+    [InlineData(HttpStatusCode.UnsupportedMediaType, nameof(ClientTelemetryFailure.Refused))]
+    [InlineData(HttpStatusCode.TooManyRequests, nameof(ClientTelemetryFailure.Throttled))]
+    [InlineData(HttpStatusCode.BadGateway, nameof(ClientTelemetryFailure.Unavailable))]
+    [InlineData(HttpStatusCode.ServiceUnavailable, nameof(ClientTelemetryFailure.Unavailable))]
+    public async Task ForwardAsync_ADestinationThatDidNotAcceptTheBatch_ReportsTheConditionThatFitsIt(
+        HttpStatusCode answered,
+        string expected)
+    {
+        // Arrange
+        using var collector = FakeHttpMessageHandler.AlwaysResponding(
+            () => new HttpResponseMessage(answered) { Content = new ByteArrayContent([]) });
+        var forwarder = ForwarderOver(collector, OtlpExportProtocol.HttpProtobuf);
+
+        // Act
+        var forwarding = await forwarder.ForwardAsync(
+            ClientTelemetrySignal.Traces,
+            Batch,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(expected, forwarding.Failure.ToString());
+    }
+
+    /// <summary>Nothing answering at the address is the condition an operator most needs named as itself.</summary>
+    [Fact]
+    public async Task ForwardAsync_ADestinationNothingAnswersAt_ReportsItAsUnreachable()
+    {
+        // Arrange
+        using var collector = new FakeHttpMessageHandler(
+            (_, _) => throw new HttpRequestException("nothing is listening"));
+        var forwarder = ForwarderOver(collector, OtlpExportProtocol.HttpProtobuf);
+
+        // Act
+        var forwarding = await forwarder.ForwardAsync(
+            ClientTelemetrySignal.Traces,
+            Batch,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(ClientTelemetryFailure.Unreachable, forwarding.Failure);
+    }
+
+    /// <summary>The gRPC frame is the whole difference between the two transports, and it has to survive both ways.</summary>
+    [Fact]
+    public async Task ForwardAsync_OverGrpc_FramesTheBatchAndTakesTheAnswerBackOutOfItsFrame()
+    {
+        // Arrange
+        byte[] answer = [0x0A, 0x02, 0x08, 0x03];
+        using var collector = FakeHttpMessageHandler.AlwaysResponding(() => GrpcAnswer(0, answer));
+        var forwarder = ForwarderOver(collector, OtlpExportProtocol.Grpc);
+
+        // Act
+        var forwarding = await forwarder.ForwardAsync(
+            ClientTelemetrySignal.Traces,
+            Batch,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var sent = Assert.Single(collector.RecordedRequests);
+        Assert.Equal(
+            new Uri("https://collector.example.test/opentelemetry.proto.collector.trace.v1.TraceService/Export"),
+            sent.RequestUri);
+        Assert.Equal([0, 0, 0, 0, (byte)Batch.Length, .. Batch], sent.Content.ToArray());
+        Assert.True(forwarding.Arrived);
+        Assert.Equal(answer, forwarding.Body);
+    }
+
+    /// <summary>A gRPC destination reports its verdict as a status rather than as a response code.</summary>
+    [Theory]
+    [InlineData(3, nameof(ClientTelemetryFailure.Refused))]
+    [InlineData(12, nameof(ClientTelemetryFailure.Refused))]
+    [InlineData(8, nameof(ClientTelemetryFailure.Throttled))]
+    [InlineData(14, nameof(ClientTelemetryFailure.Unavailable))]
+    public async Task ForwardAsync_OverGrpc_AStatusOtherThanOk_ReportsTheConditionThatFitsIt(
+        int status,
+        string expected)
+    {
+        // Arrange
+        using var collector = FakeHttpMessageHandler.AlwaysResponding(() => GrpcAnswer(status, []));
+        var forwarder = ForwarderOver(collector, OtlpExportProtocol.Grpc);
+
+        // Act
+        var forwarding = await forwarder.ForwardAsync(
+            ClientTelemetrySignal.Traces,
+            Batch,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(expected, forwarding.Failure.ToString());
+    }
+
+    /// <summary>A success is the one thing a gRPC server states explicitly, so an answer stating nothing is not one.</summary>
+    [Fact]
+    public async Task ForwardAsync_OverGrpc_AnAnswerCarryingNoStatus_IsNotReadAsASuccess()
+    {
+        // Arrange
+        using var collector = FakeHttpMessageHandler.AlwaysResponding(
+            () => new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent([]) });
+        var forwarder = ForwarderOver(collector, OtlpExportProtocol.Grpc);
+
+        // Act
+        var forwarding = await forwarder.ForwardAsync(
+            ClientTelemetrySignal.Traces,
+            Batch,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(ClientTelemetryFailure.Unavailable, forwarding.Failure);
+    }
+
+    /// <summary>The ceiling is the exporter's own, and a destination past it is a condition rather than a hung request.</summary>
+    [Fact]
+    public async Task ForwardAsync_ADestinationThatDoesNotAnswerInsideTheConfiguredTimeout_ReportsATimeout()
+    {
+        // Arrange
+        using var collector = new FakeHttpMessageHandler(async (_, cancellationToken) =>
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        var forwarder = ForwarderOver(
+            collector,
+            OtlpExportProtocol.HttpProtobuf,
+            headers: null,
+            timeout: TimeSpan.FromMilliseconds(30));
+
+        // Act
+        var forwarding = await forwarder.ForwardAsync(
+            ClientTelemetrySignal.Traces,
+            Batch,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(ClientTelemetryFailure.TimedOut, forwarding.Failure);
+    }
+
+    /// <summary>Composes one gRPC answer: the status in the trailers, and the message inside its frame.</summary>
+    private static HttpResponseMessage GrpcAnswer(int status, byte[] message)
+    {
+        byte[] framed = message.Length == 0 ? [] : [0, 0, 0, 0, (byte)message.Length, .. message];
+        var answer = new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(framed) };
+        answer.TrailingHeaders.TryAddWithoutValidation(
+            "grpc-status",
+            status.ToString(CultureInfo.InvariantCulture));
+
+        return answer;
+    }
+
+    /// <summary>Builds the forwarder over one collector, through a factory that hands out a client per call.</summary>
+    /// <remarks>
+    /// A callback rather than a fixed instance, because the forwarder disposes the client it opened — which is what
+    /// opening one per operation means — and a substitute answering the same instance twice would hand the second call
+    /// a disposed one.
+    /// </remarks>
+    private static ClientTelemetryForwarder ForwarderOver(
+        HttpMessageHandler collector,
+        OtlpExportProtocol protocol,
+        IReadOnlyList<KeyValuePair<string, string>>? headers = null,
+        TimeSpan? timeout = null)
+    {
+        var clients = Substitute.For<IHttpClientFactory>();
+        clients.CreateClient(ClientTelemetryForwarder.HttpClientName)
+            .Returns(_ => new HttpClient(collector, disposeHandler: false));
+
+        var destination = new ClientTelemetryDestination(
+            new Uri("https://collector.example.test"),
+            protocol,
+            headers ?? [],
+            timeout ?? TimeSpan.FromSeconds(10));
+
+        return new ClientTelemetryForwarder(clients, destination);
+    }
+}

--- a/backend/tests/Host.UnitTests/Observability/ClientTelemetry/ClientTelemetryForwarderTests.cs
+++ b/backend/tests/Host.UnitTests/Observability/ClientTelemetry/ClientTelemetryForwarderTests.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Net;
 using MailFathom.Host.Observability.ClientTelemetry;
 using MailFathom.TestSupport;
+using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using OpenTelemetry.Exporter;
 using Xunit;
@@ -206,13 +207,26 @@ public sealed class ClientTelemetryForwarderTests
     }
 
     /// <summary>The ceiling is the exporter's own, and a destination past it is a condition rather than a hung request.</summary>
+    /// <remarks>
+    /// The wait is the fake clock's rather than the machine's, which is what makes the deadline itself the thing under
+    /// test: the collector is entered and then blocks until its token is cancelled, so nothing here completes until the
+    /// clock is advanced past the configured timeout.
+    /// </remarks>
     [Fact]
     public async Task ForwardAsync_ADestinationThatDoesNotAnswerInsideTheConfiguredTimeout_ReportsATimeout()
     {
         // Arrange
+        var timeout = TimeSpan.FromSeconds(4);
+        var clock = new FakeTimeProvider();
+        var entered = new TaskCompletionSource();
         using var collector = new FakeHttpMessageHandler(async (_, cancellationToken) =>
         {
-            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            entered.TrySetResult();
+
+            var blocked = new TaskCompletionSource();
+            await using var registration = cancellationToken.Register(
+                () => blocked.TrySetCanceled(cancellationToken));
+            await blocked.Task;
 
             return new HttpResponseMessage(HttpStatusCode.OK);
         });
@@ -220,16 +234,20 @@ public sealed class ClientTelemetryForwarderTests
             collector,
             OtlpExportProtocol.HttpProtobuf,
             headers: null,
-            timeout: TimeSpan.FromMilliseconds(30));
+            timeout: timeout,
+            clock: clock);
 
         // Act
-        var forwarding = await forwarder.ForwardAsync(
+        var forwarding = forwarder.ForwardAsync(
             ClientTelemetrySignal.Traces,
             Batch,
             TestContext.Current.CancellationToken);
 
+        await entered.Task;
+        clock.Advance(timeout);
+
         // Assert
-        Assert.Equal(ClientTelemetryFailure.TimedOut, forwarding.Failure);
+        Assert.Equal(ClientTelemetryFailure.TimedOut, (await forwarding).Failure);
     }
 
     /// <summary>Composes one gRPC answer: the status in the trailers, and the message inside its frame.</summary>
@@ -254,7 +272,8 @@ public sealed class ClientTelemetryForwarderTests
         HttpMessageHandler collector,
         OtlpExportProtocol protocol,
         IReadOnlyList<KeyValuePair<string, string>>? headers = null,
-        TimeSpan? timeout = null)
+        TimeSpan? timeout = null,
+        TimeProvider? clock = null)
     {
         var clients = Substitute.For<IHttpClientFactory>();
         clients.CreateClient(ClientTelemetryForwarder.HttpClientName)
@@ -266,6 +285,6 @@ public sealed class ClientTelemetryForwarderTests
             headers ?? [],
             timeout ?? TimeSpan.FromSeconds(10));
 
-        return new ClientTelemetryForwarder(clients, destination);
+        return new ClientTelemetryForwarder(clients, destination, clock ?? TimeProvider.System);
     }
 }

--- a/backend/tests/Host.UnitTests/Observability/ClientTelemetry/ClientTelemetryForwarderTests.cs
+++ b/backend/tests/Host.UnitTests/Observability/ClientTelemetry/ClientTelemetryForwarderTests.cs
@@ -88,11 +88,13 @@ public sealed class ClientTelemetryForwarderTests
         Assert.Equal(partialSuccess, forwarding.Body);
     }
 
-    /// <summary>The two halves of the specification's own split: what a client should stop sending, and what it should hold.</summary>
+    /// <summary>The specification's own split — stop sending, or hold — plus the credential this deployment repairs itself.</summary>
     [Theory]
     [InlineData(HttpStatusCode.BadRequest, nameof(ClientTelemetryFailure.Refused))]
     [InlineData(HttpStatusCode.UnsupportedMediaType, nameof(ClientTelemetryFailure.Refused))]
     [InlineData(HttpStatusCode.TooManyRequests, nameof(ClientTelemetryFailure.Throttled))]
+    [InlineData(HttpStatusCode.Unauthorized, nameof(ClientTelemetryFailure.Unauthorized))]
+    [InlineData(HttpStatusCode.Forbidden, nameof(ClientTelemetryFailure.Unauthorized))]
     [InlineData(HttpStatusCode.BadGateway, nameof(ClientTelemetryFailure.Unavailable))]
     [InlineData(HttpStatusCode.ServiceUnavailable, nameof(ClientTelemetryFailure.Unavailable))]
     public async Task ForwardAsync_ADestinationThatDidNotAcceptTheBatch_ReportsTheConditionThatFitsIt(
@@ -162,6 +164,8 @@ public sealed class ClientTelemetryForwarderTests
     [Theory]
     [InlineData(3, nameof(ClientTelemetryFailure.Refused))]
     [InlineData(12, nameof(ClientTelemetryFailure.Refused))]
+    [InlineData(7, nameof(ClientTelemetryFailure.Unauthorized))]
+    [InlineData(16, nameof(ClientTelemetryFailure.Unauthorized))]
     [InlineData(8, nameof(ClientTelemetryFailure.Throttled))]
     [InlineData(14, nameof(ClientTelemetryFailure.Unavailable))]
     public async Task ForwardAsync_OverGrpc_AStatusOtherThanOk_ReportsTheConditionThatFitsIt(

--- a/backend/tests/Host.UnitTests/Observability/ClientTelemetry/ClientTelemetryForwarderTests.cs
+++ b/backend/tests/Host.UnitTests/Observability/ClientTelemetry/ClientTelemetryForwarderTests.cs
@@ -250,6 +250,46 @@ public sealed class ClientTelemetryForwarderTests
         Assert.Equal(ClientTelemetryFailure.TimedOut, (await forwarding).Failure);
     }
 
+    /// <summary>The control for the deadline above: a client that hung up is a different condition from a collector that did not answer.</summary>
+    /// <remarks>
+    /// Both arrive as the same exception out of the same linked source, so what tells them apart is which token fired.
+    /// Asserting only the timeout would leave a guard that reported a disconnected browser tab as a slow collector
+    /// passing, which is the one distinction the counter and the line an operator reads are built on.
+    /// </remarks>
+    [Fact]
+    public async Task ForwardAsync_ACallerThatCancelledWhileTheDestinationWasStillPending_ReportsCancellation()
+    {
+        // Arrange
+        var entered = new TaskCompletionSource();
+        using var collector = new FakeHttpMessageHandler(async (_, cancellationToken) =>
+        {
+            entered.TrySetResult();
+
+            var blocked = new TaskCompletionSource();
+            await using var registration = cancellationToken.Register(
+                () => blocked.TrySetCanceled(cancellationToken));
+            await blocked.Task;
+
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        var forwarder = ForwarderOver(
+            collector,
+            OtlpExportProtocol.HttpProtobuf,
+            headers: null,
+            timeout: TimeSpan.FromSeconds(4),
+            clock: new FakeTimeProvider());
+        using var caller = new CancellationTokenSource();
+
+        // Act
+        var forwarding = forwarder.ForwardAsync(ClientTelemetrySignal.Traces, Batch, caller.Token);
+
+        await entered.Task;
+        await caller.CancelAsync();
+
+        // Assert
+        Assert.Equal(ClientTelemetryFailure.Cancelled, (await forwarding).Failure);
+    }
+
     /// <summary>Composes one gRPC answer: the status in the trailers, and the message inside its frame.</summary>
     private static HttpResponseMessage GrpcAnswer(int status, byte[] message)
     {

--- a/backend/tests/Host.UnitTests/Observability/ClientTelemetry/ClientTelemetryProxyTelemetryTests.cs
+++ b/backend/tests/Host.UnitTests/Observability/ClientTelemetry/ClientTelemetryProxyTelemetryTests.cs
@@ -132,6 +132,6 @@ public sealed class ClientTelemetryProxyTelemetryTests
     [Fact]
     public void ConditionOf_EveryFailure_IsOneLowerCaseWordWrittenAsAPastParticiple() =>
         Assert.Equal(
-            ["forwarded", "refused", "throttled", "unavailable", "timed_out", "unreachable", "cancelled"],
+            ["forwarded", "refused", "throttled", "unavailable", "timed_out", "unreachable", "cancelled", "unauthorized"],
             Enum.GetValues<ClientTelemetryFailure>().Select(ClientTelemetryProxyTelemetry.ConditionOf));
 }

--- a/backend/tests/Host.UnitTests/Observability/ClientTelemetry/ClientTelemetryProxyTelemetryTests.cs
+++ b/backend/tests/Host.UnitTests/Observability/ClientTelemetry/ClientTelemetryProxyTelemetryTests.cs
@@ -1,0 +1,137 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Host.Observability.ClientTelemetry;
+using MailFathom.Host.UnitTests.TestDoubles;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Observability.ClientTelemetry;
+
+/// <summary>Covers the half of the proxy's contract that is about what it does <b>not</b> write.</summary>
+/// <remarks>
+/// Quietness is acceptance rather than taste here: a signed-in client exports every few seconds for as long as it is
+/// open, so a record per batch would make a deployment's own logs unreadable within a day. What is asserted is that the
+/// working path writes nothing at all, and that a condition that holds writes one line rather than one per batch — with
+/// the count that says what it cost.
+/// </remarks>
+public sealed class ClientTelemetryProxyTelemetryTests
+{
+    private static readonly DateTimeOffset Noon = new(2026, 9, 2, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>The ordinary case, which is every batch of every signed-in client for the life of the deployment.</summary>
+    [Fact]
+    public void RecordForwarding_ABatchThatArrived_WritesNoLogRecordAtAnyLevel()
+    {
+        // Arrange
+        var logger = new RecordingLogger<ClientTelemetryProxyTelemetry>();
+        var telemetry = new ClientTelemetryProxyTelemetry(logger, new FakeTimeProvider(Noon));
+
+        // Act
+        telemetry.RecordAccepted(ClientTelemetrySignal.Traces, records: 40);
+        telemetry.RecordForwarding(ClientTelemetrySignal.Traces, ClientTelemetryForwarding.Forwarded([]));
+
+        // Assert
+        Assert.Empty(logger.Messages);
+    }
+
+    /// <summary>A client sending what this deployment will not take is the endpoint working, not an incident.</summary>
+    [Fact]
+    public void RecordRefused_ABatchThisEndpointWouldNotRead_WritesNoLogRecord()
+    {
+        // Arrange
+        var logger = new RecordingLogger<ClientTelemetryProxyTelemetry>();
+        var telemetry = new ClientTelemetryProxyTelemetry(logger, new FakeTimeProvider(Noon));
+
+        // Act
+        telemetry.RecordRefused(ClientTelemetrySignal.Logs, "malformed");
+
+        // Assert
+        Assert.Empty(logger.Messages);
+    }
+
+    /// <summary>The regression this exists for: a collector that is down must not become the largest thing in the log.</summary>
+    [Fact]
+    public void RecordForwarding_OneConditionOverManyBatches_WritesOneLineRatherThanOnePerBatch()
+    {
+        // Arrange
+        var logger = new RecordingLogger<ClientTelemetryProxyTelemetry>();
+        var telemetry = new ClientTelemetryProxyTelemetry(logger, new FakeTimeProvider(Noon));
+
+        // Act
+        foreach (var _ in Enumerable.Range(0, 200))
+        {
+            telemetry.RecordForwarding(
+                ClientTelemetrySignal.Metrics,
+                ClientTelemetryForwarding.Failed(ClientTelemetryFailure.Unreachable));
+        }
+
+        // Assert
+        Assert.Single(logger.Messages);
+        Assert.Contains("unreachable", logger.Messages[0], StringComparison.Ordinal);
+    }
+
+    /// <summary>A condition that is still true is worth saying again, and the count is what a rate cannot tell a reader.</summary>
+    [Fact]
+    public void RecordForwarding_AConditionStillHoldingAfterTheQuietPeriod_WritesAgainWithWhatItHasCost()
+    {
+        // Arrange
+        var logger = new RecordingLogger<ClientTelemetryProxyTelemetry>();
+        var clock = new FakeTimeProvider(Noon);
+        var telemetry = new ClientTelemetryProxyTelemetry(logger, clock);
+
+        foreach (var _ in Enumerable.Range(0, 3))
+        {
+            telemetry.RecordForwarding(
+                ClientTelemetrySignal.Traces,
+                ClientTelemetryForwarding.Failed(ClientTelemetryFailure.Unavailable));
+        }
+
+        clock.Advance(TimeSpan.FromMinutes(6));
+
+        // Act
+        telemetry.RecordForwarding(
+            ClientTelemetrySignal.Traces,
+            ClientTelemetryForwarding.Failed(ClientTelemetryFailure.Unavailable));
+
+        // Assert
+        Assert.Equal(2, logger.Messages.Count);
+        Assert.Contains("1 batch(es)", logger.Messages[0], StringComparison.Ordinal);
+        Assert.Contains("3 batch(es)", logger.Messages[1], StringComparison.Ordinal);
+    }
+
+    /// <summary>Two different conditions are two things an operator acts on, so neither hides behind the other.</summary>
+    [Fact]
+    public void RecordForwarding_TwoConditions_WritesOneLineForEach()
+    {
+        // Arrange
+        var logger = new RecordingLogger<ClientTelemetryProxyTelemetry>();
+        var telemetry = new ClientTelemetryProxyTelemetry(logger, new FakeTimeProvider(Noon));
+
+        // Act
+        telemetry.RecordForwarding(
+            ClientTelemetrySignal.Traces,
+            ClientTelemetryForwarding.Failed(ClientTelemetryFailure.TimedOut));
+        telemetry.RecordForwarding(
+            ClientTelemetrySignal.Traces,
+            ClientTelemetryForwarding.Refused());
+
+        // Assert
+        Assert.Equal(2, logger.Messages.Count);
+        Assert.Contains("timed_out", logger.Messages[0], StringComparison.Ordinal);
+        Assert.Contains("refused", logger.Messages[1], StringComparison.Ordinal);
+    }
+
+    /// <summary>The condition vocabulary is what the counter and the line share, so neither can drift from the other.</summary>
+    /// <remarks>
+    /// Asserted over every member at once rather than one input at a time, so a condition added to the enumeration and
+    /// left out of the mapping fails here instead of reaching a deployment's metrics as an unnamed dimension value. The
+    /// order is the enumeration's own, which its explicit values fix.
+    /// </remarks>
+    [Fact]
+    public void ConditionOf_EveryFailure_IsOneLowerCaseWordWrittenAsAPastParticiple() =>
+        Assert.Equal(
+            ["forwarded", "refused", "throttled", "unavailable", "timed_out", "unreachable", "cancelled"],
+            Enum.GetValues<ClientTelemetryFailure>().Select(ClientTelemetryProxyTelemetry.ConditionOf));
+}

--- a/backend/tests/Host.UnitTests/Observability/ClientTelemetry/ClientTelemetryQuotaTests.cs
+++ b/backend/tests/Host.UnitTests/Observability/ClientTelemetry/ClientTelemetryQuotaTests.cs
@@ -1,0 +1,71 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Host.Observability.ClientTelemetry;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Observability.ClientTelemetry;
+
+/// <summary>Covers the bound on how often one signed-in person's client may export.</summary>
+/// <remarks>
+/// The replenishment is not driven here. What this endpoint's bound has to be is per owner rather than per surface, and
+/// that is what a test can settle without a clock: one owner spending its burst says nothing about the next owner's.
+/// </remarks>
+public sealed class ClientTelemetryQuotaTests
+{
+    /// <summary>An ordinary client exporting every few seconds is never refused, which is what the burst is sized for.</summary>
+    [Fact]
+    public void TryAdmit_WithinTheBurst_AdmitsEveryExport()
+    {
+        // Arrange
+        using var quota = new ClientTelemetryQuota();
+
+        // Act
+        var admitted = Enumerable
+            .Range(0, ClientTelemetryQuota.BurstCapacity)
+            .Select(_ => quota.TryAdmit("owner-a"))
+            .ToArray();
+
+        // Assert
+        Assert.All(admitted, Assert.True);
+    }
+
+    /// <summary>The bound the acceptance asks for: one credential cannot export without limit.</summary>
+    [Fact]
+    public void TryAdmit_PastTheBurst_RefusesRatherThanQueueing()
+    {
+        // Arrange
+        using var quota = new ClientTelemetryQuota();
+
+        foreach (var _ in Enumerable.Range(0, ClientTelemetryQuota.BurstCapacity))
+        {
+            quota.TryAdmit("owner-a");
+        }
+
+        // Act
+        var admitted = quota.TryAdmit("owner-a");
+
+        // Assert
+        Assert.False(admitted);
+    }
+
+    /// <summary>The reason this is not the surface's own bucket: one person's client must not spend another's capacity.</summary>
+    [Fact]
+    public void TryAdmit_ASecondOwner_HasCapacityOfItsOwn()
+    {
+        // Arrange
+        using var quota = new ClientTelemetryQuota();
+
+        foreach (var _ in Enumerable.Range(0, ClientTelemetryQuota.BurstCapacity))
+        {
+            quota.TryAdmit("owner-a");
+        }
+
+        // Act
+        var admitted = quota.TryAdmit("owner-b");
+
+        // Assert
+        Assert.True(admitted);
+    }
+}

--- a/backend/tests/Host.UnitTests/Observability/ClientTelemetry/OtlpExportPayloadTests.cs
+++ b/backend/tests/Host.UnitTests/Observability/ClientTelemetry/OtlpExportPayloadTests.cs
@@ -1,0 +1,160 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text;
+using MailFathom.Host.Observability.ClientTelemetry;
+using MailFathom.Host.UnitTests.TestDoubles;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Observability.ClientTelemetry;
+
+/// <summary>Covers what the proxy does to an export request before it forwards one.</summary>
+/// <remarks>
+/// Two claims carry the privacy half of this feature: the owner this deployment authenticated is on every resource that
+/// leaves, and a client's own claim under that key never is. Both are asserted against the attributes a reader takes
+/// back out of the rewritten octets, because a batch is only attributed if a collector's own parse finds the entry
+/// where a resource attribute belongs. Everything else the client sent is asserted to survive, because a proxy that
+/// quietly dropped a field would be a processor.
+/// </remarks>
+public sealed class OtlpExportPayloadTests
+{
+    private const string OwnerKey = "mailfathom.owner";
+    private const string AuthenticatedOwner = "9f2a1c64-0000-4000-8000-000000000001";
+
+    /// <summary>The claim the whole attribution rests on: a client cannot export as somebody else.</summary>
+    [Fact]
+    public void Rewrite_ABatchClaimingAnOwnerOfItsOwn_ReplacesTheClaimWithTheAuthenticatedOne()
+    {
+        // Arrange
+        var request = OtlpExportRequests.Batch([new KeyValuePair<string, string>(OwnerKey, "somebody-else")], 1);
+
+        // Act
+        var rewritten = OtlpExportPayload.Rewrite(request, OwnerKey, AuthenticatedOwner, maxRecords: 10);
+
+        // Assert
+        Assert.Equal(OtlpPayloadRefusal.None, rewritten.Refusal);
+        Assert.Equal(
+            [new KeyValuePair<string, string>(OwnerKey, AuthenticatedOwner)],
+            OtlpExportRequests.ResourceAttributes(rewritten.Body).Where(attribute => attribute.Key == OwnerKey));
+    }
+
+    /// <summary>The control for the replacement: what the client says about itself is not this deployment's to drop.</summary>
+    [Fact]
+    public void Rewrite_ABatchCarryingOtherAttributes_LeavesThemAsTheClientSentThem()
+    {
+        // Arrange
+        var request = OtlpExportRequests.Batch(
+            [
+                new KeyValuePair<string, string>("service.name", "mailfathom-client"),
+                new KeyValuePair<string, string>(OwnerKey, "somebody-else"),
+                new KeyValuePair<string, string>("browser.brands", "Chromium"),
+            ],
+            1);
+
+        // Act
+        var rewritten = OtlpExportPayload.Rewrite(request, OwnerKey, AuthenticatedOwner, maxRecords: 10);
+
+        // Assert
+        Assert.Equal(
+            [
+                new KeyValuePair<string, string>("service.name", "mailfathom-client"),
+                new KeyValuePair<string, string>("browser.brands", "Chromium"),
+                new KeyValuePair<string, string>(OwnerKey, AuthenticatedOwner),
+            ],
+            OtlpExportRequests.ResourceAttributes(rewritten.Body));
+    }
+
+    /// <summary>An envelope with no resource is the one path by which unattributed telemetry could have left.</summary>
+    [Fact]
+    public void Rewrite_AnEnvelopeCarryingNoResource_AddsOneNamingTheAuthenticatedOwner()
+    {
+        // Arrange
+        var request = OtlpExportRequests.BatchWithoutResource(2);
+
+        // Act
+        var rewritten = OtlpExportPayload.Rewrite(request, OwnerKey, AuthenticatedOwner, maxRecords: 10);
+
+        // Assert
+        Assert.Equal(OtlpPayloadRefusal.None, rewritten.Refusal);
+        Assert.Equal(
+            [new KeyValuePair<string, string>(OwnerKey, AuthenticatedOwner)],
+            OtlpExportRequests.ResourceAttributes(rewritten.Body));
+    }
+
+    /// <summary>The count is what the batch bound and the accepted-records instrument are both read from.</summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(7)]
+    public void Rewrite_ABatchOfRecords_CountsEveryOne(int records)
+    {
+        // Arrange
+        var request = OtlpExportRequests.Batch([], records);
+
+        // Act
+        var rewritten = OtlpExportPayload.Rewrite(request, OwnerKey, AuthenticatedOwner, maxRecords: 100);
+
+        // Assert
+        Assert.Equal(records, rewritten.RecordCount);
+    }
+
+    /// <summary>A receiver that forwarded whatever arrived would be a way to push arbitrary octets at somebody's collector.</summary>
+    [Theory]
+    [InlineData(new byte[] { 0xFF, 0xFF, 0xFF })]
+    [InlineData(new byte[] { 0x0A, 0x7F })]
+    [InlineData(new byte[] { 0x0B, 0x01 })]
+    public void Rewrite_OctetsThatAreNotAnExportRequest_Refuses(byte[] request)
+    {
+        // Act
+        var rewritten = OtlpExportPayload.Rewrite(request, OwnerKey, AuthenticatedOwner, maxRecords: 100);
+
+        // Assert
+        Assert.Equal(OtlpPayloadRefusal.Malformed, rewritten.Refusal);
+        Assert.Empty(rewritten.Body);
+    }
+
+    /// <summary>The batch is refused whole rather than truncated, so a client is never told a rejection was a success.</summary>
+    [Fact]
+    public void Rewrite_ABatchPastTheRecordBound_RefusesItWholeRatherThanTruncatingIt()
+    {
+        // Arrange
+        var request = OtlpExportRequests.Batch([], records: 5);
+
+        // Act
+        var rewritten = OtlpExportPayload.Rewrite(request, OwnerKey, AuthenticatedOwner, maxRecords: 4);
+
+        // Assert
+        Assert.Equal(OtlpPayloadRefusal.TooManyRecords, rewritten.Refusal);
+        Assert.Empty(rewritten.Body);
+    }
+
+    /// <summary>An empty request is a valid one, and the resource it gains is what makes it attributed.</summary>
+    [Fact]
+    public void Rewrite_AnEmptyRequest_IsAccepted()
+    {
+        // Act
+        var rewritten = OtlpExportPayload.Rewrite([], OwnerKey, AuthenticatedOwner, maxRecords: 10);
+
+        // Assert
+        Assert.Equal(OtlpPayloadRefusal.None, rewritten.Refusal);
+        Assert.Equal(0, rewritten.RecordCount);
+        Assert.Empty(rewritten.Body);
+    }
+
+    /// <summary>A refusal carries the specification's own document, which is what an exporter reads rather than a sentence.</summary>
+    [Fact]
+    public void Status_ACodeAndAMessage_EncodesBothFieldsInTheOrderTheSchemaDeclaresThem()
+    {
+        // Arrange
+        var message = "refused";
+
+        // Act
+        var status = OtlpExportPayload.Status(3, message);
+
+        // Assert
+        Assert.Equal(
+            [0x08, 0x03, 0x12, (byte)message.Length, .. Encoding.UTF8.GetBytes(message)],
+            status);
+    }
+}

--- a/backend/tests/Host.UnitTests/Observability/ClientTelemetry/OtlpExportPayloadTests.cs
+++ b/backend/tests/Host.UnitTests/Observability/ClientTelemetry/OtlpExportPayloadTests.cs
@@ -30,7 +30,12 @@ public sealed class OtlpExportPayloadTests
         var request = OtlpExportRequests.Batch([new KeyValuePair<string, string>(OwnerKey, "somebody-else")], 1);
 
         // Act
-        var rewritten = OtlpExportPayload.Rewrite(request, OwnerKey, AuthenticatedOwner, maxRecords: 10);
+        var rewritten = OtlpExportPayload.Rewrite(
+            request,
+            ClientTelemetrySignal.Traces,
+            OwnerKey,
+            AuthenticatedOwner,
+            maxRecords: 10);
 
         // Assert
         Assert.Equal(OtlpPayloadRefusal.None, rewritten.Refusal);
@@ -53,7 +58,12 @@ public sealed class OtlpExportPayloadTests
             1);
 
         // Act
-        var rewritten = OtlpExportPayload.Rewrite(request, OwnerKey, AuthenticatedOwner, maxRecords: 10);
+        var rewritten = OtlpExportPayload.Rewrite(
+            request,
+            ClientTelemetrySignal.Traces,
+            OwnerKey,
+            AuthenticatedOwner,
+            maxRecords: 10);
 
         // Assert
         Assert.Equal(
@@ -73,7 +83,12 @@ public sealed class OtlpExportPayloadTests
         var request = OtlpExportRequests.BatchWithoutResource(2);
 
         // Act
-        var rewritten = OtlpExportPayload.Rewrite(request, OwnerKey, AuthenticatedOwner, maxRecords: 10);
+        var rewritten = OtlpExportPayload.Rewrite(
+            request,
+            ClientTelemetrySignal.Traces,
+            OwnerKey,
+            AuthenticatedOwner,
+            maxRecords: 10);
 
         // Assert
         Assert.Equal(OtlpPayloadRefusal.None, rewritten.Refusal);
@@ -93,10 +108,80 @@ public sealed class OtlpExportPayloadTests
         var request = OtlpExportRequests.Batch([], records);
 
         // Act
-        var rewritten = OtlpExportPayload.Rewrite(request, OwnerKey, AuthenticatedOwner, maxRecords: 100);
+        var rewritten = OtlpExportPayload.Rewrite(
+            request,
+            ClientTelemetrySignal.Traces,
+            OwnerKey,
+            AuthenticatedOwner,
+            maxRecords: 100);
 
         // Assert
         Assert.Equal(records, rewritten.RecordCount);
+    }
+
+    /// <summary>A metric is as many records as it measured, which is what the bound has to count to be a bound at all.</summary>
+    [Theory]
+    [InlineData(1, 1, 1)]
+    [InlineData(3, 40, 120)]
+    [InlineData(2, 0, 2)]
+    public void Rewrite_AMetricsBatch_CountsItsDataPointsRatherThanItsMetrics(
+        int metrics,
+        int dataPoints,
+        int expected)
+    {
+        // Arrange
+        var request = OtlpExportRequests.MetricsBatch(metrics, dataPoints);
+
+        // Act
+        var rewritten = OtlpExportPayload.Rewrite(
+            request,
+            ClientTelemetrySignal.Metrics,
+            OwnerKey,
+            AuthenticatedOwner,
+            maxRecords: 1000);
+
+        // Assert
+        Assert.Equal(OtlpPayloadRefusal.None, rewritten.Refusal);
+        Assert.Equal(expected, rewritten.RecordCount);
+    }
+
+    /// <summary>A payload shape added after this was written counts as one rather than as none, so it never slips the bound.</summary>
+    [Fact]
+    public void Rewrite_AMetricReportedInAShapeThisDeploymentDoesNotKnow_StillCountsAsOneRecord()
+    {
+        // Arrange
+        var request = OtlpExportRequests.MetricsBatch(metrics: 2, dataPoints: 9, payloadField: 21);
+
+        // Act
+        var rewritten = OtlpExportPayload.Rewrite(
+            request,
+            ClientTelemetrySignal.Metrics,
+            OwnerKey,
+            AuthenticatedOwner,
+            maxRecords: 1000);
+
+        // Assert
+        Assert.Equal(2, rewritten.RecordCount);
+    }
+
+    /// <summary>The bound refuses a batch whose metrics are few and whose measurements are not.</summary>
+    [Fact]
+    public void Rewrite_AFewMetricsCarryingMoreDataPointsThanTheBound_RefusesTheBatch()
+    {
+        // Arrange
+        var request = OtlpExportRequests.MetricsBatch(metrics: 2, dataPoints: 30);
+
+        // Act
+        var rewritten = OtlpExportPayload.Rewrite(
+            request,
+            ClientTelemetrySignal.Metrics,
+            OwnerKey,
+            AuthenticatedOwner,
+            maxRecords: 40);
+
+        // Assert
+        Assert.Equal(OtlpPayloadRefusal.TooManyRecords, rewritten.Refusal);
+        Assert.Empty(rewritten.Body);
     }
 
     /// <summary>A receiver that forwarded whatever arrived would be a way to push arbitrary octets at somebody's collector.</summary>
@@ -107,7 +192,12 @@ public sealed class OtlpExportPayloadTests
     public void Rewrite_OctetsThatAreNotAnExportRequest_Refuses(byte[] request)
     {
         // Act
-        var rewritten = OtlpExportPayload.Rewrite(request, OwnerKey, AuthenticatedOwner, maxRecords: 100);
+        var rewritten = OtlpExportPayload.Rewrite(
+            request,
+            ClientTelemetrySignal.Traces,
+            OwnerKey,
+            AuthenticatedOwner,
+            maxRecords: 100);
 
         // Assert
         Assert.Equal(OtlpPayloadRefusal.Malformed, rewritten.Refusal);
@@ -122,7 +212,12 @@ public sealed class OtlpExportPayloadTests
         var request = OtlpExportRequests.Batch([], records: 5);
 
         // Act
-        var rewritten = OtlpExportPayload.Rewrite(request, OwnerKey, AuthenticatedOwner, maxRecords: 4);
+        var rewritten = OtlpExportPayload.Rewrite(
+            request,
+            ClientTelemetrySignal.Traces,
+            OwnerKey,
+            AuthenticatedOwner,
+            maxRecords: 4);
 
         // Assert
         Assert.Equal(OtlpPayloadRefusal.TooManyRecords, rewritten.Refusal);
@@ -134,7 +229,12 @@ public sealed class OtlpExportPayloadTests
     public void Rewrite_AnEmptyRequest_IsAccepted()
     {
         // Act
-        var rewritten = OtlpExportPayload.Rewrite([], OwnerKey, AuthenticatedOwner, maxRecords: 10);
+        var rewritten = OtlpExportPayload.Rewrite(
+            [],
+            ClientTelemetrySignal.Traces,
+            OwnerKey,
+            AuthenticatedOwner,
+            maxRecords: 10);
 
         // Assert
         Assert.Equal(OtlpPayloadRefusal.None, rewritten.Refusal);

--- a/backend/tests/Host.UnitTests/Security/Endpoints/ClientTransportSecurityExtensionsTests.cs
+++ b/backend/tests/Host.UnitTests/Security/Endpoints/ClientTransportSecurityExtensionsTests.cs
@@ -94,7 +94,7 @@ public sealed class ClientTransportSecurityExtensionsTests
         var policy = ClientCorsPolicyOf(EnabledEndpoint());
 
         // Assert
-        Assert.Equal([HttpMethods.Get], policy.Methods);
+        Assert.Equal([HttpMethods.Get, HttpMethods.Post], policy.Methods);
         Assert.Equal(
             [HeaderNames.Authorization, HeaderNames.ContentType, HeaderNames.Accept],
             policy.Headers);
@@ -104,6 +104,11 @@ public sealed class ClientTransportSecurityExtensionsTests
     [Fact]
     public void AddClientTransportSecurity_ThePolicy_LetsAPageReadTheChallengeThatTellsItWhereToAuthorize() =>
         Assert.Contains(HeaderNames.WWWAuthenticate, ClientCorsPolicyOf(EnabledEndpoint()).ExposedHeaders);
+
+    /// <summary>A client told to hold cannot obey an interval its own browser hid from it.</summary>
+    [Fact]
+    public void AddClientTransportSecurity_ThePolicy_LetsAPageReadHowLongItWasAskedToHoldFor() =>
+        Assert.Contains(HeaderNames.RetryAfter, ClientCorsPolicyOf(EnabledEndpoint()).ExposedHeaders);
 
     /// <summary>An endpoint resolves exactly one policy by name, so two surfaces sharing one would let either deployment's origins decide what the other answers.</summary>
     [Fact]

--- a/backend/tests/Host.UnitTests/TestDoubles/OtlpExportRequests.cs
+++ b/backend/tests/Host.UnitTests/TestDoubles/OtlpExportRequests.cs
@@ -17,7 +17,8 @@ namespace MailFathom.Host.UnitTests.TestDoubles;
 /// <para>
 /// The three signals are shaped identically for everything the proxy does, so one builder covers all three. A record
 /// here is a message with one field in it: nothing under a scope is read, and giving a span its real fields would be
-/// arranging a schema the subject never consults.
+/// arranging a schema the subject never consults. A metric is the exception, and only as far as the subject goes — it
+/// is given a payload holding the points it measured, because that is the one nesting the record bound counts through.
 /// </para>
 /// </remarks>
 internal static class OtlpExportRequests
@@ -25,17 +26,31 @@ internal static class OtlpExportRequests
     private const int FirstField = 1;
     private const int SecondField = 2;
 
+    /// <summary>The one-of arm a sum reports its data points in, which is one of the five a metric may use.</summary>
+    private const int SumField = 7;
+
     /// <summary>Builds one export request carrying one resource and one scope.</summary>
     /// <param name="resourceAttributes">The attributes the client claims on the resource.</param>
     /// <param name="records">How many records the scope carries.</param>
     /// <returns>The request as it would arrive.</returns>
     internal static byte[] Batch(IReadOnlyList<KeyValuePair<string, string>> resourceAttributes, int records) =>
-        Envelope(Resource(resourceAttributes), records);
+        Envelope(Resource(resourceAttributes), Enumerable.Range(0, records).Select(_ => Record()));
+
+    /// <summary>Builds one metrics export request whose scope carries metrics reporting points of their own.</summary>
+    /// <param name="metrics">How many metric definitions the scope carries.</param>
+    /// <param name="dataPoints">How many data points each of them reports.</param>
+    /// <param name="payloadField">The one-of arm the points are reported in, a sum by default and an unknown number for a shape this repository has no name for.</param>
+    /// <returns>The request as it would arrive.</returns>
+    internal static byte[] MetricsBatch(int metrics, int dataPoints, int payloadField = SumField) =>
+        Envelope(
+            Resource([]),
+            Enumerable.Range(0, metrics).Select(_ => Metric(dataPoints, payloadField)));
 
     /// <summary>Builds one export request whose envelope carries no resource at all, which a client is free to send.</summary>
     /// <param name="records">How many records the scope carries.</param>
     /// <returns>The request as it would arrive.</returns>
-    internal static byte[] BatchWithoutResource(int records) => Envelope(resource: null, records);
+    internal static byte[] BatchWithoutResource(int records) =>
+        Envelope(resource: null, Enumerable.Range(0, records).Select(_ => Record()));
 
     /// <summary>Encodes one resource attribute exactly as it appears inside a request, tag included.</summary>
     private static byte[] Attribute(string key, string value) => LengthDelimited(
@@ -68,9 +83,9 @@ internal static class OtlpExportRequests
         ];
     }
 
-    private static byte[] Envelope(byte[]? resource, int records)
+    private static byte[] Envelope(byte[]? resource, IEnumerable<byte[]> records)
     {
-        byte[] scope = [.. Enumerable.Range(0, records).SelectMany(_ => LengthDelimited(SecondField, Record()))];
+        byte[] scope = [.. records.SelectMany(record => LengthDelimited(SecondField, record))];
 
         byte[] envelope =
         [
@@ -86,6 +101,16 @@ internal static class OtlpExportRequests
 
     /// <summary>One record, whose only field is opaque to everything the proxy does with it.</summary>
     private static byte[] Record() => LengthDelimited(FirstField, Encoding.UTF8.GetBytes("r"));
+
+    /// <summary>One metric: a name it is reported under, and one payload holding the points it measured.</summary>
+    private static byte[] Metric(int dataPoints, int payloadField) =>
+    [
+        .. LengthDelimited(FirstField, Encoding.UTF8.GetBytes("m")),
+        .. LengthDelimited(
+            payloadField,
+            [.. Enumerable.Range(0, dataPoints)
+                .SelectMany(_ => LengthDelimited(FirstField, Encoding.UTF8.GetBytes("p")))]),
+    ];
 
     private static byte[] LengthDelimited(int field, ReadOnlySpan<byte> payload) =>
         [.. Varint(((ulong)field << 3) | 2), .. Varint((ulong)payload.Length), .. payload];

--- a/backend/tests/Host.UnitTests/TestDoubles/OtlpExportRequests.cs
+++ b/backend/tests/Host.UnitTests/TestDoubles/OtlpExportRequests.cs
@@ -1,0 +1,162 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text;
+
+namespace MailFathom.Host.UnitTests.TestDoubles;
+
+/// <summary>Builds the OTLP export requests a client would post, as the octets that would arrive.</summary>
+/// <remarks>
+/// <para>
+/// The proxy reads the protocol buffers wire format rather than a schema, so a test arranges the same thing: an encoder
+/// of its own, written from the format rather than from the production reader. That is what makes the assertions
+/// independent — a fault in the reader's own varint handling would otherwise be arranged into the input and read back
+/// out as agreement.
+/// </para>
+/// <para>
+/// The three signals are shaped identically for everything the proxy does, so one builder covers all three. A record
+/// here is a message with one field in it: nothing under a scope is read, and giving a span its real fields would be
+/// arranging a schema the subject never consults.
+/// </para>
+/// </remarks>
+internal static class OtlpExportRequests
+{
+    private const int FirstField = 1;
+    private const int SecondField = 2;
+
+    /// <summary>Builds one export request carrying one resource and one scope.</summary>
+    /// <param name="resourceAttributes">The attributes the client claims on the resource.</param>
+    /// <param name="records">How many records the scope carries.</param>
+    /// <returns>The request as it would arrive.</returns>
+    internal static byte[] Batch(IReadOnlyList<KeyValuePair<string, string>> resourceAttributes, int records) =>
+        Envelope(Resource(resourceAttributes), records);
+
+    /// <summary>Builds one export request whose envelope carries no resource at all, which a client is free to send.</summary>
+    /// <param name="records">How many records the scope carries.</param>
+    /// <returns>The request as it would arrive.</returns>
+    internal static byte[] BatchWithoutResource(int records) => Envelope(resource: null, records);
+
+    /// <summary>Encodes one resource attribute exactly as it appears inside a request, tag included.</summary>
+    private static byte[] Attribute(string key, string value) => LengthDelimited(
+        FirstField,
+        [.. LengthDelimited(FirstField, Encoding.UTF8.GetBytes(key)),
+         .. LengthDelimited(SecondField, LengthDelimited(FirstField, Encoding.UTF8.GetBytes(value)))]);
+
+    /// <summary>Reads back every resource attribute a request carries, decoded from the wire rather than searched for.</summary>
+    /// <param name="request">The request to read.</param>
+    /// <returns>The attributes of every resource in the request, in the order they were encoded.</returns>
+    /// <remarks>
+    /// Structural rather than a byte search, and that is the whole point of it: the encoded form of one attribute is
+    /// the encoded form of a resource carrying exactly that attribute and nothing else, so a substring search reports
+    /// a rewritten batch as correct whether the entry was written as an attribute or as the resource around it. Only a
+    /// reader that parses the nesting tells the two apart, which is what a collector does with the batch.
+    /// </remarks>
+    internal static IReadOnlyList<KeyValuePair<string, string>> ResourceAttributes(byte[] request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        return
+        [
+            .. Fields(request)
+                .Where(envelope => envelope.Field == FirstField)
+                .SelectMany(envelope => Fields(envelope.Payload))
+                .Where(resource => resource.Field == FirstField)
+                .SelectMany(resource => Fields(resource.Payload))
+                .Where(entry => entry.Field == FirstField)
+                .Select(entry => AttributeOf(entry.Payload)),
+        ];
+    }
+
+    private static byte[] Envelope(byte[]? resource, int records)
+    {
+        byte[] scope = [.. Enumerable.Range(0, records).SelectMany(_ => LengthDelimited(SecondField, Record()))];
+
+        byte[] envelope =
+        [
+            .. resource is null ? [] : LengthDelimited(FirstField, resource),
+            .. LengthDelimited(SecondField, scope),
+        ];
+
+        return LengthDelimited(FirstField, envelope);
+    }
+
+    private static byte[] Resource(IReadOnlyList<KeyValuePair<string, string>> attributes) =>
+        [.. attributes.SelectMany(attribute => Attribute(attribute.Key, attribute.Value))];
+
+    /// <summary>One record, whose only field is opaque to everything the proxy does with it.</summary>
+    private static byte[] Record() => LengthDelimited(FirstField, Encoding.UTF8.GetBytes("r"));
+
+    private static byte[] LengthDelimited(int field, ReadOnlySpan<byte> payload) =>
+        [.. Varint(((ulong)field << 3) | 2), .. Varint((ulong)payload.Length), .. payload];
+
+    /// <summary>Decodes one key-value entry, whose value this builder only ever writes as a string.</summary>
+    private static KeyValuePair<string, string> AttributeOf(byte[] entry)
+    {
+        var fields = Fields(entry);
+        var key = fields.Single(field => field.Field == FirstField).Payload;
+        var anyValue = fields.Single(field => field.Field == SecondField).Payload;
+        var value = Fields(anyValue).Single(field => field.Field == FirstField).Payload;
+
+        return new KeyValuePair<string, string>(Encoding.UTF8.GetString(key), Encoding.UTF8.GetString(value));
+    }
+
+    /// <summary>Reads the length-delimited fields of one message, which is every field this builder writes.</summary>
+    /// <remarks>
+    /// A field of any other wire type stops the reading rather than being skipped: nothing here encodes one, so meeting
+    /// one means the octets are not what this reader was pointed at, and a reader that walked past it would report
+    /// whatever came after as the message's own content.
+    /// </remarks>
+    private static List<(int Field, byte[] Payload)> Fields(ReadOnlySpan<byte> message)
+    {
+        var fields = new List<(int, byte[])>();
+        var at = 0;
+
+        while (at < message.Length)
+        {
+            var tag = ReadVarint(message, ref at);
+
+            if ((tag & 0x7) != 2)
+            {
+                throw new InvalidOperationException($"Field {tag >> 3} is not length-delimited.");
+            }
+
+            var length = (int)ReadVarint(message, ref at);
+            fields.Add(((int)(tag >> 3), message.Slice(at, length).ToArray()));
+            at += length;
+        }
+
+        return fields;
+    }
+
+    private static ulong ReadVarint(ReadOnlySpan<byte> message, ref int at)
+    {
+        ulong value = 0;
+
+        for (var shift = 0; ; shift += 7)
+        {
+            var octet = message[at++];
+            value |= (ulong)(octet & 0x7F) << shift;
+
+            if ((octet & 0x80) == 0)
+            {
+                return value;
+            }
+        }
+    }
+
+    private static byte[] Varint(ulong value)
+    {
+        var encoded = new List<byte>(10);
+
+        do
+        {
+            var octet = (byte)(value & 0x7F);
+            value >>= 7;
+            encoded.Add(value == 0 ? octet : (byte)(octet | 0x80));
+        }
+        while (value != 0);
+
+        return [.. encoded];
+    }
+}

--- a/backend/tests/PublicSurfaces.UnitTests/HttpApiContractSurface.cs
+++ b/backend/tests/PublicSurfaces.UnitTests/HttpApiContractSurface.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Nodes;
 using MailFathom.Host;
 using MailFathom.Host.Api;
 using MailFathom.Host.Api.Documentation;
+using MailFathom.Host.Configuration;
 using MailFathom.Host.Configuration.Endpoints;
 using MailFathom.Host.Configuration.RootSettings;
 using MailFathom.Host.Hosting;
@@ -46,6 +47,15 @@ namespace MailFathom.PublicSurfaces.UnitTests;
 /// deleted. The last two of those are the reason the deployment below configures an authorization server as well as a
 /// key: a surface allowing no OAuth maps no metadata document, so leaving that out would have made two of these
 /// absences mean nothing.
+/// </para>
+/// <para>
+/// One route family is absent for a reason the deployment below cannot repair: the client endpoint's OTLP proxy is
+/// mapped only where a collector is named, and <see cref="EnvironmentOnlySettings" /> refuses an <c>OTEL_*</c> value
+/// from any source but the process environment. Naming one in the in-memory configuration would therefore record a
+/// deployment the product itself rejects, and setting the variable for real would attach live exporters to a suite
+/// that reaches no network. What those routes publish is asserted where they are mapped, in
+/// <c>ClientTelemetryEndpointTests</c>, and a client discovers them from the specification's own paths rather than
+/// from this document.
 /// </para>
 /// <para>
 /// Nothing here starts a host. The routes are read from the mapping, which is the boundary

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -90,9 +90,11 @@ AppHost provisions its synthetic credential after the service reports ready;
 | `POST /api/client/telemetry/v1/metrics` | none |
 | `POST /api/client/telemetry/v1/logs` | none |
 
-There is no version segment in either path: the major version is `0` and
+No path here carries a version segment MailFathom chose: the major version is `0` and
 [ADR 0004](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0004-versioning-and-release-policy.md)
-permits breaking the contract outright, so `/v1` would be scaffolding for a promise this project has not made.
+permits breaking the contract outright, so `/v1` would be scaffolding for a promise this project has not made. The
+`/v1` in the three [telemetry routes](#the-telemetry-routes) is not one: those paths are fixed by the OTLP
+specification, so a client points its exporter at the prefix above them and appends nothing itself.
 
 ### The session route
 
@@ -1195,6 +1197,14 @@ page cannot report as somebody else however its bundle was modified. Nothing els
 batch is forwarded as it arrived, so a signal a client's own instrumentation names arrives at the collector under that
 name.
 
+**Read attribution off the resource, which is the level this holds at.** A client is free to write anything into a
+span, a log record, or a metric data point, a key spelled like the owner one included, exactly as it is free to write
+anything into a span's name — those are its own words about its own work, they are forwarded untouched like every other
+field it sends, and nothing here reads them. Reaching them would mean decoding all three signals against their schemas,
+which is what would make this a processor rather than a proxy. So a dashboard, a query, or a retention rule that has to
+know whose telemetry it is reads the **resource** attribute, and that one is the deployment's own and cannot be
+influenced from a browser.
+
 **What it forwards to is the deployment's, never the client's.** There is no second destination setting, and the
 collector's address and its credential never leave the process — a client holding either would be publishing them to
 whoever opened the developer tools. The endpoint, the protocol, the headers, and the per-export timeout are the ones
@@ -1212,9 +1222,12 @@ A batch the endpoint cannot read as a protocol-buffers export request is answere
 deployment's collector is not the place to find out whether a client's encoder works. A collector that answered a
 partial success is relayed verbatim rather than reported as a success, because a client that was told everything
 arrived stops holding what did not. A collector that refused the batch outright is answered in this endpoint's own
-words instead: what it said is about this deployment's own export — a credential it would not take, a version it does
-not speak — and is not a document to hand to a browser. Anything transient — a collector that is down, unreachable, or slower than the
-configured timeout — is answered `503`, which is what leaves the batch where the client can still send it again.
+words instead: what it said is about this deployment's own export — a version it does not speak, a message it could not
+read — and is not a document to hand to a browser. Anything transient — a collector that is down, unreachable, slower
+than the configured timeout, or refusing this deployment's own collector credential — is answered `503`, which is what
+leaves the batch where the client can still send it again. That last one is a deployment fault rather than a client
+one, so it is reported to the operator as [its own
+condition](telemetry.md#what-the-client-telemetry-proxy-emits) rather than folded into the others.
 
 **Accepting and forwarding writes no log record at any level.** A signed-in client exports every few seconds for as
 long as it is open, so a line per batch would make a deployment's own logs unreadable within a day. A forwarding

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -1,6 +1,6 @@
 # The client endpoint
 
-<!-- describes: backend/src/AppHost/Program.cs, backend/src/AppHost/OrchestrationContract.cs, backend/src/Host/Configuration/Endpoints/ClientEndpointOptions.cs, backend/src/Host/Configuration/Endpoints/ClientApplicationOptions.cs, backend/src/Host/Api/ClientApiEndpoints.cs, backend/src/Host/Api/ClientMailAccountsEndpoint.cs, backend/src/Host/Api/ClientMailFoldersEndpoint.cs, backend/src/Host/Api/ClientMailTimelineEndpoint.cs, backend/src/Host/Api/ClientMailThreadEndpoint.cs, backend/src/Host/Api/ClientMailMessageEndpoint.cs, backend/src/Host/Api/ClientMailBodyEndpoint.cs, backend/src/Host/Api/ClientMailAttachmentEndpoint.cs, backend/src/Host/Api/AttachmentContentResponse.cs, backend/src/Host/Api/ProtectedResourceMetadataEndpoint.cs, backend/src/Host/Security/Endpoints/ClientTransportSecurityExtensions.cs, backend/src/Host/Hosting/ClientApplicationFiles.cs, backend/src/Host/Hosting/Warnings/ClientTransportSecurityWarning.cs, backend/src/Host/Hosting/Warnings/PasswordClearTextTransportWarning.cs, backend/src/Host/Api/ClientOwnerRecordEndpoint.cs, backend/src/Host/Api/ClientDraftEndpoints.cs, backend/src/Host/Api/ClientDraftResponses.cs, backend/src/Host/Api/ClientOutboxEndpoints.cs -->
+<!-- describes: backend/src/AppHost/Program.cs, backend/src/AppHost/OrchestrationContract.cs, backend/src/Host/Configuration/Endpoints/ClientEndpointOptions.cs, backend/src/Host/Configuration/Endpoints/ClientApplicationOptions.cs, backend/src/Host/Api/ClientApiEndpoints.cs, backend/src/Host/Api/ClientMailAccountsEndpoint.cs, backend/src/Host/Api/ClientMailFoldersEndpoint.cs, backend/src/Host/Api/ClientMailTimelineEndpoint.cs, backend/src/Host/Api/ClientMailThreadEndpoint.cs, backend/src/Host/Api/ClientMailMessageEndpoint.cs, backend/src/Host/Api/ClientMailBodyEndpoint.cs, backend/src/Host/Api/ClientMailAttachmentEndpoint.cs, backend/src/Host/Api/AttachmentContentResponse.cs, backend/src/Host/Api/ProtectedResourceMetadataEndpoint.cs, backend/src/Host/Security/Endpoints/ClientTransportSecurityExtensions.cs, backend/src/Host/Hosting/ClientApplicationFiles.cs, backend/src/Host/Hosting/Warnings/ClientTransportSecurityWarning.cs, backend/src/Host/Hosting/Warnings/PasswordClearTextTransportWarning.cs, backend/src/Host/Api/ClientOwnerRecordEndpoint.cs, backend/src/Host/Api/ClientDraftEndpoints.cs, backend/src/Host/Api/ClientDraftResponses.cs, backend/src/Host/Api/ClientOutboxEndpoints.cs, backend/src/Host/Api/ClientTelemetryEndpoint.cs, backend/src/Host/Observability/ClientTelemetry/** -->
 
 Where the MailFathom client reaches the service, what a deployment has to enable before it answers, and what a person's
 mail client presents to get in.
@@ -86,6 +86,9 @@ AppHost provisions its synthetic credential after the service reports ready;
 | `POST /api/client/outbox/requeue` | `mailfathom.mail.send` |
 | `GET /api/client/preferences` | `mailfathom.mail.read` |
 | `POST /api/client/preferences` | `mailfathom.mail.read` |
+| `POST /api/client/telemetry/v1/traces` | none |
+| `POST /api/client/telemetry/v1/metrics` | none |
+| `POST /api/client/telemetry/v1/logs` | none |
 
 There is no version segment in either path: the major version is `0` and
 [ADR 0004](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0004-versioning-and-release-policy.md)
@@ -1163,6 +1166,66 @@ an unknown number of duplicates asked for in one request.
 **Every route here is `mailfathom.mail.send`, the two readings included.** What an outbox says is what this owner is
 sending, so a credential granted to read a mailbox learns nothing here, and withdrawing a send is part of sending
 rather than a power beside it.
+
+### The telemetry routes
+
+These three are an OTLP receiver, served for the client's own instrumentation and for nothing else. A client exports to
+`/api/client/telemetry` the way it would export to a collector — the paths beneath it are the OTLP specification's own,
+so the exporter is pointed at the prefix and appends nothing — and what it sends is forwarded to wherever this
+deployment already exports [its own telemetry](telemetry.md#the-one-switch-otel_exporter_otlp_endpoint).
+
+| Route | What it takes |
+| --- | --- |
+| `POST /api/client/telemetry/v1/traces` | One `ExportTraceServiceRequest` as `application/x-protobuf` |
+| `POST /api/client/telemetry/v1/metrics` | One `ExportMetricsServiceRequest`, same encoding |
+| `POST /api/client/telemetry/v1/logs` | One `ExportLogsServiceRequest`, same encoding |
+
+**A deployment that named no collector does not serve them at all.** The routes are mapped only where
+`OTEL_EXPORTER_OTLP_ENDPOINT` is set, so a client exporting to a deployment that exports nothing is answered `404` and
+learns from the answer rather than from a setting it would have to be told about. That is the same shape the rest of
+this surface uses for an endpoint that is off, and it is what keeps the default a privacy default: a deployment that
+decided its own signals stay in the process does not become a relay for somebody else's.
+
+**They authenticate exactly as every other route here does**, on this surface's own credentials, and they add no name to
+[the published permission set](permissions.md) — like the session route, and for a narrower reason: a permission would
+have to be granted to every client that reports anything, which makes it a component of every grant rather than a
+decision anybody takes. What the credential does decide is whose telemetry this is. The resource attributes naming the
+owner are written here from the authenticated credential and **replace** whatever the client put in their place, so a
+page cannot report as somebody else however its bundle was modified. Nothing else in the payload is transformed: the
+batch is forwarded as it arrived, so a signal a client's own instrumentation names arrives at the collector under that
+name.
+
+**What it forwards to is the deployment's, never the client's.** There is no second destination setting, and the
+collector's address and its credential never leave the process — a client holding either would be publishing them to
+whoever opened the developer tools. The endpoint, the protocol, the headers, and the per-export timeout are the ones
+the deployment's own exporter reads.
+
+**Everything is bounded**, per credential, and a refusal names the bound rather than truncating the batch:
+
+| Bound | What it is | What a client is answered |
+| --- | --- | --- |
+| Request body | 4 MiB | `413`, carrying the specification's own status message |
+| Records in one batch | 10 000 spans, metric points, or log records | `413`, with nothing forwarded |
+| Export rate | 120 requests a minute for one signed-in person, and the same again for the next | `429` with `Retry-After: 60` |
+
+A batch the endpoint cannot read as a protocol-buffers export request is answered `400` and forwarded nowhere: a
+deployment's collector is not the place to find out whether a client's encoder works. A collector that answered a
+partial success is relayed verbatim rather than reported as a success, because a client that was told everything
+arrived stops holding what did not. A collector that refused the batch outright is answered in this endpoint's own
+words instead: what it said is about this deployment's own export — a credential it would not take, a version it does
+not speak — and is not a document to hand to a browser. Anything transient — a collector that is down, unreachable, or slower than the
+configured timeout — is answered `503`, which is what leaves the batch where the client can still send it again.
+
+**Accepting and forwarding writes no log record at any level.** A signed-in client exports every few seconds for as
+long as it is open, so a line per batch would make a deployment's own logs unreadable within a day. A forwarding
+failure does write one, aggregated per condition rather than per batch and repeated at most every five minutes, naming
+the condition and how many batches it has cost since it was last reported; it carries no part of a payload. What the
+proxy accepted, refused, forwarded, and failed to forward is [reported as
+metrics](telemetry.md#what-the-client-telemetry-proxy-emits) instead, which is where a rate belongs.
+
+**A browser reaches them under the origins this surface already declares.** The preflight is answered from
+[the same list](#browser-origins) every other route here is served to, and no origin is admitted here that the rest of
+the surface refuses.
 
 ## Credentials do not cross surfaces
 

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -75,7 +75,7 @@ belong to the platform rather than to MailFathom:
 
 | Variable | What it does |
 | --- | --- |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | Attaches the OTLP exporter for logs, metrics, and traces — startup records included. Unset exports nothing. [Telemetry](telemetry.md) is the page, including the sibling `OTEL_*` variables the exporter reads itself |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Attaches the OTLP exporter for logs, metrics, and traces — startup records included — and serves [the client endpoint's OTLP routes](client-endpoint.md#the-telemetry-routes), which forward a client's own telemetry to the same destination. Unset exports nothing and serves neither. [Telemetry](telemetry.md) is the page, including the sibling `OTEL_*` variables the exporter reads itself |
 | `OTEL_SERVICE_NAME` | The service identity the startup records and every exported record carry. Unset reports the host assembly's own name |
 | `OTEL_TRACES_SAMPLER` / `OTEL_TRACES_SAMPLER_ARG` | How much of a trace is recorded. Unset records every trace this process starts and honors the decision on one it did not; [telemetry](telemetry.md#how-much-of-a-trace-is-recorded) holds the values and why that is the default |
 | `ASPNETCORE_URLS` / `ASPNETCORE_HTTP_PORTS` / `ASPNETCORE_HTTPS_PORTS` | Nothing — [each surface states where it is served](configuration-endpoints.md#where-each-surface-is-served), and setting one of these fails startup with a message naming the key that replaces it |

--- a/docs/operations/http-api-documentation.md
+++ b/docs/operations/http-api-documentation.md
@@ -105,6 +105,12 @@ MAILFATHOM_UPDATE_PUBLIC_SURFACES=1 dotnet test --project backend/tests/PublicSu
 and committed in the change that moved the contract, together with the release-note entry naming what a client has to
 do about it.
 
+One route family is deliberately not recorded either. The client endpoint's [OTLP telemetry
+routes](client-endpoint.md#the-telemetry-routes) are mapped only where a deployment names a collector, and that address
+is read from the environment rather than from configuration — so the rendering, whose configuration is composed in
+memory, describes a deployment that names none. A running instance that does name one serves them and describes them in
+its own document; what the record leaves out is the family rather than any operation's shape.
+
 Two values are deliberately not recorded. `info.version` is the running release, which every build stamps and which a
 pipeline build extends further, so the record carries a placeholder rather than a number that would move under an
 unchanged contract; and `servers` is absent, because it describes the address a process answered on rather than what it

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -1,6 +1,6 @@
 # Telemetry and the Aspire dashboard
 
-<!-- describes: backend/src/Application/Observability/**, backend/src/Common/Observability/**, backend/src/Host/Observability/**, backend/src/Host/ServiceDefaultsExtensions.cs, backend/src/Host/Hosting/Workers/**, backend/src/Infrastructure/Observability/**, backend/src/Infrastructure/Mail/MailServerConnectionBudget.cs, backend/src/Infrastructure/Mail/MailKit/MailKitImapClientFactory.cs, backend/src/Infrastructure/HostApplicationBuilderExtensions.cs, backend/src/Mcp/Observability/**, backend/src/Cli/Diagnostics/**, backend/src/AppHost/**, backend/src/AI/ProviderAdapters/OpenAiCompatibleClientFactory.cs -->
+<!-- describes: backend/src/Application/Observability/**, backend/src/Common/Observability/**, backend/src/Host/Observability/**, backend/src/Host/ServiceDefaultsExtensions.cs, backend/src/Host/Api/ClientTelemetryEndpoint.cs, backend/src/Host/Hosting/Workers/**, backend/src/Infrastructure/Observability/**, backend/src/Infrastructure/Mail/MailServerConnectionBudget.cs, backend/src/Infrastructure/Mail/MailKit/MailKitImapClientFactory.cs, backend/src/Infrastructure/HostApplicationBuilderExtensions.cs, backend/src/Mcp/Observability/**, backend/src/Cli/Diagnostics/**, backend/src/AppHost/**, backend/src/AI/ProviderAdapters/OpenAiCompatibleClientFactory.cs -->
 
 The host instruments itself with OpenTelemetry throughout — logs, metrics, and traces — and exports none of it unless
 the environment names a destination. Today exactly one environment does that out of the box: a local run under the
@@ -1134,6 +1134,39 @@ either keeps up or does not. The refusals are how much of a mailbox is being lef
 is retried on a later run rather than lost. All five read zero on a deployment with both switches off, which constructs
 no detector on this path at all.
 
+### What the client telemetry proxy emits
+
+The [client endpoint](client-endpoint.md#the-telemetry-routes) receives OTLP from the signed-in client and forwards it
+to the same destination this section's own signals leave by. That path is deliberately silent — accepting and
+forwarding writes no log record at any level, because a client open on somebody's desk exports every few seconds — so
+five counters are the whole of what an operator reads it by.
+
+| Instrument | Unit | What it counts |
+| --- | --- | --- |
+| `mailfathom.client_telemetry.accepted` | `{batch}` | Batches read, bounded, and attributed |
+| `mailfathom.client_telemetry.records` | `{record}` | Records those batches carried, which is what their volume is read against |
+| `mailfathom.client_telemetry.refused` | `{batch}` | Batches refused before anything was forwarded |
+| `mailfathom.client_telemetry.forwarded` | `{batch}` | Batches the destination accepted |
+| `mailfathom.client_telemetry.failed` | `{batch}` | Batches that did not reach the destination |
+
+All five carry `mailfathom.client_telemetry.signal`, whose values are `traces`, `metrics`, and `logs`. A refusal
+carries `mailfathom.client_telemetry.refusal` as well — `unsupported_media_type`, `rate_limited`, `too_large`,
+`too_many_records`, or `malformed`, which is this endpoint's own closed vocabulary for the bounds it enforces. A
+failure carries `mailfathom.client_telemetry.condition`, written as a past participle like every other outcome here:
+`refused` for a destination that will never take the batch, and `throttled`, `unavailable`, `timed_out`, `unreachable`,
+or `cancelled` for one that might.
+
+**None of the five names a person.** A batch is attributed to its owner in the payload that leaves for the collector,
+where it is what makes one client's traces separable from another's; the instruments here are the deployment's own
+reading of whether the relay works, and an owner dimension on them would publish how much each person's client is
+doing to whoever reads a dashboard. `refused` rising is a client sending something this deployment will not take, and
+`failed` rising is the collector rather than the client — which is the distinction the two counters exist to make,
+because the clients hold what they could not export and nothing is queued here.
+
+The one thing that does write a line is a forwarding condition that holds: one record per condition, repeated at most
+every five minutes, naming the condition and how many batches it has cost since it was last reported. That is a count a
+rate cannot give an operator reading the log after the fact, and it carries no part of a payload.
+
 ## What the administration command emits
 
 Nothing. `mfctl` runs on the operator's own machine and holds no exporter, no collector address, and no telemetry
@@ -1238,7 +1271,7 @@ variables itself:
 
 | Variable | What it does |
 | --- | --- |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | The OTLP destination; setting it is what attaches the exporter |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | The OTLP destination; setting it is what attaches the exporter, and what serves [the client endpoint's OTLP routes](client-endpoint.md#the-telemetry-routes) |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` (the default) or `http/protobuf` |
 | `OTEL_EXPORTER_OTLP_HEADERS` | Headers sent with every export, which is where a collector's credential travels |
 | `OTEL_EXPORTER_OTLP_TIMEOUT` | The per-export timeout |
@@ -1288,7 +1321,8 @@ host starts.
 
 ## Deployments export nothing by default
 
-Neither the Compose deployment nor the Helm chart sets any `OTEL_*` variable. That is a privacy default, not a gap:
+Neither the Compose deployment nor the Helm chart sets any `OTEL_*` variable, so neither exports anything and neither
+serves [the client endpoint's OTLP routes](client-endpoint.md#the-telemetry-routes). That is a privacy default, not a gap:
 MailFathom's telemetry describes activity around personal mail — account aliases, folder aliases, tool-call rates,
 failure codes — and even without content, that stream identifies people and habits. Where it flows is therefore a
 decision the operator takes explicitly, never one a deployment asset takes for them.

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -1156,6 +1156,12 @@ failure carries `mailfathom.client_telemetry.condition`, written as a past parti
 `refused` for a destination that will never take the batch, and `throttled`, `unavailable`, `timed_out`, `unreachable`,
 or `cancelled` for one that might.
 
+`unauthorized` is the eighth and the one worth alerting on, because it is the only forwarding condition an operator
+repairs rather than waits out: the collector would not take **this deployment's own** credential, which is what
+`OTEL_EXPORTER_OTLP_HEADERS` carries. It is kept apart from `unavailable` for exactly that reason, and the client is
+still told to hold — the batch was never what was wrong, and telling a browser to drop telemetry over a credential
+nobody there can repair would lose what a corrected header would have carried.
+
 **None of the five names a person.** A batch is attributed to its owner in the payload that leaves for the collector,
 where it is what makes one client's traces separable from another's; the instruments here are the deployment's own
 reading of whether the relay works, and an owner dimension on them would publish how much each person's client is


### PR DESCRIPTION
The client endpoint serves the three OTLP/HTTP signal routes beneath `/api/client/telemetry` and forwards each batch to wherever this deployment already exports its own telemetry. A browser head cannot hold the collector's address or its credential — both belong to the deployment, and a bundle carrying either would publish them to whoever opened the developer tools — so the client exports to MailFathom with the token it signed in with, and MailFathom forwards. One collector, one credential, both stacks.

Closes #1228

## What it does

| Route | What it takes |
| --- | --- |
| `POST /api/client/telemetry/v1/traces` | One `ExportTraceServiceRequest` as `application/x-protobuf` |
| `POST /api/client/telemetry/v1/metrics` | One `ExportMetricsServiceRequest`, same encoding |
| `POST /api/client/telemetry/v1/logs` | One `ExportLogsServiceRequest`, same encoding |

**The routes exist only where the deployment named a destination.** `OTEL_EXPORTER_OTLP_ENDPOINT` is the whole switch, and it is the variable the service's own exporter already reads — no second key, and nothing for the two to disagree about. A deployment that named none maps no route, so a client is answered `404` and learns from the answer rather than from a setting somebody has to tell it about. That is the same shape the rest of the surface uses for an endpoint that is off, and it keeps the export default a privacy default: a deployment that decided its own signals stay in the process does not become a relay for somebody else's.

**They authenticate on this surface's own credentials and add no name to the published permission set.** Like the session route, and for the same reason: a permission every client that reports anything would have to hold is a component of every grant rather than a decision anybody takes. What the credential does decide is whose telemetry this is — the owner resource attribute is written from the authenticated credential and **replaces** whatever arrived under that key, so a page cannot report as somebody else however its bundle was modified.

**Nothing else in the payload is transformed.** The batch is walked as protocol buffers rather than decoded against a schema, so every field this repository has no opinion about — including one OpenTelemetry adds after this was written — is copied octet for octet, in the order it arrived.

**Everything is bounded, per credential**, and a refusal names the bound rather than truncating the batch: 4 MiB of body (`413`), 10 000 records in one batch (`413`), 120 exports a minute for one signed-in person (`429` with `Retry-After: 60`). A body that is not an export request this endpoint can read is `400` and is forwarded nowhere. A collector's partial success is relayed verbatim, because a client told everything arrived stops holding what did not; anything transient answers `503`, which leaves the batch where the client can still send it again.

**Accepting and forwarding write no log record at any level.** A signed-in client exports every few seconds for as long as it is open, so a line per batch would make a deployment's own logs unreadable within a day. A forwarding failure writes one record per condition rather than per batch, at most every five minutes, naming the condition and how many batches it has cost since it was last reported, and carrying no part of a payload. Five counters under `mailfathom.client_telemetry.*` report what was accepted, refused, forwarded, and not forwarded, by signal and by refusal or condition.

## Two things worth a reviewer's attention

**A pre-existing defect in the client CORS policy is repaired here.** The policy allowed `GET` alone although the surface has served `POST` record routes since #1207 — a browser preflight for one of those was refused. It now allows `GET` and `POST` and exposes `Retry-After` beside `WWW-Authenticate`, which the rate answer above needs a page to be able to read.

**The generated HTTP API contract records no telemetry family, and that is deliberate rather than an omission.** `PublicSurfaces.UnitTests` renders the document over a configuration composed in memory, and `EnvironmentOnlySettings` refuses an `OTEL_*` value from any source but the process environment — so naming a collector there would record a deployment the product itself rejects, and setting the variable for real would attach live exporters to a suite that reaches no network. `http-api-contract.json` is therefore unchanged, the reasoning is written into `HttpApiContractSurface` and into `docs/operations/http-api-documentation.md`, and what the routes publish is asserted where they are mapped. A running instance that names a collector serves them and describes them in its own `/openapi/v1.json`.

## Contracts

No published contract breaks. The HTTP API surface **gains** three routes on a deployment that exports over OTLP; the MCP tool contract, the configuration schema, the database schema, and the deployment contract are untouched, and no golden file moved.

## Out of scope, as the issue states

gRPC OTLP ingress (the proxy speaks gRPC only *outbound*, because a deployment's exporter may be configured for it — Aspire's is); payload transformation beyond the identity attributes; buffering, which is what makes the `503` honest; and a separately configured telemetry destination.

## Verification

- `scripts/verify-full.sh` — passed (13 310 tests, 287 workflow contract assertions).
- `dotnet msbuild .config/CodeCoverage.proj -t:Collect` — 95.26% aggregate line coverage, required 85%.
- `scripts/review-obligations.sh` — every reported page opened; four updated, the rest say nothing that stopped being true.
- `$check-docs-licenses` — Docs pass, Changelog n/a, Licenses n/a (no dependency added; `OpenTelemetry.Exporter` was already pinned and already used).

One defect was found and fixed during self-review rather than after it: the owner attribute was first written into the resource without its field tag, which a byte-substring assertion could not see because the encoded attribute and the resource around it are the same octets. The assertions now decode the rewritten batch the way a collector would, and were confirmed to fail against the defect before it was fixed.
