### PR TITLE
[#1520] Hold every client setting to one rule about where it is kept

### DIFF
--- a/frontend/src/AGENTS.md
+++ b/frontend/src/AGENTS.md
@@ -71,6 +71,16 @@ Four things may never cross, in either direction:
 
 ## State: what is stored, what is derived, and where an effect is wrong
 
+- **Where a setting is kept follows one rule rather than whichever module was open first.** What a person sets
+  **after signing in is kept by the deployment**, in the per-person document behind `/api/client`, so it follows them to
+  the next machine; what they set **before signing in is kept on the device**, because the sign-in screen has no session
+  to ask with. A setting offered on both sides of signing in is placed by the earlier of the two, which is why the
+  language stays on the device although the settings screen offers it as well. An exception exists only where the issue
+  asking for the setting asked for one explicitly and said why, and two stand today: the theme is held in **both**
+  stores — the device answers first so that something is painted above the sign-in screen, and the deployment's answer
+  replaces it once a session exists — and the list/pane split is kept on the device alone, because a pane width says how
+  much room this screen has rather than how somebody wants to work. The theme is the only setting held in both, and a
+  setting that belongs to neither store is session state rather than a third place to keep one.
 - **Store the smallest thing you cannot compute.** Everything computable from stored state is computed during render,
   not stored beside it and kept in step. Two pieces of state that must agree are one piece of state and a function; the
   bug this prevents is the pair that disagrees, which no type catches and no test finds unless somebody thought of it.

--- a/frontend/src/Client.App/src/device/deviceStore.ts
+++ b/frontend/src/Client.App/src/device/deviceStore.ts
@@ -7,8 +7,8 @@
 // browser or a WebView refuses needs is written once instead of once per caller, and so the names those values are
 // written under are declared together rather than as strings spread across the screens that read them.
 //
-// What belongs here is what says how much room *this screen* has. What says how somebody wants to work follows them
-// between machines and belongs to the deployment instead, which is a surface of its own.
+// Which of the client's two stores a new setting belongs in is not decided here: `frontend/src/AGENTS.md` § *State*
+// holds the one rule and the two exceptions granted to it, both of which are values above.
 //
 // Reached as `window.localStorage` rather than as the bare global on purpose, and this is where that reason is
 // written down: Node publishes a `localStorage` global of its own, which is unavailable unless the process was started

--- a/frontend/src/Client.App/src/preferences/useClientPreferences.ts
+++ b/frontend/src/Client.App/src/preferences/useClientPreferences.ts
@@ -22,8 +22,8 @@ import { useTheme } from '../theme/useTheme';
 // then replaces it once one exists, and that replacement happens once per read rather than on every render — a screen
 // that reconciled the two continuously would fight whichever of them a person changed last.
 //
-// Language is not here. It stays on the device, because what a person reads a client in is a fact about the machine
-// they are at rather than about them.
+// Language is not here. It is chosen above the sign-in screen as well as behind it, and the rule in
+// `frontend/src/AGENTS.md` § *State* is what keeps it where the earlier of those two can reach it.
 
 /** What the client is set to, and how a person changes one of the settings that follow them. */
 export interface ClientPreferencesInForce {


### PR DESCRIPTION
Closes #1520

The client keeps what a person sets in two places and no file said which place a new setting goes to, so the next one
was placed by whichever module the person adding it happened to open. This writes that rule into
`frontend/src/AGENTS.md` § *State*, holds every setting the client offers against it, and stops the two modules from
each stating a criterion of their own beside it.

**No setting had to move.** Every one is already where the rule puts it, and the two device-kept settings a person
changes after signing in are both exceptions their own issues asked for explicitly — which is what the rule's exception
clause is for. So there is no store to move, no old store to read once, and therefore no test for a move: the change is
the contract plus the two comments that disagreed with it.

## The design project's Settings window, read first

Read at `MailFathom Prototyp.dc.html` and screenshotted at 1440×900 in the dark theme, with the account menu open and
then the Settings window open. The design draws four sections in the window — **profile** (display name, portrait,
`JPG/PNG, maks. 1 MB`), **language** (a chip per offering), **message view** (*Uproszczony* / *HTML* with a hint under
it), and **privacy** (the telemetry switch stated as the decision to withhold, with the warning that follows it) — and
in the menu the mailbox list, the tab-mode switch, the theme segments, the row into Settings, and signing out.

Held against the client:

| The design draws | The client | Verdict |
|---|---|---|
| Profile: name, portrait, bounds line | Same, plus *Remove* where a portrait exists and the three notices the deployment can answer with | Agrees |
| Language chips | Same, English first because the client lists its offerings in its own order | Agrees |
| Message view: simplified / HTML | Absent | The deployment holds no such preference; #1508 owns it, and drawing a switch that decides nothing was refused deliberately |
| Privacy: the telemetry switch and its warning | Same | Agrees |
| Menu: mailboxes, tab mode, theme, Settings, sign out | Same controls in the same order | Agrees |
| Menu: nothing between the name and the mailboxes | The client prints the client and deployment versions, and the chosen deployment's address with the way out of it | Named, not corrected — #1526 |
| Menu: mailbox rows are pickable, with a check on the one in scope | The client's rows are informational; the mailbox in scope is chosen in Discover | Named, not corrected — #1526 |

The screenshots stayed in the session's scratch directory, as a capture of a signed-in client does.

## Every setting the client offers, and where it is kept

| Setting | Where a person sets it | Kept today | Where the rule puts it |
|---|---|---|---|
| Theme | Sign-in strip; account menu | Device (`mailfathom.theme`) **and** deployment (`theme`) | Both — the one setting with a double life, because the sign-in screen has to paint something before a session exists |
| Language | Sign-in strip; Settings → Language | Device (`mailfathom.locale`) | Device: it is set before signing in, and being offered after does not move it |
| Tab mode | Account menu | Deployment (`openMailInTabs`) | Deployment |
| Telemetry | Settings → Privacy | Deployment (`telemetryEnabled`) | Deployment |
| Mark read on open | Nowhere in the client — read only | Deployment (`markReadOnOpen`) | Deployment |
| List/pane split | The grip in the Mail space | Device, per person (`mailfathom.listWidth.<digest>`) | Device — the exception #1497 asked for explicitly and gave its reason for: a pane width says how much room this screen has |
| Display name | Settings → Profile | Deployment (`/api/client/display-name`) | Deployment |
| Portrait | Settings → Profile | Deployment (`/api/client/portrait`) | Deployment |
| Chosen deployment address | Sign-in screen; the menu's *Change* | Device (`mailfathom.deployment`) | Device: it is what a session is made against, so it is set before there is one |

Not settings, and named so the enumeration is complete: the workspace a tab is looking at, the listings it has read, and
the credential are session state under `sessionStorage`, which is a lifetime rather than a third place to keep a
preference.

## What changed

- `frontend/src/AGENTS.md` § *State* gains the rule, its exception clause, and the two exceptions that stand today.
- `device/deviceStore.ts` stated a criterion of its own — *what belongs here is what says how much room this screen
  has* — which is not the rule and is false of the language it already holds. It now points at the contract.
- `preferences/useClientPreferences.ts` gave a second reason for the language being elsewhere. It now points at the
  same place, and keeps the mechanics of the theme's two sides, which are its own.

## Raised rather than corrected here

- #1526 — the account menu and the design disagree about the version line and about whether a mailbox is picked there.
  Both are the owner's call, since the design project is the source of truth.
- #1508 already owns the message view the design draws and the client does not.
- #1232 already owns the telemetry switch, which is stored and drawn but gates no exporter yet.

## Verification

`scripts/verify-full.sh` — client flow only, no service project reached.


https://claude.ai/code/session_01F5xjhJQCxjr3Dkkn6JDL3b
