### PR TITLE
[#1529] Report every request the client composes, including the ones it does not send

### DIFF
--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -1,6 +1,6 @@
 # Telemetry and the Aspire dashboard
 
-<!-- describes: backend/src/Application/Observability/**, backend/src/Common/Observability/**, backend/src/Host/Observability/**, backend/src/Host/ServiceDefaultsExtensions.cs, backend/src/Host/Api/ClientTelemetryEndpoint.cs, backend/src/Host/Hosting/Workers/**, backend/src/Infrastructure/Observability/**, backend/src/Infrastructure/Mail/MailServerConnectionBudget.cs, backend/src/Infrastructure/Mail/MailKit/MailKitImapClientFactory.cs, backend/src/Infrastructure/HostApplicationBuilderExtensions.cs, backend/src/Mcp/Observability/**, backend/src/Cli/Diagnostics/**, backend/src/AppHost/**, backend/src/AI/ProviderAdapters/OpenAiCompatibleClientFactory.cs, frontend/src/Client.App/src/telemetry/**, frontend/src/Client.Backend/src/telemetry.ts -->
+<!-- describes: backend/src/Application/Observability/**, backend/src/Common/Observability/**, backend/src/Host/Observability/**, backend/src/Host/ServiceDefaultsExtensions.cs, backend/src/Host/Api/ClientTelemetryEndpoint.cs, backend/src/Host/Hosting/Workers/**, backend/src/Infrastructure/Observability/**, backend/src/Infrastructure/Mail/MailServerConnectionBudget.cs, backend/src/Infrastructure/Mail/MailKit/MailKitImapClientFactory.cs, backend/src/Infrastructure/HostApplicationBuilderExtensions.cs, backend/src/Mcp/Observability/**, backend/src/Cli/Diagnostics/**, backend/src/AppHost/**, backend/src/AI/ProviderAdapters/OpenAiCompatibleClientFactory.cs, frontend/src/Client.App/src/telemetry/**, frontend/src/Client.Backend/src/telemetry.ts, frontend/src/Client.Backend/src/mailAttachment.ts, frontend/src/Client.Backend/src/ownDisplayName.ts, frontend/src/Client.Backend/src/ownPortrait.ts -->
 
 The host instruments itself with OpenTelemetry throughout — logs, metrics, and traces — and exports none of it unless
 the environment names a destination. Today exactly one environment does that out of the box: a local run under the
@@ -1243,6 +1243,19 @@ are the client's own contract rather than words invented here — `read` and `fa
 `mailfathom.client.failure`, carrying which of `unauthenticated`, `unauthorized`, `unavailable`, or `unreadable` the
 client mapped the answer to. A failed request's span status is an error carrying no message: what failed is already the
 dimension beside it.
+
+**Every request the client makes is one of them, including the four it does not put on the wire itself.** A file a
+message carries, and the picture the signed-in person is drawn by, arrive as octets rather than as a document, so those
+four requests are composed by the half of the client that owns the wire and sent by the half that may name a browser
+API. Where the span begins and ends is the composing half's decision either way: it opens around the composition and
+the send together and closes on what the sending half made of the answer, so the record is the same shape as every
+other request's and the request carries the trace context exactly as one this client sent itself.
+
+**The outcome says whether an answer arrived, not whether the answer was yes.** A route that deliberately refuses — a
+name this deployment will not record, a person it holds no portrait for — has answered something a screen acts on, so
+it is `read`; so is a download the person waiting on it stopped, that being their own act rather than the deployment
+failing to answer. What `failed` names is the four an operator can act on, and a file larger than the message described
+is `unreadable` among them, the body having been refused rather than absent.
 
 **Moving between screens is the client's alone to report.** Every screen after the first is rendered rather than
 fetched, so the wait a person actually has is invisible from the deployment.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -192,9 +192,16 @@ the deployment's to hold instead.
 The client carries one OpenTelemetry pipeline for all three signals, composed once in `src/Client.App/src/main.tsx`
 beside the deployment and the credential, and handed down as a value: `src/Client.App/src/telemetry/clientTelemetry.ts`
 publishes it, and a screen that reports something takes it out of context rather than registering anything of its own.
-`src/Client.Backend/src/telemetry.ts` is the other half — every request that package makes goes through it, so one span
-and two measurements per request happen in one place whatever the operation did with the answer. That package pins
+`src/Client.Backend/src/telemetry.ts` is the other half — every request that package composes goes through it, so one
+span and two measurements per request happen in one place whatever the operation did with the answer. That package pins
 `@opentelemetry/api` and nothing else, which names no browser API and so crosses none of the boundary above.
+
+**Composes rather than sends, because four of those requests are put on the wire by this package instead.** A file a
+message carries and the picture the signed-in person is drawn by answer in octets, so the `fetch` for each of them is
+in `src/Client.App/src/deployment/`. `Client.Backend` still owns the record: it publishes an operation for each, and
+not the request builder behind it, which opens the span, composes the request inside it, hands that request to the
+adapter, and closes on the reason the adapter read off the answer. A request composed outside a span would carry no
+trace context and leave no record, so composing one is not something this package lets a caller do.
 
 **That span is also what the request travels under.** It is the active context while the operation composes its
 request, so `headersFor` writes the W3C trace context into the headers and the span the deployment opens is this one's

--- a/frontend/src/Client.App/src/deployment/attachmentDelivery.test.ts
+++ b/frontend/src/Client.App/src/deployment/attachmentDelivery.test.ts
@@ -1,0 +1,27 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import { deliveryFailureOf } from './attachmentDelivery';
+
+// What a download becomes in the record `Client.Backend` keeps of it. It is asserted for every one of the six outcomes
+// rather than for the interesting ones, because this reading is what an operator's own dimension is built from: an
+// outcome mapped to the wrong reason is a dashboard that says a deployment is refusing downloads it delivered.
+
+describe('deliveryFailureOf', () => {
+    it.each(['delivered', 'abandoned'] as const)('reports %s as an answer the client acted on', (outcome) => {
+        expect(deliveryFailureOf(outcome)).toBeNull();
+    });
+
+    it('reports a file larger than the message described as a body this client refused', () => {
+        expect(deliveryFailureOf('largerThanDescribed')).toBe('unreadable');
+    });
+
+    it.each(['unauthenticated', 'unauthorized', 'unavailable'] as const)(
+        'reports %s as the failure that word already names on this surface',
+        (outcome) => {
+            expect(deliveryFailureOf(outcome)).toBe(outcome);
+        },
+    );
+});

--- a/frontend/src/Client.App/src/deployment/attachmentDelivery.ts
+++ b/frontend/src/Client.App/src/deployment/attachmentDelivery.ts
@@ -3,7 +3,12 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { createContext, useContext } from 'react';
-import { attachmentRefusalForStatus, longestResponseBody, type ClientRequest } from '@mailfathom/client-backend';
+import {
+    attachmentRefusalForStatus,
+    longestResponseBody,
+    type ClientFailureReason,
+    type ClientRequest,
+} from '@mailfathom/client-backend';
 import { readBoundedContent } from './boundedBody';
 
 // Fetching one file a message carries and handing it to the person, which is one operation rather than two: nothing
@@ -17,6 +22,28 @@ import { readBoundedContent } from './boundedBody';
 /** What happened to a download, where an expected failure is a value rather than an exception. */
 export type AttachmentDeliveryOutcome =
     'delivered' | 'abandoned' | 'unauthenticated' | 'unauthorized' | 'unavailable' | 'largerThanDescribed';
+
+/**
+ * Which failure a download amounts to, for the record `Client.Backend` keeps of the request it composed.
+ *
+ * Two of the six are not failures of the request. A delivered file plainly is not, and neither is a download somebody
+ * stopped: it ended because the person asked it to, and recording that as `unavailable` would put their change of mind
+ * in the dimension an operator reads for a deployment that is not answering. An answer larger than the message
+ * described is `unreadable` — the body was refused rather than absent, which is the reason that word already carries.
+ */
+export function deliveryFailureOf(outcome: AttachmentDeliveryOutcome): ClientFailureReason | null {
+    switch (outcome) {
+        case 'delivered':
+        case 'abandoned':
+            return null;
+        case 'largerThanDescribed':
+            return 'unreadable';
+        case 'unauthenticated':
+        case 'unauthorized':
+        case 'unavailable':
+            return outcome;
+    }
+}
 
 /**
  * Downloads one file and hands it to the person as a file to keep.

--- a/frontend/src/Client.App/src/deployment/portraitExchange.ts
+++ b/frontend/src/Client.App/src/deployment/portraitExchange.ts
@@ -5,9 +5,9 @@
 import {
     failureReasonForStatus,
     largestPortraitOctets,
-    readOwnPortraitRequest,
-    removeOwnPortraitRequest,
-    replaceOwnPortraitRequest,
+    readOwnPortrait,
+    removeOwnPortrait,
+    replaceOwnPortrait,
     type ClientFailureReason,
     type ClientRequest,
     type ClientSession,
@@ -17,8 +17,9 @@ import { readBoundedContent } from './boundedBody';
 
 // The third module in this directory that calls `fetch`, and the third for the same reason: `Client.Backend` declares
 // no DOM, so a `Blob`, a `File`, and a `FileReader` can only be named on this side of the boundary. What that package
-// still owns is the part that is the contract — the routes, the credential, the kinds, and the bound — all of which
-// arrive here as composed requests.
+// still owns is the part that is the contract — the routes, the credential, the kinds, the bound, and the span each
+// request is recorded under — so each of the three below is reached through that package's own operation, which hands
+// the composed request down to the `fetch` here and keeps the record around it.
 //
 // A read answers an address the client may draw rather than the octets themselves, so nothing above holds a picture.
 // That address is a data URL rather than a blob URL deliberately: a blob URL keeps its octets alive until somebody
@@ -58,76 +59,78 @@ export interface PortraitExchange {
 }
 
 export const portraitExchange: PortraitExchange = {
-    read: async (session, abandoned) => {
-        const request = readOwnPortraitRequest(session);
+    read: (session, abandoned) => readOwnPortrait(session, (request) => readPicture(request, abandoned), refusalOf),
 
-        let response: Response;
+    replace: (session, picture, type) =>
+        replaceOwnPortrait(session, type, (request) => stated(request, picture), refusalOf),
 
-        try {
-            response = await fetch(request.path, {
-                method: request.method,
-                headers: { ...request.headers },
-                signal: abandoned,
-            });
-        } catch {
-            return { outcome: 'refused', reason: 'unavailable' };
-        }
-
-        // Having no picture is an ordinary state of the screen rather than a failure on it: the initials are what the
-        // client draws instead, and it already has the name they come from.
-        if (response.status === 204) {
-            return { outcome: 'none' };
-        }
-
-        if (response.status !== 200) {
-            return { outcome: 'refused', reason: failureReasonForStatus(response.status) };
-        }
-
-        // An answer larger than a stored portrait could have been is not one this deployment wrote, and the bound is
-        // applied while the octets are read rather than once they are all in memory: what a ceiling at this boundary
-        // is for is that an oversized or endless answer never occupies memory at all, which matters most for an
-        // address a person named and this client has no reason yet to trust.
-        const octets = await readBoundedContent(response, largestPortraitOctets);
-
-        if (typeof octets === 'string') {
-            // An answer over the bound and a connection that stopped partway through both leave the screen with no
-            // picture to draw, which is the one thing it does about either.
-            return { outcome: 'refused', reason: 'unreadable' };
-        }
-
-        try {
-            const kind = response.headers.get('Content-Type') ?? '';
-
-            return { outcome: 'drawn', picture: await asDataUrl(new Blob([...octets], { type: kind })) };
-        } catch {
-            return { outcome: 'refused', reason: 'unreadable' };
-        }
-    },
-
-    replace: async (session, picture, type) => {
-        const request = replaceOwnPortraitRequest(session, type);
-
-        return await stated(request.method, request.path, request.headers, picture);
-    },
-
-    remove: async (session) => {
-        const request = removeOwnPortraitRequest(session);
-
-        return await stated(request.method, request.path, request.headers, null);
-    },
+    remove: (session) => removeOwnPortrait(session, (request) => stated(request, null), refusalOf),
 };
 
-/** Puts one write on the wire and reports whether it landed, an expected failure being a value here as everywhere. */
-async function stated(
-    method: ClientRequest['method'],
-    path: string,
-    headers: Readonly<Record<string, string>>,
-    body: Blob | null,
-): Promise<PortraitWrite> {
+/**
+ * Which failure an answer amounts to, for the record `Client.Backend` keeps of the request it composed.
+ *
+ * Having no picture is not one of them: a `204` is an answer the screen acts on by drawing the initials instead, and
+ * recording it as a failure would put an ordinary state of the screen in the dimension an operator reads for a
+ * deployment that is refusing or not answering. A read the screen gave up on is the one case this cannot separate: an
+ * abandoned `fetch` and an unreachable deployment arrive here as the same rejection and `PortraitRead` carries no
+ * outcome for the first, so both are recorded as `unavailable` — which is what the screen was told either way.
+ */
+function refusalOf(answer: PortraitRead | PortraitWrite): ClientFailureReason | null {
+    return answer.outcome === 'refused' ? answer.reason : null;
+}
+
+/** Fetches the picture and answers an address the client may draw it at, or why there is nothing to draw. */
+async function readPicture(request: ClientRequest, abandoned: AbortSignal): Promise<PortraitRead> {
     let response: Response;
 
     try {
-        response = await fetch(path, { method, headers: { ...headers }, body });
+        response = await fetch(request.path, {
+            method: request.method,
+            headers: { ...request.headers },
+            signal: abandoned,
+        });
+    } catch {
+        return { outcome: 'refused', reason: 'unavailable' };
+    }
+
+    // Having no picture is an ordinary state of the screen rather than a failure on it: the initials are what the
+    // client draws instead, and it already has the name they come from.
+    if (response.status === 204) {
+        return { outcome: 'none' };
+    }
+
+    if (response.status !== 200) {
+        return { outcome: 'refused', reason: failureReasonForStatus(response.status) };
+    }
+
+    // An answer larger than a stored portrait could have been is not one this deployment wrote, and the bound is
+    // applied while the octets are read rather than once they are all in memory: what a ceiling at this boundary is
+    // for is that an oversized or endless answer never occupies memory at all, which matters most for an address a
+    // person named and this client has no reason yet to trust.
+    const octets = await readBoundedContent(response, largestPortraitOctets);
+
+    if (typeof octets === 'string') {
+        // An answer over the bound and a connection that stopped partway through both leave the screen with no
+        // picture to draw, which is the one thing it does about either.
+        return { outcome: 'refused', reason: 'unreadable' };
+    }
+
+    try {
+        const kind = response.headers.get('Content-Type') ?? '';
+
+        return { outcome: 'drawn', picture: await asDataUrl(new Blob([...octets], { type: kind })) };
+    } catch {
+        return { outcome: 'refused', reason: 'unreadable' };
+    }
+}
+
+/** Puts one write on the wire and reports whether it landed, an expected failure being a value here as everywhere. */
+async function stated(request: ClientRequest, body: Blob | null): Promise<PortraitWrite> {
+    let response: Response;
+
+    try {
+        response = await fetch(request.path, { method: request.method, headers: { ...request.headers }, body });
     } catch {
         return { outcome: 'refused', reason: 'unavailable' };
     }

--- a/frontend/src/Client.App/src/readingPane/Attachment.tsx
+++ b/frontend/src/Client.App/src/readingPane/Attachment.tsx
@@ -3,10 +3,14 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { useEffect, useRef, useState } from 'react';
-import { mailAttachmentRequest, type ClientSession, type MailAttachment } from '@mailfathom/client-backend';
+import { readMailAttachment, type ClientSession, type MailAttachment } from '@mailfathom/client-backend';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
-import { useAttachmentDelivery, type AttachmentDeliveryOutcome } from '../deployment/attachmentDelivery';
+import {
+    deliveryFailureOf,
+    useAttachmentDelivery,
+    type AttachmentDeliveryOutcome,
+} from '../deployment/attachmentDelivery';
 import { sizeOf } from './octets';
 import { savedAs } from './savedFileName';
 
@@ -74,13 +78,24 @@ export function Attachment({
         running.current = abandoning;
         setDownloading({ stage: 'arriving', octets: 0 });
 
-        void deliver(
-            mailAttachmentRequest(session, storedEmailId, attachment.position, attachment.sizeOctets),
-            savedAs(attachment.fileName, attachment.position),
-            (octets) => {
-                setDownloading({ stage: 'arriving', octets });
-            },
-            abandoning.signal,
+        // The request is composed by `Client.Backend` inside the span it opens around the whole download, which is
+        // what puts this row's wait in the same trace as the deployment's work on it. What this component supplies is
+        // the part that is the screen's: where the file is saved, how much of it has arrived, and the way out.
+        void readMailAttachment(
+            session,
+            storedEmailId,
+            attachment.position,
+            attachment.sizeOctets,
+            (request) =>
+                deliver(
+                    request,
+                    savedAs(attachment.fileName, attachment.position),
+                    (octets) => {
+                        setDownloading({ stage: 'arriving', octets });
+                    },
+                    abandoning.signal,
+                ),
+            deliveryFailureOf,
         ).then((outcome) => {
             running.current = null;
             setDownloading({ stage: 'finished', outcome });

--- a/frontend/src/Client.App/src/telemetry/exporting.test.ts
+++ b/frontend/src/Client.App/src/telemetry/exporting.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { logs } from '@opentelemetry/api-logs';
 import { metrics, trace } from '@opentelemetry/api';
 import { ExportResultCode } from '@opentelemetry/core';
-import { signIn, type ClientRequest, type ClientResponse } from '@mailfathom/client-backend';
+import { readOwnPortrait, signIn, type ClientRequest, type ClientResponse } from '@mailfathom/client-backend';
 import { startRecording, type ClientPipeline } from './exporting';
 
 // What this module does is register the three providers for the whole of a run and decide, from whether a session
@@ -139,6 +139,22 @@ describe('startRecording', () => {
         // The whole W3C form is asserted rather than the header merely being present: the version, a trace identifier,
         // the span identifier the deployment parents its own span on, and the sampled flag — which is what tells the
         // deployment this trace is being recorded and is the half a caller can turn off.
+        expect(asked.headers['traceparent']).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-01$/);
+    });
+
+    it('joins a request this application sends itself to that span too, though nothing here awaits it', async () => {
+        running = startRecording();
+
+        // A portrait, an attachment, and a portrait write are composed by `Client.Backend` and put on the wire by an
+        // adapter in this package, because each answers in octets. The composition still happens inside the span that
+        // package opens — which is the whole of why it is reached through an operation rather than a request builder —
+        // and this is where that is observable, the context manager being registered by the call above.
+        const asked = await readOwnPortrait(
+            session,
+            (request) => Promise.resolve(request),
+            () => null,
+        );
+
         expect(asked.headers['traceparent']).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-01$/);
     });
 

--- a/frontend/src/Client.Backend/src/index.ts
+++ b/frontend/src/Client.Backend/src/index.ts
@@ -64,10 +64,13 @@ export {
     type MailFolderDirectory,
     type MailFolderRole,
 } from './mailFolders';
+// `mailAttachmentRequest` is deliberately unpublished: a caller composing it would compose it outside the span this
+// package opens, so the request would carry no trace context and no record would be kept of it. `readMailAttachment`
+// is how a download is reached, and the same holds for the portrait requests further down.
 export {
     attachmentRefusalForStatus,
-    mailAttachmentRequest,
     mailAttachmentRoute,
+    readMailAttachment,
     type MailAttachmentRefusal,
 } from './mailAttachment';
 export {
@@ -133,14 +136,15 @@ export {
     type OwnDisplayName,
     type OwnDisplayNameChange,
 } from './ownDisplayName';
+// `readOwnPortraitRequest` and the two beside it are deliberately unpublished, for the reason the download above gives.
 export {
     isPortraitImageType,
     largestPortraitOctets,
     ownPortraitRoute,
     portraitImageTypes,
-    readOwnPortraitRequest,
-    removeOwnPortraitRequest,
-    replaceOwnPortraitRequest,
+    readOwnPortrait,
+    removeOwnPortrait,
+    replaceOwnPortrait,
     type PortraitImageType,
 } from './ownPortrait';
 export { clientRoutePrefix, headersFor, routeFor, type ClientSession, type DeploymentAddress } from './session';

--- a/frontend/src/Client.Backend/src/mailAttachment.test.ts
+++ b/frontend/src/Client.Backend/src/mailAttachment.test.ts
@@ -3,8 +3,14 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { describe, expect, it } from 'vitest';
-import { attachmentRefusalForStatus, mailAttachmentRequest, mailAttachmentRoute } from './mailAttachment';
+import {
+    attachmentRefusalForStatus,
+    mailAttachmentRequest,
+    mailAttachmentRoute,
+    readMailAttachment,
+} from './mailAttachment';
 import type { ClientSession } from './session';
+import type { ClientRequest } from './transport';
 
 const session: ClientSession = {
     baseAddress: 'https://mail.example.invalid',
@@ -35,6 +41,43 @@ describe('mailAttachmentRequest', () => {
 
     it('reads the answer under the size the message said the file holds, so a larger one is refusable', () => {
         expect(mailAttachmentRequest(session, messageId, 0, 17).longestAnswer).toBe(17);
+    });
+});
+
+// What the download records is asserted in `telemetry.test.ts`, which is where a span can be read back from; what is
+// asserted here is that the adapter is handed the request this module composes and that its answer travels back
+// untouched, this package having no vocabulary for a download somebody stopped.
+describe('readMailAttachment', () => {
+    it('hands the composed download to the adapter that puts it on the wire', async () => {
+        const asked: ClientRequest[] = [];
+
+        await readMailAttachment(
+            session,
+            messageId,
+            1,
+            2_048,
+            (request) => {
+                asked.push(request);
+
+                return Promise.resolve('delivered');
+            },
+            () => null,
+        );
+
+        expect(asked).toEqual([mailAttachmentRequest(session, messageId, 1, 2_048)]);
+    });
+
+    it('answers exactly what the adapter answered', async () => {
+        const answer = await readMailAttachment(
+            session,
+            messageId,
+            0,
+            17,
+            () => Promise.resolve('abandoned'),
+            () => null,
+        );
+
+        expect(answer).toBe('abandoned');
     });
 });
 

--- a/frontend/src/Client.Backend/src/mailAttachment.ts
+++ b/frontend/src/Client.Backend/src/mailAttachment.ts
@@ -2,15 +2,19 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+import type { ClientFailureReason } from './failure';
 import { headersFor, routeFor, type ClientSession } from './session';
+import { reported } from './telemetry';
 import type { ClientRequest } from './transport';
 
 // The one operation on this surface that is not read through a transport, because what it answers with is octets and a
-// `MailFathomTransport` answers with text. So this module composes the request and stops there: putting it on the wire
-// with a progress report and a way to abandon it is the application's adapter, exactly as calling `fetch` at all is.
+// `MailFathomTransport` answers with text. So this module composes the request and hands it to an adapter to send:
+// putting it on the wire with a progress report and a way to abandon it is the application's, exactly as calling
+// `fetch` at all is.
 //
-// What stays here is everything the boundary owns — the route, the credential, the header the answer is asked in, and
-// the bound the answer is read under — so no screen and no adapter above learns a path or a header name.
+// What stays here is everything the boundary owns — the route, the credential, the header the answer is asked in, the
+// bound the answer is read under, and the record kept of the request — so no screen and no adapter above learns a path
+// or a header name, and none of them decides what a download is called in a trace.
 
 /** The route one file a message carries is served at, relative to the client prefix. */
 export function mailAttachmentRoute(storedEmailId: string, position: number): string {
@@ -43,6 +47,35 @@ export function mailAttachmentRequest(
         headers: { ...headersFor(session), Accept: 'application/octet-stream' },
         longestAnswer: describedSizeOctets,
     };
+}
+
+/**
+ * Downloads one file a message carries, through an adapter, and reports the request the way every other one is.
+ *
+ * The composition and the send are one operation here rather than two because the record is: a span named outside this
+ * package would be named by whichever caller sent first, and a request composed outside the span would carry no trace
+ * context at all — the header is written from whatever span is active when `mailAttachmentRequest` runs, which is why
+ * that call sits inside this one.
+ *
+ * @param deliver Puts the composed request on the wire and answers whatever the application makes of it, which is
+ * where a progress report and a way to abandon the download belong.
+ * @param failureOf Which failure that answer amounts to, or `null` where the client got an answer it acts on. The
+ * adapter reads it, this package having no vocabulary for a download somebody stopped.
+ */
+export function readMailAttachment<TOutcome>(
+    session: ClientSession,
+    storedEmailId: string,
+    position: number,
+    describedSizeOctets: number,
+    deliver: (request: ClientRequest) => Promise<TOutcome>,
+    failureOf: (outcome: TOutcome) => ClientFailureReason | null,
+): Promise<TOutcome> {
+    return reported(
+        // A template rather than the composed route: an identifier and a position in a span name are one name per file.
+        'GET /messages/{storedEmailId}/attachments/{position}',
+        () => deliver(mailAttachmentRequest(session, storedEmailId, position, describedSizeOctets)),
+        failureOf,
+    );
 }
 
 /**

--- a/frontend/src/Client.Backend/src/ownDisplayName.test.ts
+++ b/frontend/src/Client.Backend/src/ownDisplayName.test.ts
@@ -93,6 +93,9 @@ describe('readOwnDisplayName', () => {
     });
 });
 
+// What the correction records is asserted in `telemetry.test.ts`, which is where a span can be read back from — a
+// refused name among them, that being an answer the person acts on rather than a failure. What is asserted here is
+// what the operation answers, which the record does not change.
 describe('changeOwnDisplayName', () => {
     it('states the name as a document on the name route', async () => {
         const { transport, requests } = recording({ status: 200, body: recordedBody });

--- a/frontend/src/Client.Backend/src/ownDisplayName.ts
+++ b/frontend/src/Client.Backend/src/ownDisplayName.ts
@@ -5,7 +5,7 @@
 import { failed, failureReasonForStatus, read, type ClientFailure, type ClientResult } from './failure';
 import { asRecord } from './json';
 import { headersFor, routeFor, type ClientSession } from './session';
-import { spanned } from './telemetry';
+import { reported, spanned } from './telemetry';
 import { send, type ClientResponse, type MailFathomTransport } from './transport';
 
 // What the signed-in person is called, which is the one thing a client drawing them cannot compose from the credential
@@ -84,20 +84,31 @@ export type OwnDisplayNameChange =
  * The answer carries the name as it was stored rather than as it was sent, because a name is trimmed on its way in and
  * a screen that redrew what was typed would show something the deployment does not hold.
  */
-export async function changeOwnDisplayName(
+export function changeOwnDisplayName(
     session: ClientSession,
     transport: MailFathomTransport,
     displayName: string,
 ): Promise<OwnDisplayNameChange> {
-    const response = await send(transport, {
-        method: 'POST',
-        path: routeFor(session, ownDisplayNameRoute),
-        headers: { ...headersFor(session), 'Content-Type': 'application/json' },
-        body: JSON.stringify({ displayName }),
-        longestAnswer: longestDisplayNameAnswer,
-    });
+    return reported(
+        `POST ${ownDisplayNameRoute}`,
+        async () => {
+            const response = await send(transport, {
+                method: 'POST',
+                path: routeFor(session, ownDisplayNameRoute),
+                headers: { ...headersFor(session), 'Content-Type': 'application/json' },
+                body: JSON.stringify({ displayName }),
+                longestAnswer: longestDisplayNameAnswer,
+            });
 
-    return changeOf(response);
+            return changeOf(response);
+        },
+
+        // `reported` rather than `spanned` because this answers an outcome of its own, and a refused name is recorded
+        // as a read: the deployment answered, and what a person does about it is to type another name. Recording it as
+        // a failure would put a typing mistake in the dimension an operator reads for a deployment that is not
+        // answering, and none of the four reasons is true of it either.
+        (change) => (change.outcome === 'failed' ? change.failure.reason : null),
+    );
 }
 
 function changeOf(response: ClientResponse | null): OwnDisplayNameChange {

--- a/frontend/src/Client.Backend/src/ownPortrait.test.ts
+++ b/frontend/src/Client.Backend/src/ownPortrait.test.ts
@@ -6,11 +6,15 @@ import { describe, expect, it } from 'vitest';
 import {
     isPortraitImageType,
     largestPortraitOctets,
+    readOwnPortrait,
     readOwnPortraitRequest,
+    removeOwnPortrait,
     removeOwnPortraitRequest,
+    replaceOwnPortrait,
     replaceOwnPortraitRequest,
 } from './ownPortrait';
 import type { ClientSession } from './session';
+import type { ClientRequest } from './transport';
 
 const session: ClientSession = {
     baseAddress: 'https://mail.example.invalid',
@@ -56,6 +60,75 @@ describe('removeOwnPortraitRequest', () => {
         expect(request.method).toBe('DELETE');
         expect(request.path).toBe('https://mail.example.invalid/api/client/portrait');
         expect(request.headers['Authorization']).toBe('Basic dGVzdA==');
+    });
+});
+
+// The three operations the application reaches. What each of them records is asserted in `telemetry.test.ts`, which
+// is where a span can be read back from; what is asserted here is that the adapter is handed the request this module
+// composes and that its answer travels back untouched.
+describe('readOwnPortrait', () => {
+    it('hands the composed read to the adapter that puts it on the wire', async () => {
+        const asked: ClientRequest[] = [];
+
+        await readOwnPortrait(
+            session,
+            (request) => {
+                asked.push(request);
+
+                return Promise.resolve('drawn');
+            },
+            () => null,
+        );
+
+        expect(asked).toEqual([readOwnPortraitRequest(session)]);
+    });
+
+    it('answers exactly what the adapter answered, this package having no vocabulary for a picture', async () => {
+        const answer = await readOwnPortrait(
+            session,
+            () => Promise.resolve({ outcome: 'none' }),
+            () => null,
+        );
+
+        expect(answer).toEqual({ outcome: 'none' });
+    });
+});
+
+describe('replaceOwnPortrait', () => {
+    it('hands the composed replacement to the adapter, under the kind it was given', async () => {
+        const asked: ClientRequest[] = [];
+
+        await replaceOwnPortrait(
+            session,
+            'image/jpeg',
+            (request) => {
+                asked.push(request);
+
+                return Promise.resolve('stored');
+            },
+            () => null,
+        );
+
+        expect(asked).toEqual([replaceOwnPortraitRequest(session, 'image/jpeg')]);
+    });
+});
+
+describe('removeOwnPortrait', () => {
+    it('hands the composed removal to the adapter and answers what it answered', async () => {
+        const asked: ClientRequest[] = [];
+
+        const answer = await removeOwnPortrait(
+            session,
+            (request) => {
+                asked.push(request);
+
+                return Promise.resolve({ outcome: 'stored' });
+            },
+            () => null,
+        );
+
+        expect(asked).toEqual([removeOwnPortraitRequest(session)]);
+        expect(answer).toEqual({ outcome: 'stored' });
     });
 });
 

--- a/frontend/src/Client.Backend/src/ownPortrait.ts
+++ b/frontend/src/Client.Backend/src/ownPortrait.ts
@@ -2,17 +2,19 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+import type { ClientFailureReason } from './failure';
 import { headersFor, routeFor, type ClientSession } from './session';
+import { reported } from './telemetry';
 import type { ClientRequest } from './transport';
 
 // The picture the signed-in person is drawn by. Like a message's attachment, and for the same reason, this module
-// composes the requests and stops there: what a read answers with is octets and what a replacement carries is a file,
-// and a `MailFathomTransport` speaks in text — so putting these on the wire is the application's adapter, exactly as
-// calling `fetch` at all is.
+// composes the requests and hands them to an adapter to send: what a read answers with is octets and what a
+// replacement carries is a file, and a `MailFathomTransport` speaks in text — so putting these on the wire is the
+// application's, exactly as calling `fetch` at all is.
 //
 // What stays here is everything the boundary owns: the route, the credential, the kinds this surface accepts, the
-// bound an upload is refused past, and the header the answer is asked in. No screen and no adapter above learns a path
-// or a header name.
+// bound an upload is refused past, the header the answer is asked in, and the record kept of each request. No screen
+// and no adapter above learns a path or a header name, and none of them decides what these are called in a trace.
 
 /** The route the acting person's portrait is read, replaced, and removed at, relative to the client prefix. */
 export const ownPortraitRoute = '/portrait';
@@ -75,4 +77,42 @@ export function removeOwnPortraitRequest(session: ClientSession): ClientRequest 
         path: routeFor(session, ownPortraitRoute),
         headers: headersFor(session),
     };
+}
+
+/**
+ * Reads the picture through an adapter, and reports the request the way every other one on this surface is.
+ *
+ * The three operations below each compose inside their own span for the reason `readMailAttachment` gives: the trace
+ * context is written from whatever span is active while the request is composed, and what a request is named in a
+ * trace is this package's decision rather than the caller's.
+ *
+ * @param deliver Puts the composed request on the wire and answers whatever the application makes of it.
+ * @param failureOf Which failure that answer amounts to, or `null` where the client got an answer it acts on — a
+ * person with no portrait stored among them, that being a state the screen draws rather than one it reports.
+ */
+export function readOwnPortrait<TOutcome>(
+    session: ClientSession,
+    deliver: (request: ClientRequest) => Promise<TOutcome>,
+    failureOf: (outcome: TOutcome) => ClientFailureReason | null,
+): Promise<TOutcome> {
+    return reported(`GET ${ownPortraitRoute}`, () => deliver(readOwnPortraitRequest(session)), failureOf);
+}
+
+/** Replaces the picture through an adapter, which is what carries the octets, and reports the request. */
+export function replaceOwnPortrait<TOutcome>(
+    session: ClientSession,
+    type: PortraitImageType,
+    deliver: (request: ClientRequest) => Promise<TOutcome>,
+    failureOf: (outcome: TOutcome) => ClientFailureReason | null,
+): Promise<TOutcome> {
+    return reported(`POST ${ownPortraitRoute}`, () => deliver(replaceOwnPortraitRequest(session, type)), failureOf);
+}
+
+/** Removes the picture through an adapter, and reports the request. */
+export function removeOwnPortrait<TOutcome>(
+    session: ClientSession,
+    deliver: (request: ClientRequest) => Promise<TOutcome>,
+    failureOf: (outcome: TOutcome) => ClientFailureReason | null,
+): Promise<TOutcome> {
+    return reported(`DELETE ${ownPortraitRoute}`, () => deliver(removeOwnPortraitRequest(session)), failureOf);
 }

--- a/frontend/src/Client.Backend/src/telemetry.test.ts
+++ b/frontend/src/Client.Backend/src/telemetry.test.ts
@@ -17,8 +17,13 @@ import {
     SimpleSpanProcessor,
     type ReadableSpan,
 } from '@opentelemetry/sdk-trace-base';
-import { failed, read } from './failure';
-import { spanned, telemetryEndpoints, telemetryName } from './telemetry';
+import { failed, read, type ClientFailureReason } from './failure';
+import { readMailAttachment } from './mailAttachment';
+import { changeOwnDisplayName } from './ownDisplayName';
+import { readOwnPortrait, removeOwnPortrait, replaceOwnPortrait } from './ownPortrait';
+import type { ClientSession } from './session';
+import { reported, spanned, telemetryEndpoints, telemetryName } from './telemetry';
+import type { ClientRequest } from './transport';
 
 // The SDK is here and nowhere in this package's source: what a test needs is somewhere to read a span and a
 // measurement back from, and the registries the source publishes to are global. Every one of them is released in the
@@ -176,5 +181,153 @@ describe('spanned', () => {
             'mailfathom.client.request': 'GET /folders',
             'mailfathom.client.outcome': 'read',
         });
+    });
+});
+
+describe('reported', () => {
+    const nothingFailed = (): ClientFailureReason | null => null;
+
+    it('answers exactly what the operation answered, whatever shape that answer is', async () => {
+        const answer = await reported(
+            'POST /display-name',
+            () => Promise.resolve({ outcome: 'stored' }),
+            nothingFailed,
+        );
+
+        expect(answer).toEqual({ outcome: 'stored' });
+    });
+
+    it('records the failure the operation read off an answer of its own shape', async () => {
+        await reported(
+            'POST /display-name',
+            () => Promise.resolve('refused'),
+            () => 'unauthorized',
+        );
+
+        const span = onlySpan();
+
+        expect(span.attributes).toEqual({
+            'mailfathom.client.request': 'POST /display-name',
+            'mailfathom.client.outcome': 'failed',
+            'mailfathom.client.failure': 'unauthorized',
+        });
+        expect(span.status.code).toBe(SpanStatusCode.ERROR);
+    });
+
+    it('records an answer the client acts on as a read, whatever the route answered it with', async () => {
+        await reported('POST /display-name', () => Promise.resolve('notAcceptable'), nothingFailed);
+
+        const span = onlySpan();
+
+        expect(span.attributes).toEqual({
+            'mailfathom.client.request': 'POST /display-name',
+            'mailfathom.client.outcome': 'read',
+        });
+        expect(span.status.code).not.toBe(SpanStatusCode.ERROR);
+    });
+
+    it('counts and times it under the same dimensions, an answer of its own shape being no exception', async () => {
+        await reported('DELETE /portrait', () => Promise.resolve('gone'), nothingFailed);
+
+        const recorded = await recordedMeasurements();
+        const counted = recorded.find((metric) => metric.descriptor.name === 'mailfathom.client.requests');
+        const timed = recorded.find((metric) => metric.descriptor.name === 'mailfathom.client.request.duration');
+
+        expect(counted?.dataPoints[0]?.attributes).toEqual({
+            'mailfathom.client.request': 'DELETE /portrait',
+            'mailfathom.client.outcome': 'read',
+        });
+        expect(timed?.dataPoints).toHaveLength(1);
+    });
+
+    it('ends the span even where the operation threw rather than answering', async () => {
+        const thrown = reported('DELETE /portrait', () => Promise.reject(new Error('a defect')), nothingFailed);
+
+        await expect(thrown).rejects.toThrow('a defect');
+        expect(onlySpan().name).toBe('DELETE /portrait');
+    });
+
+    // What the span carries onto the wire is not observable from here: the context manager that holds an active
+    // context is registered by the application, so `context.active()` in this project answers the root whatever
+    // `reported` set. `exporting.test.ts` in `Client.App` is where a request composed inside one of these operations
+    // is shown carrying the `traceparent` written from it, for a request that package puts on the wire itself.
+});
+
+// The claim this package makes about itself, and what #1231 made it cost: a request nobody opened a span around sends
+// no trace context either, so the deployment opens a root trace for work a screen is waiting on. Each operation is
+// reached from here rather than from its own file because what is asserted is the record, and the record is read out
+// of the one harness above.
+describe('every request this package composes', () => {
+    const session: ClientSession = { baseAddress: 'https://mail.example.invalid', authorization: 'Basic dGVzdA==' };
+    const messageId = '00000000-0000-4000-8000-000000000000';
+    const nothingFailed = (): ClientFailureReason | null => null;
+    const delivered = (request: ClientRequest): Promise<ClientRequest> => Promise.resolve(request);
+
+    it('reports a name somebody corrected, though it answers an outcome of its own', async () => {
+        await changeOwnDisplayName(
+            session,
+            () =>
+                Promise.resolve({
+                    status: 200,
+                    body: JSON.stringify({ displayName: 'Ada Lovelace', changeable: true }),
+                    headers: {},
+                }),
+            'Ada Lovelace',
+        );
+
+        expect(onlySpan().name).toBe('POST /display-name');
+        expect(onlySpan().attributes['mailfathom.client.outcome']).toBe('read');
+    });
+
+    it('reports a name this deployment would not record as an answer rather than as a failure', async () => {
+        await changeOwnDisplayName(session, () => Promise.resolve({ status: 400, body: '', headers: {} }), '');
+
+        expect(onlySpan().attributes).toEqual({
+            'mailfathom.client.request': 'POST /display-name',
+            'mailfathom.client.outcome': 'read',
+        });
+    });
+
+    it('reports a name a refused credential lost, under the reason the operation mapped it to', async () => {
+        await changeOwnDisplayName(session, () => Promise.resolve({ status: 401, body: '', headers: {} }), 'Ada');
+
+        expect(onlySpan().attributes).toEqual({
+            'mailfathom.client.request': 'POST /display-name',
+            'mailfathom.client.outcome': 'failed',
+            'mailfathom.client.failure': 'unauthenticated',
+        });
+    });
+
+    it('reports a download the application put on the wire, named by a template rather than by the file', async () => {
+        await readMailAttachment(session, messageId, 1, 2_048, delivered, nothingFailed);
+
+        const span = onlySpan();
+
+        expect(span.name).toBe('GET /messages/{storedEmailId}/attachments/{position}');
+        expect(JSON.stringify(span.attributes)).not.toContain(messageId);
+    });
+
+    it('reports what the application made of that download, where it made a failure of it', async () => {
+        await readMailAttachment(session, messageId, 1, 2_048, delivered, () => 'unavailable');
+
+        expect(onlySpan().attributes['mailfathom.client.failure']).toBe('unavailable');
+    });
+
+    it('reports the portrait read the application put on the wire', async () => {
+        await readOwnPortrait(session, delivered, nothingFailed);
+
+        expect(onlySpan().name).toBe('GET /portrait');
+    });
+
+    it('reports the portrait replacement the application put on the wire', async () => {
+        await replaceOwnPortrait(session, 'image/png', delivered, nothingFailed);
+
+        expect(onlySpan().name).toBe('POST /portrait');
+    });
+
+    it('reports the portrait removal the application put on the wire', async () => {
+        await removeOwnPortrait(session, delivered, nothingFailed);
+
+        expect(onlySpan().name).toBe('DELETE /portrait');
     });
 });

--- a/frontend/src/Client.Backend/src/telemetry.ts
+++ b/frontend/src/Client.Backend/src/telemetry.ts
@@ -3,7 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { context, metrics, SpanStatusCode, trace } from '@opentelemetry/api';
-import type { ClientResult } from './failure';
+import type { ClientFailureReason, ClientResult } from './failure';
 import { routeFor, type DeploymentAddress } from './session';
 
 // What this package reports about the requests it makes. `@opentelemetry/api` is the one dependency here and it names
@@ -44,25 +44,51 @@ const requestCount = 'mailfathom.client.requests';
 const requestDuration = 'mailfathom.client.request.duration';
 
 /**
+ * Records one request to the client surface answered as a `ClientResult`, which is most of them.
+ *
+ * It is `reported` with the failure read off the result this package's own contract carries, and it exists as a name of
+ * its own because that is the shape all but five operations here answer in: repeating the reading at each of them would
+ * be one more place for the outcome vocabulary to drift.
+ *
+ * @param request The route template this asks for, method first, which is the dimension every record here is grouped
+ * by. It is a template rather than the composed path: a message identifier in a span name is one name per message.
+ * @param ask The operation, which answers a value rather than throwing for anything it expected.
+ */
+export function spanned<TValue>(
+    request: string,
+    ask: () => Promise<ClientResult<TValue>>,
+): Promise<ClientResult<TValue>> {
+    return reported(request, ask, (result) => (result.outcome === 'failed' ? result.failure.reason : null));
+}
+
+/**
  * Records one request to the client surface, and answers exactly what the operation answered.
  *
- * Every operation in this package goes through this rather than reporting for itself, which is what keeps one span and
- * one pair of measurements per request whatever the operation did with the answer. The span ends where the result is
+ * Every request this package composes goes through this rather than reporting for itself, which is what keeps one span
+ * and one pair of measurements per request whatever shape the operation answers in. The span ends where the outcome is
  * decided rather than where the response arrived, because the failure a screen acts on — a body this package refused
  * as unreadable among them — is not known until then.
  *
  * The span is also the active context the operation runs under, which is what carries it onto the wire: `headersFor`
  * writes the W3C trace context of whatever is active into the request's headers, so the deployment's span for that
  * request is this span's child and one trace covers the screen, the request, the use case, and the query beneath it.
+ * A request the application puts on the wire itself is reported the same way, because what `ask` runs for those is the
+ * composition *and* the send: the operation that binds them is here, so the span's name and its end are this package's
+ * decision rather than the caller's, and the composition happens inside the active context like every other one.
  *
  * @param request The route template this asks for, method first, which is the dimension every record here is grouped
  * by. It is a template rather than the composed path: a message identifier in a span name is one name per message.
  * @param ask The operation, which answers a value rather than throwing for anything it expected.
+ * @param failureOf Which of the four failure reasons the answer amounts to, or `null` where the client got an answer it
+ * acts on. It is the operation's reading rather than a status, and the distinction it draws is whether an answer
+ * arrived rather than whether the answer was yes: a name this deployment will not record, a person with no portrait
+ * stored, and a download somebody stopped are each answered and acted on, so each is a `read`.
  */
-export async function spanned<TValue>(
+export async function reported<TOutcome>(
     request: string,
-    ask: () => Promise<ClientResult<TValue>>,
-): Promise<ClientResult<TValue>> {
+    ask: () => Promise<TOutcome>,
+    failureOf: (outcome: TOutcome) => ClientFailureReason | null,
+): Promise<TOutcome> {
     // Both registries are asked for per request rather than held at module scope. A provider is registered once the
     // person has signed in, which is after this module was first evaluated, and an instrument taken from the registry
     // that stood before it would report to nothing for the rest of the run. Neither lookup does more than read a map.
@@ -74,19 +100,20 @@ export async function spanned<TValue>(
         // The operation runs with this span as the active context, which is what `headersFor` reads the trace context
         // out of and therefore what joins this span to the one the deployment opens for the request. Without it the
         // span would still be recorded and exported, and would sit beside the service's work rather than above it.
-        const result = await context.with(trace.setSpan(context.active(), span), ask);
+        const answer = await context.with(trace.setSpan(context.active(), span), ask);
+        const failure = failureOf(answer);
         const outcome =
-            result.outcome === 'read'
+            failure === null
                 ? { 'mailfathom.client.request': request, 'mailfathom.client.outcome': 'read' }
                 : {
                       'mailfathom.client.request': request,
                       'mailfathom.client.outcome': 'failed',
-                      'mailfathom.client.failure': result.failure.reason,
+                      'mailfathom.client.failure': failure,
                   };
 
         span.setAttributes(outcome);
 
-        if (result.outcome === 'failed') {
+        if (failure !== null) {
             // No message on the status: what a failure was is already the dimension beside it, and anything longer
             // would be a sentence composed here about an answer this package deliberately does not carry out of itself.
             span.setStatus({ code: SpanStatusCode.ERROR });
@@ -95,7 +122,7 @@ export async function spanned<TValue>(
         meter.createCounter(requestCount).add(1, outcome);
         meter.createHistogram(requestDuration, { unit: 's' }).record((Date.now() - startedAt) / 1_000, outcome);
 
-        return result;
+        return answer;
     } finally {
         span.end();
     }


### PR DESCRIPTION
Closes #1529

## What this changes

`Client.Backend` stated that every request it makes goes through one `spanned` wrapper. Five operations did not, and
a request nobody opened a span around also sends no `traceparent`, so the deployment opened a root trace for work a
screen was waiting on.

`reported(request, ask, failureOf)` is now the one place a request is recorded — one span and one pair of measurements
— and `spanned` is the thin binding for the `ClientResult` shape every other operation answers in. Nothing about the
instruments, the route templates, or the outcome vocabulary changed.

| Operation | Before | Now |
| --- | --- | --- |
| `changeOwnDisplayName` | Unwrapped: answers `OwnDisplayNameChange`, which `spanned` cannot take | Goes through `reported` directly |
| `mailAttachmentRequest` | A published builder the application composed and sent | Reached through `readMailAttachment`; the builder is unpublished |
| `readOwnPortraitRequest`, `replaceOwnPortraitRequest`, `removeOwnPortraitRequest` | Same | Reached through `readOwnPortrait`, `replaceOwnPortrait`, `removeOwnPortrait`; the builders are unpublished |

## Where the span begins and ends, for a request this package does not send

Each of those four operations takes the adapter's send and its outcome reading, then opens the span, composes the
request **inside** it so `headersFor` writes the trace context, hands the request to the adapter, and closes on the
reason the adapter read off the answer. So the name, the lifetime, and the record stay this package's decision rather
than the caller's, and the builders being unpublished is what stops the next caller reproducing the shape that carried
no trace context: a request composed outside a span cannot be composed from outside the package any more.

A callback rather than a handle for the same reason — a `{ request, reported }` pair would leave ending the span to
whoever remembered to call it.

## What an answer a route deliberately refuses is recorded as

The outcome vocabulary is `#1229`'s and unchanged, so this had to be decided rather than invented: **the outcome says
whether an answer arrived, not whether the answer was yes.**

| Answer | Recorded as | Why |
| --- | --- | --- |
| A name this deployment will not record (`400`) | `read` | The person acts on it by typing another; recording a typing mistake as a failure puts it in the dimension an operator reads for a deployment that is not answering |
| No portrait stored (`204`) | `read` | An ordinary state of the screen — it draws the initials instead |
| A download somebody stopped | `read` | Their own act rather than the deployment failing to answer |
| A file larger than the message described | `failed`, `unreadable` | The body was refused rather than absent, which is what that reason already names |

## Tests

- `telemetry.test.ts` gains `reported`'s own behaviour and a block asserting each of the five operations records under
  its route template, including that a refused name is a `read` and a refused credential is `unauthenticated`. It is
  reached from there rather than from each operation's own file because what is asserted is the record, and that file
  is the one with a span exporter in it.
- `mailAttachment.test.ts` and `ownPortrait.test.ts` assert the adapter is handed the request the module composes and
  that its answer travels back untouched.
- `exporting.test.ts` in `Client.App` asserts that a request this application sends itself carries `traceparent` in
  the full W3C form. That is the direct proof the composition happens inside the span, and it belongs there because
  registering the propagator and the context manager is that package's act — `Client.Backend`'s own project has no
  context manager, so `context.active()` there answers the root whatever `reported` set.
- `attachmentDelivery.test.ts` is new and covers all six outcomes of the mapping above.

## Documentation

- `docs/operations/telemetry.md` § *What the client publishes about itself* states both decisions above. Its
  `describes:` marker was too narrow — it covered `telemetry.ts` alone — and now names the three modules whose records
  the page describes.
- `frontend/README.md` § *What the client records about itself* says *composes* rather than *makes*, and says why the
  operation is published and the request builder is not.

## Two things worth a reviewer's eye

- **The issue's counts are off and the code follows the code.** Its table names three rows covering five functions,
  the prose says "four operations", and the acceptance says "three request builders". There are four builders
  (`mailAttachmentRequest` plus the three portrait ones) and five unreported operations. Everything is covered; the
  documentation says four builders because that is what exists.
- **An abandoned portrait read is still recorded as `unavailable`.** `PortraitRead` carries no outcome for
  abandonment, so an aborted `fetch` and an unreachable deployment arrive at that adapter as the same rejection — which
  is also what the screen is told either way. Separating them would mean a new outcome on a type screens consume, which
  is a change of its own rather than part of this one. The download does separate them, because
  `AttachmentDeliveryOutcome` already had `abandoned`. `portraitExchange.ts` carries that limit as a comment.

## Verification

- `scripts/verify-full.sh` — pass, 287/287 workflow assertions, client flow only (no path under `backend/`).
- Client suite: 100 files, 1685 tests, all passing. Coverage 94.55% statements, and every file this change touches
  reports 100%.
- No screenshot comparison: the change alters no screen. `Attachment.tsx` and `portraitExchange.ts` produce the same
  outcomes to the same components.
- No dependency moved, so `THIRD_PARTY_LICENSES.md`, both client closure censuses, and `THIRD-PARTY-NOTICES.txt` have
  nothing to re-resolve.

https://claude.ai/code/session_017tHS382wC7zLth2jXwJhJL
