### PR TITLE
[#1499] Serve a person their own portrait from the client endpoint, bounded and checked

### DIFF
--- a/backend/src/Application/Portraits/IOwnerPortraitStore.cs
+++ b/backend/src/Application/Portraits/IOwnerPortraitStore.cs
@@ -1,0 +1,51 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Access;
+
+namespace MailFathom.Application.Portraits;
+
+/// <summary>Holds the octets one person is drawn by, and hands them back to whichever machine they next sign in from.</summary>
+/// <remarks>
+/// <para>
+/// One read, one write, and one removal, each for one owner, so there is no shape here that touches two people's
+/// portraits and no query that could compose a roster out of them. All three are key lookups for that reason rather
+/// than for a plan's.
+/// </para>
+/// <para>
+/// The read hands back octets rather than a portrait, because what kind of image they are is read from them and that
+/// reading belongs to the layer that publishes the kinds. A store that returned a kind of its own would be a second
+/// opinion about the same octets.
+/// </para>
+/// <para>
+/// The write is last-write-wins and states no version, for the reason a person's preferences do: the only writers are
+/// one person's own devices, and there is nobody a lost update could belong to.
+/// </para>
+/// </remarks>
+public interface IOwnerPortraitStore
+{
+    /// <summary>Reads the octets one person is drawn by.</summary>
+    /// <param name="owner">The owner whose portrait is read.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The stored octets, or <see langword="null" /> where this deployment holds no portrait for them.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="owner" /> names nobody.</exception>
+    Task<ReadOnlyMemory<byte>?> ReadAsync(MailOwnerId owner, CancellationToken cancellationToken);
+
+    /// <summary>Replaces the portrait one person is drawn by.</summary>
+    /// <param name="owner">The owner whose portrait is written.</param>
+    /// <param name="portrait">The portrait, whose octets are stored as they were supplied.</param>
+    /// <param name="cancellationToken">Cancels the commit.</param>
+    /// <returns><see langword="true" /> when the write landed, and <see langword="false" /> when this deployment holds no such owner.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="owner" /> names nobody.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="portrait" /> is <see langword="null" />.</exception>
+    /// <remarks>An owner this deployment does not hold is reported rather than raised, because the caller is a person whose row was erased under a credential that has not yet been withdrawn.</remarks>
+    Task<bool> SaveAsync(MailOwnerId owner, OwnerPortrait portrait, CancellationToken cancellationToken);
+
+    /// <summary>Removes the portrait one person is drawn by, leaving everything else about them as it was.</summary>
+    /// <param name="owner">The owner whose portrait is removed.</param>
+    /// <param name="cancellationToken">Cancels the commit.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="owner" /> names nobody.</exception>
+    /// <remarks>Removing what is not there is not a failure and reports nothing: an owner with no portrait and an owner this deployment no longer holds have the same answer, which is that there is now no portrait of theirs.</remarks>
+    Task RemoveAsync(MailOwnerId owner, CancellationToken cancellationToken);
+}

--- a/backend/src/Application/Portraits/OwnPortrait.cs
+++ b/backend/src/Application/Portraits/OwnPortrait.cs
@@ -1,0 +1,87 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Domain.Access;
+
+namespace MailFathom.Application.Portraits;
+
+/// <summary>Reads, replaces, and removes the picture the signed-in person is drawn by.</summary>
+/// <remarks>
+/// <para>
+/// Whose portrait this is comes from the principal rather than from the request, exactly as it does for the owner
+/// record and for a person's preferences: there is no argument here for another owner's identifier, so a request about
+/// somebody else is something a caller cannot express rather than something a surface has to refuse.
+/// </para>
+/// <para>
+/// All three acts are admitted under <see cref="MailFathomPermission.MailRead" />, the grant a signed-in person
+/// already holds, and none of them adds a name to the published set. The two writes are deliberately not
+/// <see cref="MailFathomPermission.MailAccountsWrite" />: that grant decides which mailboxes this deployment connects
+/// to, an administrator maintains it for somebody whose accounts are declared in the deployment's own files, and what
+/// a person is drawn by must not be decided by a grant over their mail configuration.
+/// </para>
+/// <para>
+/// A read answers nothing where there is no portrait, rather than refusing: a client draws the initials it already has
+/// from the person's name, so an absent picture is an ordinary state of the screen rather than an error on it. Octets
+/// that are no image kind this build stores are answered the same way, because a row nothing here could have written
+/// is a row this surface has nothing to say about.
+/// </para>
+/// </remarks>
+public sealed class OwnPortrait
+{
+    private readonly AccessAuthorization authorization;
+    private readonly IOwnerPortraitStore store;
+
+    /// <summary>Initializes the use case.</summary>
+    /// <param name="authorization">Reports the grant the caller holds and the owner it acts for.</param>
+    /// <param name="store">Holds one person's portrait.</param>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    public OwnPortrait(AccessAuthorization authorization, IOwnerPortraitStore store)
+    {
+        ArgumentNullException.ThrowIfNull(authorization);
+        ArgumentNullException.ThrowIfNull(store);
+
+        this.authorization = authorization;
+        this.store = store;
+    }
+
+    /// <summary>Reads the picture the signed-in person is drawn by.</summary>
+    /// <param name="cancellationToken">Propagates caller cancellation.</param>
+    /// <returns>Their portrait, or <see langword="null" /> where this deployment holds none for them.</returns>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the caller acts for no owner, or its grant omits <see cref="MailFathomPermission.MailRead" />.</exception>
+    public async Task<OwnerPortrait?> ReadAsync(CancellationToken cancellationToken)
+    {
+        this.authorization.RequirePermission(MailFathomPermission.MailRead);
+
+        var stored = await this.store.ReadAsync(this.authorization.RequireOwner(), cancellationToken);
+
+        return stored is { } content ? OwnerPortrait.Of(content) : null;
+    }
+
+    /// <summary>Replaces the picture the signed-in person is drawn by.</summary>
+    /// <param name="portrait">The portrait, whose octets are stored as they were supplied.</param>
+    /// <param name="cancellationToken">Propagates caller cancellation.</param>
+    /// <returns><see langword="true" /> when the write landed, and <see langword="false" /> when this deployment holds no record for the caller.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="portrait" /> is <see langword="null" />.</exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the caller acts for no owner, or its grant omits <see cref="MailFathomPermission.MailRead" />.</exception>
+    public Task<bool> ReplaceAsync(OwnerPortrait portrait, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(portrait);
+
+        this.authorization.RequirePermission(MailFathomPermission.MailRead);
+
+        return this.store.SaveAsync(this.authorization.RequireOwner(), portrait, cancellationToken);
+    }
+
+    /// <summary>Removes the picture the signed-in person is drawn by.</summary>
+    /// <param name="cancellationToken">Propagates caller cancellation.</param>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the caller acts for no owner, or its grant omits <see cref="MailFathomPermission.MailRead" />.</exception>
+    /// <remarks>Nothing else about the person is touched, and the removal is silent about whether there was one to remove.</remarks>
+    public Task RemoveAsync(CancellationToken cancellationToken)
+    {
+        this.authorization.RequirePermission(MailFathomPermission.MailRead);
+
+        return this.store.RemoveAsync(this.authorization.RequireOwner(), cancellationToken);
+    }
+}

--- a/backend/src/Application/Portraits/OwnerPortrait.cs
+++ b/backend/src/Application/Portraits/OwnerPortrait.cs
@@ -1,0 +1,40 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Portraits;
+
+/// <summary>The picture one person is drawn by, as the octets they supplied and the kind those octets are.</summary>
+/// <remarks>
+/// <para>
+/// It is composed through <see cref="Of" /> and by nothing else, because what makes octets a portrait is that they
+/// open as an image this deployment stores — the one invariant here, and the one a constructor taking both halves
+/// would let a caller state rather than prove. The kind is therefore never carried beside the octets: it is read from
+/// them, so a stored portrait and its media type cannot disagree.
+/// </para>
+/// <para>
+/// Nothing here resizes, crops, re-encodes, or strips metadata from what was supplied. A portrait is served back as
+/// the person uploaded it, which is what makes the bound and the kind check the whole of what stands between an
+/// upload and the database.
+/// </para>
+/// </remarks>
+public sealed class OwnerPortrait
+{
+    private OwnerPortrait(PortraitImageType type, ReadOnlyMemory<byte> content)
+    {
+        this.Type = type;
+        this.Content = content;
+    }
+
+    /// <summary>Gets what kind of image the portrait is, which is the media type it is served under.</summary>
+    public PortraitImageType Type { get; }
+
+    /// <summary>Gets the octets the person supplied, unchanged.</summary>
+    public ReadOnlyMemory<byte> Content { get; }
+
+    /// <summary>Reads octets as a portrait, where they are one.</summary>
+    /// <param name="content">The octets as they were supplied.</param>
+    /// <returns>The portrait, or <see langword="null" /> where the octets are not an image kind this build stores.</returns>
+    public static OwnerPortrait? Of(ReadOnlyMemory<byte> content) =>
+        PortraitImageType.TryDetect(content.Span, out var type) ? new OwnerPortrait(type, content) : null;
+}

--- a/backend/src/Application/Portraits/PortraitImageType.cs
+++ b/backend/src/Application/Portraits/PortraitImageType.cs
@@ -1,0 +1,76 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Portraits;
+
+/// <summary>What kind of image a portrait is: one of the two this deployment stores, judged from the octets themselves.</summary>
+/// <remarks>
+/// <para>
+/// A closed enumeration rather than a C# <see langword="enum" /> because what a member carries is the media type a
+/// response is served under, and an ordinal would mean nothing to the client reading the header. The set is two
+/// because two is what a portrait may be: a format nothing here publishes is refused at the boundary rather than
+/// stored for a screen that could not draw it.
+/// </para>
+/// <para>
+/// <b>The kind is read from the octets and never from what the request claimed.</b> A declared content type is a
+/// string an uploader wrote, so trusting it would let anything at all be stored under an image's name and served back
+/// to a browser as one. What is matched is the signature each format opens with, which is the first thing a decoder
+/// reads too.
+/// </para>
+/// <para>
+/// Being a struct, <see langword="default" /> is reachable and is not a kind. It reports itself through
+/// <see cref="IsSpecified" /> and refuses to answer for a media type, so nothing undeclared reaches a response header.
+/// </para>
+/// </remarks>
+public readonly record struct PortraitImageType
+{
+    private readonly string? mediaType;
+
+    private PortraitImageType(string mediaType) => this.mediaType = mediaType;
+
+    /// <summary>Gets the JPEG portrait kind.</summary>
+    public static PortraitImageType Jpeg { get; } = new("image/jpeg");
+
+    /// <summary>Gets the PNG portrait kind.</summary>
+    public static PortraitImageType Png { get; } = new("image/png");
+
+    /// <summary>Gets every kind this build stores.</summary>
+    /// <remarks>Declared last so the members it lists are already initialized when this initializer runs.</remarks>
+    public static IReadOnlyList<PortraitImageType> All { get; } = [Jpeg, Png];
+
+    /// <summary>Gets whether this value names a published kind rather than the unusable struct default.</summary>
+    public bool IsSpecified => this.mediaType is not null;
+
+    /// <summary>Gets the media type a portrait of this kind is served under.</summary>
+    /// <exception cref="InvalidOperationException">Thrown when the value is the struct default rather than a kind.</exception>
+    public string MediaType => this.mediaType
+        ?? throw new InvalidOperationException("The value is the default of the struct and does not name a portrait kind.");
+
+    /// <summary>Reads what kind of image the octets are, from the signature the format opens with.</summary>
+    /// <param name="content">The octets as they were supplied.</param>
+    /// <param name="type">The kind the octets are, or the struct default when they are neither.</param>
+    /// <returns><see langword="true" /> when the octets open as a kind this build stores.</returns>
+    /// <remarks>
+    /// The signature is the whole of the check, deliberately: nothing here decodes an image, so a file that opens as a
+    /// JPEG and is damaged after its first octets is stored and served as the person supplied it. What the check is
+    /// for is that a portrait is an image at all rather than a script or an archive wearing an image's content type.
+    /// </remarks>
+    public static bool TryDetect(ReadOnlySpan<byte> content, out PortraitImageType type)
+    {
+        type = content.StartsWith(JpegSignature) ? Jpeg
+            : content.StartsWith(PngSignature) ? Png
+            : default;
+
+        return type.IsSpecified;
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => this.mediaType ?? "(unspecified)";
+
+    /// <summary>Gets the three octets every JPEG opens with: the start-of-image marker and the first marker after it.</summary>
+    private static ReadOnlySpan<byte> JpegSignature => [0xFF, 0xD8, 0xFF];
+
+    /// <summary>Gets the eight octets the PNG specification fixes as a file's first line.</summary>
+    private static ReadOnlySpan<byte> PngSignature => [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+}

--- a/backend/src/Host/Api/ClientApiEndpoints.cs
+++ b/backend/src/Host/Api/ClientApiEndpoints.cs
@@ -47,8 +47,7 @@ namespace MailFathom.Host.Api;
 /// <para>
 /// The portrait routes, which <see cref="ClientPortraitEndpoint" /> describes, hold the picture a person is drawn by.
 /// They sit beside the preferences rather than in them, because a megabyte of image octets is not a small closed
-/// document and reading a switch should not carry a photograph — and they are the one family here that answers with
-/// something other than JSON.
+/// document and reading a switch should not carry a photograph.
 /// </para>
 /// <para>
 /// The telemetry routes, which <see cref="ClientTelemetryEndpoint" /> describes, are the one family here that is not

--- a/backend/src/Host/Api/ClientApiEndpoints.cs
+++ b/backend/src/Host/Api/ClientApiEndpoints.cs
@@ -45,6 +45,12 @@ namespace MailFathom.Host.Api;
 /// an administrator maintains writes there while writing nothing to the record.
 /// </para>
 /// <para>
+/// The portrait routes, which <see cref="ClientPortraitEndpoint" /> describes, hold the picture a person is drawn by.
+/// They sit beside the preferences rather than in them, because a megabyte of image octets is not a small closed
+/// document and reading a switch should not carry a photograph — and they are the one family here that answers with
+/// something other than JSON.
+/// </para>
+/// <para>
 /// The telemetry routes, which <see cref="ClientTelemetryEndpoint" /> describes, are the one family here that is not
 /// about mail: they take the client's own OTLP export and forward it to the collector this deployment already exports
 /// to, because the collector's address and its credential belong to the deployment and a browser bundle holding either
@@ -87,6 +93,7 @@ internal static class ClientApiEndpoints
         api.MapClientOwnerRecord();
         api.MapClientDisplayName();
         api.MapClientPreferences();
+        api.MapClientPortrait();
         api.MapClientMailAccounts();
         api.MapClientMailFolders();
         api.MapClientMailTimeline();

--- a/backend/src/Host/Api/ClientPortraitEndpoint.cs
+++ b/backend/src/Host/Api/ClientPortraitEndpoint.cs
@@ -47,6 +47,12 @@ namespace MailFathom.Host.Api;
 /// revalidation: a portrait is personal data, and a replaced one has to reach the next screen rather than the next
 /// expiry.
 /// </para>
+/// <para>
+/// It is served with <c>X-Content-Type-Options: nosniff</c>, for the reason
+/// <see cref="AttachmentContentResponse" /> sets it on a message's files: the kind was proven from a signature rather
+/// than by decoding the file, so a picture whose signature is a portrait's and whose remaining octets are markup would
+/// otherwise be a page a browser might render on the address the operator publishes MailFathom at.
+/// </para>
 /// </remarks>
 internal static class ClientPortraitEndpoint
 {
@@ -107,6 +113,11 @@ internal static class ClientPortraitEndpoint
         // Private and revalidated rather than freely cacheable: a portrait is personal data, and the entity tag is what
         // turns the second screen drawing it into a 304 instead of the picture again.
         context.Response.GetTypedHeaders().CacheControl = new CacheControlHeaderValue { Private = true, NoCache = true };
+
+        // The kind was proven from a signature rather than by decoding the file, so what follows those few octets is
+        // whatever the person uploaded: the browser is told to serve it as the type stated and never to sniff its way
+        // to another one.
+        context.Response.Headers.XContentTypeOptions = "nosniff";
 
         return TypedResults.File(
             portrait.Content.ToArray(),

--- a/backend/src/Host/Api/ClientPortraitEndpoint.cs
+++ b/backend/src/Host/Api/ClientPortraitEndpoint.cs
@@ -1,0 +1,192 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Security.Cryptography;
+using MailFathom.Application.Portraits;
+using MailFathom.Domain.Access;
+using MailFathom.Host.Security.Endpoints;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Net.Http.Headers;
+
+namespace MailFathom.Host.Api;
+
+/// <summary>Serves the signed-in person the picture they are drawn by, and takes it back replaced or removed.</summary>
+/// <remarks>
+/// <para>
+/// Three routes over one picture. It is stored on the owner axis beside the preferences document rather than inside
+/// one, because a megabyte of image octets is neither configuration nor a small closed document, and reading a switch
+/// should not carry a photograph.
+/// </para>
+/// <para>
+/// <b>No route here names an owner.</b> The person is the one the credential authenticated, resolved from the request
+/// exactly as the record routes resolve it, so a request reaching somebody else's portrait cannot be composed: there
+/// is no argument to put another owner's identifier in and no listing to discover one from.
+/// </para>
+/// <para>
+/// All three are <see cref="MailFathomPermission.MailRead" />, and none adds a name to the published permission set.
+/// The two writes are deliberately not <see cref="MailFathomPermission.MailAccountsWrite" />, for the reason the
+/// preferences write is not: that grant decides which mailboxes this deployment connects to, and what a person is
+/// drawn by must not be decided by a grant over their mail configuration.
+/// </para>
+/// <para>
+/// <b>An upload is bounded and then judged by its octets.</b> The bound is applied by the routing pipeline before a
+/// handler is entered, and the kind is read from the signature the format opens with rather than from the content type
+/// the request declared — a declared type is a string an uploader wrote, so trusting it would let anything at all be
+/// stored under an image's name and served back to a browser as one. Both refusals name what they refused against.
+/// </para>
+/// <para>
+/// <b>An absent portrait is answered plainly rather than refused.</b> A client draws the initials it already has from
+/// the person's name, so having no picture is an ordinary state of the screen; <c>204</c> says exactly that, and keeps
+/// it apart from a <c>404</c>, which on this surface says a route or a record is not there.
+/// </para>
+/// <para>
+/// The served response carries an entity tag over the octets and asks the client to revalidate, so a screen that draws
+/// the portrait a second time is answered <c>304</c> rather than the picture again. It is not cached without
+/// revalidation: a portrait is personal data, and a replaced one has to reach the next screen rather than the next
+/// expiry.
+/// </para>
+/// </remarks>
+internal static class ClientPortraitEndpoint
+{
+    /// <summary>The route the acting person's portrait is read, replaced, and removed at, relative to the client prefix.</summary>
+    internal const string PortraitRoute = "/portrait";
+
+    /// <summary>The greatest upload the replacement route reads before refusing it.</summary>
+    /// <remarks>One megabyte, which is what the client's own upload screen offers and far more than a portrait drawn at any size a screen has. What it guards is that a profile field is not a way to put arbitrary octets into an operator's database.</remarks>
+    internal const int MaxPortraitBytes = 1024 * 1024;
+
+    /// <summary>Maps the portrait routes into the client group, so they inherit its requirement, its policy, and its limits.</summary>
+    /// <param name="api">The client route group.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="api" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The read is described as octets rather than left to the framework, which would record a <c>200</c> carrying
+    /// JSON for a route that answers with an image. What the document names is the two kinds this deployment stores,
+    /// which here is the whole set rather than a fallback, because the kind was proven before the row existed.
+    /// </remarks>
+    internal static void MapClientPortrait(this RouteGroupBuilder api)
+    {
+        ArgumentNullException.ThrowIfNull(api);
+
+        api.MapGet(PortraitRoute, ReadAsync)
+            .RequirePermission(MailFathomPermission.MailRead)
+            .Produces<Stream>(StatusCodes.Status200OK, PortraitImageType.Jpeg.MediaType, PortraitImageType.Png.MediaType);
+
+        // The attribute is reached for its metadata rather than as an MVC filter, exactly as every other write on this
+        // surface reaches it: it implements IRequestSizeLimitMetadata, which the routing pipeline applies to the
+        // request body feature, so a body over the bound is refused before the octets are buffered.
+        api.MapPost(PortraitRoute, ReplaceAsync)
+            .WithMetadata(new RequestSizeLimitAttribute(MaxPortraitBytes))
+            .Accepts<Stream>(PortraitImageType.Jpeg.MediaType, PortraitImageType.Png.MediaType)
+            .RequirePermission(MailFathomPermission.MailRead);
+
+        api.MapDelete(PortraitRoute, RemoveAsync)
+            .RequirePermission(MailFathomPermission.MailRead);
+    }
+
+    /// <summary>Hands the acting person the picture they are drawn by.</summary>
+    /// <param name="portraits">The acting person's own portrait.</param>
+    /// <param name="context">The request being answered, whose response carries the caching the client revalidates against.</param>
+    /// <param name="cancellationToken">Cancels the read when the client disconnects.</param>
+    /// <returns><c>200</c> with the octets under the kind they are, or <c>204</c> where this deployment holds no portrait for the caller.</returns>
+    /// <remarks>Octets the store holds that are no kind this build publishes are answered as an absent portrait, because a row nothing here could have written is a row this surface has nothing to say about.</remarks>
+    internal static async Task<Results<FileContentHttpResult, NoContent>> ReadAsync(
+        [FromServices] OwnPortrait portraits,
+        HttpContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(portraits);
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (await portraits.ReadAsync(cancellationToken) is not { } portrait)
+        {
+            return TypedResults.NoContent();
+        }
+
+        // Private and revalidated rather than freely cacheable: a portrait is personal data, and the entity tag is what
+        // turns the second screen drawing it into a 304 instead of the picture again.
+        context.Response.GetTypedHeaders().CacheControl = new CacheControlHeaderValue { Private = true, NoCache = true };
+
+        return TypedResults.File(
+            portrait.Content.ToArray(),
+            portrait.Type.MediaType,
+            entityTag: EntityTagOf(portrait));
+    }
+
+    /// <summary>Replaces the picture the acting person is drawn by with the octets the request carries.</summary>
+    /// <param name="portraits">The acting person's own portrait.</param>
+    /// <param name="context">The request being answered, whose body carries the picture.</param>
+    /// <param name="cancellationToken">Cancels the read and the commit.</param>
+    /// <returns><c>204</c> when it was stored, <c>404</c> when this deployment holds no record for the caller, <c>413</c> for an upload over the bound, <c>415</c> for octets that are neither kind, or <c>400</c> for a request carrying no picture at all.</returns>
+    internal static async Task<Results<NoContent, NotFound<ProblemDetails>, ProblemHttpResult>> ReplaceAsync(
+        [FromServices] OwnPortrait portraits,
+        HttpContext context,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(portraits);
+        ArgumentNullException.ThrowIfNull(context);
+
+        using var buffer = new MemoryStream();
+
+        try
+        {
+            await context.Request.Body.CopyToAsync(buffer, cancellationToken);
+        }
+        catch (BadHttpRequestException refusal)
+            when (refusal.StatusCode == StatusCodes.Status413PayloadTooLarge)
+        {
+            // The pipeline's own refusal carries no body, and the one thing a person needs from it is the bound they
+            // went over, so it is restated here as a problem rather than left as a bare status.
+            return Refusal(
+                $"A portrait is at most {MaxPortraitBytes / 1024 / 1024} MB.",
+                StatusCodes.Status413PayloadTooLarge);
+        }
+
+        if (buffer.Length == 0)
+        {
+            return Refusal(
+                "An upload carries the picture. A request with no body replaces nothing.",
+                StatusCodes.Status400BadRequest);
+        }
+
+        if (OwnerPortrait.Of(buffer.ToArray()) is not { } portrait)
+        {
+            return Refusal(
+                $"A portrait is {string.Join(" or ", PortraitImageType.All.Select(kind => kind.MediaType))}, judged by what the file is rather than by what the request declared it to be.",
+                StatusCodes.Status415UnsupportedMediaType);
+        }
+
+        return await portraits.ReplaceAsync(portrait, cancellationToken)
+            ? TypedResults.NoContent()
+            : TypedResults.NotFound(new ProblemDetails
+            {
+                Status = StatusCodes.Status404NotFound,
+                Detail = "This deployment holds no record for you.",
+            });
+    }
+
+    /// <summary>Removes the picture the acting person is drawn by.</summary>
+    /// <param name="portraits">The acting person's own portrait.</param>
+    /// <param name="cancellationToken">Cancels the commit.</param>
+    /// <returns><c>204</c>, whether or not there was a portrait to remove.</returns>
+    /// <remarks>Everything else about the person is left as it was, and the answer does not separate having removed one from having had none: both leave the caller with no portrait, which is the whole of what they asked for.</remarks>
+    internal static async Task<NoContent> RemoveAsync(
+        [FromServices] OwnPortrait portraits,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(portraits);
+
+        await portraits.RemoveAsync(cancellationToken);
+
+        return TypedResults.NoContent();
+    }
+
+    /// <summary>Names the served octets, so a client that already holds them is answered that they have not changed.</summary>
+    /// <remarks>A digest of the picture rather than the instant it was written: it is stable across a restore, and two writes of the same picture leave a client's copy valid.</remarks>
+    private static EntityTagHeaderValue EntityTagOf(OwnerPortrait portrait) =>
+        new($"\"{Convert.ToHexString(SHA256.HashData(portrait.Content.Span))}\"");
+
+    private static ProblemHttpResult Refusal(string detail, int statusCode) =>
+        TypedResults.Problem(detail, statusCode: statusCode);
+}

--- a/backend/src/Infrastructure/Persistence/Entities/OwnerPortraitEntity.cs
+++ b/backend/src/Infrastructure/Persistence/Entities/OwnerPortraitEntity.cs
@@ -1,0 +1,43 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using MailFathom.CodeCoverage;
+
+namespace MailFathom.Infrastructure.Persistence.Entities;
+
+/// <summary>The picture one person is drawn by: one row per owner, holding the octets they supplied.</summary>
+/// <remarks>
+/// <para>
+/// It hangs off the owner row, which is what makes erasing an owner take their portrait with everything else derived
+/// from them, without an erasure naming this table. It sits beside the preferences document rather than inside one,
+/// because a megabyte of image octets is not a small closed JSON document and a read of a switch should not carry one.
+/// </para>
+/// <para>
+/// What it does not hold is what kind of image the octets are. That is read from the octets themselves wherever it is
+/// needed, so a stored media type cannot come to disagree with what is stored under it — and the write already proved
+/// the kind before the row existed.
+/// </para>
+/// <para>
+/// The row carries no version, and that is the contract rather than an omission: a write is last-write-wins, because
+/// the only writers are one person's own devices.
+/// </para>
+/// </remarks>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "EF Core materializes this entity through the DbSet and model metadata.")]
+[RequiresIntegrationCoverage]
+internal sealed class OwnerPortraitEntity
+{
+    /// <summary>The owner whose portrait this is, which is the key and the foreign key at once.</summary>
+    public Guid OwnerId { get; set; }
+
+    /// <summary>The octets the person supplied, unchanged.</summary>
+    /// <remarks>Bounded before it reaches here by the transport, which refuses a body over the portrait's limit before a handler is entered.</remarks>
+    public required byte[] Content { get; set; }
+
+    /// <summary>When the person first supplied a portrait.</summary>
+    public DateTimeOffset CreatedAt { get; set; }
+
+    /// <summary>When they last replaced it, which is the first instant until they do.</summary>
+    public DateTimeOffset UpdatedAt { get; set; }
+}

--- a/backend/src/Infrastructure/Persistence/MailFathomDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/MailFathomDbContext.cs
@@ -15,6 +15,7 @@ using MailFathom.Infrastructure.Persistence.Entities;
 using MailFathom.Infrastructure.Persistence.Jobs.Configurations;
 using MailFathom.Infrastructure.Persistence.Mutations.Configurations;
 using MailFathom.Infrastructure.Persistence.Owners.Configurations;
+using MailFathom.Infrastructure.Persistence.Portraits.Configurations;
 using MailFathom.Infrastructure.Persistence.Preferences.Configurations;
 using MailFathom.Infrastructure.Persistence.Rules.Configurations;
 using MailFathom.Infrastructure.Persistence.Secrets.Configurations;
@@ -65,6 +66,8 @@ internal sealed class MailFathomDbContext : DbContext
         this.Set<OwnerCredentialEntity>();
 
     internal DbSet<ClientPreferencesEntity> ClientPreferences => this.Set<ClientPreferencesEntity>();
+
+    internal DbSet<OwnerPortraitEntity> OwnerPortraits => this.Set<OwnerPortraitEntity>();
 
     internal DbSet<StoredSecretEntity> StoredSecrets => this.Set<StoredSecretEntity>();
 
@@ -184,6 +187,7 @@ internal sealed class MailFathomDbContext : DbContext
         modelBuilder.ApplyConfiguration(new StoredSecretConfiguration());
         modelBuilder.ApplyConfiguration(new OwnerCredentialConfiguration());
         modelBuilder.ApplyConfiguration(new ClientPreferencesConfiguration());
+        modelBuilder.ApplyConfiguration(new OwnerPortraitConfiguration());
         modelBuilder.ApplyConfiguration(new OwnerStoredContentConfiguration());
         modelBuilder.ApplyConfiguration(new MailboxAccountConfiguration());
         modelBuilder.ApplyConfiguration(new MailFolderConfiguration());

--- a/backend/src/Infrastructure/Persistence/Migrations/20260902224524_AddOwnerPortrait.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260902224524_AddOwnerPortrait.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MailFathom.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace MailFathom.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(MailFathomDbContext))]
-    partial class MailFathomDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260902224524_AddOwnerPortrait")]
+    partial class AddOwnerPortrait
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Infrastructure/Persistence/Migrations/20260902224524_AddOwnerPortrait.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260902224524_AddOwnerPortrait.cs
@@ -1,0 +1,46 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MailFathom.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOwnerPortrait : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "owner_portraits",
+                columns: table => new
+                {
+                    OwnerId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Content = table.Column<byte[]>(type: "bytea", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_owner_portraits", x => x.OwnerId);
+                    table.ForeignKey(
+                        name: "FK_owner_portraits_settings_accounts_OwnerId",
+                        column: x => x.OwnerId,
+                        principalTable: "settings_accounts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "owner_portraits");
+        }
+    }
+}

--- a/backend/src/Infrastructure/Persistence/Portraits/Configurations/OwnerPortraitConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Portraits/Configurations/OwnerPortraitConfiguration.cs
@@ -1,0 +1,35 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Infrastructure.Persistence.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace MailFathom.Infrastructure.Persistence.Portraits.Configurations;
+
+/// <summary>Declares the row holding the picture one person is drawn by.</summary>
+/// <remarks>
+/// The owner is the primary key rather than a column beside a generated one, because one person has one portrait and
+/// nothing else identifies it: that is what makes a write an upsert on a key the caller already holds, and what makes
+/// the foreign key onto the owner row and the key the same column.
+/// </remarks>
+internal sealed class OwnerPortraitConfiguration : IEntityTypeConfiguration<OwnerPortraitEntity>
+{
+    /// <inheritdoc />
+    public void Configure(EntityTypeBuilder<OwnerPortraitEntity> entity)
+    {
+        entity.ToTable("owner_portraits");
+        entity.HasKey(portrait => portrait.OwnerId);
+        entity.Property(portrait => portrait.OwnerId).ValueGeneratedNever();
+
+        entity.Property(portrait => portrait.Content).HasColumnType("bytea").IsRequired();
+
+        // Cascade rather than a statement in the erasure walk: a person's picture is derived from them, so it goes
+        // when they do without an erasure having to know this table exists.
+        entity.HasOne<OwnerAccountEntity>()
+            .WithMany()
+            .HasForeignKey(portrait => portrait.OwnerId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/backend/src/Infrastructure/Persistence/Portraits/OwnerPortraitStore.cs
+++ b/backend/src/Infrastructure/Persistence/Portraits/OwnerPortraitStore.cs
@@ -1,0 +1,97 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Portraits;
+using MailFathom.CodeCoverage;
+using MailFathom.Domain.Access;
+using Microsoft.EntityFrameworkCore;
+
+namespace MailFathom.Infrastructure.Persistence.Portraits;
+
+/// <summary>Keeps the picture one person is drawn by in PostgreSQL, one owner's row at a time.</summary>
+/// <remarks>
+/// <para>
+/// The read is a primary-key lookup that projects the octets alone, the write is one statement, and the removal is
+/// one more. All three name the owner as a parameter and none can be aimed at another row, so an identifier learned
+/// elsewhere reaches nobody else's portrait.
+/// </para>
+/// <para>
+/// The write is an upsert rather than a read followed by an insert or an update, for the reason a person's
+/// preferences are written that way: two of one person's devices saving at once is exactly the shape that reads
+/// nothing twice and then violates the key. One statement settles it in the database, which is what makes
+/// last-write-wins true rather than merely intended.
+/// </para>
+/// <para>
+/// It inserts from the owner row rather than blindly, so an owner this deployment no longer holds affects no row and
+/// is reported as such rather than raising a foreign-key violation inside a request.
+/// </para>
+/// <para>
+/// The read carries no octet ceiling because the transport already refuses a body over the portrait's limit before a
+/// handler is entered, and this store is the only writer. A row larger than that bound is a row something other than
+/// this wrote.
+/// </para>
+/// <para>
+/// Nothing logs. What the row holds is a picture of one identified person, and the identifier is what a failure
+/// carries.
+/// </para>
+/// </remarks>
+[RequiresIntegrationCoverage]
+internal sealed class OwnerPortraitStore(MailFathomDbContext context, TimeProvider clock) : IOwnerPortraitStore
+{
+    /// <inheritdoc />
+    public async Task<ReadOnlyMemory<byte>?> ReadAsync(MailOwnerId owner, CancellationToken cancellationToken)
+    {
+        RequireNamed(owner);
+
+        var ownerValue = owner.Value;
+
+        // The provider's own contract is an array, and this is the adapter that turns it into the memory the
+        // application boundary is written in.
+        var stored = await context.OwnerPortraits
+            .AsNoTracking()
+            .Where(portrait => portrait.OwnerId == ownerValue)
+            .Select(portrait => portrait.Content)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return stored is null ? null : stored.AsMemory();
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> SaveAsync(MailOwnerId owner, OwnerPortrait portrait, CancellationToken cancellationToken)
+    {
+        RequireNamed(owner);
+        ArgumentNullException.ThrowIfNull(portrait);
+
+        var written = clock.GetUtcNow();
+
+        var rows = await context.Database.ExecuteSqlRawAsync(
+            OwnerPortraitUpsertStatement.Compose(context.Model),
+            [owner.Value, portrait.Content.ToArray(), written],
+            cancellationToken);
+
+        return rows > 0;
+    }
+
+    /// <inheritdoc />
+    public async Task RemoveAsync(MailOwnerId owner, CancellationToken cancellationToken)
+    {
+        RequireNamed(owner);
+
+        var ownerValue = owner.Value;
+
+        await context.OwnerPortraits
+            .Where(portrait => portrait.OwnerId == ownerValue)
+            .ExecuteDeleteAsync(cancellationToken);
+    }
+
+    private static void RequireNamed(MailOwnerId owner)
+    {
+        if (!owner.IsSpecified)
+        {
+            throw new ArgumentException(
+                "A portrait is read, written, and removed for a named owner, and the value names nobody.",
+                nameof(owner));
+        }
+    }
+}

--- a/backend/src/Infrastructure/Persistence/Portraits/OwnerPortraitUpsertStatement.cs
+++ b/backend/src/Infrastructure/Persistence/Portraits/OwnerPortraitUpsertStatement.cs
@@ -1,0 +1,54 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Infrastructure.Persistence.Entities;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace MailFathom.Infrastructure.Persistence.Portraits;
+
+/// <summary>Composes the one statement a person's portrait is written by.</summary>
+/// <remarks>
+/// <para>
+/// It is composed here rather than inside the store so that what it says is readable without a database, which is the
+/// only place the guarantees below are visible at all: the conflict target is what makes a second device's write
+/// replace the first rather than violate the key, and selecting from the owner table is what makes an owner this
+/// deployment no longer holds affect no row instead of raising a foreign-key violation.
+/// </para>
+/// <para>
+/// Every identifier comes from the model, so a renamed column stops the build rather than producing a statement
+/// PostgreSQL refuses inside a request. Everything else in it is a parameter, so there is nothing here for octets a
+/// caller supplied to reach.
+/// </para>
+/// </remarks>
+internal static class OwnerPortraitUpsertStatement
+{
+    /// <summary>Composes the statement, with the owner, the octets, and the instant as its three parameters in that order.</summary>
+    /// <param name="model">The model the schema is generated from.</param>
+    /// <returns>The statement, carrying <c>{0}</c> for the owner, <c>{1}</c> for the octets, and <c>{2}</c> for the instant.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="model" /> is <see langword="null" />.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the model does not map the portrait row or the owner row.</exception>
+    public static string Compose(IModel model)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+
+        var portraits = PersistedSchemaNames.EntityTypeOf<OwnerPortraitEntity>(model);
+        var owners = PersistedSchemaNames.EntityTypeOf<OwnerAccountEntity>(model);
+
+        var ownerColumn = PersistedSchemaNames.QuotedColumn(portraits, nameof(OwnerPortraitEntity.OwnerId));
+        var contentColumn = PersistedSchemaNames.QuotedColumn(portraits, nameof(OwnerPortraitEntity.Content));
+        var createdColumn = PersistedSchemaNames.QuotedColumn(portraits, nameof(OwnerPortraitEntity.CreatedAt));
+        var updatedColumn = PersistedSchemaNames.QuotedColumn(portraits, nameof(OwnerPortraitEntity.UpdatedAt));
+
+        return $$"""
+            INSERT INTO {{PersistedSchemaNames.QuotedTable(portraits)}}
+                ({{ownerColumn}}, {{contentColumn}}, {{createdColumn}}, {{updatedColumn}})
+            SELECT {0}, {1}, {2}, {2}
+            FROM {{PersistedSchemaNames.QuotedTable(owners)}}
+            WHERE {{PersistedSchemaNames.QuotedColumn(owners, nameof(OwnerAccountEntity.Id))}} = {0}
+            ON CONFLICT ({{ownerColumn}}) DO UPDATE SET
+                {{contentColumn}} = EXCLUDED.{{contentColumn}},
+                {{updatedColumn}} = EXCLUDED.{{updatedColumn}}
+            """;
+    }
+}

--- a/backend/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -60,6 +60,7 @@ using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Mail.Mutations.Destinations;
 using MailFathom.Application.Observability;
 using MailFathom.Application.Persistence;
+using MailFathom.Application.Portraits;
 using MailFathom.Application.Preferences;
 using MailFathom.Application.Resilience;
 using MailFathom.Application.Retrieval;
@@ -112,6 +113,7 @@ using MailFathom.Infrastructure.Persistence.Embeddings;
 using MailFathom.Infrastructure.Persistence.Jobs;
 using MailFathom.Infrastructure.Persistence.Mutations;
 using MailFathom.Infrastructure.Persistence.Owners;
+using MailFathom.Infrastructure.Persistence.Portraits;
 using MailFathom.Infrastructure.Persistence.Preferences;
 using MailFathom.Infrastructure.Persistence.Rules;
 using MailFathom.Infrastructure.Persistence.Secrets;
@@ -511,6 +513,11 @@ public static class ServiceCollectionExtensions
         // The caller-facing use case over it, separate from the store for the reason the contact book's two are: it
         // carries the grant a caller has to hold and the owner the act is resolved for, and the store carries neither.
         services.AddScoped<OwnClientPreferences>();
+        // The picture a person is drawn by, which hangs off the owner row beside that document rather than inside it:
+        // a megabyte of octets is not a small closed document, and a read of a switch should not carry one. Scoped and
+        // registered unconditionally for the same reasons the preferences store is.
+        services.AddScoped<IOwnerPortraitStore, OwnerPortraitStore>();
+        services.AddScoped<OwnPortrait>();
         // Taking an owner off the deployment, with everything it recorded for them. Scoped because the whole walk runs
         // in one of the request's own transactions, and separate from the provisioning above because provisioning runs
         // on every start and is idempotent while this runs when a person asked for it and cannot be undone.

--- a/backend/tests/Application.UnitTests/Portraits/OwnPortraitTests.cs
+++ b/backend/tests/Application.UnitTests/Portraits/OwnPortraitTests.cs
@@ -1,0 +1,203 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Application.Portraits;
+using MailFathom.Domain.Access;
+using MailFathom.TestSupport;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Portraits;
+
+/// <summary>
+/// Covers the use case a person reads, replaces, and removes their own portrait through. What it has to hold is that
+/// the owner acted on is the one the credential authenticated rather than one a caller could name, that the grant
+/// required is the one a signed-in person already holds rather than the grant over their mail configuration, and that
+/// having no picture is answered as such rather than as a failure.
+/// </summary>
+public sealed class OwnPortraitTests
+{
+    private static readonly byte[] Png =
+        [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x0D, 0x0A];
+
+    [Fact]
+    public async Task ReadAsync_APersonWhoSuppliedAPicture_AnswersItUnderTheKindItIs()
+    {
+        // Arrange
+        var portraits = ReachedBy(StoreHolding(Png), MailFathomPermission.MailRead);
+
+        // Act
+        var read = await portraits.ReadAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("image/png", read!.Type.MediaType);
+        Assert.Equal(Png, read.Content.ToArray());
+    }
+
+    /// <summary>A client draws the initials it already has, so an absent picture is a state of the screen rather than an error on it.</summary>
+    [Fact]
+    public async Task ReadAsync_APersonWhoSuppliedNone_AnswersNothing()
+    {
+        // Arrange
+        var store = Substitute.For<IOwnerPortraitStore>();
+        store.ReadAsync(Arg.Any<MailOwnerId>(), Arg.Any<CancellationToken>())
+            .Returns((ReadOnlyMemory<byte>?)null);
+
+        var portraits = ReachedBy(store, MailFathomPermission.MailRead);
+
+        // Assert
+        Assert.Null(await portraits.ReadAsync(TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>A row nothing here could have written is a row this use case has nothing to say about, so it answers as an absent picture rather than serving octets of an unknown kind.</summary>
+    [Fact]
+    public async Task ReadAsync_StoredOctetsOfNoKindThisBuildPublishes_AnswerAsNoPictureAtAll()
+    {
+        // Arrange
+        var portraits = ReachedBy(StoreHolding("GIF89a"u8.ToArray()), MailFathomPermission.MailRead);
+
+        // Assert
+        Assert.Null(await portraits.ReadAsync(TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>The owner is resolved from the principal, so a deployment serving two people reads the caller's own row and never the other.</summary>
+    [Fact]
+    public async Task ReadAsync_ADeploymentServingSeveralPeople_ReadsTheRowOfTheOwnerTheCredentialAuthenticated()
+    {
+        // Arrange
+        var store = Substitute.For<IOwnerPortraitStore>();
+        var portraits = ReachedBy(store, SyntheticMailOwner.Another, MailFathomPermission.MailRead);
+
+        // Act
+        await portraits.ReadAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        await store.Received(1).ReadAsync(SyntheticMailOwner.Another, Arg.Any<CancellationToken>());
+        await store.DidNotReceive().ReadAsync(SyntheticMailOwner.Deployment, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReadAsync_ACallerGrantedNothing_IsRefused()
+    {
+        // Arrange
+        var portraits = ReachedBy(Substitute.For<IOwnerPortraitStore>());
+
+        // Assert
+        await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(
+            () => portraits.ReadAsync(TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>An administrator acts for nobody's mail, so there is no picture of theirs to read here.</summary>
+    [Fact]
+    public async Task ReadAsync_ACallerActingForNoOwner_IsRefused()
+    {
+        // Arrange
+        var portraits = new OwnPortrait(
+            AccessAuthorizations.ForAdministratorGranted(MailFathomPermission.MailRead),
+            Substitute.For<IOwnerPortraitStore>());
+
+        // Assert
+        await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(
+            () => portraits.ReadAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_APersonSupplyingAPicture_WritesItForTheOwnerTheCredentialAuthenticated()
+    {
+        // Arrange
+        var store = Substitute.For<IOwnerPortraitStore>();
+        store.SaveAsync(Arg.Any<MailOwnerId>(), Arg.Any<OwnerPortrait>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        var portraits = ReachedBy(store, MailFathomPermission.MailRead);
+        var portrait = OwnerPortrait.Of(Png)!;
+
+        // Act
+        var written = await portraits.ReplaceAsync(portrait, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(written);
+        await store.Received(1)
+            .SaveAsync(SyntheticMailOwner.Deployment, portrait, Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>The write is the grant a signed-in person already holds, never the one that decides which mailboxes this deployment connects to.</summary>
+    [Fact]
+    public async Task ReplaceAsync_ACallerGrantedOnlyTheirMailConfiguration_IsRefused()
+    {
+        // Arrange
+        var store = Substitute.For<IOwnerPortraitStore>();
+        var portraits = ReachedBy(store, MailFathomPermission.MailAccountsWrite);
+
+        // Assert
+        await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(
+            () => portraits.ReplaceAsync(OwnerPortrait.Of(Png)!, TestContext.Current.CancellationToken));
+
+        await store.DidNotReceive()
+            .SaveAsync(Arg.Any<MailOwnerId>(), Arg.Any<OwnerPortrait>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_NoPictureAtAll_IsRefusedBeforeAnythingIsWritten()
+    {
+        // Arrange
+        var store = Substitute.For<IOwnerPortraitStore>();
+        var portraits = ReachedBy(store, MailFathomPermission.MailRead);
+
+        // Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => portraits.ReplaceAsync(null!, TestContext.Current.CancellationToken));
+
+        await store.DidNotReceive()
+            .SaveAsync(Arg.Any<MailOwnerId>(), Arg.Any<OwnerPortrait>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RemoveAsync_APersonTakingTheirPictureDown_RemovesTheirOwnAndNobodyElses()
+    {
+        // Arrange
+        var store = Substitute.For<IOwnerPortraitStore>();
+        var portraits = ReachedBy(store, SyntheticMailOwner.Another, MailFathomPermission.MailRead);
+
+        // Act
+        await portraits.RemoveAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        await store.Received(1).RemoveAsync(SyntheticMailOwner.Another, Arg.Any<CancellationToken>());
+        await store.DidNotReceive().RemoveAsync(SyntheticMailOwner.Deployment, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RemoveAsync_ACallerGrantedNothing_IsRefused()
+    {
+        // Arrange
+        var store = Substitute.For<IOwnerPortraitStore>();
+        var portraits = ReachedBy(store);
+
+        // Assert
+        await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(
+            () => portraits.RemoveAsync(TestContext.Current.CancellationToken));
+
+        await store.DidNotReceive().RemoveAsync(Arg.Any<MailOwnerId>(), Arg.Any<CancellationToken>());
+    }
+
+    private static IOwnerPortraitStore StoreHolding(byte[] content)
+    {
+        var store = Substitute.For<IOwnerPortraitStore>();
+        store.ReadAsync(Arg.Any<MailOwnerId>(), Arg.Any<CancellationToken>())
+            .Returns(new ReadOnlyMemory<byte>(content));
+
+        return store;
+    }
+
+    private static OwnPortrait ReachedBy(IOwnerPortraitStore store, params MailFathomPermission[] granted) =>
+        ReachedBy(store, SyntheticMailOwner.Deployment, granted);
+
+    private static OwnPortrait ReachedBy(
+        IOwnerPortraitStore store,
+        MailOwnerId owner,
+        params MailFathomPermission[] granted) =>
+        new(AccessAuthorizations.ForOwnerGranted(owner, granted), store);
+}

--- a/backend/tests/Application.UnitTests/Portraits/OwnPortraitTests.cs
+++ b/backend/tests/Application.UnitTests/Portraits/OwnPortraitTests.cs
@@ -123,6 +123,24 @@ public sealed class OwnPortraitTests
             .SaveAsync(SyntheticMailOwner.Deployment, portrait, Arg.Any<CancellationToken>());
     }
 
+    /// <summary>The row behind an authenticated caller can be gone, which is an owner erased under a credential that has not yet been withdrawn.</summary>
+    [Fact]
+    public async Task ReplaceAsync_ACallerWhoseRowHasGone_ReportsThatThereWasNobodyToWriteFor()
+    {
+        // Arrange
+        var store = Substitute.For<IOwnerPortraitStore>();
+        store.SaveAsync(Arg.Any<MailOwnerId>(), Arg.Any<OwnerPortrait>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var portraits = ReachedBy(store, MailFathomPermission.MailRead);
+
+        // Act
+        var written = await portraits.ReplaceAsync(OwnerPortrait.Of(Png)!, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(written);
+    }
+
     /// <summary>The write is the grant a signed-in person already holds, never the one that decides which mailboxes this deployment connects to.</summary>
     [Fact]
     public async Task ReplaceAsync_ACallerGrantedOnlyTheirMailConfiguration_IsRefused()

--- a/backend/tests/Application.UnitTests/Portraits/PortraitImageTypeTests.cs
+++ b/backend/tests/Application.UnitTests/Portraits/PortraitImageTypeTests.cs
@@ -1,0 +1,93 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Portraits;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Portraits;
+
+/// <summary>
+/// Covers what decides whether octets are a portrait at all. The whole of the check is the signature the format opens
+/// with, which is what makes an upload judged by what it is rather than by what its request claimed — so what has to
+/// hold here is that the two published kinds are recognized, that everything else is refused, and that nothing shorter
+/// than a signature is read past its end.
+/// </summary>
+public sealed class PortraitImageTypeTests
+{
+    [Fact]
+    public void TryDetect_OctetsOpeningAsAJpeg_ReadsThemAsOne()
+    {
+        // Act
+        var detected = PortraitImageType.TryDetect([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10], out var type);
+
+        // Assert
+        Assert.True(detected);
+        Assert.Equal("image/jpeg", type.MediaType);
+    }
+
+    [Fact]
+    public void TryDetect_OctetsOpeningAsAPng_ReadsThemAsOne()
+    {
+        // Act
+        var detected = PortraitImageType.TryDetect(
+            [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00],
+            out var type);
+
+        // Assert
+        Assert.True(detected);
+        Assert.Equal("image/png", type.MediaType);
+    }
+
+    /// <summary>A GIF is an image and is still refused, because what this publishes is two kinds rather than whatever a decoder would accept.</summary>
+    [Theory]
+    [InlineData((byte)'G', (byte)'I', (byte)'F', (byte)'8')]
+    [InlineData((byte)'%', (byte)'P', (byte)'D', (byte)'F')]
+    [InlineData((byte)'<', (byte)'s', (byte)'v', (byte)'g')]
+    [InlineData((byte)'P', (byte)'K', 0x03, 0x04)]
+    public void TryDetect_OctetsOfSomethingElse_AreNoPortraitKind(byte first, byte second, byte third, byte fourth)
+    {
+        // Act
+        var detected = PortraitImageType.TryDetect([first, second, third, fourth], out var type);
+
+        // Assert
+        Assert.False(detected);
+        Assert.False(type.IsSpecified);
+    }
+
+    /// <summary>An upload shorter than a signature is read to its end rather than past it, which is the case a fixed-length comparison would fault on.</summary>
+    [Fact]
+    public void TryDetect_FewerOctetsThanASignature_AreNoPortraitKindRatherThanARead()
+    {
+        // Act
+        var detected = PortraitImageType.TryDetect([0x89, 0x50], out _);
+
+        // Assert
+        Assert.False(detected);
+    }
+
+    [Fact]
+    public void TryDetect_NoOctetsAtAll_AreNoPortraitKind()
+    {
+        // Act
+        var detected = PortraitImageType.TryDetect([], out _);
+
+        // Assert
+        Assert.False(detected);
+    }
+
+    /// <summary>The struct default is reachable and is not a kind, so it answers for no media type rather than for an empty one.</summary>
+    [Fact]
+    public void MediaType_TheStructDefault_RefusesToNameOne()
+    {
+        // Assert
+        Assert.Throws<InvalidOperationException>(() => default(PortraitImageType).MediaType);
+    }
+
+    [Fact]
+    public void All_TheSetThisBuildStores_IsTheTwoImageKinds()
+    {
+        // Assert
+        Assert.Equal(["image/jpeg", "image/png"], PortraitImageType.All.Select(kind => kind.MediaType));
+    }
+}

--- a/backend/tests/Host.UnitTests/Api/ClientApiEndpointsTests.cs
+++ b/backend/tests/Host.UnitTests/Api/ClientApiEndpointsTests.cs
@@ -154,6 +154,9 @@ public sealed class ClientApiEndpointsTests
                 $"{ClientEndpointOptions.RoutePrefix}{ClientOutboxEndpoints.OutboxCancellationRoute}",
                 $"{ClientEndpointOptions.RoutePrefix}{ClientOutboxEndpoints.OutboxRequeueRoute}",
                 $"{ClientEndpointOptions.RoutePrefix}{ClientOutboxEndpoints.OutboxSendRoute}",
+                $"{ClientEndpointOptions.RoutePrefix}{ClientPortraitEndpoint.PortraitRoute}",
+                $"{ClientEndpointOptions.RoutePrefix}{ClientPortraitEndpoint.PortraitRoute}",
+                $"{ClientEndpointOptions.RoutePrefix}{ClientPortraitEndpoint.PortraitRoute}",
                 $"{ClientEndpointOptions.RoutePrefix}{ClientPreferencesEndpoint.PreferencesRoute}",
                 $"{ClientEndpointOptions.RoutePrefix}{ClientPreferencesEndpoint.PreferencesRoute}",
                 $"{ClientEndpointOptions.RoutePrefix}{ClientOwnerRecordEndpoint.RecordRoute}",
@@ -209,6 +212,7 @@ public sealed class ClientApiEndpointsTests
             [
                 $"DELETE {prefix}{ClientDraftEndpoints.DraftRoute} -> {MailFathomPermission.MailDraftsWrite.Name}",
                 $"DELETE {prefix}{ClientDraftEndpoints.DraftAttachmentRoute} -> {MailFathomPermission.MailDraftsWrite.Name}",
+                $"DELETE {prefix}{ClientPortraitEndpoint.PortraitRoute} -> {MailFathomPermission.MailRead.Name}",
                 $"GET {prefix}{ClientMailAccountsEndpoint.MailAccountsRoute} -> {MailFathomPermission.MailRead.Name}",
                 $"GET {prefix}{ClientDisplayNameEndpoint.DisplayNameRoute} -> {MailFathomPermission.MailRead.Name}",
                 $"GET {prefix}{ClientDraftEndpoints.DraftsRoute} -> {MailFathomPermission.MailDraftsWrite.Name}",
@@ -222,6 +226,7 @@ public sealed class ClientApiEndpointsTests
                 $"GET {prefix}{ClientMailMutationsEndpoint.MutationsRoute} -> {MailFathomPermission.MailRead.Name}",
                 $"GET {prefix}{ClientOutboxEndpoints.OutboxRoute} -> {MailFathomPermission.MailSend.Name}",
                 $"GET {prefix}{ClientOutboxEndpoints.OutboxSendRoute} -> {MailFathomPermission.MailSend.Name}",
+                $"GET {prefix}{ClientPortraitEndpoint.PortraitRoute} -> {MailFathomPermission.MailRead.Name}",
                 $"GET {prefix}{ClientPreferencesEndpoint.PreferencesRoute} -> {MailFathomPermission.MailRead.Name}",
                 $"GET {prefix}{ClientOwnerRecordEndpoint.RecordRoute} -> {MailFathomPermission.MailRead.Name}",
                 $"GET {prefix}{ClientApiEndpoints.SessionRoute} -> none",
@@ -236,6 +241,7 @@ public sealed class ClientApiEndpointsTests
                 $"POST {prefix}{ClientMailMutationsEndpoint.MoveWithdrawalsRoute} -> {MailFathomPermission.MailMove.Name}",
                 $"POST {prefix}{ClientOutboxEndpoints.OutboxCancellationRoute} -> {MailFathomPermission.MailSend.Name}",
                 $"POST {prefix}{ClientOutboxEndpoints.OutboxRequeueRoute} -> {MailFathomPermission.MailSend.Name}",
+                $"POST {prefix}{ClientPortraitEndpoint.PortraitRoute} -> {MailFathomPermission.MailRead.Name}",
                 $"POST {prefix}{ClientPreferencesEndpoint.PreferencesRoute} -> {MailFathomPermission.MailRead.Name}",
                 $"POST {prefix}{ClientOwnerRecordEndpoint.RecordRoute} -> {MailFathomPermission.MailAccountsWrite.Name}",
                 $"POST {prefix}{ClientOwnerRecordEndpoint.MailAccountsRoute} -> {MailFathomPermission.MailAccountsWrite.Name}",
@@ -272,8 +278,9 @@ public sealed class ClientApiEndpointsTests
     }
 
     /// <summary>
-    /// A read under the reading grant, and every write under a grant that says what it writes, save the two a grant
-    /// could not tell apart: the caller's own client preferences, and the client handing over its own telemetry.
+    /// A read under the reading grant, and every write under a grant that says what it writes, save the three a grant
+    /// could not tell apart: the caller's own client preferences, the caller's own portrait, and the client handing
+    /// over its own telemetry.
     /// Reading mail, changing the caller's own record, composing a draft, filing one on their server, sending,
     /// changing a flag, and moving a message are separately provisioned powers, so a route that changes anything under
     /// <c>mailfathom.mail.read</c> is one somebody added without deciding what it costs — and a credential provisioned
@@ -305,6 +312,7 @@ public sealed class ClientApiEndpointsTests
                         method == "GET"
                         || IsPublishedAsAWrite(endpoint)
                         || WritesTheCallersOwnPreferences(endpoint)
+                        || WritesTheCallersOwnPortrait(endpoint)
                         || HandsOverTheClientsOwnTelemetry(endpoint),
                         $"{method} {endpoint} changes something under a grant that does not say so."));
             });
@@ -333,6 +341,17 @@ public sealed class ClientApiEndpointsTests
         endpoint is RouteEndpoint route
         && $"/{route.RoutePattern.RawText?.TrimStart('/')}"
             == $"{ClientEndpointOptions.RoutePrefix}{ClientPreferencesEndpoint.PreferencesRoute}";
+
+    /// <summary>Reports whether a route is a write of the caller's own portrait, by the route it is served at.</summary>
+    /// <remarks>
+    /// The route rather than the grant, for the reason the preferences write is named that way: what a person is drawn
+    /// by is theirs to set under the grant they already hold, so nothing about the permission tells these two apart
+    /// from a <c>GET</c>. Naming the one route keeps the claim narrow.
+    /// </remarks>
+    private static bool WritesTheCallersOwnPortrait(Endpoint endpoint) =>
+        endpoint is RouteEndpoint route
+        && $"/{route.RoutePattern.RawText?.TrimStart('/')}"
+            == $"{ClientEndpointOptions.RoutePrefix}{ClientPortraitEndpoint.PortraitRoute}";
 
     /// <summary>Reports whether a route is the client posting its own telemetry, which changes nothing this deployment holds.</summary>
     /// <remarks>The path rather than the grant here, because these are published under none by design — the caller is handing over what it recorded about itself, and no permission in the mailbox half names that act.</remarks>
@@ -423,6 +442,32 @@ public sealed class ClientApiEndpointsTests
         Assert.Equal(
             ClientDisplayNameEndpoint.MaxWriteRequestBytes,
             write.Metadata.GetMetadata<Microsoft.AspNetCore.Http.Metadata.IRequestSizeLimitMetadata>()!.MaxRequestBodySize);
+    }
+
+    /// <summary>
+    /// The portrait upload carries a bound of its own, which is what keeps a profile field from being a way to put
+    /// arbitrary octets into an operator's database. It is the one write here whose body is measured in megabytes.
+    /// </summary>
+    [Fact]
+    public void MapClientApi_ThePortraitUpload_CarriesItsOwnRequestBodyBound()
+    {
+        // Arrange
+        var endpoints = BuildRouteBuilder();
+
+        // Act
+        endpoints.MapClientApi();
+
+        // Assert
+        var upload = endpoints.Materialize()
+            .OfType<RouteEndpoint>()
+            .Single(endpoint =>
+                $"/{endpoint.RoutePattern.RawText?.TrimStart('/')}"
+                    == $"{ClientEndpointOptions.RoutePrefix}{ClientPortraitEndpoint.PortraitRoute}"
+                && endpoint.Metadata.GetMetadata<HttpMethodMetadata>()!.HttpMethods.Contains("POST"));
+
+        Assert.Equal(
+            ClientPortraitEndpoint.MaxPortraitBytes,
+            upload.Metadata.GetMetadata<Microsoft.AspNetCore.Http.Metadata.IRequestSizeLimitMetadata>()!.MaxRequestBodySize);
     }
 
     /// <summary>

--- a/backend/tests/Host.UnitTests/Api/ClientPortraitEndpointTests.cs
+++ b/backend/tests/Host.UnitTests/Api/ClientPortraitEndpointTests.cs
@@ -1,0 +1,370 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Portraits;
+using MailFathom.Domain.Access;
+using MailFathom.Host.Api;
+using MailFathom.TestSupport;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Api;
+
+/// <summary>
+/// Covers the three routes a person reads, replaces, and removes their own portrait over. What has to hold is that an
+/// absent picture is answered plainly rather than refused, that an upload is judged by its octets rather than by what
+/// the request declared them to be, that both refusals name what they refused against, and that a client already
+/// holding the picture is told it has not changed instead of being served it again.
+/// </summary>
+public sealed class ClientPortraitEndpointTests
+{
+    private static readonly byte[] Png =
+        [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x0D, 0x0A];
+
+    private static readonly byte[] Jpeg = [0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10];
+
+    [Fact]
+    public async Task ReadAsync_APersonWhoSuppliedAPicture_ServesItUnderTheKindItIs()
+    {
+        // Arrange
+        var context = Requesting();
+
+        // Act
+        var result = await ClientPortraitEndpoint.ReadAsync(
+            SignedIn(StoreHolding(Png)),
+            context,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var served = Assert.IsType<FileContentHttpResult>(result.Result);
+
+        Assert.Equal("image/png", served.ContentType);
+        Assert.Equal(Png, served.FileContents.ToArray());
+    }
+
+    /// <summary>A client draws the initials it already has, so an absent picture is a plain answer rather than a refusal it would have to read as one.</summary>
+    [Fact]
+    public async Task ReadAsync_APersonWhoSuppliedNone_AnswersThatThereIsNoneRatherThanRefusing()
+    {
+        // Arrange
+        var store = Substitute.For<IOwnerPortraitStore>();
+        store.ReadAsync(Arg.Any<MailOwnerId>(), Arg.Any<CancellationToken>())
+            .Returns((ReadOnlyMemory<byte>?)null);
+
+        // Act
+        var result = await ClientPortraitEndpoint.ReadAsync(
+            SignedIn(store),
+            Requesting(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.IsType<NoContent>(result.Result);
+    }
+
+    /// <summary>A portrait is personal data, so it is held only against a revalidation rather than cached freely for whatever a proxy decides.</summary>
+    [Fact]
+    public async Task ReadAsync_APictureItServes_AsksTheClientToRevalidateAndKeepsItPrivate()
+    {
+        // Arrange
+        var context = Requesting();
+
+        // Act
+        await ClientPortraitEndpoint.ReadAsync(
+            SignedIn(StoreHolding(Png)),
+            context,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var caching = context.Response.GetTypedHeaders().CacheControl!;
+
+        Assert.True(caching.Private);
+        Assert.True(caching.NoCache);
+        Assert.Null(caching.MaxAge);
+    }
+
+    /// <summary>
+    /// What the acceptance calls avoiding a refetch on every screen that draws it: the served response names the
+    /// octets, and a client presenting that name back is answered that nothing changed rather than the picture again.
+    /// </summary>
+    [Fact]
+    public async Task ReadAsync_ARequestPresentingWhatItWasAlreadyServed_IsAnsweredThatNothingChanged()
+    {
+        // Arrange
+        await using var services = new ServiceCollection().AddLogging().BuildServiceProvider();
+
+        var first = Requesting(services);
+        var served = await ClientPortraitEndpoint.ReadAsync(
+            SignedIn(StoreHolding(Png)),
+            first,
+            TestContext.Current.CancellationToken);
+
+        await Assert.IsType<FileContentHttpResult>(served.Result).ExecuteAsync(first);
+
+        var again = Requesting(services);
+        again.Request.Headers.IfNoneMatch = first.Response.Headers.ETag;
+
+        // Act
+        var repeated = await ClientPortraitEndpoint.ReadAsync(
+            SignedIn(StoreHolding(Png)),
+            again,
+            TestContext.Current.CancellationToken);
+
+        await Assert.IsType<FileContentHttpResult>(repeated.Result).ExecuteAsync(again);
+
+        // Assert
+        Assert.NotEmpty(first.Response.Headers.ETag.ToString());
+        Assert.Equal(StatusCodes.Status304NotModified, again.Response.StatusCode);
+        Assert.Empty(((MemoryStream)again.Response.Body).ToArray());
+    }
+
+    /// <summary>Two different pictures are two different names, which is what makes a replaced portrait reach the next screen rather than the next expiry.</summary>
+    [Fact]
+    public async Task ReadAsync_ADifferentPicture_IsNamedDifferently()
+    {
+        // Act
+        var one = await ClientPortraitEndpoint.ReadAsync(
+            SignedIn(StoreHolding(Png)),
+            Requesting(),
+            TestContext.Current.CancellationToken);
+
+        var other = await ClientPortraitEndpoint.ReadAsync(
+            SignedIn(StoreHolding(Jpeg)),
+            Requesting(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotEqual(TagOf(one.Result), TagOf(other.Result));
+    }
+
+    [Theory]
+    [InlineData("image/png")]
+    [InlineData("image/jpeg")]
+    public async Task ReplaceAsync_AnUploadOfAKindThisDeploymentStores_StoresTheOctetsAsTheyWereSupplied(string kind)
+    {
+        // Arrange
+        var supplied = kind == "image/png" ? Png : Jpeg;
+        var store = Substitute.For<IOwnerPortraitStore>();
+        store.SaveAsync(Arg.Any<MailOwnerId>(), Arg.Any<OwnerPortrait>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
+        var result = await ClientPortraitEndpoint.ReplaceAsync(
+            SignedIn(store),
+            Uploading(supplied),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.IsType<NoContent>(result.Result);
+        await store.Received(1).SaveAsync(
+            SyntheticMailOwner.Deployment,
+            Arg.Is<OwnerPortrait>(portrait =>
+                portrait!.Type.MediaType == kind && portrait.Content.ToArray().SequenceEqual(supplied)),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// The regression this exists for: a declared content type is a string an uploader wrote, so an upload that says
+    /// it is an image and is not must be refused on what it holds rather than admitted on what it claims.
+    /// </summary>
+    [Fact]
+    public async Task ReplaceAsync_OctetsThatAreNoImageDeclaredAsOne_AreRefusedNamingTheKindsOnOffer()
+    {
+        // Arrange
+        var store = Substitute.For<IOwnerPortraitStore>();
+        var upload = Uploading("<script>alert(1)</script>"u8.ToArray());
+        upload.Request.ContentType = "image/png";
+
+        // Act
+        var result = await ClientPortraitEndpoint.ReplaceAsync(
+            SignedIn(store),
+            upload,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var refusal = Assert.IsType<ProblemHttpResult>(result.Result);
+
+        Assert.Equal(StatusCodes.Status415UnsupportedMediaType, refusal.StatusCode);
+        Assert.Contains("image/jpeg", refusal.ProblemDetails.Detail!, StringComparison.Ordinal);
+        Assert.Contains("image/png", refusal.ProblemDetails.Detail!, StringComparison.Ordinal);
+
+        await store.DidNotReceive()
+            .SaveAsync(Arg.Any<MailOwnerId>(), Arg.Any<OwnerPortrait>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>The transport refuses the body and says nothing about why, so the one thing a person needs from it — the bound they went over — is stated here.</summary>
+    [Fact]
+    public async Task ReplaceAsync_AnUploadOverTheBound_IsRefusedNamingTheLimitItHit()
+    {
+        // Arrange
+        var store = Substitute.For<IOwnerPortraitStore>();
+        var upload = Requesting();
+        upload.Request.Body = new RefusedBodyStream();
+
+        // Act
+        var result = await ClientPortraitEndpoint.ReplaceAsync(
+            SignedIn(store),
+            upload,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var refusal = Assert.IsType<ProblemHttpResult>(result.Result);
+
+        Assert.Equal(StatusCodes.Status413PayloadTooLarge, refusal.StatusCode);
+        Assert.Contains("1 MB", refusal.ProblemDetails.Detail!, StringComparison.Ordinal);
+
+        await store.DidNotReceive()
+            .SaveAsync(Arg.Any<MailOwnerId>(), Arg.Any<OwnerPortrait>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReplaceAsync_ARequestCarryingNoBodyAtAll_IsRefused()
+    {
+        // Arrange
+        var store = Substitute.For<IOwnerPortraitStore>();
+
+        // Act
+        var result = await ClientPortraitEndpoint.ReplaceAsync(
+            SignedIn(store),
+            Uploading([]),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var refusal = Assert.IsType<ProblemHttpResult>(result.Result);
+
+        Assert.Equal(StatusCodes.Status400BadRequest, refusal.StatusCode);
+
+        await store.DidNotReceive()
+            .SaveAsync(Arg.Any<MailOwnerId>(), Arg.Any<OwnerPortrait>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>The caller is a person whose row was erased under a credential that has not yet been withdrawn, and the answer to them is that there is nothing here of theirs.</summary>
+    [Fact]
+    public async Task ReplaceAsync_ADeploymentHoldingNoRecordForTheCaller_ReportsThatRatherThanStoring()
+    {
+        // Arrange
+        var store = Substitute.For<IOwnerPortraitStore>();
+        store.SaveAsync(Arg.Any<MailOwnerId>(), Arg.Any<OwnerPortrait>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        // Act
+        var result = await ClientPortraitEndpoint.ReplaceAsync(
+            SignedIn(store),
+            Uploading(Png),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(
+            StatusCodes.Status404NotFound,
+            Assert.IsType<NotFound<ProblemDetails>>(result.Result).Value!.Status);
+    }
+
+    [Fact]
+    public async Task RemoveAsync_APersonTakingTheirPictureDown_RemovesItAndAnswersThatThereIsNone()
+    {
+        // Arrange
+        var store = Substitute.For<IOwnerPortraitStore>();
+
+        // Act
+        var result = await ClientPortraitEndpoint.RemoveAsync(
+            SignedIn(store),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status204NoContent, result.StatusCode);
+        await store.Received(1).RemoveAsync(SyntheticMailOwner.Deployment, Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>Removing what is not there leaves the caller with no portrait, which is the whole of what they asked for.</summary>
+    [Fact]
+    public async Task RemoveAsync_APersonWhoSuppliedNoPicture_AnswersTheSameWay()
+    {
+        // Arrange
+        var store = Substitute.For<IOwnerPortraitStore>();
+        store.RemoveAsync(Arg.Any<MailOwnerId>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+
+        // Act
+        var result = await ClientPortraitEndpoint.RemoveAsync(
+            SignedIn(store),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status204NoContent, result.StatusCode);
+    }
+
+    private static string TagOf(IResult served) =>
+        Assert.IsType<FileContentHttpResult>(served).EntityTag!.Tag.ToString();
+
+    private static IOwnerPortraitStore StoreHolding(byte[] content)
+    {
+        var store = Substitute.For<IOwnerPortraitStore>();
+        store.ReadAsync(Arg.Any<MailOwnerId>(), Arg.Any<CancellationToken>())
+            .Returns(new ReadOnlyMemory<byte>(content));
+
+        return store;
+    }
+
+    private static DefaultHttpContext Requesting(IServiceProvider? services = null)
+    {
+        var context = new DefaultHttpContext();
+
+        if (services is not null)
+        {
+            context.RequestServices = services;
+        }
+
+        context.Response.Body = new MemoryStream();
+
+        return context;
+    }
+
+    private static DefaultHttpContext Uploading(byte[] content)
+    {
+        var context = Requesting();
+        context.Request.Body = new MemoryStream(content);
+
+        return context;
+    }
+
+    private static OwnPortrait SignedIn(IOwnerPortraitStore store) => new(
+        AccessAuthorizations.ForOwnerGranted(SyntheticMailOwner.Deployment, MailFathomPermission.MailRead),
+        store);
+
+    /// <summary>A body the server stops reading because it went past the bound the route published, which is how the transport reports an upload over the limit.</summary>
+    private sealed class RefusedBodyStream : Stream
+    {
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) =>
+            throw new BadHttpRequestException("Request body too large.", StatusCodes.Status413PayloadTooLarge);
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+            throw new BadHttpRequestException("Request body too large.", StatusCodes.Status413PayloadTooLarge);
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override void Flush()
+        {
+        }
+    }
+}

--- a/backend/tests/Host.UnitTests/Api/ClientPortraitEndpointTests.cs
+++ b/backend/tests/Host.UnitTests/Api/ClientPortraitEndpointTests.cs
@@ -88,6 +88,27 @@ public sealed class ClientPortraitEndpointTests
     }
 
     /// <summary>
+    /// The kind was proven from a signature rather than by decoding the file, so a picture that opens as one and holds
+    /// markup after that must never be a page the browser sniffs its way into rendering on the deployment's own origin.
+    /// It is the same defence a message's attachments are served with.
+    /// </summary>
+    [Fact]
+    public async Task ReadAsync_APictureItServes_TellsTheBrowserNotToSniffItsTypeFromTheOctets()
+    {
+        // Arrange
+        var context = Requesting();
+
+        // Act
+        await ClientPortraitEndpoint.ReadAsync(
+            SignedIn(StoreHolding([.. Png, .. "<script>alert(1)</script>"u8])),
+            context,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("nosniff", context.Response.Headers.XContentTypeOptions.ToString());
+    }
+
+    /// <summary>
     /// What the acceptance calls avoiding a refetch on every screen that draws it: the served response names the
     /// octets, and a client presenting that name back is answered that nothing changed rather than the picture again.
     /// </summary>

--- a/backend/tests/Infrastructure.UnitTests/Persistence/Portraits/OwnerPortraitUpsertStatementTests.cs
+++ b/backend/tests/Infrastructure.UnitTests/Persistence/Portraits/OwnerPortraitUpsertStatementTests.cs
@@ -1,0 +1,109 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Infrastructure.Persistence;
+using MailFathom.Infrastructure.Persistence.Portraits;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Persistence.Portraits;
+
+/// <summary>
+/// A person's portrait is written by one statement, and everything that write promises is in its text: that a second
+/// device replaces what the first supplied rather than colliding on the key, that an owner this deployment no longer
+/// holds affects no row instead of raising a foreign-key violation, and that the first instant is not moved by a later
+/// write. None of that is visible from the port and all of it is decidable without a server, so it is established here.
+/// </summary>
+public sealed class OwnerPortraitUpsertStatementTests
+{
+    /// <summary>Two of one person's devices uploading at once is the shape a read-then-insert would fail on, so the second write replaces what the first supplied rather than being refused.</summary>
+    [Fact]
+    public void Compose_TheWrite_ReplacesTheOctetsOnConflictWithTheOwnersExistingRow()
+    {
+        // Act
+        var statement = Composed();
+
+        // Assert
+        Assert.Contains("ON CONFLICT (\"OwnerId\") DO UPDATE SET", statement, StringComparison.Ordinal);
+        Assert.Contains("\"Content\" = EXCLUDED.\"Content\"", statement, StringComparison.Ordinal);
+    }
+
+    /// <summary>The first instant records when the person first supplied a picture, so a later write must not carry a new one into it.</summary>
+    [Fact]
+    public void Compose_AWriteOverAnExistingRow_MovesTheChangedInstantAndLeavesTheFirstOne()
+    {
+        // Act
+        var statement = Composed();
+
+        // Assert
+        Assert.Contains("\"UpdatedAt\" = EXCLUDED.\"UpdatedAt\"", statement, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"CreatedAt\" = EXCLUDED", statement, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The row is inserted from a select over the owner table, so the existence check and the write are one statement
+    /// rather than two decisions a concurrent erasure could fall between — and a caller whose row has gone is answered
+    /// by a count of nothing rather than by a constraint violation.
+    /// </summary>
+    [Fact]
+    public void Compose_TheWrite_InsertsFromTheOwnerRowRatherThanUnconditionally()
+    {
+        // Act
+        var statement = Composed();
+
+        // Assert
+        Assert.Contains("FROM \"settings_accounts\"", statement, StringComparison.Ordinal);
+        Assert.Contains("WHERE \"Id\" = {0}", statement, StringComparison.Ordinal);
+    }
+
+    /// <summary>One instant is written into both columns on an insert, so a row's two timestamps start out equal.</summary>
+    [Fact]
+    public void Compose_AnInsert_WritesOneInstantIntoBothColumns()
+    {
+        // Act
+        var statement = Composed();
+
+        // Assert
+        Assert.Contains("SELECT {0}, {1}, {2}, {2}", statement, StringComparison.Ordinal);
+    }
+
+    /// <summary>Every identifier comes from the model, so the table this writes is the one the mapping declares.</summary>
+    [Fact]
+    public void Compose_TheWrite_NamesTheTableAndColumnsTheModelStates()
+    {
+        // Act
+        var statement = Composed();
+
+        // Assert
+        Assert.Contains(
+            "INSERT INTO \"owner_portraits\"\n    (\"OwnerId\", \"Content\", \"CreatedAt\", \"UpdatedAt\")",
+            statement.ReplaceLineEndings("\n"),
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>The octets travel as a parameter, so nothing an uploader supplied is ever part of the statement's text.</summary>
+    [Fact]
+    public void Compose_TheWrite_CarriesTheOctetsAsAParameterRatherThanAsText()
+    {
+        // Act
+        var statement = Composed();
+
+        // Assert
+        Assert.Contains("{1}", statement, StringComparison.Ordinal);
+        Assert.DoesNotContain("'", statement, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Compose_NoModelAtAll_IsRefused()
+    {
+        // Assert
+        Assert.Throws<ArgumentNullException>(() => OwnerPortraitUpsertStatement.Compose(null!));
+    }
+
+    private static string Composed()
+    {
+        using var context = new MailFathomDbContextDesignTimeFactory().CreateDbContext([]);
+
+        return OwnerPortraitUpsertStatement.Compose(context.Model);
+    }
+}

--- a/backend/tests/IntegrationTests/Hosting/ComposedClientEndpointSecurityTests.cs
+++ b/backend/tests/IntegrationTests/Hosting/ComposedClientEndpointSecurityTests.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Globalization;
+using MailFathom.Host.Api;
 using MailFathom.Host.Security.Transport;
 using MailFathom.IntegrationTests.Orchestration;
 using MailFathom.Mcp;
@@ -52,6 +53,8 @@ public sealed class ComposedClientEndpointSecurityTests
     private const string ClientAccountsRoute = "/api/client/accounts";
 
     private const string ClientFoldersRoute = "/api/client/folders";
+
+    private const string ClientPortraitRoute = "/api/client/portrait";
 
     private const string AdminSessionRoute = "/api/admin/session";
 
@@ -126,6 +129,57 @@ public sealed class ComposedClientEndpointSecurityTests
         // Assert
         Assert.Equal(StatusCodes.Status404NotFound, refused.StatusCode);
         Assert.Equal(StatusCodes.Status200OK, served.StatusCode);
+    }
+
+    /// <summary>
+    /// The mechanism every write on this surface bounds its body with, established once against a started pipeline.
+    /// A route declares its bound as endpoint metadata and nothing on this surface runs the MVC filter pipeline, so
+    /// what has to be true is that the routing pipeline itself narrows the server's own limit to what the selected
+    /// endpoint declared — before the handler is entered and before any octets are buffered. Were it not, every bound
+    /// on this surface would be a comment rather than a limit, and the server's default would be what an authenticated
+    /// caller could actually send.
+    /// </summary>
+    [Fact]
+    public async Task ClientEndpoint_AWriteDeclaringABodyBound_NarrowsTheServersLimitToItBeforeTheHandlerIsEntered()
+    {
+        // Arrange
+        await using var host = await InProcessComposedHost.StartAsync(
+            EverySurfaceServed(),
+            TestContext.Current.CancellationToken);
+
+        // Act
+        var answered = await host.SendAsync(
+            HttpMethods.Post,
+            ClientPortraitRoute,
+            ClientPort,
+            (HeaderNames.Authorization, $"Bearer {ClientKey}"));
+
+        // Assert
+        Assert.Equal(ClientPortraitEndpoint.MaxPortraitBytes, host.AppliedRequestBodySizeLimit);
+
+        // The handler was reached and refused the empty body, which is what places the narrowing before it rather than
+        // in it. Nothing here read the database: the refusal precedes the store.
+        Assert.Equal(StatusCodes.Status400BadRequest, answered.StatusCode);
+    }
+
+    /// <summary>A route that declares no bound of its own leaves the server's, so the narrowing above is the endpoint's decision rather than something the pipeline does to every request.</summary>
+    [Fact]
+    public async Task ClientEndpoint_AReadDeclaringNoBodyBound_LeavesTheServersOwnLimitAlone()
+    {
+        // Arrange
+        await using var host = await InProcessComposedHost.StartAsync(
+            EverySurfaceServed(),
+            TestContext.Current.CancellationToken);
+
+        // Act
+        await host.SendAsync(
+            HttpMethods.Get,
+            ClientSessionRoute,
+            ClientPort,
+            (HeaderNames.Authorization, $"Bearer {ClientKey}"));
+
+        // Assert
+        Assert.NotEqual(ClientPortraitEndpoint.MaxPortraitBytes, host.AppliedRequestBodySizeLimit);
     }
 
     [Fact]

--- a/backend/tests/IntegrationTests/Hosting/InProcessComposedHost.cs
+++ b/backend/tests/IntegrationTests/Hosting/InProcessComposedHost.cs
@@ -71,6 +71,14 @@ internal sealed class InProcessComposedHost : IAsyncDisposable
     /// <summary>Gets the services the composition registered, as the running host resolved them.</summary>
     internal IServiceProvider Services => this.app.Services;
 
+    /// <summary>Gets the body-size limit the pipeline applied to the last request it answered.</summary>
+    /// <remarks>
+    /// A server states one and the routing pipeline narrows it to whatever the selected endpoint declared, which is
+    /// the mechanism every write on these surfaces bounds its body with. Reading it back is what tells a route's
+    /// declared bound apart from one that was declared and never reached the server.
+    /// </remarks>
+    internal long? AppliedRequestBodySizeLimit { get; private set; }
+
     /// <summary>Composes one deployment shape and starts it.</summary>
     /// <param name="configuration">The settings the shape is written as, which is the input the composition actually reads.</param>
     /// <param name="cancellationToken">Cancels the start.</param>
@@ -181,10 +189,15 @@ internal sealed class InProcessComposedHost : IAsyncDisposable
 
         await using var body = new MemoryStream();
 
+        // The limit a server carries before an endpoint narrows it, which is Kestrel's own default. It is here so a
+        // route's declared bound has something to reach: without the feature the pipeline has nowhere to write one.
+        var bodySizeLimit = new ServerRequestBodySizeLimit();
+
         var requestFeatures = new FeatureCollection();
         requestFeatures.Set<IHttpRequestFeature>(request);
         requestFeatures.Set<IHttpResponseFeature>(response);
         requestFeatures.Set<IHttpResponseBodyFeature>(new StreamResponseBodyFeature(body));
+        requestFeatures.Set<IHttpMaxRequestBodySizeFeature>(bodySizeLimit);
 
         // The port is what surface isolation matches a listener by, and the address is what the forwarded-header
         // middleware judges as a peer — a shape naming no trusted proxy trusts every address, which is the default this
@@ -198,6 +211,8 @@ internal sealed class InProcessComposedHost : IAsyncDisposable
         });
 
         await this.server.SendAsync(requestFeatures);
+
+        this.AppliedRequestBodySizeLimit = bodySizeLimit.MaxRequestBodySize;
 
         return response;
     }
@@ -218,6 +233,17 @@ internal sealed class InProcessComposedHost : IAsyncDisposable
 
         /// <inheritdoc />
         public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+
+    /// <summary>The body-size limit a server offers the pipeline, which the pipeline then narrows per endpoint.</summary>
+    /// <remarks>It enforces nothing, because enforcement is the server's half and no octets flow here; what it holds is the number the pipeline decided on, which is the part a route's declared bound has to reach.</remarks>
+    private sealed class ServerRequestBodySizeLimit : IHttpMaxRequestBodySizeFeature
+    {
+        /// <inheritdoc />
+        public bool IsReadOnly => false;
+
+        /// <inheritdoc />
+        public long? MaxRequestBodySize { get; set; } = 30 * 1024 * 1024;
     }
 
     /// <summary>Where the framework's data protection keys go while a pipeline is being driven.</summary>

--- a/backend/tests/IntegrationTests/Persistence/OrchestratedOwnerPortraitStoreTests.cs
+++ b/backend/tests/IntegrationTests/Persistence/OrchestratedOwnerPortraitStoreTests.cs
@@ -15,9 +15,16 @@ namespace MailFathom.IntegrationTests.Persistence;
 /// <summary>
 /// Proves the one statement a person's portrait is written by against a real database: that a second write replaces
 /// the octets and leaves the instant the first one recorded, that an owner this deployment does not hold affects no
-/// row rather than raising a foreign-key violation, and that a removal leaves nothing behind. None of it is decidable
-/// without PostgreSQL, which is why the store carries the integration-coverage marker.
+/// row rather than raising a foreign-key violation, that a removal leaves nothing behind, and that erasing an owner
+/// takes their picture with them. None of it is decidable without PostgreSQL, which is why the store carries the
+/// integration-coverage marker.
 /// </summary>
+/// <remarks>
+/// Every test here writes against an owner it provisions and erases in a <c>finally</c>, for the reason
+/// <c>OrchestratedForeignOwner</c> states and <c>OrchestratedOwnerSettingsDocumentTests</c> follows: the provisioned
+/// owner is one row shared by every class in this collection, and a portrait left on it would be state a later class
+/// reads without having written it. A test isolates itself through the data it writes.
+/// </remarks>
 [Collection(OrchestratedInfrastructureCollectionDefinition.Name)]
 public sealed class OrchestratedOwnerPortraitStoreTests(MailFathomOrchestrationFixture orchestration)
 {
@@ -32,22 +39,32 @@ public sealed class OrchestratedOwnerPortraitStoreTests(MailFathomOrchestrationF
         // Arrange
         var cancellationToken = TestContext.Current.CancellationToken;
         await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var owner = Guid.NewGuid();
 
-        // Act
-        Assert.True(await SaveAsync(services, services.ServedOwner, FirstPicture, cancellationToken));
-        var first = await RowAsync(services, services.ServedOwner, cancellationToken);
+        await OrchestratedForeignOwner.ProvisionAsync(services, owner, cancellationToken);
 
-        Assert.True(await SaveAsync(services, services.ServedOwner, SecondPicture, cancellationToken));
-        var replaced = await RowAsync(services, services.ServedOwner, cancellationToken);
+        try
+        {
+            // Act
+            Assert.True(await SaveAsync(services, Named(owner), FirstPicture, cancellationToken));
+            var first = await RowAsync(services, owner, cancellationToken);
 
-        // Assert
-        Assert.Equal(SecondPicture, replaced!.Content);
-        Assert.Equal(first!.CreatedAt, replaced.CreatedAt);
-        Assert.True(replaced.UpdatedAt >= first.UpdatedAt);
+            Assert.True(await SaveAsync(services, Named(owner), SecondPicture, cancellationToken));
+            var replaced = await RowAsync(services, owner, cancellationToken);
 
-        var read = await ReadAsync(services, services.ServedOwner, cancellationToken);
+            // Assert
+            Assert.Equal(SecondPicture, replaced!.Content);
+            Assert.Equal(first!.CreatedAt, replaced.CreatedAt);
+            Assert.True(replaced.UpdatedAt >= first.UpdatedAt);
 
-        Assert.Equal(SecondPicture, read!.Value.ToArray());
+            var read = await ReadAsync(services, Named(owner), cancellationToken);
+
+            Assert.Equal(SecondPicture, read!.Value.ToArray());
+        }
+        finally
+        {
+            await OrchestratedForeignOwner.EraseAsync(services, owner);
+        }
     }
 
     /// <summary>The caller is a person whose row was erased under a credential that has not yet been withdrawn, so the write reports that there is nothing here of theirs instead of raising a constraint violation.</summary>
@@ -57,10 +74,10 @@ public sealed class OrchestratedOwnerPortraitStoreTests(MailFathomOrchestrationF
         // Arrange
         var cancellationToken = TestContext.Current.CancellationToken;
         await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
-        var stranger = MailOwnerId.Create(new Guid("1f6f31d0-5cf8-4a2f-93d9-4d4e2f5a7b61"));
+        var stranger = Guid.NewGuid();
 
         // Act
-        var written = await SaveAsync(services, stranger, FirstPicture, cancellationToken);
+        var written = await SaveAsync(services, Named(stranger), FirstPicture, cancellationToken);
 
         // Assert
         Assert.False(written);
@@ -73,26 +90,57 @@ public sealed class OrchestratedOwnerPortraitStoreTests(MailFathomOrchestrationF
         // Arrange
         var cancellationToken = TestContext.Current.CancellationToken;
         await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var owner = Guid.NewGuid();
 
-        Assert.True(await SaveAsync(services, services.ServedOwner, FirstPicture, cancellationToken));
+        await OrchestratedForeignOwner.ProvisionAsync(services, owner, cancellationToken);
+
+        try
+        {
+            Assert.True(await SaveAsync(services, Named(owner), FirstPicture, cancellationToken));
+
+            // Act
+            await services.InScopeAsync(
+                async (scope, token) =>
+                {
+                    var portraits = scope.GetRequiredService<IOwnerPortraitStore>();
+
+                    await portraits.RemoveAsync(Named(owner), token);
+                    await portraits.RemoveAsync(Named(owner), token);
+
+                    return true;
+                },
+                cancellationToken);
+
+            // Assert
+            Assert.Null(await RowAsync(services, owner, cancellationToken));
+            Assert.Null(await ReadAsync(services, Named(owner), cancellationToken));
+        }
+        finally
+        {
+            await OrchestratedForeignOwner.EraseAsync(services, owner);
+        }
+    }
+
+    /// <summary>The cascade is what makes a picture go with the person, without the erasure walk having to know this table exists.</summary>
+    [Fact]
+    public async Task EraseAsync_AnOwnerWhoSuppliedAPicture_TakesItWithEverythingElseDerivedFromThem()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var owner = Guid.NewGuid();
+
+        await OrchestratedForeignOwner.ProvisionAsync(services, owner, cancellationToken);
+        Assert.True(await SaveAsync(services, Named(owner), FirstPicture, cancellationToken));
 
         // Act
-        await services.InScopeAsync(
-            async (scope, token) =>
-            {
-                var portraits = scope.GetRequiredService<IOwnerPortraitStore>();
-
-                await portraits.RemoveAsync(services.ServedOwner, token);
-                await portraits.RemoveAsync(services.ServedOwner, token);
-
-                return true;
-            },
-            cancellationToken);
+        await OrchestratedForeignOwner.EraseAsync(services, owner);
 
         // Assert
-        Assert.Null(await RowAsync(services, services.ServedOwner, cancellationToken));
-        Assert.Null(await ReadAsync(services, services.ServedOwner, cancellationToken));
+        Assert.Null(await RowAsync(services, owner, cancellationToken));
     }
+
+    private static MailOwnerId Named(Guid owner) => MailOwnerId.Create(owner);
 
     private static Task<bool> SaveAsync(
         OrchestratedMailFathomServices services,
@@ -114,19 +162,15 @@ public sealed class OrchestratedOwnerPortraitStoreTests(MailFathomOrchestrationF
 
     private static Task<StoredPortrait?> RowAsync(
         OrchestratedMailFathomServices services,
-        MailOwnerId owner,
-        CancellationToken cancellationToken)
-    {
-        var ownerValue = owner.Value;
-
-        return services.InScopeAsync(
+        Guid owner,
+        CancellationToken cancellationToken) =>
+        services.InScopeAsync(
             (scope, token) => scope.GetRequiredService<MailFathomDbContext>().OwnerPortraits
                 .AsNoTracking()
-                .Where(portrait => portrait.OwnerId == ownerValue)
+                .Where(portrait => portrait.OwnerId == owner)
                 .Select(portrait => new StoredPortrait(portrait.Content, portrait.CreatedAt, portrait.UpdatedAt))
                 .SingleOrDefaultAsync(token),
             cancellationToken);
-    }
 
     private sealed record StoredPortrait(byte[] Content, DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt);
 }

--- a/backend/tests/IntegrationTests/Persistence/OrchestratedOwnerPortraitStoreTests.cs
+++ b/backend/tests/IntegrationTests/Persistence/OrchestratedOwnerPortraitStoreTests.cs
@@ -1,0 +1,132 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Portraits;
+using MailFathom.Domain.Access;
+using MailFathom.Infrastructure.Persistence;
+using MailFathom.IntegrationTests.Orchestration;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MailFathom.IntegrationTests.Persistence;
+
+/// <summary>
+/// Proves the one statement a person's portrait is written by against a real database: that a second write replaces
+/// the octets and leaves the instant the first one recorded, that an owner this deployment does not hold affects no
+/// row rather than raising a foreign-key violation, and that a removal leaves nothing behind. None of it is decidable
+/// without PostgreSQL, which is why the store carries the integration-coverage marker.
+/// </summary>
+[Collection(OrchestratedInfrastructureCollectionDefinition.Name)]
+public sealed class OrchestratedOwnerPortraitStoreTests(MailFathomOrchestrationFixture orchestration)
+{
+    private static readonly byte[] FirstPicture =
+        [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x01, 0x02, 0x03];
+
+    private static readonly byte[] SecondPicture = [0xFF, 0xD8, 0xFF, 0xE0, 0x04, 0x05, 0x06];
+
+    [Fact]
+    public async Task SaveAsync_ASecondWriteForOnePerson_ReplacesTheOctetsAndKeepsTheFirstInstant()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+
+        // Act
+        Assert.True(await SaveAsync(services, services.ServedOwner, FirstPicture, cancellationToken));
+        var first = await RowAsync(services, services.ServedOwner, cancellationToken);
+
+        Assert.True(await SaveAsync(services, services.ServedOwner, SecondPicture, cancellationToken));
+        var replaced = await RowAsync(services, services.ServedOwner, cancellationToken);
+
+        // Assert
+        Assert.Equal(SecondPicture, replaced!.Content);
+        Assert.Equal(first!.CreatedAt, replaced.CreatedAt);
+        Assert.True(replaced.UpdatedAt >= first.UpdatedAt);
+
+        var read = await ReadAsync(services, services.ServedOwner, cancellationToken);
+
+        Assert.Equal(SecondPicture, read!.Value.ToArray());
+    }
+
+    /// <summary>The caller is a person whose row was erased under a credential that has not yet been withdrawn, so the write reports that there is nothing here of theirs instead of raising a constraint violation.</summary>
+    [Fact]
+    public async Task SaveAsync_AnOwnerThisDeploymentDoesNotHold_AffectsNoRowAndReportsIt()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var stranger = MailOwnerId.Create(new Guid("1f6f31d0-5cf8-4a2f-93d9-4d4e2f5a7b61"));
+
+        // Act
+        var written = await SaveAsync(services, stranger, FirstPicture, cancellationToken);
+
+        // Assert
+        Assert.False(written);
+        Assert.Null(await RowAsync(services, stranger, cancellationToken));
+    }
+
+    [Fact]
+    public async Task RemoveAsync_APersonTakingTheirPictureDown_LeavesNoRowAndIsSafeToRepeat()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+
+        Assert.True(await SaveAsync(services, services.ServedOwner, FirstPicture, cancellationToken));
+
+        // Act
+        await services.InScopeAsync(
+            async (scope, token) =>
+            {
+                var portraits = scope.GetRequiredService<IOwnerPortraitStore>();
+
+                await portraits.RemoveAsync(services.ServedOwner, token);
+                await portraits.RemoveAsync(services.ServedOwner, token);
+
+                return true;
+            },
+            cancellationToken);
+
+        // Assert
+        Assert.Null(await RowAsync(services, services.ServedOwner, cancellationToken));
+        Assert.Null(await ReadAsync(services, services.ServedOwner, cancellationToken));
+    }
+
+    private static Task<bool> SaveAsync(
+        OrchestratedMailFathomServices services,
+        MailOwnerId owner,
+        byte[] picture,
+        CancellationToken cancellationToken) =>
+        services.InScopeAsync(
+            (scope, token) => scope.GetRequiredService<IOwnerPortraitStore>()
+                .SaveAsync(owner, OwnerPortrait.Of(picture)!, token),
+            cancellationToken);
+
+    private static Task<ReadOnlyMemory<byte>?> ReadAsync(
+        OrchestratedMailFathomServices services,
+        MailOwnerId owner,
+        CancellationToken cancellationToken) =>
+        services.InScopeAsync(
+            (scope, token) => scope.GetRequiredService<IOwnerPortraitStore>().ReadAsync(owner, token),
+            cancellationToken);
+
+    private static Task<StoredPortrait?> RowAsync(
+        OrchestratedMailFathomServices services,
+        MailOwnerId owner,
+        CancellationToken cancellationToken)
+    {
+        var ownerValue = owner.Value;
+
+        return services.InScopeAsync(
+            (scope, token) => scope.GetRequiredService<MailFathomDbContext>().OwnerPortraits
+                .AsNoTracking()
+                .Where(portrait => portrait.OwnerId == ownerValue)
+                .Select(portrait => new StoredPortrait(portrait.Content, portrait.CreatedAt, portrait.UpdatedAt))
+                .SingleOrDefaultAsync(token),
+            cancellationToken);
+    }
+
+    private sealed record StoredPortrait(byte[] Content, DateTimeOffset CreatedAt, DateTimeOffset UpdatedAt);
+}

--- a/backend/tests/PublicSurfaces.UnitTests/http-api-contract.json
+++ b/backend/tests/PublicSurfaces.UnitTests/http-api-contract.json
@@ -9451,6 +9451,93 @@
         ]
       }
     },
+    "/api/client/portrait": {
+      "delete": {
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "tags": [
+          "Client"
+        ]
+      },
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "image/jpeg": {
+                "schema": {
+                  "$ref": "#/components/schemas/Stream"
+                }
+              },
+              "image/png": {
+                "schema": {
+                  "$ref": "#/components/schemas/Stream"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "tags": [
+          "Client"
+        ]
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "image/jpeg": {
+              "schema": {
+                "$ref": "#/components/schemas/Stream"
+              }
+            },
+            "image/png": {
+              "schema": {
+                "$ref": "#/components/schemas/Stream"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Not Found"
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ],
+        "tags": [
+          "Client"
+        ]
+      }
+    },
     "/api/client/preferences": {
       "get": {
         "responses": {

--- a/docs/architecture/stored-email-schema.md
+++ b/docs/architecture/stored-email-schema.md
@@ -293,6 +293,27 @@ and then collide on the key.
 **Erasing an owner takes it with the cascade**, like the contact book and unlike the tables the erasure names by hand:
 it keys onto the owner row and records no mail account, so nothing has to know this table exists.
 
+## The picture a person is drawn by
+
+`owner_portraits` holds one row per owner, carrying the picture the client draws them by on
+[the portrait routes](../operations/client-endpoint.md#the-portrait-routes). It sits beside the preferences document
+rather than inside one for the reason that document is not a settings service: a megabyte of image octets is not a
+small closed document, and reading a switch should not carry a photograph.
+
+| Column of `owner_portraits` | What it records |
+|---|---|
+| `OwnerId` | The owner whose picture this is, and the primary key. It is also the foreign key onto `settings_accounts` with `ON DELETE CASCADE`, for the reason `client_preferences` keys the same way: one person has one picture and nothing else identifies it |
+| `Content` | The octets the person supplied, unchanged, as `bytea`. Nothing resizes, crops, re-encodes, or strips metadata from them |
+| `CreatedAt`, `UpdatedAt` | When the person first supplied a picture, and when they last replaced it — which is the first instant until they do |
+
+**What kind of image it is, is not stored.** It is read from the octets themselves wherever it is needed, so a stored
+media type cannot come to disagree with what is stored under it — and the write had already proved the kind, from the
+signature the format opens with, before the row existed.
+
+**The write is the same one statement `client_preferences` is written by**, with the same guarantees and for the same
+reasons: last write wins, an owner this deployment no longer holds affects no row, and two devices arriving at once
+cannot both read nothing and then collide on the key. Erasing an owner takes the picture with the cascade.
+
 ## What an owner signs in with
 
 `owner_credentials` holds every credential an owner authenticates to

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -1,6 +1,6 @@
 # The client endpoint
 
-<!-- describes: backend/src/AppHost/Program.cs, backend/src/AppHost/OrchestrationContract.cs, backend/src/Host/Configuration/Endpoints/ClientEndpointOptions.cs, backend/src/Host/Configuration/Endpoints/ClientApplicationOptions.cs, backend/src/Host/Api/ClientApiEndpoints.cs, backend/src/Host/Api/ClientMailAccountsEndpoint.cs, backend/src/Host/Api/ClientMailFoldersEndpoint.cs, backend/src/Host/Api/ClientMailTimelineEndpoint.cs, backend/src/Host/Api/ClientMailThreadEndpoint.cs, backend/src/Host/Api/ClientMailMessageEndpoint.cs, backend/src/Host/Api/ClientMailBodyEndpoint.cs, backend/src/Host/Api/ClientMailAttachmentEndpoint.cs, backend/src/Host/Api/AttachmentContentResponse.cs, backend/src/Host/Api/ProtectedResourceMetadataEndpoint.cs, backend/src/Host/Security/Endpoints/ClientTransportSecurityExtensions.cs, backend/src/Host/Hosting/ClientApplicationFiles.cs, backend/src/Host/Hosting/Warnings/ClientTransportSecurityWarning.cs, backend/src/Host/Hosting/Warnings/PasswordClearTextTransportWarning.cs, backend/src/Host/Api/ClientOwnerRecordEndpoint.cs, backend/src/Host/Api/ClientDisplayNameEndpoint.cs, backend/src/Host/Configuration/OwnerSettings/Administration/OwnDisplayName.cs, backend/src/Host/Api/ClientMailMutationsEndpoint.cs, backend/src/Host/Api/ClientDraftEndpoints.cs, backend/src/Host/Api/ClientDraftResponses.cs, backend/src/Host/Api/ClientOutboxEndpoints.cs, backend/src/Host/Api/ClientTelemetryEndpoint.cs, backend/src/Host/Observability/ClientTelemetry/** -->
+<!-- describes: backend/src/AppHost/Program.cs, backend/src/AppHost/OrchestrationContract.cs, backend/src/Host/Configuration/Endpoints/ClientEndpointOptions.cs, backend/src/Host/Configuration/Endpoints/ClientApplicationOptions.cs, backend/src/Host/Api/ClientApiEndpoints.cs, backend/src/Host/Api/ClientMailAccountsEndpoint.cs, backend/src/Host/Api/ClientMailFoldersEndpoint.cs, backend/src/Host/Api/ClientMailTimelineEndpoint.cs, backend/src/Host/Api/ClientMailThreadEndpoint.cs, backend/src/Host/Api/ClientMailMessageEndpoint.cs, backend/src/Host/Api/ClientMailBodyEndpoint.cs, backend/src/Host/Api/ClientMailAttachmentEndpoint.cs, backend/src/Host/Api/AttachmentContentResponse.cs, backend/src/Host/Api/ProtectedResourceMetadataEndpoint.cs, backend/src/Host/Security/Endpoints/ClientTransportSecurityExtensions.cs, backend/src/Host/Hosting/ClientApplicationFiles.cs, backend/src/Host/Hosting/Warnings/ClientTransportSecurityWarning.cs, backend/src/Host/Hosting/Warnings/PasswordClearTextTransportWarning.cs, backend/src/Host/Api/ClientOwnerRecordEndpoint.cs, backend/src/Host/Api/ClientPortraitEndpoint.cs, backend/src/Host/Api/ClientDisplayNameEndpoint.cs, backend/src/Host/Configuration/OwnerSettings/Administration/OwnDisplayName.cs, backend/src/Host/Api/ClientMailMutationsEndpoint.cs, backend/src/Host/Api/ClientDraftEndpoints.cs, backend/src/Host/Api/ClientDraftResponses.cs, backend/src/Host/Api/ClientOutboxEndpoints.cs, backend/src/Host/Api/ClientTelemetryEndpoint.cs, backend/src/Host/Observability/ClientTelemetry/** -->
 
 Where the MailFathom client reaches the service, what a deployment has to enable before it answers, and what a person's
 mail client presents to get in.
@@ -93,6 +93,9 @@ AppHost provisions its synthetic credential after the service reports ready;
 | `POST /api/client/outbox/requeue` | `mailfathom.mail.send` |
 | `GET /api/client/preferences` | `mailfathom.mail.read` |
 | `POST /api/client/preferences` | `mailfathom.mail.read` |
+| `GET /api/client/portrait` | `mailfathom.mail.read` |
+| `POST /api/client/portrait` | `mailfathom.mail.read` |
+| `DELETE /api/client/portrait` | `mailfathom.mail.read` |
 | `POST /api/client/telemetry/v1/traces` | none |
 | `POST /api/client/telemetry/v1/metrics` | none |
 | `POST /api/client/telemetry/v1/logs` | none |
@@ -1270,6 +1273,50 @@ their preferences with everything else derived from them.
 
 **A deployment that proxies no telemetry still serves these routes** and stores the switch unchanged. What a client
 draws when there is nothing behind the switch is the client's own question.
+
+### The portrait routes
+
+These three hold the picture a person is drawn by, which the account menu and the settings screen put beside their
+name. It is stored on the owner axis beside the preferences document rather than inside one: a megabyte of image
+octets is not a small closed document, and reading a switch should not carry a photograph.
+
+| Route | What it does |
+| --- | --- |
+| `GET /api/client/portrait` | Serves the signed-in person's picture under the kind it is |
+| `POST /api/client/portrait` | Replaces it with the octets the request body carries |
+| `DELETE /api/client/portrait` | Removes it, leaving everything else about the person as it was |
+
+**An upload is at most 1 MB, and is a JPEG or a PNG.** The bound is applied before a handler is entered, and an upload
+over it is answered `413` naming the megabyte. The kind is read from the signature the file opens with rather than
+from the `Content-Type` the request declared — a declared type is a string an uploader wrote, so trusting it would let
+anything at all be stored under an image's name and served back to a browser as one. Octets that are neither kind are
+answered `415` naming both. A request carrying no body at all is answered `400`.
+
+**Nothing is done to the picture beyond that.** It is not resized, cropped, re-encoded, or stripped of its metadata,
+and it is served back exactly as it was supplied — so the bound and the kind check are the whole of what stands
+between an upload and the database. A person keeps one picture and no history of previous ones.
+
+**Having no picture is answered `204`, not `404`.** The client draws the initials it already has from the person's
+name, so an absent portrait is an ordinary state of the screen rather than an error on it; `404` on this surface says
+a route or a record is not there, which is a different thing. A person this deployment no longer holds a record for is
+answered `404` on the upload, and `204` on the removal like anybody else.
+
+**The served picture is named, and the client revalidates against that name.** The response carries an entity tag over
+the octets and `Cache-Control: private, no-cache`, so the second screen that draws the same portrait is answered `304`
+rather than the picture again, while a replaced one reaches the next screen rather than the next expiry. It is
+deliberately not cached without revalidation: a portrait is personal data.
+
+**No route here names an owner**, exactly as no record route does: the picture acted on is that of the credential that
+authenticated, resolved from the request rather than read out of the body or the path.
+
+**All three are `mailfathom.mail.read`**, and none adds a name to [the published permission set](permissions.md). The
+two writes are deliberately not `mailfathom.mail.accounts.write`, for the reason [the preferences
+write](#the-preferences-routes) is not: that grant decides which mailboxes this deployment connects to, and what a
+person is drawn by must not be decided by a grant over their mail configuration.
+
+**The octets hang off the owner row.** Erasing an owner erases their portrait with everything else derived from them,
+without an erasure naming that table.
+
 ### The drafts routes
 
 These are what a person writes mail through, and the first thing to know about them is that **a draft here is the one


### PR DESCRIPTION
Closes #1499

Three routes on the client endpoint hold the picture the account menu and the settings screen draw a person by. They sit beside the preferences document rather than inside it: a megabyte of image octets is not a small closed document, and reading a switch should not carry a photograph.

## What it serves

| Route | What it does | Grant |
| --- | --- | --- |
| `GET /api/client/portrait` | Serves the signed-in person's picture under the kind it is, or `204` where there is none | `mailfathom.mail.read` |
| `POST /api/client/portrait` | Replaces it with the octets the body carries | `mailfathom.mail.read` |
| `DELETE /api/client/portrait` | Removes it, leaving everything else about the person as it was | `mailfathom.mail.read` |

**No route names an owner.** The person is the one the credential authenticated, resolved from the request exactly as the record and preferences routes resolve it, so a request about somebody else is something a caller cannot express rather than something the surface has to refuse.

**Nothing is added to the published permission set** ADR 0012 closed. The two writes are deliberately not `mailfathom.mail.accounts.write`, for the reason the preferences write is not: that grant decides which mailboxes the deployment connects to, and what a person is drawn by must not be decided by a grant over their mail configuration. `ClientApiEndpointsTests` names the one route that may write under the read grant, so a second one added later fails that test rather than joining it.

**An upload is bounded and then judged by its octets.** 1 MB, applied by the routing pipeline before a handler is entered; the kind is read from the signature the file opens with rather than from the declared `Content-Type`, so an upload that says it is a PNG and holds markup is refused. A refusal names what it refused against — `413` naming the megabyte, `415` naming `image/jpeg` and `image/png`. Nothing is resized, cropped, re-encoded, or stripped of metadata.

**An absent portrait is `204`, not `404`.** The client draws the initials it already has from the person's name, so having no picture is an ordinary state of the screen; `404` on this surface says a route or a record is not there, which is a different thing.

**The served picture is named and revalidated.** An entity tag over the octets plus `Cache-Control: private, no-cache`, so the second screen that draws it is answered `304` while a replaced one reaches the next screen rather than the next expiry. It is deliberately not cached without revalidation: a portrait is personal data.

## Where the octets live

`owner_portraits`, one row per owner, keyed and foreign-keyed onto the owner row with `ON DELETE CASCADE` — so erasing an owner takes the picture with everything else derived from them, without the erasure naming the table. The migration is additive: one `CREATE TABLE`, no change to any existing one.

The write is the same statement shape `client_preferences` is written by — `INSERT … SELECT` from the owner row with `ON CONFLICT … DO UPDATE` — so an owner this deployment no longer holds affects no row instead of raising a foreign-key violation, and two of one person's devices arriving at once cannot both read nothing and then collide on the key.

What kind of image it is, is **not** stored. It is read from the octets wherever it is needed, so a stored media type cannot come to disagree with what is stored under it, and the write had already proved the kind before the row existed.

## Verification

- `scripts/verify-full.sh` — green.
- Unit tests: the signature check and its short-input and empty cases, the use case's owner resolution and grants, the endpoint's three routes including the `304`, both refusals, the empty body, and the erased-record answer, the upsert statement's conflict target and insert-from-owner-row, and the route inventory, the published grants, and the upload's own bound.
- One integration test against a real database for the store — the replace keeping the first instant, the unknown owner affecting no row, and the removal — since that is what the `[RequiresIntegrationCoverage]` marker on it says. It runs in the integration suite only, so it is compiled here and not run.
- The migration was reviewed as SQL with `scripts/script-migration.sh`. It was **not** applied to a local orchestrated database: another session's PostgreSQL container was live on this machine, and applying a migration in that state risks writing its identifier into the wrong worktree's history, which is not reversible. The SQL is one `CREATE TABLE` and CI's pending-model-changes job covers the model and snapshot agreeing.

## Documentation

`docs/operations/client-endpoint.md` states the three routes, the bounds, what an absent portrait answers, and that no route here names an owner. `docs/architecture/stored-email-schema.md` describes the new table. No new dependency, no new permission, no changelog entry.

https://claude.ai/code/session_01Sq2d9jvMDAmZWYbvJdKtfd
