### PR TITLE
[#1526] Hold the account menu to the design: no version line, pickable mailbox rows

### DIFF
--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -1091,11 +1091,18 @@ describe('App session', () => {
         expect(within(screen.getByRole('navigation', { name: 'Spaces' })).queryAllByRole('link')).toEqual([]);
     });
 
-    it('reports the deployment it is reading from beside the client it is running', async () => {
+    it('reports the deployment it is reading from beside the client it is running, on the settings screen', async () => {
         renderApp();
         await framed();
+        fireEvent.click(screen.getByRole('button', { name: 'Settings', hidden: true }));
 
-        expect(screen.getByText(`Client ${__MAILFATHOM_VERSION__}, deployment 0.8.7`)).toBeDefined();
+        expect(screen.getByText(`MailFathom Client ${__MAILFATHOM_VERSION__}, deployment 0.8.7`)).toBeDefined();
+    });
+
+    it('names the client it is running on the sign-in screen, no deployment having answered yet', () => {
+        renderApp(nothingAdopted, null);
+
+        expect(screen.getByText(`MailFathom Client ${__MAILFATHOM_VERSION__}`)).toBeDefined();
     });
 
     it('names each account and what its last attempt did, behind the line that summarizes them', async () => {
@@ -1471,9 +1478,15 @@ describe('App deployment', () => {
         });
     });
 
-    it('offers to be pointed elsewhere once somebody named the deployment themselves', async () => {
+    // The menu inside the frame does not carry this and the design project draws it nowhere there. Pointing the client
+    // elsewhere ends the session anyway, so the screen that offers it is the one signing out lands on.
+    it('offers to be pointed elsewhere once the session ends, where somebody named the deployment themselves', async () => {
         renderApp(chose('https://mail.example.invalid'));
         await framed();
+
+        expect(screen.queryByRole('button', { name: 'Point somewhere else', hidden: true })).toBeNull();
+
+        signOut();
 
         expect(screen.getByRole('button', { name: 'Point somewhere else', hidden: true })).toBeDefined();
     });
@@ -1505,6 +1518,7 @@ describe('App deployment', () => {
         renderApp(chose('https://mail.example.invalid'));
         await framed();
 
+        signOut();
         fireEvent.click(screen.getByRole('button', { name: 'Point somewhere else', hidden: true }));
 
         expect(screen.getByRole('textbox', { name: 'Server' })).toBeDefined();
@@ -1563,8 +1577,9 @@ describe('App deployment', () => {
         // proving what its name says the moment either literal moved.
         await credentials.keep(pointedAt, heldCredential);
 
-        renderApp(chosen, heldCredential, deploymentAnswering(), credentials);
-        await framed();
+        // Read on the sign-in screen rather than inside the frame, which is where the control now is — and where the
+        // assertion is about pointing elsewhere alone, signing out having its own reason to clear the same store.
+        renderApp(chosen, null, deploymentAnswering(), credentials);
 
         fireEvent.click(screen.getByRole('button', { name: 'Point somewhere else', hidden: true }));
 
@@ -1584,6 +1599,7 @@ describe('App deployment', () => {
         renderApp(chose('https://mail.example.invalid'));
         await framed();
 
+        signOut();
         fireEvent.click(screen.getByRole('button', { name: 'Point somewhere else', hidden: true }));
 
         expect(document.activeElement).toBe(screen.getByRole('textbox', { name: 'Server' }));
@@ -1616,6 +1632,7 @@ describe('App deployment', () => {
         renderApp(chose('https://first.example.invalid'));
         await framed();
 
+        signOut();
         fireEvent.click(screen.getByRole('button', { name: 'Point somewhere else', hidden: true }));
         typeAddress('second.example.invalid');
         signIn();
@@ -1635,6 +1652,12 @@ describe('App deployment', () => {
         });
     });
 });
+
+// The way out of the frame, taken the way a person takes it: the row in the account menu. It is what a test reaches
+// the sign-in screen through, that screen being where a chosen deployment is pointed somewhere else.
+function signOut(): void {
+    fireEvent.click(screen.getByRole('button', { name: 'Sign out', hidden: true }));
+}
 
 // Inside the frame the language and the telemetry decision are made on the settings screen rather than in the menu
 // that leads to it, which is where the design project puts them — so a test about either opens that screen the way a

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -12,6 +12,7 @@ import { forgetComposition } from './composer/keptComposition';
 import { ComposingContext } from './composer/useComposing';
 import { BrandMark } from './controls/BrandMark';
 import { SecondaryButton } from './controls/SecondaryButton';
+import { VersionLine } from './controls/VersionLine';
 import {
     forgetDeployment,
     storeDeployment,
@@ -538,11 +539,9 @@ export function App({
                                     <AccountMenu
                                         accounts={mailAccounts}
                                         deploymentVersion={deploymentSession?.version ?? null}
-                                        readingFrom={adopted?.origin === 'chosen' ? baseAddress : null}
                                         telemetryForwarding={telemetryForwardedBy(deploymentSession, baseAddress)}
                                         preferences={preferences}
                                         profile={profile}
-                                        onPointSomewhereElse={pointSomewhereElse}
                                         onSignOut={signOut}
                                     />
                                 }
@@ -716,10 +715,9 @@ function SignInScreen({
 
             <main className="flex flex-1 justify-center overflow-y-auto px-4 py-8 split:items-center split:px-12">
                 <div className="flex w-full max-w-sm flex-col gap-6">
-                    {/* The client's version is not here: the design draws neither, and the account menu already
-                        reports it beside the deployment's own once there is a session to read it against — which is
-                        where somebody comparing the two would look. Off this row the two pickers fit one line at the
-                        narrowest width, which is the composition the design draws. */}
+                    {/* The version is not on this row and is at the foot of the form, which is where the design
+                        project draws it. Off this row the two pickers fit one line at the narrowest width, which is
+                        the composition the design draws. */}
                     <div className="flex flex-wrap items-center justify-end gap-3.5">
                         <ThemeChoice />
                         <LanguageChoice />
@@ -755,6 +753,13 @@ function SignInScreen({
                     ) : (
                         <ConfigurationRefused refusal={refusal} />
                     )}
+
+                    {/* The foot of the form, under the refusal as well as under the form: what is running is one of
+                        the first things asked of somebody reporting that a deployment will not take them, and it is
+                        the client's own version alone here because no deployment has answered anything yet.
+                        The design project's foot row carries a help line on the left of it, which this client draws
+                        nowhere: no deployment publishes an address to send somebody to. */}
+                    <VersionLine deploymentVersion={null} className="text-end text-2xs text-faint" />
                 </div>
             </main>
         </div>

--- a/frontend/src/Client.App/src/controls/VersionLine.test.tsx
+++ b/frontend/src/Client.App/src/controls/VersionLine.test.tsx
@@ -1,0 +1,36 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { LocalizationProvider } from '../localization/Localization';
+import { VersionLine } from './VersionLine';
+
+function renderLine(deploymentVersion: string | null): void {
+    render(
+        <LocalizationProvider>
+            <VersionLine deploymentVersion={deploymentVersion} />
+        </LocalizationProvider>,
+    );
+}
+
+describe('VersionLine', () => {
+    it('names the product in front of the versions, which is what makes a number readable', () => {
+        renderLine(null);
+
+        expect(screen.getByText(/^MailFathom /u)).toBeDefined();
+    });
+
+    it('says what the client and the deployment are running once the deployment has answered', () => {
+        renderLine('0.9.0');
+
+        expect(screen.getByText(`MailFathom Client ${__MAILFATHOM_VERSION__}, deployment 0.9.0`)).toBeDefined();
+    });
+
+    it('says what the client alone is running while nothing has answered, that being all this machine knows', () => {
+        renderLine(null);
+
+        expect(screen.getByText(`MailFathom Client ${__MAILFATHOM_VERSION__}`)).toBeDefined();
+    });
+});

--- a/frontend/src/Client.App/src/controls/VersionLine.tsx
+++ b/frontend/src/Client.App/src/controls/VersionLine.tsx
@@ -1,0 +1,42 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { useLocalization } from '../localization/useLocalization';
+
+// What is running, drawn in the two places the design project puts it: the foot of the sign-in form, and the foot of
+// the settings screen. It is one component rather than a line written twice because the two say the same thing under
+// the same rule — the deployment's version stands beside the client's once the deployment has answered, and the
+// client's own stands alone before that, which is the only version anything on this machine knows.
+//
+// The product's name is part of it for the same reason the design project draws it there: a version with nothing in
+// front of it is a number, and the foot of a screen is where somebody reads what they are running rather than what
+// this particular pane is.
+//
+// Where it stands and what it stands on is the caller's, which is why the class name is handed in: the sign-in screen
+// puts it at the end of a row and the settings screen centres it on a bar of its own, and neither is a property of
+// the sentence.
+
+export function VersionLine({
+    deploymentVersion,
+    className,
+}: {
+    /** What the deployment answered it is running, or `null` while nothing has answered — which is every sign-in. */
+    readonly deploymentVersion: string | null;
+
+    readonly className?: string;
+}) {
+    const { translate } = useLocalization();
+
+    return (
+        <p className={className}>
+            {translate('shell.title')}{' '}
+            {deploymentVersion === null
+                ? translate('shell.clientVersion', { client: __MAILFATHOM_VERSION__ })
+                : translate('shell.versions', {
+                      client: __MAILFATHOM_VERSION__,
+                      deployment: deploymentVersion,
+                  })}
+        </p>
+    );
+}

--- a/frontend/src/Client.App/src/settings/Settings.test.tsx
+++ b/frontend/src/Client.App/src/settings/Settings.test.tsx
@@ -42,11 +42,13 @@ function renderSettings({
     profile = named,
     preferences = settings,
     telemetryForwarding = forwardedTo,
+    deploymentVersion = '0.9.0',
     onClose = () => undefined,
 }: {
     readonly profile?: OwnProfileInForce;
     readonly preferences?: ClientPreferencesInForce;
     readonly telemetryForwarding?: TelemetryForwarding;
+    readonly deploymentVersion?: string | null;
     readonly onClose?: () => void;
 } = {}): void {
     render(
@@ -55,6 +57,7 @@ function renderSettings({
                 profile={profile}
                 preferences={preferences}
                 telemetryForwarding={telemetryForwarding}
+                deploymentVersion={deploymentVersion}
                 onClose={onClose}
             />
         </LocalizationProvider>,
@@ -370,5 +373,25 @@ describe('Settings', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Close settings' }));
 
         expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it('says what the client and the deployment are running, at its foot', () => {
+        renderSettings({ deploymentVersion: '0.9.0' });
+
+        expect(screen.getByText(/deployment 0\.9\.0/u)).toBeDefined();
+    });
+
+    it('says what the client alone is running while the deployment has answered nothing', () => {
+        renderSettings({ deploymentVersion: null });
+
+        expect(screen.queryByText(/, deployment /u)).toBeNull();
+        expect(screen.getByText(/^MailFathom Client /u)).toBeDefined();
+    });
+
+    it('says it under either tab, that being about the client rather than about what is open', () => {
+        renderSettings({ deploymentVersion: '0.9.0' });
+        openApplication();
+
+        expect(screen.getByText(/deployment 0\.9\.0/u)).toBeDefined();
     });
 });

--- a/frontend/src/Client.App/src/settings/Settings.tsx
+++ b/frontend/src/Client.App/src/settings/Settings.tsx
@@ -6,6 +6,7 @@ import { useEffect, useId, useRef, useState } from 'react';
 import { Icon } from '../controls/Icon';
 import { PersonAvatar } from '../controls/PersonAvatar';
 import { Switch } from '../controls/Switch';
+import { VersionLine } from '../controls/VersionLine';
 import type { TelemetryForwarding } from '../deployment/telemetryForwarding';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
@@ -48,6 +49,7 @@ export function Settings({
     profile,
     preferences,
     telemetryForwarding,
+    deploymentVersion,
     onClose,
 }: {
     /** Who the client is drawing, and the three ways this surface changes it. */
@@ -58,6 +60,9 @@ export function Settings({
 
     /** What this deployment has said about forwarding this client's telemetry, including that it has said nothing. */
     readonly telemetryForwarding: TelemetryForwarding;
+
+    /** What the deployment answered it is running, or `null` while nothing has answered, for the line at the foot. */
+    readonly deploymentVersion: string | null;
 
     readonly onClose: () => void;
 }) {
@@ -113,6 +118,14 @@ export function Settings({
                     <Application preferences={preferences} telemetryForwarding={telemetryForwarding} />
                 )}
             </div>
+
+            {/* Outside the scrolling panel and under both tabs, which is where the design project draws it: what is
+                running is about the client rather than about whichever half of this surface is open, and a line that
+                scrolled away with the profile would be one somebody has to go looking for. */}
+            <VersionLine
+                deploymentVersion={deploymentVersion}
+                className="border-t border-line bg-sunken px-4 py-2.5 text-center text-2xs text-faint"
+            />
         </dialog>
     );
 }

--- a/frontend/src/Client.App/src/shell/AccountMenu.test.tsx
+++ b/frontend/src/Client.App/src/shell/AccountMenu.test.tsx
@@ -10,6 +10,9 @@ import { LocalizationProvider } from '../localization/Localization';
 import type { ClientPreferencesInForce } from '../preferences/useClientPreferences';
 import type { OwnProfileInForce } from '../profile/useOwnProfile';
 import { ThemeProvider } from '../theme/Theme';
+import { WorkspaceProvider } from '../workspace/Workspace';
+import type { MailScope } from '../workspace/mailScope';
+import { useWorkspace } from '../workspace/useWorkspace';
 import { AccountMenu } from './AccountMenu';
 
 function mailbox(id: string, displayName: string): MailAccount {
@@ -63,41 +66,81 @@ function atTabWidth(wideEnough: boolean): void {
 /** What the deployment answered about forwarding, which this menu only passes to the screen behind its own row. */
 const forwardedTo: TelemetryForwarding = { answered: true, destination: 'https://mail.example' };
 
+// What the menu wrote, read back the way every other screen will read it: out of the workspace rather than out of the
+// component that wrote it. The scope is the only part of it these tests are about.
+function ScopeProbe() {
+    const { workspace } = useWorkspace();
+
+    return <output>{JSON.stringify(workspace.scope)}</output>;
+}
+
+const scopeStartsAt = 'Scope the client the way the folder tree would.';
+
+// Stands in for the folder tree, which is the other place a scope is written: a test about the two agreeing needs
+// something outside the menu to write one, and the tree itself is a whole screen away from this component.
+function ScopeAs({ scope }: { readonly scope: MailScope }) {
+    const { revise } = useWorkspace();
+
+    return (
+        <button
+            type="button"
+            onClick={() => {
+                revise({ scope });
+            }}
+        >
+            {scopeStartsAt}
+        </button>
+    );
+}
+
+function scopeAsTheTreeWould(): void {
+    fireEvent.click(screen.getByRole('button', { name: scopeStartsAt }));
+}
+
+/** The scope the workspace holds, as the probe wrote it out. */
+function scopeInForce(): MailScope {
+    return JSON.parse(screen.getByRole('status').textContent) as MailScope;
+}
+
 function renderMenu({
     accounts = [],
     deploymentVersion = '0.9.0',
-    readingFrom = null,
     telemetryForwarding = forwardedTo,
     preferences = settings,
     profile = nobody,
-    onPointSomewhereElse = () => undefined,
     onSignOut = () => undefined,
+    scope = null,
 }: {
     readonly accounts?: readonly MailAccount[];
     readonly deploymentVersion?: string | null;
-    readonly readingFrom?: string | null;
     readonly telemetryForwarding?: TelemetryForwarding;
     readonly preferences?: ClientPreferencesInForce;
     readonly profile?: OwnProfileInForce;
-    readonly onPointSomewhereElse?: () => void;
     readonly onSignOut?: () => void;
+    readonly scope?: MailScope | null;
 } = {}): void {
     render(
         <LocalizationProvider>
             <ThemeProvider>
-                <AccountMenu
-                    accounts={accounts}
-                    deploymentVersion={deploymentVersion}
-                    readingFrom={readingFrom}
-                    telemetryForwarding={telemetryForwarding}
-                    preferences={preferences}
-                    profile={profile}
-                    onPointSomewhereElse={onPointSomewhereElse}
-                    onSignOut={onSignOut}
-                />
+                <WorkspaceProvider>
+                    <AccountMenu
+                        accounts={accounts}
+                        deploymentVersion={deploymentVersion}
+                        telemetryForwarding={telemetryForwarding}
+                        preferences={preferences}
+                        profile={profile}
+                        onSignOut={onSignOut}
+                    />
+                    <ScopeProbe />
+                    {scope === null ? null : <ScopeAs scope={scope} />}
+                </WorkspaceProvider>
             </ThemeProvider>
         </LocalizationProvider>,
     );
+
+    if (scope !== null) {
+        scopeAsTheTreeWould();
+    }
 }
 
 // jsdom draws a popover closed and never opens one — it implements neither the invoker nor `showPopover` — so what is
@@ -107,6 +150,10 @@ describe('AccountMenu', () => {
     afterEach(() => {
         atTabWidth(false);
         window.localStorage.clear();
+
+        // The workspace outlives a render in the browser store the provider synchronizes with, so a test that scoped
+        // the client would otherwise hand its scope to the next one.
+        window.sessionStorage.clear();
     });
 
     it('is opened by a control named for what it holds, which is the platform’s own popover', () => {
@@ -189,33 +236,62 @@ describe('AccountMenu', () => {
         expect(screen.getByRole('button', { name: 'Sign out', hidden: true })).toBeDefined();
     });
 
-    it('says what the client and the deployment are running, beside each other', () => {
+    it('draws each mailbox as something to press rather than as a line to read', () => {
+        renderMenu({ accounts: [mailbox('work', 'Work'), mailbox('board', 'Board')] });
+
+        expect(screen.getByRole('button', { name: 'Work', hidden: true })).toBeDefined();
+        expect(screen.getByRole('button', { name: 'Board', hidden: true })).toBeDefined();
+    });
+
+    it('puts the mailbox somebody presses in scope, in the workspace every other screen reads', () => {
+        renderMenu({ accounts: [mailbox('work', 'Work'), mailbox('board', 'Board')] });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Board', hidden: true }));
+
+        expect(scopeInForce()).toStrictEqual({ kind: 'account', accountId: 'board' });
+    });
+
+    it('marks the mailbox in scope and no other', () => {
+        renderMenu({
+            accounts: [mailbox('work', 'Work'), mailbox('board', 'Board')],
+            scope: { kind: 'account', accountId: 'board' },
+        });
+
+        expect(screen.getByRole('button', { name: 'Board', hidden: true }).getAttribute('aria-current')).toBe('true');
+        expect(screen.getByRole('button', { name: 'Work', hidden: true }).getAttribute('aria-current')).toBeNull();
+    });
+
+    it('marks the mailbox a folder in scope belongs to, which is what the folder tree marks too', () => {
+        renderMenu({
+            accounts: [mailbox('work', 'Work'), mailbox('board', 'Board')],
+            scope: { kind: 'folder', accountId: 'work', alias: 'INBOX' },
+        });
+
+        expect(screen.getByRole('button', { name: 'Work', hidden: true }).getAttribute('aria-current')).toBe('true');
+        expect(screen.getByRole('button', { name: 'Board', hidden: true }).getAttribute('aria-current')).toBeNull();
+    });
+
+    it('marks no mailbox where the scope is every one of them at once, or a role spanning them', () => {
+        renderMenu({
+            accounts: [mailbox('work', 'Work'), mailbox('board', 'Board')],
+            scope: { kind: 'role', role: 'Inbox' },
+        });
+
+        expect(screen.getByRole('button', { name: 'Work', hidden: true }).getAttribute('aria-current')).toBeNull();
+        expect(screen.getByRole('button', { name: 'Board', hidden: true }).getAttribute('aria-current')).toBeNull();
+    });
+
+    it('says nothing here about what is running, that being drawn on the screen behind its own row', () => {
         renderMenu({ deploymentVersion: '0.9.0' });
 
-        expect(screen.getByText(/deployment 0\.9\.0/u)).toBeDefined();
+        expect(screen.queryByText(/deployment 0\.9\.0/u)).toBeNull();
+        expect(screen.queryByText(/^MailFathom Client /u)).toBeNull();
     });
 
-    it('says what the client alone is running while the deployment has not answered', () => {
-        renderMenu({ deploymentVersion: null });
-
-        expect(screen.queryByText(/, deployment /u)).toBeNull();
-        expect(screen.getByText(/^Client /u)).toBeDefined();
-    });
-
-    it('offers to be pointed elsewhere only where somebody named the deployment themselves', () => {
-        renderMenu({ readingFrom: null });
+    it('offers no way out of the deployment, that being the sign-in screen’s once a session ends', () => {
+        renderMenu();
 
         expect(screen.queryByRole('button', { name: 'Point somewhere else', hidden: true })).toBeNull();
-    });
-
-    it('names the deployment it is reading from, and hands pointing elsewhere to the frame', () => {
-        const onPointSomewhereElse = vi.fn();
-        renderMenu({ readingFrom: 'https://mail.example.invalid', onPointSomewhereElse });
-
-        expect(screen.getByText(/https:\/\/mail\.example\.invalid/u)).toBeDefined();
-        fireEvent.click(screen.getByRole('button', { name: 'Point somewhere else', hidden: true }));
-
-        expect(onPointSomewhereElse).toHaveBeenCalledOnce();
     });
 
     it('hands signing out to the frame rather than doing anything itself', () => {

--- a/frontend/src/Client.App/src/shell/AccountMenu.tsx
+++ b/frontend/src/Client.App/src/shell/AccountMenu.tsx
@@ -12,36 +12,40 @@ import { useLocalization } from '../localization/useLocalization';
 import type { ClientPreferencesInForce } from '../preferences/useClientPreferences';
 import type { OwnProfileInForce } from '../profile/useOwnProfile';
 import { Settings } from '../settings/Settings';
+import { accountInScope, scopeOfAccount } from '../workspace/mailScope';
+import { useWorkspace } from '../workspace/useWorkspace';
 import { TabModeSwitch, ThemeSegments } from './Preferences';
 
 // The menu at the foot of the rail, which is where the design project puts everything that is about the person rather
-// than about the mail: who they are, which mailboxes this deployment reads for them, the two settings that follow them
-// between machines, what the client and the deployment are running, where the client is reading from, the way into
-// everything else about them, and the way out. It is the platform's own popover rather than a menu built out of state —
-// it opens and closes from the control that names it, closes on Escape and on a press outside it, and hands focus back
-// to that control, none of which this file has to write.
+// than about the mail: who they are, which mailboxes this deployment reads for them and which of those the client is
+// scoped to, the two settings that follow them between machines, the way into everything else about them, and the way
+// out. It is the platform's own popover rather than a menu built out of state — it opens and closes from the control
+// that names it, closes on Escape and on a press outside it, and hands focus back to that control, none of which this
+// file has to write.
 //
-// The language is not here and is on the settings screen, which is where the design project draws it: the menu holds
-// what somebody reaches for between messages, and what language the client reads in is set once.
+// Two things a reader might expect here are deliberately elsewhere, both because the design project draws them there.
+// The language is on the settings screen: the menu holds what somebody reaches for between messages, and what language
+// the client reads in is set once. What the client and the deployment are running is on the sign-in screen and at the
+// foot of that same settings screen, which is where somebody looks for a version — this menu only carries the
+// deployment's version through to the screen its own row opens.
+//
+// The way out of a deployment somebody named themselves is not here either, and that one is not a design decision:
+// pointing the client elsewhere ends the session anyway, so the sign-in screen the frame falls back to is where it is
+// offered and where it still works when a kept password has stopped being accepted.
 
 export function AccountMenu({
     accounts,
     deploymentVersion,
-    readingFrom,
     telemetryForwarding,
     preferences,
     profile,
-    onPointSomewhereElse,
     onSignOut,
 }: {
     /** The mailboxes this deployment reads for the signed-in person, which is empty while nothing has answered. */
     readonly accounts: readonly MailAccount[];
 
-    /** What the deployment answered it is running, or `null` while nothing has answered. */
+    /** What the deployment answered it is running, or `null` while nothing has answered, for the screen below. */
     readonly deploymentVersion: string | null;
-
-    /** The address somebody named for the deployment, or `null` where the origin that served the client is it. */
-    readonly readingFrom: string | null;
 
     /**
      * What this deployment has said about forwarding this client's own records, which the settings screen behind this
@@ -57,7 +61,6 @@ export function AccountMenu({
     /** Who the client is drawing, which this menu shows and the screen behind its own row edits. */
     readonly profile: OwnProfileInForce;
 
-    readonly onPointSomewhereElse: () => void;
     readonly onSignOut: () => void;
 }) {
     const { translate } = useLocalization();
@@ -105,30 +108,6 @@ export function AccountMenu({
                         <p className="truncate font-semibold">{profile.displayName}</p>
                     )}
 
-                    <p className="font-mono text-xs text-muted">
-                        {deploymentVersion === null
-                            ? translate('shell.clientVersion', { client: __MAILFATHOM_VERSION__ })
-                            : translate('shell.versions', {
-                                  client: __MAILFATHOM_VERSION__,
-                                  deployment: deploymentVersion,
-                              })}
-                    </p>
-
-                    {readingFrom === null ? null : (
-                        <p className="flex flex-wrap items-baseline gap-x-2 text-xs text-muted">
-                            <span className="break-all">
-                                {translate('deployment.reachedAt', { address: readingFrom })}
-                            </span>
-                            <button
-                                type="button"
-                                className="text-accent-strong hover:underline"
-                                onClick={onPointSomewhereElse}
-                            >
-                                {translate('deployment.change')}
-                            </button>
-                        </p>
-                    )}
-
                     <Mailboxes accounts={accounts} />
                 </div>
 
@@ -174,6 +153,7 @@ export function AccountMenu({
                     profile={profile}
                     preferences={preferences}
                     telemetryForwarding={telemetryForwarding}
+                    deploymentVersion={deploymentVersion}
                     onClose={closeSettings}
                 />
             ) : null}
@@ -181,16 +161,26 @@ export function AccountMenu({
     );
 }
 
-// Which mailboxes this deployment reads for the person, which is what makes the menu about them rather than about the
-// client. The mark is the one the folder tree draws in front of the same mailbox's folders, so a mailbox keeps one
-// colour wherever it appears; the ordinal is shifted by one because that tree's first mark stands for every mailbox at
-// once and this list has no such row.
+// Which mailboxes this deployment reads for the person, and which of them the client is scoped to — the second place
+// that is chosen, the folder tree being the first. It writes the same `MailScope` into the same workspace that tree
+// writes, so the two are one decision drawn twice rather than two notions of which mailbox is in scope; anything that
+// held its own would be the pair that comes to disagree.
+//
+// The mark is the one the folder tree draws in front of the same mailbox's folders, so a mailbox keeps one colour
+// wherever it appears; the ordinal is shifted by one because that tree's first mark stands for every mailbox at once
+// and this list has no such row.
+//
+// The check follows the account a scope belongs to rather than the scope itself, which is what makes it right for the
+// folder scopes too: somebody reading one folder of their work mailbox is in that mailbox, and the row saying so is
+// the same row they would press to widen the scope back out to all of it. Every mailbox at once, and a role spanning
+// them, belong to no account and are checked nowhere — which is the tree's own answer as well.
 //
 // Nothing is drawn where nothing answered. An empty list is a deployment that has not answered yet, one whose accounts
 // this credential may not read, and one that declares no mailbox — three sentences the connection summary already says
 // in the space a person is looking at, and repeating any of them here would be saying it twice.
 function Mailboxes({ accounts }: { readonly accounts: readonly MailAccount[] }) {
     const { translate } = useLocalization();
+    const { workspace, revise } = useWorkspace();
 
     // The words over the list name the list rather than heading a section: the menu stands inside a space whose own
     // heading level is the space's, and a heading opened here would be one out of order in a popover.
@@ -200,6 +190,8 @@ function Mailboxes({ accounts }: { readonly accounts: readonly MailAccount[] }) 
         return null;
     }
 
+    const inScope = accountInScope(workspace.scope);
+
     return (
         <>
             <p id={named} className="pt-1.5 text-2xs tracking-widest text-faint uppercase">
@@ -208,9 +200,26 @@ function Mailboxes({ accounts }: { readonly accounts: readonly MailAccount[] }) 
 
             <ul aria-labelledby={named} className="flex flex-col">
                 {accounts.map((account, ordinal) => (
-                    <li key={account.id} className="flex items-center gap-2 py-0.75 text-muted">
-                        <MailboxMark ordinal={ordinal + 1} className="size-1.5" />
-                        <span className="min-w-0 truncate text-xs">{account.displayName}</span>
+                    <li key={account.id} className="flex">
+                        {/* The row is a button rather than a list item somebody may click: what it does is an act, so
+                            it takes focus, answers Enter and Space, and is announced as something to press without
+                            any of that being written here. `aria-current` is what says which one is in scope — the
+                            check beside it is that same fact drawn, for a reader who is looking. */}
+                        <button
+                            type="button"
+                            aria-current={account.id === inScope ? 'true' : undefined}
+                            className="-mx-1 flex min-w-0 flex-1 items-center gap-2 rounded-md px-1 py-0.75 text-start text-muted transition hover:bg-hover hover:text-text"
+                            onClick={() => {
+                                revise({ scope: scopeOfAccount(account.id) });
+                            }}
+                        >
+                            <MailboxMark ordinal={ordinal + 1} className="size-1.5" />
+                            <span className="min-w-0 flex-1 truncate text-xs">{account.displayName}</span>
+
+                            {account.id === inScope ? (
+                                <Icon name="check" className="size-3.5 shrink-0 text-accent-strong" />
+                            ) : null}
+                        </button>
                     </li>
                 ))}
             </ul>

--- a/frontend/src/Client.App/src/signIn/SignIn.tsx
+++ b/frontend/src/Client.App/src/signIn/SignIn.tsx
@@ -162,9 +162,14 @@ export function SignIn({
     // The view changed, so focus is placed rather than left wherever the previous screen had it: on what this screen
     // has to say about why it is back where there is something, and otherwise on the first thing the form is asking to
     // have filled. Moving focus is an imperative browser API, which is what an effect is for.
+    //
+    // It runs again when the deployment changes, because that is the other view change this screen has: pointing away
+    // from a chosen address puts an address field on a form that had none, and this screen is often already standing
+    // when that happens — somebody signs out of the frame first and points elsewhere from here. Leaving focus in the
+    // login field would leave them typing a password against a deployment they have just abandoned.
     useEffect(() => {
         (notified.current ?? address.current ?? name.current)?.focus();
-    }, []);
+    }, [deployment]);
 
     // An attempt is answered for the deployment it was started against, so one whose deployment was abandoned while it
     // ran is called off rather than allowed to answer: the way out of a chosen address sits above this form and stays

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -576,10 +576,11 @@ test('opens in Discover, under the version it was built from and the one the dep
     await expect(page.getByRole('heading', { name: 'Discover', level: 1 })).toBeVisible();
 
     // The client's own is substituted into the bundle at build time, which is the half only a built bundle proves; the
-    // deployment's arrives over the wire beside it. Both are read in the account menu, which is where they live.
-    await openAccountMenu(page);
-    await expect(page.getByText(`Client ${declaredVersion}, deployment ${declaredVersion}`)).toBeVisible();
-    await page.keyboard.press('Escape');
+    // deployment's arrives over the wire beside it. Both are read at the foot of the settings screen, which is where
+    // the design project draws them.
+    await openSettings(page);
+    await expect(page.getByText(`MailFathom Client ${declaredVersion}, deployment ${declaredVersion}`)).toBeVisible();
+    await page.getByRole('button', { name: 'Close settings' }).click();
 
     // A first load at the root is written back to the address the space is actually reached at, which is what makes
     // the next assertion — reloading it — mean anything.


### PR DESCRIPTION
The design project draws neither what is running nor where the client is reading from inside the account menu, and it draws each mailbox row as something to press. The client is changed to match it on both counts, which is the client's half of the audit in #1520.

## The menu

`AccountMenu.tsx` drops the `shell.versions` / `shell.clientVersion` paragraph and the `deployment.reachedAt` line with its *Point somewhere else* control, and its opening comment now says what the design actually puts in the menu — including where the two things that left went and why the third is not a design decision at all.

`deploymentVersion` stays on the component and is passed through to the settings screen, which is what draws it now. `readingFrom` and `onPointSomewhereElse` are gone from it: pointing the client elsewhere ends the session anyway, and the sign-in screen has offered both all along, above the form, for the reason its own comment gives — a deployment that stopped accepting the kept password leaves somebody on that screen with no address field to correct. **The way to point the client at another deployment is therefore the sign-in screen, reached by signing out.** That path had one gap and it is fixed here: `SignIn.tsx` placed focus on mount alone, so pointing away from a chosen address while the screen was already standing put an address field on the form and left focus in the login field. Its focus effect now runs again when the deployment changes.

## The version, where the design draws it

One `VersionLine` control states it in both places, keeping the rule the menu held: the deployment's version stands beside the client's once the deployment has answered, and the client's own stands alone before that. The product's name goes in front of it, which is what the design draws in both.

- **The sign-in screen** carries it at the foot of the form, small, end-aligned, in the faint colour and in the same face as the rest rather than in the monospace one the menu used. No deployment has answered there, so it names the client's own version alone.
- **The settings screen** carries it on a bar of its own at the foot, under both tabs and outside the scrolling panel, centred and faint.

## The pick

Each row under `MAILBOXES` is a button. It writes the same `MailScope` into the same workspace the folder tree writes — `scopeOfAccount`, the same `revise` — so the menu is a second place the mailbox in scope is chosen rather than a second notion of which one it is. `aria-current` says which row is in scope and a check draws the same fact; both follow `accountInScope`, so the mark stands against the mailbox a folder scope belongs to and against none where the scope is every mailbox at once or a role. Hover, focus, and Enter or Space come from the element rather than from anything written here.

## Held against the design

Both screens were screenshotted at 1440 × 900 — the design through a rendered preview, the client through a built bundle with routed answers — and compared region by region. What remains different, and why:

- **The rows name the mailbox by its display name; the design names it by its mail address.** `/api/client/accounts` publishes no address for an account — `ClientMailAccountResponse` carries `Id`, `DisplayName`, the synchronization state, the timestamp and `Behind` — so the client has nothing to draw. Publishing one is service work rather than something this change can reach. The design's own folder tree names its mailboxes by display name, so the client is at least internally consistent.
- **The design prototype draws no check mark against the mailbox in scope.** The acceptance here asks for one and the client draws one; the prototype has not been brought forward to it.
- **The sign-in foot row carries a help line on its left in the design.** The client draws none: no deployment publishes an address to send somebody to.
- **The client's "your password is kept until…" sentence sits between the submit and the version**, where the design draws no such sentence and puts its foot row directly under the button.

## Verification

`scripts/verify-full.sh` — passed. The client suite gains coverage for the pickable rows and the check, for the menu no longer saying what is running, for the version under both tabs of the settings screen and on the sign-in screen, and for `VersionLine` itself; the browser suite reads the two versions at the foot of the settings screen instead of in the menu.

Closes #1526
