### PR TITLE
[#1475] Mark a message read when its body is drawn, and draw read state on the row

### DIFF
--- a/backend/src/Application/Preferences/ClientPreferences.cs
+++ b/backend/src/Application/Preferences/ClientPreferences.cs
@@ -8,11 +8,18 @@ namespace MailFathom.Application.Preferences;
 /// <param name="TelemetryEnabled">Whether this deployment may be told what the person's client is doing.</param>
 /// <param name="Theme">What the client is painted in once a session exists.</param>
 /// <param name="OpenMailInTabs">Whether opening a message opens a tab rather than replacing what is on the screen.</param>
+/// <param name="MarkReadOnOpen">Whether opening a message in the client marks it read on the owner's own mail server.</param>
 /// <remarks>
 /// <para>
-/// A closed set of three rather than a settings service. Each of them says how somebody wants to work rather than what
+/// A closed set of four rather than a settings service. Each of them says how somebody wants to work rather than what
 /// the screen in front of them is like, which is why they belong to the person and not to the browser profile or the
-/// desktop install they happened to set them in — and why a fourth is added when there is a fourth to add.
+/// desktop install they happened to set them in — and why a fifth is added when there is a fifth to add.
+/// </para>
+/// <para>
+/// Marking read is here rather than on the mail account for the reason
+/// <see href="https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0026-marking-a-message-read-when-a-person-opens-it-in-the-client.md">ADR 0026</see>
+/// gives: read state is what must not fragment between the machines one person reads on, so it covers every account
+/// that owner reads and is not an operator's key.
 /// </para>
 /// <para>
 /// It is deliberately not part of the owner record. That document is configuration, binds strictly against the rules a
@@ -25,14 +32,19 @@ namespace MailFathom.Application.Preferences;
 /// rather than under one an administrator maintains for them.
 /// </para>
 /// </remarks>
-public sealed record ClientPreferences(bool TelemetryEnabled, ClientThemeChoice Theme, bool OpenMailInTabs)
+public sealed record ClientPreferences(
+    bool TelemetryEnabled,
+    ClientThemeChoice Theme,
+    bool OpenMailInTabs,
+    bool MarkReadOnOpen)
 {
     /// <summary>Gets what a person who has set nothing is answered with.</summary>
     /// <remarks>
     /// Telemetry on, because the switch withdraws a default this deployment already applies rather than granting one,
     /// and a stored answer that has never been written is not a refusal. The theme follows the machine, which is what
     /// the client resolves on the device before there is a session to read this at all. Tabs are off, because a person
-    /// who has not asked for them is reading one message at a time.
+    /// who has not asked for them is reading one message at a time. Marking read is on, because every mail client the
+    /// owner already uses does it and a client that leaves their read state behind is one they keep another beside.
     /// </remarks>
-    public static ClientPreferences Unset { get; } = new(true, ClientThemeChoice.System, false);
+    public static ClientPreferences Unset { get; } = new(true, ClientThemeChoice.System, false, true);
 }

--- a/backend/src/Host/Api/ClientPreferencesEndpoint.cs
+++ b/backend/src/Host/Api/ClientPreferencesEndpoint.cs
@@ -44,7 +44,7 @@ internal static class ClientPreferencesEndpoint
 
     /// <summary>The greatest request body the write route reads before refusing it.</summary>
     /// <remarks>
-    /// Far above three scalars and their JSON escaping, and far below anything worth an allocation. The document is
+    /// Far above four scalars and their JSON escaping, and far below anything worth an allocation. The document is
     /// closed, so what the bound guards against is not a large record but a body that was never a preferences document
     /// at all; it is answered <c>413</c> before the handler is reached, as every other write on this surface is.
     /// </remarks>
@@ -127,11 +127,12 @@ internal static class ClientPreferencesEndpoint
 /// <param name="TelemetryEnabled">Whether this deployment may be told what their client is doing, or nothing to say what an unset switch says.</param>
 /// <param name="Theme">The name of what the client is painted in, or nothing to follow the machine.</param>
 /// <param name="OpenMailInTabs">Whether opening a message opens a tab, or nothing for the unset answer.</param>
+/// <param name="MarkReadOnOpen">Whether opening a message marks it read on their mail server, or nothing for the unset answer.</param>
 /// <remarks>
 /// <para>
 /// Bound strictly: a key nothing here binds fails the bind rather than being stored, which is what keeps the document
-/// closed — it holds three preferences because three is what a client can state, not because a writer happened to send
-/// three. Every one of them is optional, and an omitted one is committed as its unset answer rather than left at
+/// closed — it holds four preferences because four is what a client can state, not because a writer happened to send
+/// four. Every one of them is optional, and an omitted one is committed as its unset answer rather than left at
 /// whatever the row held.
 /// </para>
 /// <para>
@@ -145,7 +146,8 @@ internal static class ClientPreferencesEndpoint
 internal sealed record ClientPreferencesRequest(
     bool? TelemetryEnabled = null,
     string? Theme = null,
-    bool? OpenMailInTabs = null)
+    bool? OpenMailInTabs = null,
+    bool? MarkReadOnOpen = null)
 {
     /// <summary>Reads the request as the whole set the write commits.</summary>
     /// <returns>The preferences, with every one the body omitted answered as unset, or <see langword="null" /> when the body names a theme this build does not publish.</returns>
@@ -161,7 +163,8 @@ internal sealed record ClientPreferencesRequest(
         return new ClientPreferences(
             this.TelemetryEnabled ?? ClientPreferences.Unset.TelemetryEnabled,
             theme,
-            this.OpenMailInTabs ?? ClientPreferences.Unset.OpenMailInTabs);
+            this.OpenMailInTabs ?? ClientPreferences.Unset.OpenMailInTabs,
+            this.MarkReadOnOpen ?? ClientPreferences.Unset.MarkReadOnOpen);
     }
 }
 
@@ -169,13 +172,18 @@ internal sealed record ClientPreferencesRequest(
 /// <param name="TelemetryEnabled">Whether this deployment may be told what their client is doing.</param>
 /// <param name="Theme">What the client is painted in once a session exists.</param>
 /// <param name="OpenMailInTabs">Whether opening a message opens a tab rather than replacing what is on the screen.</param>
+/// <param name="MarkReadOnOpen">Whether opening a message marks it read on the owner's own mail server.</param>
 /// <remarks>
 /// Every preference is answered, whether or not the person ever set it, so a client renders one screen rather than one
 /// per combination of what happens to be stored. What it does not report is when anything was set or from where: this
 /// deployment keeps no record of the machines somebody signed in from, and a response saying when a switch last moved
 /// would be the beginning of one.
 /// </remarks>
-internal sealed record ClientPreferencesResponse(bool TelemetryEnabled, string Theme, bool OpenMailInTabs)
+internal sealed record ClientPreferencesResponse(
+    bool TelemetryEnabled,
+    string Theme,
+    bool OpenMailInTabs,
+    bool MarkReadOnOpen)
 {
     /// <summary>Describes one person's preferences on the wire.</summary>
     /// <param name="preferences">What they set.</param>
@@ -188,6 +196,7 @@ internal sealed record ClientPreferencesResponse(bool TelemetryEnabled, string T
         return new ClientPreferencesResponse(
             preferences.TelemetryEnabled,
             preferences.Theme.Name,
-            preferences.OpenMailInTabs);
+            preferences.OpenMailInTabs,
+            preferences.MarkReadOnOpen);
     }
 }

--- a/backend/src/Infrastructure/Persistence/Preferences/ClientPreferencesDocument.cs
+++ b/backend/src/Infrastructure/Persistence/Preferences/ClientPreferencesDocument.cs
@@ -12,6 +12,7 @@ namespace MailFathom.Infrastructure.Persistence.Preferences;
 /// <param name="TelemetryEnabled">What they said about telemetry, or nothing where they never said.</param>
 /// <param name="Theme">What they chose the client to be painted in, or nothing where they never chose.</param>
 /// <param name="OpenMailInTabs">What they said about tabs, or nothing where they never said.</param>
+/// <param name="MarkReadOnOpen">What they said about opening a message marking it read, or nothing where they never said.</param>
 /// <remarks>
 /// <para>
 /// Sparse, and every member is therefore optional: a key the document does not carry reads as that preference's own
@@ -33,7 +34,8 @@ namespace MailFathom.Infrastructure.Persistence.Preferences;
 internal sealed record ClientPreferencesDocument(
     bool? TelemetryEnabled,
     ClientThemeChoice? Theme,
-    bool? OpenMailInTabs)
+    bool? OpenMailInTabs,
+    bool? MarkReadOnOpen)
 {
     /// <summary>How the column is written and read, which is fixed here rather than inherited from a host's own options.</summary>
     /// <remarks>
@@ -59,7 +61,8 @@ internal sealed record ClientPreferencesDocument(
         var document = new ClientPreferencesDocument(
             preferences.TelemetryEnabled,
             preferences.Theme,
-            preferences.OpenMailInTabs);
+            preferences.OpenMailInTabs,
+            preferences.MarkReadOnOpen);
 
         return JsonSerializer.Serialize(document, StoredFormat);
     }
@@ -79,6 +82,7 @@ internal sealed record ClientPreferencesDocument(
         return new ClientPreferences(
             document.TelemetryEnabled ?? ClientPreferences.Unset.TelemetryEnabled,
             document.Theme ?? ClientPreferences.Unset.Theme,
-            document.OpenMailInTabs ?? ClientPreferences.Unset.OpenMailInTabs);
+            document.OpenMailInTabs ?? ClientPreferences.Unset.OpenMailInTabs,
+            document.MarkReadOnOpen ?? ClientPreferences.Unset.MarkReadOnOpen);
     }
 }

--- a/backend/tests/Application.UnitTests/Preferences/OwnClientPreferencesTests.cs
+++ b/backend/tests/Application.UnitTests/Preferences/OwnClientPreferencesTests.cs
@@ -19,7 +19,7 @@ namespace MailFathom.Application.UnitTests.Preferences;
 /// </summary>
 public sealed class OwnClientPreferencesTests
 {
-    private static readonly ClientPreferences Chosen = new(false, ClientThemeChoice.Dark, true);
+    private static readonly ClientPreferences Chosen = new(false, ClientThemeChoice.Dark, true, false);
 
     [Fact]
     public async Task ReadAsync_APersonWhoHasSetSomething_AnswersWhatTheySet()

--- a/backend/tests/Host.UnitTests/Api/ClientPreferencesEndpointTests.cs
+++ b/backend/tests/Host.UnitTests/Api/ClientPreferencesEndpointTests.cs
@@ -23,7 +23,7 @@ namespace MailFathom.Host.UnitTests.Api;
 /// </summary>
 public sealed class ClientPreferencesEndpointTests
 {
-    private static readonly ClientPreferences Chosen = new(false, ClientThemeChoice.Dark, true);
+    private static readonly ClientPreferences Chosen = new(false, ClientThemeChoice.Dark, true, false);
 
     [Fact]
     public async Task ReadAsync_APersonWhoHasSetSomething_HandsThemWhatTheySet()
@@ -43,11 +43,12 @@ public sealed class ClientPreferencesEndpointTests
         Assert.False(preferences.TelemetryEnabled);
         Assert.Equal("dark", preferences.Theme);
         Assert.True(preferences.OpenMailInTabs);
+        Assert.False(preferences.MarkReadOnOpen);
     }
 
     /// <summary>A first run is a screen rather than an error, so every preference is answered whether or not it was ever set.</summary>
     [Fact]
-    public async Task ReadAsync_APersonWhoHasSetNothing_AnswersTelemetryOnTheMachinesThemeAndNoTabs()
+    public async Task ReadAsync_APersonWhoHasSetNothing_AnswersTelemetryOnTheMachinesThemeNoTabsAndMarkingRead()
     {
         // Arrange
         var store = Substitute.For<IClientPreferencesStore>();
@@ -64,6 +65,7 @@ public sealed class ClientPreferencesEndpointTests
         Assert.True(preferences.TelemetryEnabled);
         Assert.Equal("system", preferences.Theme);
         Assert.False(preferences.OpenMailInTabs);
+        Assert.True(preferences.MarkReadOnOpen);
     }
 
     /// <summary>The row is one only this deployment writes, so a reader learns what to do about it and nothing about what it held.</summary>
@@ -98,7 +100,7 @@ public sealed class ClientPreferencesEndpointTests
         // Act
         var result = await ClientPreferencesEndpoint.SaveAsync(
             SignedIn(store),
-            new ClientPreferencesRequest(false, "dark", true),
+            new ClientPreferencesRequest(false, "dark", true, false),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -126,7 +128,7 @@ public sealed class ClientPreferencesEndpointTests
         // Assert
         await store.Received(1).SaveAsync(
             SyntheticMailOwner.Deployment,
-            new ClientPreferences(true, ClientThemeChoice.Light, false),
+            new ClientPreferences(true, ClientThemeChoice.Light, false, true),
             Arg.Any<CancellationToken>());
     }
 
@@ -142,7 +144,7 @@ public sealed class ClientPreferencesEndpointTests
         // Act
         var result = await ClientPreferencesEndpoint.SaveAsync(
             SignedIn(store),
-            new ClientPreferencesRequest(true, "system", false),
+            new ClientPreferencesRequest(true, "system", false, true),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -192,7 +194,7 @@ public sealed class ClientPreferencesEndpointTests
     {
         // Act
         var request = JsonSerializer.Deserialize<ClientPreferencesRequest>(
-            """{"telemetryEnabled":false,"theme":"dark","openMailInTabs":true}""",
+            """{"telemetryEnabled":false,"theme":"dark","openMailInTabs":true,"markReadOnOpen":false}""",
             WebFormat);
 
         // Assert

--- a/backend/tests/Infrastructure.UnitTests/Persistence/Preferences/ClientPreferencesDocumentTests.cs
+++ b/backend/tests/Infrastructure.UnitTests/Persistence/Preferences/ClientPreferencesDocumentTests.cs
@@ -21,10 +21,10 @@ public sealed class ClientPreferencesDocumentTests
     public void Render_APersonsPreferences_WritesEveryOneOfThemUnderItsOwnKey()
     {
         // Act
-        var document = ClientPreferencesDocument.Render(new ClientPreferences(false, ClientThemeChoice.Dark, true));
+        var document = ClientPreferencesDocument.Render(new ClientPreferences(false, ClientThemeChoice.Dark, true, false));
 
         // Assert
-        Assert.Equal("""{"telemetryEnabled":false,"theme":"dark","openMailInTabs":true}""", document);
+        Assert.Equal("""{"telemetryEnabled":false,"theme":"dark","openMailInTabs":true,"markReadOnOpen":false}""", document);
     }
 
     /// <summary>Written whole rather than as a difference from the defaults, so a stored row states what its writer meant however the defaults later move.</summary>
@@ -35,14 +35,14 @@ public sealed class ClientPreferencesDocumentTests
         var document = ClientPreferencesDocument.Render(ClientPreferences.Unset);
 
         // Assert
-        Assert.Equal("""{"telemetryEnabled":true,"theme":"system","openMailInTabs":false}""", document);
+        Assert.Equal("""{"telemetryEnabled":true,"theme":"system","openMailInTabs":false,"markReadOnOpen":true}""", document);
     }
 
     [Fact]
     public void Parse_ADocumentThisBuildWrote_ReadsBackWhatWasWritten()
     {
         // Arrange
-        var chosen = new ClientPreferences(false, ClientThemeChoice.Light, true);
+        var chosen = new ClientPreferences(false, ClientThemeChoice.Light, true, false);
 
         // Act
         var read = ClientPreferencesDocument.Parse(ClientPreferencesDocument.Render(chosen));
@@ -69,7 +69,18 @@ public sealed class ClientPreferencesDocumentTests
         var read = ClientPreferencesDocument.Parse("""{"theme":"dark"}""");
 
         // Assert
-        Assert.Equal(new ClientPreferences(true, ClientThemeChoice.Dark, false), read);
+        Assert.Equal(new ClientPreferences(true, ClientThemeChoice.Dark, false, true), read);
+    }
+
+    /// <summary>ADR 0026 defaults marking read to on, so a row written before the preference existed reads as marking rather than as declining it.</summary>
+    [Fact]
+    public void Parse_ARowWrittenBeforeMarkingReadWasAPreference_AnswersItAsOn()
+    {
+        // Act
+        var read = ClientPreferencesDocument.Parse("""{"telemetryEnabled":false,"theme":"dark","openMailInTabs":true}""");
+
+        // Assert
+        Assert.True(read.MarkReadOnOpen);
     }
 
     /// <summary>A key this build does not know is one a later build wrote, and the strict binding that refuses one belongs at the boundary a person writes through.</summary>

--- a/backend/tests/PublicSurfaces.UnitTests/http-api-contract.json
+++ b/backend/tests/PublicSurfaces.UnitTests/http-api-contract.json
@@ -1642,6 +1642,12 @@
       "ClientPreferencesRequest": {
         "additionalProperties": false,
         "properties": {
+          "markReadOnOpen": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
           "openMailInTabs": {
             "type": [
               "null",
@@ -1665,6 +1671,9 @@
       },
       "ClientPreferencesResponse": {
         "properties": {
+          "markReadOnOpen": {
+            "type": "boolean"
+          },
           "openMailInTabs": {
             "type": "boolean"
           },
@@ -1678,7 +1687,8 @@
         "required": [
           "telemetryEnabled",
           "theme",
-          "openMailInTabs"
+          "openMailInTabs",
+          "markReadOnOpen"
         ],
         "type": "object"
       },

--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -482,8 +482,9 @@ guarantee that synchronization and content retrieval never mark mail read is a p
 [ADR 0007](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0007-remote-mailbox-mutation-boundary-and-write-session.md)
 records in full — and the push session is never taken out of `IDLE` to carry a change.
 
-A rule's action, a spam verdict's action, and the `set_mail_flags` MCP tool are what ask for a change today, so an
-account whose rules write nothing, whose spam actions are off, and whose mail no caller has changed holds no such
+A rule's action, a spam verdict's action, the `set_mail_flags` MCP tool, and somebody opening a message in MailFathom's
+own client with `markReadOnOpen` on are what ask for a change today, so an account whose rules write nothing, whose spam
+actions are off, whose mail no caller has changed, and whose reader has not opened a message here holds no such
 connection and this setting costs nothing.
 
 ### Every change is written down before it is issued

--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -599,6 +599,15 @@ opens the write session and issues the command. So the flag still moves because 
 never because something read the message — and the type separation stays a property of the code rather than a rule
 somebody has to remember.
 
+**MailFathom's own client authors one too, when somebody opens a message and its words reach the screen.** That is the
+one place a person's act and a read of the local copy coincide, and it is still an authored change rather than a side
+effect of the read: the client submits it to the same route `set_mail_flags` writes through, so it holds neither session
+type either, and the account's own run is what tells the mail server. What decides whether it happens is the reader's
+own setting, on unless they turn it off, and the grant their credential signed in under — a client whose credential may
+not write a flag says so and marks nothing.
+[ADR 0026](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0026-marking-a-message-read-when-a-person-opens-it-in-the-client.md)
+is the decision, including why it is the body having been drawn rather than the selection having moved.
+
 Both directions are one mutation and one authored act, because both are the same statement about the same flag. Setting
 it is what stops mail MailFathom has already handled from sitting unread in the client the owner actually opens;
 clearing it is what lets automation put something back in front of them.

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -1036,8 +1036,10 @@ list destructive.
 
 **Nothing on this surface sets `\Seen` implicitly.** Reading a message does not mark it read anywhere — not the message
 route, not the body route, not the attachment route. Marking a message read is a flag change submitted here and nothing
-else; [ADR 0026](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0026-marking-a-message-read-when-a-person-opens-it-in-the-client.md)
-is what decides when the client submits one on a person's behalf.
+else. What MailFathom's own client does with that is
+[ADR 0026](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0026-marking-a-message-read-when-a-person-opens-it-in-the-client.md)'s
+answer rather than this route's: a person opening a message has the client submit one change here, unless they turned
+[`markReadOnOpen`](#the-preferences-routes) off or the credential was never granted `mailfathom.mail.flags.write`.
 
 **A move names the folder by its alias**, exactly as the folders route publishes it, rather than by its place on the
 server: an alias keeps its meaning when the server renames or recreates the folder behind it.
@@ -1235,19 +1237,30 @@ and somebody who set the client up the way they work should not have to set it u
 | `POST /api/client/preferences` | Replaces all of them, as one document |
 
 ```json
-{ "telemetryEnabled": true, "theme": "system", "openMailInTabs": false }
+{ "telemetryEnabled": true, "theme": "system", "openMailInTabs": false, "markReadOnOpen": true }
 ```
 
-**It holds three preferences and nothing else.** Whether this deployment may be told what the person's client is doing;
-what the client is painted in, which is `system`, `light`, or `dark`; and whether opening a message opens a tab rather
-than replacing what is on the screen. Each of them says how somebody wants to work, which is why it belongs to the
+**It holds four preferences and nothing else.** Whether this deployment may be told what the person's client is doing;
+what the client is painted in, which is `system`, `light`, or `dark`; whether opening a message opens a tab rather
+than replacing what is on the screen; and whether opening a message marks it read on the person's own mail server. Each
+of them says how somebody wants to work, which is why it belongs to the
 person. The language does not, and stays on the device: it is resolved for somebody who has not signed in and may never
 get a session. Neither does the width a person drags the message list to, which describes the screen in front of them.
 
-**Unset reads as telemetry on, the theme following the machine, and tabs off.** A person who has set nothing is
+**Unset reads as telemetry on, the theme following the machine, tabs off, and marking read on.** A person who has set
+nothing is
 answered a document rather than a refusal, so a first run draws a screen. The theme is still resolved on the device
 before sign-in — the client cannot wait on the network to paint itself, and there is no session to read this over above
 the sign-in screen — and what this answers replaces that device value once a session exists.
+
+**`markReadOnOpen` covers every account that person reads, and turning it off stores no read state instead.** It is one
+value rather than one per mailbox because read state is what must not differ between the machines somebody reads on, and
+a client whose owner has turned it off shows what their mail server last reported and remembers no reading of its own.
+It governs opening a message and nothing else: marking a message read or unread deliberately, through the flag
+mutations above, is unaffected by it.
+[ADR 0026](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0026-marking-a-message-read-when-a-person-opens-it-in-the-client.md)
+holds the reasoning, including why an operator's lever here is
+[`mailfathom.mail.flags.write`](permissions.md#the-published-set) rather than a key of their own.
 
 **A write states the whole document.** It is a closed set rather than a patch: a key nothing binds is refused rather
 than stored, a theme this deployment does not publish is refused naming the three that are, and a preference the body

--- a/docs/users/README.md
+++ b/docs/users/README.md
@@ -26,12 +26,16 @@ Two properties hold everywhere and are worth knowing before anything is installe
 
 - **Reading is local.** A read answers from the local copy and never contacts a mail server, so it is fast, works while
   the server is down, and changes nothing remotely. Every result states how fresh the local copy is.
-- **Retrieval is read-only.** Fetching mail never sets the remote `\Seen` flag, so mail MailFathom has copied still
-  shows as unread in your mail client until you read it there. Three things write to your mailbox: a mail rule whose
-  action moves, copies, deletes, or marks a message read, the spam actions that file junk and mark it read, and the
-  `set_mail_flags` tool, beside the three draft tools that put a message into your own Drafts folder. The first two are
-  off until you turn them on; the last two need grants that reading mail does not carry. A fourth path leaves your
-  deployment altogether rather than writing to your mailbox: `send_email`,
+- **Retrieval is read-only.** Fetching mail never sets the remote `\Seen` flag, so a message MailFathom has copied is
+  still unread on your mail server until something says otherwise. Four things write to your mailbox: a mail rule whose
+  action moves, copies, deletes, or marks a message read, the spam actions that file junk and mark it read, the
+  `set_mail_flags` tool, and MailFathom's own client, which marks a message read on your mail server when you open it
+  and read its words — beside the three draft tools that put a message into your own Drafts folder. The first two are
+  off until you turn them on; the tool and the drafts need grants that reading mail does not carry, and so does the
+  client, which marks nothing where its credential was not granted one. What the client does is a preference of yours
+  rather than the deployment's, held with the rest of your client settings and covering every mailbox it reads; it is
+  on unless you turn it off, and the control that turns it off arrives with the client's settings screen. A fifth path
+  leaves your deployment altogether rather than writing to your mailbox: `send_email`,
   `reply_to_email`, `forward_email`, and `send_draft`, behind
   a grant of its own, and they are the acts here nothing can take back.
 

--- a/docs/users/mailbox-providers.md
+++ b/docs/users/mailbox-providers.md
@@ -99,7 +99,9 @@ per provider here:
   [the folders, and what each service calls them](#the-folders-and-what-each-service-calls-them) what you are naming.
 - **Reading never marks mail read.** MailFathom does not set the remote `\Seen` flag while synchronizing, reconciling,
   fetching content, or answering a tool call — the sessions those run on hold no operation capable of writing a flag.
-  If mail is turning up read at your service, it is another client or a rule at the service, not this one.
+  The flag moves only where somebody asked for it: a rule you wrote, the `set_mail_flags` tool, or your opening a
+  message in MailFathom's own client. If mail is turning up read at your service and none of those was it, it is
+  another client or a rule at the service, not this one.
   [Marking mail read is an act, never a side effect of reading](../features/imap-synchronization.md#marking-mail-read-is-an-act-never-a-side-effect-of-reading)
   states the guarantee and its one deliberate exception.
 - **Whether `"Mode": "Push"` does anything is the server's answer, not a setting.** Push needs the `IDLE` extension, and

--- a/docs/users/mailbox-providers.md
+++ b/docs/users/mailbox-providers.md
@@ -99,9 +99,9 @@ per provider here:
   [the folders, and what each service calls them](#the-folders-and-what-each-service-calls-them) what you are naming.
 - **Reading never marks mail read.** MailFathom does not set the remote `\Seen` flag while synchronizing, reconciling,
   fetching content, or answering a tool call — the sessions those run on hold no operation capable of writing a flag.
-  The flag moves only where somebody asked for it: a rule you wrote, the `set_mail_flags` tool, or your opening a
-  message in MailFathom's own client. If mail is turning up read at your service and none of those was it, it is
-  another client or a rule at the service, not this one.
+  The flag moves only where somebody asked for it: a rule you wrote, a spam verdict's action you turned on, the
+  `set_mail_flags` tool, or your opening a message in MailFathom's own client. If mail is turning up read at your
+  service and none of those four was it, it is another client or a rule at the service, not this one.
   [Marking mail read is an act, never a side effect of reading](../features/imap-synchronization.md#marking-mail-read-is-an-act-never-a-side-effect-of-reading)
   states the guarantee and its one deliberate exception.
 - **Whether `"Mode": "Push"` does anything is the server's answer, not a setting.** Push needs the `IDLE` extension, and

--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -621,6 +621,14 @@ describe('App', () => {
         await screen.findByText('A drawn message.');
 
         expect(routesAsked().some((path) => path.includes('/mutations/'))).toBe(false);
+
+        // An absence nobody explained is a client that looks broken, which is what the notice strip is for — so the
+        // sentence is asserted on the screen rather than the withholding being asserted on its own.
+        expect(
+            screen.getByText(
+                'This credential may not change a flag on your mail server, so opening a message leaves it unread there and this client shows what the server last reported. Whoever runs the deployment can grant that.',
+            ),
+        ).toBeDefined();
     });
 
     it('draws no message until a row of the list opens one', async () => {

--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -188,14 +188,23 @@ const folderWithOneMessage: Answer = {
  * The two are separate routes because they are separately expensive, so the double answers them separately as well —
  * a description that also served a body would prove the pane against an exchange the service does not have.
  */
-function deploymentDrawingAMessage(): DeploymentTransport {
-    const otherwise = deploymentAnswering();
+function deploymentDrawingAMessage(session: Answer = accepted): DeploymentTransport {
+    const otherwise = deploymentAnswering(directory(true, [workAccount]), session);
 
     return (signal) => (request) => {
         if (request.path.includes('/emails')) {
             asked.push(request);
 
             return Promise.resolve(complete(folderWithOneMessage));
+        }
+
+        // The one route here that changes a mailbox. It is answered rather than left to fall through, because a
+        // submission the deployment did not write down is one the frame stops claiming — which would make an assertion
+        // about the row pass for a client that never marked anything.
+        if (request.path.endsWith('/mutations/flags')) {
+            asked.push(request);
+
+            return Promise.resolve(complete(flagsRecorded(request.body ?? '{}')));
         }
 
         if (!request.path.includes('/messages/')) {
@@ -205,6 +214,18 @@ function deploymentDrawingAMessage(): DeploymentTransport {
         asked.push(request);
 
         return Promise.resolve(complete(request.path.includes('/body') ? drawnMessage : describedMessage));
+    };
+}
+
+/** Every change a batch named, written down, which is what a deployment holding the grant answers with. */
+function flagsRecorded(stated: string): Answer {
+    const changes = (JSON.parse(stated) as { changes: readonly { storedEmailId: string }[] }).changes;
+
+    return {
+        status: 200,
+        body: JSON.stringify({
+            results: changes.map(({ storedEmailId }) => ({ storedEmailId, outcome: 'recorded' })),
+        }),
     };
 }
 
@@ -411,6 +432,10 @@ async function goTo(space: string): Promise<void> {
 const declaredMatchMedia = Object.getOwnPropertyDescriptor(window, 'matchMedia');
 
 beforeEach(() => {
+    // Cleared here as well as after each test, because a read the previous test started can answer while its tree is
+    // still being torn down and start one more — which lands in this record after the teardown emptied it, and reads
+    // as this test having asked for a route it never reached.
+    asked.length = 0;
     openingAt('/');
     Object.defineProperty(window, 'matchMedia', {
         configurable: true,
@@ -553,6 +578,49 @@ describe('App', () => {
         await waitFor(() => {
             expect(document.activeElement).toBe(screen.getByRole('article', { name: /Quarterly invoice/ }));
         });
+    });
+
+    // Three things decide whether opening a message marks it read, and all three are the frame's: the reader's own
+    // setting, the grant the credential signed in under, and there being a session to submit over. Nothing below the
+    // frame asks the question, so this is where each of them is proven.
+    it('marks read a message a row opened, where the credential may write a flag', async () => {
+        renderApp(
+            servedFrom,
+            heldCredential,
+            deploymentDrawingAMessage(
+                sessionAnswering(['mailfathom.mail.read', 'mailfathom.mail.ask', 'mailfathom.mail.flags.write']),
+            ),
+        );
+        await framed();
+
+        await goTo('Mail');
+
+        const list = await screen.findByRole('listbox', { name: 'Messages' });
+        fireEvent.pointerDown(within(list).getByRole('option', { name: /Quarterly invoice/ }));
+        await screen.findByText('A drawn message.');
+
+        await waitFor(() => {
+            expect(
+                asked.some(
+                    (request) =>
+                        request.path === 'https://mail.example.invalid/api/client/mutations/flags' &&
+                        request.method === 'POST',
+                ),
+            ).toBe(true);
+        });
+    });
+
+    it('marks nothing where the credential was never granted a flag write, and says so rather than failing', async () => {
+        renderApp(servedFrom, heldCredential, deploymentDrawingAMessage());
+        await framed();
+
+        await goTo('Mail');
+
+        const list = await screen.findByRole('listbox', { name: 'Messages' });
+        fireEvent.pointerDown(within(list).getByRole('option', { name: /Quarterly invoice/ }));
+        await screen.findByText('A drawn message.');
+
+        expect(routesAsked().some((path) => path.includes('/mutations/'))).toBe(false);
     });
 
     it('draws no message until a row of the list opens one', async () => {

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -13,6 +13,7 @@ import { useLocalization } from './localization/useLocalization';
 import { MessageList } from './messageList/MessageList';
 import { forgetListings } from './messageList/rememberedListings';
 import { useClientPreferences } from './preferences/useClientPreferences';
+import { ReadMarkingProvider } from './readMarking/ReadMarking';
 import { ReadingPane } from './readingPane/ReadingPane';
 import { useSpace } from './routing/useSpace';
 import { MailSearch } from './search/MailSearch';
@@ -146,6 +147,13 @@ export function App({
     // would meet nothing at all.
     const preferences = useClientPreferences(readsMail && connection.online ? session : null, readMail);
 
+    // Whether opening a message marks it read on the person's own mail server, which is the frame's answer rather than
+    // a screen's for the reason ADR 0026 gives about the two halves of it: the reader's own setting says what they want
+    // of every account they read, and the grant says whether this credential may write a flag at all. Either missing is
+    // the same client — one that draws what the mail server last reported and marks nothing.
+    const markingRead =
+        preferences.markReadOnOpen && deploymentSession !== null && offers(deploymentSession, 'markMailRead');
+
     function signedIn(reached: DeploymentAddress, presented: string): void {
         if (adopted === null) {
             storeDeployment(reached);
@@ -214,113 +222,118 @@ export function App({
     }
 
     return (
-        <div className="flex h-dvh flex-col bg-rail pt-safe-top pr-safe-right pb-safe-bottom pl-safe-left workspace:flex-row">
-            <div ref={workspaceRegion} tabIndex={-1} className="flex min-h-0 min-w-0 flex-1 flex-col bg-page">
-                {/* Inside the frame as well as on the sign-in screen, because a credential that could not be kept is
+        // Above the frame rather than inside a space, because three unrelated places below read what has been marked:
+        // the row that draws a message, the folder tree that counts unread mail, and the body that marks one on being
+        // drawn. What it holds goes with the credential, exactly as the workspace does.
+        <ReadMarkingProvider session={session} transport={readMail} marking={markingRead}>
+            <div className="flex h-dvh flex-col bg-rail pt-safe-top pr-safe-right pb-safe-bottom pl-safe-left workspace:flex-row">
+                <div ref={workspaceRegion} tabIndex={-1} className="flex min-h-0 min-w-0 flex-1 flex-col bg-page">
+                    {/* Inside the frame as well as on the sign-in screen, because a credential that could not be kept is
                     learned about at the moment somebody successfully signed in — which is the one of these sentences
                     whose reader is already past that screen. Beside it, and in the same strip, is what this credential
                     may not do: both are statements about the credential rather than about anything it read. */}
-                {notices.length === 0 && withheld.length === 0 ? null : (
-                    <div className="flex flex-col gap-2 border-b border-line-soft bg-panel px-4 py-2 workspace:px-8">
-                        <CredentialNotices notices={notices} />
-                        <GrantNotice withheld={withheld} />
-                    </div>
-                )}
+                    {notices.length === 0 && withheld.length === 0 ? null : (
+                        <div className="flex flex-col gap-2 border-b border-line-soft bg-panel px-4 py-2 workspace:px-8">
+                            <CredentialNotices notices={notices} />
+                            <GrantNotice withheld={withheld} />
+                        </div>
+                    )}
 
-                {/* The region the space is drawn in is there before the deployment says which space that is, so
+                    {/* The region the space is drawn in is there before the deployment says which space that is, so
                     nothing on the screen moves under a reader when the answer arrives. Until it does, what stands in
                     the region is what the connection says — reaching, retrying, offline, or refused — because that is
                     the only thing on the screen there is to read, and the way out of a deployment that never answers
                     has to be somewhere. */}
-                {space === null ? (
-                    <main className="flex-1 px-4 py-6 workspace:px-8">
-                        <ConnectionSummary connection={connection} />
-                    </main>
-                ) : (
-                    <Space
-                        space={space}
-                        // Who is signed in, taken apart in the one module that composes a credential and never here.
-                        // A screen never sees the credential; what it is handed is the name the deployment knows the
-                        // person by, which is what a preference kept per person on this machine is written under.
-                        person={userNameIn(authorization)}
-                        // Asking is what the field is for, so a credential that may not ask is not shown one. It is
-                        // absent rather than disabled: a control nobody can use says less about why than the sentence
-                        // above does. Where it stands is the space's decision, which is why it is handed in rather
-                        // than drawn here.
-                        intent={
-                            deploymentSession !== null && offers(deploymentSession, 'askMail') ? (
-                                <IntentField accounts={mailAccounts} />
-                            ) : null
-                        }
-                        status={<ConnectionSummary connection={connection} />}
-                        folders={
-                            session === null || !readsMail ? null : (
-                                <FolderTree session={session} transport={readMail} online={connection.online} />
-                            )
-                        }
-                        list={
-                            session === null || !readsMail ? null : (
-                                // Both keyed by the scope, so pointing at another mailbox starts a list and a search
-                                // rather than resetting either: every value below belongs to one mailbox read one way,
-                                // and a search carries the mailbox it was made in as a filter it would go on showing.
-                                // Searching stands above the list rather than beside it because it is where somebody
-                                // reaches for it — looking at a folder, with the message not in front of them — and
-                                // what it finds is drawn in the same column with the same row.
-                                <MailSearch
-                                    key={scopeKey(workspace.scope)}
-                                    session={session}
-                                    transport={readMail}
-                                    scope={workspace.scope}
-                                    accounts={mailAccounts}
-                                    online={connection.online}
-                                >
-                                    <MessageList
+                    {space === null ? (
+                        <main className="flex-1 px-4 py-6 workspace:px-8">
+                            <ConnectionSummary connection={connection} />
+                        </main>
+                    ) : (
+                        <Space
+                            space={space}
+                            // Who is signed in, taken apart in the one module that composes a credential and never here.
+                            // A screen never sees the credential; what it is handed is the name the deployment knows the
+                            // person by, which is what a preference kept per person on this machine is written under.
+                            person={userNameIn(authorization)}
+                            // Asking is what the field is for, so a credential that may not ask is not shown one. It is
+                            // absent rather than disabled: a control nobody can use says less about why than the sentence
+                            // above does. Where it stands is the space's decision, which is why it is handed in rather
+                            // than drawn here.
+                            intent={
+                                deploymentSession !== null && offers(deploymentSession, 'askMail') ? (
+                                    <IntentField accounts={mailAccounts} />
+                                ) : null
+                            }
+                            status={<ConnectionSummary connection={connection} />}
+                            folders={
+                                session === null || !readsMail ? null : (
+                                    <FolderTree session={session} transport={readMail} online={connection.online} />
+                                )
+                            }
+                            list={
+                                session === null || !readsMail ? null : (
+                                    // Both keyed by the scope, so pointing at another mailbox starts a list and a search
+                                    // rather than resetting either: every value below belongs to one mailbox read one way,
+                                    // and a search carries the mailbox it was made in as a filter it would go on showing.
+                                    // Searching stands above the list rather than beside it because it is where somebody
+                                    // reaches for it — looking at a folder, with the message not in front of them — and
+                                    // what it finds is drawn in the same column with the same row.
+                                    <MailSearch
                                         key={scopeKey(workspace.scope)}
                                         session={session}
                                         transport={readMail}
                                         scope={workspace.scope}
                                         accounts={mailAccounts}
                                         online={connection.online}
+                                    >
+                                        <MessageList
+                                            key={scopeKey(workspace.scope)}
+                                            session={session}
+                                            transport={readMail}
+                                            scope={workspace.scope}
+                                            accounts={mailAccounts}
+                                            online={connection.online}
+                                        />
+                                    </MailSearch>
+                                )
+                            }
+                            mail={
+                                session === null ? null : (
+                                    <OpenMail
+                                        session={session}
+                                        transport={readMail}
+                                        conversation={workspace.conversation}
+                                        storedEmailId={workspace.selection}
+                                        online={connection.online}
                                     />
-                                </MailSearch>
-                            )
-                        }
-                        mail={
-                            session === null ? null : (
-                                <OpenMail
-                                    session={session}
-                                    transport={readMail}
-                                    conversation={workspace.conversation}
-                                    storedEmailId={workspace.selection}
-                                    online={connection.online}
-                                />
-                            )
-                        }
-                    />
-                )}
-            </div>
+                                )
+                            }
+                        />
+                    )}
+                </div>
 
-            {/* Navigation is last in the document because the keyboard follows the document rather than the layout,
+                {/* Navigation is last in the document because the keyboard follows the document rather than the layout,
                 and the narrow composition puts it at the bottom of the screen: written the other way round, a reader
                 tabbing into a narrow window would reach the bottom bar before the header above it. The wide
                 composition then carries the one mismatch CSS cannot remove — a rail drawn on the left out of a node
                 that comes last — because no single document order matches both shapes, and content before navigation
                 is the direction a skip link exists to manufacture rather than the one it works around. */}
-            <SpaceNavigation
-                offered={offeredSpaces}
-                current={space}
-                account={
-                    <AccountMenu
-                        accounts={mailAccounts}
-                        deploymentVersion={deploymentSession?.version ?? null}
-                        readingFrom={adopted?.chosen === true ? baseAddress : null}
-                        preferences={preferences}
-                        onPointSomewhereElse={pointSomewhereElse}
-                        onSignOut={signOut}
-                    />
-                }
-            />
-        </div>
+                <SpaceNavigation
+                    offered={offeredSpaces}
+                    current={space}
+                    account={
+                        <AccountMenu
+                            accounts={mailAccounts}
+                            deploymentVersion={deploymentSession?.version ?? null}
+                            readingFrom={adopted?.chosen === true ? baseAddress : null}
+                            preferences={preferences}
+                            onPointSomewhereElse={pointSomewhereElse}
+                            onSignOut={signOut}
+                        />
+                    }
+                />
+            </div>
+        </ReadMarkingProvider>
     );
 }
 

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -137,9 +137,9 @@ export function App({
     const mailAccounts = connection.accounts?.outcome === 'read' ? connection.accounts.value.accounts : [];
     const readsMail = deploymentSession !== null && offers(deploymentSession, 'readMail');
 
-    // The two settings that follow the person rather than this machine. They are read here rather than in the menu that
-    // shows them because the tab mode decides what opening a message does, which is the frame's rather than a menu's —
-    // #1494 is where that half lands, and this is where it will already be.
+    // The settings that follow the person rather than this machine. They are read here rather than in the menu that
+    // shows them because two of them decide what opening a message does, which is the frame's rather than a menu's —
+    // the tab mode, whose other half lands in #1494 and will already be here, and whether opening one marks it read.
     //
     // Asked for on the same three conditions the mail itself is: somebody signed in, a machine with a network, and a
     // credential the deployment lets read. The route is admitted under the grant a reader already holds, so a

--- a/frontend/src/Client.App/src/folders/FolderTree.test.tsx
+++ b/frontend/src/Client.App/src/folders/FolderTree.test.tsx
@@ -7,6 +7,7 @@ import { fireEvent, render, screen, type RenderResult } from '@testing-library/r
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ClientSession, MailFathomTransport } from '@mailfathom/client-backend';
 import { LocalizationProvider } from '../localization/Localization';
+import { ReadMarkingContext, nothingMarkedRead, type MarkedIn, type ReadMarking } from '../readMarking/useReadMarking';
 import { WorkspaceProvider } from '../workspace/Workspace';
 import { useWorkspace, type Workspace } from '../workspace/useWorkspace';
 import { FolderTree } from './FolderTree';
@@ -94,19 +95,33 @@ function carried(): Workspace {
     return JSON.parse(probe?.textContent ?? '') as Workspace;
 }
 
-function treeUnder(transport: MailFathomTransport, online: boolean): ReactElement {
+function treeUnder(
+    transport: MailFathomTransport,
+    online: boolean,
+    marking: ReadMarking = nothingMarkedRead,
+): ReactElement {
     return (
         <LocalizationProvider>
             <WorkspaceProvider>
-                <FolderTree session={session} transport={transport} online={online} />
+                <ReadMarkingContext value={marking}>
+                    <FolderTree session={session} transport={transport} online={online} />
+                </ReadMarkingContext>
                 <ScopeProbe />
             </WorkspaceProvider>
         </LocalizationProvider>
     );
 }
 
-function renderTree(transport: MailFathomTransport, online = true): RenderResult {
-    return render(treeUnder(transport, online));
+function renderTree(transport: MailFathomTransport, online = true, marking?: ReadMarking): RenderResult {
+    return render(treeUnder(transport, online, marking));
+}
+
+/** A client that has marked the named messages read, each in the folder the list counted it in. */
+function marked(...places: readonly MarkedIn[]): ReadMarking {
+    return {
+        marked: new Map(places.map((place, at) => [`message-${String(at)}`, place])),
+        markRead: () => undefined,
+    };
 }
 
 function row(name: RegExp): HTMLElement {
@@ -179,6 +194,32 @@ describe('FolderTree', () => {
 
         expect(row(/^Inbox12 unread/).textContent).toContain('12 unread');
         expect(row(/^Inbox12 unread/).textContent).not.toContain('4,213');
+    });
+
+    // A count that still named a message the reader has just opened would disagree with the row drawing that message
+    // read, which is the one thing about an unread count somebody notices. Every level of the tree is a sum over the
+    // same folders, so the correction is applied once to the folders and each of them answers for it.
+    it('takes what this client has marked read off the folder, its mailbox, and the role across mailboxes', async () => {
+        renderTree(
+            answering(JSON.stringify(tree)),
+            true,
+            marked({ account: 'work', folder: 'INBOX' }, { account: 'work', folder: 'INBOX' }),
+        );
+
+        await drawn();
+
+        expect(row(/^Inbox10 unread/).textContent).toContain('10 unread');
+        expect(row(/^Work10 unread/).textContent).toContain('10 unread');
+        expect(row(/^Inbox13 unread/).textContent).toContain('13 unread');
+        expect(row(/^All mailboxes13 unread/).textContent).toContain('13 unread');
+    });
+
+    it('leaves a mailbox this client has marked nothing in exactly as the deployment counted it', async () => {
+        renderTree(answering(JSON.stringify(tree)), true, marked({ account: 'work', folder: 'INBOX' }));
+
+        await drawn();
+
+        expect(row(/^Personal/).textContent).toContain('3 unread');
     });
 
     it('offers every mailbox at once as the scope everything else is read under', async () => {

--- a/frontend/src/Client.App/src/folders/FolderTree.tsx
+++ b/frontend/src/Client.App/src/folders/FolderTree.tsx
@@ -14,10 +14,12 @@ import {
 import { SecondaryButton } from '../controls/SecondaryButton';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
+import { useReadMarking } from '../readMarking/useReadMarking';
 import { scopeKey } from '../workspace/mailScope';
 import { useWorkspace } from '../workspace/useWorkspace';
 import { FolderRow } from './FolderRow';
 import { folderTreeOf, visibleRows, type VisibleRow } from './folderTreeRows';
+import { unreadAfterMarking } from './unreadAfterMarking';
 
 // The client's scope selector: which mailbox and which folder everything else is about. It is a tree because the
 // mailboxes are a tree, and it is one tree rather than one per account because several mailboxes are one workspace —
@@ -54,6 +56,7 @@ export function FolderTree({
 }) {
     const { translate } = useLocalization();
     const { workspace, revise } = useWorkspace();
+    const { marked } = useReadMarking();
     const [attempt, setAttempt] = useState(0);
     const [answered, setAnswered] = useState<Answered | null>(null);
     const [focused, setFocused] = useState<string | null>(null);
@@ -128,7 +131,10 @@ export function FolderTree({
         );
     }
 
-    const directory = answered.result.value;
+    // What the deployment answered, less the mail this client has marked read since it answered. A count that still
+    // named a message the reader has just opened would disagree with the row drawing that message read, which is the
+    // one thing about an unread count somebody notices.
+    const directory = unreadAfterMarking(answered.result.value, marked);
 
     // An owner holding no account is told so and told what would fill it, rather than being handed an empty tree.
     if (directory.accounts.length === 0) {

--- a/frontend/src/Client.App/src/folders/unreadAfterMarking.test.ts
+++ b/frontend/src/Client.App/src/folders/unreadAfterMarking.test.ts
@@ -1,0 +1,105 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import type { MailAccount, MailFolder, MailFolderDirectory } from '@mailfathom/client-backend';
+import type { MarkedIn } from '../readMarking/useReadMarking';
+import { unreadAfterMarking } from './unreadAfterMarking';
+
+function account(id: string, displayName: string): MailAccount {
+    return {
+        id,
+        displayName,
+        synchronizationState: 'Synchronized',
+        lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
+        behind: false,
+    };
+}
+
+function folder(folder: Partial<MailFolder> & Pick<MailFolder, 'alias'>): MailFolder {
+    return {
+        role: null,
+        path: [folder.alias],
+        storedEmailCount: 0,
+        unreadEmailCount: 0,
+        synchronizationState: 'Synchronized',
+        lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
+        behind: false,
+        ...folder,
+    };
+}
+
+const directory: MailFolderDirectory = {
+    synchronizationEnabled: true,
+    accounts: [
+        {
+            account: account('work', 'Work'),
+            folders: [
+                folder({ alias: 'INBOX', role: 'Inbox', unreadEmailCount: 12 }),
+                folder({ alias: 'ARCHIVE', unreadEmailCount: 2 }),
+            ],
+        },
+        {
+            account: account('personal', 'Personal'),
+            folders: [folder({ alias: 'INBOX', role: 'Inbox', unreadEmailCount: 3 })],
+        },
+    ],
+};
+
+function marking(...marked: readonly (readonly [string, MarkedIn])[]): ReadonlyMap<string, MarkedIn> {
+    return new Map(marked);
+}
+
+function unreadIn(corrected: MailFolderDirectory, account: string, alias: string): number | undefined {
+    return corrected.accounts
+        .find((entry) => entry.account.id === account)
+        ?.folders.find((folder) => folder.alias === alias)?.unreadEmailCount;
+}
+
+describe('unreadAfterMarking', () => {
+    it('takes what this client has marked read off the folder it was counted in', () => {
+        const corrected = unreadAfterMarking(
+            directory,
+            marking(['first', { account: 'work', folder: 'INBOX' }], ['second', { account: 'work', folder: 'INBOX' }]),
+        );
+
+        expect(unreadIn(corrected, 'work', 'INBOX')).toBe(10);
+    });
+
+    // Two mailboxes name a folder the same way, and a count keyed by the name alone would take one person's reading
+    // off the other's inbox.
+    it('leaves a folder of the same name in another account alone', () => {
+        const corrected = unreadAfterMarking(directory, marking(['first', { account: 'work', folder: 'INBOX' }]));
+
+        expect(unreadIn(corrected, 'personal', 'INBOX')).toBe(3);
+        expect(unreadIn(corrected, 'work', 'ARCHIVE')).toBe(2);
+    });
+
+    // A folder synchronized between the marking and this read already reports the message as read, so subtracting
+    // again would count it twice — and a count below nothing is a count nobody can read.
+    it('never takes a folder below nothing', () => {
+        const corrected = unreadAfterMarking(
+            directory,
+            marking(
+                ['first', { account: 'personal', folder: 'INBOX' }],
+                ['second', { account: 'personal', folder: 'INBOX' }],
+                ['third', { account: 'personal', folder: 'INBOX' }],
+                ['fourth', { account: 'personal', folder: 'INBOX' }],
+            ),
+        );
+
+        expect(unreadIn(corrected, 'personal', 'INBOX')).toBe(0);
+    });
+
+    it('answers the directory it was given where nothing has been marked', () => {
+        expect(unreadAfterMarking(directory, marking())).toBe(directory);
+    });
+
+    it('leaves a folder this client has marked nothing in exactly as the deployment answered', () => {
+        const corrected = unreadAfterMarking(directory, marking(['first', { account: 'work', folder: 'DRAFTS' }]));
+
+        expect(unreadIn(corrected, 'work', 'INBOX')).toBe(12);
+        expect(unreadIn(corrected, 'work', 'ARCHIVE')).toBe(2);
+    });
+});

--- a/frontend/src/Client.App/src/folders/unreadAfterMarking.ts
+++ b/frontend/src/Client.App/src/folders/unreadAfterMarking.ts
@@ -1,0 +1,65 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { MailFolderDirectory } from '@mailfathom/client-backend';
+import type { MarkedIn } from '../readMarking/useReadMarking';
+
+// A folder's unread count and the rows of that folder have to say the same thing, and for minutes at a time the
+// deployment's own answer does not: marking a message read is a durable mutation the account's own pass carries to the
+// mail server, and the stored count follows the observation rather than the mutation. So the count a reader sees is
+// what the deployment reported, less what this client has marked read in that folder since.
+//
+// It is applied to the directory before the tree is built rather than to a row afterwards, which is what keeps the four
+// levels of the tree agreeing with each other: the account row, the role rows across accounts, and the whole-workspace
+// row are each a sum over the same folders, so correcting the folders corrects all of them and nothing sums a corrected
+// number twice.
+
+/**
+ * The directory with each folder's unread count reduced by what this client has marked read in it.
+ *
+ * @param directory What the folders route answered.
+ * @param marked What this client has marked read, by the message, with the folder each was counted in.
+ * @returns The directory to draw, or the one it was given where nothing has been marked.
+ */
+export function unreadAfterMarking(
+    directory: MailFolderDirectory,
+    marked: ReadonlyMap<string, MarkedIn>,
+): MailFolderDirectory {
+    if (marked.size === 0) {
+        return directory;
+    }
+
+    const markedPerFolder = new Map<string, number>();
+
+    for (const { account, folder } of marked.values()) {
+        const key = folderKey(account, folder);
+
+        markedPerFolder.set(key, (markedPerFolder.get(key) ?? 0) + 1);
+    }
+
+    return {
+        ...directory,
+        accounts: directory.accounts.map((entry) => ({
+            ...entry,
+            folders: entry.folders.map((folder) => ({
+                ...folder,
+                // Floored at nothing rather than trusted to stay positive: a folder synchronized between the marking
+                // and this read already reports the message as read, and subtracting again would count it twice.
+                unreadEmailCount: Math.max(
+                    folder.unreadEmailCount - (markedPerFolder.get(folderKey(entry.account.id, folder.alias)) ?? 0),
+                    0,
+                ),
+            })),
+        })),
+    };
+}
+
+// A message is placed by its account and its folder together, because two mailboxes name a folder the same way and a
+// key that collided would take one account's reading off the other's count. The separator is written as an escape
+// rather than as the byte, which the repository refuses in a tracked file: a literal one makes the source binary to
+// `grep` and to `git diff`. It is that byte rather than a space or a slash because a mail server's folder alias may
+// carry either, and a separator a name can contain is a separator two different pairs can spell the same way.
+function folderKey(account: string, folder: string): string {
+    return `${account}\u0000${folder}`;
+}

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -283,6 +283,8 @@ export const en = {
         'This credential may not read mail on this deployment, so no mailbox and no message is shown. Whoever runs the deployment can grant that.',
     'grant.askMail':
         'This credential may not ask questions of your mail on this deployment, so asking is not offered. Whoever runs the deployment can grant that.',
+    'grant.markMailRead':
+        'This credential may not change a flag on your mail server, so opening a message leaves it unread there and this client shows what the server last reported. Whoever runs the deployment can grant that.',
 
     'failure.unauthenticated': 'unauthenticated',
     'failure.unauthorized': 'unauthorized',

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -282,6 +282,8 @@ export const pl: Catalogue = {
         'To poświadczenie nie może odczytywać poczty w tym wdrożeniu, więc nie pokazujemy żadnej skrzynki ani wiadomości. Osoba prowadząca wdrożenie może nadać takie uprawnienie.',
     'grant.askMail':
         'To poświadczenie nie może zadawać pytań Twojej poczcie w tym wdrożeniu, więc nie oferujemy pytania. Osoba prowadząca wdrożenie może nadać takie uprawnienie.',
+    'grant.markMailRead':
+        'To poświadczenie nie może zmieniać flag na Twoim serwerze poczty, więc otwarcie wiadomości pozostawia ją tam nieprzeczytaną, a klient pokazuje to, co serwer zgłosił ostatnio. Osoba prowadząca wdrożenie może nadać takie uprawnienie.',
 
     'failure.unauthenticated': 'brak uwierzytelnienia',
     'failure.unauthorized': 'brak uprawnień',

--- a/frontend/src/Client.App/src/messageBody/Message.test.tsx
+++ b/frontend/src/Client.App/src/messageBody/Message.test.tsx
@@ -3,7 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { StrictMode } from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it } from 'vitest';
 import type { ClientResponse, ClientSession, MailFathomTransport } from '@mailfathom/client-backend';
 import { LocalizationProvider } from '../localization/Localization';
@@ -96,6 +96,22 @@ function readingInAConversation() {
                 <Message session={session} transport={transport} storedEmailId="stub-message" quotedHistoryOnRequest />
             </LocalizationProvider>
         </StrictMode>,
+    );
+}
+
+/** The same message, with somebody listening for its words having reached the screen. */
+function readingReported(onBodyDrawn: () => void, storedEmailId = 'stub-message') {
+    return (
+        <StrictMode>
+            <LocalizationProvider>
+                <Message
+                    session={session}
+                    transport={transport}
+                    storedEmailId={storedEmailId}
+                    onBodyDrawn={onBodyDrawn}
+                />
+            </LocalizationProvider>
+        </StrictMode>
     );
 }
 
@@ -272,5 +288,69 @@ describe('Message', () => {
 
         expect(await screen.findByText('The message it answers.')).toBeDefined();
         expect(screen.queryByText('The conversation this message quoted')).toBeNull();
+    });
+
+    // Opening a message is its words having reached the screen, which is what ADR 0026 marks read on. It is said once
+    // however many times the effect runs: `StrictMode` invokes it twice on mount, and saying it twice would be this
+    // client reporting a message opened that nobody opened again.
+    it('says the body was drawn once the message is on the screen, and says it once', async () => {
+        const drawn: number[] = [];
+
+        render(readingReported(() => drawn.push(1)));
+        await screen.findByText('A drawn message.');
+
+        await waitFor(() => {
+            expect(drawn).toHaveLength(1);
+        });
+    });
+
+    it('says nothing for a read the reader moved past before it answered', () => {
+        answer = () => new Promise<Answer>(() => undefined);
+
+        const drawn: number[] = [];
+        const opened = render(readingReported(() => drawn.push(1)));
+
+        opened.unmount();
+
+        expect(drawn).toStrictEqual([]);
+    });
+
+    it('says nothing for a message that could not be read, nothing having been put in front of anybody', async () => {
+        answering({ status: 503, body: '' });
+
+        const drawn: number[] = [];
+
+        render(readingReported(() => drawn.push(1)));
+        await screen.findByText('The message could not be read: unavailable.');
+
+        expect(drawn).toStrictEqual([]);
+    });
+
+    // Asking for the sender's pictures re-reads the same message, and the reader did not open it twice.
+    it('says nothing again when the reader asks for the sender’s pictures', async () => {
+        const drawn: number[] = [];
+
+        render(readingReported(() => drawn.push(1)));
+        await screen.findByText('A drawn message.');
+        answering(bodyAnswering(true));
+        fireEvent.click(screen.getByRole('button', { name: 'Load pictures from the sender' }));
+        await screen.findByText('Pictures are being loaded from the sender for this message.');
+
+        await waitFor(() => {
+            expect(drawn).toHaveLength(1);
+        });
+    });
+
+    it('says it again for the next message the reader opens', async () => {
+        const drawn: number[] = [];
+        const opened = render(readingReported(() => drawn.push(1)));
+
+        await screen.findByText('A drawn message.');
+        opened.rerender(readingReported(() => drawn.push(1), 'another-message'));
+        await screen.findByText('A drawn message.');
+
+        await waitFor(() => {
+            expect(drawn).toHaveLength(2);
+        });
     });
 });

--- a/frontend/src/Client.App/src/messageBody/Message.tsx
+++ b/frontend/src/Client.App/src/messageBody/Message.tsx
@@ -2,7 +2,7 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
     readMailBody,
     type ClientFailureReason,
@@ -66,6 +66,20 @@ interface MessageToDraw {
 
     /** Whether the conversation this message quoted is folded away until a reader asks for it, which a thread does. */
     readonly quotedHistoryOnRequest?: boolean;
+
+    /**
+     * Said once, when this message's words are on the screen, which is what opening a message means.
+     *
+     * The body having been drawn rather than a selection having moved, because a reading pane that follows the list
+     * would otherwise report fifty messages opened for one press-and-hold of the arrow key: a read the reader scrolled
+     * past is discarded rather than drawn, and a message whose body was never drawn was never opened. The round trip is
+     * what a mail client with a preview pane otherwise needs a dwell timer for, and unlike a threshold it is not a
+     * number anybody has to defend.
+     *
+     * Asking for the sender's pictures re-reads the same message and says nothing again, because the reader did not
+     * open it twice.
+     */
+    readonly onBodyDrawn?: () => void;
 }
 
 // The ceiling every message's own content is read under, stated here rather than where a message is laid out, so that
@@ -83,7 +97,13 @@ export function Message(message: MessageToDraw) {
     );
 }
 
-function MessageRead({ session, transport, storedEmailId, quotedHistoryOnRequest = false }: MessageToDraw) {
+function MessageRead({
+    session,
+    transport,
+    storedEmailId,
+    quotedHistoryOnRequest = false,
+    onBodyDrawn,
+}: MessageToDraw) {
     const { translate } = useLocalization();
     const [read, setRead] = useState<Read>({ storedEmailId, remotePictures: false, attempt: 0 });
 
@@ -116,6 +136,22 @@ function MessageRead({ session, transport, storedEmailId, quotedHistoryOnRequest
 
     const held = drawableUnder(answer, read);
     const reading = held?.read !== read;
+
+    // Which message's words are actually on the screen, which is the whole of what opening one means here — `null`
+    // while a read is in flight and for a read that failed, because neither put anything in front of anybody.
+    const drawn = held?.result.outcome === 'read' ? held.read.storedEmailId : null;
+
+    // The message this component has already reported as drawn. A ref rather than a flag in state because it has to
+    // survive `StrictMode` invoking the effect below twice on mount, for the reason the reading pane's own focus guard
+    // is one — and because saying it twice would be this client reporting a message opened that nobody opened again.
+    const reported = useRef<string | null>(null);
+
+    useEffect(() => {
+        if (drawn !== null && reported.current !== drawn) {
+            reported.current = drawn;
+            onBodyDrawn?.();
+        }
+    }, [drawn, onBodyDrawn]);
 
     // A message already drawn stays on the screen while a re-read runs, because replacing it with one line drops the
     // focus of whoever clicked and moves everything below their cursor on an interaction that changes no words. A

--- a/frontend/src/Client.App/src/messageRows/MessageRow.test.tsx
+++ b/frontend/src/Client.App/src/messageRows/MessageRow.test.tsx
@@ -6,6 +6,7 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import type { MailTimelineEntry } from '@mailfathom/client-backend';
 import { LocalizationProvider } from '../localization/Localization';
+import { ReadMarkingContext, nothingMarkedRead, type MarkedIn, type ReadMarking } from '../readMarking/useReadMarking';
 import { MessageRow } from './MessageRow';
 
 const email: MailTimelineEntry = {
@@ -28,27 +29,34 @@ const email: MailTimelineEntry = {
     preview: 'The opening of the message.',
 };
 
-function drawRow(note?: string): HTMLElement {
+function drawRow(note?: string, unread = false, marking: ReadMarking = nothingMarkedRead): HTMLElement {
     render(
         <LocalizationProvider>
-            <ul>
-                <MessageRow
-                    email={email}
-                    position={1}
-                    open={false}
-                    selected={false}
-                    focusable
-                    note={note}
-                    onOpen={() => undefined}
-                    onPoint={() => undefined}
-                    onPointerEnter={() => undefined}
-                    onElement={() => undefined}
-                />
-            </ul>
+            <ReadMarkingContext value={marking}>
+                <ul>
+                    <MessageRow
+                        email={{ ...email, unread }}
+                        position={1}
+                        open={false}
+                        selected={false}
+                        focusable
+                        note={note}
+                        onOpen={() => undefined}
+                        onPoint={() => undefined}
+                        onPointerEnter={() => undefined}
+                        onElement={() => undefined}
+                    />
+                </ul>
+            </ReadMarkingContext>
         </LocalizationProvider>,
     );
 
     return screen.getByRole('option');
+}
+
+/** What a client that has marked exactly this message read carries, which is what a row reads its state through. */
+function marked(storedEmailId: string, place: MarkedIn = { account: 'work', folder: 'INBOX' }): ReadMarking {
+    return { marked: new Map([[storedEmailId, place]]), markRead: () => undefined };
 }
 
 // The line the row's height reserves whether or not anything is in it, which is what lets the search's row and the
@@ -67,5 +75,33 @@ describe('MessageRow', () => {
 
         expect(reserved?.textContent).toBe('');
         expect(reserved?.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    // Unread is drawn as weight and colour, which a test cannot read, and said in as many words for somebody who is
+    // looking at neither — so the words are what says whether the row drew the message read.
+    it('says a message the deployment reports as unread is unread', () => {
+        drawRow(undefined, true);
+
+        expect(screen.getByText('Unread')).toBeDefined();
+    });
+
+    it('says nothing of the sort for a message the deployment reports as read', () => {
+        drawRow();
+
+        expect(screen.queryByText('Unread')).toBeNull();
+    });
+
+    // The row draws from the pending mutation rather than waiting for the account's own pass to observe the flag,
+    // which is the whole of what a folder's count and its rows have to agree about.
+    it('draws a message this client has marked read as read, though the deployment still reports it unread', () => {
+        drawRow(undefined, true, marked(email.id));
+
+        expect(screen.queryByText('Unread')).toBeNull();
+    });
+
+    it('leaves a message another one’s marking has nothing to do with unread', () => {
+        drawRow(undefined, true, marked('another-message'));
+
+        expect(screen.getByText('Unread')).toBeDefined();
     });
 });

--- a/frontend/src/Client.App/src/messageRows/MessageRow.tsx
+++ b/frontend/src/Client.App/src/messageRows/MessageRow.tsx
@@ -9,6 +9,7 @@ import { Organisation } from '../controls/Organisation';
 import { ReceivedAt } from '../controls/ReceivedAt';
 import { SenderAvatar } from '../controls/SenderAvatar';
 import { useLocalization } from '../localization/useLocalization';
+import { drawnUnread, useReadMarking } from '../readMarking/useReadMarking';
 
 // One row of mail, which is its own component for the reason a tree's row is: it is what carries state, a keyboard
 // path, and a test. What it draws is what the page answered with — nothing here reads anything of its own, so a row
@@ -51,6 +52,17 @@ export function MessageRow({
     readonly onElement: (element: HTMLLIElement | null) => void;
 }) {
     const { translate } = useLocalization();
+    const marking = useReadMarking();
+
+    // What the deployment last reported, less what this client has marked read since. The two are not the same for
+    // minutes at a time: marking read is a durable mutation the account's own pass carries to the mail server, and the
+    // stored flag is an observation of what that server was seen to hold — so the row draws from the pending mutation
+    // rather than waiting for the observation to catch up.
+    //
+    // The row stays in the list either way, including a list narrowed to unread mail. A message drawn read is a message
+    // the person is reading; taking its row out from under them the moment the pane rendered it would be the list
+    // disagreeing with the pane about what is open, and the next read of the folder is what removes it.
+    const unread = drawnUnread(marking, email.id, email.unread);
 
     return (
         <li
@@ -79,11 +91,11 @@ export function MessageRow({
             }`}
         >
             <div className="flex items-center gap-2">
-                {email.unread ? (
-                    <span className="size-2 shrink-0 rounded-full bg-accent">
-                        <span className="sr-only">{translate('list.unread')}</span>
-                    </span>
-                ) : null}
+                {/* Unread is drawn as weight and colour, which is how the design project draws it, and said in as many
+                    words for a reader who is not looking at either. Nothing marks the row visually beside that: a dot
+                    ahead of the avatar would inset every unread row a little further than every read one, which is the
+                    one thing a list of rows that have to scan as a column cannot afford. */}
+                {unread ? <span className="sr-only">{translate('list.unread')}</span> : null}
 
                 <SenderAvatar displayName={email.senderDisplayName} address={email.senderAddress} place="row" />
 
@@ -91,7 +103,7 @@ export function MessageRow({
                     is what gives way. Half rather than more because the marks and the time hold their own width: a
                     name allowed past it would push the time out of a row that clips rather than wraps. */}
                 <span
-                    className={`max-w-1/2 shrink-0 truncate text-md font-semibold ${email.unread ? 'text-text' : 'text-text-soft'}`}
+                    className={`max-w-1/2 shrink-0 truncate text-md font-semibold ${unread ? 'text-text' : 'text-text-soft'}`}
                 >
                     {correspondent(email) ?? translate('list.senderUnknown')}
                 </span>
@@ -103,7 +115,7 @@ export function MessageRow({
                 <ReceivedAt at={email.receivedAt} />
             </div>
 
-            <div className={`truncate text-md ${email.unread ? 'text-text' : 'text-text-soft'}`}>
+            <div className={`truncate text-md ${unread ? 'text-text' : 'text-text-soft'}`}>
                 {email.subject ?? translate('list.noSubject')}
             </div>
 

--- a/frontend/src/Client.App/src/preferences/useClientPreferences.test.tsx
+++ b/frontend/src/Client.App/src/preferences/useClientPreferences.test.tsx
@@ -14,8 +14,15 @@ const session: ClientSession = {
     authorization: 'Basic dGVzdA==',
 };
 
-function stored(preferences: { telemetryEnabled: boolean; theme: string; openMailInTabs: boolean }): string {
-    return JSON.stringify(preferences);
+// The whole document, because the route answers with nothing less and the package refuses an answer missing a field.
+// Marking read is defaulted rather than named at each call, since only the tests below that are about it say anything.
+function stored(preferences: {
+    telemetryEnabled: boolean;
+    theme: string;
+    openMailInTabs: boolean;
+    markReadOnOpen?: boolean;
+}): string {
+    return JSON.stringify({ markReadOnOpen: true, ...preferences });
 }
 
 // The transport is the network boundary and the whole of what these tests fake, exactly as in the package that reads
@@ -62,6 +69,24 @@ describe('useClientPreferences', () => {
 
         expect(requests[0]?.method).toBe('GET');
         expect(requests[0]?.path).toBe('https://mail.example.invalid/api/client/preferences');
+    });
+
+    it('answers marking read as on before anything has been read, which is what ADR 0026 defaults it to', () => {
+        const { transport } = recording(stored({ telemetryEnabled: true, theme: 'dark', openMailInTabs: true }));
+        const { result } = reading(transport);
+
+        expect(result.current.preferences.markReadOnOpen).toBe(true);
+    });
+
+    it('answers marking read as off once the person has turned it off', async () => {
+        const { transport } = recording(
+            stored({ telemetryEnabled: true, theme: 'system', openMailInTabs: false, markReadOnOpen: false }),
+        );
+        const { result } = reading(transport);
+
+        await waitFor(() => {
+            expect(result.current.preferences.markReadOnOpen).toBe(false);
+        });
     });
 
     it('lets the deployment’s theme replace what the device opened in', async () => {
@@ -126,6 +151,7 @@ describe('useClientPreferences', () => {
             telemetryEnabled: false,
             theme: 'light',
             openMailInTabs: true,
+            markReadOnOpen: true,
         });
     });
 
@@ -151,6 +177,7 @@ describe('useClientPreferences', () => {
                 telemetryEnabled: true,
                 theme: 'light',
                 openMailInTabs: false,
+                markReadOnOpen: true,
             });
         });
     });
@@ -229,6 +256,7 @@ describe('useClientPreferences', () => {
             telemetryEnabled: true,
             theme: 'system',
             openMailInTabs: true,
+            markReadOnOpen: true,
         });
     });
 

--- a/frontend/src/Client.App/src/preferences/useClientPreferences.ts
+++ b/frontend/src/Client.App/src/preferences/useClientPreferences.ts
@@ -14,7 +14,7 @@ import {
 import type { ThemeChoice } from '../theme/themeChoice';
 import { useTheme } from '../theme/useTheme';
 
-// The two settings that follow the person rather than the machine, read from the deployment once there is a session to
+// The settings that follow the person rather than the machine, read from the deployment once there is a session to
 // read it with and written back whole whenever one of them changes.
 //
 // The theme is the half that exists on both sides, and the order between them is deliberate. The device answers first,
@@ -25,10 +25,20 @@ import { useTheme } from '../theme/useTheme';
 // Language is not here. It stays on the device, because what a person reads a client in is a fact about the machine
 // they are at rather than about them.
 
-/** What the client is set to, and how a person changes one of the two settings that follow them. */
+/** What the client is set to, and how a person changes one of the settings that follow them. */
 export interface ClientPreferencesInForce {
     /** Whether opening a message opens a tab rather than replacing what is on the screen. */
     readonly openMailInTabs: boolean;
+
+    /**
+     * Whether opening a message marks it read on the person's own mail server, which ADR 0026 defaults to on.
+     *
+     * Read here rather than chosen here: the control that moves it belongs to the settings screen, and what the frame
+     * needs is the value in force. Somebody with nothing read yet gets the unset answer, which is the same one the
+     * deployment will confirm — so a message opened in the first moments of a session marks read rather than waiting
+     * for a preference nobody has changed.
+     */
+    readonly markReadOnOpen: boolean;
 
     /** Whether the deployment refused the last change, which is the one thing about this a screen has to say out loud. */
     readonly notStated: boolean;
@@ -152,6 +162,7 @@ export function useClientPreferences(
 
     return {
         openMailInTabs: inForce.preferences.openMailInTabs,
+        markReadOnOpen: inForce.preferences.markReadOnOpen,
         notStated: inForce.notStated,
         chooseTheme: (choice) => {
             setThemeChoice(choice);

--- a/frontend/src/Client.App/src/readMarking/ReadMarking.test.tsx
+++ b/frontend/src/Client.App/src/readMarking/ReadMarking.test.tsx
@@ -1,0 +1,234 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { ClientRequest, ClientSession, MailFathomTransport } from '@mailfathom/client-backend';
+import { ReadMarkingProvider } from './ReadMarking';
+import { drawnUnread, useReadMarking, type MessageOpened } from './useReadMarking';
+
+const session: ClientSession = {
+    baseAddress: 'https://mail.example.invalid',
+    authorization: 'Basic dGVzdA==',
+};
+
+const somebodyElse: ClientSession = { ...session, authorization: 'Basic b3RoZXI=' };
+
+function opened(storedEmailId: string, message: Partial<MessageOpened> = {}): MessageOpened {
+    return { storedEmailId, account: 'work', folder: 'INBOX', unread: true, ...message };
+}
+
+// The transport is the network boundary and the whole of what these tests fake. Every message named in a submission is
+// answered as recorded unless a test says otherwise, which is what the deployment does with mail the list just drew.
+function recording(outcomes: Readonly<Record<string, string>> = {}): {
+    transport: MailFathomTransport;
+    requests: ClientRequest[];
+} {
+    const requests: ClientRequest[] = [];
+
+    return {
+        requests,
+        transport: (request) => {
+            requests.push(request);
+
+            const stated = JSON.parse(request.body ?? '{}') as { changes: readonly { storedEmailId: string }[] };
+
+            return Promise.resolve({
+                status: 200,
+                headers: {},
+                body: JSON.stringify({
+                    results: stated.changes.map(({ storedEmailId }) => ({
+                        storedEmailId,
+                        outcome: outcomes[storedEmailId] ?? 'recorded',
+                    })),
+                }),
+            });
+        },
+    };
+}
+
+function marking(
+    transport: MailFathomTransport,
+    { marking = true, asked }: { marking?: boolean; asked?: ClientSession | null } = {},
+) {
+    const signedIn = asked === undefined ? session : asked;
+
+    return renderHook(() => useReadMarking(), {
+        wrapper: ({ children }) => (
+            <ReadMarkingProvider session={signedIn} transport={transport} marking={marking}>
+                {children}
+            </ReadMarkingProvider>
+        ),
+    });
+}
+
+function named(requests: readonly ClientRequest[]): readonly (readonly string[])[] {
+    return requests.map((request) => {
+        const stated = JSON.parse(request.body ?? '{}') as { changes: readonly { storedEmailId: string }[] };
+
+        return stated.changes.map(({ storedEmailId }) => storedEmailId);
+    });
+}
+
+describe('ReadMarkingProvider', () => {
+    it('submits one change for a message whose body was drawn, and draws its row read at once', async () => {
+        const { transport, requests } = recording();
+        const { result } = marking(transport);
+
+        act(() => {
+            result.current.markRead(opened('first'));
+        });
+
+        expect(drawnUnread(result.current, 'first', true)).toBe(false);
+
+        await waitFor(() => {
+            expect(named(requests)).toStrictEqual([['first']]);
+        });
+    });
+
+    // The pane reports the body drawn rather than the selection moved, and asking for the sender's pictures re-reads
+    // the same message — so the one thing this must never do is report a message opened twice.
+    it('submits nothing a second time for a message already marked', async () => {
+        const { transport, requests } = recording();
+        const { result } = marking(transport);
+
+        act(() => {
+            result.current.markRead(opened('first'));
+        });
+
+        await waitFor(() => {
+            expect(requests).toHaveLength(1);
+        });
+
+        act(() => {
+            result.current.markRead(opened('first'));
+        });
+
+        expect(named(requests)).toStrictEqual([['first']]);
+    });
+
+    it('submits nothing for a message the deployment already reports as read', () => {
+        const { transport, requests } = recording();
+        const { result } = marking(transport);
+
+        act(() => {
+            result.current.markRead(opened('first', { unread: false }));
+        });
+
+        expect(requests).toStrictEqual([]);
+        expect(result.current.marked.size).toBe(0);
+    });
+
+    // A conversation draws every message it shows, and each of them says so — so what the deployment is told is one
+    // batch naming them all rather than one request per message.
+    it('carries the bodies drawn together in one batch', async () => {
+        const { transport, requests } = recording();
+        const { result } = marking(transport);
+
+        act(() => {
+            result.current.markRead(opened('first'));
+            result.current.markRead(opened('second'));
+        });
+
+        await waitFor(() => {
+            expect(named(requests)).toStrictEqual([['first', 'second']]);
+        });
+    });
+
+    it('marks nothing where the reader turned it off or the credential may not write a flag', () => {
+        const { transport, requests } = recording();
+        const { result } = marking(transport, { marking: false });
+
+        act(() => {
+            result.current.markRead(opened('first'));
+        });
+
+        expect(requests).toStrictEqual([]);
+        expect(drawnUnread(result.current, 'first', true)).toBe(true);
+    });
+
+    it('marks nothing where there is nobody to submit for', () => {
+        const { transport, requests } = recording();
+        const { result } = marking(transport, { asked: null });
+
+        act(() => {
+            result.current.markRead(opened('first'));
+        });
+
+        expect(requests).toStrictEqual([]);
+        expect(result.current.marked.size).toBe(0);
+    });
+
+    // A row that stayed read against a mailbox nobody told is the defect this exists for: the deployment answering
+    // anything but `recorded` puts the message back to what the list said about it.
+    it('stops claiming a message read where the deployment did not write it down', async () => {
+        const { transport } = recording({ first: 'message-not-found' });
+        const { result } = marking(transport);
+
+        act(() => {
+            result.current.markRead(opened('first'));
+        });
+
+        await waitFor(() => {
+            expect(drawnUnread(result.current, 'first', true)).toBe(true);
+        });
+    });
+
+    it('stops claiming a message read where the deployment could not be reached', async () => {
+        const { result } = marking(() => Promise.reject(new Error('the connection was refused')));
+
+        act(() => {
+            result.current.markRead(opened('first'));
+        });
+
+        expect(drawnUnread(result.current, 'first', true)).toBe(false);
+
+        await waitFor(() => {
+            expect(drawnUnread(result.current, 'first', true)).toBe(true);
+        });
+    });
+
+    it('says where each marked message was counted, so a folder’s count can answer for it', async () => {
+        const { transport } = recording();
+        const { result } = marking(transport);
+
+        act(() => {
+            result.current.markRead(opened('first', { account: 'personal', folder: 'ARCHIVE' }));
+        });
+
+        await waitFor(() => {
+            expect(result.current.marked.get('first')).toStrictEqual({ account: 'personal', folder: 'ARCHIVE' });
+        });
+    });
+
+    // Signing out and back in on one tab keeps this component mounted, and the previous person's markings would
+    // otherwise be drawn over the next person's mail.
+    it('holds nothing of the person who signed out, so the next one reads their own mailbox', async () => {
+        const { transport } = recording();
+
+        // Held beside the render rather than passed to it, because a wrapper receives no props of its own.
+        let signedIn: ClientSession = session;
+
+        const { result, rerender } = renderHook(() => useReadMarking(), {
+            wrapper: ({ children }) => (
+                <ReadMarkingProvider session={signedIn} transport={transport} marking>
+                    {children}
+                </ReadMarkingProvider>
+            ),
+        });
+
+        act(() => {
+            result.current.markRead(opened('first'));
+        });
+
+        await waitFor(() => {
+            expect(result.current.marked.size).toBe(1);
+        });
+
+        signedIn = somebodyElse;
+        rerender();
+
+        expect(result.current.marked.size).toBe(0);
+    });
+});

--- a/frontend/src/Client.App/src/readMarking/ReadMarking.tsx
+++ b/frontend/src/Client.App/src/readMarking/ReadMarking.tsx
@@ -1,0 +1,155 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { useRef, useState, type ReactNode } from 'react';
+import {
+    markMailRead,
+    mostMessagesPerMutation,
+    type ClientSession,
+    type MailFathomTransport,
+} from '@mailfathom/client-backend';
+import {
+    ReadMarkingContext,
+    nothingMarkedRead,
+    type MarkedIn,
+    type MessageOpened,
+    type ReadMarking,
+} from './useReadMarking';
+
+// Marking a message read because somebody opened it, which ADR 0026 settles as an ordinary flag mutation their act
+// authors rather than an effect of the read that served it. Nothing here reaches a mail server: the submission writes a
+// durable record and answers, and the account's own pass is what tells the server — so an unreachable account leaves
+// the reading pending instead of failing the open.
+//
+// Three things decide whether it happens at all, and all three are the frame's rather than a screen's: the reader's own
+// setting, the grant the credential signed in under, and there being a session to submit over. Where any is missing
+// every component below reads `nothingMarkedRead`, so no screen asks the question twice.
+//
+// It marks nothing twice and marks nothing already read. What has been submitted is held in a ref rather than in the
+// state below it, because two bodies drawn in one commit both read it before either render happens — and because React
+// invokes an effect twice on mount under `StrictMode`, which is exactly the shape a state-only guard lets through.
+
+/** What is held, and whose it is, so one person's markings never outlive the credential they were made under. */
+interface HeldMarkings {
+    readonly session: ClientSession | null;
+    readonly marked: Map<string, MarkedIn>;
+}
+
+/** What a client belonging to nobody has marked, which is what a session change falls back to until the next marking. */
+const emptyMarkings: ReadonlyMap<string, MarkedIn> = new Map();
+
+export function ReadMarkingProvider({
+    session,
+    transport,
+    marking,
+    children,
+}: {
+    /** Who is asking and where, or `null` where there is nobody to submit for. */
+    readonly session: ClientSession | null;
+    readonly transport: MailFathomTransport;
+
+    /** Whether this reader asked for opening a message to mark it read, and holds the grant that writes a flag. */
+    readonly marking: boolean;
+
+    readonly children: ReactNode;
+}) {
+    const [drawn, setDrawn] = useState<HeldMarkings>({ session: null, marked: new Map() });
+    const submitted = useRef<HeldMarkings>({ session: null, marked: new Map() });
+
+    // The markings waiting for the batch they will travel in. Nothing waits for a body that has not been drawn — the
+    // flush runs on the microtask after the one that filled it — so what a batch coalesces is the bodies that were
+    // ready together rather than bodies still being read.
+    const waiting = useRef<string[]>([]);
+    const flushing = useRef(false);
+
+    // Derived rather than cleared, for the reason `preferences/useClientPreferences.ts` gives: signing out and back in
+    // on one tab keeps this component mounted, and the previous person's markings would otherwise be drawn over the
+    // next person's mail. The session the markings were made under travels beside them for that comparison; the ref
+    // below holds the same pair and is emptied in the handler, where a session change is somebody's act.
+    const inForce = drawn.session === session ? drawn.marked : emptyMarkings;
+
+    function keep(): void {
+        setDrawn({ session: submitted.current.session, marked: new Map(submitted.current.marked) });
+    }
+
+    function forget(storedEmailIds: readonly string[]): void {
+        for (const storedEmailId of storedEmailIds) {
+            submitted.current.marked.delete(storedEmailId);
+        }
+
+        keep();
+    }
+
+    function flush(): void {
+        flushing.current = false;
+
+        const batch = waiting.current;
+
+        waiting.current = [];
+
+        if (session === null) {
+            return;
+        }
+
+        // Split rather than truncated: the route refuses a longer batch whole, and a marking silently dropped here
+        // would be a row drawn read against a mailbox nobody told.
+        for (let from = 0; from < batch.length; from += mostMessagesPerMutation) {
+            submit(session, batch.slice(from, from + mostMessagesPerMutation));
+        }
+    }
+
+    function submit(asking: ClientSession, batch: readonly string[]): void {
+        void markMailRead(asking, transport, batch).then((answer) => {
+            // A marking the deployment did not write down is one the row must stop claiming. Both cases arrive here:
+            // a submission that never reached it, and a message it answered about with anything but `recorded` — mail
+            // that has moved on since the list drew it, or an account it no longer serves.
+            const recorded =
+                answer.outcome === 'read'
+                    ? new Set(
+                          answer.value
+                              .filter((result) => result.outcome === 'recorded')
+                              .map((result) => result.storedEmailId),
+                      )
+                    : new Set<string>();
+
+            const refused = batch.filter((storedEmailId) => !recorded.has(storedEmailId));
+
+            if (refused.length > 0 && submitted.current.session === asking) {
+                forget(refused);
+            }
+        });
+    }
+
+    function markRead(message: MessageOpened): void {
+        if (session === null || !message.unread) {
+            return;
+        }
+
+        if (submitted.current.session !== session) {
+            submitted.current = { session, marked: new Map() };
+            waiting.current = [];
+        }
+
+        if (submitted.current.marked.has(message.storedEmailId)) {
+            return;
+        }
+
+        submitted.current.marked.set(message.storedEmailId, {
+            account: message.account,
+            folder: message.folder,
+        });
+        keep();
+
+        waiting.current.push(message.storedEmailId);
+
+        if (!flushing.current) {
+            flushing.current = true;
+            queueMicrotask(flush);
+        }
+    }
+
+    const value: ReadMarking = marking ? { marked: inForce, markRead } : nothingMarkedRead;
+
+    return <ReadMarkingContext value={value}>{children}</ReadMarkingContext>;
+}

--- a/frontend/src/Client.App/src/readMarking/useReadMarking.ts
+++ b/frontend/src/Client.App/src/readMarking/useReadMarking.ts
@@ -1,0 +1,78 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { createContext, useContext } from 'react';
+
+// What this client has marked read since it was opened, and the one way of adding to it. It belongs to the whole
+// application rather than to a screen, because three unrelated places read it: the row that draws a message, the folder
+// tree that counts unread mail, and the body that marks one on being drawn.
+//
+// It exists at all because the deployment goes on reporting a message unread until the account's own pass has told the
+// mail server and observed the answer. That is what a durable mutation is, and it is minutes rather than milliseconds —
+// so a client drawing only what the deployment last said would leave a message somebody has just read looking unread
+// until then. What is held here is the pending mutation and nothing else: MailFathom stores no reading of its own, and
+// this goes when the tab does.
+//
+// The context and its hook sit apart from the provider that fills them for the reason `workspace/useWorkspace.ts`
+// gives: a module Vite hot-reloads may export components alone.
+
+/** The message a marking is about: what names it, where it was counted as unread, and whether it still is. */
+export interface MessageOpened {
+    readonly storedEmailId: string;
+    readonly account: string;
+    readonly folder: string;
+
+    /** Whether the deployment last reported the message without `\Seen`, which is the only case there is anything to mark. */
+    readonly unread: boolean;
+}
+
+/** Where a message this client marked read was counted as unread, which is what a folder's count is corrected by. */
+export interface MarkedIn {
+    readonly account: string;
+    readonly folder: string;
+}
+
+export interface ReadMarking {
+    /**
+     * The messages this client has marked read, by the message it was marked on.
+     *
+     * The map rather than two questions answered about it, because both of its readers ask something different: a row
+     * asks whether one message is in it, and the folder tree counts the ones in a folder. Deriving either from the
+     * other would be a second answer to keep in step with the first.
+     */
+    readonly marked: ReadonlyMap<string, MarkedIn>;
+
+    /**
+     * Marks a message read because its body has been drawn in front of the person reading it.
+     *
+     * Safe to call again for a message already marked, and for one the deployment already reports read: neither
+     * submits anything. A client whose reader turned marking off, or whose credential may not write a flag, is handed
+     * an implementation that marks nothing, so nothing below has to ask.
+     */
+    readonly markRead: (message: MessageOpened) => void;
+}
+
+/**
+ * What a tree with no provider above it reads, which is a client that marks nothing.
+ *
+ * A default rather than the refusal `useWorkspace` raises, because marking nothing is a state this application really
+ * has — the reader turned it off, the grant is absent, or there is no session — and a screen drawn under any of those
+ * is drawn from the remote flag alone. Nothing below the provider distinguishes them, which is the point: the three
+ * are one behaviour and this is it.
+ */
+export const nothingMarkedRead: ReadMarking = {
+    marked: new Map(),
+    markRead: () => undefined,
+};
+
+export const ReadMarkingContext = createContext<ReadMarking>(nothingMarkedRead);
+
+export function useReadMarking(): ReadMarking {
+    return useContext(ReadMarkingContext);
+}
+
+/** Whether a row is drawn unread: what the deployment last reported, less what this client has marked since. */
+export function drawnUnread(marking: ReadMarking, storedEmailId: string, unread: boolean): boolean {
+    return unread && !marking.marked.has(storedEmailId);
+}

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
@@ -7,6 +7,12 @@ import { describe, expect, it } from 'vitest';
 import type { ClientRequest, ClientResponse, ClientSession, MailFathomTransport } from '@mailfathom/client-backend';
 import { AttachmentDeliveryContext, type AttachmentDelivery } from '../deployment/attachmentDelivery';
 import { LocalizationProvider } from '../localization/Localization';
+import {
+    ReadMarkingContext,
+    nothingMarkedRead,
+    type MessageOpened,
+    type ReadMarking,
+} from '../readMarking/useReadMarking';
 import { IntentField } from '../shell/IntentField';
 import { LinkOpenerContext } from '../shellOperations/linkOpener';
 import { WorkspaceProvider } from '../workspace/Workspace';
@@ -82,23 +88,41 @@ function drawing(
     storedEmailId: string | null = messageId,
     online = true,
     deliver: AttachmentDelivery = deliversNothing,
+    marking: ReadMarking = nothingMarkedRead,
 ): void {
     render(
         <LocalizationProvider>
             <WorkspaceProvider>
                 <LinkOpenerContext value={() => Promise.resolve()}>
                     <AttachmentDeliveryContext value={deliver}>
-                        <ReadingPane
-                            session={session}
-                            transport={transport}
-                            storedEmailId={storedEmailId}
-                            online={online}
-                        />
+                        <ReadMarkingContext value={marking}>
+                            <ReadingPane
+                                session={session}
+                                transport={transport}
+                                storedEmailId={storedEmailId}
+                                online={online}
+                            />
+                        </ReadMarkingContext>
                     </AttachmentDeliveryContext>
                 </LinkOpenerContext>
             </WorkspaceProvider>
         </LocalizationProvider>,
     );
+}
+
+/** A client that would mark read, recording what the drawn body said was opened rather than submitting it. */
+function recordingMarkings(): { marking: ReadMarking; opened: MessageOpened[] } {
+    const opened: MessageOpened[] = [];
+
+    return {
+        opened,
+        marking: {
+            marked: new Map(),
+            markRead: (message) => {
+                opened.push(message);
+            },
+        },
+    };
 }
 
 describe('ReadingPane', () => {
@@ -360,6 +384,33 @@ describe('ReadingPane selection', () => {
         await screen.findByRole('heading', { name: 'Quarterly invoice' });
 
         expect(screen.queryByRole('button', { name: 'Show the whole conversation' })).toBeNull();
+    });
+
+    // Opening a message is its words having reached the pane, and where it stands travels with it, because the folder
+    // whose count has to answer for the marking is the folder the deployment counted the message in.
+    it('says which message was opened, and where in the mailbox it stands', async () => {
+        asked.length = 0;
+
+        const { marking, opened } = recordingMarkings();
+
+        drawing(deploymentDescribing(), messageId, true, deliversNothing, marking);
+        await screen.findByText('The invoice is attached.');
+
+        await waitFor(() => {
+            expect(opened).toStrictEqual([
+                { storedEmailId: messageId, account: 'work', folder: 'INBOX', unread: true },
+            ]);
+        });
+    });
+
+    it('says nothing was opened while the message is still being read', () => {
+        asked.length = 0;
+
+        const { marking, opened } = recordingMarkings();
+
+        drawing(answersNothing, messageId, true, deliversNothing, marking);
+
+        expect(opened).toStrictEqual([]);
     });
 });
 

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
@@ -17,6 +17,7 @@ import { SecondaryButton } from '../controls/SecondaryButton';
 import { SenderAvatar } from '../controls/SenderAvatar';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
+import { useReadMarking } from '../readMarking/useReadMarking';
 import { useWorkspace } from '../workspace/useWorkspace';
 import { Message } from '../messageBody/Message';
 import { Attachment } from './Attachment';
@@ -33,8 +34,11 @@ import { SenderVerdict } from './SenderVerdict';
 // expensive, so the header block is drawn the moment the first answers and the body says it is still reading underneath
 // it; that is this screen's partial state rather than a gap in it.
 //
-// Nothing here writes to a mailbox. Both reads are `GET`s against the local copy, so opening a message sets no remote
-// flag and tells no mail server that anybody read anything.
+// Neither of those reads writes to a mailbox, and that is the property ADR 0007 bought as a property of the types: both
+// are `GET`s against the local copy, and the route that serves a body holds no write session to reach a mail server
+// with. What does mark the message read is a mutation of its own, authored by the person having opened it and submitted
+// once the body is on the screen — ADR 0026 — so a defect in this pane cannot become a defect that writes to somebody's
+// mailbox.
 
 const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
     unauthenticated: 'failure.unauthenticated',
@@ -119,6 +123,7 @@ function OpenMessage({
 }) {
     const { locale, translate } = useLocalization();
     const { revise } = useWorkspace();
+    const { markRead } = useReadMarking();
     const [read, setRead] = useState<Read>({ storedEmailId, attempt: 0 });
     const [answer, setAnswer] = useState<Answered | null>(null);
     const [connected, setConnected] = useState(online);
@@ -319,7 +324,22 @@ function OpenMessage({
                         with the pointer settles on the release and one made with the keyboard on the key coming back
                         up, and both of them are events this region already receives. */}
                     <div ref={body} onKeyUp={capture} onMouseUp={capture}>
-                        <Message session={session} transport={transport} storedEmailId={storedEmailId} />
+                        {/* The body being drawn is what opening this message means, so it is what marks it read. The
+                            description above already says which account and folder the message is counted in, which is
+                            what a folder's unread count is corrected by. */}
+                        <Message
+                            session={session}
+                            transport={transport}
+                            storedEmailId={storedEmailId}
+                            onBodyDrawn={() => {
+                                markRead({
+                                    storedEmailId: message.storedEmailId,
+                                    account: message.account,
+                                    folder: message.folder,
+                                    unread: message.unread,
+                                });
+                            }}
+                        />
                     </div>
 
                     {message.attachments.length === 0 ? null : (

--- a/frontend/src/Client.App/src/shell/AccountMenu.test.tsx
+++ b/frontend/src/Client.App/src/shell/AccountMenu.test.tsx
@@ -22,6 +22,7 @@ function mailbox(id: string, displayName: string): MailAccount {
 
 const settings: ClientPreferencesInForce = {
     openMailInTabs: false,
+    markReadOnOpen: true,
     notStated: false,
     chooseTheme: () => undefined,
     chooseTabMode: () => undefined,

--- a/frontend/src/Client.App/src/shell/GrantNotice.tsx
+++ b/frontend/src/Client.App/src/shell/GrantNotice.tsx
@@ -17,6 +17,7 @@ import type { ClientCapability } from './capabilities';
 const capabilityNotices: Readonly<Record<ClientCapability, MessageKey>> = {
     readMail: 'grant.readMail',
     askMail: 'grant.askMail',
+    markMailRead: 'grant.markMailRead',
 };
 
 export function GrantNotice({ withheld }: { readonly withheld: readonly ClientCapability[] }) {

--- a/frontend/src/Client.App/src/shell/capabilities.ts
+++ b/frontend/src/Client.App/src/shell/capabilities.ts
@@ -14,7 +14,7 @@ import { spaces, type Space } from '../routing/spaces';
 // a sentence on the screen has to say. The one table below is where the two meet, and it is exhaustive by its own type
 // so a capability added later does not compile until it says which grant it is reached under.
 
-export const clientCapabilities = ['readMail', 'askMail'] as const;
+export const clientCapabilities = ['readMail', 'askMail', 'markMailRead'] as const;
 
 /** Something the client offers a person, where the grant permits it. */
 export type ClientCapability = (typeof clientCapabilities)[number];
@@ -22,6 +22,7 @@ export type ClientCapability = (typeof clientCapabilities)[number];
 const capabilityGrants: Readonly<Record<ClientCapability, MailFathomPermission>> = {
     readMail: 'mailfathom.mail.read',
     askMail: 'mailfathom.mail.ask',
+    markMailRead: 'mailfathom.mail.flags.write',
 };
 
 // Which capability each space is reached under. Every space that is still a placeholder carries none, because nothing

--- a/frontend/src/Client.App/src/thread/Thread.test.tsx
+++ b/frontend/src/Client.App/src/thread/Thread.test.tsx
@@ -7,6 +7,12 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it } from 'vitest';
 import type { ClientRequest, ClientResponse, ClientSession, MailFathomTransport } from '@mailfathom/client-backend';
 import { LocalizationProvider } from '../localization/Localization';
+import {
+    ReadMarkingContext,
+    nothingMarkedRead,
+    type MessageOpened,
+    type ReadMarking,
+} from '../readMarking/useReadMarking';
 import { LinkOpenerContext } from '../shellOperations/linkOpener';
 import { WorkspaceProvider } from '../workspace/Workspace';
 import type { OpenConversation } from '../workspace/openConversation';
@@ -72,6 +78,9 @@ function pageOf(
     });
 }
 
+/** What the deployment says about a message nobody has read yet. */
+const unread = { unread: true };
+
 /** One message's whole text, named after the message so a test can tell which of them was read. */
 function bodyAsWords(path: string): string {
     const storedEmailId = path.split('/messages/')[1]?.split('/')[0] ?? '';
@@ -118,12 +127,19 @@ function deploymentRefusing(status: number): MailFathomTransport {
 /** A deployment that has taken the request and not answered it, which is what a surface that waits is proven against. */
 const answersNothing: MailFathomTransport = () => new Promise<ClientResponse>(() => undefined);
 
-function inTheFrame(transport: MailFathomTransport, conversation: OpenConversation, online: boolean): ReactElement {
+function inTheFrame(
+    transport: MailFathomTransport,
+    conversation: OpenConversation,
+    online: boolean,
+    marking: ReadMarking = nothingMarkedRead,
+): ReactElement {
     return (
         <LocalizationProvider>
             <WorkspaceProvider>
                 <LinkOpenerContext value={() => Promise.resolve()}>
-                    <Thread session={session} transport={transport} conversation={conversation} online={online} />
+                    <ReadMarkingContext value={marking}>
+                        <Thread session={session} transport={transport} conversation={conversation} online={online} />
+                    </ReadMarkingContext>
                 </LinkOpenerContext>
             </WorkspaceProvider>
         </LocalizationProvider>
@@ -134,8 +150,24 @@ function drawing(
     transport: MailFathomTransport,
     conversation: OpenConversation = { threadId, openAt: null },
     online = true,
+    marking: ReadMarking = nothingMarkedRead,
 ) {
-    return render(inTheFrame(transport, conversation, online));
+    return render(inTheFrame(transport, conversation, online, marking));
+}
+
+/** A client that would mark read, recording what each drawn body said was opened rather than submitting it. */
+function recordingMarkings(): { marking: ReadMarking; opened: MessageOpened[] } {
+    const opened: MessageOpened[] = [];
+
+    return {
+        opened,
+        marking: {
+            marked: new Map(),
+            markRead: (message) => {
+                opened.push(message);
+            },
+        },
+    };
 }
 
 function bodiesAsked(): string[] {
@@ -210,6 +242,55 @@ describe('Thread', () => {
             expect(bodiesAsked()).toHaveLength(1);
         });
         expect(bodiesAsked()[0]).toContain('/messages/three/body');
+    });
+
+    // ADR 0026 marks read every body the conversation drew, which is one rule rather than two — and the conversation
+    // draws one until the reader asks for the history, so a conversation of three opens one message rather than three.
+    it('marks read the one message it drew, and none the history hides', async () => {
+        const { marking, opened } = recordingMarkings();
+
+        drawing(
+            deploymentAnswering(pageOf(['one', 'two', 'three'], {}, { one: unread, two: unread, three: unread })),
+            { threadId, openAt: null },
+            true,
+            marking,
+        );
+
+        await screen.findByText('The whole of what three says.');
+
+        await waitFor(() => {
+            expect(opened.map((message) => message.storedEmailId)).toStrictEqual(['three']);
+        });
+    });
+
+    it('marks read each message the reader shows the history for', async () => {
+        const { marking, opened } = recordingMarkings();
+
+        drawing(
+            deploymentAnswering(pageOf(['one', 'two'], {}, { one: unread, two: unread })),
+            { threadId, openAt: null },
+            true,
+            marking,
+        );
+
+        fireEvent.click(await screen.findByRole('button', { name: 'Show earlier messages (1)' }));
+        await screen.findByText('The whole of what one says.');
+
+        await waitFor(() => {
+            expect(opened.map((message) => message.storedEmailId).toSorted()).toStrictEqual(['one', 'two']);
+        });
+    });
+
+    it('says where each message it marked read stands, which is what a folder’s count answers for', async () => {
+        const { marking, opened } = recordingMarkings();
+
+        drawing(deploymentAnswering(pageOf(['one'], {}, { one: unread })), { threadId, openAt: null }, true, marking);
+
+        await screen.findByText('The whole of what one says.');
+
+        await waitFor(() => {
+            expect(opened).toStrictEqual([{ storedEmailId: 'one', account: 'work', folder: 'INBOX', unread: true }]);
+        });
     });
 
     it('reads a message the reader shows the history for, and not before', async () => {

--- a/frontend/src/Client.App/src/thread/ThreadMessage.test.tsx
+++ b/frontend/src/Client.App/src/thread/ThreadMessage.test.tsx
@@ -12,6 +12,7 @@ import type {
     MailThreadMessage,
 } from '@mailfathom/client-backend';
 import { LocalizationProvider } from '../localization/Localization';
+import { ReadMarkingContext, nothingMarkedRead, type ReadMarking } from '../readMarking/useReadMarking';
 import { LinkOpenerContext } from '../shellOperations/linkOpener';
 import { ThreadMessage } from './ThreadMessage';
 
@@ -66,22 +67,33 @@ function drawing(
         readonly onOpenOnItsOwn?: () => void;
         readonly onRegion?: (element: HTMLElement | null) => void;
     } = {},
+    marking: ReadMarking = nothingMarkedRead,
 ): void {
     render(
         <LocalizationProvider>
             <LinkOpenerContext value={() => Promise.resolve()}>
-                <ul>
-                    <ThreadMessage
-                        session={session}
-                        transport={answersNothing}
-                        message={held}
-                        onOpenOnItsOwn={handlers.onOpenOnItsOwn ?? (() => undefined)}
-                        onRegion={handlers.onRegion ?? (() => undefined)}
-                    />
-                </ul>
+                <ReadMarkingContext value={marking}>
+                    <ul>
+                        <ThreadMessage
+                            session={session}
+                            transport={answersNothing}
+                            message={held}
+                            onOpenOnItsOwn={handlers.onOpenOnItsOwn ?? (() => undefined)}
+                            onRegion={handlers.onRegion ?? (() => undefined)}
+                        />
+                    </ul>
+                </ReadMarkingContext>
             </LinkOpenerContext>
         </LocalizationProvider>,
     );
+}
+
+/** What a client that has marked exactly this message read carries, which is what the head reads its state through. */
+function marked(storedEmailId: string): ReadMarking {
+    return {
+        marked: new Map([[storedEmailId, { account: 'work', folder: 'Sent' }]]),
+        markRead: () => undefined,
+    };
 }
 
 describe('ThreadMessage', () => {
@@ -137,6 +149,14 @@ describe('ThreadMessage', () => {
         drawing(message({ unread: true }));
 
         expect(screen.getByText('Unread')).toBeDefined();
+    });
+
+    // The list's row and this head are the same message in two places, so a reader who opened it here would otherwise
+    // find it still unread there.
+    it('draws a message this client has marked read as read, though the deployment still reports it unread', () => {
+        drawing(message({ unread: true }), {}, marked('a-message'));
+
+        expect(screen.queryByText('Unread')).toBeNull();
     });
 
     it('recognises a sender by their initials, which is what a conversation of several people is scanned down', () => {

--- a/frontend/src/Client.App/src/thread/ThreadMessage.tsx
+++ b/frontend/src/Client.App/src/thread/ThreadMessage.tsx
@@ -10,6 +10,7 @@ import { SecondaryButton } from '../controls/SecondaryButton';
 import { SenderAvatar } from '../controls/SenderAvatar';
 import { useLocalization } from '../localization/useLocalization';
 import { Message } from '../messageBody/Message';
+import { drawnUnread, useReadMarking } from '../readMarking/useReadMarking';
 
 // One message of a conversation, as a head and what it says. It is its own component for the reason a list row is: it
 // is what carries the read and the way out to the message on its own.
@@ -38,8 +39,14 @@ export function ThreadMessage({
     readonly onRegion: (element: HTMLElement | null) => void;
 }) {
     const { translate } = useLocalization();
+    const marking = useReadMarking();
     const email = message.email;
     const sender = email.senderDisplayName ?? email.senderAddress ?? translate('list.senderUnknown');
+
+    // What the deployment last reported, less what this client has marked read since — the same reading the list's own
+    // row draws from, because the two are the same message in two places and a reader who opened it here would
+    // otherwise find it still unread there.
+    const unread = drawnUnread(marking, email.id, email.unread);
 
     return (
         <li>
@@ -52,15 +59,11 @@ export function ThreadMessage({
                 <div className="flex items-center gap-2.75">
                     <SenderAvatar displayName={email.senderDisplayName} address={email.senderAddress} place="card" />
 
-                    {email.unread ? (
-                        <span className="size-2 shrink-0 rounded-full bg-accent">
-                            <span className="sr-only">{translate('list.unread')}</span>
-                        </span>
-                    ) : null}
+                    {unread ? <span className="sr-only">{translate('list.unread')}</span> : null}
 
                     {/* Who wrote is what a conversation is scanned by, so it keeps its width and everything beside it
                         is what gives way. */}
-                    <span className={`shrink-0 text-md font-semibold ${email.unread ? 'text-text' : 'text-text-soft'}`}>
+                    <span className={`shrink-0 text-md font-semibold ${unread ? 'text-text' : 'text-text-soft'}`}>
                         {sender}
                     </span>
 
@@ -75,7 +78,25 @@ export function ThreadMessage({
                     {translate('thread.storedIn', { account: email.account, folder: email.folder })}
                 </p>
 
-                <Message session={session} transport={transport} storedEmailId={email.id} quotedHistoryOnRequest />
+                {/* Every body the conversation drew is marked read, which is one rule rather than two: the reading
+                    pane and a message here put the same words in front of the same person, and what marks a message
+                    read is that its body was drawn wherever it was drawn. Nothing the screen decides for itself draws
+                    more than the latest message — the rest are behind *show earlier messages*, which is a gesture the
+                    reader makes knowing the count it names. */}
+                <Message
+                    session={session}
+                    transport={transport}
+                    storedEmailId={email.id}
+                    quotedHistoryOnRequest
+                    onBodyDrawn={() => {
+                        marking.markRead({
+                            storedEmailId: email.id,
+                            account: email.account,
+                            folder: email.folder,
+                            unread: email.unread,
+                        });
+                    }}
+                />
 
                 <div>
                     <SecondaryButton label={translate('thread.openOnItsOwn')} onActivate={onOpenOnItsOwn} />

--- a/frontend/src/Client.Backend/src/clientPreferences.test.ts
+++ b/frontend/src/Client.Backend/src/clientPreferences.test.ts
@@ -12,7 +12,8 @@ const session: ClientSession = {
     authorization: 'Basic dGVzdA==',
 };
 
-const storedBody = JSON.stringify({ telemetryEnabled: false, theme: 'dark', openMailInTabs: true });
+const stored = { telemetryEnabled: false, theme: 'dark', openMailInTabs: true, markReadOnOpen: false } as const;
+const storedBody = JSON.stringify(stored);
 
 // The transport is the network boundary and the whole of what a test here fakes. Neither route reads a header off an
 // answer, so each helper supplies the empty set.
@@ -47,13 +48,10 @@ describe('readClientPreferences', () => {
         expect(requests[0]?.headers['Authorization']).toBe('Basic dGVzdA==');
     });
 
-    it('reads the three preferences the deployment answered', async () => {
+    it('reads the four preferences the deployment answered', async () => {
         const answer = await readClientPreferences(session, answering({ status: 200, body: storedBody }));
 
-        expect(answer).toStrictEqual({
-            outcome: 'read',
-            value: { telemetryEnabled: false, theme: 'dark', openMailInTabs: true },
-        });
+        expect(answer).toStrictEqual({ outcome: 'read', value: stored });
     });
 
     it('reads a person who has set nothing as the unset answers rather than as an absence', async () => {
@@ -88,6 +86,10 @@ describe('readClientPreferences', () => {
         ['a theme that is not a string', JSON.stringify({ ...unsetClientPreferences, theme: 3 })],
         ['a switch that is not a boolean', JSON.stringify({ ...unsetClientPreferences, openMailInTabs: 'yes' })],
         ['a preference the answer left out', JSON.stringify({ theme: 'dark', openMailInTabs: false })],
+        [
+            'an answer from a deployment older than one of the preferences',
+            JSON.stringify({ telemetryEnabled: true, theme: 'dark', openMailInTabs: false }),
+        ],
     ])('refuses %s as unreadable rather than reading a document with a hole in it', async (_, body) => {
         const answer = await readClientPreferences(session, answering({ status: 200, body }));
 
@@ -99,20 +101,12 @@ describe('writeClientPreferences', () => {
     it('states the whole document as JSON on the preferences route', async () => {
         const { transport, requests } = recording({ status: 200, body: storedBody });
 
-        await writeClientPreferences(session, transport, {
-            telemetryEnabled: false,
-            theme: 'dark',
-            openMailInTabs: true,
-        });
+        await writeClientPreferences(session, transport, stored);
 
         expect(requests[0]?.method).toBe('POST');
         expect(requests[0]?.path).toBe('https://mail.example.invalid/api/client/preferences');
         expect(requests[0]?.headers['Content-Type']).toBe('application/json');
-        expect(JSON.parse(requests[0]?.body ?? '')).toStrictEqual({
-            telemetryEnabled: false,
-            theme: 'dark',
-            openMailInTabs: true,
-        });
+        expect(JSON.parse(requests[0]?.body ?? '')).toStrictEqual(stored);
     });
 
     it('answers with what is now stored', async () => {
@@ -122,10 +116,7 @@ describe('writeClientPreferences', () => {
             unsetClientPreferences,
         );
 
-        expect(answer).toStrictEqual({
-            outcome: 'read',
-            value: { telemetryEnabled: false, theme: 'dark', openMailInTabs: true },
-        });
+        expect(answer).toStrictEqual({ outcome: 'read', value: stored });
     });
 
     it('reports a deployment holding no record for the caller as unavailable', async () => {

--- a/frontend/src/Client.Backend/src/clientPreferences.ts
+++ b/frontend/src/Client.Backend/src/clientPreferences.ts
@@ -26,6 +26,9 @@ export interface ClientPreferences {
     readonly telemetryEnabled: boolean;
     readonly theme: ClientThemePreference;
     readonly openMailInTabs: boolean;
+
+    /** Whether opening a message marks it read on the person's own mail server, across every account they read. */
+    readonly markReadOnOpen: boolean;
 }
 
 /**
@@ -38,12 +41,13 @@ export const unsetClientPreferences: ClientPreferences = {
     telemetryEnabled: true,
     theme: 'system',
     openMailInTabs: false,
+    markReadOnOpen: true,
 };
 
 /**
  * The most of one preferences answer this package reads before refusing it.
  *
- * The document is three scalars, so this is far above anything the deployment will legitimately send and far below
+ * The document is four scalars, so this is far above anything the deployment will legitimately send and far below
  * anything worth buffering. It is the same order the write route bounds its request body at, for the same reason:
  * what the bound guards against is an answer that was never a preferences document.
  */
@@ -122,8 +126,13 @@ function parsePreferences(body: string): ClientPreferences | null {
     const telemetryEnabled = record['telemetryEnabled'];
     const theme = record['theme'];
     const openMailInTabs = record['openMailInTabs'];
+    const markReadOnOpen = record['markReadOnOpen'];
 
-    if (typeof telemetryEnabled !== 'boolean' || typeof openMailInTabs !== 'boolean') {
+    if (
+        typeof telemetryEnabled !== 'boolean' ||
+        typeof openMailInTabs !== 'boolean' ||
+        typeof markReadOnOpen !== 'boolean'
+    ) {
         return null;
     }
 
@@ -131,7 +140,7 @@ function parsePreferences(body: string): ClientPreferences | null {
         return null;
     }
 
-    return { telemetryEnabled, theme, openMailInTabs };
+    return { telemetryEnabled, theme, openMailInTabs, markReadOnOpen };
 }
 
 function isThemePreference(value: unknown): value is ClientThemePreference {

--- a/frontend/src/Client.Backend/src/index.ts
+++ b/frontend/src/Client.Backend/src/index.ts
@@ -85,6 +85,13 @@ export {
     type MailSenderVerdict,
 } from './mailMessage';
 export {
+    mailFlagMutationsRoute,
+    markMailRead,
+    mostMessagesPerMutation,
+    type MailMutationOutcome,
+    type MailMutationResult,
+} from './mailMutations';
+export {
     longestSearchPage,
     longestSearchText,
     mailSearchRoute,

--- a/frontend/src/Client.Backend/src/mailMutations.test.ts
+++ b/frontend/src/Client.Backend/src/mailMutations.test.ts
@@ -1,0 +1,142 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import { markMailRead, mostMessagesPerMutation } from './mailMutations';
+import type { ClientSession } from './session';
+import type { ClientRequest, ClientResponse, MailFathomTransport } from './transport';
+
+const session: ClientSession = {
+    baseAddress: 'https://mail.example.invalid',
+    authorization: 'Basic dGVzdA==',
+};
+
+const storedEmailId = '2f7d4f2a-6c1e-4e0a-9a2f-1b0c9d8e7f60';
+
+type Answer = Omit<ClientResponse, 'headers'>;
+
+function answering(response: Answer): MailFathomTransport {
+    return () => Promise.resolve({ ...response, headers: {} });
+}
+
+function recording(response: Answer): { transport: MailFathomTransport; requests: ClientRequest[] } {
+    const requests: ClientRequest[] = [];
+
+    return {
+        requests,
+        transport: (request) => {
+            requests.push(request);
+
+            return Promise.resolve({ ...response, headers: {} });
+        },
+    };
+}
+
+function recorded(...storedEmailIds: readonly string[]): Answer {
+    return {
+        status: 200,
+        body: JSON.stringify({
+            results: storedEmailIds.map((id) => ({ storedEmailId: id, outcome: 'recorded' })),
+        }),
+    };
+}
+
+describe('markMailRead', () => {
+    it('states the seen flag on the client surface’s flag route for each message named', async () => {
+        const { transport, requests } = recording(recorded(storedEmailId));
+
+        await markMailRead(session, transport, [storedEmailId]);
+
+        expect(requests[0]?.method).toBe('POST');
+        expect(requests[0]?.path).toBe('https://mail.example.invalid/api/client/mutations/flags');
+        expect(requests[0]?.headers['Authorization']).toBe('Basic dGVzdA==');
+        expect(requests[0]?.headers['Content-Type']).toBe('application/json');
+        expect(JSON.parse(requests[0]?.body ?? '')).toStrictEqual({
+            changes: [{ storedEmailId, flags: { seen: true } }],
+        });
+    });
+
+    it('answers what became of each message', async () => {
+        const answer = await markMailRead(
+            session,
+            answering({
+                status: 200,
+                body: JSON.stringify({
+                    results: [
+                        { storedEmailId, outcome: 'recorded' },
+                        { storedEmailId: 'gone', outcome: 'message-not-found' },
+                    ],
+                }),
+            }),
+            [storedEmailId, 'gone'],
+        );
+
+        expect(answer).toStrictEqual({
+            outcome: 'read',
+            value: [
+                { storedEmailId, outcome: 'recorded' },
+                { storedEmailId: 'gone', outcome: 'message-not-found' },
+            ],
+        });
+    });
+
+    // The deployment refuses a batch past its bound whole rather than partly, so a caller that sent one would have
+    // marked nothing at all — which is why the size is the contract's rather than something discovered from a refusal.
+    it('names no more messages than one submission may carry', async () => {
+        const asked = Array.from({ length: mostMessagesPerMutation + 5 }, (_, at) => `message-${String(at)}`);
+        const { transport, requests } = recording(recorded());
+
+        await markMailRead(session, transport, asked);
+
+        const sent = JSON.parse(requests[0]?.body ?? '') as { changes: readonly { storedEmailId: string }[] };
+
+        expect(sent.changes).toHaveLength(mostMessagesPerMutation);
+        expect(sent.changes[mostMessagesPerMutation - 1]?.storedEmailId).toBe(
+            `message-${String(mostMessagesPerMutation - 1)}`,
+        );
+    });
+
+    it('says the deployment could not be reached where nothing answered', async () => {
+        const answer = await markMailRead(session, () => Promise.reject(new Error('the connection was refused')), [
+            storedEmailId,
+        ]);
+
+        expect(answer).toStrictEqual({ outcome: 'failed', failure: { reason: 'unavailable', status: null } });
+    });
+
+    it('says the credential may not do this where the deployment refused it', async () => {
+        const answer = await markMailRead(session, answering({ status: 403, body: '' }), [storedEmailId]);
+
+        expect(answer).toStrictEqual({ outcome: 'failed', failure: { reason: 'unauthorized', status: 403 } });
+    });
+
+    it('refuses an outcome this client does not know, rather than drawing a conclusion from it', async () => {
+        const answer = await markMailRead(
+            session,
+            answering({
+                status: 200,
+                body: JSON.stringify({ results: [{ storedEmailId, outcome: 'partly-recorded' }] }),
+            }),
+            [storedEmailId],
+        );
+
+        expect(answer).toStrictEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+
+    it('refuses an answer naming more messages than the batch could have', async () => {
+        const answer = await markMailRead(
+            session,
+            answering(recorded(...Array.from({ length: mostMessagesPerMutation + 1 }, () => storedEmailId))),
+            [storedEmailId],
+        );
+
+        expect(answer).toStrictEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+
+    it('refuses an answer that is not a batch of results at all', async () => {
+        const answer = await markMailRead(session, answering({ status: 200, body: 'not json' }), [storedEmailId]);
+
+        expect(answer).toStrictEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+});

--- a/frontend/src/Client.Backend/src/mailMutations.ts
+++ b/frontend/src/Client.Backend/src/mailMutations.ts
@@ -1,0 +1,159 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { failed, failureReasonForStatus, read, type ClientResult } from './failure';
+import { asRecord } from './json';
+import { headersFor, routeFor, type ClientSession } from './session';
+import { send, type ClientResponse, type MailFathomTransport } from './transport';
+
+// The one route in this package that changes a mailbox rather than reading one. Nothing here reaches a mail server: a
+// submission writes a durable record and answers, and the account's own reconciliation pass is what issues the IMAP
+// command — so a screen never waits on somebody else's server, and a change asked for while the account is unreachable
+// is kept rather than lost.
+//
+// What it publishes is marking read, and only that, because that is what the client asks for today. The route carries
+// every flag and tag change a mailbox takes; a second act reaching it arrives as a second exported function named for
+// what it asks, rather than as a general submitter this one is written in terms of.
+
+/** The route a batch of flag changes is written down at, relative to the client prefix. */
+export const mailFlagMutationsRoute = '/mutations/flags';
+
+/**
+ * The most messages one submission may name, which is the deployment's bound rather than a preference.
+ *
+ * Stated here rather than borrowed, so this contract says its own size: a batch past it is refused whole with a `400`
+ * rather than partly applied, which is why the caller splits instead of discovering the bound from a refusal.
+ */
+export const mostMessagesPerMutation = 200;
+
+// A result is five short fields per message, and the batch is bounded above. Generous against that arithmetic and far
+// below anything worth buffering: what the bound guards against is an answer that was never a batch of results.
+const longestMutationAnswer = 262_144;
+
+/**
+ * What became of one message in a submitted batch.
+ *
+ * `recorded` is the only outcome that wrote anything down. The other four are each about that one message rather than
+ * about the request, which is what lets a batch composed from a list that has moved on report exactly which entries did
+ * not apply and write the rest down.
+ */
+export type MailMutationOutcome =
+    | 'recorded'
+    | 'message-not-found'
+    | 'destination-not-found'
+    | 'already-in-destination'
+    | 'account-no-longer-configured'
+    | 'change-not-usable';
+
+const mutationOutcomes: readonly MailMutationOutcome[] = [
+    'recorded',
+    'message-not-found',
+    'destination-not-found',
+    'already-in-destination',
+    'account-no-longer-configured',
+    'change-not-usable',
+];
+
+/** What one message in a batch was answered with. */
+export interface MailMutationResult {
+    readonly storedEmailId: string;
+    readonly outcome: MailMutationOutcome;
+}
+
+/**
+ * Writes down that the named messages have been read, as one batch of flag changes their reader's act authored.
+ *
+ * @param session Who is asking and where.
+ * @param transport How a request reaches the deployment.
+ * @param storedEmailIds The messages to mark read, at most {@link mostMessagesPerMutation} of them.
+ * @returns One result per message the deployment answered for, or an expected failure as a value.
+ */
+export async function markMailRead(
+    session: ClientSession,
+    transport: MailFathomTransport,
+    storedEmailIds: readonly string[],
+): Promise<ClientResult<readonly MailMutationResult[]>> {
+    const changes = storedEmailIds
+        .slice(0, mostMessagesPerMutation)
+        .map((storedEmailId) => ({ storedEmailId, flags: { seen: true } }));
+
+    return answerOf(
+        await send(transport, {
+            method: 'POST',
+            path: routeFor(session, mailFlagMutationsRoute),
+            headers: { ...headersFor(session), 'Content-Type': 'application/json' },
+            body: JSON.stringify({ changes }),
+            longestAnswer: longestMutationAnswer,
+        }),
+    );
+}
+
+function answerOf(response: ClientResponse | null): ClientResult<readonly MailMutationResult[]> {
+    if (response === null) {
+        return failed('unavailable', null);
+    }
+
+    if (response.status !== 200) {
+        return failed(failureReasonForStatus(response.status), response.status);
+    }
+
+    const results = parseResults(response.body);
+
+    return results === null ? failed('unreadable', response.status) : read(results);
+}
+
+function parseResults(body: string): readonly MailMutationResult[] | null {
+    let parsed: unknown;
+
+    try {
+        parsed = JSON.parse(body);
+    } catch {
+        return null;
+    }
+
+    const record = asRecord(parsed);
+    const answered = record?.['results'];
+
+    // Bounded during the walk rather than after it, because a walk that completed has already paid for what it read.
+    if (!Array.isArray(answered) || answered.length > mostMessagesPerMutation) {
+        return null;
+    }
+
+    const results: MailMutationResult[] = [];
+
+    for (const entry of answered) {
+        const result = parseResult(entry);
+
+        if (result === null) {
+            return null;
+        }
+
+        results.push(result);
+    }
+
+    return results;
+}
+
+function parseResult(entry: unknown): MailMutationResult | null {
+    const record = asRecord(entry);
+
+    if (record === null) {
+        return null;
+    }
+
+    const storedEmailId = record['storedEmailId'];
+    const outcome = record['outcome'];
+
+    if (typeof storedEmailId !== 'string' || !isMutationOutcome(outcome)) {
+        return null;
+    }
+
+    // What each change became — the record it was written down as and where that record stands — is deliberately not
+    // read here. Nothing in this client follows a record yet, and a field parsed for nobody is a field to keep true.
+    return { storedEmailId, outcome };
+}
+
+function isMutationOutcome(value: unknown): value is MailMutationOutcome {
+    return typeof value === 'string' && mutationOutcomes.includes(value as MailMutationOutcome);
+}

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -263,7 +263,7 @@ async function servedByADeployment(page: Page): Promise<void> {
     // about the two preferences held on the deployment is that a choice made in one session is in force in the next,
     // and a route answering a fixed document would prove the read alone while quietly passing a client that wrote
     // nothing at all.
-    let held = { telemetryEnabled: true, theme: 'system', openMailInTabs: false };
+    let held = { telemetryEnabled: true, theme: 'system', openMailInTabs: false, markReadOnOpen: true };
 
     await page.route('**/api/client/preferences', (route) => {
         if (route.request().method() === 'POST') {

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -722,6 +722,7 @@ test('states the whole preferences document to the deployment when one of them i
         telemetryEnabled: true,
         theme: 'dark',
         openMailInTabs: false,
+        markReadOnOpen: true,
     });
 });
 


### PR DESCRIPTION
Opening a message in the client marks it read on the person's own mail server, and the row draws read state from what the list already carries.

Closes #1475

## What it does

[ADR 0026](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0026-marking-a-message-read-when-a-person-opens-it-in-the-client.md) is what this implements, and every one of its five chosen options is here rather than reinterpreted.

- **The trigger is the body having been drawn**, not the selection having moved. `messageBody/Message.tsx` says so once per message it actually put on a screen — a read the reader scrolled past is discarded rather than drawn, and asking for the sender's pictures re-reads the same message and says nothing again. That is what a preview pane otherwise needs a dwell timer for.
- **The submission is one flag mutation their act authors**, through the route #1208 serves. `Client.Backend/src/mailMutations.ts` is the one module in that package that changes a mailbox: it names the messages, bounds the batch at the route's own 200, and answers one outcome per message. Nothing reaches a mail server; the durable record is written and the account's own pass issues the `STORE`, so the pane never waits on IMAP and an unreachable account leaves the reading pending.
- **Bodies drawn together travel in one batch.** The provider coalesces on the next microtask, so a conversation showing its history submits one request naming every message rather than one per message, and nothing waits for a body still being read.
- **Three things decide whether it happens at all**, and all three are the frame's: the reader's own setting, the grant, and there being a session. Where any is missing, every component below reads `nothingMarkedRead` and no screen asks the question twice.
- **There is no second local read state.** What has been marked is a session-held map keyed by the credential, in one context above the frame. Signing out drops it; nothing is stored.

## What reads it

The row (`messageRows/MessageRow.tsx`), the conversation head (`thread/ThreadMessage.tsx`), and the folder tree. The tree corrects the directory once before `folderTreeOf` builds it, which is what keeps the folder, its mailbox, the role across mailboxes, and the whole-workspace row agreeing with the rows beneath them rather than each summing a different number. A count is floored at nothing, because a folder synchronized between the marking and the read already reports the message read.

A row drawn read stays in the list, including a list narrowed to unread mail — taking it out from under somebody the moment the pane rendered it would be the list disagreeing with the pane about what is open. The next read of the folder removes it.

A marking the deployment did not write down is one the row stops claiming: both a submission that never arrived and a message answered with anything but `recorded` put it back to what the list said.

## The setting

`markReadOnOpen` is the fourth field of the client preferences document, defaulting to on, covering every account — ADR 0026 E2. The client reads it and honours it. **The control that turns it off is not in this change**: the design project does not draw a settings screen yet, and a screen it does not cover is designed there before it is built. Follow-up below.

## Breaking

**Against the deployment contract**, and recorded here for the release pull request to compose from:

- `GET`/`POST /api/client/preferences` gains `markReadOnOpen`. The service supplies the default for a stored row written before the field existed, so **no operator action follows** — a person who never chose reads as marking, which is the decision's default.
- The client refuses a preferences answer that omits the field, as it already refuses one omitting any of the other three. So a client bundle newer than the deployment serving it falls back to the unset answers until the deployment is upgraded with it. The two ship together in one image, so this is reachable only for a desktop head pointed at an older deployment.
- `mailfathom.mail.flags.write` becomes a grant the client asks about. A deployment that never granted it now shows one more sentence in the credential strip and marks nothing. Nothing is refused that used to work.

**Against the design, deliberately:** the row's accent dot is removed. The design project draws unread as weight and colour and nothing else, and a dot ahead of the avatar inset every unread row a little further than every read one, which a column of rows scanned top to bottom cannot afford. The `sr-only` *Unread* stays for a reader looking at neither.

## Verification

- `scripts/verify-full.sh` — passed, 287/287 workflow contracts, both suites.
- The client suite is 1428 tests over 81 files. New: `mailMutations.test.ts`, `readMarking/ReadMarking.test.tsx`, `folders/unreadAfterMarking.test.ts`; extended: `App.test.tsx`, `Message.test.tsx`, `MessageRow.test.tsx`, `ThreadMessage.test.tsx`, `Thread.test.tsx`, `FolderTree.test.tsx`, `ReadingPane.test.tsx`, `useClientPreferences.test.tsx`. Every item on ADR 0026's own validation list has a test: a discarded read submits nothing, a drawn body submits exactly one keyed to the message shown, a conversation with its history hidden marks one and showing it marks each, and the setting defaults to on.
- The design half of the loop was done as two screenshots — the project's own rows against the built bundle driven in a browser, at one viewport — before this was opened. What that found is the dot above; the remaining differences on the row are the third line's AI note, which is stage 3, and how `ReceivedAt` words a date, neither of which this change touches.
- `backend/tests/PublicSurfaces.UnitTests/http-api-contract.json` regenerated.

## For the owner

Three things this change deliberately did not do:

1. **ADR 0026 is still `proposed`.** Accepting it is yours.
2. **Its `describes:` marker does not reach `frontend/src/Client.App/src/readMarking/**` or `.../folders/**`**, which are where the decision now actually lives. Widening it is an ADR edit and needs your approval.
3. **The control for `markReadOnOpen`** needs a screen the design project has not drawn. Worth an issue once it has.

One test-fixture defect was fixed on the way: `App.test.tsx` cleared its request record only after each test, so a read answering while the previous tree was torn down could start one more and have it read as the next test's. It now clears before as well. That is the intermittent failure seen on this file in earlier runs.

https://claude.ai/code/session_01WNq6y2zRthKHbWRP4M4wJr
