### PR TITLE
[#1516] Draw a mailbox mark from an open-ended ramp of hues

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -466,8 +466,10 @@ breakpoints the composition changes at, the safe-area insets, and the motion def
 
 Every value there is the design project's rather than this repository's, declared in OKLCH under two themes. What a
 screen composes against is never a hue but a **semantic** name — a page, a panel, a rail, a sunken region, three line
-weights, four text weights, an accent, a healthy state, a warning. Both themes declare the same names, which is what
-lets the light and the dark client be one set of utilities rather than a `dark:` variant on every one of them.
+weights, four text weights, an accent, a healthy state, a warning. A name means the same thing under both themes, which
+is what lets the light and the dark client be one set of utilities rather than a `dark:` variant on every one of them —
+the dark block redeclares the names whose value differs and leaves alone the two the design draws as one colour on both
+of its artboards, the surface a sender's markup is drawn on and the mailbox-mark ramp past its first hue.
 
 The typeface and the symbols are in the bundle for the same reason the credential never leaves it: **no screen reaches
 an external origin.** Instrument Sans is committed under `src/Client.App/src/assets/fonts/` and declared by

--- a/frontend/src/Client.App/src/controls/MailboxMark.tsx
+++ b/frontend/src/Client.App/src/controls/MailboxMark.tsx
@@ -2,6 +2,8 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+import { mailboxMarkHue } from './mailboxRamp';
+
 // The mark that tells one mailbox from the next, which the design project draws in two places: in front of a group in
 // the folder tree, and beside each address in the account menu. It is shared rather than drawn twice because the whole
 // of its meaning is that the same mailbox carries the same colour wherever it appears — two implementations would be
@@ -11,14 +13,23 @@
 // has to be seen says nothing to somebody who cannot see it.
 
 export function MailboxMark({ ordinal, className }: { readonly ordinal: number; readonly className?: string }) {
-    // Ordinal zero stands for every mailbox at once, which the folder tree has a row for, so it takes both hues; the
-    // mailboxes after it alternate between them.
+    // Ordinal zero stands for every mailbox at once, which the folder tree has a row for, so it takes the ramp's first
+    // two hues split across the diagonal; every other ordinal takes one hue, which `mailboxRamp.ts` chooses.
+    //
+    // The fill is written as a value rather than composed out of utilities because the hue is chosen while the client
+    // runs and a Tailwind class name cannot be. A utility for each hue would be a second list of the ramp's names to
+    // keep in step with `styles.css`, which is the drift the numbered ramp exists to remove; what is named here is
+    // still the token layer and never a colour.
     const fill =
         ordinal === 0
-            ? 'bg-linear-to-br from-mailbox-mark from-50% to-mailbox-mark-alternate to-50%'
-            : ordinal % 2 === 1
-              ? 'bg-mailbox-mark'
-              : 'bg-mailbox-mark-alternate';
+            ? 'linear-gradient(to bottom right, var(--color-mailbox-mark-1) 50%, var(--color-mailbox-mark-2) 50%)'
+            : `var(--color-mailbox-mark-${String(mailboxMarkHue(ordinal))})`;
 
-    return <span aria-hidden="true" className={`shrink-0 rounded-full ${className ?? 'size-2'} ${fill}`} />;
+    return (
+        <span
+            aria-hidden="true"
+            className={`shrink-0 rounded-full ${className ?? 'size-2'}`}
+            style={{ background: fill }}
+        />
+    );
 }

--- a/frontend/src/Client.App/src/controls/mailboxRamp.test.ts
+++ b/frontend/src/Client.App/src/controls/mailboxRamp.test.ts
@@ -1,0 +1,28 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import { mailboxMarkHue } from './mailboxRamp';
+
+// How many hues the ramp is declared with, restated here so that the expectations below read as statements about the
+// rule rather than about three numbers that happen to line up with it.
+const declaredHues = 3;
+
+describe('mailboxMarkHue', () => {
+    it.each([
+        [1, 1],
+        [2, 2],
+        [3, 3],
+    ])('gives the mailbox at ordinal %i the hue declared for it', (ordinal, hue) => {
+        expect(mailboxMarkHue(ordinal)).toBe(hue);
+    });
+
+    it('starts the ramp again at the mailbox after the last declared hue', () => {
+        expect(mailboxMarkHue(declaredHues + 1)).toBe(1);
+    });
+
+    it('keeps cycling for a deployment reading far more mailboxes than the ramp declares hues', () => {
+        expect(mailboxMarkHue(declaredHues * 4 + 2)).toBe(2);
+    });
+});

--- a/frontend/src/Client.App/src/controls/mailboxRamp.ts
+++ b/frontend/src/Client.App/src/controls/mailboxRamp.ts
@@ -1,0 +1,31 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+// The ramp a mailbox mark is drawn from, which `styles.css` declares as `--color-mailbox-mark-1` and the numbers after
+// it. Only the rule for reading it lives here; the hues themselves are the token layer's, as every colour in this
+// client is.
+//
+// It sits beside `MailboxMark.tsx` rather than inside it for the reason `initials.ts` sits beside `PersonAvatar.tsx`:
+// the rule is a value a test can state an expectation about, and a module a component is named after would collide
+// with the component's own file on a filesystem that ignores case.
+
+/**
+ * How many hues `styles.css` declares the ramp with. It is the one thing outside that file that moves when the ramp
+ * grows: declare `--color-mailbox-mark-4` there and raise this to four.
+ */
+const declaredHues = 3;
+
+/**
+ * Which hue of the ramp the mailbox at this ordinal takes, counted from one as the tokens are. Ordinal zero is the row
+ * standing for every mailbox at once and is not one of them — `MailboxMark` draws that as a split of the first two.
+ *
+ * A deployment reads as many mailboxes as it was configured with, which is more than any ramp declares hues for, so
+ * something has to be decided for the ones past the last. The ramp starts again at its first: two distant mailboxes
+ * sharing a hue costs far less than one mailbox carrying no mark at all, and the mark never stands alone anyway — the
+ * name beside it is what says which mailbox this is. It is written down here rather than left to whatever a modulo
+ * happens to do, so that the answer is a decision a reader can find rather than one they have to derive.
+ */
+export function mailboxMarkHue(ordinal: number): number {
+    return ((ordinal - 1) % declaredHues) + 1;
+}

--- a/frontend/src/Client.App/src/styles.css
+++ b/frontend/src/Client.App/src/styles.css
@@ -15,10 +15,11 @@
  * a screen and the project disagree the project wins and the screen changes — the icon-sampled ramp that used to stand
  * here was replaced by this one for exactly that reason, accent included.
  *
- * The light values are the ones declared in `@theme`; the block after it redeclares exactly the same names for dark and
- * nothing else. It sits outside every cascade layer deliberately: Tailwind emits `@theme` into its own `theme` layer,
- * and an unlayered declaration wins over any layered one whatever its specificity, so the override cannot be reordered
- * out of effect by a later import.
+ * The light values are the ones declared in the `@theme` blocks — the palette, and the mailbox-mark ramp after it,
+ * which is `static` for the reason stated over it; the `:root[data-theme='dark']` block redeclares the names that
+ * differ under dark and nothing else. It sits outside every cascade layer deliberately: Tailwind emits `@theme` into
+ * its own `theme` layer, and an unlayered declaration wins over any layered one whatever its specificity, so the
+ * override cannot be reordered out of effect by a later import.
  *
  * The two families are served from the bundle and from nowhere else. A deployment that keeps mail on its own server
  * does not hand a font CDN a request per reader, and the desktop head has to render with no route out at all, so the
@@ -125,11 +126,6 @@
     /* What a matched run of text is drawn on, and the rule that marks a quoted fragment as the one that was cited. */
     --color-highlight: oklch(0.945 0.07 88);
     --color-highlight-line: oklch(0.775 0.145 85);
-
-    /* What tells one mailbox from the next in the column that lists them: a mark beside each account's name, in one of
-       two hues taken in turn, and the two blended for the row standing for every account at once. */
-    --color-mailbox-mark: oklch(0.555 0.185 262);
-    --color-mailbox-mark-alternate: oklch(0.63 0.08 205);
 
     /* What a sender's own markup is drawn on, and the one token here that does not follow the theme. A message's HTML
        was written against a white page — it sets its own foreground colours and expects the rest — so drawing it on a
@@ -289,6 +285,27 @@
     --font-mono: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, monospace;
 }
 
+/* What tells one mailbox from the next wherever they are listed: a mark in front of each account, taking these hues in
+   the order the accounts are read, and the first two blended for the row standing for every account at once. The
+   sequence is numbered rather than named because it is open-ended — a deployment reads as many mailboxes as it was
+   configured with, which is more than any design draws hues for — so it grows by declaring the next number here and
+   counting it in `controls/mailboxRamp.ts`, which is also where the rule for a mailbox past the last hue is stated.
+
+   It is `static` because a hue is reached through an ordinal rather than through a utility. Tailwind emits a theme
+   variable only where something it scanned names it, and no source names this one — so a fourth hue declared in the
+   palette block above would be dropped from the bundle and the fourth mailbox would be drawn with no mark at all.
+   Nothing else here needs that, which is why this is a block of its own rather than a modifier on the palette.
+
+   The first hue is the accent and follows it into the dark theme below. The ones after it do not follow the theme: the
+   design project draws each of them as one colour on both of its artboards, so a lightened dark counterpart would be a
+   hue this client invented rather than one it was given. Nothing is lost by that — each clears 4.9:1 against the dark
+   panel and the dark rail, which is more than either clears against the light ones. */
+@theme static {
+    --color-mailbox-mark-1: oklch(0.555 0.185 262);
+    --color-mailbox-mark-2: oklch(0.643 0.079 211);
+    --color-mailbox-mark-3: oklch(0.648 0.107 81);
+}
+
 /* The same names, dark. `data-theme` is written by `theme/Theme.tsx`, which resolves the follow-the-system choice
    before the first paint, so nothing on a screen ever asks which theme is in force. */
 :root[data-theme='dark'] {
@@ -326,8 +343,7 @@
     --color-highlight: oklch(0.345 0.055 85);
     --color-highlight-line: oklch(0.72 0.13 85);
 
-    --color-mailbox-mark: oklch(0.615 0.175 262);
-    --color-mailbox-mark-alternate: oklch(0.7 0.08 205);
+    --color-mailbox-mark-1: oklch(0.615 0.175 262);
 
     --color-inset: rgb(255 255 255 / 0.045);
     --color-shadow-soft: oklch(0.1 0.03 262 / 0.5);


### PR DESCRIPTION
The mark that tells one mailbox from the next alternated between two hues, so a third mailbox took the first hue again — which is what the design project's third, amber mark disagreed with. The pair #1493 shipped is retired for a numbered ramp that grows by declaring the next hue.

## What changed

- `styles.css` declares `--color-mailbox-mark-1`, `-2`, and `-3`. Nothing is named as an "alternate" of anything, and the three are the three the design project draws: the accent, `#4d9aa8`, and `#b0873a`, written in OKLCH like every other value in the file and round-tripping to those exact bytes.
- `controls/mailboxRamp.ts` states in one place what a mailbox past the last declared hue takes — the ramp starts again at its first — rather than leaving it to whatever a modulo happens to do. It sits beside `MailboxMark.tsx` for the reason `initials.ts` sits beside `PersonAvatar.tsx`: it is a rule a test can state an expectation about, and a module named after a component would collide with that component's own file on a filesystem that ignores case.
- `MailboxMark.tsx` picks by ordinal along the ramp and is otherwise unchanged, so the folder tree and the account menu read the same component and no screen carries a mark the other does not. Ordinal zero stays the all-mailboxes mark, drawn as a diagonal split of the first two hues.

The fill is written as a value referencing the token rather than composed out of utilities, because the hue is chosen while the client runs and a Tailwind class name cannot be. A utility for each hue would be a second list of the ramp's names to keep in step with `styles.css`, which is the drift the numbered ramp exists to remove.

## Two things the design decided rather than this change

**The hues after the first do not follow the theme.** The prototype draws each of them as one colour on both of its artboards — measured, not inferred: the marks read `#477FEC`/`#4D9AA8`/`#B0873A` on the dark artboard and `#316BDD`/`#4D9AA8`/`#B0873A` on the light one, so only the first moves, and it moves because it is the accent. The dark block therefore redeclares `--color-mailbox-mark-1` alone, the way `--color-sender-markup` is already left alone there. This departs from the wording of two acceptance items, which assumed a hue per theme; nothing is lost by it, and the contrast figures below are why.

**The ramp is declared in an `@theme static` block.** Tailwind v4 emits a theme variable only where something it scanned names it, and a hue reached through an ordinal is named nowhere a scanner can see — so `--color-mailbox-mark-3` was dropped from the built CSS and the third mailbox drew no mark at all. The screenshot comparison is what caught it. `static` is what makes a fourth hue a declaration here rather than a declaration plus a utility somewhere to keep it alive.

## Contrast, against the two surfaces the mark is drawn on

| Hue | light `panel` | light `rail` | dark `panel` | dark `rail` |
| --- | --- | --- | --- | --- |
| 1 — accent | 4.90 | 4.25 | 3.30 | 3.60 |
| 2 | 3.23 | 2.80 | 5.02 | 5.47 |
| 3 | 3.29 | 2.86 | 4.91 | 5.36 |

The two figures under 3:1 are the light rail, and they are the design's own values. The mark is `aria-hidden` and never stands alone — the mailbox's name is beside it in every place it is drawn — so it is a decorative object rather than a graphical object conveying information, and 1.4.11 does not bind it. The hue that was retired sat at 2.93 on the same surface, so nothing regressed either.

## Verification

`pnpm test` passes with the ramp's rule covered, including a mailbox beyond the last hue and one far beyond it. The screens were held against the design project as images at 1440×900 in both themes — the folder tree's group marks and the account menu's mailbox list, with four accounts so the cycle is visible — and the sampled pixels agree with the artboards to within a unit of anti-aliasing.

## Related

`frontend/README.md` § _Styling, and the two themes_ said both themes declare the same names, which two tokens now do not; it says what is actually true instead.

Closes #1516

https://claude.ai/code/session_013wwFDuzZZspe41YcCiV6aa
