### PR TITLE
[#1497] Give the client one device-local store, and a grip on the list/pane split

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -169,6 +169,23 @@ library is adopted with, and it adds nothing to the bundle and nothing to `THIRD
 `.config/typos.toml` excludes `pl.ts` from the spell check, because a dictionary of English has nothing true to say
 about Polish. Every other file in this workspace stays checked, `en.ts` included.
 
+## What the device holds, and what follows the person
+
+Three things the client keeps belong to the machine somebody is reading on rather than to the person: the theme, the
+language, and how wide the message list is drawn beside the reading pane. `src/Client.App/src/device/deviceStore.ts` is
+the one module they go through — reading a value, writing one, and removing one, under the names it declares, so no
+screen spells a storage key and the handling that a browser or a WebView refusing storage needs is written once.
+
+Which implementation answers follows what the system offers rather than which system it is. The web head and the
+desktop head on either Linux or Windows reach the same origin storage through the WebView they render in, so all three
+resolve to it; a system that refuses it falls back to a store that lasts the run, so the client still mounts and a
+value then lasts the session instead of outliving it. That is the seam a head diverging later is added behind.
+
+The width of the message list is the one of the three kept **per signed-in person**, so two people sharing a machine do
+not inherit each other's split, and the key it is written under folds the name to a digest rather than spelling it out.
+What says how somebody wants to work — rather than how much room this screen has — follows them between machines and is
+the deployment's to hold instead.
+
 ## The two suites
 
 `pnpm test` is the unit suite, and `vitest.config.ts` declares one Vitest project per package because the two are tested

--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -12,6 +12,7 @@ import { AttachmentDeliveryContext, type AttachmentDelivery } from './deployment
 import type { DeploymentTransport } from './deployment/sendToDeployment';
 import { LocalizationProvider } from './localization/Localization';
 import { localeNames, locales, readStoredLocale } from './localization/locale';
+import { startingListWidth, storeListWidth } from './mailSpace/listWidth';
 import type { CredentialLifetime, CredentialStore } from './signIn/credentialStore';
 import { mostReconnectionAttempts } from './shell/useConnection';
 import { ThemeProvider } from './theme/Theme';
@@ -498,6 +499,35 @@ describe('App', () => {
         fireEvent.pointerDown(within(list).getByRole('option', { name: /Quarterly invoice/ }));
 
         expect(await screen.findByText('A drawn message.')).toBeDefined();
+    });
+
+    it('divides the mail space where the person now signed in last left it, rather than where anybody did', async () => {
+        // The width is stored against the person the held credential names, so this is the one assertion that the name
+        // the frame takes the credential apart for is the name the store was written under. Everything below the frame
+        // is handed that name and could not tell a wrong one from a right one.
+        storeListWidth('test', 468);
+
+        renderApp();
+        await framed();
+
+        await goTo('Mail');
+
+        expect(
+            (await screen.findByRole('separator', { name: 'Message list width' })).getAttribute('aria-valuenow'),
+        ).toBe('468');
+    });
+
+    it('divides it where it starts for somebody else signing in on the same machine', async () => {
+        storeListWidth('test', 468);
+
+        renderApp(servedFrom, 'Basic YW5vdGhlcjpzZWNyZXQ=');
+        await framed();
+
+        await goTo('Mail');
+
+        expect(
+            (await screen.findByRole('separator', { name: 'Message list width' })).getAttribute('aria-valuenow'),
+        ).toBe(String(startingListWidth));
     });
 
     it('opens the conversation a message belongs to, and returns to that message when it is closed', async () => {

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -24,6 +24,7 @@ import { LanguageChoice, ThemeChoice } from './shell/Preferences';
 import { Space } from './shell/Space';
 import { SpaceNavigation } from './shell/SpaceNavigation';
 import { useConnection } from './shell/useConnection';
+import { userNameIn } from './signIn/credentialEntry';
 import { CredentialNotices, type CredentialNotice } from './signIn/CredentialNotices';
 import type { CredentialStore } from './signIn/credentialStore';
 import { SignIn } from './signIn/SignIn';
@@ -226,6 +227,10 @@ export function App({
                 ) : (
                     <Space
                         space={space}
+                        // Who is signed in, taken apart in the one module that composes a credential and never here.
+                        // A screen never sees the credential; what it is handed is the name the deployment knows the
+                        // person by, which is what a preference kept per person on this machine is written under.
+                        person={userNameIn(authorization)}
                         // Asking is what the field is for, so a credential that may not ask is not shown one. It is
                         // absent rather than disabled: a control nobody can use says less about why than the sentence
                         // above does. Where it stands is the space's decision, which is why it is handed in rather

--- a/frontend/src/Client.App/src/deployment/adoptedDeployment.ts
+++ b/frontend/src/Client.App/src/deployment/adoptedDeployment.ts
@@ -29,7 +29,7 @@ export interface AdoptedDeployment {
 // Where the chosen address is written. An address is not a credential and is stored as what it is; what the desktop
 // head does with anything secret is its own question.
 //
-// Reached as `window.localStorage` rather than as the bare global for the reason `localization/locale.ts` gives: Node
+// Reached as `window.localStorage` rather than as the bare global for the reason `device/deviceStore.ts` gives: Node
 // publishes a `localStorage` global of its own that wins over the document's under the test runner, so the bare name
 // is two different objects behind one identifier.
 const storageKey = 'mailfathom.deployment';

--- a/frontend/src/Client.App/src/device/deviceStore.test.ts
+++ b/frontend/src/Client.App/src/device/deviceStore.test.ts
@@ -1,0 +1,104 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { deviceKeys, deviceStore, listWidthKey } from './deviceStore';
+
+// What a system without origin storage looks like from inside the client: reaching the property throws, which is what
+// a browser configured to refuse storage and a WebView started without it both do. Defined over the one the test
+// environment installs, and taken off again afterwards, so the store the other cases read is the document's own.
+function withoutStorage(): void {
+    Object.defineProperty(window, 'localStorage', {
+        configurable: true,
+        get: () => {
+            throw new Error('This browser is configured to refuse storage.');
+        },
+    });
+}
+
+const jsdomStorage = window.localStorage;
+
+afterEach(() => {
+    Object.defineProperty(window, 'localStorage', { configurable: true, value: jsdomStorage, writable: false });
+    window.localStorage.clear();
+});
+
+describe('deviceStore', () => {
+    it('reads back what was written, which is how the next start of either head opens on it', () => {
+        deviceStore().write(deviceKeys.locale, 'pl');
+
+        expect(deviceStore().read(deviceKeys.locale)).toBe('pl');
+    });
+
+    it('reads nothing under a key nothing was written to', () => {
+        expect(deviceStore().read(deviceKeys.themeChoice)).toBeNull();
+    });
+
+    it('reads nothing back once the value is removed', () => {
+        deviceStore().write(deviceKeys.themeChoice, 'dark');
+        deviceStore().remove(deviceKeys.themeChoice);
+
+        expect(deviceStore().read(deviceKeys.themeChoice)).toBeNull();
+    });
+
+    it('keeps a value for the run where the system refuses storage, rather than failing to answer at all', () => {
+        withoutStorage();
+
+        deviceStore().write(deviceKeys.themeChoice, 'light');
+
+        expect(deviceStore().read(deviceKeys.themeChoice)).toBe('light');
+    });
+
+    it('stays on its feet when storage that answered a read then refuses a write, which a full quota is', () => {
+        Object.defineProperty(window, 'localStorage', {
+            configurable: true,
+            value: {
+                getItem: () => null,
+                setItem: () => {
+                    throw new Error('The quota for this origin is exhausted.');
+                },
+                removeItem: () => undefined,
+            },
+        });
+
+        // The probe found storage, so this is the device store rather than the run's, and a write it refuses is a
+        // preference lost rather than a screen that fails: what matters is that the caller is answered at all.
+        expect(() => {
+            deviceStore().write(deviceKeys.themeChoice, 'dark');
+        }).not.toThrow();
+        expect(deviceStore().read(deviceKeys.themeChoice)).toBeNull();
+    });
+
+    it('forgets a value kept for the run, so a removal means the same thing on either system', () => {
+        withoutStorage();
+
+        deviceStore().write(deviceKeys.locale, 'pl');
+        deviceStore().remove(deviceKeys.locale);
+
+        expect(deviceStore().read(deviceKeys.locale)).toBeNull();
+    });
+
+    it('leaves nothing behind on the device where the system refused to hold it', () => {
+        withoutStorage();
+        deviceStore().write(deviceKeys.themeChoice, 'dark');
+
+        Object.defineProperty(window, 'localStorage', { configurable: true, value: jsdomStorage, writable: false });
+
+        expect(deviceStore().read(deviceKeys.themeChoice)).toBeNull();
+    });
+});
+
+describe('listWidthKey', () => {
+    it('answers the same key for one person, which is what lets their width survive signing out', () => {
+        expect(listWidthKey('karolina')).toBe(listWidthKey('karolina'));
+    });
+
+    it('answers a different key for somebody else, so two people sharing a machine keep their own split', () => {
+        expect(listWidthKey('karolina')).not.toBe(listWidthKey('marta'));
+    });
+
+    it('names nobody in the key itself, so the store carries no list of who reads mail on this machine', () => {
+        expect(listWidthKey('karolina')).not.toContain('karolina');
+    });
+});

--- a/frontend/src/Client.App/src/device/deviceStore.ts
+++ b/frontend/src/Client.App/src/device/deviceStore.ts
@@ -1,0 +1,143 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+// Where the client keeps what belongs to this machine rather than to the person reading on it: the theme it is painted
+// in, the language it reads in, and how the Mail space divides its width. One module, so the handling that storage a
+// browser or a WebView refuses needs is written once instead of once per caller, and so the names those values are
+// written under are declared together rather than as strings spread across the screens that read them.
+//
+// What belongs here is what says how much room *this screen* has. What says how somebody wants to work follows them
+// between machines and belongs to the deployment instead, which is a surface of its own.
+//
+// Reached as `window.localStorage` rather than as the bare global on purpose, and this is where that reason is
+// written down: Node publishes a `localStorage` global of its own, which is unavailable unless the process was started
+// with `--localstorage-file`, and it wins over the one the test environment's document carries — so the bare name is
+// the runtime's under Vitest and the document's in a browser, which is two different objects behind one identifier.
+// The two modules that still reach a browser store directly, `deployment/adoptedDeployment.ts` and
+// `workspace/rememberedWorkspace.ts`, point here for it.
+
+/** Where a value the client keeps on the device is written. Nothing outside this module spells one of these. */
+export const deviceKeys = {
+    themeChoice: 'mailfathom.theme',
+    locale: 'mailfathom.locale',
+} as const;
+
+/** Reading a value the device holds, writing one, and removing one. */
+export interface DeviceStore {
+    /** What is held under this key, or `null` where nothing is. */
+    read(key: string): string | null;
+
+    write(key: string, value: string): void;
+
+    remove(key: string): void;
+}
+
+/**
+ * The store this run keeps device-local values in.
+ *
+ * Which implementation answers follows what the system offers rather than which system it is. The web head and the
+ * desktop head on either Linux or Windows all reach the same origin storage through the WebView they render in, so all
+ * three resolve to it today; a system that refuses it — a browser configured to, a WebView started without it — falls
+ * back to one that lasts the run, so the client still mounts and a value then lasts the session rather than outliving
+ * it. That is the seam a head diverging later is added behind, and it is asked as a capability rather than as a
+ * platform because `frontend/src/AGENTS.md` § *The two heads* refuses a module chosen by target.
+ */
+export function deviceStore(): DeviceStore {
+    return storageOffered() ? keptOnTheDevice() : keptForTheRun();
+}
+
+/**
+ * What the width of the message list is written under, which names the person rather than the machine: two people
+ * sharing a machine each get their own split, and neither loses theirs by signing out.
+ *
+ * The name is folded to a digest rather than written out. A device store outlives the session, so a legible key would
+ * leave a list of who reads mail on this machine behind for anything that can read the origin's storage.
+ *
+ * What is kept is an identity the person typed rather than anything the credential answers, which is why ADR 0023's
+ * refusal to keep anything derived from the credential is not what this is: no secret, no stand-in for one, and
+ * nothing that says whether somebody is signed in. It is a name for a pane width, and the digest is what keeps even
+ * the identity out of the store.
+ *
+ * ponytail: a non-cryptographic digest, because this is read before the first paint and `SubtleCrypto` only answers
+ * asynchronously. It keeps the name out of the store rather than resisting somebody who already holds both; a
+ * cryptographic one is the upgrade if a value under one of these keys ever becomes worth more than a pane width.
+ */
+export function listWidthKey(person: string): string {
+    return `mailfathom.listWidth.${digestOf(person)}`;
+}
+
+/** Whether this system has origin storage at all, which is the whole of what decides the implementation today. */
+function storageOffered(): boolean {
+    try {
+        // Reaching the property is what throws where storage is refused, so the read is the probe and its answer is
+        // discarded. A key nothing writes keeps the probe from depending on what happens to be stored.
+        window.localStorage.getItem('mailfathom.storage');
+
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/** The values kept where the next start of either head reads them back. */
+function keptOnTheDevice(): DeviceStore {
+    return {
+        read: (key) => {
+            try {
+                return window.localStorage.getItem(key);
+            } catch {
+                return null;
+            }
+        },
+
+        write: (key, value) => {
+            try {
+                window.localStorage.setItem(key, value);
+            } catch {
+                // Storage found at the probe and refusing this write is a full quota or a permission withdrawn while
+                // the client is open. What was chosen then lasts as long as the screen holding it, which is a smaller
+                // loss than a client that fails over a preference.
+            }
+        },
+
+        remove: (key) => {
+            try {
+                window.localStorage.removeItem(key);
+            } catch {
+                // Storage that refuses a removal refused the write that would have put something there.
+            }
+        },
+    };
+}
+
+// Held for one run of the client, in memory. Module state rather than per-store, so the two calls a screen makes to
+// `deviceStore` on a system without storage read each other back instead of answering out of two empty maps.
+const heldForTheRun = new Map<string, string>();
+
+/** The values kept for as long as the client is open, where the system holds nothing between starts. */
+function keptForTheRun(): DeviceStore {
+    return {
+        read: (key) => heldForTheRun.get(key) ?? null,
+
+        write: (key, value) => {
+            heldForTheRun.set(key, value);
+        },
+
+        remove: (key) => {
+            heldForTheRun.delete(key);
+        },
+    };
+}
+
+/** FNV-1a over the name's code units, which is a stable short name for one person rather than a secure one. */
+function digestOf(text: string): string {
+    let hash = 0x811c9dc5;
+
+    for (let index = 0; index < text.length; index += 1) {
+        hash ^= text.charCodeAt(index);
+        hash = Math.imul(hash, 0x01000193);
+    }
+
+    return (hash >>> 0).toString(16);
+}

--- a/frontend/src/Client.App/src/device/deviceStore.ts
+++ b/frontend/src/Client.App/src/device/deviceStore.ts
@@ -59,9 +59,9 @@ export function deviceStore(): DeviceStore {
  * nothing that says whether somebody is signed in. It is a name for a pane width, and the digest is what keeps even
  * the identity out of the store.
  *
- * ponytail: a non-cryptographic digest, because this is read before the first paint and `SubtleCrypto` only answers
- * asynchronously. It keeps the name out of the store rather than resisting somebody who already holds both; a
- * cryptographic one is the upgrade if a value under one of these keys ever becomes worth more than a pane width.
+ * **The digest is not a cryptographic one**, because this is read before the first paint and `SubtleCrypto` only
+ * answers asynchronously. It keeps the name out of the store rather than resisting somebody who already holds both;
+ * a cryptographic one is the upgrade if a value under one of these keys ever becomes worth more than a pane width.
  */
 export function listWidthKey(person: string): string {
     return `mailfathom.listWidth.${digestOf(person)}`;

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -159,6 +159,9 @@ export const en = {
     'mail.backToList': 'Back to the list',
     'mail.listColumn': 'Message list',
     'mail.readingColumn': 'What is open',
+    'mail.listWidth': 'Message list width',
+    'mail.listWidthHint':
+        'Drag to change the list width. Double-click, or press Home, to return it to where it started.',
 
     'folder.inbox': 'Inbox',
     'folder.drafts': 'Drafts',

--- a/frontend/src/Client.App/src/localization/locale.ts
+++ b/frontend/src/Client.App/src/localization/locale.ts
@@ -2,8 +2,14 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+import { deviceKeys, deviceStore } from '../device/deviceStore';
 import { en, type Catalogue } from './en';
 import { pl } from './pl';
+
+// Which language was chosen is one of the things the device holds rather than the deployment, so it is read and written
+// through `device/deviceStore.ts` — including the handling a browser or a WebView refusing storage needs, which is that
+// module's rather than this one's. The choice survives a restart of either head because both store it in the same
+// place: the web bundle in the browser's origin storage, the desktop shell in its WebView's.
 
 /** The languages the client is offered in. Neutral rather than regional: nothing differs between regions yet. */
 export const locales = ['en', 'pl'] as const;
@@ -19,15 +25,6 @@ export const catalogues: Readonly<Record<Locale, Catalogue>> = { en, pl };
 // who has landed in a language they do not read has to recognise their own in the list, and translating the list would
 // be the one place that fails them.
 export const localeNames: Readonly<Record<Locale, string>> = { en: 'English', pl: 'Polski' };
-
-// What the explicit choice is written under. It survives a restart of either head because both store it in the same
-// place: the web bundle in the browser's origin storage, the desktop shell in its WebView's.
-//
-// Reached as `window.localStorage` rather than as the bare global on purpose. Node publishes a `localStorage` global of
-// its own, which is unavailable unless the process was started with `--localstorage-file`, and it wins over the one the
-// test environment's document carries — so the bare name is the runtime's under Vitest and the document's in a browser,
-// which is two different objects behind one identifier.
-const storageKey = 'mailfathom.locale';
 
 export function isOfferedLocale(value: unknown): value is Locale {
     return typeof value === 'string' && (locales as readonly string[]).includes(value);
@@ -51,21 +48,13 @@ export function narrowToOfferedLocale(preferences: readonly string[]): Locale {
 
 /** The language explicitly chosen on this machine, or `null` where none was chosen or what was stored is not offered. */
 export function readStoredLocale(): Locale | null {
-    try {
-        const stored = window.localStorage.getItem(storageKey);
-        return isOfferedLocale(stored) ? stored : null;
-    } catch {
-        return null;
-    }
+    const stored = deviceStore().read(deviceKeys.locale);
+
+    return isOfferedLocale(stored) ? stored : null;
 }
 
 export function storeLocale(locale: Locale): void {
-    try {
-        window.localStorage.setItem(storageKey, locale);
-    } catch {
-        // A browser configured to refuse storage still runs the client; the choice then lasts the session rather than
-        // outliving it, which is a smaller loss than a screen that fails to mount over a preference.
-    }
+    deviceStore().write(deviceKeys.locale, locale);
 }
 
 /** What the client opens in: the explicit choice, else the browser or operating-system preference, else English. */

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -159,6 +159,9 @@ export const pl: Catalogue = {
     'mail.backToList': 'Wróć do listy',
     'mail.listColumn': 'Lista wiadomości',
     'mail.readingColumn': 'To, co otwarte',
+    'mail.listWidth': 'Szerokość listy wiadomości',
+    'mail.listWidthHint':
+        'Przeciągnij, aby zmienić szerokość listy. Dwuklik lub klawisz Home przywraca szerokość początkową.',
 
     'folder.inbox': 'Odebrane',
     'folder.drafts': 'Kopie robocze',

--- a/frontend/src/Client.App/src/mailSpace/ListWidthGrip.test.tsx
+++ b/frontend/src/Client.App/src/mailSpace/ListWidthGrip.test.tsx
@@ -111,6 +111,26 @@ describe('ListWidthGrip', () => {
         expect(moved).not.toHaveBeenCalled();
     });
 
+    it('leaves the drag with the pointer that started it when a second one lands on the grip', () => {
+        const chosen = vi.fn();
+
+        render(
+            <LocalizationProvider>
+                <ListWidthGrip width={400} onWidth={vi.fn()} onChosen={chosen} />
+            </LocalizationProvider>,
+        );
+
+        const grip = screen.getByRole('separator');
+        fireEvent.pointerDown(grip, { pointerId: 1, clientX: 600 });
+        fireEvent.pointerDown(grip, { pointerId: 2, clientX: 900 });
+
+        // The second finger is ignored rather than taking the drag over, so the first pointer's release still settles
+        // the width it was dragging toward instead of being dropped as a stranger's.
+        fireEvent.pointerUp(grip, { pointerId: 1, clientX: 660 });
+
+        expect(chosen).toHaveBeenCalledWith(460);
+    });
+
     it('moves nothing on a pointer that never took the boundary', () => {
         const moved = vi.fn();
 

--- a/frontend/src/Client.App/src/mailSpace/ListWidthGrip.test.tsx
+++ b/frontend/src/Client.App/src/mailSpace/ListWidthGrip.test.tsx
@@ -1,0 +1,135 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { LocalizationProvider } from '../localization/Localization';
+import { ListWidthGrip } from './ListWidthGrip';
+import { listWidthStep, narrowestList, startingListWidth, widestList } from './listWidth';
+
+function renderGrip(width = 400): { chosen: ReturnType<typeof vi.fn>; grip: HTMLElement } {
+    const chosen = vi.fn();
+
+    render(
+        <LocalizationProvider>
+            <ListWidthGrip width={width} onWidth={vi.fn()} onChosen={chosen} />
+        </LocalizationProvider>,
+    );
+
+    return { chosen, grip: screen.getByRole('separator') };
+}
+
+describe('ListWidthGrip', () => {
+    it('stands as a separator naming what it moves, so a reader finds it by what it is', () => {
+        const { grip } = renderGrip();
+
+        expect(screen.getByRole('separator', { name: 'Message list width' })).toBe(grip);
+        expect(grip.getAttribute('aria-orientation')).toBe('vertical');
+    });
+
+    it('reports where the boundary stands and how far it may go', () => {
+        const { grip } = renderGrip(400);
+
+        expect(grip.getAttribute('aria-valuenow')).toBe('400');
+        expect(grip.getAttribute('aria-valuemin')).toBe(String(narrowestList));
+        expect(grip.getAttribute('aria-valuemax')).toBe(String(widestList));
+    });
+
+    it('is reachable from the keyboard, which is the whole of what makes the split operable without a mouse', () => {
+        const { grip } = renderGrip();
+
+        grip.focus();
+
+        expect(document.activeElement).toBe(grip);
+    });
+
+    it('narrows the list by one step on the left arrow', () => {
+        const { chosen, grip } = renderGrip(400);
+
+        fireEvent.keyDown(grip, { key: 'ArrowLeft' });
+
+        expect(chosen).toHaveBeenCalledWith(400 - listWidthStep);
+    });
+
+    it('widens the list by one step on the right arrow', () => {
+        const { chosen, grip } = renderGrip(400);
+
+        fireEvent.keyDown(grip, { key: 'ArrowRight' });
+
+        expect(chosen).toHaveBeenCalledWith(400 + listWidthStep);
+    });
+
+    it('returns the split to the width it started at on Home', () => {
+        const { chosen, grip } = renderGrip(500);
+
+        fireEvent.keyDown(grip, { key: 'Home' });
+
+        expect(chosen).toHaveBeenCalledWith(startingListWidth);
+    });
+
+    it('returns the split to the width it started at on a double-click, which is the same act with a mouse', () => {
+        const { chosen, grip } = renderGrip(500);
+
+        fireEvent.doubleClick(grip);
+
+        expect(chosen).toHaveBeenCalledWith(startingListWidth);
+    });
+
+    it('moves the boundary with the pointer, and reports the width it was let go at', () => {
+        const moved = vi.fn();
+        const chosen = vi.fn();
+
+        render(
+            <LocalizationProvider>
+                <ListWidthGrip width={400} onWidth={moved} onChosen={chosen} />
+            </LocalizationProvider>,
+        );
+
+        const grip = screen.getByRole('separator');
+        fireEvent.pointerDown(grip, { pointerId: 1, clientX: 600 });
+        fireEvent.pointerMove(grip, { pointerId: 1, clientX: 660 });
+        fireEvent.pointerUp(grip, { pointerId: 1, clientX: 680 });
+
+        expect(moved).toHaveBeenCalledWith(460);
+        expect(chosen).toHaveBeenCalledWith(480);
+    });
+
+    it('ignores a second pointer arriving mid-drag, so two fingers cannot fight over one boundary', () => {
+        const moved = vi.fn();
+
+        render(
+            <LocalizationProvider>
+                <ListWidthGrip width={400} onWidth={moved} onChosen={vi.fn()} />
+            </LocalizationProvider>,
+        );
+
+        const grip = screen.getByRole('separator');
+        fireEvent.pointerDown(grip, { pointerId: 1, clientX: 600 });
+        fireEvent.pointerMove(grip, { pointerId: 2, clientX: 900 });
+
+        expect(moved).not.toHaveBeenCalled();
+    });
+
+    it('moves nothing on a pointer that never took the boundary', () => {
+        const moved = vi.fn();
+
+        render(
+            <LocalizationProvider>
+                <ListWidthGrip width={400} onWidth={moved} onChosen={vi.fn()} />
+            </LocalizationProvider>,
+        );
+
+        fireEvent.pointerMove(screen.getByRole('separator'), { pointerId: 1, clientX: 900 });
+
+        expect(moved).not.toHaveBeenCalled();
+    });
+
+    it('leaves a key it does not answer to whatever is behind it', () => {
+        const { chosen, grip } = renderGrip();
+
+        fireEvent.keyDown(grip, { key: 'PageDown' });
+
+        expect(chosen).not.toHaveBeenCalled();
+    });
+});

--- a/frontend/src/Client.App/src/mailSpace/ListWidthGrip.tsx
+++ b/frontend/src/Client.App/src/mailSpace/ListWidthGrip.tsx
@@ -1,0 +1,124 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { useRef, type KeyboardEvent, type PointerEvent } from 'react';
+import { useLocalization } from '../localization/useLocalization';
+import { listWidthStep, narrowestList, startingListWidth, widestList } from './listWidth';
+
+// The grip on the boundary between the message list and the reading pane, which is what lets a reader give either side
+// more room. It draws the line the design project puts there and it is the control on it — those are one element
+// rather than two, because a boundary somebody can move is a boundary they have to be able to point at.
+//
+// It is a separator that takes focus, which is what ARIA calls a window splitter: the position it reports is the width
+// of the pane before it, so a reader who cannot see the columns still knows where the boundary stands and how far it
+// may go. Everything it can be done with a pointer it can be done with the keyboard — the arrows move it in steps, and
+// `Home` returns it to the width it started at, which is what a double-click does for a mouse.
+//
+// One pointer path rather than one per input, because pointer events are what a mouse, a finger, and a pen all arrive
+// as. Capturing the pointer is what keeps a drag with it once it has left the five pixels the grip is drawn at, and
+// `touch-none` is what keeps a finger dragging the boundary from scrolling the list underneath it instead.
+
+export function ListWidthGrip({
+    width,
+    onWidth,
+    onChosen,
+}: {
+    /** How wide the list is drawn right now, which is the position this reports and the width a drag starts from. */
+    readonly width: number;
+
+    /** The width to draw while the boundary is being moved. */
+    readonly onWidth: (width: number) => void;
+
+    /** The width somebody settled on, which is the one worth keeping. */
+    readonly onChosen: (width: number) => void;
+}) {
+    const { translate } = useLocalization();
+
+    // What a drag is: the pointer that started it, and where it and the boundary stood then. A ref rather than state,
+    // because nothing on the screen is drawn from it and a moving pointer would otherwise render for every pixel of
+    // its own bookkeeping.
+    const dragging = useRef<{ pointer: number; from: number; startedAt: number } | null>(null);
+
+    function beginDrag(event: PointerEvent<HTMLDivElement>): void {
+        // Without this a drag across the columns selects the rows it passes over, and the boundary arrives with half
+        // the mailbox highlighted behind it.
+        event.preventDefault();
+
+        dragging.current = { pointer: event.pointerId, from: event.clientX, startedAt: width };
+
+        try {
+            event.currentTarget.setPointerCapture(event.pointerId);
+        } catch {
+            // A runtime that is not tracking this pointer refuses to hand its capture over, which is what a synthesised
+            // event is. The drag then follows the handlers on the element instead, which is everything but the part
+            // where it keeps following a pointer that has left the grip.
+        }
+    }
+
+    function moveGrip(event: PointerEvent<HTMLDivElement>): void {
+        const drag = dragging.current;
+
+        if (drag?.pointer !== event.pointerId) {
+            return;
+        }
+
+        onWidth(drag.startedAt + (event.clientX - drag.from));
+    }
+
+    function endDrag(event: PointerEvent<HTMLDivElement>): void {
+        const drag = dragging.current;
+
+        if (drag?.pointer !== event.pointerId) {
+            return;
+        }
+
+        dragging.current = null;
+        onChosen(drag.startedAt + (event.clientX - drag.from));
+    }
+
+    function moveByKey(event: KeyboardEvent<HTMLDivElement>): void {
+        const moved = keyboardWidths[event.key];
+
+        if (moved === undefined) {
+            return;
+        }
+
+        // The arrows scroll the column behind the grip otherwise, and `Home` takes the page to the top of it.
+        event.preventDefault();
+        onChosen(moved(width));
+    }
+
+    return (
+        <div
+            role="separator"
+            aria-orientation="vertical"
+            aria-label={translate('mail.listWidth')}
+            aria-valuenow={Math.round(width)}
+            aria-valuemin={narrowestList}
+            aria-valuemax={widestList}
+            tabIndex={0}
+            title={translate('mail.listWidthHint')}
+            /* Five pixels is what the design draws, and it is less than a finger or a shaking hand can reliably hit —
+               so the line stays five pixels and the target around it is widened to twenty-five with a pseudo-element,
+               which is the accessibility obligation rather than a departure from the design. */
+            className="after:-inset-x-2.5 relative w-1.25 shrink-0 cursor-col-resize touch-none bg-line transition hover:bg-accent-line after:absolute after:inset-y-0 after:content-['']"
+            onPointerDown={beginDrag}
+            onPointerMove={moveGrip}
+            onPointerUp={endDrag}
+            onPointerCancel={endDrag}
+            onDoubleClick={() => {
+                onChosen(startingListWidth);
+            }}
+            onKeyDown={moveByKey}
+        />
+    );
+}
+
+// What each key the grip answers does to the width. A lookup rather than a chain inside the handler, so the keys the
+// control offers are one list a reader can see the whole of.
+const keyboardWidths: Readonly<Record<string, ((width: number) => number) | undefined>> = {
+    ArrowLeft: (width) => width - listWidthStep,
+    ArrowRight: (width) => width + listWidthStep,
+    Home: () => startingListWidth,
+};

--- a/frontend/src/Client.App/src/mailSpace/ListWidthGrip.tsx
+++ b/frontend/src/Client.App/src/mailSpace/ListWidthGrip.tsx
@@ -41,6 +41,15 @@ export function ListWidthGrip({
     const dragging = useRef<{ pointer: number; from: number; startedAt: number } | null>(null);
 
     function beginDrag(event: PointerEvent<HTMLDivElement>): void {
+        const drag = dragging.current;
+
+        // A second finger landing on the grip mid-drag is ignored rather than taking the drag over: the pointer that
+        // started it is the one the two handlers below answer to, so letting a newcomer replace it would leave the
+        // first pointer's move and release unmatched and the width it was dragging toward never settled.
+        if (drag !== null && drag.pointer !== event.pointerId) {
+            return;
+        }
+
         // Without this a drag across the columns selects the rows it passes over, and the boundary arrives with half
         // the mailbox highlighted behind it.
         event.preventDefault();

--- a/frontend/src/Client.App/src/mailSpace/MailSpace.test.tsx
+++ b/frontend/src/Client.App/src/mailSpace/MailSpace.test.tsx
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { LocalizationProvider } from '../localization/Localization';
 import { WorkspaceProvider } from '../workspace/Workspace';
 import { useWorkspace, type Workspace } from '../workspace/useWorkspace';
+import { listWidthStep, readListWidth, startingListWidth, storeListWidth } from './listWidth';
 import { MailSpace } from './MailSpace';
 
 // Not catalogue entries: each stands for whatever the frame composes for the region, which is the point of the props.
@@ -80,7 +81,7 @@ function Opening({ change }: { readonly change: Partial<Workspace> }) {
     return null;
 }
 
-function renderSpace(wide: boolean, opening: Partial<Workspace> = {}): void {
+function renderSpace(wide: boolean, opening: Partial<Workspace> = {}, person: string | null = 'reader'): void {
     atWidth(wide);
     withModalDialogs();
 
@@ -99,6 +100,7 @@ function renderSpace(wide: boolean, opening: Partial<Workspace> = {}): void {
                     mail={<p>{handedToMail}</p>}
                     intent={<p>{handedTheIntent}</p>}
                     status={<p>{handedTheStatus}</p>}
+                    person={person}
                 />
             </WorkspaceProvider>
         </LocalizationProvider>,
@@ -125,10 +127,53 @@ afterEach(() => {
     }
 
     window.sessionStorage.clear();
+    window.localStorage.clear();
     vi.restoreAllMocks();
 });
 
 describe('MailSpace, wide', () => {
+    it('puts a grip on the boundary, at the width this person last settled on', () => {
+        storeListWidth('karolina', 420);
+
+        renderSpace(true, {}, 'karolina');
+
+        expect(screen.getByRole('separator', { name: 'Message list width' }).getAttribute('aria-valuenow')).toBe('420');
+    });
+
+    it('opens at the starting width for somebody who has settled on none', () => {
+        renderSpace(true, {}, 'marta');
+
+        expect(screen.getByRole('separator', { name: 'Message list width' }).getAttribute('aria-valuenow')).toBe(
+            String(startingListWidth),
+        );
+    });
+
+    it('keeps the width a reader moves the grip to, and offers it back on the next start', () => {
+        renderSpace(true, {}, 'karolina');
+
+        fireEvent.keyDown(screen.getByRole('separator', { name: 'Message list width' }), { key: 'ArrowRight' });
+
+        expect(screen.getByRole('separator', { name: 'Message list width' }).getAttribute('aria-valuenow')).toBe(
+            String(startingListWidth + listWidthStep),
+        );
+        expect(readListWidth('karolina')).toBe(startingListWidth + listWidthStep);
+    });
+
+    it('moves the boundary while the grip is being dragged, and settles where it was let go', () => {
+        renderSpace(true, {}, 'karolina');
+
+        const grip = screen.getByRole('separator', { name: 'Message list width' });
+        fireEvent.pointerDown(grip, { pointerId: 1, clientX: 600 });
+        fireEvent.pointerMove(grip, { pointerId: 1, clientX: 664 });
+
+        // Read while the pointer is still down: the boundary follows the drag rather than jumping to where it ended.
+        expect(grip.getAttribute('aria-valuenow')).toBe(String(startingListWidth + 64));
+
+        fireEvent.pointerUp(grip, { pointerId: 1, clientX: 664 });
+
+        expect(readListWidth('karolina')).toBe(startingListWidth + 64);
+    });
+
     it('draws the three columns side by side, with the toolbar over them', () => {
         renderSpace(true);
 
@@ -197,6 +242,12 @@ describe('MailSpace, wide', () => {
 });
 
 describe('MailSpace, narrow', () => {
+    it('draws no grip, because one column at a time has no boundary to move', () => {
+        renderSpace(false);
+
+        expect(screen.queryByRole('separator', { name: 'Message list width' })).toBeNull();
+    });
+
     it('draws the list alone while nothing is open, with the mailboxes behind a control and no toolbar', () => {
         renderSpace(false);
 

--- a/frontend/src/Client.App/src/mailSpace/MailSpace.tsx
+++ b/frontend/src/Client.App/src/mailSpace/MailSpace.tsx
@@ -10,6 +10,8 @@ import { useWideWorkspace } from '../shell/useWideWorkspace';
 import { scopeKey } from '../workspace/mailScope';
 import { useWorkspace } from '../workspace/useWorkspace';
 import { AiFilters } from './AiFilters';
+import { ListWidthGrip } from './ListWidthGrip';
+import { listWidthWithin, readListWidth, storeListWidth } from './listWidth';
 import { MailToolbar } from './MailToolbar';
 
 // The Mail space as the design project composes it, out of the three regions a mail client is: the mailboxes, the list
@@ -26,6 +28,10 @@ import { MailToolbar } from './MailToolbar';
 // the list is a view change, and so is going back, and a reader on a keyboard is put at the start of what replaced what
 // they were on rather than left on an element that is no longer there. A resize that changes the shape is not, so the
 // width changing moves nothing.
+//
+// How the wide shape divides its width between the list and the pane is the reader's, and this is where that lives: it
+// is the composition's own number rather than either column's, and only the shape that draws both columns has a
+// boundary to move.
 
 export function MailSpace({
     folders,
@@ -33,6 +39,7 @@ export function MailSpace({
     mail,
     intent,
     status,
+    person,
 }: {
     /** The scope selector, which is the mailbox column's first thing. */
     readonly folders: ReactNode;
@@ -51,16 +58,56 @@ export function MailSpace({
 
     /** What the deployment says about the connection, which stands at the foot of the mailbox column. */
     readonly status: ReactNode;
+
+    /**
+     * Who is signed in, which is what the split is kept under: two people sharing a machine each get their own.
+     *
+     * `null` where the credential this client holds names nobody it composed, which is a split that lasts the run
+     * rather than a screen that refuses to draw.
+     */
+    readonly person: string | null;
 }) {
     const { translate } = useLocalization();
     const { workspace, revise } = useWorkspace();
     const wide = useWideWorkspace();
     const [folded, setFolded] = useState(false);
+    const [listWidth, setListWidth] = useState(() => readListWidth(person));
     const drawer = useRef<HTMLDialogElement>(null);
     const listColumn = useRef<HTMLElement>(null);
     const readingColumn = useRef<HTMLElement>(null);
 
     const readingInFront = !wide && (workspace.selection !== null || workspace.conversation !== null);
+
+    // A width chosen on one screen is read back on whatever screen the client opens on next, so the window is measured
+    // rather than trusted: what the two columns share is what they measure to, and a stored width the window no longer
+    // has room for is brought back to what fits instead of pushing the message off the side.
+    //
+    // An effect because a `ResizeObserver` is something outside React, and it watches both columns because what the
+    // two of them add up to is the measurement — a number nothing this sets can move, since the pane takes back
+    // whatever the list gives up. So it settles in one pass rather than chasing itself.
+    useEffect(() => {
+        const listed = listColumn.current;
+        const reading = readingColumn.current;
+
+        if (!wide || listed === null || reading === null || typeof ResizeObserver !== 'function') {
+            return;
+        }
+
+        const watched = new ResizeObserver(() => {
+            const room = listed.offsetWidth + reading.offsetWidth;
+
+            if (room > 0) {
+                setListWidth((chosen) => listWidthWithin(chosen, room));
+            }
+        });
+
+        watched.observe(listed);
+        watched.observe(reading);
+
+        return () => {
+            watched.disconnect();
+        };
+    }, [wide]);
 
     // Focus is placed on the shape changing what it shows, and not on the width changing the shape: both are recorded
     // and only the first moves anything. A ref rather than state, because what it holds is what was last drawn.
@@ -90,6 +137,15 @@ export function MailSpace({
 
     function goBackToList(): void {
         revise({ selection: null, conversation: null });
+    }
+
+    // Every width a move produces is held inside the same bounds, so a drag and a key cannot disagree about where the
+    // boundary may stand. A room of nothing is a layout that has not happened yet — an environment that computes no
+    // sizes, or the frame before the first one — and is read as an unmeasured window rather than as no room at all.
+    function withinTheRoom(width: number): number {
+        const room = (listColumn.current?.offsetWidth ?? 0) + (readingColumn.current?.offsetWidth ?? 0);
+
+        return listWidthWithin(width, room > 0 ? room : Number.POSITIVE_INFINITY);
     }
 
     return (
@@ -147,7 +203,15 @@ export function MailSpace({
                         ref={listColumn}
                         tabIndex={-1}
                         aria-label={translate('mail.listColumn')}
-                        className={`flex min-h-0 min-w-0 flex-col bg-panel ${wide ? 'w-message-list shrink-0 border-e border-line' : 'flex-1'}`}
+                        className={`flex min-h-0 min-w-0 flex-col bg-panel ${wide ? '' : 'flex-1'}`}
+                        /* The one width in the client a person sets rather than the design, which is why it is drawn
+                           from a value instead of a utility. The narrow shape has no boundary to move, so it takes the
+                           whole column and this says nothing about it.
+                           Left able to shrink on purpose: a width chosen on a wider screen is read back before
+                           anything has measured this one, and a column that refuses to give way in that frame would
+                           push the message off the side. Flexbox holds it inside the window until the measurement
+                           below brings it back to a width that fits. */
+                        style={wide ? { width: `${String(listWidth)}px` } : undefined}
                     >
                         {wide ? null : (
                             <div className="flex items-center px-2 pt-2">
@@ -165,6 +229,23 @@ export function MailSpace({
 
                         {wide ? null : intent}
                     </section>
+                ) : null}
+
+                {/* The boundary is only there where both columns are: one column at a time has nothing between them,
+                    and the line the grip draws is the border the list would otherwise carry. */}
+                {wide ? (
+                    <ListWidthGrip
+                        width={listWidth}
+                        onWidth={(moved) => {
+                            setListWidth(withinTheRoom(moved));
+                        }}
+                        onChosen={(chosen) => {
+                            const settled = withinTheRoom(chosen);
+
+                            setListWidth(settled);
+                            storeListWidth(person, settled);
+                        }}
+                    />
                 ) : null}
 
                 {wide || readingInFront ? (

--- a/frontend/src/Client.App/src/mailSpace/listWidth.test.ts
+++ b/frontend/src/Client.App/src/mailSpace/listWidth.test.ts
@@ -1,0 +1,83 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { listWidthKey } from '../device/deviceStore';
+import {
+    leastReadingWidth,
+    listWidthWithin,
+    narrowestList,
+    readListWidth,
+    startingListWidth,
+    storeListWidth,
+    widestList,
+} from './listWidth';
+
+const reader = 'karolina';
+
+afterEach(() => {
+    window.localStorage.clear();
+});
+
+describe('listWidthWithin', () => {
+    it('leaves a width the window has room for where it stands', () => {
+        expect(listWidthWithin(400, 1200)).toBe(400);
+    });
+
+    it('refuses to draw the list narrower than a sender and a subject fit on', () => {
+        expect(listWidthWithin(40, 1200)).toBe(narrowestList);
+    });
+
+    it('refuses to draw the list so wide that it stops being a list beside a message', () => {
+        expect(listWidthWithin(2000, 4000)).toBe(widestList);
+    });
+
+    it('brings a width a narrower window no longer has room for back to what fits', () => {
+        expect(listWidthWithin(widestList, leastReadingWidth + 400)).toBe(400);
+    });
+
+    it('keeps the list at its own minimum where the window has room for neither column in full', () => {
+        expect(listWidthWithin(widestList, narrowestList)).toBe(narrowestList);
+    });
+
+    it('answers a whole number of pixels, which is what a column can actually be drawn at', () => {
+        expect(listWidthWithin(400.6, 1200)).toBe(401);
+    });
+});
+
+describe('readListWidth', () => {
+    it('opens at the starting width where this person has chosen none', () => {
+        expect(readListWidth(reader)).toBe(startingListWidth);
+    });
+
+    it('opens at the width this person last settled on', () => {
+        storeListWidth(reader, 420);
+
+        expect(readListWidth(reader)).toBe(420);
+    });
+
+    it('opens at the starting width for somebody else on the same machine', () => {
+        storeListWidth(reader, 420);
+
+        expect(readListWidth('marta')).toBe(startingListWidth);
+    });
+
+    it('opens at the starting width where nobody is named, and keeps nothing under one', () => {
+        storeListWidth(null, 420);
+
+        expect(readListWidth(null)).toBe(startingListWidth);
+    });
+
+    it.each(['', 'wide', '0', '-1'])('reads a stored %s as nothing chosen rather than as a width', (stored) => {
+        window.localStorage.setItem(listWidthKey(reader), stored);
+
+        expect(readListWidth(reader)).toBe(startingListWidth);
+    });
+
+    it('holds a stored width to the bounds, so an edited store cannot draw a column off the screen', () => {
+        window.localStorage.setItem(listWidthKey(reader), '4000');
+
+        expect(readListWidth(reader)).toBe(widestList);
+    });
+});

--- a/frontend/src/Client.App/src/mailSpace/listWidth.ts
+++ b/frontend/src/Client.App/src/mailSpace/listWidth.ts
@@ -1,0 +1,75 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { deviceStore, listWidthKey } from '../device/deviceStore';
+
+// How wide the message list is drawn beside the reading pane, which is a decision the person reading makes and this
+// machine keeps. Everything here is arithmetic over one number, so it is a module of its own rather than state inside
+// the component: the bounds, the reset, the clamp a narrower window forces, and where the chosen width is written are
+// each testable without rendering three columns.
+//
+// The four widths below are the design project's and are written here rather than in `styles.css` because nothing in
+// the markup spells them: what reads them is the drag arithmetic, the keyboard step, and the position the grip reports
+// as a separator. A token would be a second copy of each number that only the stylesheet could see.
+
+/** The narrowest the list is drawn at, past which a sender and a subject stop fitting on one row. */
+export const narrowestList = 232;
+
+/** The widest the list is drawn at, past which it stops being a list beside a message and becomes the screen. */
+export const widestList = 560;
+
+/** What a first run opens at, and what a reset returns to. */
+export const startingListWidth = 340;
+
+/**
+ * The least room the list leaves the reading pane.
+ *
+ * It is the narrowest viewport the client is built for, which is the width below which a message stops being readable
+ * at all — so a window with less than this beside the list has nothing left to give and the list keeps its own
+ * minimum instead.
+ */
+export const leastReadingWidth = 320;
+
+/** How far one keyboard step moves the split, which is a step a reader can see land rather than a pixel. */
+export const listWidthStep = 16;
+
+/**
+ * The width actually drawn, given how much room the list and the reading pane have between them.
+ *
+ * @param width The width somebody chose, which may be one this window no longer has room for.
+ * @param room How many pixels the two columns share. `Number.POSITIVE_INFINITY` where nothing has measured yet.
+ * @returns A width inside the bounds that leaves the reading pane something to draw in.
+ */
+export function listWidthWithin(width: number, room: number): number {
+    const most = Math.max(narrowestList, Math.min(widestList, room - leastReadingWidth));
+
+    return Math.round(Math.min(Math.max(width, narrowestList), most));
+}
+
+/**
+ * The width this person last chose on this machine, or the starting width where they chose none.
+ *
+ * Read back as untrusted input, because a device store is a place a person can write: anything that is not a number
+ * inside the bounds is answered as nothing chosen rather than as a column drawn off the screen.
+ */
+export function readListWidth(person: string | null): number {
+    if (person === null) {
+        return startingListWidth;
+    }
+
+    const stored = Number(deviceStore().read(listWidthKey(person)));
+
+    return Number.isFinite(stored) && stored > 0
+        ? listWidthWithin(stored, Number.POSITIVE_INFINITY)
+        : startingListWidth;
+}
+
+/** Keeps the width this person settled on, so the next start of the client opens the Mail space at it. */
+export function storeListWidth(person: string | null, width: number): void {
+    if (person === null) {
+        return;
+    }
+
+    deviceStore().write(listWidthKey(person), String(Math.round(width)));
+}

--- a/frontend/src/Client.App/src/shell/Space.test.tsx
+++ b/frontend/src/Client.App/src/shell/Space.test.tsx
@@ -32,6 +32,7 @@ function inStrictMode(space: SpaceName): ReactNode {
                         folders={<p>{handedTheFolders}</p>}
                         list={<p>{handedTheList}</p>}
                         mail={<p>{handedToMail}</p>}
+                        person="reader"
                     />
                 </WorkspaceProvider>
             </LocalizationProvider>

--- a/frontend/src/Client.App/src/shell/Space.tsx
+++ b/frontend/src/Client.App/src/shell/Space.tsx
@@ -17,6 +17,7 @@ export function Space({
     folders,
     list,
     mail,
+    person,
 }: {
     readonly space: SpaceName;
 
@@ -29,6 +30,9 @@ export function Space({
     readonly folders: ReactNode;
     readonly list: ReactNode;
     readonly mail: ReactNode;
+
+    /** Who is signed in, which the Mail space keeps its own division of the width under. */
+    readonly person: string | null;
 }) {
     const { translate } = useLocalization();
     const region = useRef<HTMLElement>(null);
@@ -58,7 +62,7 @@ export function Space({
                 aria-label={translate(spaceLabels[space])}
                 className="flex min-h-0 flex-1 flex-col overflow-hidden"
             >
-                <MailSpace folders={folders} list={list} mail={mail} intent={intent} status={status} />
+                <MailSpace folders={folders} list={list} mail={mail} intent={intent} status={status} person={person} />
             </main>
         );
     }

--- a/frontend/src/Client.App/src/signIn/credentialEntry.test.ts
+++ b/frontend/src/Client.App/src/signIn/credentialEntry.test.ts
@@ -3,7 +3,18 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { describe, expect, it } from 'vitest';
-import { longestCredentialPart, resolveCredentialEntry, type CredentialEntryRefusal } from './credentialEntry';
+import {
+    longestCredentialPart,
+    resolveCredentialEntry,
+    userNameIn,
+    type CredentialEntryRefusal,
+} from './credentialEntry';
+
+function composed(userName: string, password: string): string {
+    const result = resolveCredentialEntry(userName, password);
+
+    return result.outcome === 'resolved' ? result.authorization : '';
+}
 
 function refusal(userName: string, password: string): CredentialEntryRefusal | 'resolved' {
     const result = resolveCredentialEntry(userName, password);
@@ -63,4 +74,28 @@ describe('resolveCredentialEntry', () => {
             expect(refusal(userName, password)).toBe('resolved');
         },
     );
+});
+
+describe('userNameIn', () => {
+    it('reads back the name a credential was composed from, which is what tells one person on a machine from another', () => {
+        expect(userNameIn(composed('karolina', 'open sesame'))).toBe('karolina');
+    });
+
+    it('reads a name back through UTF-8, so somebody whose name is not US-ASCII is still themselves', () => {
+        expect(userNameIn(composed('zażółć', 'open sesame'))).toBe('zażółć');
+    });
+
+    it('reads back only the name, whatever the password beside it carries', () => {
+        expect(userNameIn(composed('karolina', 'open:sesame'))).toBe('karolina');
+    });
+
+    it.each([
+        ['nobody signed in', null],
+        ['another scheme', 'Bearer abcdef'],
+        ['nothing base64 decodes to', 'Basic not base64 at all'],
+        ['a value with no separator in it', `Basic ${btoa('karolina')}`],
+        ['a value with an empty name', `Basic ${btoa(':open sesame')}`],
+    ])('answers nobody for %s', (_, authorization) => {
+        expect(userNameIn(authorization)).toBeNull();
+    });
 });

--- a/frontend/src/Client.App/src/signIn/credentialEntry.ts
+++ b/frontend/src/Client.App/src/signIn/credentialEntry.ts
@@ -56,6 +56,46 @@ export function resolveCredentialEntry(userName: string, password: string): Cred
     return { outcome: 'resolved', authorization: `Basic ${base64(`${userName}:${password}`)}` };
 }
 
+/**
+ * The user name inside a credential this client composed, or `null` where the value is not one it would have composed.
+ *
+ * It is here rather than at the caller for the reason the module opens with: this is the one implementation of
+ * RFC 7617 in the client, and a second place taking the value apart is a second place that can get the encoding wrong
+ * — with the password sitting beside the name in what it is taking apart. Nothing this answers is a secret; what the
+ * name is for is telling one person on a machine from another.
+ *
+ * @param authorization The finished header value, as {@link resolveCredentialEntry} produced it.
+ * @returns The name, or `null` for a value that is not a Basic credential this client could have written.
+ */
+export function userNameIn(authorization: string | null): string | null {
+    if (authorization?.startsWith('Basic ') !== true) {
+        return null;
+    }
+
+    let decoded: string;
+
+    try {
+        decoded = new TextDecoder().decode(octetsOf(atob(authorization.slice('Basic '.length))));
+    } catch {
+        return null;
+    }
+
+    const separator = decoded.indexOf(':');
+
+    return separator > 0 ? decoded.slice(0, separator) : null;
+}
+
+/** What `atob` answers, read back as the UTF-8 octets {@link base64} encoded rather than as code points. */
+function octetsOf(binary: string): Uint8Array {
+    const octets = new Uint8Array(binary.length);
+
+    for (let index = 0; index < binary.length; index += 1) {
+        octets[index] = binary.charCodeAt(index);
+    }
+
+    return octets;
+}
+
 /** What `btoa` needs: one octet of the UTF-8 encoding per character, rather than the string's own code points. */
 function base64(text: string): string {
     const encoded = new TextEncoder().encode(text);

--- a/frontend/src/Client.App/src/styles.css
+++ b/frontend/src/Client.App/src/styles.css
@@ -196,13 +196,14 @@
     --spacing-message-row: 4.75rem;
 
     /* How wide the rail is, how wide the column beside it that holds the mailbox tree is when it is open and when it
-       is folded to a strip, how wide the message list beside that is, and how wide the drawer the narrow shape holds
-       the mailboxes in is. All five are the project's, and they are here rather than on the components because the
-       first four have to add up to a composition. */
+       is folded to a strip, and how wide the drawer the narrow shape holds the mailboxes in is. All four are the
+       project's, and they are here rather than on the components because the first three have to add up to a
+       composition. The message list's width is not among them: it is the one width a person sets rather than the
+       design, so it is drawn from a value and its bounds live in `mailSpace/listWidth.ts`, where the arithmetic that
+       reads them is. */
     --spacing-rail: 6rem;
     --spacing-mailboxes: 13.125rem;
     --spacing-mailboxes-folded: 3.625rem;
-    --spacing-message-list: 21.25rem;
     --spacing-drawer: 16.375rem;
 
     /* The widest a message's own content is ever drawn, which is a ceiling rather than a width: the reading pane takes

--- a/frontend/src/Client.App/src/theme/themeChoice.ts
+++ b/frontend/src/Client.App/src/theme/themeChoice.ts
@@ -2,6 +2,13 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+import { deviceKeys, deviceStore } from '../device/deviceStore';
+
+// Which theme was chosen is one of the things the device holds rather than the deployment, so it is read and written
+// through `device/deviceStore.ts` — including the handling a browser or a WebView refusing storage needs, which is
+// that module's rather than this one's. The choice survives a restart of either head because both store it in the same
+// place: the web bundle in the browser's origin storage, the desktop shell in its WebView's.
+
 /** What a person may choose: one of the two themes, or whatever the machine is set to. */
 export const themeChoices = ['system', 'light', 'dark'] as const;
 
@@ -13,12 +20,6 @@ export type Theme = 'light' | 'dark';
 /** What a first run resolves to when nothing it reads names a choice: the machine's own. */
 export const defaultThemeChoice: ThemeChoice = 'system';
 
-// What the explicit choice is written under, beside the language. It survives a restart of either head because both
-// store it in the same place: the web bundle in the browser's origin storage, the desktop shell in its WebView's.
-//
-// Reached as `window.localStorage` rather than as the bare global, for the reason `localization/locale.ts` gives.
-const storageKey = 'mailfathom.theme';
-
 const darkQuery = '(prefers-color-scheme: dark)';
 
 export function isThemeChoice(value: unknown): value is ThemeChoice {
@@ -27,21 +28,13 @@ export function isThemeChoice(value: unknown): value is ThemeChoice {
 
 /** The theme explicitly chosen on this machine, or `null` where none was chosen or what was stored is not offered. */
 export function readStoredThemeChoice(): ThemeChoice | null {
-    try {
-        const stored = window.localStorage.getItem(storageKey);
-        return isThemeChoice(stored) ? stored : null;
-    } catch {
-        return null;
-    }
+    const stored = deviceStore().read(deviceKeys.themeChoice);
+
+    return isThemeChoice(stored) ? stored : null;
 }
 
 export function storeThemeChoice(choice: ThemeChoice): void {
-    try {
-        window.localStorage.setItem(storageKey, choice);
-    } catch {
-        // A browser configured to refuse storage still runs the client; the choice then lasts the session rather than
-        // outliving it, which is a smaller loss than a screen that fails to mount over a preference.
-    }
+    deviceStore().write(deviceKeys.themeChoice, choice);
 }
 
 /** What the client opens in: the explicit choice, else following the machine. */

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.ts
@@ -16,7 +16,7 @@ import { emptyWorkspace, type Workspace } from './useWorkspace';
 // store that dies with the tab is what makes that true of a tab somebody closed without signing out. It is the same
 // bound the web head keeps its credential under, for the same reason.
 //
-// Reached as `window.sessionStorage` rather than as the bare global for the reason `localization/locale.ts` gives:
+// Reached as `window.sessionStorage` rather than as the bare global for the reason `device/deviceStore.ts` gives:
 // Node publishes stores of its own that win over the document's under the test runner.
 const storageKey = 'mailfathom.workspace';
 


### PR DESCRIPTION
Closes #1497

## What this does

Two things the issue put together, because the second is what the first was needed for.

**One module for what the device holds.** The theme, the language, and now the width of the message
list are values that belong to the machine somebody reads on rather than to the person reading.
They were three separate reaches for `localStorage`, each spelling its key inline and each carrying
its own `try`/`catch` for a browser that refuses storage. `device/deviceStore.ts` is now the one
module they go through: it declares the keys together, holds the refusal handling once, and answers
with an implementation resolved from **what the system offers rather than which system it is** —
the web head and the desktop head on either platform all reach the same origin storage through the
WebView they render in, and a system that refuses it falls back to a store lasting the run, so the
client still mounts. That is the seam a head diverging later is added behind, and it is asked as a
capability because `frontend/src/AGENTS.md` § *The two heads* refuses a module chosen by target.
`themeChoice.ts` and `locale.ts` move onto it keeping their existing keys, so nothing already stored
on anybody's machine is lost.

**A grip on the list/pane boundary.** It is rendered only where both columns are on screen, and it
draws the line the list column's border used to. One pointer path serves mouse, touch, and pen
(`touch-action: none` plus pointer capture), it reports itself as a `separator` carrying its current
position, `ArrowLeft`/`ArrowRight` step it, and `Home` or a double-click returns it to where it
started. A `ResizeObserver` over both columns brings a width that no longer fits back inside the
window, and the wide list column deliberately does not carry `shrink-0`: a width chosen on a wider
screen is read back before anything has measured this one, and a column that refused to give way in
that frame would push the message off the side.

`--spacing-message-list` leaves the token layer with it — the list is no longer one width, and its
bounds are the arithmetic in `mailSpace/listWidth.ts`. The numbers there (232 / 340 / 560, and a
320px floor under the reading pane) are the design project's own.

## Per signed-in person, and how that stands against ADR 0023

The issue asks for the split to be stored per signed-in person, and nothing on the wire names one.
`credentialEntry.ts` — the one module in the client that implements RFC 7617 — gained `userNameIn`,
which takes the name out of the header value the frame already holds; `App.tsx` calls it and hands
the name down. The store key folds that name to a digest, so two people sharing a machine keep their
own split while the store carries no legible list of who reads mail there.

ADR 0023 says nothing derived from the credential is kept, and this is worth a reviewer's eye rather
than my silence. I read that bullet as governing the credential store: its stated reason is "an
answer the presence or absence of the credential already gives", and a pane width is not one. No
secret is stored, nothing stands in for the credential, nothing says whether somebody is signed in,
and the digest keeps even the identity out of the store. The credential itself is untouched — still
written by `credentialStore.ts` alone, still in `sessionStorage` or the keychain, still never in
`localStorage`. If the bullet should be read more widely, that is an ADR amendment rather than a
code fix, and I would rather hear it now.

## Tests

Beside the sources they cover. `deviceStore.test.ts` covers reading, writing, removal, a system that
refuses storage at the probe, storage that refuses a write after answering a read, and the per-person
key's identity, difference, and opacity. `listWidth.test.ts` covers the bounds, the clamp against a
narrower window, rounding, and untrusted stored values. `ListWidthGrip.test.tsx` covers the separator
role, name, orientation and reported position, focusability, the arrow steps, both resets, a pointer
drag, and the second-pointer and stray-pointer guards. `MailSpace.test.tsx` and `App.test.tsx` cover
the wiring end to end — the width follows the person the held credential names, and somebody else
signing in on the same machine opens at the starting width.

Two lines are left uncovered on purpose and jsdom is why: the `ResizeObserver` effect in
`MailSpace.tsx` (no layout, no `ResizeObserver`) and a read that throws after the probe passed. The
rule the effect wires is `listWidthWithin`, which is tested directly.

## Breaking changes

None. No configuration key, database column, MCP tool argument, or deployment contract moves.

## Verification

`scripts/verify-full.sh` — 75 files, 1335 tests, 94.56% statements, 287 workflow contracts, clean
tree. `scripts/review-obligations.sh` read and answered. `$check-docs-licenses`: docs `pass`
(`frontend/README.md` carries the new section), changelog `n/a`, licenses `n/a` — no manifest, lock
file, or register moved.

The Mail space was held against the design project as two screenshots at one viewport before this
was opened. The boundary region this change owns matches: both sides draw a 5px `var(--line)` band
hovering to `var(--accent-line)`. Two departures remain, and both are accessibility obligations that
outrank what the design shows — a 25px hit target behind the 5px painted line, and a focusable,
keyboard-operable separator where the design has mouse drag and double-click only. Those are
corrections owed to the design project, and they are the owner's to make — #1518 records both, with
the element and what changes on it.

https://claude.ai/code/session_01574WgLstvseBieYNVXLjyx
