### PR TITLE
[#1606] Keep what happened for the person it happened to, produced by the synchronization run

### DIFF
--- a/backend/src/Application/Notifications/INotificationStore.cs
+++ b/backend/src/Application/Notifications/INotificationStore.cs
@@ -1,0 +1,46 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Access;
+using MailFathom.Domain.Notifications;
+
+namespace MailFathom.Application.Notifications;
+
+/// <summary>Keeps what happened to a person while nobody was looking at their screen.</summary>
+/// <remarks>
+/// Every producer raises through this port rather than writing to the table, which is what makes the deduplication
+/// rule one rule: a stage that composed its own insert would decide for itself whether a condition had already been
+/// said, and two producers deciding that separately is how a notification centre starts repeating itself.
+/// </remarks>
+public interface INotificationStore
+{
+    /// <summary>Records one notification unless the condition it names is already standing unread.</summary>
+    /// <param name="notification">The notification to keep.</param>
+    /// <param name="cancellationToken">Cancels the write.</param>
+    /// <returns><see langword="true" /> when the notification was kept, and <see langword="false" /> when an unread one already names the same condition.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="notification" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The comparison is against the owner's unread notifications alone. A condition the person has already read is
+    /// free to be said again, which is what keeps a credential that is refused, repaired, and refused again from being
+    /// suppressed forever by the first statement about it.
+    /// </remarks>
+    Task<bool> RecordAsync(Notification notification, CancellationToken cancellationToken);
+
+    /// <summary>Erases up to a bounded number of one owner's notifications that describe something older than a given instant.</summary>
+    /// <param name="owner">The owner whose notifications are aged.</param>
+    /// <param name="occurredBefore">The instant a notification must describe something older than to be erased.</param>
+    /// <param name="limit">The greatest number of notifications one call may erase.</param>
+    /// <param name="cancellationToken">Cancels the erasure.</param>
+    /// <returns>How many notifications were erased, which reaching <paramref name="limit" /> means more remain.</returns>
+    /// <remarks>
+    /// It erases read and unread alike: the bound is a storage-limitation decision about a derived record, not a
+    /// reading list, and a statement nobody opened in three months is not one they are about to.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="limit" /> is not positive.</exception>
+    Task<int> EraseOccurredBeforeAsync(
+        MailOwnerId owner,
+        DateTimeOffset occurredBefore,
+        int limit,
+        CancellationToken cancellationToken);
+}

--- a/backend/src/Application/Notifications/NotificationRetention.cs
+++ b/backend/src/Application/Notifications/NotificationRetention.cs
@@ -1,0 +1,71 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Access;
+
+namespace MailFathom.Application.Notifications;
+
+/// <summary>Ages one owner's notifications out at the bound the record is held to.</summary>
+/// <remarks>
+/// <para>
+/// A notification is derived personal data — it says what reached a person's mailbox and when — so a table nobody
+/// prunes becomes a mailbox history in miniature, held for longer than anybody undertook to hold it. The bound is what
+/// stops that, and it is the record's own rather than an account's: notifications belong to the owner, and an owner
+/// reading one notification centre cannot have two answers about how long it remembers.
+/// </para>
+/// <para>
+/// It rides the account's own synchronization run, beside the retention passes already there, for the reason those
+/// ride it: an account already has a loop that comes round, and a schedule of its own would be another thing to
+/// configure and watch for one bounded delete. An owner with several accounts is therefore swept once per account,
+/// which costs a query that erases nothing rather than a second mechanism.
+/// </para>
+/// </remarks>
+public sealed class NotificationRetention
+{
+    /// <summary>How long a notification is kept after the thing it describes happened.</summary>
+    /// <remarks>
+    /// It is a constant rather than a setting because there is no operator decision behind it to take. The audit
+    /// trails are configurable because keeping a history of a person's mailbox is something a deployment undertakes
+    /// deliberately and answers for; a notification is the client's own working state, produced whether anybody asked
+    /// or not, and a knob for it would be configuration nobody has a reason to move. Three months is long enough that
+    /// somebody returning from leave still finds what happened and short enough that the table stays a working set.
+    /// </remarks>
+    public static readonly TimeSpan Window = TimeSpan.FromDays(90);
+
+    /// <summary>The greatest number of notifications one pass erases.</summary>
+    /// <remarks>
+    /// A pass that reaches the bound is followed by another on the account's next run, so the number decides how long
+    /// a backlog takes to clear rather than what is kept. What it exists for is the backlog case — a deployment
+    /// upgrading into this bound with months of notifications behind it — where an unbounded delete would lock the
+    /// table against every raise behind it.
+    /// </remarks>
+    public const int MaximumNotificationsErasedPerPass = 5_000;
+
+    private readonly INotificationStore store;
+    private readonly TimeProvider timeProvider;
+
+    /// <summary>Initializes the retention pass from the record it erases from.</summary>
+    /// <param name="store">Holds the notifications the pass erases from.</param>
+    /// <param name="timeProvider">Measures the window back from now.</param>
+    /// <exception cref="ArgumentNullException">Thrown when a required collaborator is <see langword="null" />.</exception>
+    public NotificationRetention(INotificationStore store, TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        this.store = store;
+        this.timeProvider = timeProvider;
+    }
+
+    /// <summary>Erases everything of one owner's that has outlived the window.</summary>
+    /// <param name="owner">The owner whose notifications are aged.</param>
+    /// <param name="cancellationToken">Cancels the erasure.</param>
+    /// <returns>How many notifications were erased.</returns>
+    public Task<int> EraseExpiredAsync(MailOwnerId owner, CancellationToken cancellationToken) =>
+        this.store.EraseOccurredBeforeAsync(
+            owner,
+            this.timeProvider.GetUtcNow() - Window,
+            MaximumNotificationsErasedPerPass,
+            cancellationToken);
+}

--- a/backend/src/Application/Notifications/SynchronizationNotifications.cs
+++ b/backend/src/Application/Notifications/SynchronizationNotifications.cs
@@ -77,7 +77,7 @@ public sealed class SynchronizationNotifications
                 ? "1 new message arrived."
                 : string.Create(CultureInfo.InvariantCulture, $"{newMessageCount} new messages arrived."),
             NotificationTarget.ToScreen(NotificationScreen.Mail),
-            $"mail-arrived:{account.Id.Value}",
+            condition: "mail-arrived",
             cancellationToken);
     }
 
@@ -114,7 +114,7 @@ public sealed class SynchronizationNotifications
                 CultureInfo.InvariantCulture,
                 $"{failedFolderCount} of {scheduledFolderCount} folders did not finish. MailFathom will try again."),
             NotificationTarget.Nothing,
-            $"synchronization-incomplete:{account.Id.Value}",
+            condition: "synchronization-incomplete",
             cancellationToken);
     }
 
@@ -135,7 +135,7 @@ public sealed class SynchronizationNotifications
             title: "This account needs signing in again",
             body: "The mail server refused the credential MailFathom holds, so this account is no longer being fetched.",
             NotificationTarget.ToScreen(NotificationScreen.Settings),
-            $"credential-refused:{account.Id.Value}",
+            condition: "credential-refused",
             cancellationToken);
 
     private Task<bool> RecordAsync(
@@ -144,10 +144,17 @@ public sealed class SynchronizationNotifications
         string title,
         string body,
         NotificationTarget target,
-        string deduplicationKey,
+        string condition,
         CancellationToken cancellationToken)
     {
         var occurredAt = this.timeProvider.GetUtcNow();
+        var accountId = account.Id.Value;
+
+        // An account identifier is the operator's own text and nothing bounds its length, while both places one
+        // reaches here are bounded columns. The key reduces an outsized one to a digest of itself; the source line is
+        // a label rather than an identity, so an identifier that cannot be shown leaves the kind as the whole of it
+        // rather than being shown truncated as an account nobody configured.
+        var source = accountId.Length <= Notification.MaximumSourceLength ? accountId : null;
 
         return this.store.RecordAsync(
             Notification.Compose(
@@ -156,9 +163,9 @@ public sealed class SynchronizationNotifications
                 kind,
                 title,
                 body,
-                account.Id.Value,
+                source,
                 target,
-                NotificationDeduplicationKey.Create(deduplicationKey),
+                NotificationDeduplicationKey.For(condition, account.Id.Value),
                 occurredAt),
             cancellationToken);
     }

--- a/backend/src/Application/Notifications/SynchronizationNotifications.cs
+++ b/backend/src/Application/Notifications/SynchronizationNotifications.cs
@@ -1,0 +1,165 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Globalization;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Notifications;
+
+namespace MailFathom.Application.Notifications;
+
+/// <summary>Turns what a synchronization run observed into what its owner is told about it.</summary>
+/// <remarks>
+/// <para>
+/// The run is the only producer wired today, and it produces two things: that mail arrived, and that something about
+/// the account needs a person. Both are facts the service holds and the client cannot derive, which is the whole
+/// reason the record exists.
+/// </para>
+/// <para>
+/// Mail is reported once per run rather than once per message. A run that commits forty messages is one arrival to the
+/// person who was away from the screen, and forty rows would bury every other kind of notification under one
+/// mailbox's traffic. The count is the run's, and the row leads to the mailbox rather than to any one message,
+/// because there is no one message a run is about.
+/// </para>
+/// <para>
+/// Nothing composed here reads mail. A count, an account identifier, and a fixed sentence are what a row carries, so
+/// no subject, address, body fragment, filename, or credential can reach the record, a log, or a telemetry event
+/// through this path.
+/// </para>
+/// </remarks>
+public sealed class SynchronizationNotifications
+{
+    private readonly INotificationStore store;
+    private readonly TimeProvider timeProvider;
+
+    /// <summary>Initializes the producer from the record it raises into.</summary>
+    /// <param name="store">Keeps what is raised.</param>
+    /// <param name="timeProvider">Stamps a notification with when the run observed what it describes.</param>
+    /// <exception cref="ArgumentNullException">Thrown when a required collaborator is <see langword="null" />.</exception>
+    public SynchronizationNotifications(INotificationStore store, TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        this.store = store;
+        this.timeProvider = timeProvider;
+    }
+
+    /// <summary>Reports the mail one run committed, as one notification for the run.</summary>
+    /// <param name="account">The account the run was over.</param>
+    /// <param name="newMessageCount">How many messages the run committed locally.</param>
+    /// <param name="cancellationToken">Cancels the raise.</param>
+    /// <returns><see langword="true" /> when a notification was kept.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="newMessageCount" /> is negative.</exception>
+    /// <remarks>
+    /// A run that committed nothing says nothing: an empty run is the ordinary case and is not an event anybody was
+    /// away from the screen for. Arrival is deduplicated like every other condition, so a standing unread arrival
+    /// keeps the count of the run that raised it and a later run's mail adds no second row: what the row says is that
+    /// mail arrived rather than how much is waiting, and the mailbox answers the second question when it is opened.
+    /// </remarks>
+    public Task<bool> ReportArrivedMailAsync(
+        MailAccountIdentity account,
+        int newMessageCount,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(newMessageCount);
+
+        if (newMessageCount == 0)
+        {
+            return Task.FromResult(false);
+        }
+
+        return this.RecordAsync(
+            account,
+            NotificationKind.Mail,
+            title: "New mail",
+            body: newMessageCount == 1
+                ? "1 new message arrived."
+                : string.Create(CultureInfo.InvariantCulture, $"{newMessageCount} new messages arrived."),
+            NotificationTarget.ToScreen(NotificationScreen.Mail),
+            $"mail-arrived:{account.Id.Value}",
+            cancellationToken);
+    }
+
+    /// <summary>Reports a run that ended with folders it did not finish.</summary>
+    /// <param name="account">The account the run was over.</param>
+    /// <param name="failedFolderCount">How many of the run's folders did not finish.</param>
+    /// <param name="scheduledFolderCount">How many folders the run scheduled.</param>
+    /// <param name="cancellationToken">Cancels the raise.</param>
+    /// <returns><see langword="true" /> when a notification was kept.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when either count is negative.</exception>
+    /// <remarks>
+    /// A run that finished everything it scheduled says nothing, because a working mailbox is not news. The row leads
+    /// nowhere: there is nothing for the person to open, and the account will try again on its own.
+    /// </remarks>
+    public Task<bool> ReportIncompleteRunAsync(
+        MailAccountIdentity account,
+        int failedFolderCount,
+        int scheduledFolderCount,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(failedFolderCount);
+        ArgumentOutOfRangeException.ThrowIfNegative(scheduledFolderCount);
+
+        if (failedFolderCount == 0)
+        {
+            return Task.FromResult(false);
+        }
+
+        return this.RecordAsync(
+            account,
+            NotificationKind.System,
+            title: "Some mail could not be fetched",
+            body: string.Create(
+                CultureInfo.InvariantCulture,
+                $"{failedFolderCount} of {scheduledFolderCount} folders did not finish. MailFathom will try again."),
+            NotificationTarget.Nothing,
+            $"synchronization-incomplete:{account.Id.Value}",
+            cancellationToken);
+    }
+
+    /// <summary>Reports an account whose credential the mail server refused.</summary>
+    /// <param name="account">The account the server refused.</param>
+    /// <param name="cancellationToken">Cancels the raise.</param>
+    /// <returns><see langword="true" /> when a notification was kept.</returns>
+    /// <remarks>
+    /// This is the condition the deduplication rule exists for. A refused credential is refused again on every run
+    /// until somebody replaces it, so the statement is made once and stays made until it has been read.
+    /// </remarks>
+    public Task<bool> ReportRefusedCredentialAsync(
+        MailAccountIdentity account,
+        CancellationToken cancellationToken) =>
+        this.RecordAsync(
+            account,
+            NotificationKind.System,
+            title: "This account needs signing in again",
+            body: "The mail server refused the credential MailFathom holds, so this account is no longer being fetched.",
+            NotificationTarget.ToScreen(NotificationScreen.Settings),
+            $"credential-refused:{account.Id.Value}",
+            cancellationToken);
+
+    private Task<bool> RecordAsync(
+        MailAccountIdentity account,
+        NotificationKind kind,
+        string title,
+        string body,
+        NotificationTarget target,
+        string deduplicationKey,
+        CancellationToken cancellationToken)
+    {
+        var occurredAt = this.timeProvider.GetUtcNow();
+
+        return this.store.RecordAsync(
+            Notification.Compose(
+                NotificationId.Create(Guid.CreateVersion7(occurredAt)),
+                account.Owner,
+                kind,
+                title,
+                body,
+                account.Id.Value,
+                target,
+                NotificationDeduplicationKey.Create(deduplicationKey),
+                occurredAt),
+            cancellationToken);
+    }
+}

--- a/backend/src/Application/Synchronization/Administration/MailFolderRunOutcome.cs
+++ b/backend/src/Application/Synchronization/Administration/MailFolderRunOutcome.cs
@@ -10,7 +10,7 @@ namespace MailFathom.Application.Synchronization.Administration;
 /// It is the classification a failing folder is read by, and it is deliberately a closed set of names rather than
 /// anything the failure itself carried. An administrative surface must publish neither an exception message nor a
 /// remote folder path, and what an operator acts on is which of these happened: two of them are corrected by editing a
-/// folder mapping, two are waited out, and one is a defect to report.
+/// folder mapping, two are waited out, one is a credential to replace, and one is a defect to report.
 /// </para>
 /// <para>
 /// The members mirror the branches the supervisor already separates when it logs a folder, so a value here and the line
@@ -39,4 +39,7 @@ public enum MailFolderRunOutcome
 
     /// <summary>The host began shutting down while the folder was running, so the run ended without finishing.</summary>
     InterruptedByShutdown = 6,
+
+    /// <summary>The mail server refused the account's credential, which no later run clears without somebody replacing it.</summary>
+    CredentialRefused = 7,
 }

--- a/backend/src/Application/Synchronization/Administration/MailFolderRunOutcome.cs
+++ b/backend/src/Application/Synchronization/Administration/MailFolderRunOutcome.cs
@@ -10,7 +10,8 @@ namespace MailFathom.Application.Synchronization.Administration;
 /// It is the classification a failing folder is read by, and it is deliberately a closed set of names rather than
 /// anything the failure itself carried. An administrative surface must publish neither an exception message nor a
 /// remote folder path, and what an operator acts on is which of these happened: two of them are corrected by editing a
-/// folder mapping, two are waited out, one is a credential to replace, and one is a defect to report.
+/// folder mapping, two are waited out, one is resumed by the next start after a shutdown interrupted it, one is a
+/// credential to replace, and one is a defect to report.
 /// </para>
 /// <para>
 /// The members mirror the branches the supervisor already separates when it logs a folder, so a value here and the line

--- a/backend/src/Application/Synchronization/Sessions/MailboxCredentialRefusedException.cs
+++ b/backend/src/Application/Synchronization/Sessions/MailboxCredentialRefusedException.cs
@@ -1,0 +1,44 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Failures;
+
+namespace MailFathom.Application.Synchronization.Sessions;
+
+/// <summary>Indicates that a mail server refused the credential MailFathom holds for an account.</summary>
+/// <remarks>
+/// <para>
+/// It is the opposite failure from <see cref="MailboxUnavailableException" /> and the distinction is what a worker
+/// acts on. An unavailable server is expected to serve the same work on a later run, so the account is backed off and
+/// approached again; a refused credential will be refused identically every run until a person replaces it, so the run
+/// is what reports it rather than what retries it.
+/// </para>
+/// <para>
+/// It exists as an application-owned failure so that distinction survives the adapter boundary. A mail library reports
+/// a refusal through its own exception types, and a worker reading those directly would be a worker that depends on
+/// which library opened the connection.
+/// </para>
+/// <para>
+/// The message names the account alias and nothing else: not the user name, not the mechanism the server selected, not
+/// the server's own answer, none of which can be logged.
+/// </para>
+/// </remarks>
+public sealed class MailboxCredentialRefusedException : MailFathomException
+{
+    /// <summary>Initializes a new credential refusal naming the account it stopped.</summary>
+    /// <param name="accountId">The account whose credential the mail server refused.</param>
+    /// <param name="innerException">The refusal the mail library reported.</param>
+    public MailboxCredentialRefusedException(MailAccountId accountId, Exception innerException)
+        : base(
+            $"The mail server refused the credential held for {accountId.Value}, so the account cannot be synchronized until it is replaced.",
+            innerException) =>
+        this.AccountId = accountId;
+
+    /// <inheritdoc />
+    public override MailFathomErrorCode ErrorCode => MailFathomErrorCode.MailboxCredentialRefused;
+
+    /// <summary>Gets the account whose credential was refused.</summary>
+    public MailAccountId AccountId { get; }
+}

--- a/backend/src/Domain/Failures/MailFathomErrorCode.cs
+++ b/backend/src/Domain/Failures/MailFathomErrorCode.cs
@@ -204,6 +204,9 @@ public readonly record struct MailFathomErrorCode
     /// <summary>Gets subcategory 1, authentication: a mail server advertises no authentication mechanism the account's policy permits.</summary>
     public static MailFathomErrorCode MailAuthenticationMechanismUnavailable { get; } = new(21001);
 
+    /// <summary>Gets subcategory 1, authentication: a mail server refused the credential MailFathom holds for an account.</summary>
+    public static MailFathomErrorCode MailboxCredentialRefused { get; } = new(21002);
+
     /// <summary>Gets subcategory 2, session availability: a mail server did not serve an operation within the resilience budget configured for it.</summary>
     public static MailFathomErrorCode MailboxUnavailable { get; } = new(22001);
 
@@ -985,6 +988,7 @@ public readonly record struct MailFathomErrorCode
         PrincipalNotAuthorized,
         DeploymentMailOwnerUnresolved,
         MailAuthenticationMechanismUnavailable,
+        MailboxCredentialRefused,
         MailboxUnavailable,
         MailboxFolderRecreated,
         MailboxAnswerIncomplete,

--- a/backend/src/Domain/Notifications/Notification.cs
+++ b/backend/src/Domain/Notifications/Notification.cs
@@ -1,0 +1,176 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Access;
+
+namespace MailFathom.Domain.Notifications;
+
+/// <summary>States one thing that happened to a person while nobody was looking at the screen.</summary>
+/// <remarks>
+/// <para>
+/// It belongs to the deployment rather than to a device, because the read state has to be the same in both heads and on
+/// a second machine, and because most of what produces one is visible only to the service. It is per owner, on the
+/// <c>(owner, identifier)</c> axis every account reference already uses.
+/// </para>
+/// <para>
+/// It is a pointer plus the least it takes to draw a row, and never a second copy of the mailbox. The title and the
+/// body are derived when the notification is produced rather than by re-reading mail when it is displayed, which is
+/// what keeps the notification centre readable without opening anything — and what makes the record derived personal
+/// data with the same classification as the mail behind it. Nothing here holds a mail body, an attachment, an address,
+/// or credential material.
+/// </para>
+/// <para>
+/// Being derived personal data decides the rest: a notification pointing at a message is erased with that message
+/// rather than swept for separately, it falls under the same erasure and export path as the mail it derives from, and
+/// it has a retention bound of its own so the table cannot become a mailbox history in miniature.
+/// </para>
+/// </remarks>
+public sealed record Notification
+{
+    /// <summary>The longest title stored, which is a headline rather than a sentence.</summary>
+    public const int MaximumTitleLength = 200;
+
+    /// <summary>The longest body stored, which is the row's second line rather than a message.</summary>
+    public const int MaximumBodyLength = 1000;
+
+    /// <summary>The longest source stored, which is generous for an account identifier.</summary>
+    public const int MaximumSourceLength = 128;
+
+    private Notification(
+        NotificationId id,
+        MailOwnerId owner,
+        NotificationKind kind,
+        string title,
+        string body,
+        string? source,
+        NotificationTarget target,
+        NotificationDeduplicationKey deduplicationKey,
+        DateTimeOffset occurredAt,
+        bool isRead)
+    {
+        this.Id = id;
+        this.Owner = owner;
+        this.Kind = kind;
+        this.Title = title;
+        this.Body = body;
+        this.Source = source;
+        this.Target = target;
+        this.DeduplicationKey = deduplicationKey;
+        this.OccurredAt = occurredAt;
+        this.IsRead = isRead;
+    }
+
+    /// <summary>Gets what addresses this notification.</summary>
+    public NotificationId Id { get; }
+
+    /// <summary>Gets the owner it happened to.</summary>
+    public MailOwnerId Owner { get; }
+
+    /// <summary>Gets what part of MailFathom it is about.</summary>
+    public NotificationKind Kind { get; }
+
+    /// <summary>Gets the headline the row is drawn with.</summary>
+    public string Title { get; }
+
+    /// <summary>Gets the second line the row is drawn with.</summary>
+    public string Body { get; }
+
+    /// <summary>Gets what the source line names beyond the kind, and <see langword="null" /> where the kind is the whole of it.</summary>
+    /// <remarks>
+    /// It is MailFathom's own name for where the notification came from — an account identifier, today — rather than
+    /// anything read from mail, and the client composes the displayed line from the kind and this together.
+    /// </remarks>
+    public string? Source { get; }
+
+    /// <summary>Gets where opening it leads.</summary>
+    public NotificationTarget Target { get; }
+
+    /// <summary>Gets the condition it was raised for, which is what stops it being said twice while it is unread.</summary>
+    public NotificationDeduplicationKey DeduplicationKey { get; }
+
+    /// <summary>Gets when the thing it describes happened.</summary>
+    public DateTimeOffset OccurredAt { get; }
+
+    /// <summary>Gets whether the person has read it.</summary>
+    public bool IsRead { get; }
+
+    /// <summary>Composes a notification that has not been read.</summary>
+    /// <param name="id">What addresses the notification.</param>
+    /// <param name="owner">The owner it happened to.</param>
+    /// <param name="kind">What part of MailFathom it is about.</param>
+    /// <param name="title">The headline the row is drawn with.</param>
+    /// <param name="body">The second line the row is drawn with.</param>
+    /// <param name="source">What the source line names beyond the kind, or <see langword="null" /> where the kind is the whole of it.</param>
+    /// <param name="target">Where opening it leads.</param>
+    /// <param name="deduplicationKey">The condition it was raised for.</param>
+    /// <param name="occurredAt">When the thing it describes happened.</param>
+    /// <returns>An unread notification.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="target" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="title" /> or <paramref name="body" /> is blank, when <paramref name="source" /> is present and blank, when <paramref name="owner" /> names nobody, or when <paramref name="id" /> or <paramref name="deduplicationKey" /> is the struct default.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="kind" /> is not a declared kind, or when a text exceeds the bound stated for it.</exception>
+    /// <remarks>
+    /// The owner has to be a named one, because a row written under the unspecified identity would belong to nobody:
+    /// unreachable by any read and uncollected by any erasure.
+    /// </remarks>
+    public static Notification Compose(
+        NotificationId id,
+        MailOwnerId owner,
+        NotificationKind kind,
+        string title,
+        string body,
+        string? source,
+        NotificationTarget target,
+        NotificationDeduplicationKey deduplicationKey,
+        DateTimeOffset occurredAt)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+
+        if (!owner.IsSpecified)
+        {
+            throw new ArgumentException(
+                "A notification happens to a named owner, so it is never raised under the unspecified one.",
+                nameof(owner));
+        }
+
+        if (!Enum.IsDefined(kind))
+        {
+            throw new ArgumentOutOfRangeException(nameof(kind), kind, "A notification carries a declared kind.");
+        }
+
+        if (!id.IsSpecified)
+        {
+            throw new ArgumentException("A notification is addressed by a specified identifier.", nameof(id));
+        }
+
+        if (!deduplicationKey.IsSpecified)
+        {
+            throw new ArgumentException(
+                "A notification names the condition it was raised for, so the deduplication rule has something to hold.",
+                nameof(deduplicationKey));
+        }
+
+        return new Notification(
+            id,
+            owner,
+            kind,
+            Bounded(title, MaximumTitleLength, nameof(title)),
+            Bounded(body, MaximumBodyLength, nameof(body)),
+            source is null ? null : Bounded(source, MaximumSourceLength, nameof(source)),
+            target,
+            deduplicationKey,
+            occurredAt,
+            isRead: false);
+    }
+
+    private static string Bounded(string value, int maximumLength, string parameterName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value, parameterName);
+
+        var trimmed = value.Trim();
+
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(trimmed.Length, maximumLength, parameterName);
+
+        return trimmed;
+    }
+}

--- a/backend/src/Domain/Notifications/NotificationDeduplicationKey.cs
+++ b/backend/src/Domain/Notifications/NotificationDeduplicationKey.cs
@@ -2,6 +2,9 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Security.Cryptography;
+using System.Text;
+
 namespace MailFathom.Domain.Notifications;
 
 /// <summary>Names the condition a notification was raised for, so raising it again while it is unread says nothing twice.</summary>
@@ -22,6 +25,9 @@ public readonly record struct NotificationDeduplicationKey
 {
     /// <summary>The longest key stored, which is generous for an account identifier and a fixed word.</summary>
     public const int MaximumLength = 256;
+
+    /// <summary>The width a subject too long to carry is reduced to, which is a lower-case SHA-256 in hexadecimal.</summary>
+    private const int ReducedSubjectLength = 64;
 
     private NotificationDeduplicationKey(string value) => this.Value = value;
 
@@ -49,6 +55,40 @@ public readonly record struct NotificationDeduplicationKey
         ArgumentOutOfRangeException.ThrowIfGreaterThan(trimmed.Length, MaximumLength, nameof(value));
 
         return new NotificationDeduplicationKey(trimmed);
+    }
+
+    /// <summary>Composes a key from the name of a condition and the thing it is about.</summary>
+    /// <param name="condition">MailFathom's own fixed word for what happened.</param>
+    /// <param name="subject">What the condition is about, which is an account identifier today.</param>
+    /// <returns>A validated deduplication key naming that condition about that subject.</returns>
+    /// <exception cref="ArgumentException">Thrown when either part is blank.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="condition" /> alone cannot fit within <see cref="MaximumLength" /> beside a reduced subject.</exception>
+    /// <remarks>
+    /// The subject is the unbounded half: an account identifier is the operator's own text and nothing validates its
+    /// length, so a long enough one would push the composed key past <see cref="MaximumLength" /> and refuse every
+    /// notification that account ever produced. Where the pair does not fit, the subject is replaced by a digest of
+    /// itself rather than truncated, because two accounts sharing a long prefix would otherwise share one condition
+    /// and silence each other's statements. The ordinary key stays the readable one; only an unreasonable identifier
+    /// reaches the digest.
+    /// </remarks>
+    public static NotificationDeduplicationKey For(string condition, string subject)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(condition);
+        ArgumentException.ThrowIfNullOrWhiteSpace(subject);
+
+        var trimmedCondition = condition.Trim();
+        var trimmedSubject = subject.Trim();
+
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(
+            trimmedCondition.Length + 1 + ReducedSubjectLength,
+            MaximumLength,
+            nameof(condition));
+
+        var reachableSubject = trimmedCondition.Length + 1 + trimmedSubject.Length <= MaximumLength
+            ? trimmedSubject
+            : Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(trimmedSubject)));
+
+        return new NotificationDeduplicationKey($"{trimmedCondition}:{reachableSubject}");
     }
 
     /// <inheritdoc />

--- a/backend/src/Domain/Notifications/NotificationDeduplicationKey.cs
+++ b/backend/src/Domain/Notifications/NotificationDeduplicationKey.cs
@@ -1,0 +1,56 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Domain.Notifications;
+
+/// <summary>Names the condition a notification was raised for, so raising it again while it is unread says nothing twice.</summary>
+/// <remarks>
+/// <para>
+/// It is the condition rather than the occurrence, which is the whole of the deduplication rule: an account whose
+/// credential is refused is refused again on every run until somebody acts, and a person who has not read the first
+/// statement gains nothing from forty more. Once the statement has been read the key is free again, so the same
+/// condition arising later is said again rather than suppressed forever.
+/// </para>
+/// <para>
+/// It is MailFathom's own name for the condition and never anything read from mail: an account identifier and a fixed
+/// word for what happened are what compose one, so the key carries no personal data beyond whose deployment it belongs
+/// to.
+/// </para>
+/// </remarks>
+public readonly record struct NotificationDeduplicationKey
+{
+    /// <summary>The longest key stored, which is generous for an account identifier and a fixed word.</summary>
+    public const int MaximumLength = 256;
+
+    private NotificationDeduplicationKey(string value) => this.Value = value;
+
+    /// <summary>Gets the key text.</summary>
+    public string Value { get; }
+
+    /// <summary>Gets whether this key names a condition.</summary>
+    /// <remarks>
+    /// Being a struct, <see langword="default" /> is reachable and names none, carrying a <see langword="null" />
+    /// <see cref="Value" /> that the deduplication index could not hold.
+    /// </remarks>
+    public bool IsSpecified => this.Value is not null;
+
+    /// <summary>Creates a deduplication key from the condition's own name.</summary>
+    /// <param name="value">The condition's name.</param>
+    /// <returns>A validated deduplication key.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="value" /> is blank.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="value" /> is longer than <see cref="MaximumLength" />.</exception>
+    public static NotificationDeduplicationKey Create(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+
+        var trimmed = value.Trim();
+
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(trimmed.Length, MaximumLength, nameof(value));
+
+        return new NotificationDeduplicationKey(trimmed);
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => this.Value;
+}

--- a/backend/src/Domain/Notifications/NotificationId.cs
+++ b/backend/src/Domain/Notifications/NotificationId.cs
@@ -1,0 +1,43 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Domain.Notifications;
+
+/// <summary>Identifies one notification, independently of whatever produced it.</summary>
+/// <remarks>
+/// It is an identity of its own rather than the identity of the thing it points at, because a notification points at
+/// several kinds of thing and sometimes at none: two runs over one account leave two notifications, and a system
+/// statement names no record at all.
+/// </remarks>
+public readonly record struct NotificationId
+{
+    private NotificationId(Guid value) => this.Value = value;
+
+    /// <summary>Gets the non-empty UUID value.</summary>
+    public Guid Value { get; }
+
+    /// <summary>Gets whether this identifier names a notification.</summary>
+    /// <remarks>
+    /// Being a struct, <see langword="default" /> is reachable and addresses nothing; the private constructor is what
+    /// keeps every other value validated, and this is what reports the one it cannot reach.
+    /// </remarks>
+    public bool IsSpecified => this.Value != Guid.Empty;
+
+    /// <summary>Creates a notification identifier from a non-empty UUID.</summary>
+    /// <param name="value">The UUID to wrap.</param>
+    /// <returns>A validated notification identifier.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="value" /> is empty.</exception>
+    public static NotificationId Create(Guid value)
+    {
+        if (value == Guid.Empty)
+        {
+            throw new ArgumentException("A notification identifier cannot be empty.", nameof(value));
+        }
+
+        return new NotificationId(value);
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => this.Value.ToString();
+}

--- a/backend/src/Domain/Notifications/NotificationKind.cs
+++ b/backend/src/Domain/Notifications/NotificationKind.cs
@@ -8,7 +8,7 @@ namespace MailFathom.Domain.Notifications;
 /// <remarks>
 /// The kind says how a row is drawn and grouped rather than where it leads, which is why it is separate from
 /// <see cref="NotificationTarget" />: a mail notification may lead to a message, to a screen, or nowhere, and so may a
-/// calendar one. The four kinds nothing produces yet are declared because the stages that build calendars, tasks, and
+/// calendar one. The three kinds nothing produces yet are declared because the stages that build calendars, tasks, and
 /// cases write into this same record rather than into stores of their own, so the set is the record's rather than one
 /// producer's.
 /// </remarks>

--- a/backend/src/Domain/Notifications/NotificationKind.cs
+++ b/backend/src/Domain/Notifications/NotificationKind.cs
@@ -1,0 +1,31 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Domain.Notifications;
+
+/// <summary>What part of MailFathom a notification is about.</summary>
+/// <remarks>
+/// The kind says how a row is drawn and grouped rather than where it leads, which is why it is separate from
+/// <see cref="NotificationTarget" />: a mail notification may lead to a message, to a screen, or nowhere, and so may a
+/// calendar one. The four kinds nothing produces yet are declared because the stages that build calendars, tasks, and
+/// cases write into this same record rather than into stores of their own, so the set is the record's rather than one
+/// producer's.
+/// </remarks>
+public enum NotificationKind
+{
+    /// <summary>Something happened to the person's mail.</summary>
+    Mail = 0,
+
+    /// <summary>Something happened in the person's calendar.</summary>
+    Calendar = 1,
+
+    /// <summary>Something happened to a case the person is following.</summary>
+    Case = 2,
+
+    /// <summary>Something happened to one of the person's tasks.</summary>
+    Task = 3,
+
+    /// <summary>MailFathom itself has something to say, which is usually something that needs a person.</summary>
+    System = 4,
+}

--- a/backend/src/Domain/Notifications/NotificationScreen.cs
+++ b/backend/src/Domain/Notifications/NotificationScreen.cs
@@ -1,0 +1,20 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Domain.Notifications;
+
+/// <summary>The place in the client a notification leads to when it names no single record.</summary>
+/// <remarks>
+/// It names a destination rather than a route, because a route is the client's to spell and the two heads spell it
+/// differently. Only the destinations something already leads to are declared: a member nothing produces would be a
+/// promise about a screen that need not exist, and the set is appended to as producers arrive.
+/// </remarks>
+public enum NotificationScreen
+{
+    /// <summary>The mailbox the person reads their mail in.</summary>
+    Mail = 0,
+
+    /// <summary>The settings the person administers their accounts from.</summary>
+    Settings = 1,
+}

--- a/backend/src/Domain/Notifications/NotificationTarget.cs
+++ b/backend/src/Domain/Notifications/NotificationTarget.cs
@@ -1,0 +1,66 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Emails;
+
+namespace MailFathom.Domain.Notifications;
+
+/// <summary>Where opening a notification leads.</summary>
+/// <remarks>
+/// <para>
+/// The three shapes are closed and each is reached through its own factory, so a target can never half exist — a
+/// message target with no message, or a screen target that also names one. Which of the three a producer chose is what
+/// a reader switches on, and <see cref="NotificationTargetKind" /> is that answer without unwrapping anything.
+/// </para>
+/// <para>
+/// A message target is the one that ties a notification to mail, and it is what makes a notification erasable with the
+/// message it describes: the record inherits the message's deletion rather than being swept for separately, so nothing
+/// can leave a row pointing at mail that is gone.
+/// </para>
+/// </remarks>
+public sealed record NotificationTarget
+{
+    private NotificationTarget(NotificationTargetKind kind, StoredEmailId? message, NotificationScreen? screen)
+    {
+        this.Kind = kind;
+        this.Message = message;
+        this.Screen = screen;
+    }
+
+    /// <summary>Gets which of the three shapes this target is.</summary>
+    public NotificationTargetKind Kind { get; }
+
+    /// <summary>Gets the stored message the notification leads to, and <see langword="null" /> for every other shape.</summary>
+    public StoredEmailId? Message { get; }
+
+    /// <summary>Gets the screen the notification leads to, and <see langword="null" /> for every other shape.</summary>
+    public NotificationScreen? Screen { get; }
+
+    /// <summary>Gets the target of a notification that has nothing to open.</summary>
+    public static NotificationTarget Nothing { get; } =
+        new(NotificationTargetKind.Nothing, message: null, screen: null);
+
+    /// <summary>Creates a target that leads to one stored message.</summary>
+    /// <param name="message">The message the notification is about.</param>
+    /// <returns>A message target.</returns>
+    public static NotificationTarget ToMessage(StoredEmailId message) =>
+        new(NotificationTargetKind.Message, message, screen: null);
+
+    /// <summary>Creates a target that leads to a screen rather than to a record.</summary>
+    /// <param name="screen">The screen the notification leads to.</param>
+    /// <returns>A screen target.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="screen" /> is not a declared screen.</exception>
+    public static NotificationTarget ToScreen(NotificationScreen screen)
+    {
+        if (!Enum.IsDefined(screen))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(screen),
+                screen,
+                "A notification leads to a declared screen or to nothing at all.");
+        }
+
+        return new NotificationTarget(NotificationTargetKind.Screen, message: null, screen);
+    }
+}

--- a/backend/src/Domain/Notifications/NotificationTargetKind.cs
+++ b/backend/src/Domain/Notifications/NotificationTargetKind.cs
@@ -1,0 +1,18 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Domain.Notifications;
+
+/// <summary>What kind of thing a notification leads to when somebody opens it.</summary>
+public enum NotificationTargetKind
+{
+    /// <summary>The notification leads nowhere, which is what a statement with nothing to open says.</summary>
+    Nothing = 0,
+
+    /// <summary>The notification leads to one stored message.</summary>
+    Message = 1,
+
+    /// <summary>The notification leads to a screen rather than to a record.</summary>
+    Screen = 2,
+}

--- a/backend/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
+++ b/backend/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
@@ -8,6 +8,7 @@ using MailFathom.Application.Emails.Chunking;
 using MailFathom.Application.Mail.Delivery.Outbox;
 using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Mail.Mutations.Convergence;
+using MailFathom.Application.Notifications;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Retrieval.AskMail.Audit;
 using MailFathom.Application.Rules.Evaluation;
@@ -208,6 +209,8 @@ internal sealed partial class AccountSynchronizationSupervisor
             .ToArray();
         var resolvedFolders = new ConcurrentBag<MailFolderResolution>();
         var failedFolderCount = 0;
+        var arrivedEmailCount = 0;
+        var credentialRefused = false;
         var convergenceFailed = false;
 
         // The wait for a slot is counted and the run itself is spanned, which is the split that keeps a cycle's
@@ -259,6 +262,18 @@ internal sealed partial class AccountSynchronizationSupervisor
                         resolvedFolders.Add(resolvedFolder);
                     }
 
+                    if (folderRun.StoredEmailCount > 0)
+                    {
+                        Interlocked.Add(ref arrivedEmailCount, folderRun.StoredEmailCount);
+                    }
+
+                    // A plain write rather than an interlocked one: every writer writes the same value, and awaiting
+                    // the whole loop is what publishes it to the read below.
+                    if (folderRun.CredentialRefused)
+                    {
+                        credentialRefused = true;
+                    }
+
                     if (!folderRun.Succeeded)
                     {
                         Interlocked.Increment(ref failedFolderCount);
@@ -268,10 +283,17 @@ internal sealed partial class AccountSynchronizationSupervisor
             if (!schedulingToken.IsCancellationRequested)
             {
                 await this.DeliverOutstandingMailAsync(workUnitToken);
-                await this.EraseExpiredAuditEntriesAsync(runSettings, workUnitToken);
+                await this.EraseExpiredDerivedRecordsAsync(runSettings, workUnitToken);
                 await this.ClassifyRequestedMailAsync(runSettings, workUnitToken);
                 await this.EvaluateMailRulesAsync(runSettings, workUnitToken);
                 await this.CutPassagesOfEvaluatedMailAsync(runSettings, workUnitToken);
+                await this.ReportRunToItsOwnerAsync(
+                    runSettings,
+                    scheduledFolders.Length,
+                    failedFolderCount,
+                    arrivedEmailCount,
+                    credentialRefused,
+                    workUnitToken);
             }
         }
         finally
@@ -440,13 +462,19 @@ internal sealed partial class AccountSynchronizationSupervisor
         }
     }
 
-    /// <summary>Erases whatever in this account's three records has outlived the window it was configured for.</summary>
+    /// <summary>Erases whatever in this account's four derived records has outlived the window it is held to.</summary>
     /// <remarks>
     /// <para>
-    /// All three age out here — the trail of the changes MailFathom made to the mailbox, the record of the questions
-    /// answered from it, and the history of what the rules concluded about its mail. They are separate operator
-    /// decisions with separate windows, and one pass because the pass is what the account's own loop already provides: a
-    /// second schedule would be another thing to configure and watch for work that is three bounded deletes.
+    /// All four age out here — the trail of the changes MailFathom made to the mailbox, the record of the questions
+    /// answered from it, the history of what the rules concluded about its mail, and what its owner has been told
+    /// about any of it. The first three are separate operator decisions with separate windows and the last is the
+    /// record's own bound, and they are one pass because the pass is what the account's own loop already provides: a
+    /// second schedule would be another thing to configure and watch for work that is four bounded deletes.
+    /// </para>
+    /// <para>
+    /// The notifications are the owner's rather than the account's, so an owner holding several accounts is swept once
+    /// per account. That costs a query that erases nothing rather than a mechanism of its own, which is the cheaper of
+    /// the two.
     /// </para>
     /// <para>
     /// It rides the account's own run for the reason convergence does, and runs after the folders rather than before
@@ -461,7 +489,7 @@ internal sealed partial class AccountSynchronizationSupervisor
     /// </para>
     /// </remarks>
     [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Retention is not a mail operation; an erasure that failed is logged and repeated by the next run rather than putting the account into backoff.")]
-    private async Task EraseExpiredAuditEntriesAsync(
+    private async Task EraseExpiredDerivedRecordsAsync(
         MailSynchronizationOptions runSettings,
         CancellationToken cancellationToken)
     {
@@ -497,6 +525,15 @@ internal sealed partial class AccountSynchronizationSupervisor
             {
                 this.LogRuleExecutionsErased(this.account.Id.Value, erasedExecutionCount);
             }
+
+            var erasedNotificationCount = await scope.ServiceProvider
+                .GetRequiredService<NotificationRetention>()
+                .EraseExpiredAsync(this.account.Owner, cancellationToken);
+
+            if (erasedNotificationCount > 0)
+            {
+                this.LogNotificationsErased(this.account.Id.Value, erasedNotificationCount);
+            }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -504,7 +541,65 @@ internal sealed partial class AccountSynchronizationSupervisor
         }
         catch (Exception exception)
         {
-            this.LogAuditRetentionFailed(exception, this.account.Id.Value);
+            this.LogDerivedRecordRetentionFailed(exception, this.account.Id.Value);
+        }
+    }
+
+    /// <summary>Tells this account's owner what the run observed that they were not at the screen for.</summary>
+    /// <remarks>
+    /// <para>
+    /// Last, and after every pass that can still commit mail, so the count reported is the run's whole arrival rather
+    /// than whatever had landed when the report was composed. It is one notification for the run and never one per
+    /// message, which is the record's own rule rather than this worker's choice: a run that commits forty messages is
+    /// one arrival to somebody who was away.
+    /// </para>
+    /// <para>
+    /// A failure never fails the run. A notification is a report about work that is already committed, so backing the
+    /// account off — which is to say fetching its mail less often — because a report could not be written would answer
+    /// the wrong problem with the wrong remedy. What the next run says is what that run observed; nothing here is
+    /// replayed, because a stale count is worse than a missing one.
+    /// </para>
+    /// </remarks>
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Reporting a run to its owner is not a mail operation; a report that failed is logged rather than putting the account into backoff.")]
+    private async Task ReportRunToItsOwnerAsync(
+        MailSynchronizationOptions runSettings,
+        int scheduledFolderCount,
+        int failedFolderCount,
+        int arrivedEmailCount,
+        bool credentialRefused,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var scope = this.scopeFactory.CreateScope();
+
+            scope.ServiceProvider.GetRequiredService<ScopedMailSynchronizationSettings>().UseRunSnapshot(runSettings);
+
+            var notifications = scope.ServiceProvider.GetRequiredService<SynchronizationNotifications>();
+
+            await notifications.ReportArrivedMailAsync(this.account, arrivedEmailCount, cancellationToken);
+
+            // The two system conditions are reported separately rather than as one worst outcome, because they ask the
+            // person for different things: a refused credential is theirs to repair, and an incomplete run is theirs
+            // to know about while MailFathom keeps trying.
+            if (credentialRefused)
+            {
+                await notifications.ReportRefusedCredentialAsync(this.account, cancellationToken);
+            }
+
+            await notifications.ReportIncompleteRunAsync(
+                this.account,
+                failedFolderCount,
+                scheduledFolderCount,
+                cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            this.LogOwnerNotificationFailed(exception, this.account.Id.Value);
         }
     }
 
@@ -848,7 +943,7 @@ internal sealed partial class AccountSynchronizationSupervisor
 
             this.RecordFolderRun(folder, result);
 
-            return new FolderRunOutcome(Succeeded: true, result.Folder);
+            return new FolderRunOutcome(Succeeded: true, result.Folder, result.StoredEmailCount);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -874,6 +969,17 @@ internal sealed partial class AccountSynchronizationSupervisor
             this.RecordFolderRun(folder, MailFolderRunOutcome.DeferredAfterMailServerUnavailable);
 
             return FolderRunOutcome.Failed;
+        }
+        catch (MailboxCredentialRefusedException exception)
+        {
+            // Separated from the unexpected failure below because the two ask for opposite things. Every other failure
+            // here is waited out by the account's own backoff; a refused credential is refused identically on every
+            // run until a person replaces it, so what the run owes is to say so rather than to keep trying quietly.
+            this.LogFolderSynchronizationStoppedByRefusedCredential(exception, this.account.Id.Value, folderAlias);
+            folderRun.CredentialRefused(folderAlias);
+            this.RecordFolderRun(folder, MailFolderRunOutcome.CredentialRefused);
+
+            return FolderRunOutcome.CredentialWasRefused;
         }
         catch (Exception exception)
         {
@@ -1285,8 +1391,8 @@ internal sealed partial class AccountSynchronizationSupervisor
     /// <summary>Separates a retention pass that did not run from the ordinary case of it having nothing to erase.</summary>
     [LoggerMessage(
         Level = LogLevel.Warning,
-        Message = "Erasing the expired audit entries of account {AccountId} ended unexpectedly; the account is not backed off for it and its next run erases what this one did not.")]
-    private partial void LogAuditRetentionFailed(Exception exception, string accountId);
+        Message = "Erasing the expired derived records of account {AccountId} ended unexpectedly; the account is not backed off for it and its next run erases what this one did not.")]
+    private partial void LogDerivedRecordRetentionFailed(Exception exception, string accountId);
 
     /// <summary>States what the rules did to mail that has just arrived, naming the revision so an edit is visible in the record.</summary>
     [LoggerMessage(
@@ -1431,6 +1537,25 @@ internal sealed partial class AccountSynchronizationSupervisor
         string accountId,
         string folderAlias);
 
+    /// <summary>Reports at error level the one folder failure no later run clears on its own.</summary>
+    [LoggerMessage(
+        Level = LogLevel.Error,
+        Message = "The mail server refused the credential held for {AccountId} while synchronizing {FolderAlias}; the account is not fetched until the credential is replaced.")]
+    private partial void LogFolderSynchronizationStoppedByRefusedCredential(
+        Exception exception,
+        string accountId,
+        string folderAlias);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Reporting the run of account {AccountId} to its owner ended unexpectedly; the account is not backed off for it and its next run reports what this one observed.")]
+    private partial void LogOwnerNotificationFailed(Exception exception, string accountId);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Erased {ErasedCount} expired notifications of the owner of account {AccountId}.")]
+    private partial void LogNotificationsErased(string accountId, int erasedCount);
+
     /// <summary>States what one account run produced for the two decisions that follow it.</summary>
     /// <param name="Failed">Whether at least one folder failed, which is what puts the account into backoff.</param>
     /// <param name="ResolvedFolders">
@@ -1442,9 +1567,22 @@ internal sealed partial class AccountSynchronizationSupervisor
     /// <summary>States what one folder's turn through a run produced.</summary>
     /// <param name="Succeeded">Whether the folder completed, which excludes a deferral and an unexpected failure alike.</param>
     /// <param name="ResolvedFolder">The binding the folder ran under, or <see langword="null" /> when the alias resolved to none.</param>
-    private readonly record struct FolderRunOutcome(bool Succeeded, MailFolderResolution? ResolvedFolder)
+    /// <param name="StoredEmailCount">How many occurrences the folder committed with their content, which is what the run reports as arrived mail.</param>
+    /// <param name="CredentialRefused">
+    /// Whether the mail server refused the account's credential, which is the one failure here that a later run cannot
+    /// clear on its own and is therefore reported to the person rather than only waited out.
+    /// </param>
+    private readonly record struct FolderRunOutcome(
+        bool Succeeded,
+        MailFolderResolution? ResolvedFolder,
+        int StoredEmailCount = 0,
+        bool CredentialRefused = false)
     {
         /// <summary>Gets the outcome of a folder that neither completed nor left a binding worth watching.</summary>
         internal static FolderRunOutcome Failed => new(Succeeded: false, ResolvedFolder: null);
+
+        /// <summary>Gets the outcome of a folder the mail server would not let this account reach at all.</summary>
+        internal static FolderRunOutcome CredentialWasRefused =>
+            new(Succeeded: false, ResolvedFolder: null, StoredEmailCount: 0, CredentialRefused: true);
     }
 }

--- a/backend/src/Infrastructure/Mail/MailKit/MailKitImapConnection.cs
+++ b/backend/src/Infrastructure/Mail/MailKit/MailKitImapConnection.cs
@@ -14,6 +14,7 @@ using MailFathom.Infrastructure.Mail.OAuth;
 using MailFathom.Infrastructure.Resilience;
 using MailKit;
 using MailKit.Net.Imap;
+using MailKit.Security;
 
 namespace MailFathom.Infrastructure.Mail.MailKit;
 
@@ -636,31 +637,43 @@ internal sealed class MailKitImapConnection : IAsyncDisposable
             this.transportSecurityPolicy.Authentication,
             settings.AccountId);
 
-        if (MailKitTransportSecurityMapping.TrySelectAccessTokenMechanism(
-            attemptClient.AuthenticationMechanisms,
-            this.transportSecurityPolicy.Authentication,
-            out var tokenMechanism))
+        try
         {
-            await MailKitAccessTokenAuthentication.AuthenticateAsync(
-                this.accessTokenSource,
-                tokenMechanism,
-                settings.AccountId,
-                settings.UserName,
-                attemptClient.AuthenticateAsync,
-                cancellationToken);
+            if (MailKitTransportSecurityMapping.TrySelectAccessTokenMechanism(
+                attemptClient.AuthenticationMechanisms,
+                this.transportSecurityPolicy.Authentication,
+                out var tokenMechanism))
+            {
+                await MailKitAccessTokenAuthentication.AuthenticateAsync(
+                    this.accessTokenSource,
+                    tokenMechanism,
+                    settings.AccountId,
+                    settings.UserName,
+                    attemptClient.AuthenticateAsync,
+                    cancellationToken);
 
-            return;
+                return;
+            }
+
+            // Startup validation refuses an account whose policy needs a password and configures none, so this is a
+            // configured shape rather than a value that might be missing.
+            var password = settings.Material.Password
+                ?? throw new InvalidOperationException(
+                    $"Account '{settings.AccountId}' authenticates with a password and resolved none.");
+
+            // MailKit's authentication contract takes a string, so an un-erasable copy of the password is unavoidable
+            // here. It is created at the call itself and never stored, logged, or passed on.
+            await attemptClient.AuthenticateAsync(settings.UserName, password.RevealAsString(), cancellationToken);
         }
-
-        // Startup validation refuses an account whose policy needs a password and configures none, so this is a
-        // configured shape rather than a value that might be missing.
-        var password = settings.Material.Password
-            ?? throw new InvalidOperationException(
-                $"Account '{settings.AccountId}' authenticates with a password and resolved none.");
-
-        // MailKit's authentication contract takes a string, so an un-erasable copy of the password is unavoidable
-        // here. It is created at the call itself and never stored, logged, or passed on.
-        await attemptClient.AuthenticateAsync(settings.UserName, password.RevealAsString(), cancellationToken);
+        catch (AuthenticationException refusal)
+        {
+            // The one failure here a later run cannot fix, so it leaves the adapter as its own application failure
+            // rather than as a mail-library type a worker would have to recognize. A TLS handshake failure arrives as
+            // System.Security.Authentication.AuthenticationException instead and is deliberately not caught: it says
+            // nothing about the credential, and calling it a refused one would send a person to replace a working
+            // password.
+            throw new MailboxCredentialRefusedException(this.accountId, refusal);
+        }
     }
 
     /// <summary>Selects the pinned folder with this connection's fixed access, once it is confirmed to be the one the session started on.</summary>

--- a/backend/src/Infrastructure/Observability/MailSynchronizationTelemetry.cs
+++ b/backend/src/Infrastructure/Observability/MailSynchronizationTelemetry.cs
@@ -84,6 +84,7 @@ public sealed class MailSynchronizationTelemetry : IMailSynchronizationPhaseTele
 
     internal const string ConcurrencyConflictFailureName = "concurrency_conflict";
     internal const string MailServerUnavailableFailureName = "mail_server_unavailable";
+    internal const string CredentialRefusedFailureName = "credential_refused";
     internal const string UnexpectedFailureName = "unexpected";
 
     private readonly ConcurrentDictionary<string, AccountSchedule> scheduleByAccount = new(StringComparer.Ordinal);
@@ -481,6 +482,14 @@ public sealed class MailSynchronizationTelemetry : IMailSynchronizationPhaseTele
         /// <param name="folderAlias">MailFathom's own name for the folder.</param>
         public void MailServerUnavailable(string folderAlias) =>
             this.Failed(folderAlias, MailServerUnavailableFailureName);
+
+        /// <summary>Records a folder the mail server would not let this account reach, because it refused the credential.</summary>
+        /// <param name="folderAlias">MailFathom's own name for the folder.</param>
+        /// <remarks>
+        /// Separate from every other failure name because an operator acts on it rather than waits it out: the count
+        /// under this name is the one that means somebody has to replace a credential.
+        /// </remarks>
+        public void CredentialRefused(string folderAlias) => this.Failed(folderAlias, CredentialRefusedFailureName);
 
         /// <summary>Records a folder that ended in a way nothing above it anticipated.</summary>
         /// <param name="folderAlias">MailFathom's own name for the folder, or the configured alias where no mapping was built.</param>

--- a/backend/src/Infrastructure/Persistence/Entities/NotificationEntity.cs
+++ b/backend/src/Infrastructure/Persistence/Entities/NotificationEntity.cs
@@ -1,0 +1,60 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.CodeCoverage;
+using MailFathom.Domain.Notifications;
+
+namespace MailFathom.Infrastructure.Persistence.Entities;
+
+/// <summary>One thing that happened to a person while nobody was looking at the screen.</summary>
+/// <remarks>
+/// The owner is a value, as it is on every other table, and the message is an association — which is the one place
+/// this row deliberately differs from the audit trails beside it. A trail records an act and has to outlive what it
+/// acted on; a notification describes something a person can still open, so a row pointing at mail that has been
+/// deleted is a row that leads nowhere and is erased with it.
+/// </remarks>
+[RequiresIntegrationCoverage]
+internal sealed class NotificationEntity
+{
+    public Guid Id { get; set; }
+
+    /// <summary>Gets or sets the owner it happened to, as a value rather than as an association.</summary>
+    public Guid OwnerId { get; set; }
+
+    public NotificationKind Kind { get; set; }
+
+    /// <summary>Gets or sets the headline the row is drawn with, derived when the notification was produced.</summary>
+    public required string Title { get; set; }
+
+    /// <summary>Gets or sets the second line the row is drawn with, derived when the notification was produced.</summary>
+    public required string Body { get; set; }
+
+    /// <summary>Gets or sets what the source line names beyond the kind, and <see langword="null" /> where the kind is the whole of it.</summary>
+    public string? Source { get; set; }
+
+    public NotificationTargetKind TargetKind { get; set; }
+
+    /// <summary>Gets or sets the message the notification leads to, which is the association the row is erased through.</summary>
+    public Guid? TargetStoredEmailId { get; set; }
+
+    /// <summary>Gets or sets the message the notification leads to.</summary>
+    public StoredEmailEntity? TargetStoredEmail { get; set; }
+
+    /// <summary>Gets or sets the screen the notification leads to, and <see langword="null" /> for every other shape.</summary>
+    public NotificationScreen? TargetScreen { get; set; }
+
+    /// <summary>Gets or sets the condition this notification was raised for.</summary>
+    /// <remarks>
+    /// Unique among one owner's unread rows, which is what makes a repeated raise idempotent: a condition already
+    /// standing unread is refused by the index rather than checked for before the insert, and only the index closes the
+    /// window between the check and the write.
+    /// </remarks>
+    public required string DeduplicationKey { get; set; }
+
+    /// <summary>Gets or sets when the thing this row describes happened.</summary>
+    public DateTimeOffset OccurredAt { get; set; }
+
+    /// <summary>Gets or sets whether the person has read it, which is also what frees the condition to be said again.</summary>
+    public bool IsRead { get; set; }
+}

--- a/backend/src/Infrastructure/Persistence/MailFathomDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/MailFathomDbContext.cs
@@ -14,6 +14,7 @@ using MailFathom.Infrastructure.Persistence.Embeddings.Configurations;
 using MailFathom.Infrastructure.Persistence.Entities;
 using MailFathom.Infrastructure.Persistence.Jobs.Configurations;
 using MailFathom.Infrastructure.Persistence.Mutations.Configurations;
+using MailFathom.Infrastructure.Persistence.Notifications.Configurations;
 using MailFathom.Infrastructure.Persistence.Owners.Configurations;
 using MailFathom.Infrastructure.Persistence.Portraits.Configurations;
 using MailFathom.Infrastructure.Persistence.Preferences.Configurations;
@@ -167,6 +168,8 @@ internal sealed class MailFathomDbContext : DbContext
 
     internal DbSet<JobScheduleEntity> JobSchedules => this.Set<JobScheduleEntity>();
 
+    internal DbSet<NotificationEntity> Notifications => this.Set<NotificationEntity>();
+
     /// <inheritdoc />
     /// <remarks>
     /// The order below is the order the configurations are applied in, and it is not alphabetical: a configuration that
@@ -234,5 +237,6 @@ internal sealed class MailFathomDbContext : DbContext
         modelBuilder.ApplyConfiguration(new ContactAddressConfiguration());
         modelBuilder.ApplyConfiguration(new JobConfiguration());
         modelBuilder.ApplyConfiguration(new JobScheduleConfiguration());
+        modelBuilder.ApplyConfiguration(new NotificationConfiguration());
     }
 }

--- a/backend/src/Infrastructure/Persistence/Migrations/20260903223138_AddNotifications.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260903223138_AddNotifications.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MailFathom.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace MailFathom.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(MailFathomDbContext))]
-    partial class MailFathomDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260903223138_AddNotifications")]
+    partial class AddNotifications
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Infrastructure/Persistence/Migrations/20260903223138_AddNotifications.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260903223138_AddNotifications.cs
@@ -1,0 +1,77 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MailFathom.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNotifications : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "notifications",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OwnerId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Kind = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    Title = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Body = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: false),
+                    Source = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    TargetKind = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    TargetStoredEmailId = table.Column<Guid>(type: "uuid", nullable: true),
+                    TargetScreen = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    DeduplicationKey = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    OccurredAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    IsRead = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_notifications", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_notifications_settings_accounts_OwnerId",
+                        column: x => x.OwnerId,
+                        principalTable: "settings_accounts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_notifications_stored_emails_TargetStoredEmailId",
+                        column: x => x.TargetStoredEmailId,
+                        principalTable: "stored_emails",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_notifications_owner_occurred",
+                table: "notifications",
+                columns: new[] { "OwnerId", "OccurredAt", "Id" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_notifications_owner_unread_condition",
+                table: "notifications",
+                columns: new[] { "OwnerId", "DeduplicationKey" },
+                unique: true,
+                filter: "NOT \"IsRead\"");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_notifications_TargetStoredEmailId",
+                table: "notifications",
+                column: "TargetStoredEmailId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "notifications");
+        }
+    }
+}

--- a/backend/src/Infrastructure/Persistence/Notifications/Configurations/NotificationConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Notifications/Configurations/NotificationConfiguration.cs
@@ -1,0 +1,88 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Notifications;
+using MailFathom.Infrastructure.Persistence.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace MailFathom.Infrastructure.Persistence.Notifications.Configurations;
+
+/// <summary>Declares what a person is told about, and the two ways a row leaves again.</summary>
+/// <remarks>
+/// <para>
+/// Two cascades reach this table and they answer different obligations. The owner's own row takes their notifications
+/// with them, so an erasure request never has to know this table exists; and a stored message takes the notifications
+/// that lead to it, so nothing can leave a row pointing at mail that is gone. That second one is the whole reason the
+/// message is an association here where the audit trails beside this table deliberately keep theirs as a value: a
+/// trail records an act and has to outlive what it acted on, while a notification only offers to open something.
+/// </para>
+/// <para>
+/// Nothing here is mail content. A title and a body are derived when the notification is produced and are MailFathom's
+/// own sentences about a count or a condition; the source is an account identifier; and the deduplication key is a
+/// condition's name. What makes the row personal data is that it says something reached this person's mailbox and
+/// when, which is what the retention bound and both cascades answer for.
+/// </para>
+/// </remarks>
+internal sealed class NotificationConfiguration : IEntityTypeConfiguration<NotificationEntity>
+{
+    /// <inheritdoc />
+    public void Configure(EntityTypeBuilder<NotificationEntity> entity)
+    {
+        entity.ToTable("notifications");
+        entity.HasKey(notification => notification.Id);
+        entity.Property(notification => notification.Id).ValueGeneratedNever();
+
+        // Stored as text for the reason every other enum in this model is: all three stay readable in an ad-hoc query
+        // and survive any later reordering of their enum.
+        entity.Property(notification => notification.Kind).HasConversion<string>().HasMaxLength(64).IsRequired();
+        entity.Property(notification => notification.TargetKind).HasConversion<string>().HasMaxLength(64).IsRequired();
+        entity.Property(notification => notification.TargetScreen).HasConversion<string>().HasMaxLength(64);
+
+        entity.Property(notification => notification.Title)
+            .HasMaxLength(Notification.MaximumTitleLength)
+            .IsRequired();
+        entity.Property(notification => notification.Body)
+            .HasMaxLength(Notification.MaximumBodyLength)
+            .IsRequired();
+        entity.Property(notification => notification.Source).HasMaxLength(Notification.MaximumSourceLength);
+        entity.Property(notification => notification.DeduplicationKey)
+            .HasMaxLength(NotificationDeduplicationKey.MaximumLength)
+            .IsRequired();
+
+        // Cascade rather than a statement in the erasure walk, for the reason the client's preferences cascade: what a
+        // person was told is derived from them and goes when they do. It is also what makes the row reachable at all
+        // by an erasure, since this table names no mail account and the walk enumerates the tables that do.
+        entity.HasOne<OwnerAccountEntity>()
+            .WithMany()
+            .HasForeignKey(notification => notification.OwnerId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // Optional, because most notifications lead to a screen or to nothing at all, and cascading so that the one
+        // shape that does name a message cannot outlive it.
+        entity.HasOne(notification => notification.TargetStoredEmail)
+            .WithMany()
+            .HasForeignKey(notification => notification.TargetStoredEmailId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // The deduplication rule, in the database rather than before the insert: a raise repeated while the first is
+        // still unread passes any application check, and only the constraint closes that window. It is partial so that
+        // reading the notification frees the condition to be said again when it recurs — and being partial is what
+        // also makes it the index the unread count is answered from, since the count is one owner's rows in it.
+        entity.HasIndex(notification => new { notification.OwnerId, notification.DeduplicationKey })
+            .IsUnique()
+            .HasFilter($"NOT \"{nameof(NotificationEntity.IsRead)}\"")
+            .HasDatabaseName(PersistenceConstraintNames.NotificationUnreadConditionUniqueIndexName);
+
+        // The one index the centre is walked through, and it serves both readers: a page is one owner's notifications
+        // newest first, and retention erases the same owner's oldest.
+        entity.HasIndex(notification => new
+        {
+            notification.OwnerId,
+            notification.OccurredAt,
+            notification.Id,
+        })
+            .HasDatabaseName(PersistenceConstraintNames.NotificationTimelineIndexName);
+    }
+}

--- a/backend/src/Infrastructure/Persistence/Notifications/NotificationMapping.cs
+++ b/backend/src/Infrastructure/Persistence/Notifications/NotificationMapping.cs
@@ -1,0 +1,42 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Notifications;
+using MailFathom.Infrastructure.Persistence.Entities;
+
+namespace MailFathom.Infrastructure.Persistence.Notifications;
+
+/// <summary>Turns a notification into the row it is stored as.</summary>
+/// <remarks>
+/// The target is flattened into its three columns here rather than being modelled as one, because the shape a row
+/// carries is what a reader filters and joins on: a column per shape lets the message be a foreign key, which is what
+/// erases a notification with the mail it leads to, and a serialized target could be neither.
+/// </remarks>
+internal static class NotificationMapping
+{
+    /// <summary>Maps one notification onto the row it is written as.</summary>
+    /// <param name="notification">The notification to store.</param>
+    /// <returns>The row.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="notification" /> is <see langword="null" />.</exception>
+    public static NotificationEntity ToEntity(Notification notification)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        return new NotificationEntity
+        {
+            Id = notification.Id.Value,
+            OwnerId = notification.Owner.Value,
+            Kind = notification.Kind,
+            Title = notification.Title,
+            Body = notification.Body,
+            Source = notification.Source,
+            TargetKind = notification.Target.Kind,
+            TargetStoredEmailId = notification.Target.Message?.Value,
+            TargetScreen = notification.Target.Screen,
+            DeduplicationKey = notification.DeduplicationKey.Value,
+            OccurredAt = notification.OccurredAt,
+            IsRead = notification.IsRead,
+        };
+    }
+}

--- a/backend/src/Infrastructure/Persistence/Notifications/PersistedNotificationStore.cs
+++ b/backend/src/Infrastructure/Persistence/Notifications/PersistedNotificationStore.cs
@@ -1,0 +1,113 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using MailFathom.Application.Notifications;
+using MailFathom.Application.Persistence;
+using MailFathom.CodeCoverage;
+using MailFathom.Domain.Access;
+using MailFathom.Domain.Notifications;
+using MailFathom.Infrastructure.Persistence.Sessions;
+using Microsoft.EntityFrameworkCore;
+
+namespace MailFathom.Infrastructure.Persistence.Notifications;
+
+/// <summary>Keeps what happened to a person, in PostgreSQL.</summary>
+/// <remarks>
+/// <para>
+/// The raise opens a session of its own rather than joining a caller's, because no producer has one: what raises a
+/// notification is a worker reporting on a run it has already committed, and composing the report into that run's
+/// transaction would make a notification able to fail mail that was already stored.
+/// </para>
+/// <para>
+/// It runs under the ordinary commit policy, so the read that decides whether the condition is already standing and
+/// the insert that follows it are one transaction, and a writer that got there first is a retry rather than a failure:
+/// the replay re-reads, finds the winner's unread row, and raises nothing. The partial unique index is what makes that
+/// sound instead of merely likely — the read on its own would see nothing on both sides of a race.
+/// </para>
+/// <para>
+/// The erasure uses neither: it is a set-based delete that composes with nothing a caller is holding.
+/// </para>
+/// </remarks>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The dependency injection container materializes this store.")]
+[RequiresIntegrationCoverage]
+internal sealed class PersistedNotificationStore(
+    MailFathomDbContext readContext,
+    OptimisticConcurrencyRetryPolicy commitPolicy)
+    : INotificationStore
+{
+    /// <inheritdoc />
+    public Task<bool> RecordAsync(Notification notification, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        return commitPolicy.CommitAsync(
+            (session, token) => StageAsync(session, notification, token),
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// The bounded set is read first and deleted by key, rather than bounding the delete itself, for the reason every
+    /// retention sweep here is written that way: PostgreSQL has no <c>DELETE ... LIMIT</c>, so a bound expressed on the
+    /// delete either fails to translate or becomes a subquery whose shape depends on the provider.
+    /// </remarks>
+    public async Task<int> EraseOccurredBeforeAsync(
+        MailOwnerId owner,
+        DateTimeOffset occurredBefore,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(limit);
+
+        var ownerValue = owner.Value;
+
+        var expiringIds = await readContext.Notifications
+            .AsNoTracking()
+            .Where(notification => notification.OwnerId == ownerValue && notification.OccurredAt < occurredBefore)
+            .OrderBy(notification => notification.OccurredAt)
+            .ThenBy(notification => notification.Id)
+            .Take(limit)
+            .Select(notification => notification.Id)
+            .ToArrayAsync(cancellationToken);
+
+        if (expiringIds.Length == 0)
+        {
+            return 0;
+        }
+
+        return await readContext.Notifications
+            .Where(notification => expiringIds.Contains(notification.Id))
+            .ExecuteDeleteAsync(cancellationToken);
+    }
+
+    private static async Task<bool> StageAsync(
+        IPersistenceSession session,
+        Notification notification,
+        CancellationToken cancellationToken)
+    {
+        var writeContext = await EfCorePersistenceSessionAccessor.JoinAsync(session, cancellationToken);
+        var ownerValue = notification.Owner.Value;
+        var deduplicationKey = notification.DeduplicationKey.Value;
+
+        // The change-tracker pass is explicit for the reason every alternate-key lookup here makes it explicit: a raise
+        // staged earlier in this same uncommitted session would be invisible to a query.
+        var standing = await TrackedEntityLookup.SinglePendingOrPersistedAsync(
+            writeContext.Notifications,
+            writeContext.Notifications,
+            candidate => candidate.OwnerId == ownerValue
+                && candidate.DeduplicationKey == deduplicationKey
+                && !candidate.IsRead,
+            cancellationToken);
+
+        if (standing is not null)
+        {
+            return false;
+        }
+
+        writeContext.Notifications.Add(NotificationMapping.ToEntity(notification));
+
+        return true;
+    }
+}

--- a/backend/src/Infrastructure/Persistence/PersistenceConstraintNames.cs
+++ b/backend/src/Infrastructure/Persistence/PersistenceConstraintNames.cs
@@ -474,4 +474,19 @@ internal static class PersistenceConstraintNames
     /// <summary>The index every administrative listing of one owner's credentials is answered from.</summary>
     /// <remarks>Stated because it covers the owner and the provisioning instant together, which is the listing's own order, and a name composed from the two properties would say nothing about that being why.</remarks>
     internal const string OwnerCredentialOwnerIndexName = "ix_owner_credentials_owner_created_at";
+
+    /// <summary>The constraint that keeps one unread notification per condition, whatever a repeated raise attempts.</summary>
+    /// <remarks>
+    /// It is partial rather than whole, which is the deduplication rule itself: a condition already standing unread is
+    /// not said again, and one the person has read is free to be said again when it recurs. The store reads it, because
+    /// a raise that loses the race to another writer is a condition already stated rather than a provider failure.
+    /// </remarks>
+    internal const string NotificationUnreadConditionUniqueIndexName = "ix_notifications_owner_unread_condition";
+
+    /// <summary>The index a person's notification centre is both read and aged through.</summary>
+    /// <remarks>
+    /// It covers the owner and the instant together because both readers walk exactly that: the centre lists one
+    /// person's notifications newest first, and retention erases the same person's oldest.
+    /// </remarks>
+    internal const string NotificationTimelineIndexName = "ix_notifications_owner_occurred";
 }

--- a/backend/src/Infrastructure/Persistence/Sessions/PersistenceConcurrencyConflicts.cs
+++ b/backend/src/Infrastructure/Persistence/Sessions/PersistenceConcurrencyConflicts.cs
@@ -143,6 +143,13 @@ internal static class PersistenceConcurrencyConflicts
     /// identifier, and joins it — so two halves of one conversation reach one thread rather than the second run
     /// failing on a violation it could not have avoided.
     /// </para>
+    /// <para>
+    /// The last is one condition already standing unread in a person's notification centre. Two accounts' runs, or one
+    /// account's run and a retry of it, both read that nothing has been said about the condition and both raise it; the
+    /// loser violates the partial index. The retry is the whole deduplication rule rather than a repair — it re-reads,
+    /// finds the winner's unread row, and raises nothing — and leaving it unrecognized would report a run as having
+    /// failed while the person has already been told exactly once.
+    /// </para>
     /// </remarks>
     internal static bool IsConcurrencyConflict(DbUpdateException exception) =>
         exception.InnerException is PostgresException
@@ -169,6 +176,7 @@ internal static class PersistenceConcurrencyConflicts
                 or PersistenceConstraintNames.MailDraftCopyPrimaryKeyConstraintName
                 or PersistenceConstraintNames.ContentMoveRunPrimaryKeyConstraintName
                 or PersistenceConstraintNames.StoredSecretOwnerNameUniqueIndexName
-                or PersistenceConstraintNames.EmailThreadIdentifierPrimaryKeyConstraintName,
+                or PersistenceConstraintNames.EmailThreadIdentifierPrimaryKeyConstraintName
+                or PersistenceConstraintNames.NotificationUnreadConditionUniqueIndexName,
         };
 }

--- a/backend/src/Infrastructure/Persistence/Sessions/PersistenceConcurrencyConflicts.cs
+++ b/backend/src/Infrastructure/Persistence/Sessions/PersistenceConcurrencyConflicts.cs
@@ -137,7 +137,7 @@ internal static class PersistenceConcurrencyConflicts
     /// both answers name one rotatable secret rather than exposing a persistence constraint.
     /// </para>
     /// <para>
-    /// The last is one message identifier bound to a thread by two arrivals. Two runs storing two messages of one
+    /// The next is one message identifier bound to a thread by two arrivals. Two runs storing two messages of one
     /// conversation read that nothing binds the identifier yet, and each assembles a thread and binds it; the loser
     /// violates the key. The retry is what converges them: it re-reads, finds the winner's thread bound to the
     /// identifier, and joins it — so two halves of one conversation reach one thread rather than the second run

--- a/backend/src/Infrastructure/Resilience/TransientFailureClassifier.cs
+++ b/backend/src/Infrastructure/Resilience/TransientFailureClassifier.cs
@@ -8,6 +8,7 @@ using System.Net.Sockets;
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Resilience;
+using MailFathom.Application.Synchronization.Sessions;
 using MailFathom.Infrastructure.Mail;
 using MailFathom.Infrastructure.Mail.MailKit.Delivery;
 using MailFathom.Infrastructure.Mail.OAuth;
@@ -65,6 +66,11 @@ internal sealed class TransientFailureClassifier : ITransientFailureClassifier
     private static bool IsTransientMailboxFailure(Exception failure) => failure switch
     {
         MailKit.Security.AuthenticationException => false,
+
+        // The adapter's own translation of the line above, which reaches this classifier whenever a refusal is caught
+        // above a pipeline rather than inside one. The two have to answer alike, or a refused credential would be
+        // retried for as long as the budget allows purely because it had already been named.
+        MailboxCredentialRefusedException => false,
         MailKit.Security.SslHandshakeException => false,
         System.Security.Authentication.AuthenticationException => false,
         ServiceNotAuthenticatedException => false,

--- a/backend/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -58,6 +58,7 @@ using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Mail.Mutations.Authoring;
 using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Mail.Mutations.Destinations;
+using MailFathom.Application.Notifications;
 using MailFathom.Application.Observability;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Portraits;
@@ -112,6 +113,7 @@ using MailFathom.Infrastructure.Persistence.Emails.Threads;
 using MailFathom.Infrastructure.Persistence.Embeddings;
 using MailFathom.Infrastructure.Persistence.Jobs;
 using MailFathom.Infrastructure.Persistence.Mutations;
+using MailFathom.Infrastructure.Persistence.Notifications;
 using MailFathom.Infrastructure.Persistence.Owners;
 using MailFathom.Infrastructure.Persistence.Portraits;
 using MailFathom.Infrastructure.Persistence.Preferences;
@@ -1143,6 +1145,11 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<MailboxMutationAuditTelemetry>();
         services.AddScoped<IMailboxMutationAuditTrail, MailboxMutationAuditTrail>();
         services.AddScoped<MailboxMutationAuditTrailRetention>();
+        // What a person is told about while nobody is looking at the screen, and the pass that ages it out. Scoped
+        // like every other store, because the raise opens a session on the scope's own context.
+        services.AddScoped<INotificationStore, PersistedNotificationStore>();
+        services.AddScoped<SynchronizationNotifications>();
+        services.AddScoped<NotificationRetention>();
         services.AddScoped<IMailboxMutationPerformer, MailboxMutationPerformer>();
         // A singleton, because the gauges it publishes are the process's and the account snapshots behind them outlive
         // any one run; the pass that fills them is scoped like everything else that reaches a mail server.

--- a/backend/tests/Application.UnitTests/Notifications/NotificationRetentionTests.cs
+++ b/backend/tests/Application.UnitTests/Notifications/NotificationRetentionTests.cs
@@ -1,0 +1,76 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Notifications;
+using MailFathom.Application.UnitTests.TestDoubles;
+using MailFathom.Domain.Access;
+using MailFathom.Domain.Notifications;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Notifications;
+
+/// <summary>Covers how far back a person's notification centre is allowed to reach.</summary>
+public sealed class NotificationRetentionTests
+{
+    private static readonly MailOwnerId Owner = SyntheticMailOwner.Deployment;
+
+    private static readonly DateTimeOffset RunInstant = new(2026, 9, 3, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>The window is measured back from now and the pass is bounded, so a backlog clears over several runs.</summary>
+    [Fact]
+    public async Task EraseExpiredAsync_AnyOwner_ErasesWhatHappenedBeforeTheWindowUpToTheBound()
+    {
+        // Arrange
+        var store = Substitute.For<INotificationStore>();
+        var retention = new NotificationRetention(store, new FakeTimeProvider(RunInstant));
+
+        // Act
+        await retention.EraseExpiredAsync(Owner, TestContext.Current.CancellationToken);
+
+        // Assert
+        await store.Received(1).EraseOccurredBeforeAsync(
+            Owner,
+            RunInstant - NotificationRetention.Window,
+            NotificationRetention.MaximumNotificationsErasedPerPass,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>The bound is a storage-limitation decision rather than a reading list, so an unread statement ages out like any other.</summary>
+    [Fact]
+    public async Task EraseExpiredAsync_UnreadNotificationOlderThanTheWindow_IsErasedWithTheRest()
+    {
+        // Arrange
+        var store = new InMemoryNotificationStore();
+        await store.RecordAsync(
+            NotificationOccurredAt(RunInstant - NotificationRetention.Window - TimeSpan.FromDays(1), "old"),
+            TestContext.Current.CancellationToken);
+        await store.RecordAsync(
+            NotificationOccurredAt(RunInstant - TimeSpan.FromDays(1), "recent"),
+            TestContext.Current.CancellationToken);
+
+        var retention = new NotificationRetention(store, new FakeTimeProvider(RunInstant));
+
+        // Act
+        var erasedCount = await retention.EraseExpiredAsync(Owner, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(1, erasedCount);
+        Assert.Equal("recent", Assert.Single(store.Recorded).DeduplicationKey.Value);
+    }
+
+    private static Notification NotificationOccurredAt(DateTimeOffset occurredAt, string deduplicationKey) =>
+        Notification.Compose(
+            NotificationId.Create(Guid.CreateVersion7(occurredAt)),
+            Owner,
+            NotificationKind.System,
+            title: "Something happened",
+            body: "Something happened that nobody was at the screen for.",
+            source: "work",
+            NotificationTarget.Nothing,
+            NotificationDeduplicationKey.Create(deduplicationKey),
+            occurredAt);
+}

--- a/backend/tests/Application.UnitTests/Notifications/SynchronizationNotificationsTests.cs
+++ b/backend/tests/Application.UnitTests/Notifications/SynchronizationNotificationsTests.cs
@@ -1,0 +1,220 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Notifications;
+using MailFathom.Application.UnitTests.TestDoubles;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Notifications;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Notifications;
+
+/// <summary>Covers what a synchronization run tells its owner, and what it deliberately says nothing about.</summary>
+public sealed class SynchronizationNotificationsTests
+{
+    private static readonly MailAccountIdentity Account =
+        MailAccountIdentity.Create(SyntheticMailOwner.Deployment, MailAccountId.Create("work"));
+
+    private static readonly MailAccountIdentity SecondAccount =
+        MailAccountIdentity.Create(SyntheticMailOwner.Deployment, MailAccountId.Create("personal"));
+
+    private static readonly DateTimeOffset RunInstant = new(2026, 9, 3, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>A run that commits forty messages is one arrival to somebody who was away, not forty.</summary>
+    [Fact]
+    public async Task ReportArrivedMailAsync_ManyMessagesInOneRun_RecordsOneNotificationCarryingTheCount()
+    {
+        // Arrange
+        var store = new InMemoryNotificationStore();
+        var notifications = CreateNotifications(store);
+
+        // Act
+        await notifications.ReportArrivedMailAsync(Account, 40, TestContext.Current.CancellationToken);
+
+        // Assert
+        var notification = Assert.Single(store.Recorded);
+        Assert.Equal(NotificationKind.Mail, notification.Kind);
+        Assert.Equal("40 new messages arrived.", notification.Body);
+        Assert.Equal(NotificationScreen.Mail, notification.Target.Screen);
+        Assert.Equal(RunInstant, notification.OccurredAt);
+        Assert.False(notification.IsRead);
+    }
+
+    /// <summary>The count is the run's own, so a single message is described as one rather than as a plural.</summary>
+    [Fact]
+    public async Task ReportArrivedMailAsync_OneMessage_RecordsThatOneMessageArrived()
+    {
+        // Arrange
+        var store = new InMemoryNotificationStore();
+        var notifications = CreateNotifications(store);
+
+        // Act
+        await notifications.ReportArrivedMailAsync(Account, 1, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("1 new message arrived.", Assert.Single(store.Recorded).Body);
+    }
+
+    /// <summary>An empty run is the ordinary case and is not an event anybody was away from the screen for.</summary>
+    [Fact]
+    public async Task ReportArrivedMailAsync_RunThatCommittedNothing_RecordsNothing()
+    {
+        // Arrange
+        var store = new InMemoryNotificationStore();
+        var notifications = CreateNotifications(store);
+
+        // Act
+        var recorded = await notifications.ReportArrivedMailAsync(Account, 0, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(recorded);
+        Assert.Empty(store.Recorded);
+    }
+
+    /// <summary>Nothing composed here reads mail, so a notification carries no address, subject, or body fragment.</summary>
+    [Fact]
+    public async Task ReportArrivedMailAsync_AnyRun_NamesOnlyMailFathomsOwnIdentifiers()
+    {
+        // Arrange
+        var store = new InMemoryNotificationStore();
+        var notifications = CreateNotifications(store);
+
+        // Act
+        await notifications.ReportArrivedMailAsync(Account, 3, TestContext.Current.CancellationToken);
+
+        // Assert
+        var notification = Assert.Single(store.Recorded);
+        Assert.Equal(Account.Id.Value, notification.Source);
+        Assert.Equal(NotificationTargetKind.Screen, notification.Target.Kind);
+        Assert.Null(notification.Target.Message);
+    }
+
+    /// <summary>A refused credential is refused again on every run, and a person who has not read the first statement gains nothing from a second.</summary>
+    [Fact]
+    public async Task ReportRefusedCredentialAsync_ConditionRepeatedWhileUnread_RecordsItOnce()
+    {
+        // Arrange
+        var store = new InMemoryNotificationStore();
+        var notifications = CreateNotifications(store);
+
+        // Act
+        var first = await notifications.ReportRefusedCredentialAsync(Account, TestContext.Current.CancellationToken);
+        var second = await notifications.ReportRefusedCredentialAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(first);
+        Assert.False(second);
+        Assert.Single(store.Recorded);
+    }
+
+    /// <summary>The condition is one account's, so a second account being refused is its own statement rather than a repeat.</summary>
+    [Fact]
+    public async Task ReportRefusedCredentialAsync_SecondAccountRefused_RecordsItsOwnStatement()
+    {
+        // Arrange
+        var store = new InMemoryNotificationStore();
+        var notifications = CreateNotifications(store);
+
+        // Act
+        await notifications.ReportRefusedCredentialAsync(Account, TestContext.Current.CancellationToken);
+        await notifications.ReportRefusedCredentialAsync(SecondAccount, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(2, store.Recorded.Count);
+        Assert.Equal(
+            [Account.Id.Value, SecondAccount.Id.Value],
+            store.Recorded.Select(notification => notification.Source));
+    }
+
+    /// <summary>A refused credential is the person's to repair, so the statement leads to where they repair it.</summary>
+    [Fact]
+    public async Task ReportRefusedCredentialAsync_RefusedAccount_LeadsToTheSettingsScreen()
+    {
+        // Arrange
+        var store = new InMemoryNotificationStore();
+        var notifications = CreateNotifications(store);
+
+        // Act
+        await notifications.ReportRefusedCredentialAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        var notification = Assert.Single(store.Recorded);
+        Assert.Equal(NotificationKind.System, notification.Kind);
+        Assert.Equal(NotificationScreen.Settings, notification.Target.Screen);
+    }
+
+    /// <summary>An incomplete run and a refused credential are different conditions, so one never suppresses the other.</summary>
+    [Fact]
+    public async Task ReportIncompleteRunAsync_AccountAlreadyReportedAsRefused_RecordsItsOwnCondition()
+    {
+        // Arrange
+        var store = new InMemoryNotificationStore();
+        var notifications = CreateNotifications(store);
+
+        // Act
+        await notifications.ReportRefusedCredentialAsync(Account, TestContext.Current.CancellationToken);
+        await notifications.ReportIncompleteRunAsync(Account, 2, 5, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(2, store.Recorded.Count);
+        Assert.Contains(store.Recorded, notification => notification.Body.Contains(
+            "2 of 5 folders",
+            StringComparison.Ordinal));
+    }
+
+    /// <summary>A run that finished everything it scheduled is not news.</summary>
+    [Fact]
+    public async Task ReportIncompleteRunAsync_RunThatFinishedEveryFolder_RecordsNothing()
+    {
+        // Arrange
+        var store = new InMemoryNotificationStore();
+        var notifications = CreateNotifications(store);
+
+        // Act
+        var recorded = await notifications.ReportIncompleteRunAsync(
+            Account,
+            failedFolderCount: 0,
+            scheduledFolderCount: 5,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(recorded);
+        Assert.Empty(store.Recorded);
+    }
+
+    /// <summary>An incomplete run is something MailFathom keeps working on, so there is nothing for the person to open.</summary>
+    [Fact]
+    public async Task ReportIncompleteRunAsync_IncompleteRun_LeadsNowhere()
+    {
+        // Arrange
+        var store = new InMemoryNotificationStore();
+        var notifications = CreateNotifications(store);
+
+        // Act
+        await notifications.ReportIncompleteRunAsync(Account, 2, 5, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(NotificationTargetKind.Nothing, Assert.Single(store.Recorded).Target.Kind);
+    }
+
+    /// <summary>A negative count is a caller that miscounted rather than a run with nothing to say.</summary>
+    [Fact]
+    public async Task ReportArrivedMailAsync_NegativeCount_IsRefused()
+    {
+        // Arrange
+        var notifications = CreateNotifications(new InMemoryNotificationStore());
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            () => notifications.ReportArrivedMailAsync(Account, -1, TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal("newMessageCount", refusal.ParamName);
+    }
+
+    private static SynchronizationNotifications CreateNotifications(INotificationStore store) =>
+        new(store, new FakeTimeProvider(RunInstant));
+}

--- a/backend/tests/Application.UnitTests/Notifications/SynchronizationNotificationsTests.cs
+++ b/backend/tests/Application.UnitTests/Notifications/SynchronizationNotificationsTests.cs
@@ -215,6 +215,30 @@ public sealed class SynchronizationNotificationsTests
         Assert.Equal("newMessageCount", refusal.ParamName);
     }
 
+    /// <summary>
+    /// Nothing bounds a configured account identifier, and both places one reaches are bounded, so an outsized one is
+    /// still reported rather than silently disabling every notification that account would ever produce.
+    /// </summary>
+    [Fact]
+    public async Task ReportRefusedCredentialAsync_AnAccountIdentifierPastEveryBound_IsStillRecorded()
+    {
+        // Arrange
+        var store = new InMemoryNotificationStore();
+        var notifications = CreateNotifications(store);
+        var outsized = MailAccountIdentity.Create(
+            SyntheticMailOwner.Deployment,
+            MailAccountId.Create(new string('w', 400)));
+
+        // Act
+        await notifications.ReportRefusedCredentialAsync(outsized, TestContext.Current.CancellationToken);
+
+        // Assert
+        var notification = Assert.Single(store.Recorded);
+        Assert.Null(notification.Source);
+        Assert.StartsWith("credential-refused:", notification.DeduplicationKey.Value, StringComparison.Ordinal);
+        Assert.True(notification.DeduplicationKey.Value.Length <= NotificationDeduplicationKey.MaximumLength);
+    }
+
     private static SynchronizationNotifications CreateNotifications(INotificationStore store) =>
         new(store, new FakeTimeProvider(RunInstant));
 }

--- a/backend/tests/Application.UnitTests/TestDoubles/InMemoryNotificationStore.cs
+++ b/backend/tests/Application.UnitTests/TestDoubles/InMemoryNotificationStore.cs
@@ -1,0 +1,68 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Notifications;
+using MailFathom.Domain.Access;
+using MailFathom.Domain.Notifications;
+
+namespace MailFathom.Application.UnitTests.TestDoubles;
+
+/// <summary>Keeps what a producer recorded, under the same deduplication rule the persisted store publishes.</summary>
+/// <remarks>
+/// The rule is restated here rather than substituted away because it is what the producers are written against: a
+/// producer that composed a fresh key per call would suppress nothing, and a test whose double accepted everything
+/// would pass anyway. What it deliberately does not model is the race the partial unique index settles, which no
+/// in-memory double can establish and the integration suite proves against a real database.
+/// </remarks>
+internal sealed class InMemoryNotificationStore : INotificationStore
+{
+    private readonly List<Notification> recorded = [];
+
+    /// <summary>Gets the notifications this store kept, in the order they were recorded.</summary>
+    public IReadOnlyList<Notification> Recorded => this.recorded;
+
+    /// <inheritdoc />
+    public Task<bool> RecordAsync(Notification notification, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        var standing = this.recorded.Any(candidate => candidate.Owner == notification.Owner
+            && candidate.DeduplicationKey == notification.DeduplicationKey
+            && !candidate.IsRead);
+
+        if (standing)
+        {
+            return Task.FromResult(false);
+        }
+
+        this.recorded.Add(notification);
+
+        return Task.FromResult(true);
+    }
+
+    /// <inheritdoc />
+    public Task<int> EraseOccurredBeforeAsync(
+        MailOwnerId owner,
+        DateTimeOffset occurredBefore,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(limit);
+
+        Notification[] expiring =
+        [
+            .. this.recorded
+                .Where(candidate => candidate.Owner == owner && candidate.OccurredAt < occurredBefore)
+                .OrderBy(candidate => candidate.OccurredAt)
+                .Take(limit),
+        ];
+
+        foreach (var notification in expiring)
+        {
+            this.recorded.Remove(notification);
+        }
+
+        return Task.FromResult(expiring.Length);
+    }
+}

--- a/backend/tests/Domain.UnitTests/Notifications/NotificationDeduplicationKeyTests.cs
+++ b/backend/tests/Domain.UnitTests/Notifications/NotificationDeduplicationKeyTests.cs
@@ -1,0 +1,90 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Notifications;
+using Xunit;
+
+namespace MailFathom.Domain.UnitTests.Notifications;
+
+/// <summary>Covers how a key stays inside its bound when the half nobody bounds is longer than the whole.</summary>
+public sealed class NotificationDeduplicationKeyTests
+{
+    /// <summary>The ordinary key is the readable one, because that is what a person debugging a record reads.</summary>
+    [Fact]
+    public void For_ASubjectThatFits_KeepsTheConditionAndTheSubjectAsWritten()
+    {
+        // Act
+        var key = NotificationDeduplicationKey.For("credential-refused", "work");
+
+        // Assert
+        Assert.Equal("credential-refused:work", key.Value);
+    }
+
+    /// <summary>An account identifier is the operator's own text and nothing bounds it, so the key bounds it here.</summary>
+    [Fact]
+    public void For_ASubjectPastTheBound_StaysWithinTheBound()
+    {
+        // Act
+        var key = NotificationDeduplicationKey.For("credential-refused", new string('w', 400));
+
+        // Assert
+        Assert.True(key.Value.Length <= NotificationDeduplicationKey.MaximumLength);
+        Assert.StartsWith("credential-refused:", key.Value, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Two outsized subjects sharing a prefix are reduced apart rather than together: truncation would collapse two
+    /// accounts into one condition, and each would then silence the other's statements.
+    /// </summary>
+    [Fact]
+    public void For_TwoOutsizedSubjectsSharingAPrefix_ProducesTwoKeys()
+    {
+        // Arrange
+        var prefix = new string('w', 400);
+
+        // Act
+        var first = NotificationDeduplicationKey.For("credential-refused", prefix + "a");
+        var second = NotificationDeduplicationKey.For("credential-refused", prefix + "b");
+
+        // Assert
+        Assert.NotEqual(first, second);
+    }
+
+    /// <summary>The reduction is of the subject itself, so one account's condition is named the same way every run.</summary>
+    [Fact]
+    public void For_TheSameOutsizedSubjectTwice_ProducesTheSameKey()
+    {
+        // Arrange
+        var subject = new string('w', 400);
+
+        // Act
+        var first = NotificationDeduplicationKey.For("credential-refused", subject);
+        var second = NotificationDeduplicationKey.For("credential-refused", subject);
+
+        // Assert
+        Assert.Equal(first, second);
+    }
+
+    /// <summary>A condition long enough to leave no room for a reduced subject is MailFathom's own defect, not an operator's.</summary>
+    [Fact]
+    public void For_AConditionWithNoRoomForAReducedSubject_IsRefused()
+    {
+        // Act
+        var refusal = Assert.Throws<ArgumentOutOfRangeException>(
+            () => NotificationDeduplicationKey.For(new string('c', 250), "work"));
+
+        // Assert
+        Assert.Equal("condition", refusal.ParamName);
+    }
+
+    /// <summary>Neither half names a condition on its own, so a blank one is refused rather than composed around.</summary>
+    [Theory]
+    [InlineData("", "work")]
+    [InlineData("credential-refused", "  ")]
+    public void For_ABlankHalf_IsRefused(string condition, string subject)
+    {
+        // Act and assert
+        Assert.Throws<ArgumentException>(() => NotificationDeduplicationKey.For(condition, subject));
+    }
+}

--- a/backend/tests/Domain.UnitTests/Notifications/NotificationTests.cs
+++ b/backend/tests/Domain.UnitTests/Notifications/NotificationTests.cs
@@ -1,0 +1,158 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Access;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Notifications;
+using Xunit;
+
+namespace MailFathom.Domain.UnitTests.Notifications;
+
+/// <summary>Covers what a notification refuses to be composed as, and the three shapes its target takes.</summary>
+public sealed class NotificationTests
+{
+    private static readonly MailOwnerId Owner = MailOwnerId.Create(Guid.NewGuid());
+
+    private static readonly DateTimeOffset OccurredAt = new(2026, 9, 3, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>A row written under the unspecified identity would belong to nobody, so it is refused at composition.</summary>
+    [Fact]
+    public void Compose_UnspecifiedOwner_IsRefused()
+    {
+        // Act
+        var refusal = Assert.Throws<ArgumentException>(() => Compose(owner: default(MailOwnerId)));
+
+        // Assert
+        Assert.Equal("owner", refusal.ParamName);
+    }
+
+    /// <summary>A kind outside the declared set would be stored as text nothing can draw a row from.</summary>
+    [Fact]
+    public void Compose_UndeclaredKind_IsRefused()
+    {
+        // Act
+        var refusal = Assert.Throws<ArgumentOutOfRangeException>(() => Compose(kind: (NotificationKind)99));
+
+        // Assert
+        Assert.Equal("kind", refusal.ParamName);
+    }
+
+    /// <summary>Both value types are structs, so the one value their private constructors cannot reach is refused here.</summary>
+    [Theory]
+    [InlineData("id")]
+    [InlineData("deduplicationKey")]
+    public void Compose_StructDefaultInPlaceOfAValidatedValue_IsRefused(string parameterName)
+    {
+        // Arrange
+        var id = parameterName == "id"
+            ? default
+            : NotificationId.Create(Guid.CreateVersion7(OccurredAt));
+        var deduplicationKey = parameterName == "deduplicationKey"
+            ? default
+            : NotificationDeduplicationKey.Create("something-happened:work");
+
+        // Act
+        var refusal = Assert.Throws<ArgumentException>(() => Notification.Compose(
+            id,
+            Owner,
+            NotificationKind.System,
+            title: "Something happened",
+            body: "Something happened that nobody was at the screen for.",
+            source: "work",
+            NotificationTarget.Nothing,
+            deduplicationKey,
+            OccurredAt));
+
+        // Assert
+        Assert.Equal(parameterName, refusal.ParamName);
+    }
+
+    /// <summary>The bounds are the column's, so text past one is refused here rather than by the database.</summary>
+    [Fact]
+    public void Compose_TitleLongerThanTheBound_IsRefused()
+    {
+        // Act
+        var refusal = Assert.Throws<ArgumentOutOfRangeException>(
+            () => Compose(title: new string('a', Notification.MaximumTitleLength + 1)));
+
+        // Assert
+        Assert.Equal("title", refusal.ParamName);
+    }
+
+    /// <summary>A notification is unread when it is composed, which is what makes the deduplication rule mean anything.</summary>
+    [Fact]
+    public void Compose_AnyNotification_IsUnread()
+    {
+        // Act
+        var notification = Compose();
+
+        // Assert
+        Assert.False(notification.IsRead);
+    }
+
+    /// <summary>The kind is the whole source line where nothing narrows it further, which is what absence means here.</summary>
+    [Fact]
+    public void Compose_NoSource_LeavesTheKindAsTheWholeSourceLine()
+    {
+        // Act
+        var notification = Compose(source: null);
+
+        // Assert
+        Assert.Null(notification.Source);
+    }
+
+    /// <summary>A message target is the one shape that ties a notification to mail, and it names nothing else.</summary>
+    [Fact]
+    public void ToMessage_AnyMessage_NamesTheMessageAndNoScreen()
+    {
+        // Arrange
+        var message = StoredEmailId.Create(Guid.NewGuid());
+
+        // Act
+        var target = NotificationTarget.ToMessage(message);
+
+        // Assert
+        Assert.Equal(NotificationTargetKind.Message, target.Kind);
+        Assert.Equal(message, target.Message);
+        Assert.Null(target.Screen);
+    }
+
+    /// <summary>A screen the client may not have is a promise nothing can keep, so an undeclared one is refused.</summary>
+    [Fact]
+    public void ToScreen_UndeclaredScreen_IsRefused()
+    {
+        // Act
+        var refusal = Assert.Throws<ArgumentOutOfRangeException>(
+            () => NotificationTarget.ToScreen((NotificationScreen)99));
+
+        // Assert
+        Assert.Equal("screen", refusal.ParamName);
+    }
+
+    /// <summary>A statement with nowhere to go names neither of the other two shapes.</summary>
+    [Fact]
+    public void Nothing_TheEmptyTarget_NamesNeitherAMessageNorAScreen()
+    {
+        // Assert
+        Assert.Equal(NotificationTargetKind.Nothing, NotificationTarget.Nothing.Kind);
+        Assert.Null(NotificationTarget.Nothing.Message);
+        Assert.Null(NotificationTarget.Nothing.Screen);
+    }
+
+    private static Notification Compose(
+        MailOwnerId? owner = null,
+        NotificationKind kind = NotificationKind.System,
+        string title = "Something happened",
+        string? source = "work") =>
+        Notification.Compose(
+            NotificationId.Create(Guid.CreateVersion7(OccurredAt)),
+            owner ?? Owner,
+            kind,
+            title,
+            body: "Something happened that nobody was at the screen for.",
+            source,
+            NotificationTarget.Nothing,
+            NotificationDeduplicationKey.Create("something-happened:work"),
+            OccurredAt);
+}

--- a/backend/tests/Infrastructure.UnitTests/Mail/MailKit/MailKitImapSessionResilienceTests.cs
+++ b/backend/tests/Infrastructure.UnitTests/Mail/MailKit/MailKitImapSessionResilienceTests.cs
@@ -195,13 +195,16 @@ public sealed class MailKitImapSessionResilienceTests
         var factory = CreateFactory(resilience, () => client.Client, settingsProvider);
 
         // Act
-        await Assert.ThrowsAsync<global::MailKit.Security.AuthenticationException>(() => factory.OpenReadOnlyAsync(
+        var refusal = await Assert.ThrowsAsync<MailboxCredentialRefusedException>(() => factory.OpenReadOnlyAsync(
             PrimaryAccount,
             InboxFolder,
             TlsOnConnectWithPlainPolicy,
             CancellationToken.None));
 
-        // Assert
+        // Assert: the adapter's own failure names the account and keeps the mail library's refusal underneath it, so
+        // a worker acts on which account needs a person without reading a mail-library type.
+        Assert.Equal(PrimaryAccount, refusal.AccountId);
+        Assert.IsType<global::MailKit.Security.AuthenticationException>(refusal.InnerException);
         Assert.Equal(1, client.ConnectCount);
         Assert.Single(resolvedMaterial);
     }

--- a/backend/tests/Infrastructure.UnitTests/Mail/MailKit/MailKitImapTokenAuthenticationTests.cs
+++ b/backend/tests/Infrastructure.UnitTests/Mail/MailKit/MailKitImapTokenAuthenticationTests.cs
@@ -4,7 +4,6 @@
 
 using MailFathom.Application.Synchronization.Sessions;
 using MailFathom.Infrastructure.UnitTests.TestDoubles;
-using MailKit.Security;
 using NSubstitute;
 using Xunit;
 
@@ -58,6 +57,10 @@ public sealed class MailKitImapTokenAuthenticationTests
         Assert.Equal(["access-token-1"], tokenSource.RejectedTokens);
     }
 
+    /// <summary>
+    /// The refusal leaves the adapter as MailFathom's own failure, so a worker can tell a credential that needs a
+    /// person from a server that was briefly unavailable without reading a mail-library type.
+    /// </summary>
     [Fact]
     public async Task OpenReadOnlyAsync_ServerRejectsTheRenewedTokenToo_FailsAfterExactlyOneRenewal()
     {
@@ -68,7 +71,8 @@ public sealed class MailKitImapTokenAuthenticationTests
         var tokenSource = new RecordingMailAccessTokenSource(TokenExpiry);
 
         // Act
-        await Assert.ThrowsAsync<AuthenticationException>(() => OpenAsync(resilience, client, tokenSource));
+        await Assert.ThrowsAsync<MailboxCredentialRefusedException>(
+            () => OpenAsync(resilience, client, tokenSource));
 
         // Assert: two authentications and one renewal, so a permanently refused token cannot loop.
         Assert.Equal(2, client.PresentedAccessTokens.Count);

--- a/backend/tests/Infrastructure.UnitTests/Persistence/Notifications/NotificationMappingTests.cs
+++ b/backend/tests/Infrastructure.UnitTests/Persistence/Notifications/NotificationMappingTests.cs
@@ -1,0 +1,107 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Access;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Notifications;
+using MailFathom.Infrastructure.Persistence.Notifications;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Persistence.Notifications;
+
+/// <summary>Covers the row a notification is written as, and the three shapes its target flattens into.</summary>
+public sealed class NotificationMappingTests
+{
+    private static readonly MailOwnerId Owner = MailOwnerId.Create(Guid.NewGuid());
+
+    private static readonly DateTimeOffset OccurredAt = new(2026, 9, 3, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>Everything the notification stated reaches the row, because nothing else re-derives any of it.</summary>
+    [Fact]
+    public void ToEntity_ANotificationLeadingNowhere_KeepsEveryPartOfIt()
+    {
+        // Arrange
+        var notification = Compose(NotificationTarget.Nothing);
+
+        // Act
+        var entity = NotificationMapping.ToEntity(notification);
+
+        // Assert
+        Assert.Equal(notification.Id.Value, entity.Id);
+        Assert.Equal(Owner.Value, entity.OwnerId);
+        Assert.Equal(NotificationKind.System, entity.Kind);
+        Assert.Equal("Something happened", entity.Title);
+        Assert.Equal("Something happened that nobody was at the screen for.", entity.Body);
+        Assert.Equal("work", entity.Source);
+        Assert.Equal("something-happened:work", entity.DeduplicationKey);
+        Assert.Equal(OccurredAt, entity.OccurredAt);
+        Assert.False(entity.IsRead);
+    }
+
+    /// <summary>A statement with nowhere to go carries neither of the two columns a target would fill.</summary>
+    [Fact]
+    public void ToEntity_ANotificationLeadingNowhere_FillsNeitherTargetColumn()
+    {
+        // Act
+        var entity = NotificationMapping.ToEntity(Compose(NotificationTarget.Nothing));
+
+        // Assert
+        Assert.Equal(NotificationTargetKind.Nothing, entity.TargetKind);
+        Assert.Null(entity.TargetStoredEmailId);
+        Assert.Null(entity.TargetScreen);
+    }
+
+    /// <summary>The message column is the foreign key the erasure cascade runs along, so it carries the identifier itself.</summary>
+    [Fact]
+    public void ToEntity_ANotificationLeadingToAMessage_FillsTheMessageColumnAlone()
+    {
+        // Arrange
+        var message = StoredEmailId.Create(Guid.NewGuid());
+
+        // Act
+        var entity = NotificationMapping.ToEntity(Compose(NotificationTarget.ToMessage(message)));
+
+        // Assert
+        Assert.Equal(NotificationTargetKind.Message, entity.TargetKind);
+        Assert.Equal(message.Value, entity.TargetStoredEmailId);
+        Assert.Null(entity.TargetScreen);
+    }
+
+    /// <summary>A screen is not a row anything joins on, so it fills the other column and leaves the key empty.</summary>
+    [Fact]
+    public void ToEntity_ANotificationLeadingToAScreen_FillsTheScreenColumnAlone()
+    {
+        // Act
+        var entity = NotificationMapping.ToEntity(
+            Compose(NotificationTarget.ToScreen(NotificationScreen.Settings)));
+
+        // Assert
+        Assert.Equal(NotificationTargetKind.Screen, entity.TargetKind);
+        Assert.Null(entity.TargetStoredEmailId);
+        Assert.Equal(NotificationScreen.Settings, entity.TargetScreen);
+    }
+
+    /// <summary>The kind is the whole source line where nothing narrows it, and the column says so by holding nothing.</summary>
+    [Fact]
+    public void ToEntity_ANotificationWithoutASource_LeavesTheSourceColumnEmpty()
+    {
+        // Act
+        var entity = NotificationMapping.ToEntity(Compose(NotificationTarget.Nothing, source: null));
+
+        // Assert
+        Assert.Null(entity.Source);
+    }
+
+    private static Notification Compose(NotificationTarget target, string? source = "work") =>
+        Notification.Compose(
+            NotificationId.Create(Guid.CreateVersion7(OccurredAt)),
+            Owner,
+            NotificationKind.System,
+            title: "Something happened",
+            body: "Something happened that nobody was at the screen for.",
+            source,
+            target,
+            NotificationDeduplicationKey.Create("something-happened:work"),
+            OccurredAt);
+}

--- a/backend/tests/Infrastructure.UnitTests/Persistence/Notifications/NotificationModelTests.cs
+++ b/backend/tests/Infrastructure.UnitTests/Persistence/Notifications/NotificationModelTests.cs
@@ -1,0 +1,134 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Infrastructure.Persistence;
+using MailFathom.Infrastructure.Persistence.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Persistence.Notifications;
+
+/// <summary>
+/// Holds the notification row to the two obligations that are the schema's rather than any code path's: that a
+/// notification leaves with the mail it leads to and with the person it happened to, and that one condition standing
+/// unread cannot be said twice.
+/// </summary>
+/// <remarks>
+/// The model is built in memory by the real PostgreSQL provider and no connection is opened, so what these assertions
+/// state is what the schema is generated from. That a running PostgreSQL then performs the cascade and refuses the
+/// second insert is an integration question and is measured there.
+/// </remarks>
+public sealed class NotificationModelTests
+{
+    /// <summary>A notification that leads to a message cannot outlive it, which is what deleting the mail has to mean.</summary>
+    [Fact]
+    public void Model_TheMessageANotificationLeadsTo_TakesTheNotificationWithItWhenItIsDeleted()
+    {
+        // Arrange
+        using var context = CreateContext();
+
+        // Act
+        var foreignKey = ForeignKeyOn(context, nameof(NotificationEntity.TargetStoredEmailId));
+
+        // Assert
+        Assert.Equal(nameof(StoredEmailEntity), foreignKey.PrincipalEntityType.ClrType.Name);
+        Assert.Equal(DeleteBehavior.Cascade, foreignKey.DeleteBehavior);
+    }
+
+    /// <summary>
+    /// The target is optional, because most notifications lead to a screen or to nothing at all — which is what makes
+    /// the cascade above a rule about the rows that do name a message rather than a requirement that every row does.
+    /// </summary>
+    [Fact]
+    public void Model_TheMessageANotificationLeadsTo_IsOptional()
+    {
+        // Arrange
+        using var context = CreateContext();
+
+        // Act
+        var target = EntityType(context).FindProperty(nameof(NotificationEntity.TargetStoredEmailId));
+
+        // Assert
+        Assert.NotNull(target);
+        Assert.True(target.IsNullable);
+    }
+
+    /// <summary>
+    /// This table names no mail account, so the erasure walk that enumerates the tables that do would never reach it.
+    /// The cascade from the owner row is what discharges an erasure request over it instead.
+    /// </summary>
+    [Fact]
+    public void Model_TheOwnerANotificationHappenedTo_TakesTheirNotificationsWithThem()
+    {
+        // Arrange
+        using var context = CreateContext();
+
+        // Act
+        var foreignKey = ForeignKeyOn(context, nameof(NotificationEntity.OwnerId));
+
+        // Assert
+        Assert.Equal(nameof(OwnerAccountEntity), foreignKey.PrincipalEntityType.ClrType.Name);
+        Assert.Equal(DeleteBehavior.Cascade, foreignKey.DeleteBehavior);
+    }
+
+    /// <summary>
+    /// The deduplication rule is the database's, and it is partial in exactly one direction: one unread statement per
+    /// condition, and no bound at all on conditions the person has already read.
+    /// </summary>
+    [Fact]
+    public void Model_TheDeduplicationIndex_IsUniqueOverUnreadRowsAlone()
+    {
+        // Arrange
+        using var context = CreateContext();
+
+        // Act
+        var index = EntityType(context)
+            .GetIndexes()
+            .Single(candidate => candidate.GetDatabaseName()
+                == PersistenceConstraintNames.NotificationUnreadConditionUniqueIndexName);
+
+        // Assert
+        Assert.True(index.IsUnique);
+        Assert.Equal(
+            [nameof(NotificationEntity.OwnerId), nameof(NotificationEntity.DeduplicationKey)],
+            index.Properties.Select(property => property.Name));
+        Assert.Equal($"NOT \"{nameof(NotificationEntity.IsRead)}\"", index.GetFilter());
+    }
+
+    /// <summary>The centre's page and its retention sweep are one order, so they are one index.</summary>
+    [Fact]
+    public void Model_TheTimelineIndex_LeadsWithTheOwnerAndThenTheInstant()
+    {
+        // Arrange
+        using var context = CreateContext();
+
+        // Act
+        var index = EntityType(context)
+            .GetIndexes()
+            .Single(candidate => candidate.GetDatabaseName()
+                == PersistenceConstraintNames.NotificationTimelineIndexName);
+
+        // Assert
+        Assert.Equal(
+            [
+                nameof(NotificationEntity.OwnerId),
+                nameof(NotificationEntity.OccurredAt),
+                nameof(NotificationEntity.Id),
+            ],
+            index.Properties.Select(property => property.Name));
+    }
+
+    private static IForeignKey ForeignKeyOn(MailFathomDbContext context, string propertyName) =>
+        EntityType(context)
+            .GetForeignKeys()
+            .Single(foreignKey => foreignKey.Properties.Any(property => property.Name == propertyName));
+
+    private static IEntityType EntityType(MailFathomDbContext context) =>
+        context.Model.FindEntityType(typeof(NotificationEntity))
+            ?? throw new InvalidOperationException("The model holds no notification row.");
+
+    private static MailFathomDbContext CreateContext() =>
+        new MailFathomDbContextDesignTimeFactory().CreateDbContext([]);
+}

--- a/backend/tests/Infrastructure.UnitTests/Persistence/Sessions/PersistenceConcurrencyConflictsTests.cs
+++ b/backend/tests/Infrastructure.UnitTests/Persistence/Sessions/PersistenceConcurrencyConflictsTests.cs
@@ -34,6 +34,7 @@ public sealed class PersistenceConcurrencyConflictsTests
         PersistenceConstraintNames.MailDraftCopyPrimaryKeyConstraintName,
         PersistenceConstraintNames.ContentMoveRunPrimaryKeyConstraintName,
         PersistenceConstraintNames.StoredSecretOwnerNameUniqueIndexName,
+        PersistenceConstraintNames.NotificationUnreadConditionUniqueIndexName,
     ];
 
     [Theory]

--- a/backend/tests/Infrastructure.UnitTests/Resilience/TransientFailureClassifierTests.cs
+++ b/backend/tests/Infrastructure.UnitTests/Resilience/TransientFailureClassifierTests.cs
@@ -8,6 +8,8 @@ using System.Net.Sockets;
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Resilience;
+using MailFathom.Application.Synchronization.Sessions;
+using MailFathom.Domain.Accounts;
 using MailFathom.Infrastructure.Mail;
 using MailFathom.Infrastructure.Mail.OAuth;
 using MailFathom.Infrastructure.ObjectStorage;
@@ -69,6 +71,20 @@ public sealed class TransientFailureClassifierTests
 
         // Assert
         Assert.False(isTransient);
+    }
+
+    /// <summary>The adapter's own name for the same refusal has to be classified alike, or naming it would make it retryable.</summary>
+    [Theory]
+    [MemberData(nameof(MailDependencies))]
+    public void IsTransientFailure_MailCredentialRefusalTheAdapterTranslated_IsTerminal(OutboundDependency dependency)
+    {
+        // Arrange
+        var failure = new MailboxCredentialRefusedException(
+            MailAccountId.Create("work"),
+            new AuthenticationException("The server rejected the credential."));
+
+        // Act, Assert
+        Assert.False(this.classifier.IsTransientFailure(dependency, failure));
     }
 
     [Theory]

--- a/docs/architecture/arrival-pipeline.md
+++ b/docs/architecture/arrival-pipeline.md
@@ -131,6 +131,15 @@ is down must not back an account's reading off, and a send that failed already c
 record. [Mail delivery](../features/mail-delivery.md#how-a-written-down-send-reaches-a-server) is where that half is
 described; nothing else on this page concerns it.
 
+The last step of that sequence belongs to no arrival either, and is drawn nowhere above for the same reason: once the
+passes have finished, the run tells the account's owner what happened to it — mail arrived, a credential was refused,
+some folders did not finish. It is stated per run rather than per message, which is why it cannot sit on this page's
+graph: what it reports is the run's own outcome, and the count it carries is how many messages the passes above stored
+rather than anything derived from one of them. It is the weakest link in the sequence exactly as the drain is, and for
+a stronger reason — a run whose whole point was to fetch mail must not be failed by the record saying it did.
+[What a run tells the person whose mailbox it is](../features/imap-synchronization.md#what-a-run-tells-the-person-whose-mailbox-it-is)
+describes it; nothing else on this page concerns it either.
+
 Nothing else about the pipeline crosses a process boundary while a transaction is open. The two sidecar calls happen
 outside the commit that follows them, and the embedding provider is reached only by the worker, which consumes committed
 state.

--- a/docs/architecture/outbound-resilience.md
+++ b/docs/architecture/outbound-resilience.md
@@ -102,7 +102,10 @@ without depending on Polly. `Infrastructure` implements it per protocol family:
 
 - **Mailbox** — a rejected credential, an unusable TLS handshake, an unavailable authentication mechanism, and a
   refused IMAP command are terminal. A dropped connection and a desynchronized protocol stream are transient, because
-  a repeated read changes nothing on the server.
+  a repeated read changes nothing on the server. The rejected credential is named twice, as the mail library's own
+  refusal and as the `MailboxCredentialRefusedException` the IMAP adapter translates it into, because a refusal caught
+  above a pipeline rather than inside one would otherwise arrive here under a type nothing had classified — and be
+  retried for as long as the budget allows purely for having been given a name.
 - **Delivery** — only an explicit 4yz reply is repeated, which is the server stating it did not take the message. A
   connection lost between the message data and the final reply is reported as an ordinary protocol, socket, or I/O
   failure, indistinguishable from one that happened before submission, so repeating it risks a second copy in the

--- a/docs/architecture/stored-email-schema.md
+++ b/docs/architecture/stored-email-schema.md
@@ -314,6 +314,50 @@ signature the format opens with, before the row existed.
 reasons: last write wins, an owner this deployment no longer holds affects no row, and two devices arriving at once
 cannot both read nothing and then collide on the key. Erasing an owner takes the picture with the cascade.
 
+## What happened while nobody was looking
+
+`notifications` holds what a person is told about — a synchronization run that committed new mail, and the system
+conditions that run distinguishes. It belongs to the deployment rather than to a device, because the read state has to
+be the same in both heads and on a second machine, and because most of what produces a row is visible only to the
+service.
+
+| Column of `notifications` | What it records |
+|---|---|
+| `Id` | What addresses the notification, a UUIDv7 minted from the instant it describes |
+| `OwnerId` | The owner it happened to. It is the foreign key onto `settings_accounts` with `ON DELETE CASCADE`, for the reason `client_preferences` keys the same way |
+| `Kind` | Which part of MailFathom it is about — `Mail`, `Calendar`, `Case`, `Task`, or `System` — stored as text |
+| `Title`, `Body` | The two lines a row is drawn with, derived when the notification was produced rather than by re-reading mail when it is displayed |
+| `Source` | What the source line names beyond the kind, which is an account identifier today, and absent where the kind is the whole of it |
+| `TargetKind` | Which of the three shapes opening it leads to — `Nothing`, `Message`, or `Screen` — stored as text |
+| `TargetStoredEmailId` | The message a `Message` target names, and the foreign key onto `stored_emails` with `ON DELETE CASCADE`. Absent for every other shape |
+| `TargetScreen` | The screen a `Screen` target names — `Mail` or `Settings` — stored as text. Absent for every other shape |
+| `DeduplicationKey` | MailFathom's own name for the condition the notification was raised for |
+| `OccurredAt` | When the thing it describes happened |
+| `IsRead` | Whether the person has read it, which is also what frees the condition to be said again |
+
+**A row carries no mail.** The title and the body are MailFathom's own sentences about a count or a condition, the
+source is an account identifier, and the key is a condition's name — so no subject, address, body fragment, filename,
+or credential material reaches the table. What still makes it derived personal data is that it says something reached
+this person's mailbox and when, which is what the two cascades and the retention bound answer for.
+
+**Two cascades reach it, and they answer different obligations.** The owner's row takes their notifications with them,
+so an erasure request never has to name this table — which matters here because the table records no mail account and
+the [erasure walk](#privacy-classification) enumerates the tables that do. And a stored message takes the notifications
+that lead to it, so nothing can leave a row pointing at mail that is gone. That second cascade is why the message is an
+association here where `mailbox_mutation_audit_entries` deliberately keeps its own as a plain value: a trail records an
+act and has to outlive what it acted on, while a notification only offers to open something.
+
+**Saying one condition twice is refused by the schema rather than checked for before the insert.**
+`ix_notifications_owner_unread_condition` is unique over `(OwnerId, DeduplicationKey)` and filtered to `NOT "IsRead"`,
+so a condition already standing unread cannot be raised again and one the person has read is free to be said again when
+it recurs. Being partial is also what makes it the index an unread count is answered from, since that count is one
+owner's rows in it. `ix_notifications_owner_occurred` covers `(OwnerId, OccurredAt, Id)`, which is the centre's own page
+order and the order the retention sweep erases in.
+
+**A notification is kept for ninety days after the thing it describes happened.** The bound is the record's own rather
+than an operator's setting, because a notification is the client's working state rather than a history a deployment
+undertakes to hold, and the sweep rides each account's own synchronization run beside the audit-trail retention passes.
+
 ## What an owner signs in with
 
 `owner_credentials` holds every credential an owner authenticates to
@@ -1317,6 +1361,9 @@ account reach these four tables through the same cascade every other table is re
 | `ix_jobs_owner_account` | `(OwnerId, MailboxAccountId, EnqueuedAt)` | An account's queued work, which is what erasure and any per-account bound reach a job by |
 | `ix_jobs_owner_turn` | `(OwnerId, TurnAt)` where the state is `Pending` or `Claimed` | How far one owner's waiting work has reached, which is what every enqueue asks before it stamps a turn. It carries no account column at all: the owner is on the row now, so the latest turn is one descending step into this index rather than a maximum over the accounts that owner holds joined together. Beside `ix_jobs_owner_account` rather than folded into it because the two are proportional to different things: that one spans everything the queue has ever done, and this one only what is still claimable, which is what keeps the read a backward walk of a few index entries on a queue holding a backlog of any size |
 | `ix_jobs_dead_lettered` | `(StateChangedAt, Id)` where the state is `DeadLettered` | The operator's reading of what has stopped, newest first, keyed on the pair it pages by. The filter keeps the index the size of what is waiting for a person rather than of the table, and a row leaves it the moment the decision about it is taken |
+| `ix_notifications_owner_unread_condition` | `(OwnerId, DeduplicationKey)`, unique, where `NOT "IsRead"` | The deduplication rule itself: one unread statement per condition, and no bound at all on conditions the person has already read. Being partial is also what makes it the index an unread count is answered from, since that count is one owner's rows in it — and what keeps a repeated raise a lost race a retry resolves rather than a check the application could win between the read and the write |
+| `ix_notifications_owner_occurred` | `(OwnerId, OccurredAt, Id)` | The two ways the notification centre is worked: a page of one person's notifications newest first, and the retention sweep that erases the same person's oldest. The identifier is in the key because two notifications raised in one instant need a total order for a keyset page to continue from |
+| `IX_notifications_TargetStoredEmailId` | `(TargetStoredEmailId)` | The foreign key back to the message a notification leads to, which is what erasing that message reaches its notifications by rather than scanning |
 
 The recipient, keyword, and search-vector indexes are GIN rather than B-tree because all of them serve containment tests. A B-tree over an array column serves only equality against a whole array, and over a `tsvector` it serves nothing search asks for; a GIN index is what turns either into an index scan.
 
@@ -1415,6 +1462,15 @@ any of the six reaches a log, a metric, a trace, or an exception message: a fail
 and the folder alias, never a subject, an address, a file name, or a line of what was written.
 
 `settings_accounts` is personal data of a kind nothing else on this page holds: it is the record of a person rather than of their mail, and its document is what they configured MailFathom to do on their behalf. It is therefore the row a data-subject erasure is aimed at, and the cascade beneath it is what discharges the rest — which is also why the tables that record a mail account without keying onto one are taken by the same operation rather than left for somebody to remember. The contact book is reached by the cascade rather than by that derived list: `contacts` and `contact_addresses` record no mail account, but `contacts` keys onto the owner directly and `contact_addresses` keys onto `contacts` through `(ContactId, OwnerId)`, so erasing the owner takes the whole book with them in two hops — which is what an erasure request owes about an assembled record of third parties this owner wrote down. `stored_secrets` keys onto the owner directly as well, so the sealed material behind every reference in their document leaves through that cascade. The refresh token of an account that was authorized but never synchronized is reached by the explicit owner predicate over `mailbox_refresh_tokens`; it no longer survives for lack of a `mailbox_accounts` row. Nothing in the owner row reaches a log, a metric, a trace, or an exception message: a failure names the owner's identifier, which is a value MailFathom generated, and never the document beside it.
+
+`notifications` is derived personal data by the same reading as a chunk or a classification, and by a weaker one than a
+mutation history: a row says that something reached this person's mailbox and when, without saying what. It therefore
+inherits the source message's obligations wherever it names one, and the cascade from `stored_emails` is what makes that
+structural — a notification offering to open a message that has been erased is exactly the row that must not survive.
+What the rows naming no message carry instead is a bound of the record's own: ninety days from the instant described,
+swept on each account's own run. Nothing in the table reaches a log, a metric, a trace, or an exception message; the
+owner's generated identifier and the account alias are what a failure names, and they are the two values that are not
+personal data.
 
 `embedding_profiles` is the exception on this page: it holds no personal data at all. It describes a model, and the credential that reaches that model is configuration rather than a column here, so nothing in this table is a secret or is derived from anybody's mail.
 

--- a/docs/architecture/stored-email-schema.md
+++ b/docs/architecture/stored-email-schema.md
@@ -354,6 +354,12 @@ it recurs. Being partial is also what makes it the index an unread count is answ
 owner's rows in it. `ix_notifications_owner_occurred` covers `(OwnerId, OccurredAt, Id)`, which is the centre's own page
 order and the order the retention sweep erases in.
 
+The key is composed from MailFathom's own word for the condition and the account it is about, and it is bounded at 256
+characters while nothing bounds a configured account identifier. An identifier too long to fit is therefore replaced by
+a digest of itself rather than truncated, because two accounts sharing a long prefix would otherwise share one
+condition and silence each other's statements; the same identifier is left off the row's source line entirely, since a
+label that cannot be shown is better absent than shown as an account nobody configured.
+
 **A notification is kept for ninety days after the thing it describes happened.** The bound is the record's own rather
 than an operator's setting, because a notification is the client's working state rather than a history a deployment
 undertakes to hold, and the sweep rides each account's own synchronization run beside the audit-trail retention passes.

--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -153,6 +153,57 @@ Together they separate a folder with nothing left to fetch from one that has bee
 Both show a checkpoint that has stopped moving; only the folder's last outcome says which is which, and a folder that
 raises before committing leaves that outcome as the sole signal, since each run of it still reports itself as finished.
 
+### A refused credential is reported rather than waited out
+
+Every other folder failure above is something a later run may clear on its own, which is what the backoff is for. A mail
+server that refuses the credential MailFathom holds will refuse it identically on every run until somebody replaces it,
+so the run separates that case from the rest: the adapter translates the mail library's refusal into
+`MailboxCredentialRefusedException` at the point it authenticates, the supervisor catches that on its own branch, files
+the folder as `CredentialRefused`, and logs it at error level rather than at the warning level a deferral carries. The
+folder still counts as failed and the account still backs off, because there is nothing else useful to do with the
+attempt; what the separation buys is that the condition is nameable — by an operator reading
+`mfctl mailbox status`, by the `credential_refused` outcome on the folder-run counter, and by the person whose account
+it is.
+
+A TLS handshake that fails is deliberately not folded into this. It says nothing about the credential, and reporting it
+as one would send a person to replace a password that is working.
+
+### What a run tells the person whose mailbox it is
+
+A run ends by writing down what happened for somebody who was not at the screen while it happened, into the
+[notification record](../architecture/stored-email-schema.md#what-happened-while-nobody-was-looking). Three conditions
+are reported and nothing else is:
+
+| What the run observed | What it says | Where it leads |
+| --- | --- | --- |
+| It committed new mail | One notification for the run, carrying the count — never one per message | The mailbox |
+| It ended with folders it did not finish | How many of how many, and that MailFathom will try again | Nowhere |
+| A mail server refused this account's credential | That the account needs signing in again and is no longer being fetched | The settings |
+
+**One notification for the run is the rule rather than this worker's choice.** A run that commits forty messages is one
+arrival to somebody who was away, and forty rows would bury every other kind of notification under one mailbox's
+traffic. A run that committed nothing, and a run that finished every folder it scheduled, say nothing at all.
+
+**A condition already standing unread is not said twice.** Each notification names the condition it was raised for, and
+the schema refuses a second unread row for the same one — so an account whose credential is refused on every run for a
+week leaves one statement rather than a week of them, and reading it frees the condition to be said again if it recurs.
+[The deduplication index](../architecture/stored-email-schema.md#what-happened-while-nobody-was-looking) is where that
+is enforced. Arrived mail is one of those conditions, so a standing unread arrival keeps the count of the run that
+raised it: a later run bringing more mail adds no second row and does not restate the first one's number. What the row
+says is that mail arrived rather than how much is waiting, which the mailbox itself answers when the row is opened.
+
+**Nothing in a notification is read from mail.** A count, an account identifier, and a fixed sentence are what a row
+carries, so no subject, address, body fragment, filename, or credential material can reach it. What makes it derived
+personal data anyway is that it says something reached this person's mailbox and when, which the ninety-day retention
+bound and the two cascades answer for; the bound is swept on each account's own run beside the audit-trail retention
+passes.
+
+**Reporting never fails a run.** It happens after every pass that can still commit mail, so the count is the run's whole
+arrival rather than whatever had landed when the report was composed, and a failure there is logged without putting the
+account into backoff — fetching an account's mail less often because a report could not be written would answer the
+wrong problem with the wrong remedy. Nothing is replayed either: what the next run says is what that run observed,
+because a stale count is worse than a missing one.
+
 ### Shutdown stops scheduling first and drains second
 
 Host shutdown cancels scheduling for every supervisor at once, so no further run starts and no further folder of a run

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -796,7 +796,7 @@ as it is on the folder run above.
 | `mailfathom.mail.account` | Both | MailFathom's own configured alias for the account |
 | `mailfathom.mail.folder` | Folder | MailFathom's own configured alias for the folder |
 | `mailfathom.mail.sync.outcome` | Both | How it ended: `succeeded`, `failed`, `interrupted`, and for a folder also `alias_unresolved` or `alias_ambiguous` |
-| `mailfathom.mail.sync.failure` | Folder | What stopped it: `concurrency_conflict`, `mail_server_unavailable`, or `unexpected` |
+| `mailfathom.mail.sync.failure` | Folder | What stopped it: `concurrency_conflict`, `mail_server_unavailable`, `credential_refused`, or `unexpected` |
 | `mailfathom.mail.sync.folders`, `…folders.failed` | Cycle | How many folders the cycle scheduled, and how many did not complete |
 | `mailfathom.mail.sync.stored`, `…skipped` | Folder | What the folder stored with its content, and what it recorded from the envelope alone |
 
@@ -804,6 +804,10 @@ as it is on the folder run above.
 would be an account approached less often for having been stopped. An alias that named no single advertised folder is
 kept apart for the same reason: it is a configuration mistake an edit remedies, so it is an outcome rather than a
 failure, and it counts against nothing.
+
+`credential_refused` is separate from `unexpected` for the opposite reason: it is the one failure here nothing waits
+out. Every other value names a condition a later run may clear on its own, and this one names a credential a person has
+to replace, so it is the count an alert is worth attaching to.
 
 | Instrument | What it answers |
 | --- | --- |


### PR DESCRIPTION
Closes #1606

## What this adds

A per-owner **notification record** — what happened to a person while nobody was looking at the screen — raised through an application port and produced by an account's synchronization run.

- **Domain** (`backend/src/Domain/Notifications/`): `Notification` with its kind, title, body, source, target, occurrence time and read state, plus the value types that bound it — `NotificationId`, `NotificationDeduplicationKey`, and a `NotificationTarget` that is a message, a screen, or nothing. Both structs carry `IsSpecified` and the factory refuses the struct default, because a private constructor validates every value except the one it cannot reach.
- **Application** (`backend/src/Application/Notifications/`): `INotificationStore` as the port, `SynchronizationNotifications` as the run's producer, and `NotificationRetention` as the bound.
- **Infrastructure**: `NotificationEntity`, its configuration, the mapping, and `PersistedNotificationStore`, which records under the ordinary commit policy so a lost race retries and converges rather than failing.
- **Host**: the run reports last, after every pass that can still commit mail, and a fourth retention pass rides beside the three already there.

## The three conditions a run reports

| What the run observed | What it says | Where it leads |
| --- | --- | --- |
| It committed new mail | One notification for the run, carrying the count — never one per message | The mailbox |
| It ended with folders it did not finish | How many of how many, and that MailFathom will try again | Nowhere |
| A mail server refused this account's credential | That the account needs signing in again and is no longer being fetched | The settings |

**Deduplication is a partial unique index** over `(OwnerId, DeduplicationKey) WHERE NOT "IsRead"`, so a condition already standing unread is not said twice and reading it frees the condition to be said again. Its name is registered in `PersistenceConcurrencyConflicts`, which is what turns a lost race into a retry that re-reads and raises nothing.

**Deletion follows the mail**: a notification pointing at a message carries a cascading foreign key to `stored_emails`, and every row cascades from `settings_accounts` on the owner.

**Nothing in a notification is read from mail.** A count, an account identifier and a fixed sentence are what a row carries, so no subject, address, body fragment, filename or credential material can reach the record, a log or a telemetry event through this path. Copy is English, as everything written in this repository is.

## A refused credential is now a terminal failure with a name of its own

`MailKitImapConnection` translates MailKit's `AuthenticationException` into a new `MailboxCredentialRefusedException` (`MailFathomErrorCode` 21002). `TransientFailureClassifier` sorts it as terminal, `MailFolderRunOutcome` gains `CredentialRefused`, and the telemetry failure tag gains `credential_refused`. A TLS `System.Security.Authentication.AuthenticationException` is deliberately *not* caught — it is not a credential the person can replace.

**This changes two existing tests**, which asserted that the raw MailKit exception escapes authentication; both now expect the translation, and their remarks say why.

## Decisions worth a reviewer's attention

- **The retention window is a constant (90 days), not an operator setting.** The audit trails are configurable because keeping a history of a person's mailbox is something a deployment undertakes deliberately; a notification is the client's own working state, produced whether anybody asked or not. Stated in `NotificationRetention.Window`'s own remarks.
- **Arrived mail is deduplicated like every other condition**, so a standing unread arrival keeps the count of the run that raised it and a later run's mail adds no second row. What the row says is that mail arrived rather than how much is waiting. Documented in both the code and `docs/features/imap-synchronization.md`.
- **The mail row targets the Mail screen rather than a thread**, because a run's arrival is about no one message. The `Message` target shape exists in the model and carries the cascade that satisfies deletion following the mail.
- **The sweep is per owner but rides each account's run**, so an owner with several accounts is swept once per account — a query that erases nothing rather than a second scheduling mechanism.

## Contracts

No published contract moves: the four `PublicSurfaces.UnitTests` golden files are unchanged. The database schema gains one additive migration.

## The migration was reviewed as SQL and not applied to a database

`20260903223138_AddNotifications` is purely additive — one table, two cascading foreign keys, the partial unique index and the timeline index, no destructive operation — and was reviewed through `scripts/script-migration.sh`.

**Steps 3 and 4 of `$add-migration` were not performed**: at the owner's explicit request during this session, no Aspire orchestration was started, `ef-database-update` was not run, and `scripts/dump-local-schema.sh` was not refreshed, because the machine was heavily loaded. The migration has therefore never been applied to a real PostgreSQL server here; the model's shape is proven by `NotificationModelTests` against the design-time model, and the schema artifact is left for a run that can start the database.

## Verification

- `scripts/verify-full.sh` — passed (13 821 unit tests, 287 contract assertions, 0 failed)
- `dotnet msbuild .config/CodeCoverage.proj -t:Collect` — aggregate line coverage 95.27%, required 85%
- `scripts/review-obligations.sh` — every documentation row answered
- `$check-docs-licenses` — Docs pass, Changelog n/a, Licenses n/a (no dependency moved)

https://claude.ai/code/session_019KX772p1jtX1J4Sf79TEq1
