### PR TITLE
[#1505] Give the reading column a ceiling so a wide window adds margin, not line length

### DIFF
--- a/frontend/src/Client.App/src/mailSpace/MailSpace.tsx
+++ b/frontend/src/Client.App/src/mailSpace/MailSpace.tsx
@@ -187,9 +187,18 @@ export function MailSpace({
                             </div>
                         )}
 
-                        <div className="min-h-0 flex-1 overflow-y-auto">{mail}</div>
+                        {/* The reading column keeps the width the design draws it at and stops there, so a window
+                            wider than the design's adds margin rather than line length. The ceiling is the one thing a
+                            mail client cannot leave to the viewport: a paragraph running 1900 pixels is past the
+                            measure at which the eye finds the start of the next line. It binds above that width and
+                            nowhere else, so the narrow shape and the workspace shape are untouched by it. */}
+                        <div className="min-h-0 flex-1 overflow-y-auto">
+                            <div className="mx-auto flex min-h-full w-full max-w-reading flex-col">{mail}</div>
+                        </div>
 
-                        {intent}
+                        {/* The question stands under the message rather than under the pane, so the column reads as
+                            one width from the sender's name down to the field the reader asks in. */}
+                        <div className="mx-auto w-full max-w-reading">{intent}</div>
                     </section>
                 ) : null}
             </div>

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
@@ -83,7 +83,7 @@ export function ReadingPane({
     const { translate } = useLocalization();
 
     return (
-        <section className="flex min-h-full flex-col">
+        <section className="flex flex-1 flex-col">
             {storedEmailId === null ? (
                 <p className="flex flex-1 items-center justify-center px-6 py-10 text-base text-muted">
                     {translate('message.nothingOpen')}

--- a/frontend/src/Client.App/src/styles.css
+++ b/frontend/src/Client.App/src/styles.css
@@ -205,6 +205,12 @@
     --spacing-message-list: 21.25rem;
     --spacing-drawer: 16.375rem;
 
+    /* The widest the reading column is ever drawn, which is a ceiling rather than a width: the pane takes whatever the
+       three columns leave it, and this is where it stops taking more. It is the width the design draws the pane at, so
+       a window the size the project was drawn against is unchanged by it and a wider one gains margin instead of line
+       length. A `--container-*` name rather than a `--spacing-*` one because what reads it is `max-w-reading`. */
+    --container-reading: 56rem;
+
     /* What a notch, a rounded corner, or a system bar takes out of the viewport. Zero everywhere a window has none,
        which is every head this repository builds today; declaring it as a token is what keeps a screen from reaching
        for a fixed padding the day one of them has one. */


### PR DESCRIPTION
## What this changes

The reading pane took whatever the three-column composition left it, so on a wide screen a message's
own text ran the full width of the pane — nearly 1300 pixels at 1920, well past the measure at which
the eye finds the start of the next line.

`--container-reading` is the ceiling, declared beside the other widths the composition is built from
and set to the width the design draws the pane at. Above it the window gains margin; at or below it
nothing changes, so the workspace shape and the narrow shape are untouched.

It binds three things rather than one, because all three are drawn into the same region of
`mailSpace/MailSpace.tsx`: the message, the conversation, and the question the reader asks beneath
them — so the column reads as one width from the sender's name down to the field.

`ReadingPane` now takes its height from the flex parent rather than as a percentage of it. That is
what keeps the empty pane's sentence vertically centred once a wrapper stands between the pane and
the scrolled region: `min-h-full` against a parent of automatic height resolves to nothing.

## How it was verified

Screenshots of the built bundle in a real browser, against the stubbed transport the browser suite
uses, taken before and after the change: a message at 1920×1080, the empty pane at the same width,
and a message at 400×900. The wide message column is bounded and centred, the empty pane's sentence
is still centred both ways, and the narrow shape is unchanged. `scripts/verify-fast.sh` passed over
the tree; the full gate runs here.

No test is added. What changed is which utilities a layout element carries, and a unit test asserting
a class name would be a test of the implementation rather than of a behaviour — the browser is what
can see a width, and the two captures above are that reading.

Closes #1505
