### PR TITLE
[#1536] Redraw Settings as two compositions with two tabs, and let a thread open expanded

### DIFF
--- a/backend/src/Application/Preferences/ClientPreferences.cs
+++ b/backend/src/Application/Preferences/ClientPreferences.cs
@@ -9,11 +9,12 @@ namespace MailFathom.Application.Preferences;
 /// <param name="Theme">What the client is painted in once a session exists.</param>
 /// <param name="OpenMailInTabs">Whether opening a message opens a tab rather than replacing what is on the screen.</param>
 /// <param name="MarkReadOnOpen">Whether opening a message in the client marks it read on the owner's own mail server.</param>
+/// <param name="ExpandWholeThread">Whether opening a conversation draws every message in it rather than the one it was opened at.</param>
 /// <remarks>
 /// <para>
-/// A closed set of four rather than a settings service. Each of them says how somebody wants to work rather than what
+/// A closed set of five rather than a settings service. Each of them says how somebody wants to work rather than what
 /// the screen in front of them is like, which is why they belong to the person and not to the browser profile or the
-/// desktop install they happened to set them in — and why a fifth is added when there is a fifth to add.
+/// desktop install they happened to set them in — and why a sixth is added when there is a sixth to add.
 /// </para>
 /// <para>
 /// Marking read is here rather than on the mail account for the reason
@@ -36,7 +37,8 @@ public sealed record ClientPreferences(
     bool TelemetryEnabled,
     ClientThemeChoice Theme,
     bool OpenMailInTabs,
-    bool MarkReadOnOpen)
+    bool MarkReadOnOpen,
+    bool ExpandWholeThread)
 {
     /// <summary>Gets what a person who has set nothing is answered with.</summary>
     /// <remarks>
@@ -45,6 +47,8 @@ public sealed record ClientPreferences(
     /// the client resolves on the device before there is a session to read this at all. Tabs are off, because a person
     /// who has not asked for them is reading one message at a time. Marking read is on, because every mail client the
     /// owner already uses does it and a client that leaves their read state behind is one they keep another beside.
+    /// A conversation opens at the message it was opened at, because that is the message somebody came for and the
+    /// history behind it is one control away.
     /// </remarks>
-    public static ClientPreferences Unset { get; } = new(true, ClientThemeChoice.System, false, true);
+    public static ClientPreferences Unset { get; } = new(true, ClientThemeChoice.System, false, true, false);
 }

--- a/backend/src/Host/Api/ClientPreferencesEndpoint.cs
+++ b/backend/src/Host/Api/ClientPreferencesEndpoint.cs
@@ -44,7 +44,7 @@ internal static class ClientPreferencesEndpoint
 
     /// <summary>The greatest request body the write route reads before refusing it.</summary>
     /// <remarks>
-    /// Far above four scalars and their JSON escaping, and far below anything worth an allocation. The document is
+    /// Far above five scalars and their JSON escaping, and far below anything worth an allocation. The document is
     /// closed, so what the bound guards against is not a large record but a body that was never a preferences document
     /// at all; it is answered <c>413</c> before the handler is reached, as every other write on this surface is.
     /// </remarks>
@@ -128,11 +128,12 @@ internal static class ClientPreferencesEndpoint
 /// <param name="Theme">The name of what the client is painted in, or nothing to follow the machine.</param>
 /// <param name="OpenMailInTabs">Whether opening a message opens a tab, or nothing for the unset answer.</param>
 /// <param name="MarkReadOnOpen">Whether opening a message marks it read on their mail server, or nothing for the unset answer.</param>
+/// <param name="ExpandWholeThread">Whether a conversation opens with every message drawn, or nothing for the unset answer.</param>
 /// <remarks>
 /// <para>
 /// Bound strictly: a key nothing here binds fails the bind rather than being stored, which is what keeps the document
-/// closed — it holds four preferences because four is what a client can state, not because a writer happened to send
-/// four. Every one of them is optional, and an omitted one is committed as its unset answer rather than left at
+/// closed — it holds five preferences because five is what a client can state, not because a writer happened to send
+/// five. Every one of them is optional, and an omitted one is committed as its unset answer rather than left at
 /// whatever the row held.
 /// </para>
 /// <para>
@@ -147,7 +148,8 @@ internal sealed record ClientPreferencesRequest(
     bool? TelemetryEnabled = null,
     string? Theme = null,
     bool? OpenMailInTabs = null,
-    bool? MarkReadOnOpen = null)
+    bool? MarkReadOnOpen = null,
+    bool? ExpandWholeThread = null)
 {
     /// <summary>Reads the request as the whole set the write commits.</summary>
     /// <returns>The preferences, with every one the body omitted answered as unset, or <see langword="null" /> when the body names a theme this build does not publish.</returns>
@@ -164,7 +166,8 @@ internal sealed record ClientPreferencesRequest(
             this.TelemetryEnabled ?? ClientPreferences.Unset.TelemetryEnabled,
             theme,
             this.OpenMailInTabs ?? ClientPreferences.Unset.OpenMailInTabs,
-            this.MarkReadOnOpen ?? ClientPreferences.Unset.MarkReadOnOpen);
+            this.MarkReadOnOpen ?? ClientPreferences.Unset.MarkReadOnOpen,
+            this.ExpandWholeThread ?? ClientPreferences.Unset.ExpandWholeThread);
     }
 }
 
@@ -173,6 +176,7 @@ internal sealed record ClientPreferencesRequest(
 /// <param name="Theme">What the client is painted in once a session exists.</param>
 /// <param name="OpenMailInTabs">Whether opening a message opens a tab rather than replacing what is on the screen.</param>
 /// <param name="MarkReadOnOpen">Whether opening a message marks it read on the owner's own mail server.</param>
+/// <param name="ExpandWholeThread">Whether a conversation opens with every message drawn rather than at the one it was opened at.</param>
 /// <remarks>
 /// Every preference is answered, whether or not the person ever set it, so a client renders one screen rather than one
 /// per combination of what happens to be stored. What it does not report is when anything was set or from where: this
@@ -183,7 +187,8 @@ internal sealed record ClientPreferencesResponse(
     bool TelemetryEnabled,
     string Theme,
     bool OpenMailInTabs,
-    bool MarkReadOnOpen)
+    bool MarkReadOnOpen,
+    bool ExpandWholeThread)
 {
     /// <summary>Describes one person's preferences on the wire.</summary>
     /// <param name="preferences">What they set.</param>
@@ -197,6 +202,7 @@ internal sealed record ClientPreferencesResponse(
             preferences.TelemetryEnabled,
             preferences.Theme.Name,
             preferences.OpenMailInTabs,
-            preferences.MarkReadOnOpen);
+            preferences.MarkReadOnOpen,
+            preferences.ExpandWholeThread);
     }
 }

--- a/backend/src/Infrastructure/Persistence/Preferences/ClientPreferencesDocument.cs
+++ b/backend/src/Infrastructure/Persistence/Preferences/ClientPreferencesDocument.cs
@@ -13,6 +13,7 @@ namespace MailFathom.Infrastructure.Persistence.Preferences;
 /// <param name="Theme">What they chose the client to be painted in, or nothing where they never chose.</param>
 /// <param name="OpenMailInTabs">What they said about tabs, or nothing where they never said.</param>
 /// <param name="MarkReadOnOpen">What they said about opening a message marking it read, or nothing where they never said.</param>
+/// <param name="ExpandWholeThread">What they said about a conversation opening expanded, or nothing where they never said.</param>
 /// <remarks>
 /// <para>
 /// Sparse, and every member is therefore optional: a key the document does not carry reads as that preference's own
@@ -35,7 +36,8 @@ internal sealed record ClientPreferencesDocument(
     bool? TelemetryEnabled,
     ClientThemeChoice? Theme,
     bool? OpenMailInTabs,
-    bool? MarkReadOnOpen)
+    bool? MarkReadOnOpen,
+    bool? ExpandWholeThread)
 {
     /// <summary>How the column is written and read, which is fixed here rather than inherited from a host's own options.</summary>
     /// <remarks>
@@ -62,7 +64,8 @@ internal sealed record ClientPreferencesDocument(
             preferences.TelemetryEnabled,
             preferences.Theme,
             preferences.OpenMailInTabs,
-            preferences.MarkReadOnOpen);
+            preferences.MarkReadOnOpen,
+            preferences.ExpandWholeThread);
 
         return JsonSerializer.Serialize(document, StoredFormat);
     }
@@ -83,6 +86,7 @@ internal sealed record ClientPreferencesDocument(
             document.TelemetryEnabled ?? ClientPreferences.Unset.TelemetryEnabled,
             document.Theme ?? ClientPreferences.Unset.Theme,
             document.OpenMailInTabs ?? ClientPreferences.Unset.OpenMailInTabs,
-            document.MarkReadOnOpen ?? ClientPreferences.Unset.MarkReadOnOpen);
+            document.MarkReadOnOpen ?? ClientPreferences.Unset.MarkReadOnOpen,
+            document.ExpandWholeThread ?? ClientPreferences.Unset.ExpandWholeThread);
     }
 }

--- a/backend/tests/Application.UnitTests/Preferences/OwnClientPreferencesTests.cs
+++ b/backend/tests/Application.UnitTests/Preferences/OwnClientPreferencesTests.cs
@@ -19,7 +19,7 @@ namespace MailFathom.Application.UnitTests.Preferences;
 /// </summary>
 public sealed class OwnClientPreferencesTests
 {
-    private static readonly ClientPreferences Chosen = new(false, ClientThemeChoice.Dark, true, false);
+    private static readonly ClientPreferences Chosen = new(false, ClientThemeChoice.Dark, true, false, true);
 
     [Fact]
     public async Task ReadAsync_APersonWhoHasSetSomething_AnswersWhatTheySet()

--- a/backend/tests/Host.UnitTests/Api/ClientPreferencesEndpointTests.cs
+++ b/backend/tests/Host.UnitTests/Api/ClientPreferencesEndpointTests.cs
@@ -23,7 +23,7 @@ namespace MailFathom.Host.UnitTests.Api;
 /// </summary>
 public sealed class ClientPreferencesEndpointTests
 {
-    private static readonly ClientPreferences Chosen = new(false, ClientThemeChoice.Dark, true, false);
+    private static readonly ClientPreferences Chosen = new(false, ClientThemeChoice.Dark, true, false, true);
 
     [Fact]
     public async Task ReadAsync_APersonWhoHasSetSomething_HandsThemWhatTheySet()
@@ -44,11 +44,12 @@ public sealed class ClientPreferencesEndpointTests
         Assert.Equal("dark", preferences.Theme);
         Assert.True(preferences.OpenMailInTabs);
         Assert.False(preferences.MarkReadOnOpen);
+        Assert.True(preferences.ExpandWholeThread);
     }
 
     /// <summary>A first run is a screen rather than an error, so every preference is answered whether or not it was ever set.</summary>
     [Fact]
-    public async Task ReadAsync_APersonWhoHasSetNothing_AnswersTelemetryOnTheMachinesThemeNoTabsAndMarkingRead()
+    public async Task ReadAsync_APersonWhoHasSetNothing_AnswersTelemetryOnTheMachinesThemeNoTabsMarkingReadAndNoExpansion()
     {
         // Arrange
         var store = Substitute.For<IClientPreferencesStore>();
@@ -66,6 +67,7 @@ public sealed class ClientPreferencesEndpointTests
         Assert.Equal("system", preferences.Theme);
         Assert.False(preferences.OpenMailInTabs);
         Assert.True(preferences.MarkReadOnOpen);
+        Assert.False(preferences.ExpandWholeThread);
     }
 
     /// <summary>The row is one only this deployment writes, so a reader learns what to do about it and nothing about what it held.</summary>
@@ -100,7 +102,7 @@ public sealed class ClientPreferencesEndpointTests
         // Act
         var result = await ClientPreferencesEndpoint.SaveAsync(
             SignedIn(store),
-            new ClientPreferencesRequest(false, "dark", true, false),
+            new ClientPreferencesRequest(false, "dark", true, false, true),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -128,7 +130,7 @@ public sealed class ClientPreferencesEndpointTests
         // Assert
         await store.Received(1).SaveAsync(
             SyntheticMailOwner.Deployment,
-            new ClientPreferences(true, ClientThemeChoice.Light, false, true),
+            new ClientPreferences(true, ClientThemeChoice.Light, false, true, false),
             Arg.Any<CancellationToken>());
     }
 
@@ -144,7 +146,7 @@ public sealed class ClientPreferencesEndpointTests
         // Act
         var result = await ClientPreferencesEndpoint.SaveAsync(
             SignedIn(store),
-            new ClientPreferencesRequest(true, "system", false, true),
+            new ClientPreferencesRequest(true, "system", false, true, false),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -194,11 +196,24 @@ public sealed class ClientPreferencesEndpointTests
     {
         // Act
         var request = JsonSerializer.Deserialize<ClientPreferencesRequest>(
-            """{"telemetryEnabled":false,"theme":"dark","openMailInTabs":true,"markReadOnOpen":false}""",
+            """{"telemetryEnabled":false,"theme":"dark","openMailInTabs":true,"markReadOnOpen":false,"expandWholeThread":true}""",
             WebFormat);
 
         // Assert
         Assert.Equal(Chosen, request!.Stated());
+    }
+
+    /// <summary>The fifth preference binds like the four beside it, and a body written before it existed still states the rest.</summary>
+    [Fact]
+    public void Deserialize_ABodyOmittingThreadExpansion_StatesItAsTheUnsetAnswer()
+    {
+        // Act
+        var request = JsonSerializer.Deserialize<ClientPreferencesRequest>(
+            """{"telemetryEnabled":false,"theme":"dark","openMailInTabs":true,"markReadOnOpen":false}""",
+            WebFormat);
+
+        // Assert
+        Assert.False(request!.Stated()!.ExpandWholeThread);
     }
 
     /// <summary>How the transport reads a body, so the binding these assert is the one a request actually meets.</summary>

--- a/backend/tests/Infrastructure.UnitTests/Persistence/Preferences/ClientPreferencesDocumentTests.cs
+++ b/backend/tests/Infrastructure.UnitTests/Persistence/Preferences/ClientPreferencesDocumentTests.cs
@@ -21,10 +21,13 @@ public sealed class ClientPreferencesDocumentTests
     public void Render_APersonsPreferences_WritesEveryOneOfThemUnderItsOwnKey()
     {
         // Act
-        var document = ClientPreferencesDocument.Render(new ClientPreferences(false, ClientThemeChoice.Dark, true, false));
+        var document = ClientPreferencesDocument.Render(
+            new ClientPreferences(false, ClientThemeChoice.Dark, true, false, true));
 
         // Assert
-        Assert.Equal("""{"telemetryEnabled":false,"theme":"dark","openMailInTabs":true,"markReadOnOpen":false}""", document);
+        Assert.Equal(
+            """{"telemetryEnabled":false,"theme":"dark","openMailInTabs":true,"markReadOnOpen":false,"expandWholeThread":true}""",
+            document);
     }
 
     /// <summary>Written whole rather than as a difference from the defaults, so a stored row states what its writer meant however the defaults later move.</summary>
@@ -35,14 +38,16 @@ public sealed class ClientPreferencesDocumentTests
         var document = ClientPreferencesDocument.Render(ClientPreferences.Unset);
 
         // Assert
-        Assert.Equal("""{"telemetryEnabled":true,"theme":"system","openMailInTabs":false,"markReadOnOpen":true}""", document);
+        Assert.Equal(
+            """{"telemetryEnabled":true,"theme":"system","openMailInTabs":false,"markReadOnOpen":true,"expandWholeThread":false}""",
+            document);
     }
 
     [Fact]
     public void Parse_ADocumentThisBuildWrote_ReadsBackWhatWasWritten()
     {
         // Arrange
-        var chosen = new ClientPreferences(false, ClientThemeChoice.Light, true, false);
+        var chosen = new ClientPreferences(false, ClientThemeChoice.Light, true, false, true);
 
         // Act
         var read = ClientPreferencesDocument.Parse(ClientPreferencesDocument.Render(chosen));
@@ -69,7 +74,19 @@ public sealed class ClientPreferencesDocumentTests
         var read = ClientPreferencesDocument.Parse("""{"theme":"dark"}""");
 
         // Assert
-        Assert.Equal(new ClientPreferences(true, ClientThemeChoice.Dark, false, true), read);
+        Assert.Equal(new ClientPreferences(true, ClientThemeChoice.Dark, false, true, false), read);
+    }
+
+    /// <summary>Opening a conversation at the message it was opened at is what the client did before the preference existed, so a row written then reads as that rather than as expanding.</summary>
+    [Fact]
+    public void Parse_ARowWrittenBeforeThreadExpansionWasAPreference_AnswersItAsOff()
+    {
+        // Act
+        var read = ClientPreferencesDocument.Parse(
+            """{"telemetryEnabled":false,"theme":"dark","openMailInTabs":true,"markReadOnOpen":true}""");
+
+        // Assert
+        Assert.False(read.ExpandWholeThread);
     }
 
     /// <summary>ADR 0026 defaults marking read to on, so a row written before the preference existed reads as marking rather than as declining it.</summary>

--- a/backend/tests/PublicSurfaces.UnitTests/http-api-contract.json
+++ b/backend/tests/PublicSurfaces.UnitTests/http-api-contract.json
@@ -1653,6 +1653,12 @@
       "ClientPreferencesRequest": {
         "additionalProperties": false,
         "properties": {
+          "expandWholeThread": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
           "markReadOnOpen": {
             "type": [
               "null",
@@ -1682,6 +1688,9 @@
       },
       "ClientPreferencesResponse": {
         "properties": {
+          "expandWholeThread": {
+            "type": "boolean"
+          },
           "markReadOnOpen": {
             "type": "boolean"
           },
@@ -1699,7 +1708,8 @@
           "telemetryEnabled",
           "theme",
           "openMailInTabs",
-          "markReadOnOpen"
+          "markReadOnOpen",
+          "expandWholeThread"
         ],
         "type": "object"
       },

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -1267,19 +1267,26 @@ and somebody who set the client up the way they work should not have to set it u
 | `POST /api/client/preferences` | Replaces all of them, as one document |
 
 ```json
-{ "telemetryEnabled": true, "theme": "system", "openMailInTabs": false, "markReadOnOpen": true }
+{
+  "telemetryEnabled": true,
+  "theme": "system",
+  "openMailInTabs": false,
+  "markReadOnOpen": true,
+  "expandWholeThread": false
+}
 ```
 
-**It holds four preferences and nothing else.** Whether this deployment may be told what the person's client is doing;
+**It holds five preferences and nothing else.** Whether this deployment may be told what the person's client is doing;
 what the client is painted in, which is `system`, `light`, or `dark`; whether opening a message opens a tab rather
-than replacing what is on the screen; and whether opening a message marks it read on the person's own mail server. Each
-of them says how somebody wants to work, which is why it belongs to the
-person. The language does not, and stays on the device: it is resolved for somebody who has not signed in and may never
-get a session. Neither does the width a person drags the message list to, which describes the screen in front of them.
+than replacing what is on the screen; whether opening a message marks it read on the person's own mail server; and
+whether opening a conversation draws every message in it rather than the one it was opened at. Each of them says how
+somebody wants to work, which is why it belongs to the person. The language does not, and stays on the device: it is
+resolved for somebody who has not signed in and may never get a session. Neither does the width a person drags the
+message list to, which describes the screen in front of them.
 
-**Unset reads as telemetry on, the theme following the machine, tabs off, and marking read on.** A person who has set
-nothing is
-answered a document rather than a refusal, so a first run draws a screen. The theme is still resolved on the device
+**Unset reads as telemetry on, the theme following the machine, tabs off, marking read on, and a conversation opening at
+the message it was opened at.** A person who has set nothing is answered a document rather than a refusal, so a first
+run draws a screen. The theme is still resolved on the device
 before sign-in — the client cannot wait on the network to paint itself, and there is no session to read this over above
 the sign-in screen — and what this answers replaces that device value once a session exists.
 
@@ -1291,6 +1298,12 @@ mutations above, is unaffected by it.
 [ADR 0026](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0026-marking-a-message-read-when-a-person-opens-it-in-the-client.md)
 holds the reasoning, including why an operator's lever here is
 [`mailfathom.mail.flags.write`](permissions.md#the-published-set) rather than a key of their own.
+
+**`expandWholeThread` decides how a conversation opens and nothing more.** With it unset or off, a conversation opens at
+the message it was opened at and the messages before it stand behind one control naming how many there are — which is
+what the client does, and what a reader who came from a search result wants. With it on, the same conversation opens
+with all of them drawn. It is read when a conversation opens rather than watched while one is on the screen, so moving
+the switch changes the next conversation rather than the one being read, and the control is still there either way.
 
 **A write states the whole document.** It is a closed set rather than a patch: a key nothing binds is refused rather
 than stored, a theme this deployment does not publish is refused naming the three that are, and a preference the body

--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -119,7 +119,13 @@ function deploymentAnswering(
 function preferencesAnswering(telemetryEnabled: boolean): Answer {
     return {
         status: 200,
-        body: JSON.stringify({ telemetryEnabled, theme: 'system', openMailInTabs: false, markReadOnOpen: true }),
+        body: JSON.stringify({
+            telemetryEnabled,
+            theme: 'system',
+            openMailInTabs: false,
+            markReadOnOpen: true,
+            expandWholeThread: false,
+        }),
     };
 }
 
@@ -283,6 +289,7 @@ function deploymentWorkingInTabs(): DeploymentTransport {
                     theme: 'system',
                     openMailInTabs: true,
                     markReadOnOpen: true,
+                    expandWholeThread: false,
                 }),
             }),
         );
@@ -1575,9 +1582,10 @@ describe('App deployment', () => {
 
 // Inside the frame the language and the telemetry decision are made on the settings screen rather than in the menu
 // that leads to it, which is where the design project puts them — so a test about either opens that screen the way a
-// person does.
+// person does, on the tab that holds both, which is the second of its two.
 function openSettings(): void {
     fireEvent.click(screen.getByRole('button', { name: 'Settings', hidden: true }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Application', hidden: true }));
 }
 
 describe('App language', () => {

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -293,6 +293,7 @@ export function App({
                 conversation={workspace.conversation}
                 storedEmailId={workspace.selection}
                 online={connection.online}
+                expandWholeThread={preferences.expandWholeThread}
             />
         );
     }
@@ -454,12 +455,16 @@ function OpenMail({
     conversation,
     storedEmailId,
     online,
+    expandWholeThread,
 }: {
     readonly session: ClientSession;
     readonly transport: MailFathomTransport;
     readonly conversation: OpenConversation | null;
     readonly storedEmailId: string | null;
     readonly online: boolean;
+
+    /** Whether the reader asked for conversations to open with every message drawn, which only the conversation reads. */
+    readonly expandWholeThread: boolean;
 }) {
     // Whether the pane below is being arrived at rather than landed on. Closing a conversation swaps this position from
     // one component to the other, so the pane mounts afresh exactly as it does on a cold start and cannot tell the two
@@ -489,6 +494,7 @@ function OpenMail({
             transport={transport}
             conversation={conversation}
             online={online}
+            expandWholeThread={expandWholeThread}
         />
     );
 }

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -134,7 +134,9 @@ export const en = {
 
     'settings.title': 'Settings',
     'settings.close': 'Close settings',
+    'settings.sections': 'Settings sections',
     'settings.profile': 'Profile',
+    'settings.application': 'Application',
     'settings.name': 'Full name',
     'settings.nameNotYours':
         'Whoever runs this deployment keeps your name, so it is shown here rather than offered for you to change.',
@@ -147,6 +149,12 @@ export const en = {
     'settings.pictureNotAnImageKind': 'That file is neither a JPEG nor a PNG, so it was not sent.',
     'settings.pictureTooLarge': 'That picture is larger than 1 MB, so it was not sent.',
     'settings.pictureNotStored': 'That picture was not saved to the deployment, so you are still drawn as you were.',
+    'settings.profileHeld':
+        'Your name and picture are held by the deployment you signed in to, so they follow you between machines. Neither is sent to your mail server.',
+    'settings.messageView': 'Message view',
+    'settings.expandWholeThread': 'Expand the whole thread automatically',
+    'settings.expandWholeThreadExplanation':
+        'Without it, a conversation opens at the message you chose and the rest sit behind a control.',
     'settings.privacy': 'Privacy',
     'settings.telemetryWithheld': 'Do not send telemetry',
     'settings.telemetryExplanation': 'Error diagnostics and usage statistics stay on this device.',

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -134,7 +134,9 @@ export const pl: Catalogue = {
 
     'settings.title': 'Ustawienia',
     'settings.close': 'Zamknij ustawienia',
+    'settings.sections': 'Sekcje ustawień',
     'settings.profile': 'Profil',
+    'settings.application': 'Aplikacja',
     'settings.name': 'Imię i nazwisko',
     'settings.nameNotYours':
         'Twoje imię i nazwisko prowadzi ten, kto zarządza tym wdrożeniem, więc jest tu pokazane, a nie oddane do zmiany.',
@@ -149,6 +151,12 @@ export const pl: Catalogue = {
     'settings.pictureTooLarge': 'To zdjęcie jest większe niż 1 MB, więc nie zostało wysłane.',
     'settings.pictureNotStored':
         'To zdjęcie nie zostało zapisane na wdrożeniu, więc nadal jesteś rysowany tak jak wcześniej.',
+    'settings.profileHeld':
+        'Imię, nazwisko i zdjęcie przechowuje wdrożenie, na które się logujesz, więc idą za Tobą między maszynami. Żadne z nich nie trafia na Twój serwer poczty.',
+    'settings.messageView': 'Widok wiadomości',
+    'settings.expandWholeThread': 'Rozwijaj cały wątek automatycznie',
+    'settings.expandWholeThreadExplanation':
+        'Bez tego wątek otwiera się na wybranej wiadomości, a pozostałe są pod przyciskiem.',
     'settings.privacy': 'Prywatność',
     'settings.telemetryWithheld': 'Nie wysyłaj danych telemetrycznych',
     'settings.telemetryExplanation': 'Diagnostyka błędów i statystyki użycia zostają na tym urządzeniu.',

--- a/frontend/src/Client.App/src/preferences/useClientPreferences.test.tsx
+++ b/frontend/src/Client.App/src/preferences/useClientPreferences.test.tsx
@@ -21,14 +21,16 @@ const anna = 'anna';
 const bartek = 'bartek';
 
 // The whole document, because the route answers with nothing less and the package refuses an answer missing a field.
-// Marking read is defaulted rather than named at each call, since only the tests below that are about it say anything.
+// The two preferences no control in this hook's own tests moves are defaulted rather than named at each call, so only
+// the tests that are about one of them say anything about it.
 function stored(preferences: {
     telemetryEnabled: boolean;
     theme: string;
     openMailInTabs: boolean;
     markReadOnOpen?: boolean;
+    expandWholeThread?: boolean;
 }): string {
-    return JSON.stringify({ markReadOnOpen: true, ...preferences });
+    return JSON.stringify({ markReadOnOpen: true, expandWholeThread: false, ...preferences });
 }
 
 // The transport is the network boundary and the whole of what these tests fake, exactly as in the package that reads
@@ -158,6 +160,7 @@ describe('useClientPreferences', () => {
             theme: 'light',
             openMailInTabs: true,
             markReadOnOpen: true,
+            expandWholeThread: false,
         });
     });
 
@@ -184,6 +187,7 @@ describe('useClientPreferences', () => {
                 theme: 'light',
                 openMailInTabs: false,
                 markReadOnOpen: true,
+                expandWholeThread: false,
             });
         });
     });
@@ -237,6 +241,7 @@ describe('useClientPreferences', () => {
             theme: 'dark',
             openMailInTabs: true,
             markReadOnOpen: true,
+            expandWholeThread: false,
         });
     });
 
@@ -302,6 +307,7 @@ describe('useClientPreferences', () => {
             theme: 'system',
             openMailInTabs: true,
             markReadOnOpen: true,
+            expandWholeThread: false,
         });
     });
 
@@ -332,6 +338,7 @@ describe('useClientPreferences', () => {
             theme: 'dark',
             openMailInTabs: false,
             markReadOnOpen: true,
+            expandWholeThread: false,
         });
         expect(window.localStorage.getItem(telemetryKey(anna))).toBe('false');
     });

--- a/frontend/src/Client.App/src/preferences/useClientPreferences.ts
+++ b/frontend/src/Client.App/src/preferences/useClientPreferences.ts
@@ -50,12 +50,21 @@ export interface ClientPreferencesInForce {
      */
     readonly telemetryEnabled: boolean;
 
+    /**
+     * Whether opening a conversation draws every message in it rather than the one it was opened at.
+     *
+     * Unset reads as off, which is the conversation the client has always drawn: the message somebody came for, with
+     * the history behind it one control away.
+     */
+    readonly expandWholeThread: boolean;
+
     /** Whether the deployment refused the last change, which is the one thing about this a screen has to say out loud. */
     readonly notStated: boolean;
 
     readonly chooseTheme: (choice: ThemeChoice) => void;
     readonly chooseTabMode: (openMailInTabs: boolean) => void;
     readonly chooseTelemetry: (telemetryEnabled: boolean) => void;
+    readonly chooseThreadExpansion: (expandWholeThread: boolean) => void;
 }
 
 // What is held, and whose it is. The session is carried beside the document rather than trusted to have stayed the
@@ -84,7 +93,7 @@ const heldForNobody: HeldPreferences = {
  * offline or the grant does not let it read, and somebody is still signed in through all of that. It decides one thing
  * only — whose remembered telemetry answer the device is asked for — and getting it wrong is what would hand the next
  * person the last person's answer.
- * @returns The settings in force, and the two ways of changing one.
+ * @returns The settings in force, and the four ways of changing one.
  */
 export function useClientPreferences(
     session: ClientSession | null,
@@ -203,6 +212,7 @@ export function useClientPreferences(
         // It costs a storage read on the renders before an answer has arrived and none afterwards, the branch not
         // being taken once there is one.
         telemetryEnabled: inForce.session === null ? rememberedTelemetry(person) : inForce.preferences.telemetryEnabled,
+        expandWholeThread: inForce.preferences.expandWholeThread,
         notStated: inForce.notStated,
         chooseTheme: (choice) => {
             setThemeChoice(choice);
@@ -213,6 +223,9 @@ export function useClientPreferences(
         },
         chooseTelemetry: (telemetryEnabled) => {
             state({ ...composedFrom(), telemetryEnabled });
+        },
+        chooseThreadExpansion: (expandWholeThread) => {
+            state({ ...composedFrom(), expandWholeThread });
         },
     };
 }

--- a/frontend/src/Client.App/src/settings/Settings.test.tsx
+++ b/frontend/src/Client.App/src/settings/Settings.test.tsx
@@ -15,10 +15,12 @@ const settings: ClientPreferencesInForce = {
     openMailInTabs: false,
     markReadOnOpen: true,
     telemetryEnabled: true,
+    expandWholeThread: false,
     notStated: false,
     chooseTheme: () => undefined,
     chooseTabMode: () => undefined,
     chooseTelemetry: () => undefined,
+    chooseThreadExpansion: () => undefined,
 };
 
 const named: OwnProfileInForce = {
@@ -50,7 +52,6 @@ function renderSettings({
     render(
         <LocalizationProvider>
             <Settings
-                open
                 profile={profile}
                 preferences={preferences}
                 telemetryForwarding={telemetryForwarding}
@@ -58,6 +59,11 @@ function renderSettings({
             />
         </LocalizationProvider>,
     );
+}
+
+/** The second tab opened, which is where everything about the client rather than about the person is. */
+function openApplication(): void {
+    fireEvent.click(screen.getByRole('tab', { name: 'Application' }));
 }
 
 /** One file of a stated kind and size, which is the whole of what the client judges a chosen picture by. */
@@ -213,6 +219,7 @@ describe('Settings', () => {
 
     it('draws telemetry as the decision to withhold it, so the switch being on is the private answer', () => {
         renderSettings({ preferences: { ...settings, telemetryEnabled: false } });
+        openApplication();
 
         expect(screen.getByRole('switch', { name: /Do not send telemetry/u })).toHaveProperty('checked', true);
     });
@@ -220,6 +227,7 @@ describe('Settings', () => {
     it('hands the switch to what holds the preference, stated as what may be sent', () => {
         const chooseTelemetry = vi.fn();
         renderSettings({ preferences: { ...settings, chooseTelemetry } });
+        openApplication();
 
         fireEvent.click(screen.getByRole('switch', { name: /Do not send telemetry/u }));
 
@@ -228,24 +236,28 @@ describe('Settings', () => {
 
     it('says what withholding telemetry costs, and only while it is withheld', () => {
         renderSettings({ preferences: { ...settings, telemetryEnabled: true } });
+        openApplication();
 
         expect(screen.queryByText(/support is harder/u)).toBeNull();
     });
 
     it('says what withholding telemetry costs once it is withheld', () => {
         renderSettings({ preferences: { ...settings, telemetryEnabled: false } });
+        openApplication();
 
         expect(screen.getByText(/support is harder/u)).toBeDefined();
     });
 
     it('names where the records go, so the decision is about something rather than about a word', () => {
         renderSettings({ telemetryForwarding: forwardedTo });
+        openApplication();
 
         expect(screen.getByText(/Sent to https:\/\/mail\.example/u)).toBeDefined();
     });
 
     it('says what a record carries and what it never carries', () => {
         renderSettings();
+        openApplication();
 
         expect(screen.getByText(/never your mail, your addresses, your folders, or your password/u)).toBeDefined();
     });
@@ -254,6 +266,7 @@ describe('Settings', () => {
     // that decides nothing about a client that is already sending nothing.
     it('offers no switch where the deployment forwards no telemetry, and says why', () => {
         renderSettings({ telemetryForwarding: { answered: true, destination: null } });
+        openApplication();
 
         expect(screen.getByText(/forwards no telemetry/u)).toBeDefined();
         expect(screen.queryByRole('switch', { name: /Do not send telemetry/u })).toBeNull();
@@ -263,6 +276,7 @@ describe('Settings', () => {
     // it waits — so drawing the confirmed sentence here would say nothing is being sent while something is.
     it('says it is waiting rather than that there is nothing to turn off, before the deployment answers', () => {
         renderSettings({ telemetryForwarding: { answered: false } });
+        openApplication();
 
         expect(screen.getByText(/Waiting for this deployment to say whether it forwards telemetry/u)).toBeDefined();
         expect(screen.queryByText(/forwards no telemetry/u)).toBeNull();
@@ -271,8 +285,82 @@ describe('Settings', () => {
 
     it('offers the language here rather than in the menu that leads here', () => {
         renderSettings();
+        openApplication();
 
         expect(screen.getByRole('group', { name: 'Language' })).toBeDefined();
+    });
+
+    it('opens on the person rather than on the client, which is the order the design project puts the two in', () => {
+        renderSettings();
+
+        expect(screen.getByRole('tab', { selected: true })).toHaveProperty('textContent', 'Profile');
+        expect(screen.getByRole('textbox', { name: 'Full name' })).toBeDefined();
+        expect(screen.queryByRole('group', { name: 'Language' })).toBeNull();
+    });
+
+    it('announces the tab that is open as the selected one and draws only its own half', () => {
+        renderSettings();
+        openApplication();
+
+        expect(screen.getByRole('tab', { selected: true })).toHaveProperty('textContent', 'Application');
+        expect(screen.queryByRole('textbox', { name: 'Full name' })).toBeNull();
+    });
+
+    it('moves between the tabs with the arrow keys, which is the keyboard a tab list carries', () => {
+        renderSettings();
+
+        fireEvent.keyDown(screen.getByRole('tablist'), { key: 'ArrowRight' });
+
+        expect(screen.getByRole('tab', { selected: true })).toHaveProperty('textContent', 'Application');
+
+        fireEvent.keyDown(screen.getByRole('tablist'), { key: 'ArrowLeft' });
+
+        expect(screen.getByRole('tab', { selected: true })).toHaveProperty('textContent', 'Profile');
+    });
+
+    it('stays on the tab at the end of the list rather than wrapping round to the other one', () => {
+        renderSettings();
+
+        fireEvent.keyDown(screen.getByRole('tablist'), { key: 'ArrowLeft' });
+
+        expect(screen.getByRole('tab', { selected: true })).toHaveProperty('textContent', 'Profile');
+    });
+
+    it('leaves one tab stop on the list, which is the tab that is open', () => {
+        renderSettings();
+
+        expect(screen.getByRole('tab', { name: 'Profile' })).toHaveProperty('tabIndex', 0);
+        expect(screen.getByRole('tab', { name: 'Application' })).toHaveProperty('tabIndex', -1);
+    });
+
+    it('says where the name and the picture are held, and where they are not sent', () => {
+        renderSettings();
+
+        expect(screen.getByText(/Neither is sent to your mail server/u)).toBeDefined();
+    });
+
+    it('draws a conversation opening expanded as a choice that is off until it is made', () => {
+        renderSettings();
+        openApplication();
+
+        expect(screen.getByRole('switch', { name: /Expand the whole thread/u })).toHaveProperty('checked', false);
+    });
+
+    it('hands the thread-expansion switch to what holds the preference', () => {
+        const chooseThreadExpansion = vi.fn();
+        renderSettings({ preferences: { ...settings, chooseThreadExpansion } });
+        openApplication();
+
+        fireEvent.click(screen.getByRole('switch', { name: /Expand the whole thread/u }));
+
+        expect(chooseThreadExpansion).toHaveBeenCalledWith(true);
+    });
+
+    it('draws the thread-expansion switch as on where that is what the person set', () => {
+        renderSettings({ preferences: { ...settings, expandWholeThread: true } });
+        openApplication();
+
+        expect(screen.getByRole('switch', { name: /Expand the whole thread/u })).toHaveProperty('checked', true);
     });
 
     it('closes from its own control, which is the way out that does not need a keyboard', () => {

--- a/frontend/src/Client.App/src/settings/Settings.tsx
+++ b/frontend/src/Client.App/src/settings/Settings.tsx
@@ -7,38 +7,53 @@ import { Icon } from '../controls/Icon';
 import { PersonAvatar } from '../controls/PersonAvatar';
 import { Switch } from '../controls/Switch';
 import type { TelemetryForwarding } from '../deployment/telemetryForwarding';
+import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
 import type { ClientPreferencesInForce } from '../preferences/useClientPreferences';
 import type { OwnProfileInForce } from '../profile/useOwnProfile';
 import { LanguageSegments } from '../shell/Preferences';
 import { chosenPortrait, type PortraitChoice } from './chosenPortrait';
 
-// The screen behind the account menu's own row, and the one place the client edits the person rather than the mail.
-// The design project draws it as a modal panel of a fixed width holding three sections: who they are, what the client
-// reads in, and what may be said about them.
+// The surface behind the account menu's own row, and the one place the client edits the person rather than the mail.
 //
-// It is a `dialog` opened as a modal rather than a panel drawn to look like one, because everything the acceptance
-// asks of it is what that element already does: it takes focus, it keeps focus, it closes on Escape, it puts the page
-// behind it out of reach, and closing it hands focus back to whatever opened it. A hand-written trap would be a second
-// implementation of all five, and the one that gets them wrong.
+// One surface in two compositions, chosen by width exactly as every other pane in this client is: over the workspace
+// breakpoint the design project draws it as a card of a stated width and height over a scrim, and below it as the whole
+// screen with a larger head and a taller body. Nothing here branches on that. The difference is entirely what a card
+// looks like against what a screen looks like, so it is written as the width variant on the element itself — a
+// component asking which composition it is in would be the same defect as one asking which head it is running on.
 //
-// One section the project draws is missing, and deliberately: the choice between the simplified and the HTML view of a
-// message edits a preference this deployment does not hold, so drawing it would be a switch that decides nothing.
-// It is #1508.
+// It is a `dialog` opened as a modal rather than a panel drawn to look like one, in both compositions, because
+// everything the acceptance asks of it is what that element already does: it takes focus, it keeps focus, it closes on
+// Escape, it puts the page behind it out of reach, and closing it hands focus back to whatever opened it. A
+// hand-written trap would be a second implementation of all five, and the one that gets them wrong.
+//
+// It is mounted while it is open and unmounted when it closes, which is what makes "the tab last open is remembered
+// nowhere" a property of the tree rather than a reset somebody has to remember to write.
+//
+// One control the project draws is missing, and deliberately: the choice between the simplified and the HTML view of a
+// message edits a preference this deployment does not hold, so drawing it would be a switch that decides nothing. It is
+// #1508, and the section heading it belongs under is here because the thread-expansion switch stands under it too.
+
+/** Which half of the surface is being read, in the order the design project puts the two tabs in. */
+const tabs = ['profile', 'application'] as const;
+
+type SettingsTab = (typeof tabs)[number];
+
+const tabNames: Readonly<Record<SettingsTab, MessageKey>> = {
+    profile: 'settings.profile',
+    application: 'settings.application',
+};
 
 export function Settings({
-    open,
     profile,
     preferences,
     telemetryForwarding,
     onClose,
 }: {
-    readonly open: boolean;
-
-    /** Who the client is drawing, and the three ways this screen changes it. */
+    /** Who the client is drawing, and the three ways this surface changes it. */
     readonly profile: OwnProfileInForce;
 
-    /** The settings that follow the person, of which this screen edits one. */
+    /** The settings that follow the person, of which this surface edits two. */
     readonly preferences: ClientPreferencesInForce;
 
     /** What this deployment has said about forwarding this client's telemetry, including that it has said nothing. */
@@ -49,41 +64,29 @@ export function Settings({
     const { translate } = useLocalization();
     const panel = useRef<HTMLDialogElement>(null);
     const named = useId();
+    const tabId = useId();
+    const [open, setOpen] = useState<SettingsTab>('profile');
 
-    // The one imperative browser API this screen synchronizes with, which is the whole of what an effect is for. The
-    // element's own state is asked rather than assumed, because `close` fires for Escape as well as for the control
-    // and the answer above would otherwise be told to close something already closed.
+    // The one imperative browser API this surface synchronizes with, which is the whole of what an effect is for. It
+    // runs once, because the element is in the document exactly as long as the surface is open.
     useEffect(() => {
-        const element = panel.current;
-
-        if (element === null) {
-            return;
-        }
-
-        if (open && !element.open) {
-            element.showModal();
-        }
-
-        if (!open && element.open) {
-            element.close();
-        }
-    }, [open]);
+        panel.current?.showModal();
+    }, []);
 
     return (
         <dialog
             ref={panel}
             aria-labelledby={named}
             onClose={onClose}
-            className="m-auto w-95 max-w-full rounded-3xl border border-line bg-panel p-0 text-base text-text shadow-dialog backdrop:bg-scrim"
+            className="m-0 h-full max-h-full w-full max-w-full rounded-none border-0 bg-panel p-0 text-base text-text backdrop:bg-scrim open:flex open:flex-col workspace:m-auto workspace:h-settings-card workspace:w-settings workspace:rounded-3xl workspace:border workspace:border-line workspace:shadow-dialog"
         >
-            <div className="flex items-center gap-3 border-b border-line bg-sunken px-3.5 py-2.5">
-                <h2 id={named} className="text-md font-semibold">
+            <div className="flex items-center gap-3 border-b border-line bg-sunken px-3.5 pt-3.5 pb-3 workspace:pt-2.5 workspace:pb-2.5">
+                <h2 id={named} className="text-2xl font-semibold workspace:text-md">
                     {translate('settings.title')}
                 </h2>
 
                 {/* Closed through the element rather than by answering upwards, so that the native `close` event is
-                    the one path out and `onClose` is called once however the screen was left. Calling it here as well
-                    would run it twice — once directly, and once when the effect above closed a dialog still open. */}
+                    the one path out and `onClose` is called once however the surface was left. */}
                 <button
                     type="button"
                     aria-label={translate('settings.close')}
@@ -96,21 +99,116 @@ export function Settings({
                 </button>
             </div>
 
-            <div className="flex flex-col gap-2.25 overflow-y-auto px-3.5 py-3">
-                <Profile profile={profile} />
+            <SettingsTabs id={tabId} open={open} onOpen={setOpen} />
 
-                <Divider />
-
-                <SectionName>{translate('shell.language')}</SectionName>
-                <LanguageSegments />
-
-                <Divider />
-
-                <SectionName>{translate('settings.privacy')}</SectionName>
-                <Telemetry preferences={preferences} forwarding={telemetryForwarding} />
+            <div
+                role="tabpanel"
+                id={`${tabId}-panel`}
+                aria-labelledby={`${tabId}-${open}`}
+                className="flex min-h-0 flex-1 flex-col gap-2.75 overflow-y-auto px-4 pt-3.5 pb-7 workspace:gap-2.25 workspace:pb-5"
+            >
+                {open === 'profile' ? (
+                    <Profile profile={profile} />
+                ) : (
+                    <Application preferences={preferences} telemetryForwarding={telemetryForwarding} />
+                )}
             </div>
         </dialog>
     );
+}
+
+/**
+ * The two halves of the surface as a tab list, which is what the design project draws and what a screen reader is owed.
+ *
+ * Buttons carrying the tab role rather than radio inputs, because a tab list has its own keyboard contract: one tab
+ * stop for the whole list, the arrow keys moving between the tabs inside it, and Home and End reaching the ends. That
+ * is what the roving `tabIndex` below is — the selected tab is the one the Tab key lands on, and the arrows move both
+ * the selection and the focus, which is the pattern for tabs whose panel follows the selection.
+ */
+function SettingsTabs({
+    id,
+    open,
+    onOpen,
+}: {
+    readonly id: string;
+    readonly open: SettingsTab;
+    readonly onOpen: (tab: SettingsTab) => void;
+}) {
+    const { translate } = useLocalization();
+
+    // The two tabs themselves, so a key press can put focus on the one it selected. Held by identity rather than found
+    // by a selector, because `useId` composes identifiers a CSS selector would have to be escaped for.
+    const buttons = useRef(new Map<SettingsTab, HTMLButtonElement>());
+
+    function move(to: SettingsTab): void {
+        onOpen(to);
+        buttons.current.get(to)?.focus();
+    }
+
+    return (
+        <div
+            role="tablist"
+            aria-label={translate('settings.sections')}
+            className="flex items-stretch gap-3.5 border-b border-line bg-sunken px-3.5"
+            onKeyDown={(event) => {
+                const stepped = steppedTo(event.key);
+
+                if (stepped !== null) {
+                    event.preventDefault();
+                    move(stepped);
+                }
+            }}
+        >
+            {tabs.map((offered) => (
+                <button
+                    key={offered}
+                    ref={(element) => {
+                        if (element === null) {
+                            buttons.current.delete(offered);
+                        } else {
+                            buttons.current.set(offered, element);
+                        }
+                    }}
+                    id={`${id}-${offered}`}
+                    type="button"
+                    role="tab"
+                    aria-selected={offered === open}
+                    aria-controls={`${id}-panel`}
+                    tabIndex={offered === open ? 0 : -1}
+                    className={`border-b-2 px-px pt-2.5 pb-2 text-sm whitespace-nowrap transition ${
+                        offered === open
+                            ? 'border-accent font-semibold text-text'
+                            : 'border-transparent text-muted hover:text-text'
+                    }`}
+                    onClick={() => {
+                        onOpen(offered);
+                    }}
+                >
+                    {translate(tabNames[offered])}
+                </button>
+            ))}
+        </div>
+    );
+}
+
+/**
+ * Which tab a key press moves to, or `null` where the press is not one this list answers.
+ *
+ * The list does not wrap at its ends, which is what makes Home and End the same answers as the two arrows while there
+ * are two tabs: a list of two that wrapped would make the left and right arrows one gesture, and holding either down
+ * would oscillate the selection under the reader.
+ */
+function steppedTo(key: string): SettingsTab | null {
+    switch (key) {
+        case 'ArrowLeft':
+        case 'Home':
+            return 'profile';
+        case 'ArrowRight':
+        case 'End':
+            return 'application';
+        default:
+            return null;
+    }
 }
 
 function Divider() {
@@ -121,6 +219,53 @@ function SectionName({ children }: { readonly children: string }) {
     return <p className="text-2xs tracking-widest text-faint uppercase">{children}</p>;
 }
 
+// What the client is read in and how it draws a conversation, in the design project's own order: the language, then
+// the message view, then the privacy section carrying the telemetry decision.
+function Application({
+    preferences,
+    telemetryForwarding,
+}: {
+    readonly preferences: ClientPreferencesInForce;
+    readonly telemetryForwarding: TelemetryForwarding;
+}) {
+    const { translate } = useLocalization();
+
+    return (
+        <>
+            <SectionName>{translate('shell.language')}</SectionName>
+            <LanguageSegments />
+
+            <Divider />
+
+            <SectionName>{translate('settings.messageView')}</SectionName>
+            <ThreadExpansion preferences={preferences} />
+
+            <Divider />
+
+            <SectionName>{translate('settings.privacy')}</SectionName>
+            <Telemetry preferences={preferences} forwarding={telemetryForwarding} />
+        </>
+    );
+}
+
+// Whether a conversation opens with every message drawn. Stated as the choice rather than as its absence, which is the
+// way round the design project draws it: the switch being on is the conversation opening expanded, and the line under
+// it says what the client does without it — which is what it does today and what an unset preference reads as.
+function ThreadExpansion({ preferences }: { readonly preferences: ClientPreferencesInForce }) {
+    const { translate } = useLocalization();
+
+    return (
+        <label className="flex cursor-pointer items-start gap-2.75 rounded-xl border border-line bg-sunken px-2.5 py-2.25 transition hover:bg-hover">
+            <span className="flex min-w-0 flex-1 flex-col gap-0.75">
+                {translate('settings.expandWholeThread')}
+                <span className="text-xs text-muted">{translate('settings.expandWholeThreadExplanation')}</span>
+            </span>
+
+            <Switch on={preferences.expandWholeThread} onChange={preferences.chooseThreadExpansion} />
+        </label>
+    );
+}
+
 // What the deployment records the person as, and the picture they are drawn by. The name is corrected in place rather
 // than through a form with a button: there is one field, and a person who has typed their name and moved on has said
 // what they mean as plainly as one who pressed Save.
@@ -128,7 +273,7 @@ function Profile({ profile }: { readonly profile: OwnProfileInForce }) {
     const { translate } = useLocalization();
 
     // What a file the person picked was refused for, which belongs to the control they picked it with rather than to
-    // the profile: it is decided here and never sent, so nothing outside this screen has anything to do about it.
+    // the profile: it is decided here and never sent, so nothing outside this surface has anything to do about it.
     const [refused, setRefused] = useState<PortraitChoice | null>(null);
     const named = useId();
 
@@ -148,8 +293,6 @@ function Profile({ profile }: { readonly profile: OwnProfileInForce }) {
 
     return (
         <>
-            <SectionName>{translate('settings.profile')}</SectionName>
-
             <div className="flex items-center gap-2.75">
                 <PersonAvatar displayName={profile.displayName} picture={profile.picture} place="profile" />
 
@@ -159,7 +302,7 @@ function Profile({ profile }: { readonly profile: OwnProfileInForce }) {
                     </label>
 
                     {/* Uncontrolled, and remounted by the name the deployment holds. What somebody is typing is not
-                        state this screen has any use for, and a second copy of it beside the stored name is the pair
+                        state this surface has any use for, and a second copy of it beside the stored name is the pair
                         that comes to disagree; keying on the stored name is what redraws the field when an answer
                         arrives without discarding a correction that has not been sent yet. */}
                     <input
@@ -227,6 +370,8 @@ function Profile({ profile }: { readonly profile: OwnProfileInForce }) {
                     <PictureNotice profile={profile} refused={refused} />
                 </div>
             </div>
+
+            <p className="text-2xs text-muted">{translate('settings.profileHeld')}</p>
 
             {profile.changeable ? null : <p className="text-2xs text-muted">{translate('settings.nameNotYours')}</p>}
 

--- a/frontend/src/Client.App/src/shell/AccountMenu.test.tsx
+++ b/frontend/src/Client.App/src/shell/AccountMenu.test.tsx
@@ -26,10 +26,12 @@ const settings: ClientPreferencesInForce = {
     openMailInTabs: false,
     markReadOnOpen: true,
     telemetryEnabled: true,
+    expandWholeThread: false,
     notStated: false,
     chooseTheme: () => undefined,
     chooseTabMode: () => undefined,
     chooseTelemetry: () => undefined,
+    chooseThreadExpansion: () => undefined,
 };
 
 const nobody: OwnProfileInForce = {

--- a/frontend/src/Client.App/src/shell/AccountMenu.tsx
+++ b/frontend/src/Client.App/src/shell/AccountMenu.tsx
@@ -51,7 +51,7 @@ export function AccountMenu({
      */
     readonly telemetryForwarding: TelemetryForwarding;
 
-    /** The settings that follow the person, and the three ways of changing one. */
+    /** The settings that follow the person, and the four ways of changing one. */
     readonly preferences: ClientPreferencesInForce;
 
     /** Who the client is drawing, which this menu shows and the screen behind its own row edits. */
@@ -167,14 +167,16 @@ export function AccountMenu({
             </div>
 
             {/* Outside the popover rather than inside it, because the menu is folded away while this is open and a
-                dialog inside something the platform sets `display: none` on is a dialog nobody can see. */}
-            <Settings
-                open={settingsOpen}
-                profile={profile}
-                preferences={preferences}
-                telemetryForwarding={telemetryForwarding}
-                onClose={closeSettings}
-            />
+                dialog inside something the platform sets `display: none` on is a dialog nobody can see. Rendered only
+                while it is open, which is what keeps the tab it was last left on out of anything that outlives it. */}
+            {settingsOpen ? (
+                <Settings
+                    profile={profile}
+                    preferences={preferences}
+                    telemetryForwarding={telemetryForwarding}
+                    onClose={closeSettings}
+                />
+            ) : null}
         </>
     );
 }

--- a/frontend/src/Client.App/src/styles.css
+++ b/frontend/src/Client.App/src/styles.css
@@ -219,6 +219,15 @@
     --spacing-mailboxes-folded: 4.8125rem;
     --spacing-drawer: 16.375rem;
 
+    /* The settings surface, in the composition where it is a card rather than the whole screen: the width the design
+       project draws it at, and the height it holds whatever is in it — so its body scrolls inside a card that does not
+       change size as somebody moves between its two tabs, and a tall window does not stretch it past what it needs.
+       Both are the project's, and both are a size the card is given rather than a ceiling it stops at, which is why
+       they sit here beside the rail's widths rather than among the `--container-*` measures a column is read against.
+       Below the workspace breakpoint neither is read, because the surface is the screen. */
+    --spacing-settings: 28.75rem;
+    --spacing-settings-card: min(78vh, 37.5rem);
+
     /* The widest a message's own content is ever drawn, which is a ceiling rather than a width: the reading pane takes
        whatever the three columns leave it, and this is where the words inside it stop taking more. It is the width the
        design draws the pane at, so a window the size the project was drawn against is unchanged by it and a wider one
@@ -235,13 +244,6 @@
        three the design project's. Below the floor the pane itself is the measure, which is what the narrow composition
        is. */
     --container-conversation: clamp(42.5rem, 62vw, 68.75rem);
-
-    /* The settings surface, in the composition where it is a card rather than the whole screen: the width the design
-       project draws it at, and the height it holds whatever is in it — so its body scrolls inside a card that does not
-       change size as somebody moves between its two tabs, and a tall window does not stretch it past what it needs.
-       Both are the project's. Below the workspace breakpoint neither is read, because the surface is the screen. */
-    --container-settings: 28.75rem;
-    --spacing-settings-card: min(78vh, 37.5rem);
 
     /* The widest one tab in the strip above the content pane is drawn, which is a ceiling in the same sense: a tab
        takes the room its title needs and stops here, so a long subject is cut rather than pushing every other tab off

--- a/frontend/src/Client.App/src/styles.css
+++ b/frontend/src/Client.App/src/styles.css
@@ -236,6 +236,13 @@
        is. */
     --container-conversation: clamp(42.5rem, 62vw, 68.75rem);
 
+    /* The settings surface, in the composition where it is a card rather than the whole screen: the width the design
+       project draws it at, and the height it holds whatever is in it — so its body scrolls inside a card that does not
+       change size as somebody moves between its two tabs, and a tall window does not stretch it past what it needs.
+       Both are the project's. Below the workspace breakpoint neither is read, because the surface is the screen. */
+    --container-settings: 28.75rem;
+    --spacing-settings-card: min(78vh, 37.5rem);
+
     /* The widest one tab in the strip above the content pane is drawn, which is a ceiling in the same sense: a tab
        takes the room its title needs and stops here, so a long subject is cut rather than pushing every other tab off
        the side. It is the width the design project draws a tab at. */

--- a/frontend/src/Client.App/src/thread/Thread.test.tsx
+++ b/frontend/src/Client.App/src/thread/Thread.test.tsx
@@ -138,13 +138,20 @@ function inTheFrame(
     conversation: OpenConversation,
     online: boolean,
     marking: ReadMarking = nothingMarkedRead,
+    expandWholeThread = false,
 ): ReactElement {
     return (
         <LocalizationProvider>
             <WorkspaceProvider>
                 <LinkOpenerContext value={() => Promise.resolve()}>
                     <ReadMarkingContext value={marking}>
-                        <Thread session={session} transport={transport} conversation={conversation} online={online} />
+                        <Thread
+                            session={session}
+                            transport={transport}
+                            conversation={conversation}
+                            online={online}
+                            expandWholeThread={expandWholeThread}
+                        />
                     </ReadMarkingContext>
                 </LinkOpenerContext>
             </WorkspaceProvider>
@@ -157,8 +164,9 @@ function drawing(
     conversation: OpenConversation = { threadId, openAt: null },
     online = true,
     marking: ReadMarking = nothingMarkedRead,
+    expandWholeThread = false,
 ) {
-    return render(inTheFrame(transport, conversation, online, marking));
+    return render(inTheFrame(transport, conversation, online, marking, expandWholeThread));
 }
 
 /** A client that would mark read, recording what each drawn body said was opened rather than submitting it. */
@@ -198,6 +206,35 @@ describe('Thread', () => {
         expect(await screen.findByText('The whole of what one says.')).toBeDefined();
 
         fireEvent.click(screen.getByRole('button', { name: 'Hide earlier messages' }));
+
+        expect(screen.getAllByRole('listitem')).toHaveLength(1);
+        expect(screen.queryByText('The whole of what one says.')).toBeNull();
+    });
+
+    it('opens with every message drawn where the reader asked conversations to open expanded', async () => {
+        drawing(
+            deploymentAnswering(pageOf(['one', 'two', 'three'])),
+            { threadId, openAt: null },
+            true,
+            nothingMarkedRead,
+            true,
+        );
+
+        expect(await screen.findByText('The whole of what one says.')).toBeDefined();
+        expect(screen.getAllByRole('listitem')).toHaveLength(3);
+        expect(screen.getByRole('button', { name: 'Hide earlier messages' })).toBeDefined();
+    });
+
+    it('still hides the history from a reader who asked for it expanded and then pressed the control', async () => {
+        drawing(
+            deploymentAnswering(pageOf(['one', 'two', 'three'])),
+            { threadId, openAt: null },
+            true,
+            nothingMarkedRead,
+            true,
+        );
+
+        fireEvent.click(await screen.findByRole('button', { name: 'Hide earlier messages' }));
 
         expect(screen.getAllByRole('listitem')).toHaveLength(1);
         expect(screen.queryByText('The whole of what one says.')).toBeNull();

--- a/frontend/src/Client.App/src/thread/Thread.tsx
+++ b/frontend/src/Client.App/src/thread/Thread.tsx
@@ -58,11 +58,15 @@ export function Thread({
     transport,
     conversation,
     online,
+    expandWholeThread,
 }: {
     readonly session: ClientSession;
     readonly transport: MailFathomTransport;
     readonly conversation: OpenConversation;
     readonly online: boolean;
+
+    /** Whether the reader asked for conversations to open with every message drawn rather than at the one they came for. */
+    readonly expandWholeThread: boolean;
 }) {
     const { locale, translate } = useLocalization();
     const { revise } = useWorkspace();
@@ -80,9 +84,12 @@ export function Thread({
     // does: nothing in a conversation brings one back, and a conversation reached a second time is a second mount.
     const [settled, setSettled] = useState(false);
 
-    // Whether the messages before the latest are drawn. Decided once by where the reader arrived — a message the
-    // history holds cannot be arrived at while the history is hidden — and theirs from then on.
-    const [historyShown, setHistoryShown] = useState(false);
+    // Whether the messages before the latest are drawn. It opens on what the reader asked conversations to open on,
+    // and is then decided by where they arrived — a message the history holds cannot be arrived at while the history
+    // is hidden — and theirs from then on. The preference is read once, on mounting, because it says how a conversation
+    // *opens*: a switch moved while one is on the screen changes the next conversation rather than this one, which is
+    // also why the control below still hides a history the preference showed.
+    const [historyShown, setHistoryShown] = useState(expandWholeThread);
 
     const regions = useRef(new Map<string, HTMLElement>());
 

--- a/frontend/src/Client.Backend/src/clientPreferences.test.ts
+++ b/frontend/src/Client.Backend/src/clientPreferences.test.ts
@@ -12,7 +12,13 @@ const session: ClientSession = {
     authorization: 'Basic dGVzdA==',
 };
 
-const stored = { telemetryEnabled: false, theme: 'dark', openMailInTabs: true, markReadOnOpen: false } as const;
+const stored = {
+    telemetryEnabled: false,
+    theme: 'dark',
+    openMailInTabs: true,
+    markReadOnOpen: false,
+    expandWholeThread: true,
+} as const;
 const storedBody = JSON.stringify(stored);
 
 // The transport is the network boundary and the whole of what a test here fakes. Neither route reads a header off an
@@ -48,7 +54,7 @@ describe('readClientPreferences', () => {
         expect(requests[0]?.headers['Authorization']).toBe('Basic dGVzdA==');
     });
 
-    it('reads the four preferences the deployment answered', async () => {
+    it('reads the five preferences the deployment answered', async () => {
         const answer = await readClientPreferences(session, answering({ status: 200, body: storedBody }));
 
         expect(answer).toStrictEqual({ outcome: 'read', value: stored });
@@ -89,6 +95,15 @@ describe('readClientPreferences', () => {
         [
             'an answer from a deployment older than one of the preferences',
             JSON.stringify({ telemetryEnabled: true, theme: 'dark', openMailInTabs: false }),
+        ],
+        [
+            'an answer from a deployment older than the thread-expansion preference',
+            JSON.stringify({
+                telemetryEnabled: true,
+                theme: 'dark',
+                openMailInTabs: false,
+                markReadOnOpen: true,
+            }),
         ],
     ])('refuses %s as unreadable rather than reading a document with a hole in it', async (_, body) => {
         const answer = await readClientPreferences(session, answering({ status: 200, body }));

--- a/frontend/src/Client.Backend/src/clientPreferences.ts
+++ b/frontend/src/Client.Backend/src/clientPreferences.ts
@@ -30,6 +30,9 @@ export interface ClientPreferences {
 
     /** Whether opening a message marks it read on the person's own mail server, across every account they read. */
     readonly markReadOnOpen: boolean;
+
+    /** Whether opening a conversation draws every message in it rather than the one it was opened at. */
+    readonly expandWholeThread: boolean;
 }
 
 /**
@@ -43,12 +46,13 @@ export const unsetClientPreferences: ClientPreferences = {
     theme: 'system',
     openMailInTabs: false,
     markReadOnOpen: true,
+    expandWholeThread: false,
 };
 
 /**
  * The most of one preferences answer this package reads before refusing it.
  *
- * The document is four scalars, so this is far above anything the deployment will legitimately send and far below
+ * The document is five scalars, so this is far above anything the deployment will legitimately send and far below
  * anything worth buffering. It is the same order the write route bounds its request body at, for the same reason:
  * what the bound guards against is an answer that was never a preferences document.
  */
@@ -132,11 +136,13 @@ function parsePreferences(body: string): ClientPreferences | null {
     const theme = record['theme'];
     const openMailInTabs = record['openMailInTabs'];
     const markReadOnOpen = record['markReadOnOpen'];
+    const expandWholeThread = record['expandWholeThread'];
 
     if (
         typeof telemetryEnabled !== 'boolean' ||
         typeof openMailInTabs !== 'boolean' ||
-        typeof markReadOnOpen !== 'boolean'
+        typeof markReadOnOpen !== 'boolean' ||
+        typeof expandWholeThread !== 'boolean'
     ) {
         return null;
     }
@@ -145,7 +151,7 @@ function parsePreferences(body: string): ClientPreferences | null {
         return null;
     }
 
-    return { telemetryEnabled, theme, openMailInTabs, markReadOnOpen };
+    return { telemetryEnabled, theme, openMailInTabs, markReadOnOpen, expandWholeThread };
 }
 
 function isThemePreference(value: unknown): value is ClientThemePreference {

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -819,8 +819,13 @@ test('draws the settings surface as a card over the workspace in a wide window',
 
     const panel = await page.getByRole('dialog', { name: 'Settings' }).boundingBox();
 
-    expect(panel?.width).toBeLessThan(wideWindow.width);
-    expect(panel?.height).toBeLessThan(wideWindow.height);
+    // The card's own measurements rather than merely "narrower than the window": a dialog the width utility failed to
+    // reach would still be a few pixels off the viewport's width once a scrollbar is counted, so bounding it below the
+    // window would pass for exactly the regression this test exists to catch. Both numbers are the tokens the design
+    // project's card is drawn at, in pixels at the root size this suite runs under — 28.75rem, and 78% of a 720-pixel
+    // window, which is the lower of that token's two terms here.
+    expect(panel?.width).toBeCloseTo(460, 0);
+    expect(panel?.height).toBeCloseTo(0.78 * wideWindow.height, 0);
 
     // The workspace is still behind it, which is what makes changing one setting something that opens over what
     // somebody was doing rather than a place they navigated to.

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -264,7 +264,13 @@ async function servedByADeployment(page: Page): Promise<void> {
     // about the two preferences held on the deployment is that a choice made in one session is in force in the next,
     // and a route answering a fixed document would prove the read alone while quietly passing a client that wrote
     // nothing at all.
-    let held = { telemetryEnabled: true, theme: 'system', openMailInTabs: false, markReadOnOpen: true };
+    let held = {
+        telemetryEnabled: true,
+        theme: 'system',
+        openMailInTabs: false,
+        markReadOnOpen: true,
+        expandWholeThread: false,
+    };
 
     await page.route('**/api/client/preferences', (route) => {
         if (route.request().method() === 'POST') {
@@ -425,6 +431,12 @@ async function openSettings(page: Page): Promise<void> {
     await openAccountMenu(page);
     await page.getByRole('button', { name: 'Settings', exact: true }).click();
     await expect(page.getByRole('dialog', { name: 'Settings' })).toBeVisible();
+}
+
+/** The settings surface opened on its second tab, which is where everything about the client rather than the person is. */
+async function openApplicationSettings(page: Page): Promise<void> {
+    await openSettings(page);
+    await page.getByRole('tab', { name: 'Application' }).click();
 }
 
 /**
@@ -744,6 +756,7 @@ test('states the whole preferences document to the deployment when one of them i
         theme: 'dark',
         openMailInTabs: false,
         markReadOnOpen: true,
+        expandWholeThread: false,
     });
 });
 
@@ -754,7 +767,7 @@ test('opens again in the language that was chosen, after the page is loaded afre
     await expect(discover).toBeVisible();
     await expect(page.locator('html')).toHaveAttribute('lang', 'en');
 
-    await openSettings(page);
+    await openApplicationSettings(page);
     await page.getByRole('group', { name: 'Language' }).getByText('Polski', { exact: true }).click();
     await page.reload();
 
@@ -794,6 +807,35 @@ test('closes the settings screen on Escape, handing focus back to the row that o
 
     await expect(page.getByRole('dialog', { name: 'Settings' })).toBeHidden();
     await expect(page.getByRole('button', { name: 'Settings', exact: true })).toBeFocused();
+});
+
+// The two compositions the design project draws the settings surface in, and the one assertion only a browser can
+// make about them: jsdom computes no geometry, so what a unit test can prove is that the surface is one component
+// with one set of controls, and what is left is the composition itself.
+test('draws the settings surface as a card over the workspace in a wide window', async ({ page }) => {
+    await page.setViewportSize(wideWindow);
+    await openSignedIn(page);
+    await openSettings(page);
+
+    const panel = await page.getByRole('dialog', { name: 'Settings' }).boundingBox();
+
+    expect(panel?.width).toBeLessThan(wideWindow.width);
+    expect(panel?.height).toBeLessThan(wideWindow.height);
+
+    // The workspace is still behind it, which is what makes changing one setting something that opens over what
+    // somebody was doing rather than a place they navigated to.
+    await expect(page.getByRole('heading', { name: 'Discover', level: 1 })).toBeVisible();
+});
+
+test('draws the settings surface as the whole screen in a single-pane window', async ({ page }) => {
+    await page.setViewportSize(narrowWindow);
+    await openSignedIn(page);
+    await openSettings(page);
+
+    const panel = await page.getByRole('dialog', { name: 'Settings' }).boundingBox();
+
+    expect(panel?.width).toBe(narrowWindow.width);
+    expect(panel?.height).toBe(narrowWindow.height);
 });
 
 // What language the client opens in when nobody has chosen one. Only a browser can answer it: `navigator.languages` is


### PR DESCRIPTION
Redraws the client's Settings as the design project now draws it, and adds the fifth per-person preference the project
introduces.

## What changed

**One surface in two compositions.** `Settings.tsx` is still a native `<dialog>` opened with `showModal()`, so focus
entry, the trap, Escape, the backdrop, and the focus return remain the platform's. What is new is that the element
carries both compositions as width variants: below the workspace breakpoint it is the whole screen with a larger head
and a taller body, and above it the card of the width and height the project draws, over the scrim. Nothing branches on
width in TypeScript, which is what `frontend/src/AGENTS.md` § *The two heads* asks for. Two new tokens carry the card's
measurements — `--container-settings` and `--spacing-settings-card` — so no size is written outside the token layer.

**Two tabs.** `Profil` and `Aplikacja` are a WAI-ARIA tab list: `role="tablist"`, `role="tab"`, `aria-selected`, a
roving `tabIndex` leaving one tab stop on the list, and the arrow, Home, and End keys moving both the selection and the
focus. `Profil` keeps the portrait, the name, the bound, the refusal, and a sentence about where the two values are
held; `Aplikacja` holds the language, the message-view heading, the new thread-expansion switch, and the privacy
section. Which tab was last open is remembered nowhere, structurally: `AccountMenu` mounts `<Settings>` only while it
is open, so the tab state cannot outlive the surface.

**A fifth preference: `expandWholeThread`.** It travels the whole path the four beside it do — `ClientPreferences`,
`ClientPreferencesDocument`, the `POST`/`GET` shapes on `/api/client/preferences`, and the client's own strict parser,
which refuses a document whose value is not a boolean exactly as it does for the others. Unset reads as `false`, which
is the behaviour the client already had, and a row written before the preference existed parses to that. `Thread`
reads it once on mounting, because it says how a conversation *opens*: moving the switch changes the next conversation
rather than the one on the screen, and the existing control still opens and closes the history either way.

## Breaking change

`ClientPreferencesResponse` gains a required `expandWholeThread` property and `ClientPreferencesRequest` an optional
one, so the client HTTP surface changes; `http-api-contract.json` is regenerated in this change. **No operator action
is required**: a stored document written before this release parses with the preference off, and a request omitting it
is committed as off.

## Design verification

Both compositions were held against the design project as screenshots at one viewport each — 1440×900 for the card and
390×844 for the full surface — with mock data and the Polish catalogue, since the project is drawn in Polish. The card
lands at the same position and size as the project draws it, and the head, tab row, section headings, switch rows,
dividers, and copy match region by region. Three differences are named rather than closed:

- **The message-view segmented control is absent.** It edits a preference this deployment does not hold, so drawing it
  would be a switch that decides nothing; it is #1508. Its section heading is present, because the thread-expansion
  switch stands under it.
- **The language chips read `English | Polski` rather than `Polski | English`.** The order is the catalogue's fixed
  one from #1496 and is unchanged here.
- **The card's corner radius is the theme's `rounded-3xl` (14px) against the project's 13px.** No token carries 13px,
  and adding one for a single 1px difference is not worth a theme entry.

A fourth difference is a design correction rather than a client defect, and is handed to the owner separately: the
project's `Profil` tab says the name and picture are visible only locally and are not sent, which is not true of
MailFathom — both are held by the deployment. The client states what actually happens.

## Verification

- `scripts/verify-full.sh` — pass.
- Backend suites: 13787 tests, all passing.
- Client: `pnpm typecheck`, `pnpm lint`, and 1777 tests across 102 files, all passing.
- `MAILFATHOM_UPDATE_PUBLIC_SURFACES=1` regenerated `http-api-contract.json`.
- `frontend/tests/client.spec.ts` gains two specs asserting the two compositions' geometry, because jsdom computes none
  and a unit test asserting a class name would prove nothing.

Closes #1536

https://claude.ai/code/session_015mt11kMqFq2AbgoH5vC8o4
