### PR TITLE
[#1509] Bind the reading ceiling to a message's content, ranged left

### DIFF
--- a/frontend/src/Client.App/src/mailSpace/MailSpace.tsx
+++ b/frontend/src/Client.App/src/mailSpace/MailSpace.tsx
@@ -187,18 +187,13 @@ export function MailSpace({
                             </div>
                         )}
 
-                        {/* The reading column keeps the width the design draws it at and stops there, so a window
-                            wider than the design's adds margin rather than line length. The ceiling is the one thing a
-                            mail client cannot leave to the viewport: a paragraph running 1900 pixels is past the
-                            measure at which the eye finds the start of the next line. It binds above that width and
-                            nowhere else, so the narrow shape and the workspace shape are untouched by it. */}
-                        <div className="min-h-0 flex-1 overflow-y-auto">
-                            <div className="mx-auto flex min-h-full w-full max-w-reading flex-col">{mail}</div>
-                        </div>
+                        {/* Everything the pane lays out takes the pane's own width. The ceiling a wide window needs
+                            binds the words of a message rather than the column they sit in — `messageBody/Message.tsx`
+                            carries it — because a head, a verdict, a row of attachment cards, and the field the reader
+                            asks in are not text read line by line and have no measure to keep. */}
+                        <div className="min-h-0 flex-1 overflow-y-auto">{mail}</div>
 
-                        {/* The question stands under the message rather than under the pane, so the column reads as
-                            one width from the sender's name down to the field the reader asks in. */}
-                        <div className="mx-auto w-full max-w-reading">{intent}</div>
+                        {intent}
                     </section>
                 ) : null}
             </div>

--- a/frontend/src/Client.App/src/messageBody/Message.tsx
+++ b/frontend/src/Client.App/src/messageBody/Message.tsx
@@ -18,7 +18,7 @@ import { MessageBody } from './MessageBody';
 
 // One message's body, read and drawn. Which message that is, and everything the reading pane lays out around it, is
 // `readingPane/ReadingPane.tsx`'s; what this owns is the body read itself, the reader's own ask for pictures from the
-// sender, and the five states a surface that waits owes somebody.
+// sender, the five states a surface that waits owes somebody, and the width all of it is read at.
 //
 // Asking for pictures re-reads that one message with the ask in the query, and neither this component nor anything
 // beneath it writes the answer down: leaving the message and coming back asks again, which is the whole of what
@@ -59,19 +59,31 @@ function drawableUnder(answer: Answered | null, read: Read): Answered | null {
     return answer.read.remotePictures && !read.remotePictures ? null : answer;
 }
 
-export function Message({
-    session,
-    transport,
-    storedEmailId,
-    quotedHistoryOnRequest = false,
-}: {
+interface MessageToDraw {
     readonly session: ClientSession;
     readonly transport: MailFathomTransport;
     readonly storedEmailId: string;
 
     /** Whether the conversation this message quoted is folded away until a reader asks for it, which a thread does. */
     readonly quotedHistoryOnRequest?: boolean;
-}) {
+}
+
+// The ceiling every message's own content is read under, stated here rather than where a message is laid out, so that
+// it holds wherever one is drawn and for whatever the content later becomes: the reading pane draws one message and a
+// conversation draws several, and neither has to know the width. It binds the content alone — the head above it, the
+// verdict about who sent it, the files it carries, the actions, and the field the reader asks in have no measure to
+// keep and take the pane's own width — and what it binds is ranged left, so a window wider than the content's ceiling
+// leaves its margin on the empty side of the pane rather than pushing the words away from the list they were opened
+// from.
+export function Message(message: MessageToDraw) {
+    return (
+        <div className="max-w-reading">
+            <MessageRead {...message} />
+        </div>
+    );
+}
+
+function MessageRead({ session, transport, storedEmailId, quotedHistoryOnRequest = false }: MessageToDraw) {
     const { translate } = useLocalization();
     const [read, setRead] = useState<Read>({ storedEmailId, remotePictures: false, attempt: 0 });
 

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
@@ -83,7 +83,7 @@ export function ReadingPane({
     const { translate } = useLocalization();
 
     return (
-        <section className="flex flex-1 flex-col">
+        <section className="flex min-h-full flex-col">
             {storedEmailId === null ? (
                 <p className="flex flex-1 items-center justify-center px-6 py-10 text-base text-muted">
                     {translate('message.nothingOpen')}

--- a/frontend/src/Client.App/src/styles.css
+++ b/frontend/src/Client.App/src/styles.css
@@ -205,10 +205,12 @@
     --spacing-message-list: 21.25rem;
     --spacing-drawer: 16.375rem;
 
-    /* The widest the reading column is ever drawn, which is a ceiling rather than a width: the pane takes whatever the
-       three columns leave it, and this is where it stops taking more. It is the width the design draws the pane at, so
-       a window the size the project was drawn against is unchanged by it and a wider one gains margin instead of line
-       length. A `--container-*` name rather than a `--spacing-*` one because what reads it is `max-w-reading`. */
+    /* The widest a message's own content is ever drawn, which is a ceiling rather than a width: the reading pane takes
+       whatever the three columns leave it, and this is where the words inside it stop taking more. It is the width the
+       design draws the pane at, so a window the size the project was drawn against is unchanged by it and a wider one
+       gains margin instead of line length. It binds the content alone and everything the pane lays out around that
+       keeps the pane's width, which is why the name says reading rather than pane. A `--container-*` name rather than
+       a `--spacing-*` one because what reads it is `max-w-reading`. */
     --container-reading: 56rem;
 
     /* What a notch, a rounded corner, or a system bar takes out of the viewport. Zero everywhere a window has none,

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -957,6 +957,34 @@ test('draws the three columns of the Mail space without the page scrolling sidew
     }
 });
 
+test('stops a message’s own content at the reading ceiling and leaves everything around it the pane', async ({
+    page,
+}) => {
+    // Wider than the width the design draws the pane at, which is the only regime where the ceiling binds at all: at
+    // the width the composition was drawn against the pane is already narrower than it, and a pane that had lost the
+    // ceiling entirely would look identical there.
+    await page.setViewportSize({ width: 1920, height: 1080 });
+
+    await openTheFirstMessage(page);
+    await expect(page.getByRole('heading', messageHeading)).toBeVisible();
+
+    // The sender's own heading stands inside the message's content and the attachments heading beside it does not, so
+    // the two boxes are the whole comparison — same left edge, different widths. What the ceiling is worth in pixels
+    // is the token's business rather than this suite's; what is asserted is the shape, because both ways of getting it
+    // wrong are visible here and nowhere jsdom can reach. A ceiling dropped again draws the two at one width, and a
+    // centred one moves the content's left edge off the edge everything around it keeps.
+    const content = await boxOf(page.getByRole('heading', messageHeading));
+    const aroundIt = await boxOf(page.getByRole('heading', { name: 'Files this message carries' }));
+
+    expect(content.width).toBeLessThan(aroundIt.width);
+    expect(content.x).toBeCloseTo(aroundIt.x, 0);
+
+    // And the region the pane draws the message in keeps the pane's own width, which is what the ceiling stopped
+    // binding: a head laid out to a measure meant for paragraphs is the defect this asserts against.
+    const region = await boxOf(page.getByRole('article', messageRegion));
+    expect(region.width).toBeGreaterThan(content.width);
+});
+
 test('holds a window of rows in the document however far down the folder it is scrolled', async ({ page }) => {
     await openSignedIn(page, '/#/mail');
 


### PR DESCRIPTION
Closes #1509.

#1506 gave the reading column a ceiling and applied it as `mx-auto … max-w-reading` around the whole scrolled region and around the question field beneath it. Two things about that were wrong on a wide screen: it centred the column, so a message drifted away from the list it was opened from across a strip of empty panel, and it bound everything the pane draws rather than the words that have a measure to keep.

## What changed

The ceiling moved to `messageBody/Message.tsx`, which is the one place a message's own content is drawn — once by the reading pane and once per message of a conversation — so it is stated once and holds wherever content appears, including whatever the content later becomes: the frame #1508 draws the sender's markup in sits inside that same subtree and stops at the same ceiling.

`mailSpace/MailSpace.tsx` goes back to laying the pane out at the pane's own width, and `readingPane/ReadingPane.tsx` back to taking its height from `min-h-full` now that no wrapper stands between it and the scrolled region. What the ceiling binds is ranged left rather than centred, so a window wider than the ceiling leaves its margin on the empty side of the pane. The token's own comment in `styles.css` now says what it binds; its value is unchanged, which #1506 settled.

## Verification

The acceptance items are layout, which jsdom cannot answer and `frontend/tests/AGENTS.md` asserts nowhere, so they were read off a real browser against the built bundle with a throwaway Playwright spec and stubbed routes — no deployment, no real mail — at 1920 × 1080, 1280 × 720, and 380 × 720:

- A message's paragraphs stop at `--container-reading` and begin at the left edge of the pane; the head, the actions, the attachment cards, and the question field span the pane.
- A conversation is bounded the same way per message: each message's content stops at the ceiling and its head does not.
- At 1280 the ceiling does not bind and the screen is what it was before #1506; the narrow shape and the empty pane's centred sentence are unchanged.

`scripts/verify-full.sh` — 287 passed, 0 failed, re-run after rebasing onto `origin/main`.

https://claude.ai/code/session_01M4sAbgAM2WmecHzUCM5Sd6
