### PR TITLE
[#1582] Name each attached file kind and download them all in one act

### DIFF
--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -543,7 +543,8 @@ export const en = {
     'sender.authenticatedBy': 'Authenticated by {domain}, which is who actually sent it rather than the name above.',
     'sender.authenticatedByNobody': 'Nothing authenticated a sender for this message.',
 
-    'attachments.heading': 'Files this message carries',
+    'attachments.list': 'Files this message carries',
+    'attachments.downloadAll': 'Download all',
     'attachment.unnamed': 'Unnamed file',
     'attachment.download': 'Download {name}',
     'attachment.nameWasRewritten':

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -551,7 +551,8 @@ export const pl: Catalogue = {
         'Uwierzytelniona przez {domain} — to ona naprawdę ją wysłała, a nie nazwa widoczna powyżej.',
     'sender.authenticatedByNobody': 'Nic nie uwierzytelniło nadawcy tej wiadomości.',
 
-    'attachments.heading': 'Pliki dołączone do tej wiadomości',
+    'attachments.list': 'Pliki dołączone do tej wiadomości',
+    'attachments.downloadAll': 'Pobierz wszystkie',
     'attachment.unnamed': 'Plik bez nazwy',
     'attachment.download': 'Pobierz {name}',
     'attachment.nameWasRewritten':

--- a/frontend/src/Client.App/src/readingPane/Attachment.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/Attachment.test.tsx
@@ -2,23 +2,11 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import { act, fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
-import type { ClientRequest, ClientSession, MailAttachment } from '@mailfathom/client-backend';
-import {
-    AttachmentDeliveryContext,
-    type AttachmentDelivery,
-    type AttachmentDeliveryOutcome,
-} from '../deployment/attachmentDelivery';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { MailAttachment } from '@mailfathom/client-backend';
 import { LocalizationProvider } from '../localization/Localization';
-import { Attachment } from './Attachment';
-
-const session: ClientSession = {
-    baseAddress: 'https://mail.example.invalid',
-    authorization: 'Basic dGVzdA==',
-};
-
-const messageId = '00000000-0000-4000-8000-000000000000';
+import { Attachment, type Downloading } from './Attachment';
 
 const invoice: MailAttachment = {
     position: 1,
@@ -28,53 +16,26 @@ const invoice: MailAttachment = {
     sizeOctets: 2_048,
 };
 
-/** What a download was asked to do, so a test asserts on the request and the name rather than on a call being made. */
-interface Asked {
-    readonly request: ClientRequest;
-    readonly fileName: string;
-    readonly arrived: (octets: number) => void;
-    readonly abandoned: AbortSignal;
-}
+function drawing(
+    attachment: MailAttachment,
+    downloading?: Downloading,
+): { onDownload: () => void; onStop: () => void } {
+    const controls = { onDownload: vi.fn(), onStop: vi.fn() };
 
-/** A delivery that records what it was asked and answers when the test says so, never on its own. */
-function deliveryHeldOpen(): {
-    deliver: AttachmentDelivery;
-    asked: Asked[];
-    answer: (outcome: AttachmentDeliveryOutcome) => void;
-} {
-    const asked: Asked[] = [];
-    let settle: ((outcome: AttachmentDeliveryOutcome) => void) | null = null;
-
-    return {
-        asked,
-        answer: (outcome) => {
-            settle?.(outcome);
-        },
-        deliver: (request, fileName, arrived, abandoned) => {
-            asked.push({ request, fileName, arrived, abandoned });
-
-            return new Promise<AttachmentDeliveryOutcome>((resolve) => {
-                settle = resolve;
-            });
-        },
-    };
-}
-
-function drawing(attachment: MailAttachment, deliver: AttachmentDelivery): void {
     render(
         <LocalizationProvider>
-            <AttachmentDeliveryContext value={deliver}>
-                <ul>
-                    <Attachment session={session} storedEmailId={messageId} attachment={attachment} />
-                </ul>
-            </AttachmentDeliveryContext>
+            <ul>
+                <Attachment attachment={attachment} downloading={downloading} {...controls} />
+            </ul>
         </LocalizationProvider>,
     );
+
+    return controls;
 }
 
 describe('Attachment', () => {
     it('describes the file before anything is fetched, so a reader decides before it arrives', () => {
-        drawing(invoice, () => Promise.resolve('delivered'));
+        drawing(invoice);
 
         expect(screen.getByText('invoice.pdf')).toBeDefined();
         expect(screen.getByText('pdf')).toBeDefined();
@@ -85,19 +46,19 @@ describe('Attachment', () => {
     });
 
     it('names an unnamed part rather than offering a control with nothing to say', () => {
-        drawing({ ...invoice, fileName: null }, () => Promise.resolve('delivered'));
+        drawing({ ...invoice, fileName: null });
 
         expect(screen.getByRole('button', { name: 'Download Unnamed file' })).toBeDefined();
     });
 
-    it('names the kind of an unnamed part from what it declares itself to be', () => {
-        drawing({ ...invoice, fileName: null, mediaType: 'image/svg+xml' }, () => Promise.resolve('delivered'));
+    it('names the kind of a part from what the message declared it to be', () => {
+        drawing({ ...invoice, fileName: 'photo.jpg', mediaType: 'image/jpeg' });
 
-        expect(screen.getByText('svg')).toBeDefined();
+        expect(screen.getByText('image')).toBeDefined();
     });
 
     it('says where the sender wrote a file name the deployment would not use', () => {
-        drawing({ ...invoice, wasFileNameNormalized: true }, () => Promise.resolve('delivered'));
+        drawing({ ...invoice, wasFileNameNormalized: true });
 
         expect(
             screen.getByText(
@@ -106,68 +67,40 @@ describe('Attachment', () => {
         ).toBeDefined();
     });
 
-    it('fetches nothing until the download is asked for', () => {
-        const held = deliveryHeldOpen();
-        drawing(invoice, held.deliver);
+    it('asks for the file when the chip is pressed', () => {
+        const controls = drawing(invoice);
 
-        expect(held.asked).toEqual([]);
+        fireEvent.click(screen.getByRole('button', { name: 'Download invoice.pdf' }));
+
+        expect(controls.onDownload).toHaveBeenCalledTimes(1);
     });
 
-    it('asks for the file at the position the message described it at, under the size it stated', () => {
-        const held = deliveryHeldOpen();
-        drawing(invoice, held.deliver);
+    it('asks for nothing more while the file is still arriving', () => {
+        const controls = drawing(invoice, { stage: 'arriving', octets: 0 });
 
         fireEvent.click(screen.getByRole('button', { name: 'Download invoice.pdf' }));
 
-        expect(held.asked[0]?.request).toEqual({
-            method: 'GET',
-            path: `https://mail.example.invalid/api/client/messages/${messageId}/attachments/1`,
-            headers: { Accept: 'application/octet-stream', Authorization: 'Basic dGVzdA==' },
-            longestAnswer: 2_048,
-        });
+        expect(controls.onDownload).not.toHaveBeenCalled();
     });
 
-    it('says how much has arrived while the file is still arriving', async () => {
-        const held = deliveryHeldOpen();
-        drawing(invoice, held.deliver);
+    it('says how much has arrived while the file is still arriving', () => {
+        drawing(invoice, { stage: 'arriving', octets: 1_024 });
 
-        fireEvent.click(screen.getByRole('button', { name: 'Download invoice.pdf' }));
-
-        act(() => {
-            held.asked[0]?.arrived(1_024);
-        });
-
-        expect(await screen.findByText(`${sizeReadAs(1_024)} of ${sizeReadAs(2_048)}`)).toBeDefined();
+        expect(screen.getByText(`${sizeReadAs(1_024)} of ${sizeReadAs(2_048)}`)).toBeDefined();
     });
 
-    it('starts one download however often the control is pressed while that one is arriving', () => {
-        const held = deliveryHeldOpen();
-        drawing(invoice, held.deliver);
+    it('offers a way out of a download in flight', () => {
+        const controls = drawing(invoice, { stage: 'arriving', octets: 1_024 });
 
-        fireEvent.click(screen.getByRole('button', { name: 'Download invoice.pdf' }));
-        fireEvent.click(screen.getByRole('button', { name: 'Download invoice.pdf' }));
-
-        expect(held.asked.length).toBe(1);
-    });
-
-    it('offers a way out of a download in flight, and abandons it when that is taken', () => {
-        const held = deliveryHeldOpen();
-        drawing(invoice, held.deliver);
-
-        fireEvent.click(screen.getByRole('button', { name: 'Download invoice.pdf' }));
         fireEvent.click(screen.getByRole('button', { name: 'Stop downloading' }));
 
-        expect(held.asked[0]?.abandoned.aborted).toBe(true);
+        expect(controls.onStop).toHaveBeenCalledTimes(1);
     });
 
-    it('says the file was downloaded once it has been', async () => {
-        const held = deliveryHeldOpen();
-        drawing(invoice, held.deliver);
+    it('says the file was downloaded once it has been', () => {
+        drawing(invoice, { stage: 'finished', outcome: 'delivered' });
 
-        fireEvent.click(screen.getByRole('button', { name: 'Download invoice.pdf' }));
-        held.answer('delivered');
-
-        expect(await screen.findByText('invoice.pdf was downloaded.')).toBeDefined();
+        expect(screen.getByText('invoice.pdf was downloaded.')).toBeDefined();
     });
 
     it.each([
@@ -182,14 +115,10 @@ describe('Attachment', () => {
             'The deployment sent more than this message said the file holds, so nothing was saved. Report this as a defect.',
         ],
         ['abandoned', 'The download was stopped, so nothing was saved.'],
-    ] as const)('says what became of a download that answered %s', async (outcome, said) => {
-        const held = deliveryHeldOpen();
-        drawing(invoice, held.deliver);
+    ] as const)('says what became of a download that answered %s', (outcome, said) => {
+        drawing(invoice, { stage: 'finished', outcome });
 
-        fireEvent.click(screen.getByRole('button', { name: 'Download invoice.pdf' }));
-        held.answer(outcome);
-
-        expect(await screen.findByText(said)).toBeDefined();
+        expect(screen.getByRole('alert').textContent).toBe(said);
     });
 });
 

--- a/frontend/src/Client.App/src/readingPane/Attachment.tsx
+++ b/frontend/src/Client.App/src/readingPane/Attachment.tsx
@@ -2,25 +2,21 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import { useEffect, useRef, useState } from 'react';
-import { readMailAttachment, type ClientSession, type MailAttachment } from '@mailfathom/client-backend';
+import type { MailAttachment } from '@mailfathom/client-backend';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
-import {
-    deliveryFailureOf,
-    useAttachmentDelivery,
-    type AttachmentDeliveryOutcome,
-} from '../deployment/attachmentDelivery';
+import type { AttachmentDeliveryOutcome } from '../deployment/attachmentDelivery';
 import { sizeOf } from '../localization/octets';
-import { savedAs } from './savedFileName';
+import { kindOf } from './fileKind';
 
-// One file a message carries. It is described before anything is fetched — what it is called, what it declares itself to
-// be, and how large it is — so that opening a message costs the same whether the sender attached a note or a video, and
-// so that a reader decides whether a file is worth having before it starts arriving.
+// One file a message carries. It is described before anything is fetched — what kind of file it is, what it is called,
+// and how large it is — so that opening a message costs the same whether the sender attached a note or a video, and so
+// that a reader decides whether a file is worth having before it starts arriving.
 //
 // It is drawn as the design project draws it: a chip naming the kind of file, its name, and its size, which is the
-// control that fetches it. The row is its own component because it is what gains state: a download in flight, how much
-// of it has arrived, a way to stop it, and what became of it.
+// control that fetches it. The row is its own component because it is what a reader can name — one file, and what
+// became of asking for it. What it does not own is the asking: `Attachments.tsx` beside it holds every download,
+// because downloading all of them is an act on the message rather than on any one row.
 
 const refusalMessages: Readonly<Record<Exclude<AttachmentDeliveryOutcome, 'delivered'>, MessageKey>> = {
     abandoned: 'attachment.abandoned',
@@ -30,77 +26,29 @@ const refusalMessages: Readonly<Record<Exclude<AttachmentDeliveryOutcome, 'deliv
     largerThanDescribed: 'attachment.refusedLargerThanDescribed',
 };
 
-// The most of a kind the chip shows. A kind is a file's extension where the name has one and the media subtype where it
-// does not, and either can be long enough to be a sentence; the chip is a glance rather than a description.
-const longestKind = 8;
-
-/** What the row is doing, which is one piece of state rather than a flag beside a count that has to agree with it. */
-type Downloading =
-    | { readonly stage: 'described' }
+/** What is becoming of one file, which is one piece of state rather than a flag beside a count that has to agree. */
+export type Downloading =
     | { readonly stage: 'arriving'; readonly octets: number }
     | { readonly stage: 'finished'; readonly outcome: AttachmentDeliveryOutcome };
 
 export function Attachment({
-    session,
-    storedEmailId,
     attachment,
+    downloading,
+    onDownload,
+    onStop,
 }: {
-    readonly session: ClientSession;
-    readonly storedEmailId: string;
     readonly attachment: MailAttachment;
+
+    /** What is becoming of this file, or nothing where nobody has asked for it yet. */
+    readonly downloading: Downloading | undefined;
+
+    readonly onDownload: () => void;
+    readonly onStop: () => void;
 }) {
     const { locale, translate } = useLocalization();
-    const deliver = useAttachmentDelivery();
-    const [downloading, setDownloading] = useState<Downloading>({ stage: 'described' });
-
-    // The one thing a render does not own: a download in flight outlives the render that started it, and the way out of
-    // it has to be reachable from the button that stops it and from the cleanup below alike.
-    const running = useRef<AbortController | null>(null);
-
-    // A download whose row has gone is a download nobody is waiting for, and letting it finish would write a file to
-    // somebody's machine after they left the message it belongs to.
-    useEffect(
-        () => () => {
-            running.current?.abort();
-        },
-        [],
-    );
 
     const shown = attachment.fileName ?? translate('attachment.unnamed');
-    const arriving = downloading.stage === 'arriving';
-
-    function start(): void {
-        if (arriving) {
-            return;
-        }
-
-        const abandoning = new AbortController();
-        running.current = abandoning;
-        setDownloading({ stage: 'arriving', octets: 0 });
-
-        // The request is composed by `Client.Backend` inside the span it opens around the whole download, which is
-        // what puts this row's wait in the same trace as the deployment's work on it. What this component supplies is
-        // the part that is the screen's: where the file is saved, how much of it has arrived, and the way out.
-        void readMailAttachment(
-            session,
-            storedEmailId,
-            attachment.position,
-            attachment.sizeOctets,
-            (request) =>
-                deliver(
-                    request,
-                    savedAs(attachment.fileName, attachment.position),
-                    (octets) => {
-                        setDownloading({ stage: 'arriving', octets });
-                    },
-                    abandoning.signal,
-                ),
-            deliveryFailureOf,
-        ).then((outcome) => {
-            running.current = null;
-            setDownloading({ stage: 'finished', outcome });
-        });
-    }
+    const arriving = downloading?.stage === 'arriving';
 
     return (
         <li className="flex max-w-full flex-col gap-1 text-sm">
@@ -113,9 +61,13 @@ export function Attachment({
                 title={attachment.mediaType}
                 className="flex max-w-full cursor-pointer items-center gap-2.25 rounded-md border border-line bg-sunken px-3 py-2.25 text-start transition hover:border-accent hover:bg-hover aria-disabled:opacity-60"
                 type="button"
-                onClick={start}
+                onClick={() => {
+                    if (!arriving) {
+                        onDownload();
+                    }
+                }}
             >
-                <span className="shrink-0 text-xs font-semibold tracking-wide text-muted uppercase">
+                <span className="shrink-0 text-xs text-muted uppercase">
                     {kindOf(attachment.fileName, attachment.mediaType)}
                 </span>
                 <span className="min-w-0 truncate text-md text-text">{shown}</span>
@@ -128,17 +80,11 @@ export function Attachment({
                 <p className="text-muted">{translate('attachment.nameWasRewritten')}</p>
             ) : null}
 
-            {downloading.stage === 'arriving' ? (
-                <Arriving
-                    octets={downloading.octets}
-                    of={attachment.sizeOctets}
-                    onStop={() => {
-                        running.current?.abort();
-                    }}
-                />
+            {downloading?.stage === 'arriving' ? (
+                <Arriving octets={downloading.octets} of={attachment.sizeOctets} onStop={onStop} />
             ) : null}
 
-            {downloading.stage === 'finished' ? (
+            {downloading?.stage === 'finished' ? (
                 <p
                     className={downloading.outcome === 'delivered' ? 'text-muted' : 'text-warning'}
                     role={downloading.outcome === 'delivered' ? undefined : 'alert'}
@@ -150,14 +96,6 @@ export function Attachment({
             ) : null}
         </li>
     );
-}
-
-/** The kind of file the chip names: the name's extension where it has one, and the declared subtype otherwise. */
-function kindOf(fileName: string | null, mediaType: string): string {
-    const extension = fileName?.match(/\.([A-Za-z0-9]{1,8})$/)?.[1];
-    const subtype = mediaType.split('/')[1]?.split(/[+.;]/)[0] ?? '';
-
-    return (extension ?? subtype).slice(0, longestKind);
 }
 
 // How much has arrived and the way to stop it, said in the place the file will appear. `progress` is the element the

--- a/frontend/src/Client.App/src/readingPane/Attachments.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/Attachments.test.tsx
@@ -1,0 +1,209 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { ClientRequest, ClientSession, MailAttachment } from '@mailfathom/client-backend';
+import {
+    AttachmentDeliveryContext,
+    type AttachmentDelivery,
+    type AttachmentDeliveryOutcome,
+} from '../deployment/attachmentDelivery';
+import { LocalizationProvider } from '../localization/Localization';
+import { Attachments } from './Attachments';
+
+const session: ClientSession = {
+    baseAddress: 'https://mail.example.invalid',
+    authorization: 'Basic dGVzdA==',
+};
+
+const messageId = '00000000-0000-4000-8000-000000000000';
+
+const invoice: MailAttachment = {
+    position: 1,
+    fileName: 'invoice.pdf',
+    wasFileNameNormalized: false,
+    mediaType: 'application/pdf',
+    sizeOctets: 2_048,
+};
+
+const photograph: MailAttachment = {
+    position: 2,
+    fileName: 'photo.jpg',
+    wasFileNameNormalized: false,
+    mediaType: 'image/jpeg',
+    sizeOctets: 4_096,
+};
+
+/** What a download was asked to do, so a test asserts on the request and the name rather than on a call being made. */
+interface Asked {
+    readonly request: ClientRequest;
+    readonly fileName: string;
+    readonly arrived: (octets: number) => void;
+    readonly abandoned: AbortSignal;
+}
+
+/** A delivery that records what it was asked and answers when the test says so, never on its own. */
+function deliveryHeldOpen(): {
+    deliver: AttachmentDelivery;
+    asked: Asked[];
+    answer: (outcome: AttachmentDeliveryOutcome, at?: number) => void;
+} {
+    const asked: Asked[] = [];
+    const settling: ((outcome: AttachmentDeliveryOutcome) => void)[] = [];
+
+    return {
+        asked,
+        answer: (outcome, at) => {
+            settling[at ?? settling.length - 1]?.(outcome);
+        },
+        deliver: (request, fileName, arrived, abandoned) => {
+            asked.push({ request, fileName, arrived, abandoned });
+
+            return new Promise<AttachmentDeliveryOutcome>((resolve) => {
+                settling.push(resolve);
+            });
+        },
+    };
+}
+
+function drawing(attachments: readonly MailAttachment[], deliver: AttachmentDelivery) {
+    return render(
+        <LocalizationProvider>
+            <AttachmentDeliveryContext value={deliver}>
+                <Attachments session={session} storedEmailId={messageId} attachments={attachments} />
+            </AttachmentDeliveryContext>
+        </LocalizationProvider>,
+    );
+}
+
+describe('Attachments', () => {
+    it('fetches nothing until a download is asked for', () => {
+        const held = deliveryHeldOpen();
+        drawing([invoice, photograph], held.deliver);
+
+        expect(held.asked).toEqual([]);
+    });
+
+    it('asks for the file at the position the message described it at, under the size it stated', () => {
+        const held = deliveryHeldOpen();
+        drawing([invoice, photograph], held.deliver);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Download photo.jpg' }));
+
+        expect(held.asked[0]?.request).toEqual({
+            method: 'GET',
+            path: `https://mail.example.invalid/api/client/messages/${messageId}/attachments/2`,
+            headers: { Accept: 'application/octet-stream', Authorization: 'Basic dGVzdA==' },
+            longestAnswer: 4_096,
+        });
+    });
+
+    it('says how much has arrived while the file is still arriving', async () => {
+        const held = deliveryHeldOpen();
+        drawing([invoice], held.deliver);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Download invoice.pdf' }));
+
+        act(() => {
+            held.asked[0]?.arrived(1_024);
+        });
+
+        expect(await screen.findByText(`${sizeReadAs(1_024)} of ${sizeReadAs(2_048)}`)).toBeDefined();
+    });
+
+    it('starts one download however often the control is pressed while that one is arriving', () => {
+        const held = deliveryHeldOpen();
+        drawing([invoice], held.deliver);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Download invoice.pdf' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Download invoice.pdf' }));
+
+        expect(held.asked.length).toBe(1);
+    });
+
+    it('abandons a download in flight when the way out of it is taken', () => {
+        const held = deliveryHeldOpen();
+        drawing([invoice], held.deliver);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Download invoice.pdf' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Stop downloading' }));
+
+        expect(held.asked[0]?.abandoned.aborted).toBe(true);
+    });
+
+    it('says the file was downloaded once it has been', async () => {
+        const held = deliveryHeldOpen();
+        drawing([invoice], held.deliver);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Download invoice.pdf' }));
+        held.answer('delivered');
+
+        expect(await screen.findByText('invoice.pdf was downloaded.')).toBeDefined();
+    });
+
+    it('offers no way to download everything where the message carries one file', () => {
+        drawing([invoice], () => Promise.resolve('delivered'));
+
+        expect(screen.queryByRole('button', { name: 'Download all' })).toBeNull();
+    });
+
+    it('downloads every file the message carries, one after the next', async () => {
+        const held = deliveryHeldOpen();
+        drawing([invoice, photograph], held.deliver);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Download all' }));
+
+        expect(held.asked.length).toBe(1);
+        expect(held.asked[0]?.fileName).toBe('invoice.pdf');
+
+        held.answer('delivered');
+        await screen.findByText('invoice.pdf was downloaded.');
+
+        expect(held.asked.length).toBe(2);
+        expect(held.asked[1]?.fileName).toBe('photo.jpg');
+    });
+
+    it('asks for no further file once the message it belongs to has been closed', async () => {
+        const held = deliveryHeldOpen();
+        const { unmount } = drawing([invoice, photograph], held.deliver);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Download all' }));
+        unmount();
+
+        // The answer the abandoned download settles with, and then the microtasks the loop would continue on: what is
+        // being proven is that the file after it is never asked for, so the turns it would be asked in have to pass.
+        await act(async () => {
+            held.answer('abandoned');
+            await Promise.resolve();
+        });
+
+        expect(held.asked.length).toBe(1);
+    });
+
+    it('reports a refusal against the file it refused and downloads the rest anyway', async () => {
+        const held = deliveryHeldOpen();
+        drawing([invoice, photograph], held.deliver);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Download all' }));
+        held.answer('unavailable');
+        await screen.findByText('The deployment did not answer, so the file was not downloaded. Try again.');
+
+        held.answer('delivered');
+
+        expect(await screen.findByText('photo.jpg was downloaded.')).toBeDefined();
+        expect(screen.getAllByRole('alert').length).toBe(1);
+    });
+});
+
+// The size is `Intl`'s under the active language, so a test asks it the same question the screen asked rather than
+// spelling out an answer that would be about this machine.
+function sizeReadAs(octets: number): string {
+    return new Intl.NumberFormat('en', {
+        style: 'unit',
+        unit: 'kilobyte',
+        unitDisplay: 'short',
+        maximumFractionDigits: 1,
+    }).format(octets / 1_000);
+}

--- a/frontend/src/Client.App/src/readingPane/Attachments.tsx
+++ b/frontend/src/Client.App/src/readingPane/Attachments.tsx
@@ -1,0 +1,152 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { useEffect, useRef, useState } from 'react';
+import { readMailAttachment, type ClientSession, type MailAttachment } from '@mailfathom/client-backend';
+import { Icon } from '../controls/Icon';
+import { useLocalization } from '../localization/useLocalization';
+import { deliveryFailureOf, useAttachmentDelivery } from '../deployment/attachmentDelivery';
+import { Attachment, type Downloading } from './Attachment';
+import { savedAs } from './savedFileName';
+
+// The files one message carries, and the downloads of them. Both belong here rather than to a row, because downloading
+// every file is an act on the message: the row that would own its own download cannot be asked to start one by the
+// control beside the list, and a parent reaching into a child to start one is the effect `frontend/src/AGENTS.md`
+// refuses. So the strip owns what each file is doing and the row draws it.
+//
+// The bulk download drives the same per-file download the chip does, one file after the next, rather than asking the
+// deployment for a bundle: the route serves one part, and what a reader gets is the same files under the same names.
+// Waiting for each before starting the next is what keeps a message carrying twenty files from opening twenty requests
+// and holding twenty answers in memory at once. What that costs is that each file arrives as its own download, which is
+// where this differs from the design project — that draws one archive, which no route serves.
+
+export function Attachments({
+    session,
+    storedEmailId,
+    attachments,
+}: {
+    readonly session: ClientSession;
+    readonly storedEmailId: string;
+    readonly attachments: readonly MailAttachment[];
+}) {
+    const { translate } = useLocalization();
+    const deliver = useAttachmentDelivery();
+    const [downloading, setDownloading] = useState<ReadonlyMap<number, Downloading>>(new Map());
+    const [downloadingAll, setDownloadingAll] = useState(false);
+
+    // The one thing a render does not own: a download in flight outlives the render that started it, and the way out of
+    // it has to be reachable from the control that stops it and from the cleanup below alike.
+    const running = useRef(new Map<number, AbortController>());
+
+    // Whether the message these files belong to is still on the screen. Abandoning what is in flight is not enough on
+    // its own: the bulk download is a loop that asks for the next file once the one before it has settled, and a loop
+    // that kept going would start a download the cleanup below has already run past.
+    const opened = useRef(true);
+
+    // A download whose message has gone is a download nobody is waiting for, and letting it finish would write a file
+    // to somebody's machine after they left the message it belongs to.
+    useEffect(() => {
+        const abandoning = running.current;
+        opened.current = true;
+
+        return () => {
+            opened.current = false;
+
+            for (const download of abandoning.values()) {
+                download.abort();
+            }
+        };
+    }, []);
+
+    function record(position: number, stage: Downloading): void {
+        setDownloading((current) => new Map(current).set(position, stage));
+    }
+
+    async function start(attachment: MailAttachment): Promise<void> {
+        // A file already arriving is left to arrive. The chip refuses a second press for the same reason, and the bulk
+        // download reaches files somebody may already have asked for one at a time.
+        if (!opened.current || running.current.has(attachment.position)) {
+            return;
+        }
+
+        const abandoning = new AbortController();
+        running.current.set(attachment.position, abandoning);
+        record(attachment.position, { stage: 'arriving', octets: 0 });
+
+        // The request is composed by `Client.Backend` inside the span it opens around the whole download, which is
+        // what puts this wait in the same trace as the deployment's work on it. What this component supplies is the
+        // part that is the screen's: where the file is saved, how much of it has arrived, and the way out.
+        const outcome = await readMailAttachment(
+            session,
+            storedEmailId,
+            attachment.position,
+            attachment.sizeOctets,
+            (request) =>
+                deliver(
+                    request,
+                    savedAs(attachment.fileName, attachment.position),
+                    (octets) => {
+                        record(attachment.position, { stage: 'arriving', octets });
+                    },
+                    abandoning.signal,
+                ),
+            deliveryFailureOf,
+        );
+
+        running.current.delete(attachment.position);
+        record(attachment.position, { stage: 'finished', outcome });
+    }
+
+    // Each file is asked for in turn and each answer is recorded against the file it belongs to, so one refusal is one
+    // file's refusal: the files after it are still asked for, and the reader is told which one did not arrive.
+    async function startAll(): Promise<void> {
+        setDownloadingAll(true);
+
+        for (const attachment of attachments) {
+            await start(attachment);
+        }
+
+        setDownloadingAll(false);
+    }
+
+    return (
+        // The bulk control is an item of this list rather than something beside it, which is how the design draws it:
+        // one row that wraps as one, with the control following the last file however many lines the files took.
+        <ul aria-label={translate('attachments.list')} className="flex flex-wrap items-center gap-2.25">
+            {attachments.map((attachment) => (
+                <Attachment
+                    key={attachment.position}
+                    attachment={attachment}
+                    downloading={downloading.get(attachment.position)}
+                    onDownload={() => {
+                        void start(attachment);
+                    }}
+                    onStop={() => {
+                        running.current.get(attachment.position)?.abort();
+                    }}
+                />
+            ))}
+
+            {/* Offered where there is more than one file to download, which is where it saves a press: the design
+                project draws it on exactly that message and nothing else. */}
+            {attachments.length > 1 ? (
+                <li>
+                    <button
+                        aria-disabled={downloadingAll}
+                        className="flex cursor-pointer items-center gap-1.5 rounded-md bg-accent-soft px-3 py-2.25 text-sm text-accent-deep transition hover:bg-accent-strong hover:text-on-accent aria-disabled:opacity-60"
+                        type="button"
+                        onClick={() => {
+                            if (!downloadingAll) {
+                                void startAll();
+                            }
+                        }}
+                    >
+                        <Icon name="download" className="size-4" />
+                        {translate('attachments.downloadAll')}
+                    </button>
+                </li>
+            ) : null}
+        </ul>
+    );
+}

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
@@ -204,7 +204,7 @@ describe('ReadingPane', () => {
         drawing(deploymentDescribing());
         await screen.findByRole('heading', { name: 'Quarterly invoice', level: 2 });
 
-        expect(screen.queryByText('Files this message carries')).toBeNull();
+        expect(screen.queryByRole('list', { name: 'Files this message carries' })).toBeNull();
     });
 
     it('describes every file the message carries before any of them is fetched', async () => {
@@ -212,6 +212,7 @@ describe('ReadingPane', () => {
 
         expect(await screen.findByRole('button', { name: 'Download invoice.pdf' })).toBeDefined();
         expect(screen.getByRole('button', { name: 'Download photo.jpg' })).toBeDefined();
+        expect(screen.getByRole('list', { name: 'Files this message carries' })).toBeDefined();
     });
 
     it('says what a message carries besides its files, where any of it is true', async () => {

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
@@ -20,7 +20,7 @@ import { useLocalization } from '../localization/useLocalization';
 import { useReadMarking } from '../readMarking/useReadMarking';
 import { useWorkspace } from '../workspace/useWorkspace';
 import { Message } from '../messageBody/Message';
-import { Attachment } from './Attachment';
+import { Attachments } from './Attachments';
 import { MessageHeaders } from './MessageHeaders';
 import { sizeOf } from '../localization/octets';
 import { SenderVerdict } from './SenderVerdict';
@@ -367,20 +367,11 @@ function OpenMessage({
                     </div>
 
                     {message.attachments.length === 0 ? null : (
-                        <section className="flex flex-col gap-2 border-t border-line-soft pt-3">
-                            <h3 className="text-sm font-medium text-text-soft">{translate('attachments.heading')}</h3>
-
-                            <ul className="flex flex-wrap gap-2">
-                                {message.attachments.map((attachment) => (
-                                    <Attachment
-                                        key={attachment.position}
-                                        session={session}
-                                        storedEmailId={storedEmailId}
-                                        attachment={attachment}
-                                    />
-                                ))}
-                            </ul>
-                        </section>
+                        <Attachments
+                            session={session}
+                            storedEmailId={storedEmailId}
+                            attachments={message.attachments}
+                        />
                     )}
                 </div>
 

--- a/frontend/src/Client.App/src/readingPane/fileKind.test.ts
+++ b/frontend/src/Client.App/src/readingPane/fileKind.test.ts
@@ -1,0 +1,42 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import { kindOf } from './fileKind';
+
+describe('kindOf', () => {
+    it.each([
+        ['application/pdf', 'pdf'],
+        ['application/msword', 'doc'],
+        ['application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'docx'],
+        ['application/vnd.ms-excel', 'xls'],
+        ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'xlsx'],
+        ['application/vnd.ms-powerpoint', 'ppt'],
+        ['application/vnd.openxmlformats-officedocument.presentationml.presentation', 'pptx'],
+        ['image/png', 'image'],
+        ['image/svg+xml', 'image'],
+    ])('names the family a message declared %s under', (mediaType, kind) => {
+        expect(kindOf('carried', mediaType)).toBe(kind);
+    });
+
+    it('names the family the message declared rather than the one the sender named the file after', () => {
+        expect(kindOf('figures.pdf', 'application/vnd.ms-excel')).toBe('xls');
+    });
+
+    it('reads a media type back through its parameters and its casing, which a sender writes as they please', () => {
+        expect(kindOf(null, 'Application/PDF; name="polisa.pdf"')).toBe('pdf');
+    });
+
+    it('falls back to the extension where the declared type names no family', () => {
+        expect(kindOf('archive.zip', 'application/octet-stream')).toBe('zip');
+    });
+
+    it('falls back to the declared subtype where there is no name to read an extension from', () => {
+        expect(kindOf(null, 'text/calendar')).toBe('calendar');
+    });
+
+    it('cuts a kind long enough to be a description down to the glance the badge is', () => {
+        expect(kindOf('no-extension', 'application/octet-stream')).toBe('octet-st');
+    });
+});

--- a/frontend/src/Client.App/src/readingPane/fileKind.ts
+++ b/frontend/src/Client.App/src/readingPane/fileKind.ts
@@ -1,0 +1,46 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+// What kind of file a badge names, so that a reader tells a document from a spreadsheet without reading a file name.
+//
+// It is answered from the media type the message declares the part under before anything else, because that is what
+// MailFathom recorded the part as; a name is text a sender wrote, and a spreadsheet called `report.pdf` would otherwise
+// be drawn as a document. The name is what answers it where the declared type names no family — a sender whose client
+// declared every attachment `application/octet-stream` still has an extension worth showing.
+
+/** The families a badge names, by the media type a message declares one under. */
+const families: Readonly<Record<string, string | undefined>> = {
+    'application/pdf': 'pdf',
+    'application/msword': 'doc',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
+    'application/vnd.ms-excel': 'xls',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
+    'application/vnd.ms-powerpoint': 'ppt',
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'pptx',
+};
+
+// The most of a kind the badge shows. A kind that falls through to the name or the subtype can be long enough to be a
+// sentence; the badge is a glance rather than a description.
+const longestKind = 8;
+
+/**
+ * The kind of file a badge names: the family the declared media type belongs to, and the name's extension or the
+ * declared subtype for anything no family covers.
+ *
+ * @param fileName The name the message carries for the part, already normalized, or nothing where it carries none.
+ * @param mediaType What the message declares the part to be, parameters and casing as the sender wrote them.
+ */
+export function kindOf(fileName: string | null, mediaType: string): string {
+    const declared = mediaType.split(';')[0]?.trim().toLowerCase() ?? '';
+    const family = families[declared] ?? (declared.startsWith('image/') ? 'image' : undefined);
+
+    if (family !== undefined) {
+        return family;
+    }
+
+    const extension = /\.([A-Za-z0-9]{1,8})$/u.exec(fileName ?? '')?.[1];
+    const subtype = declared.split('/')[1]?.split(/[+.]/u)[0] ?? '';
+
+    return (extension ?? subtype).slice(0, longestKind);
+}

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -1231,13 +1231,13 @@ test('stops a message’s own content at the reading ceiling and leaves everythi
     await openTheFirstMessage(page);
     await expect(page.getByRole('heading', messageHeading)).toBeVisible();
 
-    // The sender's own heading stands inside the message's content and the attachments heading beside it does not, so
-    // the two boxes are the whole comparison — same left edge, different widths. What the ceiling is worth in pixels
+    // The sender's own heading stands inside the message's content and the list of files beside it does not, so the
+    // two boxes are the whole comparison — same left edge, different widths. What the ceiling is worth in pixels
     // is the token's business rather than this suite's; what is asserted is the shape, because both ways of getting it
     // wrong are visible here and nowhere jsdom can reach. A ceiling dropped again draws the two at one width, and a
     // centred one moves the content's left edge off the edge everything around it keeps.
     const content = await boxOf(page.getByRole('heading', messageHeading));
-    const aroundIt = await boxOf(page.getByRole('heading', { name: 'Files this message carries' }));
+    const aroundIt = await boxOf(page.getByRole('list', { name: 'Files this message carries' }));
 
     expect(content.width).toBeLessThan(aroundIt.width);
     expect(content.x).toBeCloseTo(aroundIt.x, 0);


### PR DESCRIPTION
## What changed

The reading pane's attachment strip now names each file's kind from what the message declared it to
be, and offers one control that downloads every file the message carries.

- **`readingPane/fileKind.ts`** answers the badge from the media type rather than from the sender's
  own file name: PDF, the Office formats (`doc`/`docx`, `xls`/`xlsx`, `ppt`/`pptx`), and `image` for
  any image type, falling back to the name's extension and then to the declared subtype for anything
  else. A spreadsheet a sender called `report.pdf` is drawn as a spreadsheet.
- **`readingPane/Attachments.tsx`** is new and owns every download on the message. It asks for each
  file in turn, records each answer against the file it belongs to, and stops asking once the message
  is closed — so a refusal on one file is reported on that file and the files after it are still
  asked for. `Attachment.tsx` is now the row alone: it draws what it is told and fetches nothing.
- **"Download all"** appears where the message carries more than one file, which is the case the
  design project draws it on.
- The visible heading above the strip is gone, as the design draws it, and the list carries the same
  words as its accessible name instead.

## Held against the design project

Both screens were captured at 1440 × 900, the design through `render_preview` and the client against
the built bundle with stubbed routes. The chip, its badge, name and size, the spacing, the tokens,
and the bulk control's placement all match. Three differences remain and each is named rather than
absorbed:

- **No separate download control inside the chip.** The design divides each chip: the body opens a
  preview and a 32-pixel segment beside it downloads. Opening a preview is #1521, so today both halves
  would download, which is two controls with one action and one accessible name. The split lands with
  #1521, when the two halves have two actions.
- **The bulk control downloads each file rather than one archive.** The design draws `folder_zip` and
  packages `zalaczniki.zip`; a bundled response is a route change, which this issue puts out of scope.
  The control therefore carries the `download` symbol and delivers the files themselves.
- **The badge is not coloured.** The issue's context says the design gives each type a coloured badge;
  the project draws every one of them in `var(--muted)`, on this surface and in the Discover gallery
  alike. The project won, so the badge is muted and this paragraph is the correction the issue needed.

## Verification

- `scripts/verify-full.sh` — passed. 2063 unit tests, 287 workflow assertions, statements 94.96%.
- The browser suite's reading-ceiling test now anchors on the list rather than on the removed heading;
  it was run and passes.
- New unit tests: the badge for each media-type family and for both fallbacks, and "download all"
  against a mixed success and failure, against a message closed mid-run, and against a message
  carrying one file.

Closes #1582

https://claude.ai/code/session_01VbsfvWEWbpipcXMFMGAt2s
