### PR TITLE
[#1232] Let a person turn the client's telemetry off, and prove it never carries mail

### DIFF
--- a/backend/src/Host/Api/ClientApiEndpoints.cs
+++ b/backend/src/Host/Api/ClientApiEndpoints.cs
@@ -5,6 +5,7 @@
 using MailFathom.Application.Access;
 using MailFathom.Domain.Access;
 using MailFathom.Host.Configuration.Endpoints;
+using MailFathom.Host.Observability.ClientTelemetry;
 using MailFathom.Host.Security.Endpoints;
 using MailFathom.Versioning;
 
@@ -83,10 +84,16 @@ internal static class ClientApiEndpoints
         // depends on this line staying first.
         api.AddEndpointFilter(RouteAuthorization.RefusingUnpermitted(ProtectedSurface.Mail));
 
+        // Whether the telemetry routes are served at all, read once where they are mapped rather than per request: the
+        // destination is resolved while the host is composed, so a request could only ever get the same answer more
+        // expensively. It is reported because a client cannot find out any other way without exporting a batch to see
+        // whether it is refused, and a switch over a deployment that forwards nothing is a control deciding nothing.
+        var forwardsTelemetry = endpoints.ServiceProvider.GetService<ClientTelemetryDestination>() is not null;
+
         // TypedResults rather than Results, so the response type reaches the endpoint's metadata and the generated
         // OpenAPI document describes what this answers with rather than an untyped 200.
         api.MapGet(SessionRoute, (IAuthorizedPrincipalSource principals) =>
-                TypedResults.Ok(ClientSessionResponse.For(principals.Current)))
+                TypedResults.Ok(ClientSessionResponse.For(principals.Current, forwardsTelemetry)))
             .RequireNoPermission();
 
         api.MapClientOwnerRecord();
@@ -114,6 +121,7 @@ internal static class ClientApiEndpoints
 /// <param name="Service">The product this is, so a client can tell it reached MailFathom rather than something else answering the port.</param>
 /// <param name="Version">The running version, which is what tells a client which contract it is talking to.</param>
 /// <param name="Permissions">The published names of what this caller's grant carries, in the order this repository publishes them, and empty for a credential granted nothing.</param>
+/// <param name="Telemetry">Whether this deployment forwards a client's own telemetry, which is the same answer for every caller because it is a deployment's configuration rather than a grant.</param>
 /// <remarks>
 /// <para>
 /// It names no credential, which is the one way it differs from what the administrative surface answers. That surface's
@@ -127,19 +135,28 @@ internal static class ClientApiEndpoints
 /// ask about itself. A request that established no principal reports an empty grant rather than failing, which is the
 /// accurate answer to what such a caller may do.
 /// </para>
+/// <para>
+/// Whether telemetry is forwarded stands beside the grant rather than inside it, because it is not one: every caller
+/// gets the same answer, and what decides it is whether the deployment named a collector. It is reported so that a
+/// client can say there is nothing behind its own telemetry switch instead of offering a control that decides nothing
+/// — the alternative being to export a batch and read the <c>404</c>, which is finding out by doing the thing.
+/// </para>
 /// </remarks>
 internal sealed record ClientSessionResponse(
     string Service,
     string Version,
-    IReadOnlyList<string> Permissions)
+    IReadOnlyList<string> Permissions,
+    bool Telemetry)
 {
     /// <summary>Describes what the credential that reached this route was granted.</summary>
     /// <param name="principal">What the application layer was told admitted this request, or nothing where the transport established none.</param>
+    /// <param name="forwardsTelemetry">Whether this deployment serves the telemetry routes, which it does where it named a collector of its own.</param>
     /// <returns>The response body.</returns>
-    internal static ClientSessionResponse For(AuthorizedPrincipal? principal) => new(
+    internal static ClientSessionResponse For(AuthorizedPrincipal? principal, bool forwardsTelemetry) => new(
         "MailFathom",
         StampedAssemblyVersion.ReadFrom(typeof(ClientSessionResponse).Assembly).Version,
-        GrantOf(principal));
+        GrantOf(principal),
+        forwardsTelemetry);
 
     /// <summary>Names what the caller holds, in the order this repository publishes the set.</summary>
     /// <remarks>The published order rather than the grant's own, so two credentials granted the same permissions are reported identically whichever order an operator wrote them in.</remarks>

--- a/backend/tests/Host.UnitTests/Api/ClientSessionResponseTests.cs
+++ b/backend/tests/Host.UnitTests/Api/ClientSessionResponseTests.cs
@@ -29,7 +29,7 @@ public sealed class ClientSessionResponseTests
             [MailFathomPermission.MailSend, MailFathomPermission.MailRead]);
 
         // Act
-        var session = ClientSessionResponse.For(principal);
+        var session = ClientSessionResponse.For(principal, forwardsTelemetry: true);
 
         // Assert
         Assert.Equal(
@@ -46,9 +46,11 @@ public sealed class ClientSessionResponseTests
     {
         // Act
         var first = ClientSessionResponse.For(
-            AuthorizedPrincipal.Caller("one", [MailFathomPermission.MailRead, MailFathomPermission.MailSend]));
+            AuthorizedPrincipal.Caller("one", [MailFathomPermission.MailRead, MailFathomPermission.MailSend]),
+            forwardsTelemetry: true);
         var second = ClientSessionResponse.For(
-            AuthorizedPrincipal.Caller("two", [MailFathomPermission.MailSend, MailFathomPermission.MailRead]));
+            AuthorizedPrincipal.Caller("two", [MailFathomPermission.MailSend, MailFathomPermission.MailRead]),
+            forwardsTelemetry: true);
 
         // Assert
         Assert.Equal(first.Permissions, second.Permissions);
@@ -57,12 +59,12 @@ public sealed class ClientSessionResponseTests
     /// <summary>A credential granted nothing reaches this route and nowhere else, and "nothing" is the accurate answer.</summary>
     [Fact]
     public void For_ACallerGrantedNothing_ReportsAnEmptyGrantRatherThanFailing() =>
-        Assert.Empty(ClientSessionResponse.For(AuthorizedPrincipal.Caller("retired", [])).Permissions);
+        Assert.Empty(ClientSessionResponse.For(AuthorizedPrincipal.Caller("retired", []), forwardsTelemetry: true).Permissions);
 
     /// <summary>A request that established no principal is answered rather than faulted, for the same reason.</summary>
     [Fact]
     public void For_ARequestThatEstablishedNoPrincipal_ReportsAnEmptyGrant() =>
-        Assert.Empty(ClientSessionResponse.For(principal: null).Permissions);
+        Assert.Empty(ClientSessionResponse.For(principal: null, forwardsTelemetry: true).Permissions);
 
     /// <summary>
     /// The one way this differs from the administrative session route. The name is the deployment's own configured
@@ -77,7 +79,9 @@ public sealed class ClientSessionResponseTests
 
         // Act
         var body = JsonSerializer.Serialize(
-            ClientSessionResponse.For(AuthorizedPrincipal.Caller(credentialName, [MailFathomPermission.MailRead])));
+            ClientSessionResponse.For(
+                AuthorizedPrincipal.Caller(credentialName, [MailFathomPermission.MailRead]),
+                forwardsTelemetry: true));
 
         // Assert
         Assert.DoesNotContain(credentialName, body, StringComparison.OrdinalIgnoreCase);
@@ -88,10 +92,30 @@ public sealed class ClientSessionResponseTests
     public void For_AnyCaller_NamesTheProductAndTheRunningVersion()
     {
         // Act
-        var session = ClientSessionResponse.For(principal: null);
+        var session = ClientSessionResponse.For(principal: null, forwardsTelemetry: true);
 
         // Assert
         Assert.Equal("MailFathom", session.Service);
         Assert.NotEmpty(session.Version);
+    }
+
+    /// <summary>
+    /// What lets a client say there is nothing behind its telemetry switch. It follows the deployment rather than the
+    /// grant, so a credential granted nothing is told the same thing as one granted everything.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void For_ADeploymentThatDoesOrDoesNotForwardTelemetry_ReportsThatToEveryCaller(bool forwardsTelemetry)
+    {
+        // Act
+        var granted = ClientSessionResponse.For(
+            AuthorizedPrincipal.Caller("reader", [MailFathomPermission.MailRead]),
+            forwardsTelemetry);
+        var ungranted = ClientSessionResponse.For(principal: null, forwardsTelemetry);
+
+        // Assert
+        Assert.Equal(forwardsTelemetry, granted.Telemetry);
+        Assert.Equal(forwardsTelemetry, ungranted.Telemetry);
     }
 }

--- a/backend/tests/PublicSurfaces.UnitTests/http-api-contract.json
+++ b/backend/tests/PublicSurfaces.UnitTests/http-api-contract.json
@@ -1714,6 +1714,9 @@
           "service": {
             "type": "string"
           },
+          "telemetry": {
+            "type": "boolean"
+          },
           "version": {
             "type": "string"
           }
@@ -1721,7 +1724,8 @@
         "required": [
           "service",
           "version",
-          "permissions"
+          "permissions",
+          "telemetry"
         ],
         "type": "object"
       },

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -108,13 +108,21 @@ specification, so a client points its exporter at the prefix above them and appe
 
 ### The session route
 
-It answers with three fields: `service`, which is always `MailFathom`; `version`, the running release; and
-`permissions`, the published names the credential just presented carries, in the order this project publishes them.
+It answers with four fields: `service`, which is always `MailFathom`; `version`, the running release; `permissions`, the
+published names the credential just presented carries, in the order this project publishes them; and `telemetry`,
+whether this deployment forwards a client's own telemetry.
 
 That is what a client needs before it has drawn a single message: that this is MailFathom rather than something else
 answering the port, which contract it speaks, and what the rest of the surface will serve it. It is also what lets
 sign-in be built and proven end to end before a screen exists — a client that reached here with a token it had just been
 issued knows the token works.
+
+**`telemetry` is not part of the grant and never varies by credential.** What decides it is whether the deployment named
+a collector, which is the same condition that decides whether
+[the telemetry routes](#the-telemetry-routes) are served at all — so the two cannot disagree. A client reads it to
+decide whether to record anything and whether its own switch is worth offering; the only other way to find out is to
+export a batch and read the `404`, which is finding out by doing the thing. A client older than this field, or one
+reading an answer that omits it, treats it as `false` and sends nothing.
 
 It has a second reader, holding nothing at all. A person naming their deployment in the client types a host, and the
 client asks here before it sends anything to that address, so a mistyped one is reported as an address that answers as
@@ -1306,8 +1314,10 @@ to [the published permission set](permissions.md).
 signed in from, and a response saying when a switch last moved would be the beginning of one. Erasing an owner erases
 their preferences with everything else derived from them.
 
-**A deployment that proxies no telemetry still serves these routes** and stores the switch unchanged. What a client
-draws when there is nothing behind the switch is the client's own question.
+**A deployment that proxies no telemetry still serves these routes** and stores the switch unchanged, so a person's
+answer survives a deployment that starts forwarding later. What such a deployment tells a client is
+[`"telemetry": false` on the session route](#the-session-route), and what MailFathom's own client draws for that is
+a sentence saying so in place of the switch — a control over a client that is already sending nothing decides nothing.
 
 ### The portrait routes
 

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -1216,7 +1216,9 @@ it. Turning it back on begins at that moment and reaches back over nothing.
 [`"telemetry": false` on the session route](client-endpoint.md#the-session-route); the client stops recording the moment
 it reads that and throws away what it had held, and the settings screen says so in place of a control that would decide
 nothing. Until a deployment has said either way the client records, because a deployment nobody has reached yet is
-every cold start and every failed sign-in — which is what the buffer below exists to keep.
+every cold start and every failed sign-in — which is what the buffer below exists to keep. The screen says that too,
+in place of either of the other two: a deployment that has not answered has not refused, so drawing the sentence above
+over that state would tell somebody nothing is being sent at the one moment something is.
 
 **The client exports nothing until somebody has signed in, and records from the moment it opens.** The exporter reaches
 [the telemetry routes](client-endpoint.md#the-telemetry-routes) on the deployment the client is pointed at and

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -1195,6 +1195,26 @@ the owner attributes itself, from the credential the export presented, replacing
 | `service.version` | The same `<VersionPrefix>` the deployment reports, substituted into the bundle at build time |
 | `mailfathom.client.head` | `web` or `desktop` — which head produced the record, not which operating system it ran on |
 
+**Whoever is reading decides whether any of it is recorded, and the switch is on the client's settings screen.** It is
+held by the deployment rather than by the browser profile or the desktop install it was moved in — it is
+[one of the four client preferences](client-endpoint.md#the-preferences-routes), so declining once holds on every
+machine that person signs in from — and the client keeps the last answer it was given on the device as well, so a
+restart honours a decision before the first read comes back rather than recording for the second it takes. That cache
+is not a second opinion: nothing writes it but the deployment's answer and the switch itself, and a client that has
+been answered never reads it again for the rest of the run.
+
+**Off means nothing is recorded, not that records are dropped on the way out.** The switch stops the writing, so a
+person who declined pays nothing to run the client instead of paying for everything but the upload. What was recorded
+before the answer arrived is thrown away rather than flushed: a client that has never been told stands on the unset
+answer and records into the buffer described below, so an answer of off empties that buffer without ever addressing
+it. Turning it back on begins at that moment and reaches back over nothing.
+
+**A deployment that forwards no telemetry offers no switch.** It answers
+[`"telemetry": false` on the session route](client-endpoint.md#the-session-route); the client stops recording the moment
+it reads that and throws away what it had held, and the settings screen says so in place of a control that would decide
+nothing. Until a deployment has said either way the client records, because a deployment nobody has reached yet is
+every cold start and every failed sign-in — which is what the buffer below exists to keep.
+
 **The client exports nothing until somebody has signed in, and records from the moment it opens.** The exporter reaches
 [the telemetry routes](client-endpoint.md#the-telemetry-routes) on the deployment the client is pointed at and
 authenticates there with the session's own credential, so there is no destination and nothing to present before that.
@@ -1267,7 +1287,9 @@ fetched, so the wait a person actually has is invisible from the deployment.
 | `mailfathom.client.arrival.duration` | `s` | How long the document itself took to arrive |
 
 The first two carry `mailfathom.client.space`, whose values are the client's own space names, and each move opens a
-span named `navigate <space>`. The space a run opens on is not a move and is reported by none of them.
+span named `navigate <space>`. The space a run opens on is not a move and is reported by none of them. An address
+naming anything else is reported as `other` rather than as itself, which is what keeps a route carrying a message
+identifier out of a span name and out of a dimension however the client's addresses grow.
 
 **`mailfathom.client.arrival.duration` is reported only by a client the deployment itself served**, and that is the
 one place the two heads differ in what they can say. The browser times every document it loads, and that number means
@@ -1286,8 +1308,12 @@ somebody's desk would make a deployment's log unreadable within a day, which is 
 applies to itself.
 
 **Nothing the client sends carries what was on the screen.** No address, no subject, no correspondent, no search text,
-no message identifier, and no part of the credential reaches a span name, an attribute, a measurement, or a log record.
-The route templates and the space names above are the whole of the vocabulary, and both are closed sets.
+no message identifier, no folder name, and no part of the credential reaches a span name, an attribute, a measurement,
+or a log record. The route templates and the space names above are the whole of the vocabulary, and both are closed
+sets. That is a test rather than a claim: the client's unit suite drives every operation the wire package can make with
+mail in each argument that takes one, asserts that none of those values reaches a record, and asserts the stronger form
+beside it — that every request the client names itself is a method and a route template whose segments are literals or
+`{placeholder}` holes, which is what holds for a value nobody thought to forbid.
 
 ### What a client-originated trace contains
 

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -1200,8 +1200,11 @@ held by the deployment rather than by the browser profile or the desktop install
 [one of the four client preferences](client-endpoint.md#the-preferences-routes), so declining once holds on every
 machine that person signs in from — and the client keeps the last answer it was given on the device as well, so a
 restart honours a decision before the first read comes back rather than recording for the second it takes. That cache
-is not a second opinion: nothing writes it but the deployment's answer and the switch itself, and a client that has
-been answered never reads it again for the rest of the run.
+is not a second opinion: nothing writes it but the deployment's answer and the switch itself, and a client holding that
+person's own answer never reads it again for the rest of their session. A sign-out, or somebody else signing in on the
+same tab, reads it again — and reads it **under that person's own name**, because the cache is kept per person rather
+than per machine: two people sharing a machine hold two answers, and one of them being a refusal is exactly why a
+single name for both would be a defect rather than a saving.
 
 **Off means nothing is recorded, not that records are dropped on the way out.** The switch stops the writing, so a
 person who declined pays nothing to run the client instead of paying for everything but the upload. What was recorded

--- a/frontend/src/AGENTS.md
+++ b/frontend/src/AGENTS.md
@@ -76,11 +76,14 @@ Four things may never cross, in either direction:
   the next machine; what they set **before signing in is kept on the device**, because the sign-in screen has no session
   to ask with. A setting offered on both sides of signing in is placed by the earlier of the two, which is why the
   language stays on the device although the settings screen offers it as well. An exception exists only where the issue
-  asking for the setting asked for one explicitly and said why, and two stand today: the theme is held in **both**
+  asking for the setting asked for one explicitly and said why, and three stand today: the theme is held in **both**
   stores — the device answers first so that something is painted above the sign-in screen, and the deployment's answer
-  replaces it once a session exists — and the list/pane split is kept on the device alone, because a pane width says how
-  much room this screen has rather than how somebody wants to work. The theme is the only setting held in both, and a
-  setting that belongs to neither store is session state rather than a third place to keep one.
+  replaces it once a session exists; whether telemetry may be recorded is held in both for a stronger reason, that a
+  client which has not yet been told anything has to honour a refusal rather than record until an answer arrives, so the
+  device's copy is keyed per person and read only until the deployment answers; and the list/pane split is kept on the
+  device alone, because a pane width says how much room this screen has rather than how somebody wants to work. Those
+  two are the only settings held in both, and a setting that belongs to neither store is session state rather than a
+  third place to keep one.
 - **Store the smallest thing you cannot compute.** Everything computable from stored state is computed during render,
   not stored beside it and kept in step. Two pieces of state that must agree are one piece of state and a function; the
   bug this prevents is the pair that disagrees, which no type catches and no test finds unless somebody thought of it.

--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -30,11 +30,15 @@ type Answer = Omit<ClientResponse, 'headers'> & { readonly headers?: Readonly<Re
 /** What a deployment answers a caller it accepts, which is what proves the address is MailFathom and the password works. */
 const accepted = sessionAnswering(['mailfathom.mail.read', 'mailfathom.mail.ask']);
 
-/** A deployment reporting itself and what it grants the credential that just reached it. */
-function sessionAnswering(permissions: readonly string[]): Answer {
+/**
+ * A deployment reporting itself, what it grants the credential that just reached it, and whether it forwards the
+ * client's own telemetry. The last of those is what decides whether the client records anything at all, so a test
+ * about telemetry states it and every other test takes a deployment that forwards it.
+ */
+function sessionAnswering(permissions: readonly string[], telemetry = true): Answer {
     return {
         status: 200,
-        body: JSON.stringify({ service: 'MailFathom', version: '0.8.7', permissions }),
+        body: JSON.stringify({ service: 'MailFathom', version: '0.8.7', permissions, telemetry }),
     };
 }
 
@@ -447,16 +451,20 @@ function renderApp(
 function telemetryRecording(): {
     readonly telemetry: ClientTelemetry;
     readonly exportedFor: (ClientSession | null)[];
+    readonly permitted: boolean[];
     readonly stopped: number[];
     readonly events: ClientEvent[];
 } {
     const exportedFor: (ClientSession | null)[] = [];
+    const permitted: boolean[] = [];
     const stopped: number[] = [];
     const events: ClientEvent[] = [];
 
     return {
         telemetry: {
-            exportFor: (session) => {
+            exportFor: (session, allowed) => {
+                permitted.push(allowed);
+
                 const started = exportedFor.push(session);
 
                 return () => stopped.push(started);
@@ -467,6 +475,7 @@ function telemetryRecording(): {
             },
         },
         exportedFor,
+        permitted,
         stopped,
         events,
     };
@@ -1554,5 +1563,38 @@ describe('App telemetry', () => {
         await screen.findByText('This deployment has stopped accepting the password that was kept. Sign in again.');
 
         expect(recording.events).toContain('credential_no_longer_accepted');
+    });
+
+    // A deployment that forwards nothing is not known to forward nothing until it says so, and until then the client
+    // records into the buffer #1230 holds — which is why what is asserted is where this ends rather than that it never
+    // permitted anything. The pipeline throws away what it held when that answer arrives, which `exporting.test.ts`
+    // and `holding.test.ts` are what prove.
+    it('stops recording against a deployment that says it forwards no telemetry', async () => {
+        const recording = telemetryRecording();
+
+        renderApp(
+            servedFrom,
+            heldCredential,
+            deploymentAnswering(undefined, sessionAnswering(['mailfathom.mail.read', 'mailfathom.mail.ask'], false)),
+            storeKeeping(),
+            recording.telemetry,
+        );
+        await framed();
+
+        expect(recording.permitted.at(-1)).toBe(false);
+    });
+
+    // What a restart owes somebody who turned it off on this machine: the decision is honoured from the first effect,
+    // before the deployment has answered anything, rather than for the second it takes that answer to come back.
+    it('honours a decision this device remembers before the deployment has answered again', async () => {
+        window.localStorage.setItem('mailfathom.telemetry', 'false');
+
+        const recording = telemetryRecording();
+
+        renderApp(servedFrom, heldCredential, deploymentAnswering(), storeKeeping(), recording.telemetry);
+        await framed();
+
+        expect(recording.permitted).not.toContain(true);
+        expect(recording.events).not.toContain('session_started');
     });
 });

--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ClientRequest, ClientResponse, ClientSession } from '@mailfathom/client-backend';
 import { App } from './App';
 import type { AdoptedDeployment } from './deployment/adoptedDeployment';
+import { telemetryKey } from './device/deviceStore';
 import { AttachmentDeliveryContext, type AttachmentDelivery } from './deployment/attachmentDelivery';
 import type { PortraitExchange } from './deployment/portraitExchange';
 import type { DeploymentTransport } from './deployment/sendToDeployment';
@@ -56,6 +57,9 @@ const workAccount = {
 
 /** What a run opens already holding, where something was kept for it. */
 const heldCredential = 'Basic dGVzdDpzZWNyZXQ=';
+
+/** Who `heldCredential` names, which is what the device's remembered telemetry answer is kept under. */
+const heldPerson = 'test';
 
 /** What the screen composes out of what `signIn` below types, which is what a test asserts was kept and presented. */
 const typedCredential = 'Basic b3duZXI6b3BlbiBzZXNhbWU=';
@@ -1587,7 +1591,7 @@ describe('App telemetry', () => {
     // What a restart owes somebody who turned it off on this machine: the decision is honoured from the first effect,
     // before the deployment has answered anything, rather than for the second it takes that answer to come back.
     it('honours a decision this device remembers before the deployment has answered again', async () => {
-        window.localStorage.setItem('mailfathom.telemetry', 'false');
+        window.localStorage.setItem(telemetryKey(heldPerson), 'false');
 
         const recording = telemetryRecording();
 

--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -88,10 +88,17 @@ const emptyFolder: Answer = {
     body: JSON.stringify({ emails: [], nextCursor: null, previousCursor: null, pageSize: 100 }),
 };
 
-/** A deployment that accepts any credential and answers the session and the accounts with what a test named. */
+/**
+ * A deployment that accepts any credential and answers the session and the accounts with what a test named.
+ *
+ * The preferences route answers nothing readable unless a test states it, which is what every test that is not about
+ * a preference wants: the client then draws the unset document rather than one this file would have to keep in step
+ * with the deployment's own. A test about a preference states the answer and gets it.
+ */
 function deploymentAnswering(
     accounts: Answer = directory(true, [workAccount]),
     session: Answer = accepted,
+    preferences: Answer | null = null,
 ): DeploymentTransport {
     return () => (request) => {
         asked.push(request);
@@ -100,7 +107,19 @@ function deploymentAnswering(
             return Promise.resolve(complete(emptyFolder));
         }
 
+        if (preferences !== null && request.path.endsWith('/preferences')) {
+            return Promise.resolve(complete(preferences));
+        }
+
         return Promise.resolve(complete(request.path.endsWith('/session') ? session : accounts));
+    };
+}
+
+/** The whole preferences document, because the route answers all of it whether or not anything was ever set. */
+function preferencesAnswering(telemetryEnabled: boolean): Answer {
+    return {
+        status: 200,
+        body: JSON.stringify({ telemetryEnabled, theme: 'system', openMailInTabs: false, markReadOnOpen: true }),
     };
 }
 
@@ -1485,8 +1504,9 @@ describe('App deployment', () => {
     });
 });
 
-// Inside the frame the language is chosen on the settings screen rather than in the menu that leads to it, which is
-// where the design project puts it — so a test about the language opens that screen the way a person does.
+// Inside the frame the language and the telemetry decision are made on the settings screen rather than in the menu
+// that leads to it, which is where the design project puts them — so a test about either opens that screen the way a
+// person does.
 function openSettings(): void {
     fireEvent.click(screen.getByRole('button', { name: 'Settings', hidden: true }));
 }
@@ -1588,9 +1608,9 @@ describe('App telemetry', () => {
         expect(recording.permitted.at(-1)).toBe(false);
     });
 
-    // What a restart owes somebody who turned it off on this machine: the decision is honoured from the first effect,
-    // before the deployment has answered anything, rather than for the second it takes that answer to come back.
-    it('honours a decision this device remembers before the deployment has answered again', async () => {
+    // What a restart owes somebody who turned it off on this machine: the decision is honoured from the first effect
+    // rather than for the second it takes an answer to come back, and it stands for as long as no answer does.
+    it('honours a decision this device remembers while the deployment has answered nothing', async () => {
         window.localStorage.setItem(telemetryKey(heldPerson), 'false');
 
         const recording = telemetryRecording();
@@ -1600,5 +1620,57 @@ describe('App telemetry', () => {
 
         expect(recording.permitted).not.toContain(true);
         expect(recording.events).not.toContain('session_started');
+    });
+
+    // The other half of that: the device's copy is a cache and not a second opinion, so the deployment's own answer
+    // replaces it — which is what makes a decision taken on one machine reach this one.
+    it('lets the deployment replace what this device remembers once it answers', async () => {
+        window.localStorage.setItem(telemetryKey(heldPerson), 'false');
+
+        const recording = telemetryRecording();
+
+        renderApp(
+            servedFrom,
+            heldCredential,
+            deploymentAnswering(undefined, accepted, preferencesAnswering(true)),
+            storeKeeping(),
+            recording.telemetry,
+        );
+        await framed();
+
+        expect(recording.permitted[0]).toBe(false);
+        await waitFor(() => {
+            expect(recording.permitted.at(-1)).toBe(true);
+        });
+    });
+
+    // What began is the session rather than the recording, so moving the switch off and on again reports nothing a
+    // second time. The guard is a ref rather than a derived value because the record is an event and not a state.
+    it('reports a session beginning once across a switch moved twice', async () => {
+        const recording = telemetryRecording();
+
+        renderApp(
+            servedFrom,
+            heldCredential,
+            deploymentAnswering(undefined, accepted, preferencesAnswering(true)),
+            storeKeeping(),
+            recording.telemetry,
+        );
+        await framed();
+        openSettings();
+
+        const withhold = screen.getByRole('switch', { name: /Do not send telemetry/ });
+
+        fireEvent.click(withhold);
+        await waitFor(() => {
+            expect(recording.permitted.at(-1)).toBe(false);
+        });
+
+        fireEvent.click(withhold);
+        await waitFor(() => {
+            expect(recording.permitted.at(-1)).toBe(true);
+        });
+
+        expect(recording.events.filter((event) => event === 'session_started')).toHaveLength(1);
     });
 });

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -86,19 +86,6 @@ export function App({
         [baseAddress, authorization],
     );
 
-    // What this client reports about itself goes out under the session that is signed in, so it starts when one exists
-    // and stops with it. Signing out, or being pointed at another deployment, therefore leaves nothing queued for a
-    // deployment somebody has left — and the session beginning is itself the first thing recorded.
-    useEffect(() => {
-        const stop = telemetry.exportFor(session);
-
-        if (session !== null) {
-            telemetry.happened('session_started');
-        }
-
-        return stop;
-    }, [session, telemetry]);
-
     // The transport those reads are made through, built once for the same reason. It carries a signal nothing ever
     // fires: the tree, the reading pane, and the body renderer each discard the answer to a read they stopped listening
     // for rather than cancelling it, which is what a screen that may be looking at another message by then actually
@@ -174,6 +161,40 @@ export function App({
     // credential without it would meet a refusal the screen has nothing to do about, and a machine with no network
     // would meet nothing at all.
     const preferences = useClientPreferences(readsMail && connection.online ? session : null, readMail);
+
+    // What this client reports about itself goes out under the session that is signed in, so it starts when one exists
+    // and stops with it. Signing out, or being pointed at another deployment, therefore leaves nothing queued for a
+    // deployment somebody has left — and the session beginning is itself the first thing recorded.
+    //
+    // Both halves of the permission have to hold: somebody has to have agreed to be reported on, and the deployment
+    // has to forward telemetry at all. They travel with the session rather than through a call of their own, so a
+    // change to any of the three restarts one effect — the pipeline that was running is torn down before the next is
+    // asked for, which is the ordering a separate stop and start racing each other would not have.
+    //
+    // The two halves are unanswered differently on purpose. What the person agreed to is answered from this device
+    // until the deployment answers, so a client that had been turned off records nothing in the seconds a read takes.
+    // What the deployment forwards is unknown rather than refused until it says — a deployment nobody has reached yet
+    // is every cold start and every failed sign-in, which is exactly what the pipeline holds records for, so refusing
+    // there would throw away the failures somebody cannot otherwise describe. Only `false`, which is a deployment
+    // stating that it forwards nothing, stops it; and stopping it discards what was held rather than sending it.
+    const telemetryPermitted = preferences.telemetryEnabled && deploymentSession?.telemetryForwarded !== false;
+
+    // Which session has already been reported as having begun, so that it is reported once however many times this
+    // effect runs. It runs again whenever the permission changes, and the permission is false until the deployment has
+    // answered what it forwards — so without this, an ordinary sign-in would record nothing and moving the switch
+    // twice would record a session beginning twice.
+    const sessionReported = useRef<ClientSession | null>(null);
+
+    useEffect(() => {
+        const stop = telemetry.exportFor(session, telemetryPermitted);
+
+        if (session !== null && telemetryPermitted && sessionReported.current !== session) {
+            sessionReported.current = session;
+            telemetry.happened('session_started');
+        }
+
+        return stop;
+    }, [session, telemetry, telemetryPermitted]);
 
     // Whether opening a message marks it read on the person's own mail server, which is the frame's answer rather than
     // a screen's for the reason ADR 0026 gives about the two halves of it: the reader's own setting says what they want
@@ -394,6 +415,7 @@ export function App({
                             accounts={mailAccounts}
                             deploymentVersion={deploymentSession?.version ?? null}
                             readingFrom={adopted?.chosen === true ? baseAddress : null}
+                            telemetryDestination={deploymentSession?.telemetryForwarded === true ? baseAddress : null}
                             preferences={preferences}
                             profile={profile}
                             onPointSomewhereElse={pointSomewhereElse}

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -160,7 +160,11 @@ export function App({
     // credential the deployment lets read. The route is admitted under the grant a reader already holds, so a
     // credential without it would meet a refusal the screen has nothing to do about, and a machine with no network
     // would meet nothing at all.
-    const preferences = useClientPreferences(readsMail && connection.online ? session : null, readMail);
+    const preferences = useClientPreferences(
+        readsMail && connection.online ? session : null,
+        readMail,
+        userNameIn(authorization),
+    );
 
     // What this client reports about itself goes out under the session that is signed in, so it starts when one exists
     // and stops with it. Signing out, or being pointed at another deployment, therefore leaves nothing queued for a

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -9,6 +9,7 @@ import { SecondaryButton } from './controls/SecondaryButton';
 import { forgetDeployment, storeDeployment, type AdoptedDeployment } from './deployment/adoptedDeployment';
 import type { PortraitExchange } from './deployment/portraitExchange';
 import type { DeploymentTransport } from './deployment/sendToDeployment';
+import { telemetryForwardedBy } from './deployment/telemetryForwarding';
 import { FolderTree } from './folders/FolderTree';
 import { useLocalization } from './localization/useLocalization';
 import { NothingOpen } from './mailSpace/NothingOpen';
@@ -419,7 +420,7 @@ export function App({
                             accounts={mailAccounts}
                             deploymentVersion={deploymentSession?.version ?? null}
                             readingFrom={adopted?.chosen === true ? baseAddress : null}
-                            telemetryDestination={deploymentSession?.telemetryForwarded === true ? baseAddress : null}
+                            telemetryForwarding={telemetryForwardedBy(deploymentSession, baseAddress)}
                             preferences={preferences}
                             profile={profile}
                             onPointSomewhereElse={pointSomewhereElse}

--- a/frontend/src/Client.App/src/deployment/telemetryForwarding.test.ts
+++ b/frontend/src/Client.App/src/deployment/telemetryForwarding.test.ts
@@ -1,0 +1,33 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import type { DeploymentSession } from '@mailfathom/client-backend';
+import { telemetryForwardedBy } from './telemetryForwarding';
+
+const address = 'https://mail.example.invalid';
+
+function answering(telemetryForwarded: boolean): DeploymentSession {
+    return { version: '0.8.7', permissions: [], telemetryForwarded };
+}
+
+describe('telemetryForwardedBy', () => {
+    it('names the deployment somebody is signed in to, where it forwards telemetry', () => {
+        expect(telemetryForwardedBy(answering(true), address)).toEqual({ answered: true, destination: address });
+    });
+
+    it('answers that a deployment forwarding none has nothing behind the switch', () => {
+        expect(telemetryForwardedBy(answering(false), address)).toEqual({ answered: true, destination: null });
+    });
+
+    // The distinction the screen exists to draw: a deployment that has said nothing has not said no, and the frame
+    // records under the person's own answer meanwhile — so a screen told these two apart says nothing untrue.
+    it('answers nothing either way while no session has been read', () => {
+        expect(telemetryForwardedBy(null, address)).toEqual({ answered: false });
+    });
+
+    it('answers nothing either way where there is no deployment to have answered', () => {
+        expect(telemetryForwardedBy(answering(true), null)).toEqual({ answered: false });
+    });
+});

--- a/frontend/src/Client.App/src/deployment/telemetryForwarding.ts
+++ b/frontend/src/Client.App/src/deployment/telemetryForwarding.ts
@@ -1,0 +1,36 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { DeploymentSession } from '@mailfathom/client-backend';
+
+/**
+ * What the deployment has said about forwarding this client's own records: an address it forwards them to, that it
+ * forwards none, or — until it has answered — nothing either way.
+ *
+ * The third case is not the second, and it is a type rather than an absent string because collapsing the two was a
+ * defect. The permission the frame computes reads an unanswered deployment as permission rather than as a refusal, so
+ * that a cold start and a failed sign-in are recorded rather than thrown away; a screen drawing "there is nothing to
+ * turn off" over that same state would therefore tell somebody nothing is being sent at exactly the moment something
+ * is.
+ */
+export type TelemetryForwarding =
+    { readonly answered: false } | { readonly answered: true; readonly destination: string | null };
+
+/**
+ * Reads it off the session the deployment answered with, where there is one.
+ *
+ * A session that has not been read has answered nothing whatever the reason — the round trip is still out, the
+ * machine has no network, or the credential was refused — so all three are the unanswered case rather than three
+ * states a screen would have to word separately.
+ */
+export function telemetryForwardedBy(
+    session: DeploymentSession | null,
+    baseAddress: string | null,
+): TelemetryForwarding {
+    if (session === null || baseAddress === null) {
+        return { answered: false };
+    }
+
+    return { answered: true, destination: session.telemetryForwarded ? baseAddress : null };
+}

--- a/frontend/src/Client.App/src/device/deviceStore.ts
+++ b/frontend/src/Client.App/src/device/deviceStore.ts
@@ -21,17 +21,6 @@
 export const deviceKeys = {
     themeChoice: 'mailfathom.theme',
     locale: 'mailfathom.locale',
-
-    /**
-     * The last telemetry answer the deployment gave this person, kept so a restart honours it before the deployment
-     * answers again.
-     *
-     * It is the one value here that is not the device's own decision, and it is deliberately not a second opinion: the
-     * deployment holds the answer and this is a cache of it, read only until the first read comes back and written by
-     * nothing but that read and the switch itself. What it buys is the seconds between a client opening and the
-     * deployment answering, in which a client that had been told no would otherwise record and export again.
-     */
-    telemetry: 'mailfathom.telemetry',
 } as const;
 
 /** Reading a value the device holds, writing one, and removing one. */
@@ -76,6 +65,26 @@ export function deviceStore(): DeviceStore {
  */
 export function listWidthKey(person: string): string {
     return `mailfathom.listWidth.${digestOf(person)}`;
+}
+
+/**
+ * What the last telemetry answer the deployment gave is written under, which names the person for the same reason the
+ * width above does — and here it is a privacy obligation rather than a convenience.
+ *
+ * Two people sharing a machine hold two different answers, and one of them is a refusal. A single name for both would
+ * hand the second person the first person's answer for the length of one read, which is exactly long enough to record
+ * and export something they had declined; a name per person cannot, because a key nobody has written reads as nothing
+ * chosen and the unset answer is the deployment's own.
+ *
+ * It is the one value in this module that is not the device's own decision. The deployment holds the answer and this is
+ * a cache of it, read only until that person's own read comes back and written by nothing but that read and the switch
+ * itself. What it buys is the seconds between a client opening and the deployment answering, in which a client that had
+ * been told no would otherwise record and export again.
+ *
+ * The digest and its limits are the width's above, and so is what it keeps out of the store.
+ */
+export function telemetryKey(person: string): string {
+    return `mailfathom.telemetry.${digestOf(person)}`;
 }
 
 /** Whether this system has origin storage at all, which is the whole of what decides the implementation today. */

--- a/frontend/src/Client.App/src/device/deviceStore.ts
+++ b/frontend/src/Client.App/src/device/deviceStore.ts
@@ -21,6 +21,17 @@
 export const deviceKeys = {
     themeChoice: 'mailfathom.theme',
     locale: 'mailfathom.locale',
+
+    /**
+     * The last telemetry answer the deployment gave this person, kept so a restart honours it before the deployment
+     * answers again.
+     *
+     * It is the one value here that is not the device's own decision, and it is deliberately not a second opinion: the
+     * deployment holds the answer and this is a cache of it, read only until the first read comes back and written by
+     * nothing but that read and the switch itself. What it buys is the seconds between a client opening and the
+     * deployment answering, in which a client that had been told no would otherwise record and export again.
+     */
+    telemetry: 'mailfathom.telemetry',
 } as const;
 
 /** Reading a value the device holds, writing one, and removing one. */

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -142,6 +142,8 @@ export const en = {
         'Sent to {address}, which forwards it to whichever collector it is configured with. It carries which screens you opened and how long they took, never your mail, your addresses, your folders, or your password.',
     'settings.telemetryNotForwarded':
         'This deployment forwards no telemetry, so this client sends none and there is nothing to turn off.',
+    'settings.telemetryUnanswered':
+        'Waiting for this deployment to say whether it forwards telemetry. Until it answers, your own decision is what holds.',
 
     'deployment.reachedAt': 'Reading from {address}',
     'deployment.change': 'Point somewhere else',

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -138,6 +138,10 @@ export const en = {
     'settings.telemetryExplanation': 'Error diagnostics and usage statistics stay on this device.',
     'settings.telemetryWithheldWarning':
         'Without telemetry, support is harder — problems have to be described by hand, and some failures cannot be reproduced by whoever is helping you.',
+    'settings.telemetryDestination':
+        'Sent to {address}, which forwards it to whichever collector it is configured with. It carries which screens you opened and how long they took, never your mail, your addresses, your folders, or your password.',
+    'settings.telemetryNotForwarded':
+        'This deployment forwards no telemetry, so this client sends none and there is nothing to turn off.',
 
     'deployment.reachedAt': 'Reading from {address}',
     'deployment.change': 'Point somewhere else',

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -140,6 +140,10 @@ export const pl: Catalogue = {
     'settings.telemetryExplanation': 'Diagnostyka błędów i statystyki użycia zostają na tym urządzeniu.',
     'settings.telemetryWithheldWarning':
         'Bez telemetrii pomoc techniczna będzie utrudniona — zgłoszenia trzeba będzie opisywać ręcznie, a części błędów nie da się odtworzyć po stronie wsparcia.',
+    'settings.telemetryDestination':
+        'Wysyłane do {address}, które przekazuje je dalej do skonfigurowanego kolektora. Zawierają to, które ekrany otwierasz i jak długo się otwierały — nigdy Twojej poczty, adresów, folderów ani hasła.',
+    'settings.telemetryNotForwarded':
+        'To wdrożenie nie przekazuje telemetrii, więc ten klient jej nie wysyła i nie ma czego wyłączać.',
 
     'deployment.reachedAt': 'Odczyt z {address}',
     'deployment.change': 'Wskaż inne wdrożenie',

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -144,6 +144,8 @@ export const pl: Catalogue = {
         'Wysyłane do {address}, które przekazuje je dalej do skonfigurowanego kolektora. Zawierają to, które ekrany otwierasz i jak długo się otwierały — nigdy Twojej poczty, adresów, folderów ani hasła.',
     'settings.telemetryNotForwarded':
         'To wdrożenie nie przekazuje telemetrii, więc ten klient jej nie wysyła i nie ma czego wyłączać.',
+    'settings.telemetryUnanswered':
+        'Czekamy, aż to wdrożenie powie, czy przekazuje telemetrię. Dopóki nie odpowie, obowiązuje Twoja własna decyzja.',
 
     'deployment.reachedAt': 'Odczyt z {address}',
     'deployment.change': 'Wskaż inne wdrożenie',

--- a/frontend/src/Client.App/src/preferences/rememberedTelemetry.test.ts
+++ b/frontend/src/Client.App/src/preferences/rememberedTelemetry.test.ts
@@ -1,0 +1,38 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { rememberedTelemetry, rememberTelemetry } from './rememberedTelemetry';
+
+afterEach(() => {
+    window.localStorage.clear();
+});
+
+describe('rememberedTelemetry', () => {
+    it('answers what the deployment last said, so a restart honours it before it answers again', () => {
+        rememberTelemetry(false);
+
+        expect(rememberedTelemetry()).toBe(false);
+    });
+
+    it('answers the deployment own unset answer where this device has never been told anything', () => {
+        expect(rememberedTelemetry()).toBe(true);
+    });
+
+    it('is replaced rather than added to, so the last answer is the only one held', () => {
+        rememberTelemetry(false);
+        rememberTelemetry(true);
+
+        expect(rememberedTelemetry()).toBe(true);
+    });
+
+    // Anything but what this module wrote is read as withheld rather than guessed at. Another origin cannot reach this
+    // store, so what would put something else there is a client of another version — and where a parser has to decide
+    // something about somebody's privacy, the direction it is allowed to be wrong in is the one that sends nothing.
+    it.each(['yes', '', 'TRUE', '1'])('reads %o as a decision to send nothing', (stored) => {
+        window.localStorage.setItem('mailfathom.telemetry', stored);
+
+        expect(rememberedTelemetry()).toBe(false);
+    });
+});

--- a/frontend/src/Client.App/src/preferences/rememberedTelemetry.test.ts
+++ b/frontend/src/Client.App/src/preferences/rememberedTelemetry.test.ts
@@ -3,7 +3,11 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { afterEach, describe, expect, it } from 'vitest';
+import { telemetryKey } from '../device/deviceStore';
 import { rememberedTelemetry, rememberTelemetry } from './rememberedTelemetry';
+
+const anna = 'anna';
+const bartek = 'bartek';
 
 afterEach(() => {
     window.localStorage.clear();
@@ -11,28 +15,60 @@ afterEach(() => {
 
 describe('rememberedTelemetry', () => {
     it('answers what the deployment last said, so a restart honours it before it answers again', () => {
-        rememberTelemetry(false);
+        rememberTelemetry(anna, false);
 
-        expect(rememberedTelemetry()).toBe(false);
+        expect(rememberedTelemetry(anna)).toBe(false);
     });
 
     it('answers the deployment own unset answer where this device has never been told anything', () => {
-        expect(rememberedTelemetry()).toBe(true);
+        expect(rememberedTelemetry(anna)).toBe(true);
     });
 
     it('is replaced rather than added to, so the last answer is the only one held', () => {
-        rememberTelemetry(false);
-        rememberTelemetry(true);
+        rememberTelemetry(anna, false);
+        rememberTelemetry(anna, true);
 
-        expect(rememberedTelemetry()).toBe(true);
+        expect(rememberedTelemetry(anna)).toBe(true);
+    });
+
+    // The reason this is held per person rather than per machine. One name for both would answer the second person
+    // with the first person's answer for the length of one read, and where the first had permitted and the second
+    // declined, that read is long enough to record and export what the second refused.
+    it('answers one person without ever answering for another', () => {
+        rememberTelemetry(anna, true);
+
+        expect(rememberedTelemetry(bartek)).toBe(true);
+
+        rememberTelemetry(bartek, false);
+
+        expect(rememberedTelemetry(anna)).toBe(true);
+        expect(rememberedTelemetry(bartek)).toBe(false);
+    });
+
+    it('answers nobody with the unset answer and keeps nothing under a name it does not have', () => {
+        rememberTelemetry(null, false);
+
+        expect(rememberedTelemetry(null)).toBe(true);
+        expect(window.localStorage.length).toBe(0);
+    });
+
+    // What is stored names the person as a digest rather than as the name they typed, so a store that outlives the
+    // session does not leave a list of who reads mail on this machine behind it.
+    it('names the person nowhere a reader of the store could read it', () => {
+        rememberTelemetry(anna, false);
+
+        const [stored] = Object.keys(window.localStorage);
+
+        expect(stored).toBe(telemetryKey(anna));
+        expect(stored).not.toContain(anna);
     });
 
     // Anything but what this module wrote is read as withheld rather than guessed at. Another origin cannot reach this
     // store, so what would put something else there is a client of another version — and where a parser has to decide
     // something about somebody's privacy, the direction it is allowed to be wrong in is the one that sends nothing.
     it.each(['yes', '', 'TRUE', '1'])('reads %o as a decision to send nothing', (stored) => {
-        window.localStorage.setItem('mailfathom.telemetry', stored);
+        window.localStorage.setItem(telemetryKey(anna), stored);
 
-        expect(rememberedTelemetry()).toBe(false);
+        expect(rememberedTelemetry(anna)).toBe(false);
     });
 });

--- a/frontend/src/Client.App/src/preferences/rememberedTelemetry.ts
+++ b/frontend/src/Client.App/src/preferences/rememberedTelemetry.ts
@@ -1,0 +1,28 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { unsetClientPreferences } from '@mailfathom/client-backend';
+import { deviceKeys, deviceStore } from '../device/deviceStore';
+
+// The last telemetry answer this deployment gave, kept on the device so that a restart honours it before the answer
+// arrives again. The deployment holds the decision — `useClientPreferences.ts` is what reads and writes it there — and
+// this is a cache of it rather than a second place it is decided: nothing writes here that did not first come from, or
+// go to, the deployment, and a client that has been given an answer never reads this again for the rest of the run.
+//
+// It exists because the alternative is worse than a stale value: a client that opened knowing nothing would record and
+// export for the second or two before the read comes back, which is exactly the second or two somebody who turned it
+// off did not agree to. The cost of being stale is the mirror of that — a decision changed on another machine is
+// honoured one read late here — and that is the smaller of the two, because it errs towards sending nothing.
+
+/** What this device was last told, or the deployment's own unset answer where it has never been told anything. */
+export function rememberedTelemetry(): boolean {
+    const stored = deviceStore().read(deviceKeys.telemetry);
+
+    return stored === null ? unsetClientPreferences.telemetryEnabled : stored === 'true';
+}
+
+/** Keeps what the deployment answered, or what somebody just chose, for the next start of this client. */
+export function rememberTelemetry(telemetryEnabled: boolean): void {
+    deviceStore().write(deviceKeys.telemetry, String(telemetryEnabled));
+}

--- a/frontend/src/Client.App/src/preferences/rememberedTelemetry.ts
+++ b/frontend/src/Client.App/src/preferences/rememberedTelemetry.ts
@@ -3,26 +3,47 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { unsetClientPreferences } from '@mailfathom/client-backend';
-import { deviceKeys, deviceStore } from '../device/deviceStore';
+import { deviceStore, telemetryKey } from '../device/deviceStore';
 
-// The last telemetry answer this deployment gave, kept on the device so that a restart honours it before the answer
-// arrives again. The deployment holds the decision — `useClientPreferences.ts` is what reads and writes it there — and
-// this is a cache of it rather than a second place it is decided: nothing writes here that did not first come from, or
-// go to, the deployment, and a client that has been given an answer never reads this again for the rest of the run.
+// The last telemetry answer the deployment gave one person, kept on the device so that a restart honours it before the
+// answer arrives again. The deployment holds the decision — `useClientPreferences.ts` is what reads and writes it there
+// — and this is a cache of it rather than a second place it is decided: nothing writes here that did not first come
+// from, or go to, the deployment, and a client holding that person's own answer never reads this again for the rest of
+// their session.
 //
 // It exists because the alternative is worse than a stale value: a client that opened knowing nothing would record and
 // export for the second or two before the read comes back, which is exactly the second or two somebody who turned it
 // off did not agree to. The cost of being stale is the mirror of that — a decision changed on another machine is
 // honoured one read late here — and that is the smaller of the two, because it errs towards sending nothing.
+//
+// It is held per person and never as one value for the machine, which is the whole of what makes the paragraph above
+// true of a machine two people read on. One name for both would answer the second person with the first person's
+// answer for the length of one read, and where the first had permitted and the second declined, that read is long
+// enough to record and export what the second refused. A name per person cannot do that: nothing is stored under a
+// person nobody has answered for, and what a client does then is take the deployment's own unset answer.
 
-/** What this device was last told, or the deployment's own unset answer where it has never been told anything. */
-export function rememberedTelemetry(): boolean {
-    const stored = deviceStore().read(deviceKeys.telemetry);
+/**
+ * What this device was last told about one person, or the deployment's unset answer where it has been told nothing.
+ *
+ * @param person Whose answer to read, or `null` where nobody is signed in — which reads as nothing stored, the address
+ * being the only thing that could say otherwise and there being none.
+ */
+export function rememberedTelemetry(person: string | null): boolean {
+    const stored = person === null ? null : deviceStore().read(telemetryKey(person));
 
     return stored === null ? unsetClientPreferences.telemetryEnabled : stored === 'true';
 }
 
-/** Keeps what the deployment answered, or what somebody just chose, for the next start of this client. */
-export function rememberTelemetry(telemetryEnabled: boolean): void {
-    deviceStore().write(deviceKeys.telemetry, String(telemetryEnabled));
+/**
+ * Keeps what the deployment answered about this person, or what they just chose, for the next start of this client.
+ *
+ * @param person Whose answer this is, or `null` where nobody is signed in — in which case nothing is written rather
+ * than something being stored under a name that would be read back for somebody else.
+ */
+export function rememberTelemetry(person: string | null, telemetryEnabled: boolean): void {
+    if (person === null) {
+        return;
+    }
+
+    deviceStore().write(telemetryKey(person), String(telemetryEnabled));
 }

--- a/frontend/src/Client.App/src/preferences/useClientPreferences.test.tsx
+++ b/frontend/src/Client.App/src/preferences/useClientPreferences.test.tsx
@@ -305,6 +305,37 @@ describe('useClientPreferences', () => {
         });
     });
 
+    // A write states the whole document, and the account menu offers the theme from the moment it is drawn — so this
+    // is the window between signing in and the read coming back, in which every other value is the route's own unset
+    // answer. Telemetry may not be: the device is holding the answer this person actually gave, and sending the unset
+    // one would turn their refusal into permission on the deployment, in the cache, and on the screen, silently.
+    it('composes a write made before the read returns from what this device remembers', () => {
+        window.localStorage.setItem(telemetryKey(anna), 'false');
+
+        const requests: ClientRequest[] = [];
+        const transport: MailFathomTransport = (request) => {
+            requests.push(request);
+
+            return new Promise(() => undefined);
+        };
+
+        const { result } = reading(transport);
+
+        act(() => {
+            result.current.preferences.chooseTheme('dark');
+        });
+
+        const written = requests.find((asked) => asked.method === 'POST');
+
+        expect(JSON.parse(written?.body ?? '')).toStrictEqual({
+            telemetryEnabled: false,
+            theme: 'dark',
+            openMailInTabs: false,
+            markReadOnOpen: true,
+        });
+        expect(window.localStorage.getItem(telemetryKey(anna))).toBe('false');
+    });
+
     it('lets a choice made while the read is still out stand rather than being read over', async () => {
         const answered: ((answer: { status: number; body: string; headers: Record<string, string> }) => void)[] = [];
         const requests: ClientRequest[] = [];

--- a/frontend/src/Client.App/src/preferences/useClientPreferences.test.tsx
+++ b/frontend/src/Client.App/src/preferences/useClientPreferences.test.tsx
@@ -352,4 +352,58 @@ describe('useClientPreferences', () => {
         // a second run would already have pushed a second request rather than being about to.
         expect(requests).toHaveLength(1);
     });
+
+    // The telemetry answer is the one setting a client has to honour before it has been read, because the seconds
+    // between opening and the first answer are seconds a client that had been turned off would otherwise record in.
+    describe('the telemetry answer this device remembers', () => {
+        it('keeps what the deployment answered, so the next start honours it before it answers again', async () => {
+            const { transport } = recording(
+                stored({ telemetryEnabled: false, theme: 'system', openMailInTabs: false }),
+            );
+            const { result } = reading(transport);
+
+            await waitFor(() => {
+                expect(result.current.preferences.telemetryEnabled).toBe(false);
+            });
+
+            expect(window.localStorage.getItem('mailfathom.telemetry')).toBe('false');
+        });
+
+        it('keeps what somebody chose here, without waiting for the deployment to confirm it', async () => {
+            const { transport } = recording(stored({ telemetryEnabled: true, theme: 'system', openMailInTabs: false }));
+            const { result } = reading(transport);
+
+            await waitFor(() => {
+                expect(result.current.preferences.telemetryEnabled).toBe(true);
+            });
+
+            act(() => {
+                result.current.preferences.chooseTelemetry(false);
+            });
+
+            expect(window.localStorage.getItem('mailfathom.telemetry')).toBe('false');
+        });
+
+        it('answers it while there is no session to read one with, rather than the unset answer', () => {
+            window.localStorage.setItem('mailfathom.telemetry', 'false');
+
+            const { transport } = recording(stored({ telemetryEnabled: true, theme: 'system', openMailInTabs: false }));
+            const { result } = reading(transport, null);
+
+            expect(result.current.preferences.telemetryEnabled).toBe(false);
+        });
+
+        it('is replaced by what the deployment answers, holding no second opinion beyond that', async () => {
+            window.localStorage.setItem('mailfathom.telemetry', 'false');
+
+            const { transport } = recording(stored({ telemetryEnabled: true, theme: 'system', openMailInTabs: false }));
+            const { result } = reading(transport);
+
+            await waitFor(() => {
+                expect(result.current.preferences.telemetryEnabled).toBe(true);
+            });
+
+            expect(window.localStorage.getItem('mailfathom.telemetry')).toBe('true');
+        });
+    });
 });

--- a/frontend/src/Client.App/src/preferences/useClientPreferences.test.tsx
+++ b/frontend/src/Client.App/src/preferences/useClientPreferences.test.tsx
@@ -5,6 +5,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import type { ClientRequest, ClientSession, MailFathomTransport } from '@mailfathom/client-backend';
+import { telemetryKey } from '../device/deviceStore';
 import { ThemeProvider } from '../theme/Theme';
 import { useTheme } from '../theme/useTheme';
 import { useClientPreferences } from './useClientPreferences';
@@ -13,6 +14,11 @@ const session: ClientSession = {
     baseAddress: 'https://mail.example.invalid',
     authorization: 'Basic dGVzdA==',
 };
+
+// Who is signed in, which this hook is told beside the session because the device's remembered telemetry answer is
+// held under the person rather than under the machine.
+const anna = 'anna';
+const bartek = 'bartek';
 
 // The whole document, because the route answers with nothing less and the package refuses an answer missing a field.
 // Marking read is defaulted rather than named at each call, since only the tests below that are about it say anything.
@@ -42,13 +48,13 @@ function recording(body: string, status = 200): { transport: MailFathomTransport
 
 // The theme is read beside the settings because it is the one of them the device also holds, so what the deployment
 // did to it is only visible through the provider that paints it.
-function reading(transport: MailFathomTransport, asked: ClientSession | null = session) {
+function reading(transport: MailFathomTransport, asked: ClientSession | null = session, person: string | null = anna) {
     return renderHook(
-        ({ session: presenting }: { session: ClientSession | null }) => ({
-            preferences: useClientPreferences(presenting, transport),
+        ({ session: presenting, person: whose }: { session: ClientSession | null; person: string | null }) => ({
+            preferences: useClientPreferences(presenting, transport, whose),
             theme: useTheme(),
         }),
-        { initialProps: { session: asked }, wrapper: ThemeProvider },
+        { initialProps: { session: asked, person }, wrapper: ThemeProvider },
     );
 }
 
@@ -244,7 +250,7 @@ describe('useClientPreferences', () => {
             expect(requests).toHaveLength(1);
         });
 
-        rerender({ session: { ...session, authorization: 'Basic b3RoZXI=' } });
+        rerender({ session: { ...session, authorization: 'Basic b3RoZXI=' }, person: bartek });
 
         await waitFor(() => {
             expect(requests).toHaveLength(2);
@@ -261,7 +267,7 @@ describe('useClientPreferences', () => {
             expect(result.current.preferences.openMailInTabs).toBe(true);
         });
 
-        rerender({ session: null });
+        rerender({ session: null, person: anna });
 
         expect(result.current.preferences.openMailInTabs).toBe(false);
     });
@@ -276,8 +282,8 @@ describe('useClientPreferences', () => {
             expect(result.current.preferences.openMailInTabs).toBe(true);
         });
 
-        rerender({ session: null });
-        rerender({ session: { ...session, authorization: 'Basic b3RoZXI=' } });
+        rerender({ session: null, person: anna });
+        rerender({ session: { ...session, authorization: 'Basic b3RoZXI=' }, person: bartek });
 
         act(() => {
             result.current.preferences.chooseTabMode(true);
@@ -366,7 +372,7 @@ describe('useClientPreferences', () => {
                 expect(result.current.preferences.telemetryEnabled).toBe(false);
             });
 
-            expect(window.localStorage.getItem('mailfathom.telemetry')).toBe('false');
+            expect(window.localStorage.getItem(telemetryKey(anna))).toBe('false');
         });
 
         it('keeps what somebody chose here, without waiting for the deployment to confirm it', async () => {
@@ -381,11 +387,11 @@ describe('useClientPreferences', () => {
                 result.current.preferences.chooseTelemetry(false);
             });
 
-            expect(window.localStorage.getItem('mailfathom.telemetry')).toBe('false');
+            expect(window.localStorage.getItem(telemetryKey(anna))).toBe('false');
         });
 
         it('answers it while there is no session to read one with, rather than the unset answer', () => {
-            window.localStorage.setItem('mailfathom.telemetry', 'false');
+            window.localStorage.setItem(telemetryKey(anna), 'false');
 
             const { transport } = recording(stored({ telemetryEnabled: true, theme: 'system', openMailInTabs: false }));
             const { result } = reading(transport, null);
@@ -394,7 +400,7 @@ describe('useClientPreferences', () => {
         });
 
         it('is replaced by what the deployment answers, holding no second opinion beyond that', async () => {
-            window.localStorage.setItem('mailfathom.telemetry', 'false');
+            window.localStorage.setItem(telemetryKey(anna), 'false');
 
             const { transport } = recording(stored({ telemetryEnabled: true, theme: 'system', openMailInTabs: false }));
             const { result } = reading(transport);
@@ -403,7 +409,40 @@ describe('useClientPreferences', () => {
                 expect(result.current.preferences.telemetryEnabled).toBe(true);
             });
 
-            expect(window.localStorage.getItem('mailfathom.telemetry')).toBe('true');
+            expect(window.localStorage.getItem(telemetryKey(anna))).toBe('true');
+        });
+
+        // Signing out and back in as somebody else on one tab keeps this hook mounted, which is the case the whole
+        // derivation above exists for. The second person's own answer has not arrived yet, so what is drawn is what
+        // the device holds — and holding it for the machine rather than for the person would hand them the first
+        // person's permission for exactly as long as their own read takes, which is long enough to export under their
+        // credential something they had declined.
+        it('never answers one person with what this device remembers about another', () => {
+            window.localStorage.setItem(telemetryKey(anna), 'true');
+            window.localStorage.setItem(telemetryKey(bartek), 'false');
+
+            const { transport } = recording(stored({ telemetryEnabled: true, theme: 'system', openMailInTabs: false }));
+            const { result, rerender } = reading(transport, null, anna);
+
+            expect(result.current.preferences.telemetryEnabled).toBe(true);
+
+            rerender({ session: null, person: bartek });
+
+            expect(result.current.preferences.telemetryEnabled).toBe(false);
+        });
+
+        it('keeps one person’s answer without writing anything about another', async () => {
+            const { transport } = recording(
+                stored({ telemetryEnabled: false, theme: 'system', openMailInTabs: false }),
+            );
+            const { result } = reading(transport, session, bartek);
+
+            await waitFor(() => {
+                expect(result.current.preferences.telemetryEnabled).toBe(false);
+            });
+
+            expect(window.localStorage.getItem(telemetryKey(bartek))).toBe('false');
+            expect(window.localStorage.getItem(telemetryKey(anna))).toBeNull();
         });
     });
 });

--- a/frontend/src/Client.App/src/preferences/useClientPreferences.ts
+++ b/frontend/src/Client.App/src/preferences/useClientPreferences.ts
@@ -175,8 +175,19 @@ export function useClientPreferences(
 
     // What the next write is composed out of: the document last read or last chosen, and the unset one where that
     // belongs to a session this is no longer.
+    //
+    // One value is not taken from the unset document there, and it is the same one the return below derives rather
+    // than holds. A write states the whole document, and the account menu offers the theme and the tab mode from the
+    // moment it is drawn — so somebody who had declined telemetry and changes either of those before the read comes
+    // back would send `telemetryEnabled: true` under their own credential, abandon the read that would have said
+    // otherwise, and have the device's copy rewritten to match. Nobody stated that value; it is the shape of the
+    // route's answer standing in for an answer, and the device is holding the one they actually gave.
     function composedFrom(): ClientPreferences {
-        return latest.current.session === session ? latest.current.preferences : unsetClientPreferences;
+        if (latest.current.session === session) {
+            return latest.current.preferences;
+        }
+
+        return { ...unsetClientPreferences, telemetryEnabled: rememberedTelemetry(person) };
     }
 
     return {

--- a/frontend/src/Client.App/src/preferences/useClientPreferences.ts
+++ b/frontend/src/Client.App/src/preferences/useClientPreferences.ts
@@ -13,6 +13,7 @@ import {
 } from '@mailfathom/client-backend';
 import type { ThemeChoice } from '../theme/themeChoice';
 import { useTheme } from '../theme/useTheme';
+import { rememberedTelemetry, rememberTelemetry } from './rememberedTelemetry';
 
 // The settings that follow the person rather than the machine, read from the deployment once there is a session to
 // read it with and written back whole whenever one of them changes.
@@ -40,7 +41,13 @@ export interface ClientPreferencesInForce {
      */
     readonly markReadOnOpen: boolean;
 
-    /** Whether this deployment may be told what the person's client is doing. */
+    /**
+     * Whether this deployment may be told what the person's client is doing.
+     *
+     * Answered before the deployment has said anything, from what this device was last told, so that a client which
+     * had been turned off does not record and export for the second the first read takes. Everything else here is the
+     * deployment's answer alone.
+     */
     readonly telemetryEnabled: boolean;
 
     /** Whether the deployment refused the last change, which is the one thing about this a screen has to say out loud. */
@@ -93,6 +100,13 @@ export function useClientPreferences(
     // back and then have to be undone by a second write nobody asked for.
     const reading = useRef<AbortController | null>(null);
 
+    // What this device was last told about telemetry, which stands in for the deployment's answer until one arrives and
+    // is replaced by every answer and every choice afterwards. It is state rather than a value read here, because the
+    // store is the device's rather than React's and reading it per render would be a storage read per render for a
+    // value that moves twice in a session. It is not a second copy of what the deployment holds: the two are different
+    // facts, and this one is only ever rendered while there is no answer for this session at all.
+    const [remembered, setRemembered] = useState(rememberedTelemetry);
+
     // Everything below reads through this rather than out of the state directly, which is what keeps one person's
     // answers off the next person's screen without a reset anywhere. Signing out and back in on one tab keeps this
     // hook mounted, so what was read for the credential before is still in state when the new one arrives — and it
@@ -123,6 +137,8 @@ export function useClientPreferences(
             const read = { session, preferences: answer.value, notStated: false };
 
             latest.current = read;
+            setRemembered(answer.value.telemetryEnabled);
+            rememberTelemetry(answer.value.telemetryEnabled);
             setHeld(read);
 
             // The deployment's answer replaces the device's, which is the whole of why these two settings are held
@@ -145,6 +161,8 @@ export function useClientPreferences(
         const chosen = { session, preferences, notStated: false };
 
         latest.current = chosen;
+        setRemembered(preferences.telemetryEnabled);
+        rememberTelemetry(preferences.telemetryEnabled);
         setHeld(chosen);
 
         if (session === null) {
@@ -167,7 +185,9 @@ export function useClientPreferences(
     return {
         openMailInTabs: inForce.preferences.openMailInTabs,
         markReadOnOpen: inForce.preferences.markReadOnOpen,
-        telemetryEnabled: inForce.preferences.telemetryEnabled,
+        // The one setting answered from the device while the deployment has said nothing for this session, for the
+        // reason `rememberedTelemetry.ts` gives. Every other one takes its unset answer, which a screen can draw.
+        telemetryEnabled: inForce.session === null ? remembered : inForce.preferences.telemetryEnabled,
         notStated: inForce.notStated,
         chooseTheme: (choice) => {
             setThemeChoice(choice);

--- a/frontend/src/Client.App/src/preferences/useClientPreferences.ts
+++ b/frontend/src/Client.App/src/preferences/useClientPreferences.ts
@@ -44,9 +44,9 @@ export interface ClientPreferencesInForce {
     /**
      * Whether this deployment may be told what the person's client is doing.
      *
-     * Answered before the deployment has said anything, from what this device was last told, so that a client which
-     * had been turned off does not record and export for the second the first read takes. Everything else here is the
-     * deployment's answer alone.
+     * Answered before the deployment has said anything about this person, from what this device was last told about
+     * them, so that a client which had been turned off does not record and export for the second the first read takes.
+     * Everything else here is the deployment's answer alone.
      */
     readonly telemetryEnabled: boolean;
 
@@ -79,11 +79,17 @@ const heldForNobody: HeldPreferences = {
  * or a credential this deployment does not let read — in which case nothing is read and both settings are the
  * device's alone.
  * @param transport How a request reaches the deployment.
+ * @param person Who is signed in, or `null` where nobody is. It is asked for beside the session rather than read out
+ * of it because the two are absent at different moments: a session is withheld from this hook while the client is
+ * offline or the grant does not let it read, and somebody is still signed in through all of that. It decides one thing
+ * only — whose remembered telemetry answer the device is asked for — and getting it wrong is what would hand the next
+ * person the last person's answer.
  * @returns The settings in force, and the two ways of changing one.
  */
 export function useClientPreferences(
     session: ClientSession | null,
     transport: MailFathomTransport,
+    person: string | null,
 ): ClientPreferencesInForce {
     const { setThemeChoice } = useTheme();
     const [held, setHeld] = useState<HeldPreferences>(heldForNobody);
@@ -99,13 +105,6 @@ export function useClientPreferences(
     // want more recently than the document being fetched, and applying that answer on arrival would put the setting
     // back and then have to be undone by a second write nobody asked for.
     const reading = useRef<AbortController | null>(null);
-
-    // What this device was last told about telemetry, which stands in for the deployment's answer until one arrives and
-    // is replaced by every answer and every choice afterwards. It is state rather than a value read here, because the
-    // store is the device's rather than React's and reading it per render would be a storage read per render for a
-    // value that moves twice in a session. It is not a second copy of what the deployment holds: the two are different
-    // facts, and this one is only ever rendered while there is no answer for this session at all.
-    const [remembered, setRemembered] = useState(rememberedTelemetry);
 
     // Everything below reads through this rather than out of the state directly, which is what keeps one person's
     // answers off the next person's screen without a reset anywhere. Signing out and back in on one tab keeps this
@@ -137,8 +136,7 @@ export function useClientPreferences(
             const read = { session, preferences: answer.value, notStated: false };
 
             latest.current = read;
-            setRemembered(answer.value.telemetryEnabled);
-            rememberTelemetry(answer.value.telemetryEnabled);
+            rememberTelemetry(person, answer.value.telemetryEnabled);
             setHeld(read);
 
             // The deployment's answer replaces the device's, which is the whole of why these two settings are held
@@ -149,7 +147,7 @@ export function useClientPreferences(
         return () => {
             attempted.abort();
         };
-    }, [session, transport, setThemeChoice]);
+    }, [session, transport, person, setThemeChoice]);
 
     // What is on the screen changes because a person pressed something, so it changes in the handler rather than in an
     // effect watching what the handler set. The write states the whole document — the route takes nothing less — which
@@ -161,8 +159,7 @@ export function useClientPreferences(
         const chosen = { session, preferences, notStated: false };
 
         latest.current = chosen;
-        setRemembered(preferences.telemetryEnabled);
-        rememberTelemetry(preferences.telemetryEnabled);
+        rememberTelemetry(person, preferences.telemetryEnabled);
         setHeld(chosen);
 
         if (session === null) {
@@ -185,9 +182,16 @@ export function useClientPreferences(
     return {
         openMailInTabs: inForce.preferences.openMailInTabs,
         markReadOnOpen: inForce.preferences.markReadOnOpen,
-        // The one setting answered from the device while the deployment has said nothing for this session, for the
+        // The one setting answered from the device while the deployment has said nothing about this person, for the
         // reason `rememberedTelemetry.ts` gives. Every other one takes its unset answer, which a screen can draw.
-        telemetryEnabled: inForce.session === null ? remembered : inForce.preferences.telemetryEnabled,
+        //
+        // Derived here rather than held in state, and asked for under the person rather than for the machine. Both
+        // halves are the same rule `inForce` above is: a value that no longer belongs to whoever is signed in is not
+        // state to correct but state to stop reading, and holding this one would mean carrying the last person's
+        // answer across a sign-out on the same tab — which is the one direction a privacy answer may not be wrong in.
+        // It costs a storage read on the renders before an answer has arrived and none afterwards, the branch not
+        // being taken once there is one.
+        telemetryEnabled: inForce.session === null ? rememberedTelemetry(person) : inForce.preferences.telemetryEnabled,
         notStated: inForce.notStated,
         chooseTheme: (choice) => {
             setThemeChoice(choice);

--- a/frontend/src/Client.App/src/settings/Settings.test.tsx
+++ b/frontend/src/Client.App/src/settings/Settings.test.tsx
@@ -5,6 +5,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { largestPortraitOctets } from '@mailfathom/client-backend';
+import type { TelemetryForwarding } from '../deployment/telemetryForwarding';
 import { LocalizationProvider } from '../localization/Localization';
 import type { ClientPreferencesInForce } from '../preferences/useClientPreferences';
 import type { OwnProfileInForce } from '../profile/useOwnProfile';
@@ -32,15 +33,18 @@ const named: OwnProfileInForce = {
     removePicture: () => undefined,
 };
 
+/** The ordinary case: a deployment that answered, and forwards what this client records to itself. */
+const forwardedTo: TelemetryForwarding = { answered: true, destination: 'https://mail.example' };
+
 function renderSettings({
     profile = named,
     preferences = settings,
-    telemetryDestination = 'https://mail.example',
+    telemetryForwarding = forwardedTo,
     onClose = () => undefined,
 }: {
     readonly profile?: OwnProfileInForce;
     readonly preferences?: ClientPreferencesInForce;
-    readonly telemetryDestination?: string | null;
+    readonly telemetryForwarding?: TelemetryForwarding;
     readonly onClose?: () => void;
 } = {}): void {
     render(
@@ -49,7 +53,7 @@ function renderSettings({
                 open
                 profile={profile}
                 preferences={preferences}
-                telemetryDestination={telemetryDestination}
+                telemetryForwarding={telemetryForwarding}
                 onClose={onClose}
             />
         </LocalizationProvider>,
@@ -235,7 +239,7 @@ describe('Settings', () => {
     });
 
     it('names where the records go, so the decision is about something rather than about a word', () => {
-        renderSettings({ telemetryDestination: 'https://mail.example' });
+        renderSettings({ telemetryForwarding: forwardedTo });
 
         expect(screen.getByText(/Sent to https:\/\/mail\.example/u)).toBeDefined();
     });
@@ -249,9 +253,19 @@ describe('Settings', () => {
     // A deployment that forwards nothing has nothing behind the switch, so it says so rather than offering a control
     // that decides nothing about a client that is already sending nothing.
     it('offers no switch where the deployment forwards no telemetry, and says why', () => {
-        renderSettings({ telemetryDestination: null });
+        renderSettings({ telemetryForwarding: { answered: true, destination: null } });
 
         expect(screen.getByText(/forwards no telemetry/u)).toBeDefined();
+        expect(screen.queryByRole('switch', { name: /Do not send telemetry/u })).toBeNull();
+    });
+
+    // A deployment that has said nothing has not said no, and the frame records under the person's own answer while
+    // it waits — so drawing the confirmed sentence here would say nothing is being sent while something is.
+    it('says it is waiting rather than that there is nothing to turn off, before the deployment answers', () => {
+        renderSettings({ telemetryForwarding: { answered: false } });
+
+        expect(screen.getByText(/Waiting for this deployment to say whether it forwards telemetry/u)).toBeDefined();
+        expect(screen.queryByText(/forwards no telemetry/u)).toBeNull();
         expect(screen.queryByRole('switch', { name: /Do not send telemetry/u })).toBeNull();
     });
 

--- a/frontend/src/Client.App/src/settings/Settings.test.tsx
+++ b/frontend/src/Client.App/src/settings/Settings.test.tsx
@@ -35,15 +35,23 @@ const named: OwnProfileInForce = {
 function renderSettings({
     profile = named,
     preferences = settings,
+    telemetryDestination = 'https://mail.example',
     onClose = () => undefined,
 }: {
     readonly profile?: OwnProfileInForce;
     readonly preferences?: ClientPreferencesInForce;
+    readonly telemetryDestination?: string | null;
     readonly onClose?: () => void;
 } = {}): void {
     render(
         <LocalizationProvider>
-            <Settings open profile={profile} preferences={preferences} onClose={onClose} />
+            <Settings
+                open
+                profile={profile}
+                preferences={preferences}
+                telemetryDestination={telemetryDestination}
+                onClose={onClose}
+            />
         </LocalizationProvider>,
     );
 }
@@ -224,6 +232,27 @@ describe('Settings', () => {
         renderSettings({ preferences: { ...settings, telemetryEnabled: false } });
 
         expect(screen.getByText(/support is harder/u)).toBeDefined();
+    });
+
+    it('names where the records go, so the decision is about something rather than about a word', () => {
+        renderSettings({ telemetryDestination: 'https://mail.example' });
+
+        expect(screen.getByText(/Sent to https:\/\/mail\.example/u)).toBeDefined();
+    });
+
+    it('says what a record carries and what it never carries', () => {
+        renderSettings();
+
+        expect(screen.getByText(/never your mail, your addresses, your folders, or your password/u)).toBeDefined();
+    });
+
+    // A deployment that forwards nothing has nothing behind the switch, so it says so rather than offering a control
+    // that decides nothing about a client that is already sending nothing.
+    it('offers no switch where the deployment forwards no telemetry, and says why', () => {
+        renderSettings({ telemetryDestination: null });
+
+        expect(screen.getByText(/forwards no telemetry/u)).toBeDefined();
+        expect(screen.queryByRole('switch', { name: /Do not send telemetry/u })).toBeNull();
     });
 
     it('offers the language here rather than in the menu that leads here', () => {

--- a/frontend/src/Client.App/src/settings/Settings.tsx
+++ b/frontend/src/Client.App/src/settings/Settings.tsx
@@ -6,6 +6,7 @@ import { useEffect, useId, useRef, useState } from 'react';
 import { Icon } from '../controls/Icon';
 import { PersonAvatar } from '../controls/PersonAvatar';
 import { Switch } from '../controls/Switch';
+import type { TelemetryForwarding } from '../deployment/telemetryForwarding';
 import { useLocalization } from '../localization/useLocalization';
 import type { ClientPreferencesInForce } from '../preferences/useClientPreferences';
 import type { OwnProfileInForce } from '../profile/useOwnProfile';
@@ -29,7 +30,7 @@ export function Settings({
     open,
     profile,
     preferences,
-    telemetryDestination,
+    telemetryForwarding,
     onClose,
 }: {
     readonly open: boolean;
@@ -40,8 +41,8 @@ export function Settings({
     /** The settings that follow the person, of which this screen edits one. */
     readonly preferences: ClientPreferencesInForce;
 
-    /** Where this client's telemetry is sent, or `null` where this deployment forwards none. */
-    readonly telemetryDestination: string | null;
+    /** What this deployment has said about forwarding this client's telemetry, including that it has said nothing. */
+    readonly telemetryForwarding: TelemetryForwarding;
 
     readonly onClose: () => void;
 }) {
@@ -106,7 +107,7 @@ export function Settings({
                 <Divider />
 
                 <SectionName>{translate('settings.privacy')}</SectionName>
-                <Telemetry preferences={preferences} destination={telemetryDestination} />
+                <Telemetry preferences={preferences} forwarding={telemetryForwarding} />
             </div>
         </dialog>
     );
@@ -271,20 +272,33 @@ function PictureNotice({
 // Whether this deployment may be told what the client is doing, drawn the way the design project states it: as the
 // decision to withhold rather than the decision to permit, so that the switch being on is the private answer.
 //
-// Two things stand beside the switch that the design project does not draw, both of them the acceptance of #1232 and
-// both about the same thing — that a decision is only a decision if what is being decided is stated. Where the records
+// Three things stand beside the switch that the design project does not draw, all of them the acceptance of #1232 and
+// all about the same thing — that a decision is only a decision if what is being decided is stated. Where the records
 // go is named, because "telemetry" says nothing about who ends up holding it, and this client sends to the deployment
-// somebody signed in to rather than anywhere else. And a deployment that forwards none is said out loud instead of
-// being drawn as a switch: there is nothing behind it there, so moving it would decide nothing.
+// somebody signed in to rather than anywhere else. A deployment that forwards none is said out loud instead of being
+// drawn as a switch: there is nothing behind it there, so moving it would decide nothing. And a deployment that has
+// not answered yet says that instead of either, because the frame records under the person's own answer while it
+// waits — so drawing "nothing to turn off" over that state would be telling somebody nothing is being sent at exactly
+// the moment something is.
 function Telemetry({
     preferences,
-    destination,
+    forwarding,
 }: {
     readonly preferences: ClientPreferencesInForce;
-    readonly destination: string | null;
+    readonly forwarding: TelemetryForwarding;
 }) {
     const { translate } = useLocalization();
     const withheld = !preferences.telemetryEnabled;
+
+    if (!forwarding.answered) {
+        return (
+            <p className="rounded-xl border border-line bg-sunken px-2.5 py-2.25 text-xs text-muted">
+                {translate('settings.telemetryUnanswered')}
+            </p>
+        );
+    }
+
+    const { destination } = forwarding;
 
     if (destination === null) {
         return (

--- a/frontend/src/Client.App/src/settings/Settings.tsx
+++ b/frontend/src/Client.App/src/settings/Settings.tsx
@@ -29,6 +29,7 @@ export function Settings({
     open,
     profile,
     preferences,
+    telemetryDestination,
     onClose,
 }: {
     readonly open: boolean;
@@ -38,6 +39,9 @@ export function Settings({
 
     /** The settings that follow the person, of which this screen edits one. */
     readonly preferences: ClientPreferencesInForce;
+
+    /** Where this client's telemetry is sent, or `null` where this deployment forwards none. */
+    readonly telemetryDestination: string | null;
 
     readonly onClose: () => void;
 }) {
@@ -102,7 +106,7 @@ export function Settings({
                 <Divider />
 
                 <SectionName>{translate('settings.privacy')}</SectionName>
-                <Telemetry preferences={preferences} />
+                <Telemetry preferences={preferences} destination={telemetryDestination} />
             </div>
         </dialog>
     );
@@ -266,9 +270,29 @@ function PictureNotice({
 
 // Whether this deployment may be told what the client is doing, drawn the way the design project states it: as the
 // decision to withhold rather than the decision to permit, so that the switch being on is the private answer.
-function Telemetry({ preferences }: { readonly preferences: ClientPreferencesInForce }) {
+//
+// Two things stand beside the switch that the design project does not draw, both of them the acceptance of #1232 and
+// both about the same thing — that a decision is only a decision if what is being decided is stated. Where the records
+// go is named, because "telemetry" says nothing about who ends up holding it, and this client sends to the deployment
+// somebody signed in to rather than anywhere else. And a deployment that forwards none is said out loud instead of
+// being drawn as a switch: there is nothing behind it there, so moving it would decide nothing.
+function Telemetry({
+    preferences,
+    destination,
+}: {
+    readonly preferences: ClientPreferencesInForce;
+    readonly destination: string | null;
+}) {
     const { translate } = useLocalization();
     const withheld = !preferences.telemetryEnabled;
+
+    if (destination === null) {
+        return (
+            <p className="rounded-xl border border-line bg-sunken px-2.5 py-2.25 text-xs text-muted">
+                {translate('settings.telemetryNotForwarded')}
+            </p>
+        );
+    }
 
     return (
         <>
@@ -285,6 +309,10 @@ function Telemetry({ preferences }: { readonly preferences: ClientPreferencesInF
                     }}
                 />
             </label>
+
+            <p className="text-2xs text-faint">
+                {translate('settings.telemetryDestination', { address: destination })}
+            </p>
 
             {withheld ? (
                 <p className="flex items-start gap-2 rounded-xl border border-warning bg-warning-soft px-2.5 py-2.25 text-xs text-warning-text">

--- a/frontend/src/Client.App/src/shell/AccountMenu.test.tsx
+++ b/frontend/src/Client.App/src/shell/AccountMenu.test.tsx
@@ -5,6 +5,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { MailAccount } from '@mailfathom/client-backend';
+import type { TelemetryForwarding } from '../deployment/telemetryForwarding';
 import { LocalizationProvider } from '../localization/Localization';
 import type { ClientPreferencesInForce } from '../preferences/useClientPreferences';
 import type { OwnProfileInForce } from '../profile/useOwnProfile';
@@ -57,11 +58,14 @@ function atTabWidth(wideEnough: boolean): void {
     });
 }
 
+/** What the deployment answered about forwarding, which this menu only passes to the screen behind its own row. */
+const forwardedTo: TelemetryForwarding = { answered: true, destination: 'https://mail.example' };
+
 function renderMenu({
     accounts = [],
     deploymentVersion = '0.9.0',
     readingFrom = null,
-    telemetryDestination = 'https://mail.example',
+    telemetryForwarding = forwardedTo,
     preferences = settings,
     profile = nobody,
     onPointSomewhereElse = () => undefined,
@@ -70,7 +74,7 @@ function renderMenu({
     readonly accounts?: readonly MailAccount[];
     readonly deploymentVersion?: string | null;
     readonly readingFrom?: string | null;
-    readonly telemetryDestination?: string | null;
+    readonly telemetryForwarding?: TelemetryForwarding;
     readonly preferences?: ClientPreferencesInForce;
     readonly profile?: OwnProfileInForce;
     readonly onPointSomewhereElse?: () => void;
@@ -83,7 +87,7 @@ function renderMenu({
                     accounts={accounts}
                     deploymentVersion={deploymentVersion}
                     readingFrom={readingFrom}
-                    telemetryDestination={telemetryDestination}
+                    telemetryForwarding={telemetryForwarding}
                     preferences={preferences}
                     profile={profile}
                     onPointSomewhereElse={onPointSomewhereElse}

--- a/frontend/src/Client.App/src/shell/AccountMenu.test.tsx
+++ b/frontend/src/Client.App/src/shell/AccountMenu.test.tsx
@@ -61,6 +61,7 @@ function renderMenu({
     accounts = [],
     deploymentVersion = '0.9.0',
     readingFrom = null,
+    telemetryDestination = 'https://mail.example',
     preferences = settings,
     profile = nobody,
     onPointSomewhereElse = () => undefined,
@@ -69,6 +70,7 @@ function renderMenu({
     readonly accounts?: readonly MailAccount[];
     readonly deploymentVersion?: string | null;
     readonly readingFrom?: string | null;
+    readonly telemetryDestination?: string | null;
     readonly preferences?: ClientPreferencesInForce;
     readonly profile?: OwnProfileInForce;
     readonly onPointSomewhereElse?: () => void;
@@ -81,6 +83,7 @@ function renderMenu({
                     accounts={accounts}
                     deploymentVersion={deploymentVersion}
                     readingFrom={readingFrom}
+                    telemetryDestination={telemetryDestination}
                     preferences={preferences}
                     profile={profile}
                     onPointSomewhereElse={onPointSomewhereElse}

--- a/frontend/src/Client.App/src/shell/AccountMenu.tsx
+++ b/frontend/src/Client.App/src/shell/AccountMenu.tsx
@@ -27,6 +27,7 @@ export function AccountMenu({
     accounts,
     deploymentVersion,
     readingFrom,
+    telemetryDestination,
     preferences,
     profile,
     onPointSomewhereElse,
@@ -40,6 +41,13 @@ export function AccountMenu({
 
     /** The address somebody named for the deployment, or `null` where the origin that served the client is it. */
     readonly readingFrom: string | null;
+
+    /**
+     * Where this client's own telemetry is sent, or `null` where this deployment forwards none and there is therefore
+     * nothing behind the switch. It is the deployment's address whether or not somebody typed it, because what the
+     * settings screen has to name is where the records actually go rather than how the client came to be pointed there.
+     */
+    readonly telemetryDestination: string | null;
 
     /** The settings that follow the person, and the three ways of changing one. */
     readonly preferences: ClientPreferencesInForce;
@@ -158,7 +166,13 @@ export function AccountMenu({
 
             {/* Outside the popover rather than inside it, because the menu is folded away while this is open and a
                 dialog inside something the platform sets `display: none` on is a dialog nobody can see. */}
-            <Settings open={settingsOpen} profile={profile} preferences={preferences} onClose={closeSettings} />
+            <Settings
+                open={settingsOpen}
+                profile={profile}
+                preferences={preferences}
+                telemetryDestination={telemetryDestination}
+                onClose={closeSettings}
+            />
         </>
     );
 }

--- a/frontend/src/Client.App/src/shell/AccountMenu.tsx
+++ b/frontend/src/Client.App/src/shell/AccountMenu.tsx
@@ -7,6 +7,7 @@ import type { MailAccount } from '@mailfathom/client-backend';
 import { Icon } from '../controls/Icon';
 import { MailboxMark } from '../controls/MailboxMark';
 import { PersonAvatar } from '../controls/PersonAvatar';
+import type { TelemetryForwarding } from '../deployment/telemetryForwarding';
 import { useLocalization } from '../localization/useLocalization';
 import type { ClientPreferencesInForce } from '../preferences/useClientPreferences';
 import type { OwnProfileInForce } from '../profile/useOwnProfile';
@@ -27,7 +28,7 @@ export function AccountMenu({
     accounts,
     deploymentVersion,
     readingFrom,
-    telemetryDestination,
+    telemetryForwarding,
     preferences,
     profile,
     onPointSomewhereElse,
@@ -43,11 +44,12 @@ export function AccountMenu({
     readonly readingFrom: string | null;
 
     /**
-     * Where this client's own telemetry is sent, or `null` where this deployment forwards none and there is therefore
-     * nothing behind the switch. It is the deployment's address whether or not somebody typed it, because what the
-     * settings screen has to name is where the records actually go rather than how the client came to be pointed there.
+     * What this deployment has said about forwarding this client's own records, which the settings screen behind this
+     * menu's own row words. A forwarded one carries the deployment's address whether or not somebody typed it, because
+     * what that screen has to name is where the records actually go rather than how the client came to be pointed
+     * there.
      */
-    readonly telemetryDestination: string | null;
+    readonly telemetryForwarding: TelemetryForwarding;
 
     /** The settings that follow the person, and the three ways of changing one. */
     readonly preferences: ClientPreferencesInForce;
@@ -170,7 +172,7 @@ export function AccountMenu({
                 open={settingsOpen}
                 profile={profile}
                 preferences={preferences}
-                telemetryDestination={telemetryDestination}
+                telemetryForwarding={telemetryForwarding}
                 onClose={closeSettings}
             />
         </>

--- a/frontend/src/Client.App/src/shell/ConnectionSummary.test.tsx
+++ b/frontend/src/Client.App/src/shell/ConnectionSummary.test.tsx
@@ -40,7 +40,7 @@ const unreachableAccount: MailAccount = { ...failingAccount, synchronizationStat
 
 const reading: ClientResult<DeploymentSession> = {
     outcome: 'read',
-    value: { version: '0.8.7', permissions: ['mailfathom.mail.read'] },
+    value: { version: '0.8.7', permissions: ['mailfathom.mail.read'], telemetryForwarded: true },
 };
 
 function directory(
@@ -141,7 +141,9 @@ describe('ConnectionSummary', () => {
     });
 
     it('says nothing about freshness where the credential may not read mail, that being said elsewhere', () => {
-        renderSummary({ session: { outcome: 'read', value: { version: '0.8.7', permissions: [] } } });
+        renderSummary({
+            session: { outcome: 'read', value: { version: '0.8.7', permissions: [], telemetryForwarded: true } },
+        });
 
         expect(screen.queryByText(/account/i)).toBeNull();
     });

--- a/frontend/src/Client.App/src/telemetry/clientTelemetry.test.ts
+++ b/frontend/src/Client.App/src/telemetry/clientTelemetry.test.ts
@@ -440,6 +440,23 @@ describe('exportFor', () => {
         });
     });
 
+    // The order React produces when only the permission changed: the previous effect's cleanup, then the next effect's
+    // body. Holding flushes, so a hold that went ahead here would send the batch somebody had just declined — and the
+    // discard behind it would then be throwing away an empty buffer while the records were already on the wire.
+    it('throws away rather than flushing when a session that was permitted is refused', async () => {
+        const telemetry = clientTelemetryForThisApplication();
+
+        const stop = telemetry.exportFor(session, true);
+
+        stop();
+        telemetry.exportFor(session, false);
+
+        await vi.waitFor(() => {
+            expect(pipeline.steps).toEqual(['export Basic c2FtcGxl', 'discard']);
+        });
+        expect(pipeline.steps).not.toContain('hold');
+    });
+
     it('keeps the session that is signed in when one ends and the next begins in the same turn', async () => {
         const telemetry = clientTelemetryForThisApplication();
 

--- a/frontend/src/Client.App/src/telemetry/clientTelemetry.test.ts
+++ b/frontend/src/Client.App/src/telemetry/clientTelemetry.test.ts
@@ -42,6 +42,12 @@ const pipeline = vi.hoisted(() => {
             return Promise.resolve();
         },
 
+        discard() {
+            steps.push('discard');
+
+            return Promise.resolve();
+        },
+
         shutdown: () => Promise.resolve(),
     };
 });
@@ -56,7 +62,7 @@ beforeEach(() => {
 
 describe('noTelemetry', () => {
     it('records nothing and hands back a teardown that is safe to call', () => {
-        const stop = noTelemetry.exportFor(session);
+        const stop = noTelemetry.exportFor(session, true);
 
         expect(() => {
             noTelemetry.navigated('mail', performance.timeOrigin);
@@ -129,6 +135,24 @@ describe('clientTelemetryForThisApplication', () => {
         expect(span?.attributes).toEqual({ 'mailfathom.client.space': 'mail' });
     });
 
+    // An address is what a person put in the fragment, so what reaches this is whatever survived reading it rather
+    // than a value the compiler chose. Each of these is something a later route could legitimately carry, and none of
+    // them may become a span name or a dimension value.
+    it.each([
+        ['a message identifier', 'mail/018f2c31-2f2c-7c1e-9f0e-3a1b6f9c0d21'],
+        ['a folder somebody named', 'mail/INBOX/Clients/Acme'],
+        ['what somebody searched for', 'search?q=salary%20review'],
+    ])('reports a move to %s as an unnamed space', async (_, address) => {
+        const telemetry = clientTelemetryForThisApplication();
+
+        telemetry.navigated(address, performance.timeOrigin + performance.now());
+
+        const [span] = await written(() => spans.getFinishedSpans());
+
+        expect(span?.name).toBe('navigate other');
+        expect(span?.attributes).toEqual({ 'mailfathom.client.space': 'other' });
+    });
+
     it('counts a move and times it, under the space it reached', async () => {
         const telemetry = clientTelemetryForThisApplication();
 
@@ -184,10 +208,44 @@ describe('clientTelemetryForThisApplication', () => {
         expect(recorded).not.toContain('mail.example');
     });
 
+    describe('somebody who has not agreed to be reported on', () => {
+        it('has nothing written about them, whether or not there is a session to export it', async () => {
+            const telemetry = clientTelemetryForThisApplication();
+
+            telemetry.exportFor(session, false);
+            telemetry.navigated('mail', performance.timeOrigin + performance.now());
+            telemetry.happened('session_started');
+
+            // Nothing arrives to wait for, so what is waited on is the pipeline having been asked to throw away what
+            // it held — everything above was queued before that and would be in front of it had it been recorded.
+            await vi.waitFor(() => {
+                expect(pipeline.steps).toContain('discard');
+            });
+
+            expect(spans.getFinishedSpans()).toHaveLength(0);
+            expect(records.getFinishedLogRecords()).toHaveLength(0);
+        });
+
+        it('is recorded again from the moment they say so', async () => {
+            const telemetry = clientTelemetryForThisApplication();
+
+            telemetry.exportFor(session, false);
+            telemetry.navigated('mail', performance.timeOrigin + performance.now());
+            telemetry.exportFor(session, true);
+            telemetry.navigated('discover', performance.timeOrigin + performance.now());
+
+            const [span] = await written(() => spans.getFinishedSpans());
+
+            // One span rather than two: the move made while they had said no is not recovered by them saying yes.
+            expect(spans.getFinishedSpans()).toHaveLength(1);
+            expect(span?.name).toBe('navigate discover');
+        });
+    });
+
     it('leaves the registries alone for a client that has not signed in', async () => {
         const telemetry = clientTelemetryForThisApplication();
 
-        telemetry.exportFor(null)();
+        telemetry.exportFor(null, true)();
         telemetry.navigated('mail', performance.timeOrigin + performance.now());
 
         // The span still reaches the exporter this test registered, which is what says nothing replaced it.
@@ -215,7 +273,7 @@ describe('clientTelemetryForThisApplication', () => {
         it('reports it where the deployment is what served this client', async () => {
             const telemetry = clientTelemetryForThisApplication();
 
-            telemetry.exportFor({ ...session, baseAddress: window.location.origin });
+            telemetry.exportFor({ ...session, baseAddress: window.location.origin }, true);
 
             await vi.waitFor(async () => {
                 expect(await arrivalDuration()).toBe(1.5);
@@ -230,7 +288,7 @@ describe('clientTelemetryForThisApplication', () => {
             // What a session restored from a stored credential looks like: it is signed in before the load event, and
             // the entry then describes a document still arriving. This run gets one sign-in and no second attempt, so
             // reading it here is losing the measurement rather than deferring it.
-            telemetry.exportFor({ ...session, baseAddress: window.location.origin });
+            telemetry.exportFor({ ...session, baseAddress: window.location.origin }, true);
 
             // Queued behind the start, so its record appearing is how this knows the start finished — reading the
             // histogram before that would find it empty whether the measurement was deferred or merely late.
@@ -257,8 +315,8 @@ describe('clientTelemetryForThisApplication', () => {
             // What is read is the entry being consulted at all, rather than where the value landed: starting a second
             // pipeline takes the registries this test put there away, so the histogram is no longer this test's to
             // read by then. Consulting the entry is the whole of what the first session must not have used up.
-            telemetry.exportFor(session);
-            telemetry.exportFor({ ...session, baseAddress: window.location.origin });
+            telemetry.exportFor(session, true);
+            telemetry.exportFor({ ...session, baseAddress: window.location.origin }, true);
 
             await vi.waitFor(() => {
                 expect(timing).toHaveBeenCalled();
@@ -271,7 +329,7 @@ describe('clientTelemetryForThisApplication', () => {
             // Signed in to a deployment elsewhere, which is every desktop shell and every development server. The
             // teardown is queued behind the start, so waiting for it is how this knows the start finished rather than
             // that it has not begun.
-            telemetry.exportFor(session)();
+            telemetry.exportFor(session, true)();
 
             await vi.waitFor(() => {
                 expect(pipeline.steps).toContain('hold');
@@ -301,7 +359,7 @@ describe('exportFor', () => {
 
     it('names the session as the destination, and takes it away again when the session ends', async () => {
         const telemetry = clientTelemetryForThisApplication();
-        const stop = telemetry.exportFor(session);
+        const stop = telemetry.exportFor(session, true);
 
         // The pipeline is fetched rather than bundled, so it arrives a moment after the client composed it. This waits
         // on what it was asked to do rather than on a duration.
@@ -319,11 +377,11 @@ describe('exportFor', () => {
     it('asks for no destination at all for a client that has not signed in', async () => {
         const telemetry = clientTelemetryForThisApplication();
 
-        telemetry.exportFor(null)();
+        telemetry.exportFor(null, true)();
 
         // Signing in afterwards is what makes the absence provable: the queue is ordered, so a destination or a hold
         // asked for by the call above would sit in front of this one.
-        telemetry.exportFor(session);
+        telemetry.exportFor(session, true);
 
         await vi.waitFor(() => {
             expect(pipeline.steps).toEqual(['export Basic c2FtcGxl']);
@@ -340,7 +398,7 @@ describe('exportFor', () => {
         const loggers = new LoggerProvider({ processors: [new SimpleLogRecordProcessor({ exporter: arriving })] });
         const telemetry = clientTelemetryForThisApplication();
 
-        const stop = telemetry.exportFor(session);
+        const stop = telemetry.exportFor(session, true);
 
         telemetry.happened('session_started');
         logs.setGlobalLoggerProvider(loggers);
@@ -357,16 +415,41 @@ describe('exportFor', () => {
         await loggers.shutdown();
     });
 
+    it('throws away what was held rather than exporting it, when the answer arrives as off', async () => {
+        const telemetry = clientTelemetryForThisApplication();
+
+        // What a fresh client does: it records against the deployment's unset answer while the preference is being
+        // read, and the answer comes back off. Nothing may be addressed, so the discard stands alone in the queue —
+        // an export before it would be the one batch the person had asked never to be sent.
+        telemetry.navigated('mail', performance.timeOrigin + performance.now());
+        telemetry.exportFor(session, false);
+
+        await vi.waitFor(() => {
+            expect(pipeline.steps).toEqual(['discard']);
+        });
+    });
+
+    it('exports for a session again once the answer comes back the other way', async () => {
+        const telemetry = clientTelemetryForThisApplication();
+
+        telemetry.exportFor(session, false);
+        telemetry.exportFor(session, true);
+
+        await vi.waitFor(() => {
+            expect(pipeline.steps).toEqual(['discard', 'export Basic c2FtcGxl']);
+        });
+    });
+
     it('keeps the session that is signed in when one ends and the next begins in the same turn', async () => {
         const telemetry = clientTelemetryForThisApplication();
 
         // What signing out and straight back in looks like from here, and what React does on every mount in strict
         // mode: the teardown and the next start are asked for before the first one has finished arriving. Left to
         // race, the hold lands last and leaves the session that is now signed in holding for the rest of the run.
-        const stop = telemetry.exportFor(session);
+        const stop = telemetry.exportFor(session, true);
 
         stop();
-        telemetry.exportFor({ ...session, authorization: 'Basic c29tZWJvZHkgZWxzZQ==' });
+        telemetry.exportFor({ ...session, authorization: 'Basic c29tZWJvZHkgZWxzZQ==' }, true);
 
         await vi.waitFor(() => {
             expect(pipeline.steps).toEqual(['export Basic c2FtcGxl', 'hold', 'export Basic c29tZWJvZHkgZWxzZQ==']);

--- a/frontend/src/Client.App/src/telemetry/clientTelemetry.ts
+++ b/frontend/src/Client.App/src/telemetry/clientTelemetry.ts
@@ -6,6 +6,7 @@ import { createContext, useContext } from 'react';
 import { metrics, trace } from '@opentelemetry/api';
 import { logs, SeverityNumber } from '@opentelemetry/api-logs';
 import { telemetryName, type ClientSession } from '@mailfathom/client-backend';
+import { isSpace } from '../routing/spaces';
 import type { ClientPipeline } from './exporting';
 
 // The client's one telemetry pipeline: the three signals, one resource, and one place any of it is composed. Every
@@ -17,8 +18,12 @@ import type { ClientPipeline } from './exporting';
 // there exactly as every read does, so there is no destination and no credential to present until a session exists —
 // but starting up, resolving which deployment this client belongs to, and a sign-in that did not succeed are exactly
 // the failures somebody cannot describe, and they are invisible to the deployment because nothing reached it. So
-// `holding.ts` holds them in memory, bounded, until there is a session to attribute them to. Turning any of this off
-// is #1232's.
+// `holding.ts` holds them in memory, bounded, until there is a session to attribute them to.
+//
+// Whether any of it happens at all is the person's, and it arrives here beside the session through `exportFor`. Off
+// stops the recording rather than filtering the export, and what was held from before that answer arrived is discarded
+// rather than flushed: a client that has never been told stands on the deployment's unset answer and records into that
+// buffer, so the first thing somebody who wants none of this says has to reach the buffer as well as the wire.
 //
 // Nothing here records what was on the screen. A space is named, a route template is named, and an occurrence is
 // named; no address, no message, no correspondent, no search text, and no part of a credential reaches a span, a
@@ -26,6 +31,9 @@ import type { ClientPipeline } from './exporting';
 
 /** Something that happened to this client's session, which is an occurrence rather than a quantity to measure. */
 export type ClientEvent = 'session_started' | 'credential_no_longer_accepted';
+
+/** What a move is reported as where the address named something this client does not publish as a space. */
+export const unnamedSpace = 'other';
 
 /**
  * What the application may report about itself.
@@ -42,10 +50,24 @@ export interface ClientTelemetry {
      *
      * A session of `null` exports nothing and answers with a teardown that does nothing, which is what a client that
      * has signed out or has not signed in yet passes. The pipeline goes on recording either way.
+     *
+     * @param session Who is signed in and where their telemetry goes, or `null` where nobody is.
+     * @param permitted Whether this person has agreed to be reported on at all. It is stated here rather than through
+     * a setter of its own because it answers the same question as which session is exporting — one caller states both
+     * from one effect, and two ways of saying "stop" would be two orderings to reason about. `false` records nothing
+     * from the moment it is stated and discards what was held before it, which is the difference between a switch and
+     * a filter on the way out.
      */
-    readonly exportFor: (session: ClientSession | null) => () => void;
+    readonly exportFor: (session: ClientSession | null, permitted: boolean) => () => void;
 
-    /** A person reached a space, having asked for it at `askedAt` — an epoch instant in milliseconds. */
+    /**
+     * A person reached a space, having asked for it at `askedAt` — an epoch instant in milliseconds.
+     *
+     * The space is redacted to {@link unnamedSpace} unless it is one the client publishes, so an address naming
+     * something else — a message, a folder, anything a later route could carry — cannot become a span name or a
+     * dimension value. The argument is a string rather than the space type deliberately: a compiler refusal would hold
+     * only for what is written today, and what this has to survive is a caller reached from an address.
+     */
     readonly navigated: (space: string, askedAt: number) => void;
 
     /** Records that something happened to the session, with no measurement attached to it. */
@@ -81,6 +103,11 @@ export function clientTelemetryForThisApplication(): ClientTelemetry {
         .then(({ startRecording }) => startRecording())
         .catch(() => null);
 
+    // Whether anything may be recorded at all. It begins permitted because that is the deployment's own unset answer,
+    // and the frame states the remembered one on its first effect — before any request has come back, which is what
+    // makes a restart honour a decision rather than record until it is confirmed.
+    let permitted = true;
+
     // Everything this module does is put in a queue rather than run where it was asked for, and that is a correctness
     // rule rather than tidiness. A registry answers whoever is registered at the instant it is asked, and a record
     // written before the pipeline arrives is dropped for good — there is no retroactive delivery once the real
@@ -101,8 +128,30 @@ export function clientTelemetryForThisApplication(): ClientTelemetry {
         });
     }
 
+    // A record goes through the same queue and is refused before it joins it, which is what makes the switch a switch:
+    // nothing is written into a provider, so there is nothing for a later export to carry and nothing in the buffer
+    // for a person to have to trust an exporter about.
+    function record(write: () => void): void {
+        if (!permitted) {
+            return;
+        }
+
+        next(write);
+    }
+
     return {
-        exportFor(session) {
+        exportFor(session, allowed) {
+            permitted = allowed;
+
+            if (!allowed) {
+                // Read rather than exported, and read before anything else this queue holds: what was recorded while
+                // the deployment had said nothing is exactly what a person turning this off has not agreed to, so it
+                // leaves the buffer without ever having been addressed.
+                next((pipeline) => pipeline?.discard());
+
+                return nothingToStop;
+            }
+
             if (session === null) {
                 return nothingToStop;
             }
@@ -123,16 +172,17 @@ export function clientTelemetryForThisApplication(): ClientTelemetry {
         },
 
         navigated(space, askedAt) {
-            const at = { 'mailfathom.client.space': space };
+            const named = isSpace(space) ? space : unnamedSpace;
+            const at = { 'mailfathom.client.space': named };
 
             // Read where the move ended rather than where it was written, so queueing the write moves when the record
             // reaches a registry and not what the record says.
             const reached = performance.timeOrigin + performance.now();
 
-            next(() => {
+            record(() => {
                 trace
                     .getTracer(telemetryName)
-                    .startSpan(`navigate ${space}`, { startTime: askedAt, attributes: at })
+                    .startSpan(`navigate ${named}`, { startTime: askedAt, attributes: at })
                     .end(reached);
 
                 const meter = metrics.getMeter(telemetryName);
@@ -149,7 +199,7 @@ export function clientTelemetryForThisApplication(): ClientTelemetry {
             // session began at the moment the client next got a word in.
             const at = performance.timeOrigin + performance.now();
 
-            next(() => {
+            record(() => {
                 logs.getLogger(telemetryName).emit({
                     timestamp: at,
                     severityNumber: severities[event],

--- a/frontend/src/Client.App/src/telemetry/clientTelemetry.ts
+++ b/frontend/src/Client.App/src/telemetry/clientTelemetry.ts
@@ -167,7 +167,14 @@ export function clientTelemetryForThisApplication(): ClientTelemetry {
             });
 
             return () => {
-                next((pipeline) => pipeline?.hold());
+                // What this stop does is decided when it runs rather than when it was created, and that is what makes
+                // a refusal taken mid-session safe. React runs a cleanup before the effect body that replaced it, so
+                // somebody moving the switch to off queues this hold first and the discard above second — and holding
+                // flushes on purpose, which would put exactly the records they had just declined onto the wire under
+                // the credential they declined them with, leaving the discard behind it nothing to throw away. Both
+                // steps are queued in one turn, so by the time this one runs the body has already stated the new
+                // answer: reading it here is reading the decision rather than guessing what follows.
+                next((pipeline) => (permitted ? pipeline?.hold() : undefined));
             };
         },
 

--- a/frontend/src/Client.App/src/telemetry/exporting.test.ts
+++ b/frontend/src/Client.App/src/telemetry/exporting.test.ts
@@ -21,6 +21,7 @@ import { startRecording, type ClientPipeline } from './exporting';
 
 const destinations = vi.hoisted(() => {
     const built: { readonly url: string; readonly authorization: string }[] = [];
+    const exported: { readonly url: string; readonly records: number }[] = [];
     const shutDown: string[] = [];
 
     class FakeDestination {
@@ -31,7 +32,8 @@ const destinations = vi.hoisted(() => {
             built.push({ url: options.url, authorization: options.headers['Authorization'] ?? '' });
         }
 
-        export(_records: unknown, done: (result: { code: ExportResultCode }) => void): void {
+        export(records: unknown, done: (result: { code: ExportResultCode }) => void): void {
+            exported.push({ url: this.url, records: Array.isArray(records) ? records.length : 1 });
             done({ code: ExportResultCode.SUCCESS });
         }
 
@@ -46,7 +48,7 @@ const destinations = vi.hoisted(() => {
         }
     }
 
-    return { built, shutDown, FakeDestination };
+    return { built, exported, shutDown, FakeDestination };
 });
 
 vi.mock('@opentelemetry/exporter-trace-otlp-proto', () => ({ OTLPTraceExporter: destinations.FakeDestination }));
@@ -59,6 +61,7 @@ let running: ClientPipeline | null = null;
 
 beforeEach(() => {
     destinations.built.length = 0;
+    destinations.exported.length = 0;
     destinations.shutDown.length = 0;
 });
 
@@ -211,6 +214,25 @@ describe('startRecording', () => {
         await running.exportTo({ ...session, authorization: 'Basic c29tZWJvZHkgZWxzZQ==' });
 
         expect(destinations.built).toHaveLength(6);
+    });
+
+    it('throws away what it held rather than exporting it, once somebody refuses to be reported on', async () => {
+        running = startRecording();
+
+        record();
+
+        await running.discard();
+
+        // Signing in afterwards is what makes the absence provable: a buffer that had merely gone back to holding
+        // would empty into this destination, and this destination is the first one that has ever existed.
+        await running.exportTo(session);
+
+        // The measurements are the one signal with nothing to throw away — cumulative totals in the instruments rather
+        // than a buffer — which is the ceiling the `ponytail:` note beside `hold` names against #1227. What a person
+        // refusing to be reported on must not have exported is what was written about them, and both of the signals
+        // that carry that are empty.
+        expect(destinations.built).toHaveLength(3);
+        expect(destinations.exported.filter((batch) => !batch.url.endsWith('/metrics'))).toEqual([]);
     });
 
     it('stops recording when the run that composed it lets it go', async () => {

--- a/frontend/src/Client.App/src/telemetry/exporting.ts
+++ b/frontend/src/Client.App/src/telemetry/exporting.ts
@@ -46,6 +46,15 @@ export interface ClientPipeline {
     readonly hold: () => Promise<void>;
 
     /**
+     * Returns to holding and throws away what the three signals were holding, addressing none of it.
+     *
+     * This is what a person who does not want to be reported on does to the records made before they were asked. The
+     * providers go on being registered, because the answer is a person's rather than a run's and can be given again
+     * the other way; what leaves is the transcript, which is what makes the switch a switch rather than a filter.
+     */
+    readonly discard: () => Promise<void>;
+
+    /**
      * Stops recording altogether and lets the three providers go.
      *
      * The client itself never reaches this: a run records for as long as it is open, and closing the page is what ends
@@ -130,6 +139,20 @@ export function startRecording(): ClientPipeline {
             // meter provider per session, which the global registry refuses to re-register; #1227 is where that would
             // be taken up if a deployment reads a person's own totals rather than the deployment's.
             await releaseDestinations();
+        },
+
+        async discard() {
+            // The destination goes first and nothing is flushed into one, which is the whole difference from holding
+            // above: what the two processors still have queued then drains into a buffer that addresses nothing, and
+            // emptying that buffer afterwards is what leaves nothing for a later session to carry. Flushing first, as
+            // holding does, would put exactly the records somebody is refusing onto the wire under the credential
+            // they are refusing it with.
+            await releaseDestinations();
+            await Promise.all([traces.forceFlush(), meters.forceFlush(), loggers.forceFlush()]);
+
+            spans.discard();
+            measurements.discard();
+            records.discard();
         },
 
         async shutdown() {

--- a/frontend/src/Client.App/src/telemetry/holding.test.ts
+++ b/frontend/src/Client.App/src/telemetry/holding.test.ts
@@ -179,6 +179,19 @@ describe('the buffers a client holds before it signs in', () => {
             expect(destination.exported).toHaveLength(0);
         });
 
+        it('throws away what it held rather than exporting it, once somebody refuses to be reported on', async () => {
+            const destination = fakeDestination<ReadableSpan>();
+
+            await record('navigate mail');
+            held.discard();
+
+            // Named afterwards rather than before, because what is being proved is that the records are gone rather
+            // than that this destination did not get them: a buffer that merely held them would empty into this one.
+            await held.exportTo(destination);
+
+            expect(destination.exported.flat()).toHaveLength(0);
+        });
+
         it('drops the oldest records once it is holding more than it may, and counts them', async () => {
             const destination = fakeDestination<ReadableSpan>();
 
@@ -270,6 +283,22 @@ describe('the buffers a client holds before it signs in', () => {
 
             await loggers.shutdown();
         });
+
+        it('throws away what it held rather than exporting it, once somebody refuses to be reported on', async () => {
+            const destination = fakeDestination<ReadableLogRecord>();
+            const held = heldLogRecordExporter();
+            const loggers = new LoggerProvider({ processors: [new SimpleLogRecordProcessor({ exporter: held })] });
+
+            loggers.getLogger('MailFathom').emit({ body: 'A client session began.' });
+            await loggers.forceFlush();
+
+            held.discard();
+            await held.exportTo(destination);
+
+            expect(destination.exported.flat()).toHaveLength(0);
+
+            await loggers.shutdown();
+        });
     });
 
     describe('heldMetricExporter', () => {
@@ -315,6 +344,18 @@ describe('the buffers a client holds before it signs in', () => {
             await recorded.forceFlush();
 
             expect(await dropsCounted()).toEqual([]);
+        });
+
+        it('addresses nothing once somebody refuses to be reported on, having nothing to throw away', async () => {
+            const destination = fakeMeasurementDestination();
+
+            await held.exportTo(destination);
+            held.discard();
+
+            recorded.getMeter('MailFathom').createCounter('mailfathom.client.navigations').add(1);
+            await recorded.forceFlush();
+
+            expect(destination.exported).toEqual([]);
         });
     });
 });

--- a/frontend/src/Client.App/src/telemetry/holding.ts
+++ b/frontend/src/Client.App/src/telemetry/holding.ts
@@ -67,6 +67,16 @@ export interface Held<TDestination> {
 
     /** Returns to holding. Nothing reaches the network again until a destination is named. */
     readonly hold: () => void;
+
+    /**
+     * Returns to holding and throws away what was already held, without addressing any of it.
+     *
+     * This is what somebody saying they do not want to be reported on does to the records made before they were asked.
+     * A person who has never answered stands on the deployment's unset answer, so a fresh client records into the
+     * buffer above from the composition root; the answer that arrives as off has to reach those records too, or the
+     * switch would be a filter on the way out with a transcript sitting behind it.
+     */
+    readonly discard: () => void;
 }
 
 /** Holds spans until somebody signs in, and exports to the deployment that session is signed in to afterwards. */
@@ -123,7 +133,15 @@ export function heldMetricExporter(): PushMetricExporter & Held<PushMetricExport
             return Promise.resolve();
         },
 
+        // Nothing is buffered here, for the reason above, so throwing away what was held is holding. What the
+        // instruments themselves carry is not reset with it — the totals are cumulative and the provider belongs to
+        // the run — which is the ceiling the same `ponytail:` note in `exporting.ts` already names against #1227.
+        // Nothing personal is in them either way: they count moves between a closed set of space names.
         hold() {
+            destination = null;
+        },
+
+        discard() {
             destination = null;
         },
     };
@@ -221,6 +239,12 @@ function heldRecords<TRecord>(signal: Signal, sizeOf: (record: TRecord) => numbe
 
         hold() {
             destination = null;
+        },
+
+        discard() {
+            destination = null;
+            held = [];
+            heldBytes = 0;
         },
     };
 }

--- a/frontend/src/Client.Backend/src/deploymentSession.test.ts
+++ b/frontend/src/Client.Backend/src/deploymentSession.test.ts
@@ -13,7 +13,7 @@ function answering(response: Partial<ClientResponse>): MailFathomTransport {
 }
 
 function sessionBody(permissions: unknown, version: unknown = '0.8.0', service: unknown = 'MailFathom'): string {
-    return JSON.stringify({ service, version, permissions });
+    return JSON.stringify({ service, version, permissions, telemetry: true });
 }
 
 describe('readDeploymentSession', () => {
@@ -43,14 +43,42 @@ describe('readDeploymentSession', () => {
 
         expect(result).toEqual({
             outcome: 'read',
-            value: { version: '0.8.1', permissions: ['mailfathom.mail.read', 'mailfathom.mail.ask'] },
+            value: {
+                version: '0.8.1',
+                permissions: ['mailfathom.mail.read', 'mailfathom.mail.ask'],
+                telemetryForwarded: true,
+            },
         });
     });
 
     it('reads a credential granted nothing as one holding an empty grant rather than as a refusal', async () => {
         const result = await readDeploymentSession(session, answering({ body: sessionBody([]) }));
 
-        expect(result).toEqual({ outcome: 'read', value: { version: '0.8.0', permissions: [] } });
+        expect(result).toEqual({
+            outcome: 'read',
+            value: { version: '0.8.0', permissions: [], telemetryForwarded: true },
+        });
+    });
+
+    it.each([
+        ['a deployment that forwards telemetry', true, true],
+        ['a deployment that forwards none', false, false],
+        // Read as not forwarded rather than refusing the answer, so a deployment older than this client still signs
+        // somebody in — and the direction it is wrong in is the one that sends nothing.
+        ['a deployment answering nothing about it', undefined, false],
+        ['an answer stating something that is not a decision', 'yes', false],
+    ])('reads %s', async (_, telemetry, forwarded) => {
+        const result = await readDeploymentSession(
+            session,
+            answering({
+                body: JSON.stringify({ service: 'MailFathom', version: '0.8.0', permissions: [], telemetry }),
+            }),
+        );
+
+        expect(result).toEqual({
+            outcome: 'read',
+            value: { version: '0.8.0', permissions: [], telemetryForwarded: forwarded },
+        });
     });
 
     it('keeps the names it knows out of an answer that also carries one it does not', async () => {
@@ -59,7 +87,10 @@ describe('readDeploymentSession', () => {
             answering({ body: sessionBody(['mailfathom.mail.read', 'mailfathom.mail.telepathy']) }),
         );
 
-        expect(result).toEqual({ outcome: 'read', value: { version: '0.8.0', permissions: ['mailfathom.mail.read'] } });
+        expect(result).toEqual({
+            outcome: 'read',
+            value: { version: '0.8.0', permissions: ['mailfathom.mail.read'], telemetryForwarded: true },
+        });
     });
 
     it('names an administrative permission nowhere, that half being one this surface never grants', async () => {
@@ -68,7 +99,10 @@ describe('readDeploymentSession', () => {
             answering({ body: sessionBody(['mailfathom.admin.read']) }),
         );
 
-        expect(result).toEqual({ outcome: 'read', value: { version: '0.8.0', permissions: [] } });
+        expect(result).toEqual({
+            outcome: 'read',
+            value: { version: '0.8.0', permissions: [], telemetryForwarded: true },
+        });
     });
 
     it('names a permission once however many times the answer repeated it', async () => {
@@ -77,7 +111,10 @@ describe('readDeploymentSession', () => {
             answering({ body: sessionBody(['mailfathom.mail.read', 'mailfathom.mail.read']) }),
         );
 
-        expect(result).toEqual({ outcome: 'read', value: { version: '0.8.0', permissions: ['mailfathom.mail.read'] } });
+        expect(result).toEqual({
+            outcome: 'read',
+            value: { version: '0.8.0', permissions: ['mailfathom.mail.read'], telemetryForwarded: true },
+        });
     });
 
     it.each([

--- a/frontend/src/Client.Backend/src/deploymentSession.ts
+++ b/frontend/src/Client.Backend/src/deploymentSession.ts
@@ -49,6 +49,16 @@ export interface DeploymentSession {
      * be turned away.
      */
     readonly permissions: readonly MailFathomPermission[];
+
+    /**
+     * Whether this deployment forwards a client's own telemetry to a collector of its own.
+     *
+     * It is not part of the grant and never varies by credential: what decides it is whether the deployment named a
+     * collector at all. A client reads it so that it can say there is nothing behind its telemetry switch rather than
+     * offering a control that decides nothing — the only other way to find out being to export a batch and read the
+     * refusal, which is finding out by doing the thing.
+     */
+    readonly telemetryForwarded: boolean;
 }
 
 // The most names one answer may carry. The published set is smaller than this by a wide margin and may grow; what the
@@ -146,7 +156,11 @@ export function parseDeploymentSession(body: string): DeploymentSession | null {
         }
     }
 
-    return { version, permissions };
+    // Absent reads as not forwarded rather than refusing the whole answer, which is the same leniency the unknown
+    // permission name above gets and for the same reason: a deployment older than this client answers without it, and
+    // refusing there would stop somebody signing in over a field about a switch. Absent therefore fails towards
+    // sending nothing, which is the direction a privacy answer is allowed to be wrong in.
+    return { version, permissions, telemetryForwarded: answered['telemetry'] === true };
 }
 
 function isMailPermission(value: string): value is MailFathomPermission {

--- a/frontend/src/Client.Backend/src/telemetry.test.ts
+++ b/frontend/src/Client.Backend/src/telemetry.test.ts
@@ -17,13 +17,24 @@ import {
     SimpleSpanProcessor,
     type ReadableSpan,
 } from '@opentelemetry/sdk-trace-base';
+import { readClientPreferences, unsetClientPreferences, writeClientPreferences } from './clientPreferences';
+import { readDeploymentSession } from './deploymentSession';
 import { failed, read, type ClientFailureReason } from './failure';
+import { readMailAccounts } from './mailAccounts';
 import { readMailAttachment } from './mailAttachment';
-import { changeOwnDisplayName } from './ownDisplayName';
+import { readMailBody } from './mailBody';
+import { readMailFolders } from './mailFolders';
+import { readMailMessage } from './mailMessage';
+import { markMailRead } from './mailMutations';
+import { readMailSearch } from './mailSearch';
+import { readMailThread } from './mailThread';
+import { readMailTimeline } from './mailTimeline';
+import { changeOwnDisplayName, readOwnDisplayName } from './ownDisplayName';
 import { readOwnPortrait, removeOwnPortrait, replaceOwnPortrait } from './ownPortrait';
 import type { ClientSession } from './session';
+import { reachDeployment, signIn } from './signIn';
 import { reported, spanned, telemetryEndpoints, telemetryName } from './telemetry';
-import type { ClientRequest } from './transport';
+import type { ClientRequest, MailFathomTransport } from './transport';
 
 // The SDK is here and nowhere in this package's source: what a test needs is somewhere to read a span and a
 // measurement back from, and the registries the source publishes to are global. Every one of them is released in the
@@ -329,5 +340,130 @@ describe('every request this package composes', () => {
         await removeOwnPortrait(session, delivered, nothingFailed);
 
         expect(onlySpan().name).toBe('DELETE /portrait');
+    });
+});
+
+// Everything this package can be asked to do, driven with mail in every argument that takes one, so that the promise
+// #1232 makes about the client is a test rather than a sentence in a document. Every operation records through
+// `spanned` or `reported` and this package records nowhere else, so covering the operations covers the whole of the
+// surface — and an operation added later that named a composed path rather than a route template fails the shape
+// assertion below rather than shipping one span name per message.
+//
+// The values below are what a real screen would pass and are exactly the things that must never leave: a message
+// identifier, a thread identifier, a folder somebody named, an address, the name a person goes by, a search somebody
+// typed, the credential the session presents, and the deployment it presents it to. None of them comes from a real
+// mailbox, which `frontend/AGENTS.md` requires of anything standing in for mail here.
+//
+// The block above asserts what each operation names its own span; this one asserts what none of them may carry, over
+// all of them at once. Reading an operation into both is the point rather than a duplication: the drive is what makes
+// the promise hold for whatever is recorded next rather than for what happened to be recorded when it was written.
+describe('what the whole of this package records', () => {
+    const storedEmailId = '018f2c31-2f2c-7c1e-9f0e-3a1b6f9c0d21';
+    const threadId = '018f2c31-2f2c-7c1e-9f0e-000000000002';
+    const folder = 'INBOX/Clients/Acme';
+    const address = 'anna.kowalska@example.test';
+    const searchText = 'salary review';
+    const credential = 'Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==';
+    const ownName = 'Anna Kowalska';
+    const session: ClientSession = { baseAddress: 'https://mail.example.invalid', authorization: credential };
+
+    // What this package could have read is not what the test is about, so every answer is refused: the operation then
+    // reports a failure, which is the branch carrying the failure dimension as well and therefore the wider of the two.
+    const refusing: MailFathomTransport = () => Promise.resolve({ status: 500, body: '', headers: {} });
+
+    // The operations that compose a request instead of sending one are handed the composer the application hands
+    // them, and it answers with the request itself — which is what puts the composed path in front of the assertions
+    // below rather than only the template the span was named after.
+    const delivered = (request: ClientRequest): Promise<ClientRequest> => Promise.resolve(request);
+    const nothingFailed = (): ClientFailureReason | null => null;
+
+    const window = {
+        account: 'work',
+        folder,
+        includeJunk: false,
+        unread: null,
+        flagged: null,
+        hasAttachments: null,
+        pageSize: 50,
+        cursor: null,
+    };
+
+    async function driveTheWholeSurface(): Promise<void> {
+        await reachDeployment(session, refusing);
+        await signIn(session, refusing);
+        await readDeploymentSession(session, refusing);
+        await readClientPreferences(session, refusing);
+        await writeClientPreferences(session, refusing, unsetClientPreferences);
+        await readOwnDisplayName(session, refusing);
+        await changeOwnDisplayName(session, refusing, ownName);
+        await readOwnPortrait(session, delivered, nothingFailed);
+        await replaceOwnPortrait(session, 'image/png', delivered, nothingFailed);
+        await removeOwnPortrait(session, delivered, nothingFailed);
+        await readMailAccounts(session, refusing);
+        await readMailFolders(session, refusing);
+        await readMailTimeline(session, refusing, { ...window, order: 'newestFirst', direction: 'forward' });
+        await readMailSearch(session, refusing, {
+            ...window,
+            text: searchText,
+            sender: address,
+            recipient: address,
+            receivedOnOrAfter: null,
+            receivedBefore: null,
+        });
+        await readMailThread(session, refusing, threadId, 'a cursor');
+        await readMailMessage(session, refusing, storedEmailId);
+        await readMailBody(session, refusing, storedEmailId, true);
+        await readMailAttachment(session, storedEmailId, 1, 2_048, delivered, nothingFailed);
+        await markMailRead(session, refusing, [storedEmailId, threadId]);
+    }
+
+    it.each([
+        ['a message identifier', storedEmailId],
+        ['a thread identifier', threadId],
+        ['a folder somebody named', folder],
+        ['an address', address],
+        ['the name the signed-in person goes by', ownName],
+        ['a search somebody typed', searchText],
+        ['the credential', credential],
+        ['the deployment it is signed in to', 'mail.example.invalid'],
+    ])('carries no %s into a span or a measurement', async (_, forbidden) => {
+        await driveTheWholeSurface();
+
+        const recorded = JSON.stringify([
+            spans.getFinishedSpans().map((span) => [span.name, span.attributes, span.status.message]),
+            await recordedMeasurements(),
+        ]);
+
+        expect(recorded).not.toContain(forbidden);
+    });
+
+    // The stronger half of the same claim, and the half that survives a value nobody thought to forbid: every request
+    // this package names itself is a method and a route template, whose segments are literals or `{placeholder}` holes
+    // and nothing else. A composed path would put one value per message into a span name and into a metric dimension,
+    // which is a cardinality defect as well as a disclosure.
+    //
+    // A literal segment is lower-case words joined by hyphens and carries no digit, which is what makes the pattern an
+    // assertion rather than a shape: an identifier, an address, a folder name, and a percent-encoded search term each
+    // fail it on a character a route this package publishes never has.
+    const literalSegment = String.raw`[a-z][a-zA-Z]*(-[a-z][a-zA-Z]*)*`;
+    const routeTemplate = new RegExp(String.raw`^(GET|POST|PUT|DELETE) (\/(${literalSegment}|\{[a-zA-Z]+\}))+$`);
+
+    it('names every request it makes by a route template rather than by a path it composed', async () => {
+        await driveTheWholeSurface();
+
+        const named = spans.getFinishedSpans().map((span) => span.name);
+
+        expect(named.length).toBeGreaterThan(0);
+        expect(named.filter((name) => !routeTemplate.test(name))).toEqual([]);
+    });
+
+    it('names a span after exactly what it put in the dimension beside it', async () => {
+        await driveTheWholeSurface();
+
+        const disagreeing = spans
+            .getFinishedSpans()
+            .filter((span) => span.attributes['mailfathom.client.request'] !== span.name);
+
+        expect(disagreeing).toEqual([]);
     });
 });

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -30,6 +30,7 @@ const sessionAnswer = {
     service: 'MailFathom',
     version: declaredVersion,
     permissions: ['mailfathom.mail.read', 'mailfathom.mail.ask'],
+    telemetry: true,
 };
 
 const mailAccounts = {


### PR DESCRIPTION
Closes #1232

The client's telemetry switch now decides whether anything is **recorded**, not whether records are
exported — and the client says where the records go, or says that this deployment forwards none.

## What changed

**The switch stops the recording.** `ClientTelemetry.exportFor` takes the permission beside the
session, so one effect in the frame owns both: a change to either tears the running pipeline down
before the next is asked for, which a separate stop and start racing each other would not. `false`
refuses every write at the queue, so nothing reaches a provider and there is nothing for a later
export to carry.

**Refusing also empties the buffer #1230 introduced.** A client that has never been told stands on
the deployment's unset answer and records into that buffer from the composition root, so an answer
of off has to reach those records as well as the wire. `ClientPipeline.discard` releases the
destination first, drains the two processors into a buffer that addresses nothing, and then empties
it — the opposite order from `hold`, which flushes on purpose so a session's last record is not the
one that never leaves.

The two halves are unanswered differently, and that is deliberate. What the person agreed to is
answered from this device until the deployment answers, so a client that had been turned off records
nothing in the seconds a read takes. What the deployment forwards is *unknown* rather than refused
until it says — a deployment nobody has reached yet is every cold start and every failed sign-in,
which is exactly what the pipeline holds records for, so refusing there would throw away the
failures somebody cannot otherwise describe.

**The deployment now says whether it forwards anything.** `GET /api/client/session` answers a
fourth field, `telemetry`, resolved where the OTLP routes are mapped from the same
`ClientTelemetryDestination` registration that decides whether they are served at all — so the two
cannot disagree, and a client no longer has to export a batch and read the `404` to find out. An
absent or non-boolean value reads as `false`, which fails towards sending nothing.

**The settings screen states what is being decided.** Where the deployment forwards telemetry, a
line under the switch names the address and what a record carries; where it forwards none, one
sentence stands in place of a switch that would decide nothing. Both in Polish and English.

**The device remembers the last answer**, so a restart honours it before the first preferences read
comes back. It is a cache and not a second opinion: only the deployment's answer and the switch
itself write it, and it is read only while there is no answer for this session at all.

**A move to an address the client does not publish as a space is reported as `other`**, so a route
carrying a message identifier cannot become a span name or a dimension value however the client's
addresses grow.

## The whole-surface test

The acceptance asks for one test over the client's whole surface, and this is it. It drives every
operation the wire package has with mail in each argument that takes one — a message identifier, a
thread identifier, a folder somebody named, an address, the name a person goes by, a search somebody
typed, the credential, and the deployment address — and asserts that none of them reaches a span
name, an attribute, a measurement, or a log record. Then it asserts the stronger form beside it:
every request the client names itself is a method and a route template whose segments are literals
or `{placeholder}` holes, which holds for a value nobody thought to forbid. The two write operations
are driven although one of them records nothing today, because an operation is covered by that shape
assertion only if something calls it.

## Breaking change

**`ClientSessionResponse` gains a required `telemetry` member**, which breaks the published HTTP API
contract. `backend/tests/PublicSurfaces.UnitTests/http-api-contract.json` is regenerated with the
field in `properties` and in `required`.

No operator action is needed on the deployment side: the field is answered by the running release
from configuration it already has, and nothing an operator sets moves it. What it costs is any
client written against the three-field document — every one of them must accept a fourth member,
and a client that validated the document strictly refuses the new answer until it does. MailFathom's
own client reads an omitted or non-boolean value as `false`, so an older deployment still signs
somebody in and simply sends nothing.

## Handed back to the owner

The design project draws neither of the two states the settings screen gained — the destination line
and the "this deployment forwards none" state — so #1543 carries the exact correction: the file, the
lines, the members, the enclosing blocks, and the copy word for word. The design project is the
owner's to write, so that is an issue rather than part of this change.

One acceptance item is met by what already exists rather than by new code: *a client never given an
answer records into #1230's buffer*. #1230 landed while this was in progress, so the buffer is real
and `discard` is what this change adds to it.

## Verification

- `scripts/verify-full.sh` — passed. Backend aggregate line coverage 95.29% (40708/42721) against
  the 85% floor.
- Client suite: 100 files, 1700 tests.
- The two privacy states were screenshotted from the running client at 1440×900 in dark mode and
  Polish, and held region by region against the design prototype's own screenshot at the same
  viewport. Everything the design draws matches — section label, card geometry, title and subtitle
  weight, switch position and off state. The two differences are the additions above, which is what
  #1543 records.
