### PR TITLE
[#1639] Tab into the mailbox rows before the tab mode, which is where they now stand

### DIFF
--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -691,6 +691,11 @@ test('opens the account menu from its control and hands focus back to it on Esca
     await control.click();
     await expect(page.getByRole('button', { name: 'Sign out' })).toBeVisible();
 
+    // The mailbox rows are the first thing under the person's name and the first thing a keyboard reaches, because
+    // each is a control that puts that mailbox in scope rather than a line to read.
+    await page.keyboard.press('Tab');
+    await expect(page.getByRole('button', { name: 'Work' })).toBeFocused();
+
     await page.keyboard.press('Tab');
     await expect(page.getByRole('switch', { name: /Tab mode/u })).toBeFocused();
 


### PR DESCRIPTION
`main` is red, and every client pull request opened against it inherits the failure.

[#1638](https://github.com/Krzysztof318/MailFathom/pull/1638) made each mailbox row in the account menu a control, which puts it in the tab order above the tab-mode switch — the order the rows are drawn in. The browser suite was not brought forward with it: *opens the account menu from its control and hands focus back to it on Escape* still pressed `Tab` once from the opening control and expected the switch, so it now finds the first mailbox row and fails.

It reached `main` because the browser suite runs in the pipeline rather than in either verification gate, so the gate that change ran was green while the job that reads this file was not.

## What changed

One assertion, and the sentence saying why it is there. The tab order itself is correct — the rows are drawn above the switch, so a keyboard that reaches them first is following the document, which is what that test exists to prove — so the spec is brought to the order rather than the order to the spec.

## Verification

`scripts/verify-full.sh` — passed. `pnpm test:browser -- -g "account menu from its control"` — passed. The whole browser suite passed on this branch, including *moves a keyboard through a narrow window in the order the window shows*, which is the intermittent failure [#1514](https://github.com/Krzysztof318/MailFathom/issues/1514) already tracks and which reproduces on `main` as well as here.

Closes #1639
