### PR TITLE
[#1583] Draw the mailboxes as an icon rail when the column folds

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -290,14 +290,17 @@ nothing configured.
 `src/workspace/` is what survives moving between spaces, and it is mounted above the frame for exactly that reason. It
 holds one **scope** — every mailbox at once, one role across all of them, one mailbox, or one folder of one — beside the
 question, the message that is open, the conversation being read in front of it, the messages that have been picked
-out, what was searched for before, and the rows of the folder tree somebody has folded away. It is kept in the store the web head keeps its credential in, so a reload returns to what was on the
+out, what was searched for before, the rows of the folder tree somebody has folded away, and whether the mailbox column
+itself is folded to its rail. It is kept in the store the web head keeps its credential in, so a reload returns to what was on the
 screen; signing in and signing out both empty it, because what somebody was looking at and about to ask is theirs rather
 than the machine's.
 
 `src/folders/` is what writes that scope. It draws the owner's mailboxes and their folders as one tree, read from the
 folders route in a single exchange, with the roles that span every mailbox above them — so asking about every inbox at
 once is one act rather than three. A folder is placed and named by the role the deployment gave it rather than by what
-its server calls it, because a name is whatever a provider chose in whatever language.
+its server calls it, because a name is whatever a provider chose in whatever language. The same tree is what the folded
+column draws: a row keeps its place and its symbol and loses its label, a mailbox is marked by its colour where its name
+stood, and the two folds stay independent — narrowing the column changes nothing about which mailboxes are open in it.
 
 `src/messageList/` is what that scope is drawn as. It reads `/api/client/emails`, which is keyset-paged in both
 directions, and it is where the client's three hardest constraints meet: a mailbox of two hundred and fourteen thousand

--- a/frontend/src/Client.App/src/folders/FolderRow.tsx
+++ b/frontend/src/Client.App/src/folders/FolderRow.tsx
@@ -24,6 +24,12 @@ import type { FolderTreeRow } from './folderTreeRows';
 // Two shapes, as the design project draws them. The first level is the groups — the whole workspace and each mailbox —
 // drawn as a small heading with a mark in front of it, and everything under a group is a folder drawn with the symbol
 // of what it is: the role's own where it plays one, and a folder's otherwise.
+//
+// Each of those two is drawn twice again, because the column it stands in folds to a rail. Folded, a group is its mark
+// alone — the colour is what tells one mailbox from the next once the name is gone — and a folder is its symbol alone,
+// drawn larger, because a narrower column still has to be hit reliably. What goes is the drawing rather than the
+// saying: the name, the state, and the count stay in the row for a reader who is not looking at it, which is what
+// keeps a rail of unlabelled symbols something a screen reader can still work through.
 
 // How far in each level under a group sits. Stated as one list rather than as a width worked out from the level,
 // because a computed indentation is a value written outside the token layer however it is arrived at. Anything deeper
@@ -44,6 +50,35 @@ const roleIcons: Readonly<Record<MailFolderRole, IconName>> = {
     Outbox: 'outbox',
 };
 
+// How a row is drawn, which is four cases rather than one expression: a group or a folder, each at the column's width
+// or at the rail's. Named here rather than spelled into the markup, for the reason `frontend/src`'s instructions give
+// about where markup ends — a reader of the element should see what is on the row, not how it is measured.
+function rowShape({
+    group,
+    folded,
+    selected,
+    indent,
+}: {
+    readonly group: boolean;
+    readonly folded: boolean;
+    readonly selected: boolean;
+    readonly indent: string;
+}): string {
+    const across = folded ? 'justify-center' : `gap-2 pe-2 ${indent}`;
+
+    if (group) {
+        const marked = folded ? 'py-2' : 'py-1.25 ps-2.25 text-xs tracking-wide';
+
+        return `${across} mt-3 rounded-sm first:mt-0 ${marked} ${
+            selected ? 'font-semibold text-accent-deep' : 'text-muted hover:text-text'
+        }`;
+    }
+
+    return `${across} rounded-md ${folded ? 'py-1.25' : 'py-1.75 text-md'} ${
+        selected ? 'bg-accent-soft font-semibold text-accent-deep' : 'text-text-soft hover:bg-hover'
+    }`;
+}
+
 export function FolderRow({
     row,
     position,
@@ -51,6 +86,7 @@ export function FolderRow({
     expanded,
     selected,
     focusable,
+    folded,
     groupOrdinal,
     onSelect,
     onToggle,
@@ -63,6 +99,9 @@ export function FolderRow({
     readonly expanded: boolean | null;
     readonly selected: boolean;
     readonly focusable: boolean;
+
+    /** Whether the column this row stands in is folded to its rail, in which case the row is drawn as a symbol alone. */
+    readonly folded: boolean;
 
     /** Which group this row heads, counted from the whole workspace at zero, or `null` for a row under one. */
     readonly groupOrdinal: number | null;
@@ -88,36 +127,35 @@ export function FolderRow({
             tabIndex={focusable ? 0 : -1}
             onClick={onSelect}
             onKeyDown={onKeyDown}
-            className={`flex items-center gap-2 pe-2 transition ${indent} ${row.scope === null ? '' : 'cursor-pointer'} ${
-                group
-                    ? `mt-3 rounded-sm py-1.25 ps-2.25 text-xs tracking-wide first:mt-0 ${
-                          selected ? 'font-semibold text-accent-deep' : 'text-muted hover:text-text'
-                      }`
-                    : `rounded-md py-1.75 text-md ${
-                          selected ? 'bg-accent-soft font-semibold text-accent-deep' : 'text-text-soft hover:bg-hover'
-                      }`
-            }`}
+            className={`flex items-center transition ${row.scope === null ? '' : 'cursor-pointer'} ${rowShape({ group, folded, selected, indent })}`}
         >
             {group ? (
                 <MailboxMark ordinal={groupOrdinal} />
             ) : (
                 <Icon
                     name={row.role === null ? 'folder' : roleIcons[row.role]}
-                    className={`size-4.5 shrink-0 ${selected ? 'text-accent-deep' : 'text-muted'}`}
+                    className={`${folded ? 'size-6' : 'size-4.5'} shrink-0 ${selected ? 'text-accent-deep' : 'text-muted'}`}
                 />
             )}
 
-            <span className="min-w-0 flex-1 truncate">{nameOf(row, translate)}</span>
+            {/* Everything the rail has no room to draw, kept for the reader who hears the row rather than sees it. */}
+            <span className={folded ? 'sr-only' : 'flex min-w-0 flex-1 items-center gap-2'}>
+                <span className="min-w-0 flex-1 truncate">{nameOf(row, translate)}</span>
 
-            <State row={row} />
-            <Unread count={row.unreadEmailCount} />
+                <State row={row} />
+                <Unread count={row.unreadEmailCount} />
+            </span>
 
-            <Twist
-                expanded={expanded}
-                onToggle={() => {
-                    onToggle();
-                }}
-            />
+            {/* A rail has nowhere to put it, and nothing is lost with it: the arrow keys are what fold a row, and the
+                control is hidden from the accessibility tree wherever it is drawn. */}
+            {folded ? null : (
+                <Twist
+                    expanded={expanded}
+                    onToggle={() => {
+                        onToggle();
+                    }}
+                />
+            )}
         </li>
     );
 }

--- a/frontend/src/Client.App/src/folders/FolderTree.test.tsx
+++ b/frontend/src/Client.App/src/folders/FolderTree.test.tsx
@@ -87,6 +87,40 @@ function ScopeProbe() {
     return <output>{JSON.stringify(workspace)}</output>;
 }
 
+const foldTheColumn = 'Fold the column, as the composition around the tree would.';
+
+// Stands in for the control the mail space draws over this column: the tree reads the folded state out of the
+// workspace rather than being handed it, so what the test needs is something that writes it there.
+function FoldTheColumn() {
+    const { workspace, revise } = useWorkspace();
+
+    return (
+        <button
+            type="button"
+            onClick={() => {
+                revise({ mailboxesFolded: !workspace.mailboxesFolded });
+            }}
+        >
+            {foldTheColumn}
+        </button>
+    );
+}
+
+function foldTheColumnAway(): void {
+    fireEvent.click(screen.getByRole('button', { name: foldTheColumn }));
+}
+
+/** The part of a row that carries its name, its state, and its count — drawn beside the symbol, or said and not drawn. */
+function saidOn(named: HTMLElement): HTMLElement {
+    const said = named.querySelector<HTMLElement>('span:not([aria-hidden])');
+
+    if (said === null) {
+        throw new Error(`The row "${named.textContent}" says nothing about what it is.`);
+    }
+
+    return said;
+}
+
 // An `output` reports itself as a status region, exactly as the tree's own waiting line does, so the probe is picked
 // out by being the one carrying a workspace rather than a sentence.
 function carried(): Workspace {
@@ -106,6 +140,7 @@ function treeUnder(
                 <ReadMarkingContext value={marking}>
                     <FolderTree session={session} transport={transport} online={online} />
                 </ReadMarkingContext>
+                <FoldTheColumn />
                 <ScopeProbe />
             </WorkspaceProvider>
         </LocalizationProvider>
@@ -429,5 +464,88 @@ describe('FolderTree', () => {
 
         expect(screen.getByText(/This machine is offline\./)).toBeDefined();
         expect(transport).not.toHaveBeenCalled();
+    });
+});
+
+describe('FolderTree, in a folded column', () => {
+    it('draws a folder as its symbol alone, and says the name it no longer draws', async () => {
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+        foldTheColumnAway();
+
+        const inbox = row(/^Inbox12 unread/);
+
+        expect(saidOn(inbox).className).toContain('sr-only');
+        expect(inbox.querySelector('svg')).not.toBeNull();
+        expect(inbox.textContent).toContain('12 unread');
+    });
+
+    it('draws a folder symbol larger than the column draws one, a narrower target having to be hit as reliably', async () => {
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+
+        expect(
+            row(/^Inbox12 unread/)
+                .querySelector('svg')
+                ?.getAttribute('class'),
+        ).toContain('size-4.5');
+
+        foldTheColumnAway();
+
+        expect(
+            row(/^Inbox12 unread/)
+                .querySelector('svg')
+                ?.getAttribute('class'),
+        ).toContain('size-6');
+    });
+
+    it('marks a mailbox by its colour where the column named it, so the mailboxes stay tellable apart', async () => {
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+        foldTheColumnAway();
+
+        const work = row(/^Work/);
+
+        expect(saidOn(work).className).toContain('sr-only');
+        expect(work.querySelector('[aria-hidden="true"].rounded-full')).not.toBeNull();
+        expect(work.textContent).toContain('Work');
+    });
+
+    it('offers no per-row control in the rail, the arrow keys being what folds a row there', async () => {
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+
+        const drawnControls = row(/^Work/).querySelectorAll('svg').length;
+
+        foldTheColumnAway();
+
+        expect(row(/^Work/).querySelectorAll('svg').length).toBe(drawnControls - 1);
+    });
+
+    it('leaves what a reader folded away folded, folding the column being the other question', async () => {
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+        const work = row(/^Work/);
+
+        work.focus();
+        fireEvent.keyDown(work, { key: 'ArrowLeft' });
+
+        expect(screen.queryByRole('treeitem', { name: /^Archiwum/ })).toBeNull();
+
+        foldTheColumnAway();
+
+        expect(carried().collapsed).toEqual(['account:work']);
+        expect(screen.queryByRole('treeitem', { name: /^Archiwum/ })).toBeNull();
+        expect(row(/^Work/).getAttribute('aria-expanded')).toBe('false');
+
+        foldTheColumnAway();
+
+        expect(carried().collapsed).toEqual(['account:work']);
+        expect(screen.queryByRole('treeitem', { name: /^Archiwum/ })).toBeNull();
     });
 });

--- a/frontend/src/Client.App/src/folders/FolderTree.tsx
+++ b/frontend/src/Client.App/src/folders/FolderTree.tsx
@@ -31,6 +31,12 @@ import { unreadAfterMarking } from './unreadAfterMarking';
 //
 // What it does not do is decide anything about the mail itself. Selecting a row writes the scope into the workspace,
 // and the list, the search, and the next question read it from there.
+//
+// Two things fold here and they are different questions. A row folds away what is under it, which is this tree's own
+// and is what `workspace.collapsed` holds. The column folds to a rail, which is the composition's and is what
+// `workspace.mailboxesFolded` holds — read here rather than handed in because the composition that owns it renders
+// this tree as a region it was given rather than as a child it built. Neither touches the other: a rail draws the
+// same rows a column would, each as a symbol.
 
 const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
     unauthenticated: 'failure.unauthenticated',
@@ -255,6 +261,7 @@ export function FolderTree({
                     expanded={visibleRow.expanded}
                     selected={visibleRow.row.key === inScope}
                     focusable={visibleRow.row.key === carryingFocus?.row.key}
+                    folded={workspace.mailboxesFolded}
                     groupOrdinal={groupOrdinals.get(visibleRow.row.key) ?? null}
                     onSelect={() => {
                         setFocused(visibleRow.row.key);

--- a/frontend/src/Client.App/src/mailSpace/AiFilters.tsx
+++ b/frontend/src/Client.App/src/mailSpace/AiFilters.tsx
@@ -17,7 +17,7 @@ const filters: readonly { readonly icon: IconName; readonly label: MessageKey }[
     { icon: 'schedule', label: 'aiFilters.deadlinesThisWeek' },
 ];
 
-export function AiFilters() {
+export function AiFilters({ folded }: { readonly folded: boolean }) {
     const { translate } = useLocalization();
 
     return (
@@ -25,14 +25,19 @@ export function AiFilters() {
             aria-label={translate('aiFilters.heading')}
             className="mt-4 flex flex-col gap-1.5 border-t border-line pt-3.5"
         >
-            <p className="px-2.75 text-xs tracking-widest text-muted uppercase">{translate('aiFilters.heading')}</p>
+            {/* The heading names a group a reader can see the whole of; the rail draws the group as its symbols and the
+                section's own name is what a reader who cannot see them is given instead. */}
+            {folded ? null : (
+                <p className="px-2.75 text-xs tracking-widest text-muted uppercase">{translate('aiFilters.heading')}</p>
+            )}
 
             {filters.map((filter) => (
                 <PlannedControl
                     key={filter.icon}
                     label={translate(filter.label)}
                     icon={filter.icon}
-                    className="justify-start"
+                    shape={folded ? 'symbol' : 'labelled'}
+                    className={folded ? 'self-center' : 'justify-start'}
                 />
             ))}
         </section>

--- a/frontend/src/Client.App/src/mailSpace/MailSpace.test.tsx
+++ b/frontend/src/Client.App/src/mailSpace/MailSpace.test.tsx
@@ -197,17 +197,40 @@ describe('MailSpace, wide', () => {
         );
     });
 
-    it('folds the mailbox column to a strip and opens it again, from a control named for each', () => {
+    it('folds the mailbox column to a rail and opens it again, from a control named for each', () => {
         renderSpace(true);
 
         fireEvent.click(screen.getByRole('button', { name: 'Collapse the mailbox column' }));
 
-        expect(screen.queryByText(handedTheFolders)).toBeNull();
         expect(screen.queryByRole('button', { name: 'Collapse the mailbox column' })).toBeNull();
+        expect(screen.getByRole('complementary').className).toContain('w-mailboxes-folded');
 
         fireEvent.click(screen.getByRole('button', { name: 'Expand the mailbox column' }));
 
+        expect(screen.queryByRole('button', { name: 'Expand the mailbox column' })).toBeNull();
+        expect(screen.getByRole('complementary').className).toContain('w-mailboxes');
+    });
+
+    it('keeps the mailboxes in the folded rail, and drops what a rail has no room to say', () => {
+        renderSpace(true);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Collapse the mailbox column' }));
+
         expect(screen.getByText(handedTheFolders)).toBeDefined();
+        expect(screen.queryByText('Folders')).toBeNull();
+        expect(screen.queryByText(handedTheStatus)).toBeNull();
+    });
+
+    it('draws the AI filters as symbols in the folded rail, where their names would not fit', () => {
+        renderSpace(true);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Collapse the mailbox column' }));
+
+        const filters = screen.getByRole('region', { name: 'AI filters' });
+
+        expect(filters.querySelectorAll('button[aria-disabled="true"]').length).toBe(3);
+        expect(filters.textContent).toBe('');
+        expect(screen.getByRole('button', { name: 'Needs a decision — not built yet' })).toBeDefined();
     });
 
     it('draws every unbuilt action of the toolbar as one that says so in its own name', () => {

--- a/frontend/src/Client.App/src/mailSpace/MailSpace.tsx
+++ b/frontend/src/Client.App/src/mailSpace/MailSpace.tsx
@@ -83,13 +83,17 @@ export function MailSpace({
     const { translate } = useLocalization();
     const { workspace, revise } = useWorkspace();
     const wide = useWideWorkspace();
-    const [folded, setFolded] = useState(false);
     const [listWidth, setListWidth] = useState(() => readListWidth(person));
     const drawer = useRef<HTMLDialogElement>(null);
     const listColumn = useRef<HTMLElement>(null);
     const readingColumn = useRef<HTMLElement>(null);
 
     const readingInFront = !wide && (workspace.selection !== null || workspace.conversation !== null);
+
+    // Read from the workspace rather than held here, because the column is not the only thing that draws differently
+    // once it is folded: the tree inside it draws a symbol where it drew a name, and the tree is a region handed in
+    // already built rather than a child this component could pass a prop to.
+    const folded = workspace.mailboxesFolded;
 
     // A width chosen on one screen is read back on whatever screen the client opens on next, so the window is measured
     // rather than trusted: what the two columns share is what they measure to, and a stored width the window no longer
@@ -181,7 +185,7 @@ export function MailSpace({
                                     label={translate(folded ? 'mailboxes.unfold' : 'mailboxes.fold')}
                                     icon={folded ? 'chevron_right' : 'chevron_left'}
                                     onActivate={() => {
-                                        setFolded(!folded);
+                                        revise({ mailboxesFolded: !folded });
                                     }}
                                 />
                             }
@@ -309,6 +313,11 @@ export function MailSpace({
 
 // The mailbox column's contents, drawn once for the two places they stand: the column beside the list, and the drawer
 // in front of it. The heading, the tree, the filters MailFathom's own reading will add, and the connection at the foot.
+//
+// Folded, it is the same tree at the rail's width rather than a column emptied of it: the point of folding is to give
+// the width to the list while keeping the mailboxes one click away, and a rail with nothing in it would make the
+// control the only thing left to click. What the rail does drop is the heading, which names a column a reader can see
+// the whole of, and the connection line at the foot, which is a sentence and has nowhere to wrap to.
 function Mailboxes({
     folders,
     status,
@@ -324,7 +333,7 @@ function Mailboxes({
 
     return (
         <>
-            <div className={`flex items-center px-2.25 pt-3 pb-1.5 ${folded ? 'justify-center' : 'justify-between'}`}>
+            <div className={`flex items-center px-2.25 pt-3 pb-1.5 ${folded ? 'justify-end' : 'justify-between'}`}>
                 {folded ? null : (
                     <p className="ps-1.5 text-xs tracking-widest text-muted uppercase">
                         {translate('mailboxes.heading')}
@@ -334,16 +343,12 @@ function Mailboxes({
                 {control}
             </div>
 
-            {folded ? null : (
-                <>
-                    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-2.25 py-1">
-                        {folders}
-                        <AiFilters />
-                    </div>
+            <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-2.25 py-1">
+                {folders}
+                <AiFilters folded={folded} />
+            </div>
 
-                    <div className="border-t border-line px-3.5 py-2.5">{status}</div>
-                </>
-            )}
+            {folded ? null : <div className="border-t border-line px-3.5 py-2.5">{status}</div>}
         </>
     );
 }

--- a/frontend/src/Client.App/src/styles.css
+++ b/frontend/src/Client.App/src/styles.css
@@ -208,7 +208,7 @@
        reads them is. */
     --spacing-rail: 6rem;
     --spacing-mailboxes: 13.125rem;
-    --spacing-mailboxes-folded: 3.625rem;
+    --spacing-mailboxes-folded: 4.8125rem;
     --spacing-drawer: 16.375rem;
 
     /* The widest a message's own content is ever drawn, which is a ceiling rather than a width: the reading pane takes

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
@@ -11,6 +11,7 @@ const storageKey = 'mailfathom.workspace';
 const kept: Workspace = {
     scope: { kind: 'folder', accountId: 'work', alias: 'INBOX' },
     collapsed: ['account:personal'],
+    mailboxesFolded: true,
     selection: 'AAMkAD-42',
     conversation: { threadId: '9b2a1c74-4a4e-4c93-9a2e-3f6f0a1b2c3d', openAt: 'AAMkAD-42' },
     fragment: null,
@@ -58,6 +59,23 @@ describe('rememberedWorkspace', () => {
 
         expect(rememberedWorkspace()).toEqual({ ...kept, recentSearches: [] });
         expect(recentSearches).toHaveLength(1);
+    });
+
+    // A workspace kept before the column could be folded is one this client wrote, so it opens on what was kept with
+    // the column at the width every workspace before it was drawn at.
+    it('reads a workspace kept before the column could fold as one drawn at the column width', () => {
+        const { mailboxesFolded, ...before } = kept;
+
+        stored(before);
+
+        expect(rememberedWorkspace()).toEqual({ ...kept, mailboxesFolded: false });
+        expect(mailboxesFolded).toBe(true);
+    });
+
+    it('refuses a folded column that is not one, a store being a place a person can write', () => {
+        stored({ ...emptyWorkspace, mailboxesFolded: 'yes' });
+
+        expect(rememberedWorkspace()).toEqual(emptyWorkspace);
     });
 
     it.each([

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.ts
@@ -95,6 +95,7 @@ function workspaceIn(value: unknown): Workspace | null {
     const record = value as Record<string, unknown>;
     const scope = scopeIn(record['scope']);
     const collapsed = collapsedIn(record['collapsed']);
+    const mailboxesFolded = record['mailboxesFolded'] ?? false;
     const selection = record['selection'] ?? null;
     const selected = selectedIn(record['selected']);
     const question = record['question'];
@@ -115,11 +116,25 @@ function workspaceIn(value: unknown): Workspace | null {
         return null;
     }
 
+    if (typeof mailboxesFolded !== 'boolean') {
+        return null;
+    }
+
     if (typeof question !== 'string' || question.length > longestQuestion) {
         return null;
     }
 
-    return { scope, collapsed, selection, conversation, fragment: null, selected, question, recentSearches };
+    return {
+        scope,
+        collapsed,
+        mailboxesFolded,
+        selection,
+        conversation,
+        fragment: null,
+        selected,
+        question,
+        recentSearches,
+    };
 }
 
 // The searches read back, each held to what this surface ranks against at all: text longer than that is not a search

--- a/frontend/src/Client.App/src/workspace/useWorkspace.ts
+++ b/frontend/src/Client.App/src/workspace/useWorkspace.ts
@@ -25,6 +25,16 @@ export interface Workspace {
      */
     readonly collapsed: readonly string[];
 
+    /**
+     * Whether the mailbox column is folded to its icon rail rather than drawn at the width that carries names.
+     *
+     * Beside the rows somebody folded rather than inside the column that draws it, because two things read it: the
+     * composition, which decides how wide the column is, and the tree inside it, which decides whether a row is a name
+     * or a symbol. It is a second axis rather than the same one — folding a mailbox away hides its folders, and folding
+     * the column narrows every row that is still there — which is why neither value is derivable from the other.
+     */
+    readonly mailboxesFolded: boolean;
+
     /** What the person has open, once a space offers something to open. */
     readonly selection: string | null;
 
@@ -78,6 +88,7 @@ export interface WorkspaceRevision {
 export const emptyWorkspace: Workspace = {
     scope: everything,
     collapsed: [],
+    mailboxesFolded: false,
     selection: null,
     conversation: null,
     fragment: null,


### PR DESCRIPTION
## What this changes

The mailbox column already folded to a strip, but the strip was empty — folding it hid the tree
rather than narrowing it, so the one control left in the column was the one that unfolded it again.
It now folds to the rail the design project draws: one symbol per folder row, drawn larger than the
column draws it, and a mailbox marked by its colour where its name stood.

- `workspace/useWorkspace.ts` holds `mailboxesFolded` beside the rows a reader folded away. Two
  components read it — the composition, which decides the column's width, and the tree inside it,
  which decides whether a row is a name or a symbol — and the tree is a region `MailSpace` is handed
  already built rather than a child it could pass a prop to. It is a second axis rather than the same
  one: narrowing the column changes nothing about which mailboxes are open in it.
- `folders/FolderRow.tsx` draws each of its two shapes twice. Folded, a group is its `MailboxMark`
  alone and a folder is its symbol at 24px rather than 18px, with the row's name, synchronization
  state, and unread count kept in the row as `sr-only` — so a rail of unlabelled symbols is still
  something a screen reader works through, and every row keeps the accessible name it had. The
  per-row twist is not drawn there: the arrow keys are what fold a row, and the control was hidden
  from the accessibility tree wherever it was drawn.
- `mailSpace/MailSpace.tsx` keeps the tree in the folded column and drops what a rail has no room to
  say — the heading, which names a column a reader can see the whole of, and the connection line at
  the foot, which is a sentence with nowhere to wrap to. Its toggle moves to the right of the rail,
  where the design puts it.
- `mailSpace/AiFilters.tsx` draws its three placeholders as symbols in the rail. Building those
  filters is AI-stage work the parent orders two stages later; what this does is stop three labelled
  controls from being drawn in a 77px column.
- `styles.css` moves `--spacing-mailboxes-folded` from 58px to 77px, which is the width the design
  draws the folded column at — measured, not guessed; see below.

The narrow composition is untouched: the drawer passes `folded={false}`, so the toggle exists only
where the mailboxes are a column at all.

`mailboxesFolded` goes into the session store with the rest of the workspace, so a reload returns to
the rail exactly as it returns to the rows somebody folded away. That is the workspace rather than a
preference document: nothing here reads or writes one, and the issue's exclusion stands.

## Held against the design

Both sides screenshotted at 1440×900 — the design through `render_preview`, the client through a
throwaway spec against `vite preview` — and measured pixel by pixel rather than eyeballed.

Matching:

- folded column 77px in both;
- the mailbox mark 8×8, centred, in both;
- the folded folder symbol: `send` inks 17×14 in both, against 13×10 in the drawn column;
- the divider above the AI filters, and the group spacing between mailboxes.

Still differing:

- the folded toggle sits about 6px left of where the design puts it;
- the AI filters in the rail are drawn at the client's existing symbol-control size, which is a
  little taller than the design's row pitch there;
- the **expanded** column is 210px against the design's 239px. That predates this change and is
  untouched by it — the two other widths beside it read the same way — so it is worth its own look
  rather than a correction smuggled into this diff.

## Tests

`FolderTree.test.tsx` gains a suite for the rail: a folder drawn as its symbol with the name said and
not drawn, the symbol growing from `size-4.5` to `size-6`, a mailbox marked by its colour where its
name was, no per-row control in the rail, and a row folded away staying folded across a fold and an
unfold of the whole column. `MailSpace.test.tsx` asserts the column's two widths, that the tree stays
in the rail while the heading and the connection line go, and that the AI filters draw as symbols.
`rememberedWorkspace.test.ts` covers reading back a workspace written before the column could fold,
and refusing a stored value that is not a boolean.

Closes #1583
