### PR TITLE
[#1485] Show a message's full HTML on a second surface, in a sandboxed frame the lint rule still names

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -351,6 +351,22 @@ measured off a rendered row rather than written down twice, and the assertion th
 request. A row that ever stops being one height is the argument for reopening this, and it fails a test rather than
 degrading quietly.
 
+`src/fullHtml/` is the second surface [ADR 0024](../docs/decisions/0024-rendering-mail-in-the-client-as-a-closed-document-tree.md)
+takes, and it stands in front of the message the same way a conversation does. What the reading pane draws is a closed
+document tree; what this draws is the markup the sender actually wrote, and two different mechanisms are what make that
+safe rather than one. The frame it is drawn in carries a `sandbox` attribute naming neither `allow-scripts` nor
+`allow-same-origin`, so nothing in the markup runs whatever the markup holds; and what is drawn in it is the
+self-contained representation the service composes, whose every remote address is already gone, so nothing in it
+reaches the sender until a reader asks for that one message's pictures. The footer states those two separately and
+credits each to what actually holds it, because a reader who is told the frame stops both learns nothing about what
+asking for the pictures gives up.
+
+Reaching it is a question rather than a control: pressing the one on the message's head opens a confirmation, and
+neither answer is written down — per message, per reader, or at all. `workspace/rememberedWorkspace.ts` is what keeps
+that true across a reload, by refusing to keep the value and refusing to read one back. `messageBody/MessageMarkupFrame.tsx`
+is the one file in this tree permitted to write `srcdoc` at all, and `eslint.config.ts` names it by path rather than
+letting a call site suppress the rule.
+
 `src/search/` stands above that list rather than on a screen of its own, because that is where somebody reaches for
 it: they are looking at a folder and the message is not in front of them. It reads `/api/client/emails/search`, which
 ranks by words and by meaning at once and says in its answer which of the two happened — so a page ranked by words

--- a/frontend/eslint.config.ts
+++ b/frontend/eslint.config.ts
@@ -24,9 +24,9 @@ const readOutAttributeMessage =
 
 // The calls that turn a value back into markup: `dangerouslySetInnerHTML`, `innerHTML`, `outerHTML`,
 // `insertAdjacentHTML`, `document.write`, `document.writeln`, `setHTMLUnsafe` on an element or a shadow root,
-// `DOMParser.parseFromString`, `Range.createContextualFragment`, and an `iframe`'s `srcdoc` in either form. The client is handed no markup and writes none, which is the
-// whole of ADR 0024's safety statement and the reason no sanitizer is pinned: a message reaches a screen as a closed
-// tree of typed values, and React escapes every one of them. Writing any of these is the single change that would
+// `DOMParser.parseFromString`, and `Range.createContextualFragment`. The client is handed no markup and writes none,
+// which is the whole of ADR 0024's safety statement and the reason no sanitizer is pinned: a message reaches a screen
+// as a closed tree of typed values, and React escapes every one of them. Writing any of these is the change that would
 // undo that, so it is made unwritable rather than left to a reviewer — the same shape the localization rule takes.
 //
 // They are declared here because `no-restricted-syntax` is replaced rather than merged when a later configuration
@@ -62,15 +62,75 @@ const markupWritingSyntax = [
         message:
             'This parses a string into nodes, which is the parser ADR 0024 exists not to have: a message reaches a screen as a closed tree of typed values and nothing here builds one from markup.',
     },
+];
+
+// The path the exception below is written against: the one component a message's own markup is drawn as markup in.
+// ADR 0024 names it as the single exception rather than leaving it to a suppression at the call site, so moving or
+// renaming that file is a change to this line and therefore to the record — which is the whole point of stating it
+// here.
+const theOneMarkupSurface = 'src/Client.App/src/messageBody/MessageMarkupFrame.tsx';
+
+// `srcdoc` is the tenth way a value becomes markup, and the only one with an exception. It is separated from the nine
+// above so the exception can be stated as *this rule minus these two selectors* on one named file, rather than as a
+// second list somebody would have to keep in step with the first.
+//
+// The exception is narrowed, not lifted. Every other file under `src/` is refused a frame, and the file that is not
+// carries the reasoning for both mechanisms it depends on.
+const srcdocSyntax = [
     {
-        selector: 'JSXAttribute[name.name="srcdoc"]',
-        message:
-            "srcdoc is a document written from a value and parsed as markup. ADR 0024 draws a message with typed components in the application's own document, and neither a frame nor a second parser is part of that.",
+        // Both spellings, because they are two different things to two different readers: the DOM attribute is
+        // `srcdoc` and React's prop for it is `srcDoc`, and a selector naming one of them would refuse the form
+        // nobody writes while passing the form everybody writes.
+        selector: 'JSXAttribute[name.name=/^(srcdoc|srcDoc)$/]',
+        message: `srcdoc is a document written from a value and parsed as markup. ADR 0024 draws a message with typed components in the application's own document, and the one frame it permits is ${theOneMarkupSurface}.`,
     },
     {
-        selector: 'MemberExpression[property.name="srcdoc"]',
+        selector: 'MemberExpression[property.name=/^(srcdoc|srcDoc)$/]',
+        message: `srcdoc is a document written from a value and parsed as markup. ADR 0024 draws a message with typed components in the application's own document, and the one frame it permits is ${theOneMarkupSurface}.`,
+    },
+];
+
+// Every user-visible string leaves the component that shows it, which is the one rule that decides whether a third
+// language is a catalogue or a sweep through every screen written before it. A literal in markup is refused here
+// rather than noticed in review, because review is exactly what stops catching it once there are enough screens to
+// read. `no-restricted-syntax` is what states it: `Intl` and the catalogues are the whole of the mechanism, so there
+// is no plugin to install for this and nothing joins the bundle.
+//
+// Declared beside the two lists above for the same reason they are: the rule is replaced rather than merged, so every
+// configuration object naming it has to carry all of it.
+const localizationSyntax = [
+    {
+        selector: 'JSXText[value=/\\S/]',
         message:
-            "srcdoc is a document written from a value and parsed as markup. ADR 0024 draws a message with typed components in the application's own document, and neither a frame nor a second parser is part of that.",
+            'A user-visible string belongs in src/Client.App/src/localization/en.ts, with its Polish counterpart, and reaches the screen through translate().',
+    },
+    {
+        selector: ':matches(JSXElement, JSXFragment) > JSXExpressionContainer > Literal[value=/\\S/]',
+        message:
+            'A user-visible string belongs in src/Client.App/src/localization/en.ts and reaches the screen through translate(); a number is written with Intl under the active locale.',
+    },
+    {
+        selector: ':matches(JSXElement, JSXFragment) > JSXExpressionContainer > TemplateLiteral',
+        message:
+            'A sentence assembled in markup cannot be reordered by a translator. Write it as one catalogue entry with a {name} hole and fill it through translate().',
+    },
+    // The same attribute in its three written forms, because a selector is matched against the syntax
+    // rather than against the value: `alt="…"` puts the literal directly under the attribute, while
+    // `alt={'…'}` and ``alt={`…`}`` put it one level down inside an expression container. A rule catching
+    // only the first would pass the two a person reaches for after being refused once. The step is
+    // deliberately not a descendant match: `aria-label={translate('shell.language')}` carries a string
+    // literal too, and it is the catalogue key rather than a sentence.
+    {
+        selector: `${readOutAttribute} > Literal`,
+        message: readOutAttributeMessage,
+    },
+    {
+        selector: `${readOutAttribute} > JSXExpressionContainer > Literal[value=/\\S/]`,
+        message: readOutAttributeMessage,
+    },
+    {
+        selector: `${readOutAttribute} > JSXExpressionContainer > TemplateLiteral`,
+        message: readOutAttributeMessage,
     },
 ];
 
@@ -134,7 +194,7 @@ export default defineConfig(
         // screen against an arrangement the application refuses.
         files: ['src/*/**/*.{ts,tsx}'],
         rules: {
-            'no-restricted-syntax': ['error', ...markupWritingSyntax],
+            'no-restricted-syntax': ['error', ...markupWritingSyntax, ...srcdocSyntax],
         },
     },
     {
@@ -142,50 +202,19 @@ export default defineConfig(
         extends: [reactHooks.configs.flat.recommended, reactRefresh.configs.vite],
     },
     {
-        // Every user-visible string leaves the component that shows it, which is the one rule that decides whether a
-        // third language is a catalogue or a sweep through every screen written before it. A literal in markup is
-        // refused here rather than noticed in review, because review is exactly what stops catching it once there are
-        // enough screens to read. `no-restricted-syntax` is what states it: `Intl` and the catalogues are the whole of
-        // the mechanism, so there is no plugin to install for this and nothing joins the bundle.
         files: ['src/Client.App/**/*.tsx'],
         rules: {
-            'no-restricted-syntax': [
-                'error',
-                ...markupWritingSyntax,
-                {
-                    selector: 'JSXText[value=/\\S/]',
-                    message:
-                        'A user-visible string belongs in src/Client.App/src/localization/en.ts, with its Polish counterpart, and reaches the screen through translate().',
-                },
-                {
-                    selector: ':matches(JSXElement, JSXFragment) > JSXExpressionContainer > Literal[value=/\\S/]',
-                    message:
-                        'A user-visible string belongs in src/Client.App/src/localization/en.ts and reaches the screen through translate(); a number is written with Intl under the active locale.',
-                },
-                {
-                    selector: ':matches(JSXElement, JSXFragment) > JSXExpressionContainer > TemplateLiteral',
-                    message:
-                        'A sentence assembled in markup cannot be reordered by a translator. Write it as one catalogue entry with a {name} hole and fill it through translate().',
-                },
-                // The same attribute in its three written forms, because a selector is matched against the syntax
-                // rather than against the value: `alt="…"` puts the literal directly under the attribute, while
-                // `alt={'…'}` and ``alt={`…`}`` put it one level down inside an expression container. A rule catching
-                // only the first would pass the two a person reaches for after being refused once. The step is
-                // deliberately not a descendant match: `aria-label={translate('shell.language')}` carries a string
-                // literal too, and it is the catalogue key rather than a sentence.
-                {
-                    selector: `${readOutAttribute} > Literal`,
-                    message: readOutAttributeMessage,
-                },
-                {
-                    selector: `${readOutAttribute} > JSXExpressionContainer > Literal[value=/\\S/]`,
-                    message: readOutAttributeMessage,
-                },
-                {
-                    selector: `${readOutAttribute} > JSXExpressionContainer > TemplateLiteral`,
-                    message: readOutAttributeMessage,
-                },
-            ],
+            'no-restricted-syntax': ['error', ...markupWritingSyntax, ...srcdocSyntax, ...localizationSyntax],
+        },
+    },
+    {
+        // The one exception ADR 0024 grants, written here rather than waived at the call site. This file draws a
+        // message's own markup in a frame, so it is the only place under `src/` where `srcdoc` is writable — and the
+        // exception is stated as the block above minus `srcdocSyntax`, so every other rule still holds on it and a
+        // rule added to either list reaches it without anybody remembering to.
+        files: [theOneMarkupSurface],
+        rules: {
+            'no-restricted-syntax': ['error', ...markupWritingSyntax, ...localizationSyntax],
         },
     },
     prettier,

--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -748,6 +748,32 @@ describe('App', () => {
         });
     });
 
+    it('returns to the message from the sender own markup, and places the reader in it', async () => {
+        renderApp(servedFrom, heldCredential, deploymentDrawingAConversation());
+        await framed();
+
+        await goTo('Mail');
+
+        const list = await screen.findByRole('listbox', { name: 'Messages' });
+        fireEvent.pointerDown(within(list).getByRole('option', { name: /Quarterly invoice/ }));
+
+        fireEvent.click(await screen.findByRole('button', { name: 'Show the full HTML version' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Show the HTML' }));
+
+        const surface = await screen.findByRole('region', { name: "The sender's own version of this message" });
+
+        fireEvent.click(within(surface).getByRole('button', { name: 'Close this view' }));
+
+        expect(await screen.findByText('A drawn message.')).toBeDefined();
+
+        // The same rule the conversation above is held to, and the one the two surfaces would otherwise disagree on:
+        // what decides it is that *something* was in front of the message rather than which of the two it was, so a
+        // reader leaving this one is placed exactly as a reader leaving that one is.
+        await waitFor(() => {
+            expect(document.activeElement).toBe(screen.getByRole('article', { name: /Quarterly invoice/ }));
+        });
+    });
+
     // Three things decide whether opening a message marks it read, and all three are the frame's: the reader's own
     // setting, the grant the credential signed in under, and there being a session to submit over. Nothing below the
     // frame asks the question, so this is where each of them is proven.

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -17,6 +17,7 @@ import type { PortraitExchange } from './deployment/portraitExchange';
 import type { DeploymentTransport } from './deployment/sendToDeployment';
 import { telemetryForwardedBy } from './deployment/telemetryForwarding';
 import { FolderTree } from './folders/FolderTree';
+import { FullHtmlSurface } from './fullHtml/FullHtmlSurface';
 import type { MessageKey } from './localization/en';
 import { useLocalization } from './localization/useLocalization';
 import { NothingOpen } from './mailSpace/NothingOpen';
@@ -291,9 +292,12 @@ export function App({
                 session={session}
                 transport={readMail}
                 conversation={workspace.conversation}
+                fullHtml={workspace.fullHtml}
                 storedEmailId={workspace.selection}
                 online={connection.online}
                 expandWholeThread={preferences.expandWholeThread}
+                onShowFullHtml={openTabs.openFullHtml}
+                onCloseFullHtml={openTabs.closeFullHtml}
             />
         );
     }
@@ -442,9 +446,13 @@ export function App({
     );
 }
 
-// What is being read on the right of the mail space: one message, or the conversation it belongs to standing in front
-// of it. The conversation is in front rather than instead, which is why the message it was opened from is still what
-// this component is holding — closing the conversation draws it again with nothing having had to remember it.
+// What is being read on the right of the mail space: one message, the conversation it belongs to, or the sender's own
+// markup — the last two standing in front of the message rather than instead of it, which is why the message they were
+// opened from is still what this component is holding. Closing either draws it again with nothing having had to
+// remember it.
+//
+// The markup surface is in front of the conversation as well as of the message, because it is opened from a message's
+// head and returns to whatever that head was drawn in.
 //
 // Keyed by the conversation together with the message it was opened at, because what a conversation opens with is
 // decided once from what it holds then: opening the same conversation at another message is a screen of its own rather
@@ -453,15 +461,21 @@ function OpenMail({
     session,
     transport,
     conversation,
+    fullHtml,
     storedEmailId,
     online,
     expandWholeThread,
+    onShowFullHtml,
+    onCloseFullHtml,
 }: {
     readonly session: ClientSession;
     readonly transport: MailFathomTransport;
     readonly conversation: OpenConversation | null;
+    readonly fullHtml: string | null;
     readonly storedEmailId: string | null;
     readonly online: boolean;
+    readonly onShowFullHtml: (storedEmailId: string, subject: string | null) => void;
+    readonly onCloseFullHtml: () => void;
 
     /** Whether the reader asked for conversations to open with every message drawn, which only the conversation reads. */
     readonly expandWholeThread: boolean;
@@ -479,12 +493,25 @@ function OpenMail({
         setArriving(conversation === null);
     }
 
+    if (fullHtml !== null) {
+        return (
+            <FullHtmlSurface
+                key={fullHtml}
+                session={session}
+                transport={transport}
+                storedEmailId={fullHtml}
+                onClose={onCloseFullHtml}
+            />
+        );
+    }
+
     return conversation === null ? (
         <ReadingPane
             session={session}
             transport={transport}
             storedEmailId={storedEmailId}
             online={online}
+            onShowFullHtml={onShowFullHtml}
             arriving={arriving}
         />
     ) : (

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -480,17 +480,23 @@ function OpenMail({
     /** Whether the reader asked for conversations to open with every message drawn, which only the conversation reads. */
     readonly expandWholeThread: boolean;
 }) {
-    // Whether the pane below is being arrived at rather than landed on. Closing a conversation swaps this position from
-    // one component to the other, so the pane mounts afresh exactly as it does on a cold start and cannot tell the two
-    // apart from anything it holds itself — this is the only place that saw the conversation go. Adjusted during render,
-    // which is React's answer to state that a changed prop invalidates, rather than read from a ref written during one:
-    // a ref would be written twice under StrictMode and the second pass would report no conversation had been there.
-    const [reading, setReading] = useState(conversation !== null);
+    // Whether the pane below is being arrived at rather than landed on. Closing whatever stood in front of the message
+    // swaps this position from one component to the other, so the pane mounts afresh exactly as it does on a cold start
+    // and cannot tell the two apart from anything it holds itself — this is the only place that saw the surface go.
+    // Adjusted during render, which is React's answer to state that a changed prop invalidates, rather than read from a
+    // ref written during one: a ref would be written twice under StrictMode and the second pass would report that
+    // nothing had been in front.
+    //
+    // The question is *whether something was in front* rather than which of the two it was, so the conversation and the
+    // markup surface are one value here. Asking it per surface is how closing the second one would leave focus on a
+    // control that has just been unmounted, while closing the first placed it correctly.
+    const covered = conversation !== null || fullHtml !== null;
+    const [wasCovered, setWasCovered] = useState(covered);
     const [arriving, setArriving] = useState(false);
 
-    if (reading !== (conversation !== null)) {
-        setReading(conversation !== null);
-        setArriving(conversation === null);
+    if (wasCovered !== covered) {
+        setWasCovered(covered);
+        setArriving(!covered);
     }
 
     if (fullHtml !== null) {
@@ -500,6 +506,7 @@ function OpenMail({
                 session={session}
                 transport={transport}
                 storedEmailId={fullHtml}
+                online={online}
                 onClose={onCloseFullHtml}
             />
         );

--- a/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.test.tsx
+++ b/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.test.tsx
@@ -73,10 +73,19 @@ function deploymentServing(markup: unknown = asSent): { transport: MailFathomTra
     };
 }
 
-async function drawing(transport: MailFathomTransport, onClose: () => void = () => undefined): Promise<void> {
+async function drawing(
+    transport: MailFathomTransport,
+    { onClose = () => undefined, online = true }: { onClose?: () => void; online?: boolean } = {},
+): Promise<void> {
     render(
         <LocalizationProvider>
-            <FullHtmlSurface session={session} transport={transport} storedEmailId={messageId} onClose={onClose} />
+            <FullHtmlSurface
+                session={session}
+                transport={transport}
+                storedEmailId={messageId}
+                online={online}
+                onClose={onClose}
+            />
         </LocalizationProvider>,
     );
 
@@ -164,7 +173,7 @@ describe('FullHtmlSurface', () => {
         const closed = vi.fn();
         const { transport } = deploymentServing();
 
-        await drawing(transport, closed);
+        await drawing(transport, { onClose: closed });
         press('Close this view');
 
         expect(closed).toHaveBeenCalledOnce();
@@ -176,5 +185,55 @@ describe('FullHtmlSurface', () => {
         await drawing(refusing);
 
         expect(await screen.findByText(/could not be read: unavailable/)).toBeDefined();
+    });
+
+    it('says the message itself could not be read rather than drawing a frame under a head that never arrives', async () => {
+        // Only the read behind the head refuses. Without one failure state for the two reads this is the quiet case:
+        // the frame draws the markup and the head goes on saying it is reading, so the surface looks like it worked.
+        const halfServing: MailFathomTransport = (request) =>
+            request.path.includes('/body')
+                ? Promise.resolve({ status: 200, body: body(asSent), headers: {} })
+                : Promise.reject(new Error('the deployment is not there'));
+
+        await drawing(halfServing);
+
+        expect(await screen.findByText(/could not be read: unavailable/)).toBeDefined();
+        expect(screen.queryByTitle("The sender's own markup, drawn in isolation")).toBeNull();
+        expect(screen.getByRole('button', { name: 'Try again' })).toBeDefined();
+    });
+
+    it('reads both the head and the markup again when the reader tries again', async () => {
+        let refusals = 2;
+
+        const recovering: MailFathomTransport = (request) => {
+            if (refusals > 0) {
+                refusals -= 1;
+
+                return Promise.reject(new Error('the deployment is not there'));
+            }
+
+            const answer: ClientResponse = request.path.includes('/body')
+                ? { status: 200, body: body(asSent), headers: {} }
+                : { status: 200, body: description, headers: {} };
+
+            return Promise.resolve(answer);
+        };
+
+        await drawing(recovering);
+        await screen.findByText(/could not be read: unavailable/);
+        press('Try again');
+
+        expect(await screen.findByTitle("The sender's own markup, drawn in isolation")).toBeDefined();
+        expect(screen.getByText('Quarterly invoice')).toBeDefined();
+    });
+
+    it('says the machine has no network rather than reporting the deployment as unavailable', async () => {
+        const { transport, asked } = deploymentServing();
+
+        await drawing(transport, { online: false });
+
+        expect(await screen.findByText(/This machine is offline/)).toBeDefined();
+        expect(screen.queryByText(/could not be read/)).toBeNull();
+        expect(asked).toEqual([]);
     });
 });

--- a/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.test.tsx
+++ b/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.test.tsx
@@ -73,23 +73,30 @@ function deploymentServing(markup: unknown = asSent): { transport: MailFathomTra
     };
 }
 
+/** Draws the surface, and answers with the way to hand it a network that came or went afterwards. */
 async function drawing(
     transport: MailFathomTransport,
     { onClose = () => undefined, online = true }: { onClose?: () => void; online?: boolean } = {},
-): Promise<void> {
-    render(
+): Promise<(nowOnline: boolean) => void> {
+    const surface = (hasNetwork: boolean) => (
         <LocalizationProvider>
             <FullHtmlSurface
                 session={session}
                 transport={transport}
                 storedEmailId={messageId}
-                online={online}
+                online={hasNetwork}
                 onClose={onClose}
             />
-        </LocalizationProvider>,
+        </LocalizationProvider>
     );
 
+    const view = render(surface(online));
+
     await screen.findByRole('region', { name: "The sender's own version of this message" });
+
+    return (nowOnline) => {
+        view.rerender(surface(nowOnline));
+    };
 }
 
 function press(name: string): void {
@@ -262,6 +269,29 @@ describe('FullHtmlSurface', () => {
 
         expect(await screen.findByTitle("The sender's own markup, drawn in isolation")).toBeDefined();
         expect(screen.getByText('Quarterly invoice')).toBeDefined();
+    });
+
+    it('keeps a markup it has already drawn when the network goes, because nothing about it stopped being true', async () => {
+        const { transport } = deploymentServing();
+
+        const network = await drawing(transport);
+        await screen.findByTitle("The sender's own markup, drawn in isolation");
+        network(false);
+
+        expect(screen.getByTitle("The sender's own markup, drawn in isolation")).toBeDefined();
+        expect(screen.queryByText(/This machine is offline/)).toBeNull();
+    });
+
+    it('stops saying it is reading the message once that read has definitively failed', async () => {
+        const halfServing: MailFathomTransport = (request) =>
+            request.path.includes('/body')
+                ? Promise.resolve({ status: 200, body: body(asSent), headers: {} })
+                : Promise.reject(new Error('the deployment is not there'));
+
+        await drawing(halfServing);
+
+        expect(await screen.findByText(/could not be read: unavailable/)).toBeDefined();
+        expect(screen.queryByText(/Reading the sender/)).toBeNull();
     });
 
     it('says the machine has no network rather than reporting the deployment as unavailable', async () => {

--- a/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.test.tsx
+++ b/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.test.tsx
@@ -169,6 +169,21 @@ describe('FullHtmlSurface', () => {
         ]);
     });
 
+    it('leaves the head alone when the pictures are asked for, rather than re-reading and blanking it', async () => {
+        const { transport, asked } = deploymentServing();
+
+        await drawing(transport);
+        await screen.findByTitle("The sender's own markup, drawn in isolation");
+        press('Load pictures from the sender');
+
+        await screen.findByText(/so their servers can tell it was opened/);
+
+        expect(asked.map((request) => request.path).filter((path) => !path.includes('/body'))).toEqual([
+            `${session.baseAddress}/api/client/messages/${messageId}`,
+        ]);
+        expect(screen.getByText('Quarterly invoice')).toBeDefined();
+    });
+
     it('leaves the surface through the control that closes it', async () => {
         const closed = vi.fn();
         const { transport } = deploymentServing();

--- a/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.test.tsx
+++ b/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.test.tsx
@@ -1,0 +1,180 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ClientRequest, ClientResponse, ClientSession, MailFathomTransport } from '@mailfathom/client-backend';
+import { LocalizationProvider } from '../localization/Localization';
+import { FullHtmlSurface } from './FullHtmlSurface';
+
+// The network boundary is the transport and it is the whole of what these tests fake, so the query the surface asks
+// under, the parsing that reads the answer, and the failure mapping are all under test rather than replaced.
+
+const session: ClientSession = {
+    baseAddress: 'https://mail.example.invalid',
+    authorization: 'Basic dGVzdA==',
+};
+
+const messageId = '00000000-0000-4000-8000-000000000000';
+
+const description = JSON.stringify({
+    storedEmailId: messageId,
+    account: 'work',
+    folder: 'INBOX',
+    threadId: null,
+    sizeOctets: 40_960,
+    headers: {
+        subject: 'Quarterly invoice',
+        sentAt: '2026-08-31T09:41:00+00:00',
+        receivedAt: '2026-08-31T09:41:10+00:00',
+        participants: [{ role: 'From', address: 'billing@example.invalid', displayName: 'Billing' }],
+        messageId: 'abc@example.invalid',
+        inReplyTo: null,
+        references: [],
+    },
+    body: { availability: 'Readable', plainText: true, html: true },
+    sender: { authorAuthentication: 'Authenticated', deploymentTrust: 'Unknown', authenticatedDomain: null },
+    attachments: [],
+    carried: null,
+    unread: true,
+    flagged: false,
+    answered: false,
+});
+
+function body(markup: unknown, remoteImagesRequested = false): string {
+    return JSON.stringify({
+        storedEmailId: messageId,
+        availability: 'Readable',
+        plainText: { text: 'The invoice is attached.', originalCharacterCount: 24, truncation: 'None' },
+        document: null,
+        selfContainedHtml: markup,
+        remoteImagesRequested,
+    });
+}
+
+const asSent = { text: '<p>The invoice, as it was sent.</p>', originalCharacterCount: 35, truncation: 'None' };
+
+/** A deployment answering both reads the surface makes, recording what each of them asked for. */
+function deploymentServing(markup: unknown = asSent): { transport: MailFathomTransport; asked: ClientRequest[] } {
+    const asked: ClientRequest[] = [];
+
+    return {
+        asked,
+        transport: (request) => {
+            asked.push(request);
+
+            const answer: ClientResponse = request.path.includes('/body')
+                ? { status: 200, body: body(markup, request.path.includes('remoteImages=true')), headers: {} }
+                : { status: 200, body: description, headers: {} };
+
+            return Promise.resolve(answer);
+        },
+    };
+}
+
+async function drawing(transport: MailFathomTransport, onClose: () => void = () => undefined): Promise<void> {
+    render(
+        <LocalizationProvider>
+            <FullHtmlSurface session={session} transport={transport} storedEmailId={messageId} onClose={onClose} />
+        </LocalizationProvider>,
+    );
+
+    await screen.findByRole('region', { name: "The sender's own version of this message" });
+}
+
+function press(name: string): void {
+    fireEvent.click(screen.getByRole('button', { name }));
+}
+
+describe('FullHtmlSurface', () => {
+    it('asks the deployment for the sender own markup rather than for the reduced tree alone', async () => {
+        const { transport, asked } = deploymentServing();
+
+        await drawing(transport);
+        await screen.findByTitle("The sender's own markup, drawn in isolation");
+
+        expect(asked.map((request) => request.path).filter((path) => path.includes('/body'))).toEqual([
+            `${session.baseAddress}/api/client/messages/${messageId}/body?fullHtml=true`,
+        ]);
+    });
+
+    it('names the message it is showing, and who sent it and when', async () => {
+        const { transport } = deploymentServing();
+
+        await drawing(transport);
+
+        expect(await screen.findByText('Quarterly invoice')).toBeDefined();
+        expect(screen.getByText(/^Billing · /)).toBeDefined();
+    });
+
+    it('takes focus into its own head, because opening it is a view change', async () => {
+        const { transport } = deploymentServing();
+
+        await drawing(transport);
+
+        expect(document.activeElement).toBe(
+            screen.getByRole('region', { name: "The sender's own version of this message" }),
+        );
+    });
+
+    it('says who holds each guarantee, rather than crediting the frame with both', async () => {
+        const { transport } = deploymentServing();
+
+        await drawing(transport);
+        await screen.findByTitle("The sender's own markup, drawn in isolation");
+
+        expect(screen.getByText(/the frame it is drawn in permits no script at all/)).toBeDefined();
+        expect(screen.getByText(/removed before this message was sent to the client/)).toBeDefined();
+    });
+
+    it('says so in words where the deployment served no markup for this message', async () => {
+        const { transport } = deploymentServing(null);
+
+        await drawing(transport);
+
+        expect(await screen.findByText(/no formatted version of this message/)).toBeDefined();
+        expect(screen.queryByTitle("The sender's own markup, drawn in isolation")).toBeNull();
+    });
+
+    it('reports the picture bound as its own loss, which the character bounds cannot name', async () => {
+        const { transport } = deploymentServing({ ...asSent, truncation: 'InlineImageOctetLimit' });
+
+        await drawing(transport);
+
+        expect(await screen.findByText(/more pictures of its own than one view holds/)).toBeDefined();
+    });
+
+    it('re-reads the one message with the ask when the reader wants the sender pictures', async () => {
+        const { transport, asked } = deploymentServing();
+
+        await drawing(transport);
+        await screen.findByTitle("The sender's own markup, drawn in isolation");
+        press('Load pictures from the sender');
+
+        await screen.findByText(/so their servers can tell it was opened/);
+
+        expect(asked.map((request) => request.path).filter((path) => path.includes('/body'))).toEqual([
+            `${session.baseAddress}/api/client/messages/${messageId}/body?fullHtml=true`,
+            `${session.baseAddress}/api/client/messages/${messageId}/body?remoteImages=true&fullHtml=true`,
+        ]);
+    });
+
+    it('leaves the surface through the control that closes it', async () => {
+        const closed = vi.fn();
+        const { transport } = deploymentServing();
+
+        await drawing(transport, closed);
+        press('Close this view');
+
+        expect(closed).toHaveBeenCalledOnce();
+    });
+
+    it('says what failed rather than showing an empty frame', async () => {
+        const refusing: MailFathomTransport = () => Promise.reject(new Error('the deployment is not there'));
+
+        await drawing(refusing);
+
+        expect(await screen.findByText(/could not be read: unavailable/)).toBeDefined();
+    });
+});

--- a/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.test.tsx
+++ b/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.test.tsx
@@ -146,6 +146,28 @@ describe('FullHtmlSurface', () => {
         expect(screen.queryByTitle("The sender's own markup, drawn in isolation")).toBeNull();
     });
 
+    it('says so in words where the markup arrived empty, rather than drawing a frame with nothing in it', async () => {
+        const { transport } = deploymentServing({ text: '', originalCharacterCount: 0, truncation: 'None' });
+
+        await drawing(transport);
+
+        expect(await screen.findByText(/no formatted version of this message/)).toBeDefined();
+        expect(screen.queryByTitle("The sender's own markup, drawn in isolation")).toBeNull();
+    });
+
+    it('names the bound that cut the markup to nothing, rather than reporting it as never written', async () => {
+        const { transport } = deploymentServing({
+            text: '',
+            originalCharacterCount: 90_000,
+            truncation: 'ReadCharacterBudget',
+        });
+
+        await drawing(transport);
+
+        expect(await screen.findByText(/longer than one read returns/)).toBeDefined();
+        expect(screen.queryByText(/no formatted version of this message/)).toBeNull();
+    });
+
     it('reports the picture bound as its own loss, which the character bounds cannot name', async () => {
         const { transport } = deploymentServing({ ...asSent, truncation: 'InlineImageOctetLimit' });
 

--- a/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.tsx
+++ b/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.tsx
@@ -2,7 +2,7 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
     readMailBody,
     readMailMessage,
@@ -64,6 +64,9 @@ interface Read {
     readonly attempt: number;
 }
 
+/** The part of a `Read` the head is read under. The sender's pictures are a body ask and are not in it. */
+type HeadRead = Pick<Read, 'storedEmailId' | 'attempt'>;
+
 export function FullHtmlSurface({
     session,
     transport,
@@ -85,9 +88,18 @@ export function FullHtmlSurface({
 }) {
     const { locale, translate } = useLocalization();
     const [read, setRead] = useState<Read>({ storedEmailId, remotePictures: false, attempt: 0 });
-    const [described, setDescribed] = useState<{ read: Read; result: ClientResult<MailMessage> } | null>(null);
+    const [described, setDescribed] = useState<{ read: HeadRead; result: ClientResult<MailMessage> } | null>(null);
     const [answer, setAnswer] = useState<{ read: Read; result: ClientResult<MailBody> } | null>(null);
     const [connected, setConnected] = useState(online);
+
+    // What the head is read under, held as one object so that both the effect below and the answer it keeps are keyed
+    // on the same identity. Asking for the sender's pictures leaves that identity alone, which is what makes the ask a
+    // second read of the body rather than of the whole message — and what stops the subject blanking while an identical
+    // head request repeats.
+    const headRead = useMemo<HeadRead>(
+        () => ({ storedEmailId: read.storedEmailId, attempt: read.attempt }),
+        [read.storedEmailId, read.attempt],
+    );
 
     // Opening the surface is a view change, so focus goes to the start of it rather than staying on the control that
     // was pressed — which the platform has just put focus back on as the confirmation closed, and which is on a screen
@@ -120,9 +132,9 @@ export function FullHtmlSurface({
         }
     }
 
-    // Both reads are keyed on the same `Read`, so one retry re-runs both and neither can be left behind on an older
-    // attempt than the other. Nothing is read without a network, and coming back re-runs them — which is the whole of
-    // the recovery from that direction and what makes the offline sentence's promise a true one.
+    // Both reads carry the same attempt, so one retry re-runs both and neither can be left behind on an older attempt
+    // than the other. Nothing is read without a network, and coming back re-runs them — which is the whole of the
+    // recovery from that direction and what makes the offline sentence's promise a true one.
     useEffect(() => {
         if (!online) {
             return;
@@ -130,16 +142,16 @@ export function FullHtmlSurface({
 
         let listening = true;
 
-        void readMailMessage(session, transport, read.storedEmailId).then((answered) => {
+        void readMailMessage(session, transport, headRead.storedEmailId).then((answered) => {
             if (listening) {
-                setDescribed({ read, result: answered });
+                setDescribed({ read: headRead, result: answered });
             }
         });
 
         return () => {
             listening = false;
         };
-    }, [session, transport, read, online]);
+    }, [session, transport, headRead, online]);
 
     useEffect(() => {
         if (!online) {
@@ -160,7 +172,7 @@ export function FullHtmlSurface({
         };
     }, [session, transport, read, online]);
 
-    const describing = described?.read === read ? described.result : null;
+    const describing = described?.read === headRead ? described.result : null;
     const drawn = answer?.read === read ? answer.result : null;
     const message = describing?.outcome === 'read' ? describing.value : null;
     const author = message?.headers.participants.find((participant) => participant.role === 'From') ?? null;

--- a/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.tsx
+++ b/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.tsx
@@ -309,6 +309,18 @@ function Markup({
 
     const cut = truncationNotes[markup.truncation];
 
+    // A representation that reduced to nothing is said in words, which is the obligation `MessageMarkupFrame` leaves to
+    // this surface: it draws no frame for an empty document, because only the surface knows why the markup is absent.
+    // A bound that cut it to nothing is what a reader is told where one did, and that the sender wrote none where none
+    // did — an empty frame would be a white rectangle claiming neither.
+    if (markup.text === '') {
+        return (
+            <p className="px-4 py-3 text-sm text-muted" role="status">
+                {translate(cut ?? 'fullHtml.noMarkup')}
+            </p>
+        );
+    }
+
     return (
         <>
             <MessageMarkupFrame markup={markup.text} />

--- a/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.tsx
+++ b/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.tsx
@@ -1,0 +1,268 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { useEffect, useRef, useState } from 'react';
+import {
+    readMailBody,
+    readMailMessage,
+    type ClientFailureReason,
+    type ClientResult,
+    type ClientSession,
+    type MailBody,
+    type MailBodyTruncation,
+    type MailFathomTransport,
+    type MailMessage,
+} from '@mailfathom/client-backend';
+import { Icon } from '../controls/Icon';
+import { SecondaryButton } from '../controls/SecondaryButton';
+import type { MessageKey } from '../localization/en';
+import { wordInstant } from '../localization/instants';
+import { useLocalization } from '../localization/useLocalization';
+import { MessageMarkupFrame } from '../messageBody/MessageMarkupFrame';
+
+// The second surface ADR 0024 takes: what the sender actually sent, drawn away from the reading pane for the reader
+// whose message reduced badly. It is a surface rather than a dialog — the content area where a message is read, or a
+// tab of its own where somebody works in tabs — and what it composes is the head the design project draws, the frame
+// beneath it, and the footer that says what is actually holding each promise.
+//
+// **The footer states two guarantees and attributes each to what holds it**, per #1483. The frame is what stops the
+// markup running. The representation is what stops it reporting: no sandboxing flag governs what a framed document
+// fetches, so the addresses are gone before the markup reaches this client rather than refused once it is here. A
+// footer that credited the frame with both would be reassurance the platform does not keep, on the one surface a
+// careful reader opens precisely because they do not trust the sender.
+//
+// Two reads stand behind it, as they do in the reading pane and for the same reason: the head is what the message
+// route answers and the markup is what the body route answers, so the head is drawn as soon as the first arrives.
+// Asking for the sender's pictures re-reads the body alone, on the terms the pane already uses — per message, nothing
+// durable, and gone again the moment the surface is closed.
+
+const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
+    unauthenticated: 'failure.unauthenticated',
+    unauthorized: 'failure.unauthorized',
+    unavailable: 'failure.unavailable',
+    unreadable: 'failure.unreadable',
+};
+
+// What a reader is told about each bound that could have cut this representation short, and nothing where none did.
+// A picture the sender attached that was left out is worth saying on this surface above all others, because a picture
+// that is absent and a picture that was never there look identical: the surface exists to check the reduction, so a
+// second silent loss on it would defeat the point of opening it.
+const truncationNotes: Readonly<Record<MailBodyTruncation, MessageKey | null>> = {
+    None: null,
+    BodyCharacterLimit: 'fullHtml.truncated',
+    ReadCharacterBudget: 'fullHtml.truncated',
+    SensitiveContentScanCeiling: 'fullHtml.truncated',
+    InlineImageOctetLimit: 'fullHtml.picturesTruncated',
+};
+
+/** What is being read: which message, under which ask, and which attempt at it. A change to any of the three reads. */
+interface Read {
+    readonly storedEmailId: string;
+    readonly remotePictures: boolean;
+    readonly attempt: number;
+}
+
+export function FullHtmlSurface({
+    session,
+    transport,
+    storedEmailId,
+    onClose,
+}: {
+    readonly session: ClientSession;
+    readonly transport: MailFathomTransport;
+
+    /** The message whose own markup is being shown, which the reader confirmed one press ago. */
+    readonly storedEmailId: string;
+
+    /** Leaves the surface, which returns to whatever the reading column was drawing before it. */
+    readonly onClose: () => void;
+}) {
+    const { locale, translate } = useLocalization();
+    const [read, setRead] = useState<Read>({ storedEmailId, remotePictures: false, attempt: 0 });
+    const [described, setDescribed] = useState<ClientResult<MailMessage> | null>(null);
+    const [answer, setAnswer] = useState<{ read: Read; result: ClientResult<MailBody> } | null>(null);
+
+    // Opening the surface is a view change, so focus goes to the start of it rather than staying on the control that
+    // was pressed — which the platform has just put focus back on as the confirmation closed, and which is on a screen
+    // the reader has now left. A ref rather than a flag, for the reason the reading pane's own guard is one: it has to
+    // survive StrictMode invoking the effect twice.
+    const head = useRef<HTMLElement>(null);
+    const focusedOn = useRef<string | null>(null);
+
+    useEffect(() => {
+        if (focusedOn.current !== storedEmailId) {
+            focusedOn.current = storedEmailId;
+            head.current?.focus();
+        }
+    }, [storedEmailId]);
+
+    useEffect(() => {
+        let listening = true;
+
+        void readMailMessage(session, transport, storedEmailId).then((answered) => {
+            if (listening) {
+                setDescribed(answered);
+            }
+        });
+
+        return () => {
+            listening = false;
+        };
+    }, [session, transport, storedEmailId]);
+
+    useEffect(() => {
+        let listening = true;
+        const ask = { remoteImages: read.remotePictures, fullHtml: true };
+
+        void readMailBody(session, transport, read.storedEmailId, ask).then((answered) => {
+            if (listening) {
+                setAnswer({ read, result: answered });
+            }
+        });
+
+        return () => {
+            listening = false;
+        };
+    }, [session, transport, read]);
+
+    const message = described?.outcome === 'read' ? described.value : null;
+    const author = message?.headers.participants.find((participant) => participant.role === 'From') ?? null;
+    const sentAt = message === null ? null : wordInstant(message.headers.sentAt, locale, 'full');
+
+    return (
+        <section ref={head} tabIndex={-1} aria-label={translate('fullHtml.surface')} className="flex h-full flex-col">
+            <header className="flex flex-wrap items-center gap-3 border-b border-line px-4 py-2.5">
+                <span className="rounded-xs bg-accent px-1.75 py-0.75 text-xs tracking-widest text-on-accent">
+                    {translate('fullHtml.mark')}
+                </span>
+
+                <div className="flex min-w-0 flex-1 basis-48 flex-col">
+                    <span className="truncate text-md font-semibold">
+                        {message === null
+                            ? translate('fullHtml.reading')
+                            : (message.headers.subject ?? translate('message.noSubject'))}
+                    </span>
+
+                    <span className="truncate text-sm text-muted">
+                        {translate('fullHtml.sentBy', {
+                            author: author?.displayName ?? author?.address ?? translate('message.noAuthor'),
+                            when: sentAt ?? translate('message.sentAtUnknown'),
+                        })}
+                    </span>
+                </div>
+
+                <button
+                    type="button"
+                    aria-label={translate('fullHtml.close')}
+                    title={translate('fullHtml.close')}
+                    className="flex size-8 shrink-0 items-center justify-center rounded-md text-muted transition hover:bg-hover hover:text-text"
+                    onClick={onClose}
+                >
+                    <Icon name="close" className="size-5" />
+                </button>
+            </header>
+
+            <Markup
+                answered={answer?.read === read ? answer.result : null}
+                onRetry={() => {
+                    setRead({ ...read, attempt: read.attempt + 1 });
+                }}
+            />
+
+            <Isolation
+                remotePictures={read.remotePictures}
+                onShowRemotePictures={() => {
+                    setRead({ ...read, remotePictures: true });
+                }}
+            />
+        </section>
+    );
+}
+
+// The markup itself, in the five states a surface that waits owes somebody. A body that answered without the
+// representation is the one state a frame cannot express, so it is said in words: the deployment sent no markup for
+// this message, which is what a message with no formatted part looks like from here.
+function Markup({
+    answered,
+    onRetry,
+}: {
+    readonly answered: ClientResult<MailBody> | null;
+    readonly onRetry: () => void;
+}) {
+    const { translate } = useLocalization();
+
+    if (answered === null) {
+        return (
+            <p className="px-4 py-3 text-sm text-muted" role="status">
+                {translate('fullHtml.reading')}
+            </p>
+        );
+    }
+
+    if (answered.outcome === 'failed') {
+        return (
+            <div className="flex flex-col items-start gap-2 px-4 py-3">
+                <p className="text-sm text-warning" role="alert">
+                    {translate('fullHtml.failed', { reason: translate(failureLabels[answered.failure.reason]) })}
+                </p>
+
+                {/* Reading again is the way out of exactly one of the four failures, for the reason
+                    `shell/ConnectionSummary.tsx` gives: the other three repeat identically on a second attempt. */}
+                {answered.failure.reason === 'unavailable' ? (
+                    <SecondaryButton label={translate('connection.retry')} onActivate={onRetry} />
+                ) : null}
+            </div>
+        );
+    }
+
+    const markup = answered.value.selfContainedHtml;
+
+    if (markup === null) {
+        return (
+            <p className="px-4 py-3 text-sm text-muted" role="status">
+                {translate('fullHtml.noMarkup')}
+            </p>
+        );
+    }
+
+    const cut = truncationNotes[markup.truncation];
+
+    return (
+        <>
+            <MessageMarkupFrame markup={markup.text} />
+
+            {cut === null ? null : (
+                <p className="border-t border-line-soft px-4 py-2 text-sm text-muted">{translate(cut)}</p>
+            )}
+        </>
+    );
+}
+
+// The footer, which is the whole reason the two mechanisms are named separately anywhere. The first sentence belongs to
+// the frame and the second to the representation, and the second changes once the reader has asked for the sender's
+// pictures: from *nothing here reaches them* to *this one message is fetching from them, and nothing remembers that*.
+function Isolation({
+    remotePictures,
+    onShowRemotePictures,
+}: {
+    readonly remotePictures: boolean;
+    readonly onShowRemotePictures: () => void;
+}) {
+    const { translate } = useLocalization();
+
+    return (
+        <footer className="flex flex-wrap items-center gap-x-3 gap-y-1.5 border-t border-line bg-sunken px-4 py-2.5 text-sm text-muted">
+            <Icon name="lock" className="size-4 shrink-0" />
+
+            <p className="min-w-0 flex-1 basis-64">
+                {translate('fullHtml.cannotRun')}{' '}
+                {translate(remotePictures ? 'fullHtml.picturesAsked' : 'fullHtml.reachesNobody')}
+            </p>
+
+            {remotePictures ? null : (
+                <SecondaryButton label={translate('body.showRemotePictures')} onActivate={onShowRemotePictures} />
+            )}
+        </footer>
+    );
+}

--- a/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.tsx
+++ b/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from 'react';
 import {
     readMailBody,
     readMailMessage,
+    type ClientFailure,
     type ClientFailureReason,
     type ClientResult,
     type ClientSession,
@@ -67,6 +68,7 @@ export function FullHtmlSurface({
     session,
     transport,
     storedEmailId,
+    online,
     onClose,
 }: {
     readonly session: ClientSession;
@@ -75,43 +77,75 @@ export function FullHtmlSurface({
     /** The message whose own markup is being shown, which the reader confirmed one press ago. */
     readonly storedEmailId: string;
 
+    /** Whether this machine has a network, which is a different thing from the deployment refusing to answer. */
+    readonly online: boolean;
+
     /** Leaves the surface, which returns to whatever the reading column was drawing before it. */
     readonly onClose: () => void;
 }) {
     const { locale, translate } = useLocalization();
     const [read, setRead] = useState<Read>({ storedEmailId, remotePictures: false, attempt: 0 });
-    const [described, setDescribed] = useState<ClientResult<MailMessage> | null>(null);
+    const [described, setDescribed] = useState<{ read: Read; result: ClientResult<MailMessage> } | null>(null);
     const [answer, setAnswer] = useState<{ read: Read; result: ClientResult<MailBody> } | null>(null);
+    const [connected, setConnected] = useState(online);
 
     // Opening the surface is a view change, so focus goes to the start of it rather than staying on the control that
     // was pressed — which the platform has just put focus back on as the confirmation closed, and which is on a screen
     // the reader has now left. A ref rather than a flag, for the reason the reading pane's own guard is one: it has to
     // survive StrictMode invoking the effect twice.
-    const head = useRef<HTMLElement>(null);
+    const region = useRef<HTMLElement>(null);
     const focusedOn = useRef<string | null>(null);
 
     useEffect(() => {
         if (focusedOn.current !== storedEmailId) {
             focusedOn.current = storedEmailId;
-            head.current?.focus();
+            region.current?.focus();
         }
     }, [storedEmailId]);
 
+    // A failure the network gap itself caused goes with the gap, so what stands while there is no network is the
+    // offline sentence rather than a refusal a reader would have to press through. Adjusted during render, which is
+    // where React answers a changed prop, exactly as `readingPane/ReadingPane.tsx` answers the same prop.
+    if (connected !== online) {
+        setConnected(online);
+
+        if (!online) {
+            if (described?.result.outcome === 'failed') {
+                setDescribed(null);
+            }
+
+            if (answer?.result.outcome === 'failed') {
+                setAnswer(null);
+            }
+        }
+    }
+
+    // Both reads are keyed on the same `Read`, so one retry re-runs both and neither can be left behind on an older
+    // attempt than the other. Nothing is read without a network, and coming back re-runs them — which is the whole of
+    // the recovery from that direction and what makes the offline sentence's promise a true one.
     useEffect(() => {
+        if (!online) {
+            return;
+        }
+
         let listening = true;
 
-        void readMailMessage(session, transport, storedEmailId).then((answered) => {
+        void readMailMessage(session, transport, read.storedEmailId).then((answered) => {
             if (listening) {
-                setDescribed(answered);
+                setDescribed({ read, result: answered });
             }
         });
 
         return () => {
             listening = false;
         };
-    }, [session, transport, storedEmailId]);
+    }, [session, transport, read, online]);
 
     useEffect(() => {
+        if (!online) {
+            return;
+        }
+
         let listening = true;
         const ask = { remoteImages: read.remotePictures, fullHtml: true };
 
@@ -124,14 +158,23 @@ export function FullHtmlSurface({
         return () => {
             listening = false;
         };
-    }, [session, transport, read]);
+    }, [session, transport, read, online]);
 
-    const message = described?.outcome === 'read' ? described.value : null;
+    const describing = described?.read === read ? described.result : null;
+    const drawn = answer?.read === read ? answer.result : null;
+    const message = describing?.outcome === 'read' ? describing.value : null;
     const author = message?.headers.participants.find((participant) => participant.role === 'From') ?? null;
     const sentAt = message === null ? null : wordInstant(message.headers.sentAt, locale, 'full');
 
+    // **One failure state for two reads.** Either read failing leaves this surface unable to be what it is — the head
+    // names the message and the body is the message — so a reader is told once, with one way out, rather than being
+    // shown a frame under a header that never stops saying it is reading. The head's failure is reported first because
+    // it is the one that would otherwise be silent: a frame drawn below it looks like a surface that worked.
+    const failure =
+        describing?.outcome === 'failed' ? describing.failure : drawn?.outcome === 'failed' ? drawn.failure : null;
+
     return (
-        <section ref={head} tabIndex={-1} aria-label={translate('fullHtml.surface')} className="flex h-full flex-col">
+        <section ref={region} tabIndex={-1} aria-label={translate('fullHtml.surface')} className="flex h-full flex-col">
             <header className="flex flex-wrap items-center gap-3 border-b border-line px-4 py-2.5">
                 <span className="rounded-xs bg-accent px-1.75 py-0.75 text-xs tracking-widest text-on-accent">
                     {translate('fullHtml.mark')}
@@ -144,12 +187,17 @@ export function FullHtmlSurface({
                             : (message.headers.subject ?? translate('message.noSubject'))}
                     </span>
 
-                    <span className="truncate text-sm text-muted">
-                        {translate('fullHtml.sentBy', {
-                            author: author?.displayName ?? author?.address ?? translate('message.noAuthor'),
-                            when: sentAt ?? translate('message.sentAtUnknown'),
-                        })}
-                    </span>
+                    {/* Nothing is claimed about who sent a message that has not been read. A line naming an unknown
+                        author beside an unknown time is a sentence about this client's state dressed as a fact about
+                        the message, on the surface a reader opened because they were checking. */}
+                    {message === null ? null : (
+                        <span className="truncate text-sm text-muted">
+                            {translate('fullHtml.sentBy', {
+                                author: author?.displayName ?? author?.address ?? translate('message.noAuthor'),
+                                when: sentAt ?? translate('message.sentAtUnknown'),
+                            })}
+                        </span>
+                    )}
                 </div>
 
                 <button
@@ -164,7 +212,9 @@ export function FullHtmlSurface({
             </header>
 
             <Markup
-                answered={answer?.read === read ? answer.result : null}
+                online={online}
+                failure={failure}
+                drawn={drawn}
                 onRetry={() => {
                     setRead({ ...read, attempt: read.attempt + 1 });
                 }}
@@ -180,19 +230,54 @@ export function FullHtmlSurface({
     );
 }
 
-// The markup itself, in the five states a surface that waits owes somebody. A body that answered without the
-// representation is the one state a frame cannot express, so it is said in words: the deployment sent no markup for
-// this message, which is what a message with no formatted part looks like from here.
+// The markup itself, in the five states a surface that waits owes somebody. Two of them are said in words because no
+// frame can express either: a body that answered without the representation, which is what a message with no formatted
+// part looks like from here, and a machine with no network, which is a different thing from a deployment refusing.
+//
+// The failure it draws is either read's, resolved by the surface above rather than read off the body alone — a header
+// stuck on *reading* above a frame that worked is the shape this exists to refuse.
 function Markup({
-    answered,
+    online,
+    failure,
+    drawn,
     onRetry,
 }: {
-    readonly answered: ClientResult<MailBody> | null;
+    readonly online: boolean;
+    readonly failure: ClientFailure | null;
+    readonly drawn: ClientResult<MailBody> | null;
     readonly onRetry: () => void;
 }) {
     const { translate } = useLocalization();
 
-    if (answered === null) {
+    // Offline is its own sentence rather than a failure worded politely, and it is said in place of everything else:
+    // unlike the reading pane, this surface has nothing already drawn to keep, because a reader reaches it by pressing
+    // a control and there is no earlier answer standing behind that press.
+    if (!online) {
+        return (
+            <p className="px-4 py-3 text-sm text-muted" role="status">
+                {translate('message.offline')}
+            </p>
+        );
+    }
+
+    if (failure !== null) {
+        return (
+            <div className="flex flex-col items-start gap-2 px-4 py-3">
+                <p className="text-sm text-warning" role="alert">
+                    {translate('fullHtml.failed', { reason: translate(failureLabels[failure.reason]) })}
+                </p>
+
+                {/* Reading again is the way out of exactly one of the four failures, for the reason
+                    `shell/ConnectionSummary.tsx` gives: the other three repeat identically on a second attempt. It
+                    re-runs both reads, because both are keyed on the one attempt. */}
+                {failure.reason === 'unavailable' ? (
+                    <SecondaryButton label={translate('connection.retry')} onActivate={onRetry} />
+                ) : null}
+            </div>
+        );
+    }
+
+    if (drawn?.outcome !== 'read') {
         return (
             <p className="px-4 py-3 text-sm text-muted" role="status">
                 {translate('fullHtml.reading')}
@@ -200,23 +285,7 @@ function Markup({
         );
     }
 
-    if (answered.outcome === 'failed') {
-        return (
-            <div className="flex flex-col items-start gap-2 px-4 py-3">
-                <p className="text-sm text-warning" role="alert">
-                    {translate('fullHtml.failed', { reason: translate(failureLabels[answered.failure.reason]) })}
-                </p>
-
-                {/* Reading again is the way out of exactly one of the four failures, for the reason
-                    `shell/ConnectionSummary.tsx` gives: the other three repeat identically on a second attempt. */}
-                {answered.failure.reason === 'unavailable' ? (
-                    <SecondaryButton label={translate('connection.retry')} onActivate={onRetry} />
-                ) : null}
-            </div>
-        );
-    }
-
-    const markup = answered.value.selfContainedHtml;
+    const markup = drawn.value.selfContainedHtml;
 
     if (markup === null) {
         return (

--- a/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.tsx
+++ b/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.tsx
@@ -185,6 +185,17 @@ export function FullHtmlSurface({
     const failure =
         describing?.outcome === 'failed' ? describing.failure : drawn?.outcome === 'failed' ? drawn.failure : null;
 
+    // The head names the message once it has been read, says it is reading while it is, and says nothing otherwise. A
+    // head that failed is reported below, with the way out beside it; repeating it here in the present tense would have
+    // the surface saying it is still reading something it has already given up on. With no network nothing is being
+    // read at all, which is the same sentence for the same reason.
+    const naming =
+        message !== null
+            ? (message.headers.subject ?? translate('message.noSubject'))
+            : online && describing === null
+              ? translate('fullHtml.reading')
+              : null;
+
     return (
         <section ref={region} tabIndex={-1} aria-label={translate('fullHtml.surface')} className="flex h-full flex-col">
             <header className="flex flex-wrap items-center gap-3 border-b border-line px-4 py-2.5">
@@ -193,11 +204,7 @@ export function FullHtmlSurface({
                 </span>
 
                 <div className="flex min-w-0 flex-1 basis-48 flex-col">
-                    <span className="truncate text-md font-semibold">
-                        {message === null
-                            ? translate('fullHtml.reading')
-                            : (message.headers.subject ?? translate('message.noSubject'))}
-                    </span>
+                    {naming === null ? null : <span className="truncate text-md font-semibold">{naming}</span>}
 
                     {/* Nothing is claimed about who sent a message that has not been read. A line naming an unknown
                         author beside an unknown time is a sentence about this client's state dressed as a fact about
@@ -261,10 +268,11 @@ function Markup({
 }) {
     const { translate } = useLocalization();
 
-    // Offline is its own sentence rather than a failure worded politely, and it is said in place of everything else:
-    // unlike the reading pane, this surface has nothing already drawn to keep, because a reader reaches it by pressing
-    // a control and there is no earlier answer standing behind that press.
-    if (!online) {
+    // Offline is its own sentence rather than a failure worded politely, and it is said in place of everything else —
+    // except a markup that already arrived. A drawn frame needs no network to go on showing what it shows, and nothing
+    // about it stopped being true when the network went, which is exactly the guard `readingPane/ReadingPane.tsx` puts
+    // on the same prop. What the sentence replaces is a surface with nothing on it yet.
+    if (!online && drawn?.outcome !== 'read') {
         return (
             <p className="px-4 py-3 text-sm text-muted" role="status">
                 {translate('message.offline')}

--- a/frontend/src/Client.App/src/fullHtml/ShowFullHtml.test.tsx
+++ b/frontend/src/Client.App/src/fullHtml/ShowFullHtml.test.tsx
@@ -3,57 +3,18 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { LocalizationProvider } from '../localization/Localization';
 import { ShowFullHtml } from './ShowFullHtml';
 
-const declaredShowModal = Object.getOwnPropertyDescriptor(HTMLDialogElement.prototype, 'showModal');
-const declaredClose = Object.getOwnPropertyDescriptor(HTMLDialogElement.prototype, 'close');
-
-// The confirmation is the platform's own modal dialog, which jsdom implements none of. What is stood in for here is
-// only what the assertions below read, and all of it is what the platform's own close algorithm does: the `open`
-// attribute it sets and clears, the return value an answer leaves behind, and the `close` event that carries the
-// answer back to the page. The focus trap and the restoration afterwards are the two parts not modelled, because
-// jsdom has no top layer to hold or restore focus from — what a test here can hold is that both answers leave through
-// `close()`, which is what the platform's own restoration hangs off, and the browser suite is what has a browser.
-function withModalDialogs(): void {
-    Object.defineProperty(HTMLDialogElement.prototype, 'showModal', {
-        configurable: true,
-        value(this: HTMLDialogElement) {
-            this.setAttribute('open', '');
-        },
-    });
-    Object.defineProperty(HTMLDialogElement.prototype, 'close', {
-        configurable: true,
-        value(this: HTMLDialogElement, returnValue?: string) {
-            this.removeAttribute('open');
-
-            if (returnValue !== undefined) {
-                this.returnValue = returnValue;
-            }
-
-            this.dispatchEvent(new Event('close'));
-        },
-    });
-}
-
-afterEach(() => {
-    if (declaredShowModal === undefined) {
-        Reflect.deleteProperty(HTMLDialogElement.prototype, 'showModal');
-    } else {
-        Object.defineProperty(HTMLDialogElement.prototype, 'showModal', declaredShowModal);
-    }
-
-    if (declaredClose === undefined) {
-        Reflect.deleteProperty(HTMLDialogElement.prototype, 'close');
-    } else {
-        Object.defineProperty(HTMLDialogElement.prototype, 'close', declaredClose);
-    }
-});
+// The confirmation is the platform's own modal dialog, and `vitest.setup.ts` stands in for the two methods jsdom does
+// not implement: the `open` state, the answer `close()` records, and the event that carries it back to the page — which
+// is the whole of what the assertions below read. The focus trap and the restoration afterwards are the two parts
+// nothing here models, because jsdom has no top layer to hold or restore focus from. What a test here can hold is that
+// both answers leave through `close()`, which is what the platform's own restoration hangs off; the browser suite is
+// what has a browser.
 
 function drawing(onShow: () => void): void {
-    withModalDialogs();
-
     render(
         <LocalizationProvider>
             <ShowFullHtml onShow={onShow} />

--- a/frontend/src/Client.App/src/fullHtml/ShowFullHtml.test.tsx
+++ b/frontend/src/Client.App/src/fullHtml/ShowFullHtml.test.tsx
@@ -1,0 +1,122 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { LocalizationProvider } from '../localization/Localization';
+import { ShowFullHtml } from './ShowFullHtml';
+
+const declaredShowModal = Object.getOwnPropertyDescriptor(HTMLDialogElement.prototype, 'showModal');
+const declaredClose = Object.getOwnPropertyDescriptor(HTMLDialogElement.prototype, 'close');
+
+// The confirmation is the platform's own modal dialog, which jsdom implements none of. What is stood in for here is
+// only what the assertions below read, and all of it is what the platform's own close algorithm does: the `open`
+// attribute it sets and clears, the return value an answer leaves behind, and the `close` event that carries the
+// answer back to the page. The focus trap and the restoration afterwards are the two parts not modelled, because
+// jsdom has no top layer to hold or restore focus from — what a test here can hold is that both answers leave through
+// `close()`, which is what the platform's own restoration hangs off, and the browser suite is what has a browser.
+function withModalDialogs(): void {
+    Object.defineProperty(HTMLDialogElement.prototype, 'showModal', {
+        configurable: true,
+        value(this: HTMLDialogElement) {
+            this.setAttribute('open', '');
+        },
+    });
+    Object.defineProperty(HTMLDialogElement.prototype, 'close', {
+        configurable: true,
+        value(this: HTMLDialogElement, returnValue?: string) {
+            this.removeAttribute('open');
+
+            if (returnValue !== undefined) {
+                this.returnValue = returnValue;
+            }
+
+            this.dispatchEvent(new Event('close'));
+        },
+    });
+}
+
+afterEach(() => {
+    if (declaredShowModal === undefined) {
+        Reflect.deleteProperty(HTMLDialogElement.prototype, 'showModal');
+    } else {
+        Object.defineProperty(HTMLDialogElement.prototype, 'showModal', declaredShowModal);
+    }
+
+    if (declaredClose === undefined) {
+        Reflect.deleteProperty(HTMLDialogElement.prototype, 'close');
+    } else {
+        Object.defineProperty(HTMLDialogElement.prototype, 'close', declaredClose);
+    }
+});
+
+function drawing(onShow: () => void): void {
+    withModalDialogs();
+
+    render(
+        <LocalizationProvider>
+            <ShowFullHtml onShow={onShow} />
+        </LocalizationProvider>,
+    );
+}
+
+function press(name: string): void {
+    fireEvent.click(screen.getByRole('button', { name }));
+}
+
+describe('ShowFullHtml', () => {
+    it('shows nothing until the reader has been asked, so pressing it opens the question rather than the markup', () => {
+        const shown = vi.fn();
+
+        drawing(shown);
+
+        expect(screen.queryByRole('heading', { name: 'Show the full HTML?' })).toBeNull();
+
+        press('Show the full HTML version');
+
+        expect(screen.getByRole('heading', { name: 'Show the full HTML?' })).toBeDefined();
+        expect(shown).not.toHaveBeenCalled();
+    });
+
+    it('names what a stranger markup can carry and what this client does about it', () => {
+        drawing(vi.fn());
+
+        press('Show the full HTML version');
+
+        expect(screen.getByText(/tracking pixels/)).toBeDefined();
+        expect(screen.getByText(/Nothing in it can run/)).toBeDefined();
+    });
+
+    it('leaves the message exactly as it was when the reader stays with the reduced version', () => {
+        const shown = vi.fn();
+
+        drawing(shown);
+        press('Show the full HTML version');
+        press('Stay with the reduced version');
+
+        expect(shown).not.toHaveBeenCalled();
+        expect(screen.queryByRole('heading', { name: 'Show the full HTML?' })).toBeNull();
+    });
+
+    it('opens the surface once the reader has answered the question', () => {
+        const shown = vi.fn();
+
+        drawing(shown);
+        press('Show the full HTML version');
+        press('Show the HTML');
+
+        expect(shown).toHaveBeenCalledOnce();
+    });
+
+    it('asks again the next time, because neither answer is remembered', () => {
+        const shown = vi.fn();
+
+        drawing(shown);
+        press('Show the full HTML version');
+        press('Stay with the reduced version');
+        press('Show the full HTML version');
+
+        expect(screen.getByRole('heading', { name: 'Show the full HTML?' })).toBeDefined();
+    });
+});

--- a/frontend/src/Client.App/src/fullHtml/ShowFullHtml.tsx
+++ b/frontend/src/Client.App/src/fullHtml/ShowFullHtml.tsx
@@ -1,0 +1,96 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { useRef } from 'react';
+import { Icon } from '../controls/Icon';
+import { useLocalization } from '../localization/useLocalization';
+
+// The control the design project puts on a message's head, and the question it asks before anything is shown. Pressing
+// it opens neither a frame nor a read: it opens a confirmation, because what the surface behind it draws is markup a
+// stranger wrote and the reader is owed the chance to stay where they are.
+//
+// The question names what that markup can carry and what this client does about it, and it is careful about which half
+// is which. Scripts and remote resources are blocked; the sender may still be able to tell the message was opened,
+// because a reader who then asks for the pictures has asked for exactly that. Overstating either half is the failure
+// mode a confirmation has — a reader who learns the words are reassurance stops reading them.
+//
+// Nothing about either answer is written down, per message or otherwise. Declining leaves the message as it was and
+// pressing again asks again; accepting opens the surface for as long as it stays open and no longer, which is what
+// `workspace/rememberedWorkspace.ts` keeps true across a reload.
+//
+// The platform's own modal dialog, so four things are the browser's rather than this file's: the page behind it is
+// inert, focus moves into it and is held there, Escape leaves it, and leaving it puts focus back on the control that
+// opened it. Both answers therefore leave through `close()`, and which one it was travels the way the platform carries
+// it — in the return value.
+
+const markupShows = 'show-the-markup';
+
+export function ShowFullHtml({ onShow }: { readonly onShow: () => void }) {
+    const { translate } = useLocalization();
+    const asked = useRef<HTMLDialogElement>(null);
+
+    return (
+        <>
+            <button
+                type="button"
+                aria-label={translate('fullHtml.show')}
+                title={translate('fullHtml.show')}
+                className="flex size-8 shrink-0 items-center justify-center rounded-md text-muted transition hover:bg-hover hover:text-text"
+                onClick={() => {
+                    asked.current?.showModal();
+                }}
+            >
+                <Icon name="code" className="size-5" />
+            </button>
+
+            <dialog
+                ref={asked}
+                aria-labelledby="show-full-html"
+                className="m-auto w-104 max-w-full rounded-3xl border border-line bg-panel p-5 text-text shadow-dialog backdrop:bg-scrim"
+                onClose={() => {
+                    if (asked.current?.returnValue === markupShows) {
+                        onShow();
+                    }
+                }}
+            >
+                <div className="flex flex-col gap-3.5">
+                    <div className="flex items-start gap-2.5">
+                        <Icon name="warning" className="mt-0.5 size-5 shrink-0 text-warning" />
+
+                        <div className="flex min-w-0 flex-col gap-1.5">
+                            <h2 id="show-full-html" className="text-xl font-semibold">
+                                {translate('fullHtml.question')}
+                            </h2>
+
+                            <p className="text-base text-muted">{translate('fullHtml.whatItCanCarry')}</p>
+                            <p className="text-base text-muted">{translate('fullHtml.whatIsBlocked')}</p>
+                        </div>
+                    </div>
+
+                    <div className="flex flex-wrap justify-end gap-2">
+                        <button
+                            type="button"
+                            className="rounded-lg border border-line bg-sunken px-3.75 py-2 text-base text-text-soft transition hover:bg-hover"
+                            onClick={() => {
+                                asked.current?.close();
+                            }}
+                        >
+                            {translate('fullHtml.stayReduced')}
+                        </button>
+
+                        <button
+                            type="button"
+                            className="rounded-lg bg-accent px-4 py-2 text-base font-semibold text-on-accent transition hover:opacity-90"
+                            onClick={() => {
+                                asked.current?.close(markupShows);
+                            }}
+                        >
+                            {translate('fullHtml.confirm')}
+                        </button>
+                    </div>
+                </div>
+            </dialog>
+        </>
+    );
+}

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -390,6 +390,31 @@ export const en = {
     'body.undrawnPicturesCount': 'Pictures too large to draw: {count}',
     'body.quotedHistory': 'The conversation this message quoted',
 
+    'fullHtml.show': 'Show the full HTML version',
+    'fullHtml.question': 'Show the full HTML?',
+    'fullHtml.whatItCanCarry':
+        'The sender wrote this markup themselves. It can carry tracking pixels, a layout imitating a brand you know, and links that go somewhere other than they say.',
+    'fullHtml.whatIsBlocked':
+        'Nothing in it can run, and nothing in it reaches the sender until you ask for their pictures.',
+    'fullHtml.stayReduced': 'Stay with the reduced version',
+    'fullHtml.confirm': 'Show the HTML',
+    'fullHtml.surface': "The sender's own version of this message",
+    'fullHtml.mark': 'HTML',
+    'fullHtml.frame': "The sender's own markup, drawn in isolation",
+    'fullHtml.sentBy': '{author} · {when}',
+    'fullHtml.close': 'Close this view',
+    'fullHtml.reading': "Reading the sender's own version…",
+    'fullHtml.failed': "The sender's own version could not be read: {reason}.",
+    'fullHtml.noMarkup': 'The sender wrote no formatted version of this message, so there is nothing to show here.',
+    'fullHtml.truncated': 'This message is longer than one read returns, so it stops here.',
+    'fullHtml.picturesTruncated':
+        'This message carried more pictures of its own than one view holds, so some of them are missing.',
+    'fullHtml.cannotRun': 'This message cannot run anything: the frame it is drawn in permits no script at all.',
+    'fullHtml.reachesNobody':
+        'It carries no address that would reach the sender — every one of them was removed before this message was sent to the client.',
+    'fullHtml.picturesAsked':
+        'Pictures are being loaded from the sender for this message, so their servers can tell it was opened. Nothing about that is kept: leaving this message and coming back asks again.',
+
     'thread.label': 'Conversation',
     'thread.open': 'Show the whole conversation',
     'thread.close': 'Back to the message',

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -394,6 +394,31 @@ export const pl: Catalogue = {
     'body.undrawnPicturesCount': 'Obrazów zbyt dużych, by je narysować: {count}',
     'body.quotedHistory': 'Rozmowa cytowana w tej wiadomości',
 
+    'fullHtml.show': 'Pokaż pełną wersję HTML',
+    'fullHtml.question': 'Pokazać pełny HTML?',
+    'fullHtml.whatItCanCarry':
+        'Ten kod napisał sam nadawca. Może zawierać piksele śledzące, układ podszywający się pod znaną markę i odnośniki prowadzące gdzie indziej, niż zapowiadają.',
+    'fullHtml.whatIsBlocked':
+        'Nic w nim nie może się wykonać i nic nie sięga do nadawcy, dopóki nie poprosisz o jego obrazy.',
+    'fullHtml.stayReduced': 'Zostań przy wersji uproszczonej',
+    'fullHtml.confirm': 'Pokaż HTML',
+    'fullHtml.surface': 'Własna wersja tej wiadomości od nadawcy',
+    'fullHtml.mark': 'HTML',
+    'fullHtml.frame': 'Kod napisany przez nadawcę, rysowany w izolacji',
+    'fullHtml.sentBy': '{author} · {when}',
+    'fullHtml.close': 'Zamknij ten widok',
+    'fullHtml.reading': 'Wczytywanie wersji od nadawcy…',
+    'fullHtml.failed': 'Nie udało się odczytać wersji od nadawcy: {reason}.',
+    'fullHtml.noMarkup': 'Nadawca nie napisał sformatowanej wersji tej wiadomości, więc nie ma tu czego pokazać.',
+    'fullHtml.truncated': 'Ta wiadomość jest dłuższa, niż zwraca jeden odczyt, więc urywa się w tym miejscu.',
+    'fullHtml.picturesTruncated':
+        'Ta wiadomość niosła więcej własnych obrazów, niż mieści jeden widok, więc części z nich tu nie ma.',
+    'fullHtml.cannotRun': 'Ta wiadomość nie może niczego wykonać: ramka, w której ją rysujemy, nie dopuszcza skryptów.',
+    'fullHtml.reachesNobody':
+        'Nie niesie żadnego adresu, który sięgałby do nadawcy — wszystkie usunięto, zanim ta wiadomość trafiła do klienta.',
+    'fullHtml.picturesAsked':
+        'Obrazy tej wiadomości są pobierane od nadawcy, więc jego serwery mogą rozpoznać, że ją otwarto. Nic z tego nie jest zapamiętywane: po wyjściu z wiadomości i powrocie pytamy ponownie.',
+
     'thread.label': 'Rozmowa',
     'thread.open': 'Pokaż całą rozmowę',
     'thread.close': 'Wróć do wiadomości',

--- a/frontend/src/Client.App/src/mailSpace/openTabs.test.ts
+++ b/frontend/src/Client.App/src/mailSpace/openTabs.test.ts
@@ -8,9 +8,14 @@ import { activated, closed, nothingOpen, nothingOpened, opened, tabFor, tabIn, t
 const quarterly = tabFor('thread', 'message-1', 'The quarterly figures', {
     selection: 'message-1',
     conversation: null,
+    fullHtml: null,
 });
 
-const invoice = tabFor('thread', 'message-2', 'The invoice', { selection: 'message-2', conversation: null });
+const invoice = tabFor('thread', 'message-2', 'The invoice', {
+    selection: 'message-2',
+    conversation: null,
+    fullHtml: null,
+});
 
 const nowhere = nothingOpened;
 
@@ -45,9 +50,9 @@ describe('opened', () => {
 
     it('leaves the tab it moved off holding where the reader had got to in it', () => {
         const conversation = { threadId: 'thread-1', openAt: 'message-1' };
-        const open = opened(twoOpen(), quarterly, { selection: 'message-2', conversation }, true);
+        const open = opened(twoOpen(), quarterly, { selection: 'message-2', conversation, fullHtml: null }, true);
 
-        expect(tabIn(open, invoice.key)?.opened).toEqual({ selection: 'message-2', conversation });
+        expect(tabIn(open, invoice.key)?.opened).toEqual({ selection: 'message-2', conversation, fullHtml: null });
     });
 
     it('replaces what is open where the person is not working in tabs, so one tab is what is on the screen', () => {
@@ -60,10 +65,18 @@ describe('opened', () => {
 
 describe('activated', () => {
     it('reads the tab named and leaves the one it moved off holding where it was', () => {
-        const open = activated(twoOpen(), quarterly.key, { selection: 'message-2', conversation: null });
+        const open = activated(twoOpen(), quarterly.key, {
+            selection: 'message-2',
+            conversation: null,
+            fullHtml: null,
+        });
 
         expect(open.active).toBe(quarterly.key);
-        expect(tabIn(open, invoice.key)?.opened).toEqual({ selection: 'message-2', conversation: null });
+        expect(tabIn(open, invoice.key)?.opened).toEqual({
+            selection: 'message-2',
+            conversation: null,
+            fullHtml: null,
+        });
     });
 
     it('changes nothing where no tab carries the key', () => {

--- a/frontend/src/Client.App/src/mailSpace/openTabs.ts
+++ b/frontend/src/Client.App/src/mailSpace/openTabs.ts
@@ -14,19 +14,22 @@ import type { OpenConversation } from '../workspace/openConversation';
 // step: the pane reads the workspace exactly as it did before tabs existed, and every screen that opens or closes a
 // conversation goes on doing it without knowing a tab is holding its place.
 
-/** What the reading column draws: the message open, and the conversation standing in front of it. */
+/** What the reading column draws: the message open, and whichever surface stands in front of it. */
 export interface OpenedMail {
     readonly selection: string | null;
     readonly conversation: OpenConversation | null;
+
+    /** The message whose own markup is being shown, or `null` where the reduced tree is what is being read. */
+    readonly fullHtml: string | null;
 }
 
 /**
  * The four things the design project gives a tab of its own.
  *
- * Three of them have no screen behind them yet — a message's full HTML is #1485, a draft is the composer of #1210, and
- * an attachment opens as a download rather than as a surface — so nothing constructs one today. They are named here
- * rather than added later because the strip is what draws whichever kind a tab has, and a kind it could not draw would
- * be a strip rewritten by each of those changes instead of a tab handed to it.
+ * Two of them have no screen behind them yet — a draft is the composer of #1210, and an attachment opens as a download
+ * rather than as a surface — so nothing constructs one today. They are named here rather than added later because the
+ * strip is what draws whichever kind a tab has, and a kind it could not draw would be a strip rewritten by each of
+ * those changes instead of a tab handed to it.
  */
 export type OpenTabKind = 'thread' | 'attachment' | 'fullHtml' | 'draft';
 
@@ -54,7 +57,7 @@ export interface OpenTabs {
 export const nothingOpen: OpenTabs = { tabs: [], active: null };
 
 /** Nothing being read, which is what a tab that is not a message was opened beside. */
-export const nothingOpened: OpenedMail = { selection: null, conversation: null };
+export const nothingOpened: OpenedMail = { selection: null, conversation: null, fullHtml: null };
 
 /**
  * One tab, identified by what it holds.

--- a/frontend/src/Client.App/src/mailSpace/useOpenTabs.test.tsx
+++ b/frontend/src/Client.App/src/mailSpace/useOpenTabs.test.tsx
@@ -16,6 +16,8 @@ const openTheQuarterlyAgain = 'Open the quarterly figures a second time.';
 const readDownTheConversation = 'Read down the conversation, as the pane would.';
 const closeEverything = 'Close everything.';
 const reopenTheLastRead = 'Open the last message read.';
+const showTheMarkup = 'Show the quarterly figures as the sender sent it.';
+const closeTheMarkup = 'Close the markup surface.';
 
 function Tabs({ inTabs }: { readonly inTabs: boolean }) {
     const { workspace, revise } = useWorkspace();
@@ -24,6 +26,7 @@ function Tabs({ inTabs }: { readonly inTabs: boolean }) {
     const open = `Open: ${titles.join(', ') || 'nothing'}`;
     const reading = `Reading: ${workspace.selection ?? 'nothing'}`;
     const inFrontOfIt = `In front of it: ${workspace.conversation?.threadId ?? 'nothing'}`;
+    const markup = `Markup shown for: ${workspace.fullHtml ?? 'nothing'}`;
     const emptied = `Emptied by closing: ${String(tabs.emptiedByClosing)}`;
 
     return (
@@ -31,6 +34,7 @@ function Tabs({ inTabs }: { readonly inTabs: boolean }) {
             <p>{open}</p>
             <p>{reading}</p>
             <p>{inFrontOfIt}</p>
+            <p>{markup}</p>
             <p>{emptied}</p>
 
             <button
@@ -101,6 +105,19 @@ function Tabs({ inTabs }: { readonly inTabs: boolean }) {
                 );
             })}
 
+            <button
+                type="button"
+                onClick={() => {
+                    tabs.openFullHtml('message-1', 'The quarterly figures');
+                }}
+            >
+                {showTheMarkup}
+            </button>
+
+            <button type="button" onClick={tabs.closeFullHtml}>
+                {closeTheMarkup}
+            </button>
+
             <button type="button" onClick={tabs.closeEverything}>
                 {closeEverything}
             </button>
@@ -132,6 +149,10 @@ function open(): string {
 
 function reading(): string {
     return screen.getByText(/^Reading: /).textContent;
+}
+
+function markupShownFor(): string {
+    return screen.getByText(/^Markup shown for: /).textContent;
 }
 
 describe('useOpenTabs, working in tabs', () => {
@@ -246,5 +267,56 @@ describe('useOpenTabs, not working in tabs', () => {
 
         expect(open()).toBe('Open: The invoice');
         expect(reading()).toBe('Reading: message-2');
+    });
+});
+
+// The markup surface takes one of the two shapes the space has, and which one it takes decides where closing it goes
+// back to. Both are asserted, because a surface that returned to the wrong place is the defect this split exists to
+// avoid rather than a preference about layout.
+describe('useOpenTabs opening the sender own markup', () => {
+    it('gives the markup a tab of its own where the person works in tabs', () => {
+        renderTabs(true);
+
+        press(openTheQuarterly);
+        press(openTheInvoice);
+        press(showTheMarkup);
+
+        expect(open()).toBe('Open: The quarterly figures, The invoice, The quarterly figures');
+        expect(markupShownFor()).toBe('Markup shown for: message-1');
+    });
+
+    it('closes that tab back to whatever else was open rather than to the message it came from', () => {
+        renderTabs(true);
+
+        press(openTheQuarterly);
+        press(openTheInvoice);
+        press(showTheMarkup);
+        press(closeTheMarkup);
+
+        expect(open()).toBe('Open: The quarterly figures, The invoice');
+        expect(reading()).toBe('Reading: message-2');
+        expect(markupShownFor()).toBe('Markup shown for: nothing');
+    });
+
+    it('stands the markup in front of the message where the person does not work in tabs', () => {
+        renderTabs(false);
+
+        press(openTheQuarterly);
+        press(showTheMarkup);
+
+        expect(open()).toBe('Open: The quarterly figures');
+        expect(reading()).toBe('Reading: message-1');
+        expect(markupShownFor()).toBe('Markup shown for: message-1');
+    });
+
+    it('closes it back to the message it was opened from where there is one reading column', () => {
+        renderTabs(false);
+
+        press(openTheQuarterly);
+        press(showTheMarkup);
+        press(closeTheMarkup);
+
+        expect(reading()).toBe('Reading: message-1');
+        expect(markupShownFor()).toBe('Markup shown for: nothing');
     });
 });

--- a/frontend/src/Client.App/src/mailSpace/useOpenTabs.test.tsx
+++ b/frontend/src/Client.App/src/mailSpace/useOpenTabs.test.tsx
@@ -192,6 +192,22 @@ describe('useOpenTabs, working in tabs', () => {
         expect(screen.getByText('In front of it: thread-9')).toBeDefined();
     });
 
+    it('leaves what is in front of a message alone when its own tab is pressed again', () => {
+        renderTabs(true);
+
+        press(openTheQuarterly);
+        press(readDownTheConversation);
+
+        // A tab's `opened` is where it was *left*, written as it stops being active, so the tab in front holds a copy
+        // that is stale for exactly as long as somebody is using it. Bringing it forward again would revise the
+        // workspace back to that copy — closing the conversation the reader is reading, which they never asked for and
+        // cannot undo.
+        press('Bring forward The quarterly figures');
+
+        expect(reading()).toBe('Reading: message-1');
+        expect(screen.getByText('In front of it: thread-9')).toBeDefined();
+    });
+
     it('reads the last remaining tab when the one being read is closed', () => {
         renderTabs(true);
 

--- a/frontend/src/Client.App/src/mailSpace/useOpenTabs.ts
+++ b/frontend/src/Client.App/src/mailSpace/useOpenTabs.ts
@@ -44,6 +44,17 @@ export interface OpenTabsInForce {
     /** Opens a message — in a tab of its own where the person works in tabs, and in the pane where they do not. */
     readonly openMail: (storedEmailId: string, subject: string | null) => void;
 
+    /**
+     * Opens the surface that draws one message's own markup, the reader having been asked first.
+     *
+     * A tab of its own where the person works in tabs, so closing it returns to whatever else was open rather than to
+     * the message it was opened from; in front of the message where they do not, so closing it returns to the message.
+     */
+    readonly openFullHtml: (storedEmailId: string, subject: string | null) => void;
+
+    /** Closes that surface, whichever of the two shapes it was drawn in. */
+    readonly closeFullHtml: () => void;
+
     /** Brings a tab forward, returning the reading column to where that tab was left. */
     readonly activate: (key: string) => void;
 
@@ -81,7 +92,37 @@ export function useOpenTabs(inTabs: boolean): OpenTabsInForce {
     // Where the tab being left is left: what the workspace holds at the moment somebody moves off it. Read here rather
     // than kept beside the tab, because the active tab's place is the workspace itself and a second copy of it would be
     // the pair that disagrees.
-    const here = { selection: workspace.selection, conversation: workspace.conversation };
+    const here = {
+        selection: workspace.selection,
+        conversation: workspace.conversation,
+        fullHtml: workspace.fullHtml,
+    };
+
+    // Opening one thing, whatever kind it is: the tab set gains it, and the reading column goes where that tab was
+    // last left. Written once because the two things a person opens differ in what they hold rather than in what
+    // opening one does, and a second copy of this is how the two would come to disagree about where a tab returns to.
+    function open(tab: OpenTab): void {
+        setHeld((current) => opened(current, tab, here, inTabs));
+        setEmptiedByClosing(false);
+        revise(tabIn(held, tab.key)?.opened ?? tab.opened);
+    }
+
+    function closeTab(key: string): void {
+        const after = closed(held, key);
+        const going = tabIn(held, key);
+
+        setHeld(after);
+        setEmptiedByClosing(after.tabs.length === 0);
+
+        if (held.active !== key) {
+            return;
+        }
+
+        // Where it was left rather than where it was opened, so the one way back reopens the conversation the
+        // reader had in front of the message as well as the message.
+        setLastRead(going === null ? null : { ...going, opened: here });
+        revise(after.active === null ? nothingOpened : (tabIn(after, after.active)?.opened ?? nothingOpened));
+    }
 
     return {
         tabs: held.tabs,
@@ -89,7 +130,11 @@ export function useOpenTabs(inTabs: boolean): OpenTabsInForce {
         emptiedByClosing,
 
         openMail: (storedEmailId, subject) => {
-            const tab = tabFor('thread', storedEmailId, subject, { selection: storedEmailId, conversation: null });
+            const tab = tabFor('thread', storedEmailId, subject, {
+                selection: storedEmailId,
+                conversation: null,
+                fullHtml: null,
+            });
 
             // The message already being read is already open, so opening it again is nothing — and doing the work
             // anyway would put the reading column back where this tab was opened, closing a conversation the reader
@@ -98,12 +143,38 @@ export function useOpenTabs(inTabs: boolean): OpenTabsInForce {
                 return;
             }
 
-            setHeld((current) => opened(current, tab, here, inTabs));
-            setEmptiedByClosing(false);
+            open(tab);
+        },
 
-            // A tab already open is brought forward at the place it was left, so returning to a message returns to the
-            // conversation somebody had in front of it rather than to the message on its own.
-            revise(tabIn(held, tab.key)?.opened ?? tab.opened);
+        // The surface is a tab of its own only where a person works in tabs. Where they do not there is one reading
+        // column and nothing to put a second tab beside, so the surface stands in front of the message the way a
+        // conversation does — which is what makes closing it a return to that message rather than to nothing.
+        openFullHtml: (storedEmailId, subject) => {
+            if (!inTabs) {
+                revise({ fullHtml: storedEmailId });
+
+                return;
+            }
+
+            open(
+                tabFor('fullHtml', storedEmailId, subject, {
+                    selection: storedEmailId,
+                    conversation: null,
+                    fullHtml: storedEmailId,
+                }),
+            );
+        },
+
+        closeFullHtml: () => {
+            const active = held.active === null ? null : tabIn(held, held.active);
+
+            if (active?.kind === 'fullHtml') {
+                closeTab(active.key);
+
+                return;
+            }
+
+            revise({ fullHtml: null });
         },
 
         activate: (key) => {
@@ -117,22 +188,7 @@ export function useOpenTabs(inTabs: boolean): OpenTabsInForce {
             revise(tab.opened);
         },
 
-        close: (key) => {
-            const after = closed(held, key);
-            const going = tabIn(held, key);
-
-            setHeld(after);
-            setEmptiedByClosing(after.tabs.length === 0);
-
-            if (held.active !== key) {
-                return;
-            }
-
-            // Where it was left rather than where it was opened, so the one way back reopens the conversation the
-            // reader had in front of the message as well as the message.
-            setLastRead(going === null ? null : { ...going, opened: here });
-            revise(after.active === null ? nothingOpened : (tabIn(after, after.active)?.opened ?? nothingOpened));
-        },
+        close: closeTab,
 
         closeEverything: () => {
             const going = held.active === null ? null : tabIn(held, held.active);
@@ -147,9 +203,7 @@ export function useOpenTabs(inTabs: boolean): OpenTabsInForce {
             lastRead === null
                 ? null
                 : () => {
-                      setHeld((current) => opened(current, lastRead, here, inTabs));
-                      setEmptiedByClosing(false);
-                      revise(lastRead.opened);
+                      open(lastRead);
                   },
     };
 }

--- a/frontend/src/Client.App/src/mailSpace/useOpenTabs.ts
+++ b/frontend/src/Client.App/src/mailSpace/useOpenTabs.ts
@@ -184,6 +184,16 @@ export function useOpenTabs(inTabs: boolean): OpenTabsInForce {
                 return;
             }
 
+            // Bringing forward the tab already in front is nothing, and doing the work anyway is destructive: a tab's
+            // `opened` is where it was *left*, written as it stops being active, so an active tab's copy is stale by
+            // design for exactly as long as somebody is using it. Re-activating it would revise the workspace back to
+            // that stale place — closing the conversation or the markup surface the reader has in front of the message,
+            // which is a thing they never asked for and cannot undo. `openMail` above guards the same way for the same
+            // reason; the strip calls this on every press rather than only on a press that changes something.
+            if (held.active === key) {
+                return;
+            }
+
             setHeld((current) => activated(current, key, here));
             revise(tab.opened);
         },

--- a/frontend/src/Client.App/src/messageBody/Message.tsx
+++ b/frontend/src/Client.App/src/messageBody/Message.tsx
@@ -113,7 +113,9 @@ export function Message({
     useEffect(() => {
         let listening = true;
 
-        void readMailBody(session, transport, read.storedEmailId, read.remotePictures).then((answered) => {
+        const ask = { remoteImages: read.remotePictures, fullHtml: false };
+
+        void readMailBody(session, transport, read.storedEmailId, ask).then((answered) => {
             if (listening) {
                 setAnswer({ read, result: answered });
             }

--- a/frontend/src/Client.App/src/messageBody/MessageBody.test.tsx
+++ b/frontend/src/Client.App/src/messageBody/MessageBody.test.tsx
@@ -39,6 +39,7 @@ const readable: MailBody = {
     availability: 'Readable',
     plainText: { text: 'A message, as words.', originalCharacterCount: 20, truncation: 'None' },
     document: drawnDocument,
+    selfContainedHtml: null,
     remoteImagesRequested: false,
 };
 

--- a/frontend/src/Client.App/src/messageBody/MessageMarkupFrame.test.tsx
+++ b/frontend/src/Client.App/src/messageBody/MessageMarkupFrame.test.tsx
@@ -1,0 +1,55 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { LocalizationProvider } from '../localization/Localization';
+import { MessageMarkupFrame } from './MessageMarkupFrame';
+
+// The `sandbox` attribute is the one thing asserted here that is not what a person sees, and it is asserted anyway:
+// it is the whole of what stops a stranger's markup running, this is the only file permitted to write the element it
+// sits on, and an edit that widened it would be invisible in every other test in the suite. What jsdom cannot answer —
+// whether a browser honours it — is the browser suite's.
+
+function drawing(markup: string): void {
+    render(
+        <LocalizationProvider>
+            <MessageMarkupFrame markup={markup} />
+        </LocalizationProvider>,
+    );
+}
+
+function frame(): HTMLIFrameElement {
+    const drawn = screen.getByTitle("The sender's own markup, drawn in isolation");
+
+    if (!(drawn instanceof HTMLIFrameElement)) {
+        throw new Error('The markup is drawn in something other than a frame.');
+    }
+
+    return drawn;
+}
+
+describe('MessageMarkupFrame', () => {
+    it('draws the markup it was handed in a frame of its own', () => {
+        drawing('<p>As the sender wrote it.</p>');
+
+        expect(frame().getAttribute('srcdoc')).toBe('<p>As the sender wrote it.</p>');
+    });
+
+    it('permits the framed document neither script nor an origin of its own', () => {
+        drawing('<p>As the sender wrote it.</p>');
+
+        const permitted = frame().getAttribute('sandbox');
+
+        expect(permitted).toBe('');
+        expect(permitted).not.toContain('allow-scripts');
+        expect(permitted).not.toContain('allow-same-origin');
+    });
+
+    it('draws nothing at all where the deployment served no markup for this message', () => {
+        drawing('');
+
+        expect(screen.queryByTitle("The sender's own markup, drawn in isolation")).toBeNull();
+    });
+});

--- a/frontend/src/Client.App/src/messageBody/MessageMarkupFrame.tsx
+++ b/frontend/src/Client.App/src/messageBody/MessageMarkupFrame.tsx
@@ -23,6 +23,9 @@ import { useLocalization } from '../localization/useLocalization';
 // for both rather than one per surface. It takes no such parameter today: nothing draws that surface yet, and a value
 // nobody passes is a widening of the one thing on this screen that must not widen by accident.
 //
+// What it is drawn on is `--color-sender-markup`, which is the one token in this client that stays the same in both
+// themes, and `styles.css` carries the reason beside the declaration rather than here.
+//
 // It draws nothing where there is no markup to draw. A frame with an empty document is a white rectangle that says
 // nothing, and what a reader is owed instead is a sentence — which is the surface's to say, because only the surface
 // knows why the markup is absent.
@@ -39,7 +42,7 @@ export function MessageMarkupFrame({ markup }: { readonly markup: string }) {
             title={translate('fullHtml.frame')}
             sandbox=""
             srcDoc={markup}
-            className="min-h-0 w-full flex-1 border-0 bg-white"
+            className="min-h-0 w-full flex-1 border-0 bg-sender-markup"
         />
     );
 }

--- a/frontend/src/Client.App/src/messageBody/MessageMarkupFrame.tsx
+++ b/frontend/src/Client.App/src/messageBody/MessageMarkupFrame.tsx
@@ -1,0 +1,45 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { useLocalization } from '../localization/useLocalization';
+
+// The one file in this client that writes an `iframe`'s `srcdoc`, and the only place a message's own markup is drawn
+// as markup. Everywhere else under `src/` the lint rule refuses it outright, and the exception is written into
+// `eslint.config.ts` against this path rather than waived at the call site — so a second frame is a configuration diff
+// a reviewer meets rather than a line nobody sees. ADR 0024 names this file as that exception.
+//
+// **Two mechanisms hold two different promises here, and neither substitutes for the other.** The frame is what stops
+// the markup running: `sandbox` with neither `allow-scripts` nor `allow-same-origin` denies script, forms, popups,
+// navigation, downloads, and an origin of its own. It is *not* what stops the markup reporting — no sandboxing flag
+// the HTML Standard defines governs what a framed document may fetch, so a sandboxed frame would load a tracking pixel
+// exactly as an unsandboxed one does. What keeps that out is the representation: the service prepares the markup with
+// every remote address already removed, unless the reader asked for this one message's pictures. Weakening either half
+// is a change to both.
+//
+// ADR 0024 answered a third question with a second markup surface — the embedded view #1508 builds, which draws each
+// open message inline and carries `sandbox="allow-scripts"` so the client's own prepended script can report the frame's
+// height. That surface is **this** component with the value it needs handed to it, because the record names one file
+// for both rather than one per surface. It takes no such parameter today: nothing draws that surface yet, and a value
+// nobody passes is a widening of the one thing on this screen that must not widen by accident.
+//
+// It draws nothing where there is no markup to draw. A frame with an empty document is a white rectangle that says
+// nothing, and what a reader is owed instead is a sentence — which is the surface's to say, because only the surface
+// knows why the markup is absent.
+
+export function MessageMarkupFrame({ markup }: { readonly markup: string }) {
+    const { translate } = useLocalization();
+
+    if (markup === '') {
+        return null;
+    }
+
+    return (
+        <iframe
+            title={translate('fullHtml.frame')}
+            sandbox=""
+            srcDoc={markup}
+            className="min-h-0 w-full flex-1 border-0 bg-white"
+        />
+    );
+}

--- a/frontend/src/Client.App/src/readingPane/MessageHeaders.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/MessageHeaders.test.tsx
@@ -3,7 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { MailMessageHeaders } from '@mailfathom/client-backend';
 import { LocalizationProvider } from '../localization/Localization';
 import { MessageHeaders } from './MessageHeaders';
@@ -34,10 +34,10 @@ function disclosure(): HTMLDetailsElement {
     return opened;
 }
 
-function drawing(written: Partial<MailMessageHeaders> = {}): void {
+function drawing(written: Partial<MailMessageHeaders> = {}, onShowFullHtml: () => void = () => undefined): void {
     render(
         <LocalizationProvider>
-            <MessageHeaders headers={{ ...headers, ...written }} />
+            <MessageHeaders headers={{ ...headers, ...written }} onShowFullHtml={onShowFullHtml} />
         </LocalizationProvider>,
     );
 }
@@ -139,5 +139,23 @@ describe('MessageHeaders', () => {
         });
 
         expect(screen.getByText('<script>alert(1)</script> <billing@example.invalid>')).toBeDefined();
+    });
+});
+
+// The one control on this head that does something today, and what it does is ask before anything is shown.
+describe('MessageHeaders and the sender own markup', () => {
+    it('offers the way to the sender own version of this message', () => {
+        drawing();
+
+        expect(screen.getByRole('button', { name: 'Show the full HTML version' })).toBeDefined();
+    });
+
+    it('asks the reader before it opens anything, so pressing it opens nothing on its own', () => {
+        const shown = vi.fn();
+
+        drawing({}, shown);
+        fireEvent.click(screen.getByRole('button', { name: 'Show the full HTML version' }));
+
+        expect(shown).not.toHaveBeenCalled();
     });
 });

--- a/frontend/src/Client.App/src/readingPane/MessageHeaders.tsx
+++ b/frontend/src/Client.App/src/readingPane/MessageHeaders.tsx
@@ -4,6 +4,7 @@
 
 import type { MailMessageHeaders, MailParticipant, MailParticipantRole } from '@mailfathom/client-backend';
 import { PlannedControl } from '../controls/PlannedControl';
+import { ShowFullHtml } from '../fullHtml/ShowFullHtml';
 import type { MessageKey } from '../localization/en';
 import { wordInstant } from '../localization/instants';
 import { useLocalization } from '../localization/useLocalization';
@@ -14,7 +15,10 @@ import { useLocalization } from '../localization/useLocalization';
 // front of the words somebody opened it to read.
 //
 // Beside the subject stand the three things the design project offers to do with a message from its head. None of them
-// exists in the client yet, so each is drawn as what it is: a control the product will have, inert until it does.
+// exists in the client yet, so each is drawn as what it is: a control the product will have, inert until it does. The
+// fourth beside them does exist: the control that opens the sender's own markup on a surface of its own, which is the
+// message head's because that is where the design project draws it and because it is a fact about this message rather
+// than about the body underneath it.
 //
 // Every value here is text a sender chose. It is drawn as text and never as markup, so a display name written to look
 // like an address, a heading, or a control arrives as the characters it is.
@@ -34,7 +38,15 @@ const roleLabels: Readonly<Record<DisclosedRole, MessageKey>> = {
     Bcc: 'participant.bcc',
 };
 
-export function MessageHeaders({ headers }: { readonly headers: MailMessageHeaders }) {
+export function MessageHeaders({
+    headers,
+    onShowFullHtml,
+}: {
+    readonly headers: MailMessageHeaders;
+
+    /** Opens this message's own markup on the surface that draws it, the reader having confirmed it first. */
+    readonly onShowFullHtml: () => void;
+}) {
     const { locale, translate } = useLocalization();
 
     const authors = headers.participants.filter((participant) => participant.role === 'From');
@@ -53,6 +65,7 @@ export function MessageHeaders({ headers }: { readonly headers: MailMessageHeade
                     <PlannedControl label={translate('mail.reply')} icon="reply" />
                     <PlannedControl label={translate('mail.forward')} icon="forward" />
                     <PlannedControl label={translate('mail.flag')} icon="flag" />
+                    <ShowFullHtml onShow={onShowFullHtml} />
                 </div>
             </div>
 

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
@@ -101,6 +101,7 @@ function drawing(
                                 transport={transport}
                                 storedEmailId={storedEmailId}
                                 online={online}
+                                onShowFullHtml={() => undefined}
                             />
                         </ReadMarkingContext>
                     </AttachmentDeliveryContext>
@@ -285,6 +286,7 @@ function paneReading(transport: MailFathomTransport, online: boolean) {
                             transport={transport}
                             storedEmailId={messageId}
                             online={online}
+                            onShowFullHtml={() => undefined}
                         />
                     </AttachmentDeliveryContext>
                 </LinkOpenerContext>
@@ -305,6 +307,7 @@ function paneFor(storedEmailId: string) {
                             transport={deploymentDescribing()}
                             storedEmailId={storedEmailId}
                             online
+                            onShowFullHtml={() => undefined}
                         />
                     </AttachmentDeliveryContext>
                 </LinkOpenerContext>
@@ -328,6 +331,7 @@ describe('ReadingPane selection', () => {
                                 transport={deploymentDescribing()}
                                 storedEmailId={messageId}
                                 online
+                                onShowFullHtml={() => undefined}
                             />
                         </AttachmentDeliveryContext>
                     </LinkOpenerContext>

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
@@ -68,12 +68,22 @@ export function ReadingPane({
     transport,
     storedEmailId,
     online,
+    onShowFullHtml,
     arriving = false,
 }: {
     readonly session: ClientSession;
     readonly transport: MailFathomTransport;
     readonly storedEmailId: string | null;
     readonly online: boolean;
+
+    /**
+     * Opens the surface drawing the sender's own markup for the message named, which the head's own control asks for.
+     *
+     * Handed in rather than reached for, because where that surface goes is the Mail space's decision — a tab of its
+     * own beside everything else open, or in front of the message where a person does not work in tabs — and a pane
+     * that decided it would be deciding something it cannot see.
+     */
+    readonly onShowFullHtml: (storedEmailId: string, subject: string | null) => void;
 
     /**
      * Whether the reader is arriving at this message rather than landing on it, which decides whether focus is placed.
@@ -98,6 +108,7 @@ export function ReadingPane({
                     transport={transport}
                     storedEmailId={storedEmailId}
                     online={online}
+                    onShowFullHtml={onShowFullHtml}
                     arriving={arriving}
                 />
             )}
@@ -113,12 +124,14 @@ function OpenMessage({
     transport,
     storedEmailId,
     online,
+    onShowFullHtml,
     arriving,
 }: {
     readonly session: ClientSession;
     readonly transport: MailFathomTransport;
     readonly storedEmailId: string;
     readonly online: boolean;
+    readonly onShowFullHtml: (storedEmailId: string, subject: string | null) => void;
     readonly arriving: boolean;
 }) {
     const { locale, translate } = useLocalization();
@@ -274,7 +287,12 @@ function OpenMessage({
             aria-label={message.headers.subject ?? translate('message.noSubject')}
             className="flex flex-col"
         >
-            <MessageHeaders headers={message.headers} />
+            <MessageHeaders
+                headers={message.headers}
+                onShowFullHtml={() => {
+                    onShowFullHtml(storedEmailId, message.headers.subject);
+                }}
+            />
 
             <div className="flex flex-col gap-3 px-5.5 py-4.5">
                 <SenderVerdict verdict={message.sender} />

--- a/frontend/src/Client.App/src/styles.css
+++ b/frontend/src/Client.App/src/styles.css
@@ -125,6 +125,13 @@
     --color-mailbox-mark: oklch(0.555 0.185 262);
     --color-mailbox-mark-alternate: oklch(0.63 0.08 205);
 
+    /* What a sender's own markup is drawn on, and the one token here that does not follow the theme. A message's HTML
+       was written against a white page — it sets its own foreground colours and expects the rest — so drawing it on a
+       dark surface leaves whatever it left unstated unreadable, which is the whole document for most mail. It is
+       declared here rather than written into the frame so that the exception is stated where every other colour is
+       decided, and so the dark block below can be read as not redefining it on purpose. */
+    --color-sender-markup: oklch(1 0 0);
+
     /* Not surfaces but light: the hairline that lifts a raised surface off the one behind it, what a shadow is cast in
        at two depths, and what the page is dimmed to behind something modal. */
     --color-inset: rgb(255 255 255 / 0.65);

--- a/frontend/src/Client.App/src/workspace/Workspace.test.tsx
+++ b/frontend/src/Client.App/src/workspace/Workspace.test.tsx
@@ -164,6 +164,38 @@ describe('the conversation beside the selection', () => {
     });
 });
 
+// The markup surface stands in front of a message the same way, and closing it on a change of message matters more:
+// what it draws is a stranger's own markup, shown for one message after the reader was asked about that message.
+describe('the markup surface beside the selection', () => {
+    it('closes the surface when a different message is picked, so no message inherits another consent', () => {
+        applying([
+            { selection: 'the-message-it-was-opened-from' },
+            { fullHtml: 'the-message-it-was-opened-from' },
+            { selection: 'another-message' },
+        ]);
+
+        expect(carried().fullHtml).toBeNull();
+        expect(carried().selection).toBe('another-message');
+    });
+
+    it('keeps the surface where the same message is picked again, which changes nothing', () => {
+        applying([
+            { selection: 'the-message-it-was-opened-from' },
+            { fullHtml: 'the-message-it-was-opened-from' },
+            { selection: 'the-message-it-was-opened-from' },
+        ]);
+
+        expect(carried().fullHtml).toBe('the-message-it-was-opened-from');
+    });
+
+    it('leaves a revision naming both alone, because that is the surface being opened on another message', () => {
+        applying([{ selection: 'another-message', fullHtml: 'another-message' }]);
+
+        expect(carried().fullHtml).toBe('another-message');
+        expect(carried().selection).toBe('another-message');
+    });
+});
+
 describe('useWorkspace', () => {
     it('refuses to answer outside the provider rather than inventing a workspace of its own', () => {
         expect(() => {

--- a/frontend/src/Client.App/src/workspace/Workspace.tsx
+++ b/frontend/src/Client.App/src/workspace/Workspace.tsx
@@ -15,25 +15,33 @@ import { WorkspaceContext, type Workspace, type WorkspaceRevision } from './useW
 // invokes twice under StrictMode, or make `revise` a new function on every render, which is a read restarted on every
 // render for everything holding it.
 
-// A conversation stands in front of the message it was opened from, so picking a different message is what closes it.
-// The two are one decision rather than two values kept in step: left free to disagree, a conversation would stay on the
-// screen with nothing reacting to the click behind it, and the way out of it — back to the message — would return to
-// whichever row somebody picked last rather than to the one they opened it from.
+// A conversation and the full-HTML surface both stand in front of the message they were opened from, so picking a
+// different message is what closes either. Each is one decision with the selection rather than a value kept in step
+// with it: left free to disagree, one would stay on the screen with nothing reacting to the click behind it, and the
+// way out of it — back to the message — would return to whichever row somebody picked last rather than to the one they
+// opened it from. The surface has a second reason of its own: it draws a stranger's markup for one message, and
+// carrying it onto the next would draw markup nobody asked to be shown.
 //
 // It is decided here rather than wherever a row is clicked because this is where both live: a screen that picks a
-// message would otherwise each have to remember to close a conversation it never knew about, and the one that forgets
-// is the defect.
-function withoutAStaleConversation(current: Workspace, change: Partial<Workspace>): Partial<Workspace> {
-    const picked = change.selection !== undefined && change.selection !== current.selection;
+// message would otherwise each have to remember to close what it never knew was in front of it, and the one that
+// forgets is the defect.
+function withoutAStaleFront(current: Workspace, change: Partial<Workspace>): Partial<Workspace> {
+    if (change.selection === undefined || change.selection === current.selection) {
+        return change;
+    }
 
-    return picked && change.conversation === undefined ? { ...change, conversation: null } : change;
+    return {
+        ...change,
+        conversation: change.conversation ?? null,
+        fullHtml: change.fullHtml ?? null,
+    };
 }
 
 export function WorkspaceProvider({ children }: { readonly children: ReactNode }) {
     const [workspace, setWorkspace] = useState<Workspace>(rememberedWorkspace);
 
     const revise = useCallback((change: Partial<Workspace>) => {
-        setWorkspace((current) => ({ ...current, ...withoutAStaleConversation(current, change) }));
+        setWorkspace((current) => ({ ...current, ...withoutAStaleFront(current, change) }));
     }, []);
 
     useEffect(() => {

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
@@ -14,6 +14,7 @@ const kept: Workspace = {
     mailboxesFolded: true,
     selection: 'AAMkAD-42',
     conversation: { threadId: '9b2a1c74-4a4e-4c93-9a2e-3f6f0a1b2c3d', openAt: 'AAMkAD-42' },
+    fullHtml: null,
     fragment: null,
     selected: ['AAMkAD-42', 'AAMkAD-43'],
     question: 'what did Nordwind send',
@@ -42,6 +43,21 @@ describe('rememberWorkspace', () => {
 
         expect(window.sessionStorage.getItem(storageKey)).not.toContain('somebody pointed at');
         expect(rememberedWorkspace().fragment).toBeNull();
+    });
+
+    // A consent given for one message after being told what a stranger's markup can carry, which is why a reload finds
+    // the surface closed and the control asks again rather than reopening it.
+    it('keeps no record of the markup surface having been open', () => {
+        rememberWorkspace({ ...kept, fullHtml: 'AAMkAD-42' });
+
+        expect(window.sessionStorage.getItem(storageKey)).not.toContain('"fullHtml":"AAMkAD-42"');
+        expect(rememberedWorkspace().fullHtml).toBeNull();
+    });
+
+    it('opens the surface for nobody where a store was edited to say it was open', () => {
+        window.sessionStorage.setItem(storageKey, JSON.stringify({ ...kept, fullHtml: 'AAMkAD-42' }));
+
+        expect(rememberedWorkspace().fullHtml).toBeNull();
     });
 });
 

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.ts
@@ -71,13 +71,16 @@ export function rememberedWorkspace(): Workspace {
 /**
  * Keeps what this tab is looking at, so a reload returns to it.
  *
- * Everything but the selected fragment, which is a passage of somebody's mail rather than a name the service assigned:
- * keeping it would put mail content in a browser store for nothing, since the reading pane drops the fragment as the
- * message it belongs to opens and a reload is that message opening again.
+ * Everything but two values, each left out for a reason of its own. The selected fragment is a passage of somebody's
+ * mail rather than a name the service assigned, so keeping it would put mail content in a browser store for nothing —
+ * the reading pane drops the fragment as the message it belongs to opens, and a reload is that message opening again.
+ * The full-HTML surface is left out because it is a consent rather than a place: it was given for one message after
+ * being told what a stranger's markup can carry, and a surface that reopened itself on a reload would be that consent
+ * remembered. So a reload returns to the message with the surface closed, and pressing the control asks again.
  */
 export function rememberWorkspace(workspace: Workspace): void {
     try {
-        window.sessionStorage.setItem(storageKey, JSON.stringify({ ...workspace, fragment: null }));
+        window.sessionStorage.setItem(storageKey, JSON.stringify({ ...workspace, fragment: null, fullHtml: null }));
     } catch {
         // A browser refusing storage still runs the client; what a person was looking at then lasts the run rather
         // than outliving it, which is a smaller loss than a client that fails over a preference.
@@ -124,12 +127,16 @@ function workspaceIn(value: unknown): Workspace | null {
         return null;
     }
 
+    // Neither the fragment nor the full-HTML surface is read back, because neither was written: what a store holds for
+    // them is whatever somebody put there by hand, and reading that would be this client opening a surface nobody
+    // pressed a control to open.
     return {
         scope,
         collapsed,
         mailboxesFolded,
         selection,
         conversation,
+        fullHtml: null,
         fragment: null,
         selected,
         question,

--- a/frontend/src/Client.App/src/workspace/useWorkspace.ts
+++ b/frontend/src/Client.App/src/workspace/useWorkspace.ts
@@ -47,6 +47,16 @@ export interface Workspace {
     readonly conversation: OpenConversation | null;
 
     /**
+     * The message whose own markup is being shown on the full-HTML surface, or `null` where nobody asked for one.
+     *
+     * Beside the selection for the same reason a conversation is, and never written down anywhere else: the reader's
+     * consent to be shown a stranger's markup is given per message and outlives nothing, so a reload finds it gone and
+     * asks again. `rememberedWorkspace` is where that is enforced rather than here, because that is the only place
+     * this value could otherwise survive one.
+     */
+    readonly fullHtml: string | null;
+
+    /**
      * The part of what is open that a question would be asked about, or `null` where the whole of it is.
      *
      * It is the words a person selected rather than a position in anything, because what the intent field does with it
@@ -91,6 +101,7 @@ export const emptyWorkspace: Workspace = {
     mailboxesFolded: false,
     selection: null,
     conversation: null,
+    fullHtml: null,
     fragment: null,
     selected: [],
     question: '',

--- a/frontend/src/Client.App/vitest.setup.ts
+++ b/frontend/src/Client.App/vitest.setup.ts
@@ -49,10 +49,13 @@ for (const method of ['showPopover', 'hidePopover'] as const) {
 
 // jsdom implements the `dialog` element but neither of the two methods a modal one is driven by. What is put back is
 // the part of them a document can have: opening marks the element open, so it is exposed as a dialog and what is
-// inside it is readable, and closing unmarks it and fires the `close` event a component listens for. What is
-// deliberately *not* here is everything a modal actually is — the top layer, the backdrop, the focus trap, and Escape —
-// because none of that is this application's code, and a suite that reimplemented it would be asserting the
-// reimplementation. Those belong to the browser suite, which has a browser.
+// inside it is readable, and closing unmarks it, records the answer it was closed with, and fires the `close` event a
+// component listens for. The answer is part of it rather than an extra — the platform's close algorithm sets
+// `returnValue` from the argument, and a component that reads which button was pressed reads it there, so a stand-in
+// that dropped it would report every answer as the same one. What is deliberately *not* here is everything a modal
+// actually is — the top layer, the backdrop, the focus trap, and Escape — because none of that is this application's
+// code, and a suite that reimplemented it would be asserting the reimplementation. Those belong to the browser suite,
+// which has a browser.
 if (typeof HTMLDialogElement.prototype.showModal !== 'function') {
     Object.defineProperty(HTMLDialogElement.prototype, 'showModal', {
         configurable: true,
@@ -67,8 +70,13 @@ if (typeof HTMLDialogElement.prototype.close !== 'function') {
     Object.defineProperty(HTMLDialogElement.prototype, 'close', {
         configurable: true,
         writable: true,
-        value(this: HTMLDialogElement) {
+        value(this: HTMLDialogElement, returnValue?: string) {
             this.open = false;
+
+            if (returnValue !== undefined) {
+                this.returnValue = returnValue;
+            }
+
             this.dispatchEvent(new Event('close'));
         },
     });

--- a/frontend/src/Client.Backend/src/index.ts
+++ b/frontend/src/Client.Backend/src/index.ts
@@ -25,6 +25,7 @@ export {
     readMailBody,
     type MailBlockAlignment,
     type MailBody,
+    type MailBodyAsk,
     type MailBodyAvailability,
     type MailBodyText,
     type MailBodyTruncation,

--- a/frontend/src/Client.Backend/src/mailBody.test.ts
+++ b/frontend/src/Client.Backend/src/mailBody.test.ts
@@ -57,6 +57,10 @@ function documentWith(blocks: readonly unknown[], overrides: Readonly<Record<str
 
 type Answer = Omit<ClientResponse, 'headers'>;
 
+// What opening a message asks for: the tree and the words, and neither of the two things a reader has to press a
+// control to be shown.
+const readingTheMessage = { remoteImages: false, fullHtml: false };
+
 function answering(response: Answer): MailFathomTransport {
     return () => Promise.resolve({ ...response, headers: {} });
 }
@@ -78,7 +82,7 @@ async function readingDocument(blocks: readonly unknown[], remoteImages = false)
     const document = documentWith(blocks);
     const body = bodyWith(document, { remoteImagesRequested: remoteImages });
 
-    return readMailBody(session, answering({ status: 200, body }), storedEmailId, remoteImages);
+    return readMailBody(session, answering({ status: 200, body }), storedEmailId, { remoteImages, fullHtml: false });
 }
 
 async function refusing(blocks: readonly unknown[], remoteImages = false) {
@@ -89,15 +93,89 @@ async function refusing(blocks: readonly unknown[], remoteImages = false) {
 
 describe('mailBodyRoute', () => {
     it('asks for the tree alone when the reader has not asked for remote pictures', () => {
-        expect(mailBodyRoute(storedEmailId, false)).toBe(`/messages/${storedEmailId}/body`);
+        expect(mailBodyRoute(storedEmailId, readingTheMessage)).toBe(`/messages/${storedEmailId}/body`);
     });
 
     it('carries the reader ask for remote pictures as the whole of that state', () => {
-        expect(mailBodyRoute(storedEmailId, true)).toBe(`/messages/${storedEmailId}/body?remoteImages=true`);
+        expect(mailBodyRoute(storedEmailId, { remoteImages: true, fullHtml: false })).toBe(
+            `/messages/${storedEmailId}/body?remoteImages=true`,
+        );
     });
 
     it('escapes an identifier rather than writing it into the path as it arrived', () => {
-        expect(mailBodyRoute('../accounts', false)).toBe('/messages/..%2Faccounts/body');
+        expect(mailBodyRoute('../accounts', readingTheMessage)).toBe('/messages/..%2Faccounts/body');
+    });
+
+    it('carries the ask for the sender own markup as a second query of its own', () => {
+        const asked = mailBodyRoute(storedEmailId, { remoteImages: false, fullHtml: true });
+
+        expect(asked).toBe(`/messages/${storedEmailId}/body?fullHtml=true`);
+    });
+
+    it('carries both asks at once, because a reader on the markup surface may ask for its pictures too', () => {
+        const asked = mailBodyRoute(storedEmailId, { remoteImages: true, fullHtml: true });
+
+        expect(asked).toBe(`/messages/${storedEmailId}/body?remoteImages=true&fullHtml=true`);
+    });
+});
+
+describe('readMailBody reading the sender own markup', () => {
+    const showingTheMarkup = { remoteImages: false, fullHtml: true };
+
+    it('reads the markup the deployment served beside the tree it did not replace', async () => {
+        const body = bodyWith(documentWith([]), {
+            selfContainedHtml: { text: '<p>As sent.</p>', originalCharacterCount: 15, truncation: 'None' },
+        });
+
+        const result = await readMailBody(session, answering({ status: 200, body }), storedEmailId, showingTheMarkup);
+
+        expect(result.outcome === 'read' && result.value.selfContainedHtml).toEqual({
+            text: '<p>As sent.</p>',
+            originalCharacterCount: 15,
+            truncation: 'None',
+        });
+    });
+
+    it('reads the bound that left a picture out, which is the one loss the character bounds cannot name', async () => {
+        const body = bodyWith(documentWith([]), {
+            selfContainedHtml: {
+                text: '<p>As sent.</p>',
+                originalCharacterCount: 15,
+                truncation: 'InlineImageOctetLimit',
+            },
+        });
+
+        const result = await readMailBody(session, answering({ status: 200, body }), storedEmailId, showingTheMarkup);
+
+        expect(result.outcome === 'read' && result.value.selfContainedHtml?.truncation).toBe('InlineImageOctetLimit');
+    });
+
+    it('answers a read that opened no surface for it with no markup at all', async () => {
+        const body = bodyWith(documentWith([]));
+
+        const result = await readMailBody(session, answering({ status: 200, body }), storedEmailId, readingTheMessage);
+
+        expect(result.outcome === 'read' && result.value.selfContainedHtml).toBeNull();
+    });
+
+    it('refuses markup that arrived under a read nobody opened a surface for', async () => {
+        const body = bodyWith(documentWith([]), {
+            selfContainedHtml: { text: '<p>As sent.</p>', originalCharacterCount: 15, truncation: 'None' },
+        });
+
+        const result = await readMailBody(session, answering({ status: 200, body }), storedEmailId, readingTheMessage);
+
+        expect(result).toEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+
+    it('refuses markup whose own account of itself is not one this contract describes', async () => {
+        const body = bodyWith(documentWith([]), {
+            selfContainedHtml: { text: '<p>As sent.</p>', originalCharacterCount: 15, truncation: 'Whatever' },
+        });
+
+        const result = await readMailBody(session, answering({ status: 200, body }), storedEmailId, showingTheMarkup);
+
+        expect(result).toEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
     });
 });
 
@@ -105,7 +183,7 @@ describe('readMailBody', () => {
     it('asks for the body route on the client surface with the session it was given', async () => {
         const { transport, requests } = recording({ status: 200, body: bodyWith(documentWith([])) });
 
-        await readMailBody(session, transport, storedEmailId, false);
+        await readMailBody(session, transport, storedEmailId, readingTheMessage);
 
         expect(requests).toEqual([
             {
@@ -144,6 +222,7 @@ describe('readMailBody', () => {
                     undrawnInlineImageCount: 0,
                     truncated: false,
                 },
+                selfContainedHtml: null,
                 remoteImagesRequested: false,
             },
         });
@@ -153,7 +232,7 @@ describe('readMailBody', () => {
         const document = documentWith([], { refusal: 'NoHtmlPart' });
         const body = bodyWith(document);
 
-        const result = await readMailBody(session, answering({ status: 200, body }), storedEmailId, false);
+        const result = await readMailBody(session, answering({ status: 200, body }), storedEmailId, readingTheMessage);
 
         expect(result.outcome === 'read' && result.value.document?.refusal).toBe('NoHtmlPart');
     });
@@ -164,7 +243,7 @@ describe('readMailBody', () => {
         [404, 'unavailable'],
         [500, 'unavailable'],
     ])('reads status %i as the failure a screen acts on', async (status, reason) => {
-        const result = await readMailBody(session, answering({ status, body: '' }), storedEmailId, false);
+        const result = await readMailBody(session, answering({ status, body: '' }), storedEmailId, readingTheMessage);
 
         expect(result).toEqual({ outcome: 'failed', failure: { reason, status } });
     });
@@ -172,13 +251,18 @@ describe('readMailBody', () => {
     it('reports a deployment nothing answered from as unavailable, rather than throwing at its caller', async () => {
         const refusing: MailFathomTransport = () => Promise.reject(new Error('the deployment is not there'));
 
-        const result = await readMailBody(session, refusing, storedEmailId, false);
+        const result = await readMailBody(session, refusing, storedEmailId, readingTheMessage);
 
         expect(result).toEqual({ outcome: 'failed', failure: { reason: 'unavailable', status: null } });
     });
 
     it('refuses a body that is not JSON rather than reading it as an empty message', async () => {
-        const result = await readMailBody(session, answering({ status: 200, body: 'not json' }), storedEmailId, false);
+        const result = await readMailBody(
+            session,
+            answering({ status: 200, body: 'not json' }),
+            storedEmailId,
+            readingTheMessage,
+        );
 
         expect(result).toEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
     });
@@ -186,7 +270,7 @@ describe('readMailBody', () => {
     it('reads a message the deployment holds nothing readable for as that state', async () => {
         const body = bodyWith(null, { availability: 'EncryptedNotReadableLocally' });
 
-        const result = await readMailBody(session, answering({ status: 200, body }), storedEmailId, false);
+        const result = await readMailBody(session, answering({ status: 200, body }), storedEmailId, readingTheMessage);
 
         expect(result.outcome === 'read' && result.value).toMatchObject({
             availability: 'EncryptedNotReadableLocally',
@@ -199,7 +283,7 @@ describe('readMailBody refusing a document this deployment did not compose', () 
     it('refuses a document written against a schema revision this build does not implement', async () => {
         const body = bodyWith(documentWith([], { schemaVersion: 2 }));
 
-        const result = await readMailBody(session, answering({ status: 200, body }), storedEmailId, false);
+        const result = await readMailBody(session, answering({ status: 200, body }), storedEmailId, readingTheMessage);
 
         expect(result.outcome).toBe('failed');
     });
@@ -296,7 +380,7 @@ describe('readMailBody refusing a document this deployment did not compose', () 
     it('refuses an answer composed for a different request than the one that was made', async () => {
         const body = bodyWith(documentWith([]), { remoteImagesRequested: true });
 
-        const result = await readMailBody(session, answering({ status: 200, body }), storedEmailId, false);
+        const result = await readMailBody(session, answering({ status: 200, body }), storedEmailId, readingTheMessage);
 
         expect(result.outcome).toBe('failed');
     });
@@ -644,7 +728,7 @@ describe('readMailBody refusing a malformed answer', () => {
         ['a truncation flag that is not a flag', bodyWith(documentWith([], { truncated: 'yes' }))],
         ['a refusal outside the set', bodyWith(documentWith([], { refusal: 'Undecided' }))],
     ])('refuses %s', async (_, body) => {
-        const result = await readMailBody(session, answering({ status: 200, body }), storedEmailId, false);
+        const result = await readMailBody(session, answering({ status: 200, body }), storedEmailId, readingTheMessage);
 
         expect(result).toEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
     });

--- a/frontend/src/Client.Backend/src/mailBody.ts
+++ b/frontend/src/Client.Backend/src/mailBody.ts
@@ -13,19 +13,37 @@ import { send, type MailFathomTransport } from './transport';
 // here sanitizes anything: it establishes that what arrived is a document this deployment produced, and refuses the
 // whole of it when it is not. ADR 0024 records why that is the boundary and what each of its parts holds.
 
-/** The route one message's body is served at, relative to the client prefix. */
-export function mailBodyRoute(storedEmailId: string, remoteImages: boolean): string {
-    const asked = remoteImages ? '?remoteImages=true' : '';
+/**
+ * What one read of a body asks for beyond the message itself.
+ *
+ * Two questions rather than two flags on a call: each of them widens what the answer carries, each is the reader's own
+ * act on one message, and neither is remembered by either side. Written as a value so that a call site says which of
+ * the two it is asking, rather than reading as a pair of positional booleans nobody can tell apart.
+ */
+export interface MailBodyAsk {
+    /** Whether the reader asked this message's remote references to be resolved, having been told what that reveals. */
+    readonly remoteImages: boolean;
 
-    return `/messages/${encodeURIComponent(storedEmailId)}/body${asked}`;
+    /** Whether the sender's own markup is wanted beside the reduced tree, which only the surface drawing it asks for. */
+    readonly fullHtml: boolean;
+}
+
+/** The route one message's body is served at, relative to the client prefix. */
+export function mailBodyRoute(storedEmailId: string, ask: MailBodyAsk): string {
+    const asked = [...(ask.remoteImages ? ['remoteImages=true'] : []), ...(ask.fullHtml ? ['fullHtml=true'] : [])];
+
+    const query = asked.length === 0 ? '' : `?${asked.join('&')}`;
+
+    return `/messages/${encodeURIComponent(storedEmailId)}/body${query}`;
 }
 
 /** Whether the body could be read at all, or why the deployment holds nothing to draw. */
 export type MailBodyAvailability =
     'Readable' | 'EncryptedNotReadableLocally' | 'NotStoredExceededSizeLimit' | 'NotStoredAwaitingStorageHeadroom';
 
-/** Which bound cut the plain text short, or that none did. */
-export type MailBodyTruncation = 'None' | 'BodyCharacterLimit' | 'ReadCharacterBudget' | 'SensitiveContentScanCeiling';
+/** Which bound cut a representation short, or that none did. */
+export type MailBodyTruncation =
+    'None' | 'BodyCharacterLimit' | 'ReadCharacterBudget' | 'SensitiveContentScanCeiling' | 'InlineImageOctetLimit';
 
 /** Why the body is read as its plain text rather than as a document, or that it is not. */
 export type MailDocumentRefusal = 'None' | 'NoHtmlPart' | 'ReductionFailed' | 'NothingRenderable';
@@ -185,12 +203,23 @@ export interface MailBodyText {
     readonly truncation: MailBodyTruncation;
 }
 
-/** One message's body, in the two renderings a reading pane draws it from. */
+/** One message's body, in the renderings a read asked the service for. */
 export interface MailBody {
     readonly storedEmailId: string;
     readonly availability: MailBodyAvailability;
     readonly plainText: MailBodyText;
     readonly document: MailDocument | null;
+
+    /**
+     * The sender's own markup, self-contained, or `null` where this read did not ask for it.
+     *
+     * It is markup rather than a tree, which is why nothing draws it in this application's own document: it is the one
+     * value here a screen hands to a frame instead of rendering. What makes that safe is not the frame alone — the
+     * service prepares it with nothing executable in it and, unless the reader asked otherwise, with no address that
+     * resolves against another host. ADR 0024 records which mechanism holds which of those two promises.
+     */
+    readonly selfContainedHtml: MailBodyText | null;
+
     readonly remoteImagesRequested: boolean;
 }
 
@@ -250,6 +279,7 @@ const truncations: readonly MailBodyTruncation[] = [
     'BodyCharacterLimit',
     'ReadCharacterBudget',
     'SensitiveContentScanCeiling',
+    'InlineImageOctetLimit',
 ];
 
 const refusals: readonly MailDocumentRefusal[] = ['None', 'NoHtmlPart', 'ReductionFailed', 'NothingRenderable'];
@@ -289,20 +319,20 @@ const noEmphasis: MailTextEmphasis = {
 /**
  * Reads one message's body, answering an expected failure as a value rather than by throwing.
  *
- * `remoteImages` is the reader's own act on this one message, told to the service as a query and remembered by
- * neither side: opening the message again asks again. It is also what the parser holds a remote picture against, so a
- * document carrying an address nobody asked for is refused rather than drawn.
+ * Both halves of `ask` are the reader's own act on this one message, told to the service as a query and remembered by
+ * neither side: opening the message again asks again. The ask is also what the parser holds the answer against, so a
+ * document carrying an address nobody asked for, or markup nobody opened a surface for, is refused rather than drawn.
  */
 export function readMailBody(
     session: ClientSession,
     transport: MailFathomTransport,
     storedEmailId: string,
-    remoteImages: boolean,
+    ask: MailBodyAsk,
 ): Promise<ClientResult<MailBody>> {
     return spanned('GET /messages/{storedEmailId}/body', async () => {
         const response = await send(transport, {
             method: 'GET',
-            path: routeFor(session, mailBodyRoute(storedEmailId, remoteImages)),
+            path: routeFor(session, mailBodyRoute(storedEmailId, ask)),
             headers: headersFor(session),
             longestAnswer: longestBodyAnswer,
         });
@@ -315,7 +345,7 @@ export function readMailBody(
             return failed(failureReasonForStatus(response.status), response.status);
         }
 
-        const body = parseBody(response.body, remoteImages);
+        const body = parseBody(response.body, ask);
 
         return body === null ? failed('unreadable', response.status) : read(body);
     });
@@ -329,7 +359,7 @@ interface RemainingBudget {
     inlineImageOctets: number;
 }
 
-function parseBody(body: string, remoteImages: boolean): MailBody | null {
+function parseBody(body: string, ask: MailBodyAsk): MailBody | null {
     const record = asRecord(parsed(body));
     if (record === null) {
         return null;
@@ -365,11 +395,24 @@ function parseBody(body: string, remoteImages: boolean): MailBody | null {
     // The query the read was made with and the answer's own account of it have to agree, because everything the parser
     // admits about a remote picture is decided by that one boolean. A disagreement is a document composed for another
     // request, and reading it would be reading a picture reference against a permission nobody granted.
-    if (remoteImagesRequested !== remoteImages) {
+    if (remoteImagesRequested !== ask.remoteImages) {
         return null;
     }
 
-    return { storedEmailId, availability, plainText, document, remoteImagesRequested };
+    // The markup is held to the same rule from the other direction: a read that opened no surface for it is answered
+    // without it, so markup arriving unasked is an answer composed for a different request. Refusing it here is what
+    // keeps the one place a value becomes a document reachable only from the read that asked to draw one.
+    const markup = record['selfContainedHtml'] ?? null;
+    if (!ask.fullHtml && markup !== null) {
+        return null;
+    }
+
+    const selfContainedHtml = markup === null ? null : parseText(markup);
+    if (markup !== null && selfContainedHtml === null) {
+        return null;
+    }
+
+    return { storedEmailId, availability, plainText, document, selfContainedHtml, remoteImagesRequested };
 }
 
 function parseText(value: unknown): MailBodyText | null {

--- a/frontend/src/Client.Backend/src/telemetry.test.ts
+++ b/frontend/src/Client.Backend/src/telemetry.test.ts
@@ -412,7 +412,7 @@ describe('what the whole of this package records', () => {
         });
         await readMailThread(session, refusing, threadId, 'a cursor');
         await readMailMessage(session, refusing, storedEmailId);
-        await readMailBody(session, refusing, storedEmailId, true);
+        await readMailBody(session, refusing, storedEmailId, { remoteImages: true, fullHtml: true });
         await readMailAttachment(session, storedEmailId, 1, 2_048, delivered, nothingFailed);
         await markMailRead(session, refusing, [storedEmailId, threadId]);
     }

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -147,7 +147,25 @@ function messageBlocks(pictureSource: string) {
     ];
 }
 
-function messageBody(remoteImages: boolean): string {
+// The sender's own markup, as the self-contained representation serves it: the pictures inlined and every remote
+// address gone, unless the reader asked for this one message's pictures.
+//
+// It carries a script deliberately, which the representation itself never would. What that stands in for is the second
+// mechanism ADR 0024 keeps on this surface: the frame permits no script whatever the markup holds, so a representation
+// that ever stopped removing one would still not run it. The script fetches from a host of its own, so a browser says
+// whether it ran without anything having to read inside a frame it cannot reach into.
+function senderMarkup(remoteImages: boolean): string {
+    const picture = remoteImages ? 'https://pictures.invalid/mark.png' : transparentPicture;
+
+    return (
+        '<html><body><h1>This week at Example</h1>' +
+        '<script>new Image().src = "https://ranscript.invalid/beacon.png";</script>' +
+        `<img src="${picture}" alt="A mark">` +
+        '</body></html>'
+    );
+}
+
+function messageBody(remoteImages: boolean, fullHtml: boolean): string {
     return JSON.stringify({
         storedEmailId: '00000000-0000-4000-8000-000000000000',
         availability: 'Readable',
@@ -166,6 +184,9 @@ function messageBody(remoteImages: boolean): string {
             undrawnInlineImageCount: 0,
             truncated: false,
         },
+        selfContainedHtml: fullHtml
+            ? { text: senderMarkup(remoteImages), originalCharacterCount: 320, truncation: 'None' }
+            : null,
         remoteImagesRequested: remoteImages,
     });
 }
@@ -320,7 +341,10 @@ async function servedByADeployment(page: Page): Promise<void> {
         route.fulfill({
             status: 200,
             contentType: 'application/json',
-            body: messageBody(new URL(route.request().url()).searchParams.get('remoteImages') === 'true'),
+            body: messageBody(
+                new URL(route.request().url()).searchParams.get('remoteImages') === 'true',
+                new URL(route.request().url()).searchParams.get('fullHtml') === 'true',
+            ),
         }),
     );
 }
@@ -1079,6 +1103,71 @@ test('fetches nothing from the sender until the reader asks, and asks again next
     // Nothing on either side wrote the ask down, so the message opens asking again. Only a real document reloaded
     // proves that: browser storage is what a durable answer would have been kept in.
     await expect(page.getByRole('button', { name: 'Load pictures from the sender' })).toBeVisible();
+});
+
+// What only a browser can say about the second surface ADR 0024 takes: what the built bundle put in the document, and
+// what it did and did not fetch. Everything else about it — the confirmation, the footer, the states, and every
+// sentence — is jsdom's and lives in the unit suite beside the source.
+
+/** The frame the sender's markup is drawn in, named by what a reader is told it is. */
+const markupFrame = "The sender's own markup, drawn in isolation";
+
+async function showTheSenderMarkup(page: Page): Promise<void> {
+    await page.getByRole('button', { name: 'Show the full HTML version' }).click();
+    await page.getByRole('button', { name: 'Show the HTML' }).click();
+}
+
+test('draws the sender own markup in a frame that permits neither script nor an origin', async ({ page }) => {
+    await openTheFirstMessage(page);
+    await showTheSenderMarkup(page);
+
+    const frame = page.locator(`iframe[title="${markupFrame}"]`);
+
+    await expect(frame).toHaveAttribute('sandbox', '');
+    await expect(frame).toHaveAttribute('srcdoc', /This week at Example/);
+});
+
+test('runs nothing the markup carries, and reaches no host but its own until the reader asks', async ({ page }) => {
+    const hosts = new Set<string>();
+
+    page.on('request', (request) => {
+        hosts.add(new URL(request.url()).hostname);
+    });
+
+    await openTheFirstMessage(page);
+    await showTheSenderMarkup(page);
+    await expect(page.locator(`iframe[title="${markupFrame}"]`)).toBeVisible();
+
+    // The script inside the frame fetches from a host of its own, so a request to it would be that script having run.
+    // The picture's host is the other half: the representation carries no address for it until the reader asks, so a
+    // frame that fetched one would be drawing markup this client composed rather than the one it was served.
+    await expect(page.getByText(/permits no script at all/)).toBeVisible();
+    expect([...hosts]).not.toContain('ranscript.invalid');
+    expect([...hosts]).not.toContain('pictures.invalid');
+
+    await page.getByRole('button', { name: 'Load pictures from the sender' }).click();
+
+    // Asking is what makes the request, on this surface exactly as in the pane. The script is unaffected by it: the
+    // consent restores addresses and never restores anything that runs.
+    await expect(page.getByText(/their servers can tell it was opened/)).toBeVisible();
+    await expect.poll(() => [...hosts]).toContain('pictures.invalid');
+    expect([...hosts]).not.toContain('ranscript.invalid');
+});
+
+test('leaves the markup surface for the message it was opened from, and asks again next time', async ({ page }) => {
+    await openTheFirstMessage(page);
+    await showTheSenderMarkup(page);
+    await expect(page.locator(`iframe[title="${markupFrame}"]`)).toBeVisible();
+
+    await page.getByRole('button', { name: 'Close this view' }).click();
+
+    await expect(page.getByRole('heading', messageHeading)).toBeVisible();
+    await expect(page.locator(`iframe[title="${markupFrame}"]`)).toHaveCount(0);
+
+    // Nothing on either side wrote the answer down, so the control asks again rather than reopening what was shown.
+    await page.getByRole('button', { name: 'Show the full HTML version' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Show the full HTML?' })).toBeVisible();
 });
 
 // What only a browser can say about the message list: every row is one height, the document holds a window of rows


### PR DESCRIPTION
The reading pane draws a closed document tree, which is what ADR 0024 decided and what stops a sender's markup running or reporting. What that costs a reader is the sender's own layout, and the record left one way back to it: a second surface, opened deliberately, drawing the representation #1484 serves in a frame that permits nothing.

## What it does

A `code` control on the message head opens a **question**, never the surface. Declining leaves the message exactly as it was; accepting opens the surface for as long as it stays open and no longer. **Neither answer is written down** — per message, per reader, or at all: `rememberedWorkspace.ts` refuses to keep the value and refuses to read one back, so a reload asks again and a hand-edited store cannot open the surface on anybody's behalf.

The surface is the pane the design project draws — head, frame, footer — in the content area, and a tab of its own where tab mode is on. Closing it returns to whatever was open rather than to the message, because the workspace still holds that.

## Two mechanisms, and the footer says which holds which

`sandbox=""` denies script, forms, popups, navigation, downloads, and an origin of its own. It denies **nothing** about fetching — no flag the HTML Standard defines governs what a framed document may load — so a footer crediting the frame with both promises would be reassurance the platform does not keep, on the one surface a careful reader opens precisely because they do not trust the sender.

So the footer states them separately, per #1483:

- *the frame it is drawn in permits no script at all* — held by the frame;
- *it carries no address that would reach the sender: every one of them was removed before this message was sent to the client* — held by the representation.

Asking for the sender's pictures re-reads the one message on the pane's own terms, and the second sentence changes to say so.

## The lint rule, and a hole in it

`messageBody/MessageMarkupFrame.tsx` is the one file permitted to write `srcdoc`, named in `eslint.config.ts` **by path** rather than waived at the call site. ADR 0024 names it as the single component both markup surfaces are drawn in, so the embedded view #1508 builds extends this file rather than adding a second; a comment there says so, and says why it takes no `sandbox` parameter while nothing draws that surface.

**The rule had a hole and would have refused nothing in this tree.** Its selectors matched the attribute `srcdoc` alone, which is the DOM spelling; React's JSX prop is `srcDoc`, so a component writing one passed the rule silently. Both selectors now match either spelling, and the exception is stated as the general list *minus* the `srcdoc` one, so a rule added to either list later reaches the excepted file too. Proven by writing a throwaway second frame component, watching the rule report it, and deleting it.

## The wire

`readMailBody` took a positional `remoteImages: boolean`; it now takes a `MailBodyAsk`, because a second flag beside the first is where a positional pair becomes unreadable at the call site. `MailBody` gained `selfContainedHtml`, `MailBodyTruncation` gained `InlineImageOctetLimit`, and a body carrying markup that was **never asked for** is refused rather than read.

## Held against the design project

Screenshots taken at 1440×900 from the project's own artboard and from the built bundle, region by region. Head, frame, and footer bar match. Four differences remain, and each is the issue overriding the design rather than the client drifting — they are handed over as design corrections rather than defended here:

1. **Where the surface stands.** The project draws three shapes: in-pane under tab mode, full-screen at a narrow width, and a centred `min(1000px,100%) × min(90vh,100%)` window over a scrim at a wide width outside tab mode. The issue names one — the content area, plus a tab of its own. Built to the issue; the centred window is unbuilt.
2. **The footer.** The project's is one sentence, crediting the frame with both promises. The two-guarantee rule above is what replaced it, so the footer runs to three lines at this width where the project's is one, and it carries the *load pictures from the sender* control the project's footer does not.
3. **The confirmation's second sentence.** The project says the sender may be able to tell the message was opened. The client says nothing in it reaches the sender until the reader asks for the pictures. Both are true of different moments, and the client's is the one true of the state the question is read in.
4. **The warning glyph.** The project draws `gpp_maybe`; the client draws `warning`, which the icon set already carries. A second warning outline would cost an upstream file and a register row for a shape.

One placement is worth naming separately: the project puts the `code` control in the **per-message head inside a conversation**. This change draws it in the reading pane's action row, which is the message head the issue's other acceptance items are written about — *the reading pane's document still holds no `iframe`*. From a conversation the path is *open on its own* and then the control. `ThreadMessage` carries no control of its own, deliberately.

## Proof

- **Browser suite**, against the built bundle: the frame carries `sandbox=""` and the markup the deployment served; no request leaves for the host the fixture's `<script>` fetches from, so a script that ran would say so; no request leaves for the picture host until the reader asks and one does afterwards; the surface closes back to the message and the control asks again.
- **Unit suite**: the confirmation's behaviour and that declining changes nothing; the surface's focus placement, its five states, both footer sentences, the picture re-read and the query each read asks under; that the frame draws nothing where the representation is absent; that neither store keeps nor reads back the surface.
- The `lock` outline is new, from the pinned `google/material-design-icons` revision the rest of the set came from. Both places that state the count moved with it — `THIRD_PARTY_LICENSES.md` and the notice the bundle ships.

Closes #1485

https://claude.ai/code/session_01KYAhTa4qUUT6FVTDMQD7HX
