### PR TITLE
[#1637] Report as arrived mail only unread inbox mail, and hold a notification for thirty days

### DIFF
--- a/backend/src/Application/Notifications/NotificationRetention.cs
+++ b/backend/src/Application/Notifications/NotificationRetention.cs
@@ -28,10 +28,12 @@ public sealed class NotificationRetention
     /// It is a constant rather than a setting because there is no operator decision behind it to take. The audit
     /// trails are configurable because keeping a history of a person's mailbox is something a deployment undertakes
     /// deliberately and answers for; a notification is the client's own working state, produced whether anybody asked
-    /// or not, and a knob for it would be configuration nobody has a reason to move. Three months is long enough that
-    /// somebody returning from leave still finds what happened and short enough that the table stays a working set.
+    /// or not, and a knob for it would be configuration nobody has a reason to move. A month is what a working set is:
+    /// long enough that somebody back from leave still finds what happened while they were away, and short enough that
+    /// the table never becomes the thing the bound exists to prevent — three months of a person's arrivals is their
+    /// mailbox in miniature, kept by a record nobody undertook to keep a history in.
     /// </remarks>
-    public static readonly TimeSpan Window = TimeSpan.FromDays(90);
+    public static readonly TimeSpan Window = TimeSpan.FromDays(30);
 
     /// <summary>The greatest number of notifications one pass erases.</summary>
     /// <remarks>

--- a/backend/src/Application/Synchronization/MailboxSynchronizer.cs
+++ b/backend/src/Application/Synchronization/MailboxSynchronizer.cs
@@ -235,6 +235,13 @@ public sealed class MailboxSynchronizer
         var collection = this.contactCollection.OpenRun(account, folderRole);
 
         var storedCount = 0;
+
+        // What the run reports as arrived mail, decided here rather than by a query afterwards: the folder's role and
+        // the server's own flag are both in hand at the moment an occurrence is stored, and neither survives to a later
+        // reader — the stored row's flag belongs to the backward pass, and no consumer of the count should have to
+        // reconstruct which of a run's messages were news.
+        var arrivedCount = 0;
+        var storesArrivingMail = folderRole == MailFolderSpecialUse.Inbox;
         var skippedOversizedCount = 0;
         var deferredForStorageCount = 0;
         var deferredForOwnerStorageCount = 0;
@@ -339,6 +346,13 @@ public sealed class MailboxSynchronizer
                     {
                         case StoredEmailContentAvailability.Available:
                             storedCount++;
+
+                            // A copy MailFathom filed of the owner's own outgoing message is never arrival, whatever
+                            // folder it landed in: the person wrote it, so nothing about it reached them.
+                            if (storesArrivingMail && !metadata.IsRemotelySeen && filing is null)
+                            {
+                                arrivedCount++;
+                            }
 
                             break;
 
@@ -452,6 +466,7 @@ public sealed class MailboxSynchronizer
         return MailboxSynchronizationResult.Synchronized(
             folder,
             storedCount,
+            arrivedCount,
             skippedOversizedCount,
             unreadableMimeCount + refill.UnreadableMimeEmailCount,
             relocatedCount,
@@ -1179,6 +1194,12 @@ public enum MailboxSynchronizationOutcome
 /// <param name="Outcome">Whether the run reached a folder.</param>
 /// <param name="Folder">The binding the run worked under, which is present exactly when <paramref name="Outcome" /> is <see cref="MailboxSynchronizationOutcome.Synchronized" />.</param>
 /// <param name="StoredEmailCount">How many occurrences were stored with their content.</param>
+/// <param name="ArrivedEmailCount">
+/// How many of the stored occurrences were mail arriving for the person: stored in the inbox, unread on the server when
+/// the run stored them, and not a copy MailFathom filed of the owner's own outgoing message. It is a subset of
+/// <paramref name="StoredEmailCount" /> and is what a run reports as arrived mail, so no consumer has to rebuild the
+/// rule from a count that means something wider.
+/// </param>
 /// <param name="SkippedOversizedEmailCount">How many occurrences were stored as metadata only.</param>
 /// <param name="UnreadableMimeEmailCount">How many stored occurrences carried MIME that enrichment could not read.</param>
 /// <param name="RelocatedEmailCount">
@@ -1205,6 +1226,7 @@ public sealed record MailboxSynchronizationResult(
     MailboxSynchronizationOutcome Outcome,
     MailFolderResolution? Folder,
     int StoredEmailCount,
+    int ArrivedEmailCount,
     int SkippedOversizedEmailCount,
     int UnreadableMimeEmailCount,
     int RelocatedEmailCount,
@@ -1217,6 +1239,7 @@ public sealed record MailboxSynchronizationResult(
     /// <summary>Reports a run that reached its folder.</summary>
     /// <param name="folder">The binding the run worked under.</param>
     /// <param name="storedEmailCount">How many occurrences were stored with their content.</param>
+    /// <param name="arrivedEmailCount">How many of those were unread inbox mail the owner did not send themselves.</param>
     /// <param name="skippedOversizedEmailCount">How many occurrences were stored as metadata only.</param>
     /// <param name="unreadableMimeEmailCount">How many stored occurrences carried unreadable MIME.</param>
     /// <param name="relocatedEmailCount">How many discovered occurrences carried an existing local email across.</param>
@@ -1230,6 +1253,7 @@ public sealed record MailboxSynchronizationResult(
     public static MailboxSynchronizationResult Synchronized(
         MailFolderResolution folder,
         int storedEmailCount,
+        int arrivedEmailCount,
         int skippedOversizedEmailCount,
         int unreadableMimeEmailCount,
         int relocatedEmailCount,
@@ -1247,6 +1271,7 @@ public sealed record MailboxSynchronizationResult(
             MailboxSynchronizationOutcome.Synchronized,
             folder,
             storedEmailCount,
+            arrivedEmailCount,
             skippedOversizedEmailCount,
             unreadableMimeEmailCount,
             relocatedEmailCount,
@@ -1280,6 +1305,7 @@ public sealed record MailboxSynchronizationResult(
         return new MailboxSynchronizationResult(
             outcome,
             Folder: null,
+            0,
             0,
             0,
             0,

--- a/backend/src/Application/Synchronization/MailboxSynchronizer.cs
+++ b/backend/src/Application/Synchronization/MailboxSynchronizer.cs
@@ -347,9 +347,13 @@ public sealed class MailboxSynchronizer
                         case StoredEmailContentAvailability.Available:
                             storedCount++;
 
-                            // A copy MailFathom filed of the owner's own outgoing message is never arrival, whatever
-                            // folder it landed in: the person wrote it, so nothing about it reached them.
-                            if (storesArrivingMail && !metadata.IsRemotelySeen && filing is null)
+                            // Nothing MailFathom itself put here is arrival, whichever of the two acts put it there:
+                            // a copy filed of the owner's own outgoing message, which the person wrote, and a copy a
+                            // rule made into a folder mapped as the inbox, which carries the source's flags and would
+                            // otherwise announce as new mail the message it was copied from. Both are already
+                            // recognized as this deployment's own act, and the run suppresses the appearance each of
+                            // them raises for the same reason.
+                            if (storesArrivingMail && !metadata.IsRemotelySeen && filing is null && copy is null)
                             {
                                 arrivedCount++;
                             }
@@ -1196,7 +1200,8 @@ public enum MailboxSynchronizationOutcome
 /// <param name="StoredEmailCount">How many occurrences were stored with their content.</param>
 /// <param name="ArrivedEmailCount">
 /// How many of the stored occurrences were mail arriving for the person: stored in the inbox, unread on the server when
-/// the run stored them, and not a copy MailFathom filed of the owner's own outgoing message. It is a subset of
+/// the run stored them, and placed there by neither of MailFathom's own two acts — filing a copy of the owner's
+/// outgoing message, and a rule copying a message into a folder mapped as the inbox. It is a subset of
 /// <paramref name="StoredEmailCount" /> and is what a run reports as arrived mail, so no consumer has to rebuild the
 /// rule from a count that means something wider.
 /// </param>
@@ -1239,7 +1244,7 @@ public sealed record MailboxSynchronizationResult(
     /// <summary>Reports a run that reached its folder.</summary>
     /// <param name="folder">The binding the run worked under.</param>
     /// <param name="storedEmailCount">How many occurrences were stored with their content.</param>
-    /// <param name="arrivedEmailCount">How many of those were unread inbox mail the owner did not send themselves.</param>
+    /// <param name="arrivedEmailCount">How many of those were unread inbox mail that MailFathom did not place there itself.</param>
     /// <param name="skippedOversizedEmailCount">How many occurrences were stored as metadata only.</param>
     /// <param name="unreadableMimeEmailCount">How many stored occurrences carried unreadable MIME.</param>
     /// <param name="relocatedEmailCount">How many discovered occurrences carried an existing local email across.</param>

--- a/backend/src/Application/Synchronization/RemoteEmailMetadata.cs
+++ b/backend/src/Application/Synchronization/RemoteEmailMetadata.cs
@@ -7,4 +7,21 @@ using MailFathom.Domain.Emails;
 namespace MailFathom.Application.Synchronization;
 
 /// <summary>Contains privacy-minimized metadata required for local mailbox timelines and synchronization progress.</summary>
-public sealed record RemoteEmailMetadata(EmailOccurrenceId OccurrenceId, string? InternetMessageId, string? Subject, DateTimeOffset? SentAt, long SizeOctets);
+/// <param name="OccurrenceId">Where the message sits on the server, which is its identity for this account.</param>
+/// <param name="InternetMessageId">The message identifier its author's client wrote, when the server reported one.</param>
+/// <param name="Subject">The subject line the envelope carried, when the server reported one.</param>
+/// <param name="SentAt">When the envelope says the message was sent, normalized to UTC.</param>
+/// <param name="SizeOctets">How large the server says the message is, which is what the content budget is spent against.</param>
+/// <param name="IsRemotelySeen">
+/// Whether the server had marked the message <c>\Seen</c> when it described it. It is read here rather than from the
+/// stored row because the row's flag is written by the backward pass, whose window need not cover what the forward pass
+/// has just stored — so a message stored in this run has no reconciled flag to consult and would read as unread
+/// whatever the server said. What turns on it is whether the run reports the message as mail that arrived.
+/// </param>
+public sealed record RemoteEmailMetadata(
+    EmailOccurrenceId OccurrenceId,
+    string? InternetMessageId,
+    string? Subject,
+    DateTimeOffset? SentAt,
+    long SizeOctets,
+    bool IsRemotelySeen);

--- a/backend/src/Application/Synchronization/RemoteEmailMetadata.cs
+++ b/backend/src/Application/Synchronization/RemoteEmailMetadata.cs
@@ -17,6 +17,8 @@ namespace MailFathom.Application.Synchronization;
 /// stored row because the row's flag is written by the backward pass, whose window need not cover what the forward pass
 /// has just stored — so a message stored in this run has no reconciled flag to consult and would read as unread
 /// whatever the server said. What turns on it is whether the run reports the message as mail that arrived.
+/// A reconstruction describing an occurrence some earlier run discovered therefore has no such report to carry and
+/// says <see langword="true" />, which is the reading no arrival can follow from, rather than a column it must not read.
 /// </param>
 public sealed record RemoteEmailMetadata(
     EmailOccurrenceId OccurrenceId,

--- a/backend/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
+++ b/backend/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
@@ -262,9 +262,9 @@ internal sealed partial class AccountSynchronizationSupervisor
                         resolvedFolders.Add(resolvedFolder);
                     }
 
-                    if (folderRun.StoredEmailCount > 0)
+                    if (folderRun.ArrivedEmailCount > 0)
                     {
-                        Interlocked.Add(ref arrivedEmailCount, folderRun.StoredEmailCount);
+                        Interlocked.Add(ref arrivedEmailCount, folderRun.ArrivedEmailCount);
                     }
 
                     // A plain write rather than an interlocked one: every writer writes the same value, and awaiting
@@ -943,7 +943,7 @@ internal sealed partial class AccountSynchronizationSupervisor
 
             this.RecordFolderRun(folder, result);
 
-            return new FolderRunOutcome(Succeeded: true, result.Folder, result.StoredEmailCount);
+            return new FolderRunOutcome(Succeeded: true, result.Folder, result.ArrivedEmailCount);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -1567,7 +1567,7 @@ internal sealed partial class AccountSynchronizationSupervisor
     /// <summary>States what one folder's turn through a run produced.</summary>
     /// <param name="Succeeded">Whether the folder completed, which excludes a deferral and an unexpected failure alike.</param>
     /// <param name="ResolvedFolder">The binding the folder ran under, or <see langword="null" /> when the alias resolved to none.</param>
-    /// <param name="StoredEmailCount">How many occurrences the folder committed with their content, which is what the run reports as arrived mail.</param>
+    /// <param name="ArrivedEmailCount">How many of the folder's stored occurrences were mail arriving for the person, which is what the run reports as arrived mail.</param>
     /// <param name="CredentialRefused">
     /// Whether the mail server refused the account's credential, which is the one failure here that a later run cannot
     /// clear on its own and is therefore reported to the person rather than only waited out.
@@ -1575,7 +1575,7 @@ internal sealed partial class AccountSynchronizationSupervisor
     private readonly record struct FolderRunOutcome(
         bool Succeeded,
         MailFolderResolution? ResolvedFolder,
-        int StoredEmailCount = 0,
+        int ArrivedEmailCount = 0,
         bool CredentialRefused = false)
     {
         /// <summary>Gets the outcome of a folder that neither completed nor left a binding worth watching.</summary>
@@ -1583,6 +1583,6 @@ internal sealed partial class AccountSynchronizationSupervisor
 
         /// <summary>Gets the outcome of a folder the mail server would not let this account reach at all.</summary>
         internal static FolderRunOutcome CredentialWasRefused =>
-            new(Succeeded: false, ResolvedFolder: null, StoredEmailCount: 0, CredentialRefused: true);
+            new(Succeeded: false, ResolvedFolder: null, ArrivedEmailCount: 0, CredentialRefused: true);
     }
 }

--- a/backend/src/Infrastructure/Mail/MailKit/MailKitImapMailboxSession.cs
+++ b/backend/src/Infrastructure/Mail/MailKit/MailKitImapMailboxSession.cs
@@ -91,6 +91,17 @@ internal sealed class MailKitImapMailboxSession(
     internal const MessageSummaryItems ReconciliationSummaryItems =
         MessageSummaryItems.Flags | MessageSummaryItems.UniqueId;
 
+    /// <summary>The only items the discovery fetch may ever ask for.</summary>
+    /// <remarks>
+    /// It is bound by the same read-only invariant as <see cref="ReconciliationSummaryItems" /> and named for the same
+    /// reason: every item here is answered out of the envelope and the folder's own state, so the command IMAP receives
+    /// cannot set <c>\Seen</c> on the messages a run is discovering. <c>FLAGS</c> rides the fetch that was already being
+    /// issued, which is what lets a run know whether the server had marked a message read without a second round trip
+    /// and without touching it.
+    /// </remarks>
+    internal const MessageSummaryItems DiscoverySummaryItems =
+        MessageSummaryItems.Envelope | MessageSummaryItems.UniqueId | MessageSummaryItems.Size | MessageSummaryItems.Flags;
+
     /// <inheritdoc />
     public ValueTask DisposeAsync() => connection.DisposeAsync();
 
@@ -196,15 +207,20 @@ internal sealed class MailKitImapMailboxSession(
         var inspectedThroughUid = hasMore ? batchedUids[^1].Id : highestAssignedUid.Value;
         var summaries = batchedUids.Length == 0
             ? []
-            : await openFolder.FetchAsync(batchedUids, MessageSummaryItems.Envelope | MessageSummaryItems.UniqueId | MessageSummaryItems.Size, cancellationToken);
+            : await openFolder.FetchAsync(batchedUids, DiscoverySummaryItems, cancellationToken);
 
         var uidValidity = ImapUidValidity.Create(openFolder.UidValidity);
+
+        // A server that answered without FLAGS leaves the message indistinguishable from one it reported as unread,
+        // and the safe reading of that silence is the one that reports less rather than more: an arrival stated about
+        // mail the person had already read is the defect this flag exists to remove.
         var messages = summaries.Select(summary => new RemoteEmailMetadata(
             EmailOccurrenceId.Create(accountId, folder.Id, uidValidity, ImapUid.Create(summary.UniqueId.Id)),
             summary.Envelope?.MessageId,
             summary.Envelope?.Subject,
             summary.Envelope?.Date?.ToUniversalTime(),
-            summary.Size ?? 0)).ToArray();
+            summary.Size ?? 0,
+            summary.Flags?.HasFlag(MessageFlags.Seen) ?? true)).ToArray();
 
         return new RemoteEmailMetadataBatch(messages, ImapUid.Create(inspectedThroughUid), hasMore);
     }

--- a/backend/src/Infrastructure/Persistence/Emails/StoredEmailContentInventory.cs
+++ b/backend/src/Infrastructure/Persistence/Emails/StoredEmailContentInventory.cs
@@ -80,6 +80,7 @@ internal sealed class StoredEmailContentInventory(MailFathomDbContext dbContext)
                 email.Subject,
                 email.SentAt,
                 email.SizeOctets,
+                email.IsRemotelySeen,
                 email.FiledFromOutgoingEmailId,
             })
             .ToArrayAsync(cancellationToken);
@@ -92,7 +93,8 @@ internal sealed class StoredEmailContentInventory(MailFathomDbContext dbContext)
                     candidate.InternetMessageId,
                     candidate.Subject,
                     candidate.SentAt,
-                    candidate.SizeOctets),
+                    candidate.SizeOctets,
+                    candidate.IsRemotelySeen),
                 candidate.FiledFromOutgoingEmailId is not null)),
         ];
     }

--- a/backend/src/Infrastructure/Persistence/Emails/StoredEmailContentInventory.cs
+++ b/backend/src/Infrastructure/Persistence/Emails/StoredEmailContentInventory.cs
@@ -80,7 +80,6 @@ internal sealed class StoredEmailContentInventory(MailFathomDbContext dbContext)
                 email.Subject,
                 email.SentAt,
                 email.SizeOctets,
-                email.IsRemotelySeen,
                 email.FiledFromOutgoingEmailId,
             })
             .ToArrayAsync(cancellationToken);
@@ -94,7 +93,13 @@ internal sealed class StoredEmailContentInventory(MailFathomDbContext dbContext)
                     candidate.Subject,
                     candidate.SentAt,
                     candidate.SizeOctets,
-                    candidate.IsRemotelySeen),
+
+                    // These occurrences were discovered by an earlier run, which is where the server's own report of
+                    // the seen flag was and is not recoverable now: the stored column is the backward pass's to write,
+                    // on a schedule that need not have reached this row, and asking the server again would be the
+                    // second fetch per message this design refuses. So the reconstruction states what a refill is —
+                    // content stored for a message already stored — which is the reading no arrival can follow from.
+                    IsRemotelySeen: true),
                 candidate.FiledFromOutgoingEmailId is not null)),
         ];
     }

--- a/backend/tests/Application.UnitTests/Notifications/NotificationRetentionTests.cs
+++ b/backend/tests/Application.UnitTests/Notifications/NotificationRetentionTests.cs
@@ -20,6 +20,18 @@ public sealed class NotificationRetentionTests
 
     private static readonly DateTimeOffset RunInstant = new(2026, 9, 3, 12, 0, 0, TimeSpan.Zero);
 
+    /// <summary>
+    /// The number is asserted rather than derived, because every other test here reads the window symbolically and
+    /// would go on passing if it moved. A month is what the record undertakes to hold, and widening it is a privacy
+    /// decision rather than a tuning one.
+    /// </summary>
+    [Fact]
+    public void Window_AnyDeployment_HoldsANotificationForThirtyDays()
+    {
+        // Arrange, Act, Assert
+        Assert.Equal(TimeSpan.FromDays(30), NotificationRetention.Window);
+    }
+
     /// <summary>The window is measured back from now and the pass is bounded, so a backlog clears over several runs.</summary>
     [Fact]
     public async Task EraseExpiredAsync_AnyOwner_ErasesWhatHappenedBeforeTheWindowUpToTheBound()

--- a/backend/tests/Application.UnitTests/Synchronization/MailboxSynchronizerTests.cs
+++ b/backend/tests/Application.UnitTests/Synchronization/MailboxSynchronizerTests.cs
@@ -444,7 +444,9 @@ public sealed class MailboxSynchronizerTests
     /// A copy leaves the email where it was, so nothing is carried across and the second live occurrence is a second
     /// local email, which is what
     /// <see href="https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0008-copied-message-local-identity.md">ADR 0008</see>
-    /// decided. What it must not do is set a rule off, which is a question about provenance rather than about rows.
+    /// decided. What it must not do is set a rule off or be reported to the person as mail that arrived, both of which
+    /// are questions about provenance rather than about rows: an IMAP copy carries the source's flags, so a copy of an
+    /// unread message is itself unread and would otherwise announce the message it was copied from.
     /// </remarks>
     [Fact]
     public async Task SynchronizeAsync_DiscoversTheOccurrenceACopyPlaced_StoresItAndWithholdsTheArrival()
@@ -493,6 +495,7 @@ public sealed class MailboxSynchronizerTests
 
         // Assert
         Assert.Equal(1, result.StoredEmailCount);
+        Assert.Equal(0, result.ArrivedEmailCount);
         Assert.Equal(0, result.RelocatedEmailCount);
         await metadataRepository.DidNotReceiveWithAnyArgs().TryCarryToOccurrenceAsync(
             Arg.Any<IPersistenceSession>(),

--- a/backend/tests/Application.UnitTests/Synchronization/MailboxSynchronizerTests.cs
+++ b/backend/tests/Application.UnitTests/Synchronization/MailboxSynchronizerTests.cs
@@ -52,8 +52,18 @@ public sealed class MailboxSynchronizerTests
     private static readonly MailFolderMapping InboxMapping =
         MailFolderMapping.ToSpecialUse(InboxAlias, MailFolderSpecialUse.Inbox);
 
+    private static readonly MailFolderAlias ArchiveAlias = MailFolderAlias.Create("archive");
+
+    private static readonly RemoteFolderPath ArchiveRemotePath = RemoteFolderPath.Create("Archive", '/');
+
+    private static readonly MailFolderMapping ArchiveMapping =
+        MailFolderMapping.ToSpecialUse(ArchiveAlias, MailFolderSpecialUse.Archive);
+
     private static readonly MailFolderResolution InboxFolder =
         MailFolderResolution.FirstBindingOf(InboxAlias, InboxRemotePath);
+
+    private static readonly MailFolderResolution ArchiveFolder =
+        MailFolderResolution.FirstBindingOf(ArchiveAlias, ArchiveRemotePath);
 
     private static readonly MailTransportSecurityPolicy RequiredTlsPolicy = MailTransportSecurityPolicy.Create(
         MailConnectionSecurity.TlsOnConnect,
@@ -84,7 +94,7 @@ public sealed class MailboxSynchronizerTests
         var clock = new FakeTimeProvider(new DateTimeOffset(2026, 7, 24, 12, 0, 0, TimeSpan.Zero));
         var options = new MailboxSynchronizationOptions { MaxMetadataBatchSize = 25, MaxRawMimeBytes = 1024 };
         var synchronizer = CreateSynchronizer(sessionFactory, checkpointStore, sessionScopeFactory, metadataRepository, contentStore, clock, options);
-        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero), 128);
+        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero), 128, IsRemotelySeen: false);
         var content = new RemoteEmailContent(occurrence, new ReadOnlyMemory<byte>([1, 2, 3]));
         var storedEmailId = StoredEmailId.Create(Guid.CreateVersion7());
         var metadataStored = false;
@@ -117,6 +127,90 @@ public sealed class MailboxSynchronizerTests
         await checkpointStore.Received(1).SaveCheckpointAsync(persistenceSession, MailAccountIdentity.Create(SyntheticMailOwner.Deployment, accountId), folder.Id, Arg.Any<SynchronizationCheckpoint?>(), Arg.Is<SynchronizationCheckpoint>(checkpoint => checkpoint!.LastSeenUid == uid), CancellationToken.None);
     }
 
+    /// <summary>What a run reports as arrived mail: stored in the inbox, and unread on the server when it was stored.</summary>
+    [Fact]
+    public async Task SynchronizeAsync_UnreadMessageStoredInTheInbox_ReportsItAsArrivedMail()
+    {
+        // Arrange
+        var accountId = MailAccountId.Create("primary");
+        var uidValidity = ImapUidValidity.Create(5);
+        var occurrence = EmailOccurrenceId.Create(accountId, InboxFolder.Id, uidValidity, ImapUid.Create(10));
+        var options = new MailboxSynchronizationOptions { MaxMetadataBatchSize = 25, MaxRawMimeBytes = 1024 };
+        var arrangement = ArrangeContentRun(options, uidValidity, [MetadataOf(occurrence, 600)], occurrence.Uid);
+        StubRetrievedContent(arrangement.Session, options, occurrence, 600);
+
+        // Act
+        var result = await arrangement.Synchronizer.SynchronizeAsync(
+            MailAccountIdentity.Create(SyntheticMailOwner.Deployment, accountId),
+            InboxMapping,
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, result.StoredEmailCount);
+        Assert.Equal(1, result.ArrivedEmailCount);
+    }
+
+    /// <summary>
+    /// Mail the server had already marked <c>\Seen</c> is news to nobody: the person read it somewhere else, and a run
+    /// that says it arrived is announcing a backfill rather than an arrival.
+    /// </summary>
+    [Fact]
+    public async Task SynchronizeAsync_MessageTheServerHadAlreadyMarkedRead_StoresItWithoutReportingItAsArrival()
+    {
+        // Arrange
+        var accountId = MailAccountId.Create("primary");
+        var uidValidity = ImapUidValidity.Create(5);
+        var occurrence = EmailOccurrenceId.Create(accountId, InboxFolder.Id, uidValidity, ImapUid.Create(10));
+        var options = new MailboxSynchronizationOptions { MaxMetadataBatchSize = 25, MaxRawMimeBytes = 1024 };
+        var arrangement = ArrangeContentRun(
+            options,
+            uidValidity,
+            [MetadataOf(occurrence, 600, isRemotelySeen: true)],
+            occurrence.Uid);
+        StubRetrievedContent(arrangement.Session, options, occurrence, 600);
+
+        // Act
+        var result = await arrangement.Synchronizer.SynchronizeAsync(
+            MailAccountIdentity.Create(SyntheticMailOwner.Deployment, accountId),
+            InboxMapping,
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, result.StoredEmailCount);
+        Assert.Equal(0, result.ArrivedEmailCount);
+    }
+
+    /// <summary>
+    /// Only the inbox raises an arrival. Mail this run stored in an archive, a sent folder, or anywhere else the
+    /// account synchronizes is mail the run fetched rather than mail waiting for a person.
+    /// </summary>
+    [Fact]
+    public async Task SynchronizeAsync_UnreadMessageStoredOutsideTheInbox_StoresItWithoutReportingItAsArrival()
+    {
+        // Arrange
+        var accountId = MailAccountId.Create("primary");
+        var uidValidity = ImapUidValidity.Create(5);
+        var occurrence = EmailOccurrenceId.Create(accountId, ArchiveFolder.Id, uidValidity, ImapUid.Create(10));
+        var options = new MailboxSynchronizationOptions { MaxMetadataBatchSize = 25, MaxRawMimeBytes = 1024 };
+        var arrangement = ArrangeContentRun(
+            options,
+            uidValidity,
+            [MetadataOf(occurrence, 600)],
+            occurrence.Uid,
+            runFolder: ArchiveFolder);
+        StubRetrievedContent(arrangement.Session, options, occurrence, 600);
+
+        // Act
+        var result = await arrangement.Synchronizer.SynchronizeAsync(
+            MailAccountIdentity.Create(SyntheticMailOwner.Deployment, accountId),
+            ArchiveMapping,
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, result.StoredEmailCount);
+        Assert.Equal(0, result.ArrivedEmailCount);
+    }
+
     /// <summary>The run records what the classification gate says about an arriving message, although it derives nothing from it.</summary>
     /// <remarks>
     /// The two withholding answers are reached nowhere else: every later stage either sees a message the gate admits or
@@ -140,7 +234,7 @@ public sealed class MailboxSynchronizerTests
         var clock = new FakeTimeProvider(new DateTimeOffset(2026, 7, 24, 12, 0, 0, TimeSpan.Zero));
         var options = new MailboxSynchronizationOptions { MaxMetadataBatchSize = 25, MaxRawMimeBytes = 1024 };
         var gateTelemetry = new RecordingDerivedWorkGateTelemetry();
-        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero), 128);
+        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero), 128, IsRemotelySeen: false);
         var synchronizer = CreateSynchronizer(
             sessionFactory,
             checkpointStore,
@@ -192,7 +286,7 @@ public sealed class MailboxSynchronizerTests
         var jobStore = Substitute.For<IJobStore>();
         var clock = new FakeTimeProvider(new DateTimeOffset(2026, 7, 24, 12, 0, 0, TimeSpan.Zero));
         var options = new MailboxSynchronizationOptions { MaxMetadataBatchSize = 25, MaxRawMimeBytes = 1024 };
-        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero), 128);
+        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero), 128, IsRemotelySeen: false);
         var synchronizer = CreateSynchronizer(
             sessionFactory,
             checkpointStore,
@@ -243,7 +337,7 @@ public sealed class MailboxSynchronizerTests
         var jobStore = Substitute.For<IJobStore>();
         var clock = new FakeTimeProvider(new DateTimeOffset(2026, 7, 24, 12, 0, 0, TimeSpan.Zero));
         var options = new MailboxSynchronizationOptions { MaxMetadataBatchSize = 25, MaxRawMimeBytes = 1024 };
-        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero), 4096);
+        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero), 4096, IsRemotelySeen: false);
         var synchronizer = CreateSynchronizer(
             sessionFactory,
             checkpointStore,
@@ -675,7 +769,7 @@ public sealed class MailboxSynchronizerTests
         var clock = new FakeTimeProvider(new DateTimeOffset(2026, 7, 24, 12, 0, 0, TimeSpan.Zero));
         var options = new MailboxSynchronizationOptions { MaxMetadataBatchSize = 25, MaxRawMimeBytes = 1024 };
         var synchronizer = CreateSynchronizer(sessionFactory, checkpointStore, sessionScopeFactory, metadataRepository, contentStore, clock, options);
-        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero), 2048);
+        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero), 2048, IsRemotelySeen: false);
         checkpointStore.GetCheckpointAsync(MailAccountIdentity.Create(SyntheticMailOwner.Deployment, accountId), folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
         sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
         session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
@@ -760,7 +854,7 @@ public sealed class MailboxSynchronizerTests
             clock,
             options,
             synchronizationWindow: window);
-        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero), 128);
+        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero), 128, IsRemotelySeen: false);
         checkpointStore.GetCheckpointAsync(MailAccountIdentity.Create(SyntheticMailOwner.Deployment, accountId), folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
         sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
         session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
@@ -855,7 +949,7 @@ public sealed class MailboxSynchronizerTests
             clock,
             options,
             synchronizationWindow: window);
-        var includedMetadata = new RemoteEmailMetadata(includedOccurrence, "message-90@example.test", "Subject", new DateTimeOffset(2026, 7, 20, 8, 0, 0, TimeSpan.Zero), 128);
+        var includedMetadata = new RemoteEmailMetadata(includedOccurrence, "message-90@example.test", "Subject", new DateTimeOffset(2026, 7, 20, 8, 0, 0, TimeSpan.Zero), 128, IsRemotelySeen: false);
         checkpointStore.GetCheckpointAsync(MailAccountIdentity.Create(SyntheticMailOwner.Deployment, accountId), folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
         sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
         session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
@@ -895,7 +989,7 @@ public sealed class MailboxSynchronizerTests
         var clock = new FakeTimeProvider(new DateTimeOffset(2026, 7, 24, 12, 0, 0, TimeSpan.Zero));
         var options = new MailboxSynchronizationOptions { MaxMetadataBatchSize = 25, MaxRawMimeBytes = 1024, MaxMetadataBatchesPerRun = 1 };
         var synchronizer = CreateSynchronizer(sessionFactory, checkpointStore, sessionScopeFactory, metadataRepository, contentStore, clock, options);
-        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero), 0);
+        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero), 0, IsRemotelySeen: false);
         checkpointStore.GetCheckpointAsync(MailAccountIdentity.Create(SyntheticMailOwner.Deployment, accountId), folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
         sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
         session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
@@ -938,7 +1032,7 @@ public sealed class MailboxSynchronizerTests
             contentStore,
             clock,
             options);
-        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", clock.GetUtcNow(), 128);
+        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", clock.GetUtcNow(), 128, IsRemotelySeen: false);
         var content = new RemoteEmailContent(occurrence, new ReadOnlyMemory<byte>([1, 2, 3]));
         var contentFetched = false;
         checkpointStore.GetCheckpointAsync(MailAccountIdentity.Create(SyntheticMailOwner.Deployment, accountId), folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
@@ -1021,13 +1115,15 @@ public sealed class MailboxSynchronizerTests
             "message-1@example.test",
             "First",
             new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero),
-            128);
+            128,
+            IsRemotelySeen: false);
         var secondMetadata = new RemoteEmailMetadata(
             secondOccurrence,
             "message-2@example.test",
             "Second",
             new DateTimeOffset(2026, 7, 24, 9, 0, 0, TimeSpan.Zero),
-            128);
+            128,
+            IsRemotelySeen: false);
         var firstContent = new RemoteEmailContent(firstOccurrence, new ReadOnlyMemory<byte>([1]));
         var secondContent = new RemoteEmailContent(secondOccurrence, new ReadOnlyMemory<byte>([2]));
         checkpointStore.GetCheckpointAsync(MailAccountIdentity.Create(SyntheticMailOwner.Deployment, accountId), folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
@@ -1183,7 +1279,8 @@ public sealed class MailboxSynchronizerTests
             "message-1@example.test",
             "Subject",
             new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero),
-            128);
+            128,
+            IsRemotelySeen: false);
         var content = new RemoteEmailContent(occurrence, new ReadOnlyMemory<byte>([1, 2, 3]));
         var storedEmailId = StoredEmailId.Create(Guid.CreateVersion7());
         checkpointStore.GetCheckpointAsync(MailAccountIdentity.Create(SyntheticMailOwner.Deployment, accountId), folder.Id, CancellationToken.None)
@@ -1279,7 +1376,8 @@ public sealed class MailboxSynchronizerTests
             "message-1@example.test",
             "Subject",
             new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero),
-            128);
+            128,
+            IsRemotelySeen: false);
         var content = new RemoteEmailContent(occurrence, new ReadOnlyMemory<byte>([1, 2, 3]));
         var storedEmailId = StoredEmailId.Create(Guid.CreateVersion7());
         var initialCheckpoint = SynchronizationCheckpoint.None(uidValidity);
@@ -1693,7 +1791,7 @@ public sealed class MailboxSynchronizerTests
             clock,
             options,
             mimeReader: mimeReader);
-        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", null, 128);
+        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", null, 128, IsRemotelySeen: false);
         var content = new RemoteEmailContent(occurrence, new ReadOnlyMemory<byte>([1, 2, 3]));
         checkpointStore.GetCheckpointAsync(MailAccountIdentity.Create(SyntheticMailOwner.Deployment, accountId), folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
         sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
@@ -1745,7 +1843,7 @@ public sealed class MailboxSynchronizerTests
             clock,
             options,
             mimeReader: mimeReader);
-        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", null, 128);
+        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", null, 128, IsRemotelySeen: false);
         checkpointStore.GetCheckpointAsync(MailAccountIdentity.Create(SyntheticMailOwner.Deployment, accountId), folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
         sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
         session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
@@ -1797,7 +1895,7 @@ public sealed class MailboxSynchronizerTests
             clock,
             options,
             mimeReader: mimeReader);
-        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", null, 128);
+        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", null, 128, IsRemotelySeen: false);
         checkpointStore.GetCheckpointAsync(MailAccountIdentity.Create(SyntheticMailOwner.Deployment, accountId), folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
         sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
         session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
@@ -1860,8 +1958,8 @@ public sealed class MailboxSynchronizerTests
         session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
         session.GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None).Returns(new RemoteEmailMetadataBatch(
             [
-                new RemoteEmailMetadata(unreadableOccurrence, "message-1@example.test", "Subject", null, 128),
-                new RemoteEmailMetadata(readableOccurrence, "message-2@example.test", "Subject", null, 128),
+                new RemoteEmailMetadata(unreadableOccurrence, "message-1@example.test", "Subject", null, 128, IsRemotelySeen: false),
+                new RemoteEmailMetadata(readableOccurrence, "message-2@example.test", "Subject", null, 128, IsRemotelySeen: false),
             ],
             ImapUid.Create(11),
             HasMore: false));
@@ -1915,7 +2013,7 @@ public sealed class MailboxSynchronizerTests
         sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
         session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
         session.GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None).Returns(new RemoteEmailMetadataBatch(
-            [new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", null, 2048)],
+            [new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", null, 2048, IsRemotelySeen: false)],
             uid,
             HasMore: false));
 
@@ -2106,12 +2204,16 @@ public sealed class MailboxSynchronizerTests
         remoteFolderCatalog
             .ListFoldersAsync(Arg.Any<MailAccountId>(), Arg.Any<MailTransportSecurityPolicy>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<RemoteFolder>>(
-                [new RemoteFolder(InboxRemotePath, [MailFolderSpecialUse.Inbox])]));
+                [
+                    new RemoteFolder(InboxRemotePath, [MailFolderSpecialUse.Inbox]),
+                    new RemoteFolder(ArchiveRemotePath, [MailFolderSpecialUse.Archive]),
+                ]));
 
         var resolutionStore = Substitute.For<IMailFolderResolutionStore>();
         resolutionStore
             .GetCurrentResolutionAsync(Arg.Any<MailAccountIdentity>(), Arg.Any<MailFolderAlias>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<MailFolderResolution?>(InboxFolder));
+            .Returns(call => Task.FromResult<MailFolderResolution?>(
+                call.Arg<MailFolderAlias>() == ArchiveMapping.Alias ? ArchiveFolder : InboxFolder));
 
         return new MailFolderResolver(
             remoteFolderCatalog,
@@ -2416,7 +2518,8 @@ public sealed class MailboxSynchronizerTests
             "relocated@example.test",
             "Subject",
             new DateTimeOffset(2026, 8, 7, 8, 0, 0, TimeSpan.Zero),
-            128);
+            128,
+            IsRemotelySeen: false);
 
         session.GetUidValidityAsync(Arg.Any<CancellationToken>()).Returns(uidValidity);
         session
@@ -2677,7 +2780,28 @@ public sealed class MailboxSynchronizerTests
 
         // Assert
         Assert.Equal(1, result.StoredEmailCount);
+        Assert.Equal(1, result.ArrivedEmailCount);
         await context.AssertStoredAsArrivingMailAsync();
+    }
+
+    /// <summary>
+    /// The owner wrote it, so nothing about it reached them. A copy MailFathom filed lands in a folder like any other
+    /// message and carries whatever flags the server gave it, which is why the filing record rather than the folder or
+    /// the flag is what keeps it out of the count.
+    /// </summary>
+    [Fact]
+    public async Task SynchronizeAsync_ACopyThisDeploymentFiled_IsNeverReportedAsArrivedMail()
+    {
+        // Arrange
+        var context = new FiledCopyContext(uid: ImapUid.Create(34));
+        context.FileCopyAtPlacement();
+
+        // Act
+        var result = await context.SynchronizeAsync();
+
+        // Assert
+        Assert.Equal(1, result.StoredEmailCount);
+        Assert.Equal(0, result.ArrivedEmailCount);
     }
 
     /// <summary>Answers as a deployment that has never filed a copy of its own outgoing mail, which is most of them.</summary>
@@ -3249,12 +3373,16 @@ public sealed class MailboxSynchronizerTests
         await arrangement.Session.Received(1).FetchEmailContentWithoutSettingSeenAsync(occurrence, options.MaxRawMimeBytes, CancellationToken.None);
     }
 
-    private static RemoteEmailMetadata MetadataOf(EmailOccurrenceId occurrenceId, long sizeOctets) => new(
+    private static RemoteEmailMetadata MetadataOf(
+        EmailOccurrenceId occurrenceId,
+        long sizeOctets,
+        bool isRemotelySeen = false) => new(
         occurrenceId,
         $"message-{occurrenceId.Uid.Value}@example.test",
         "Subject",
         new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero),
-        sizeOctets);
+        sizeOctets,
+        isRemotelySeen);
 
     private static void StubRetrievedContent(
         IMailboxSession session,
@@ -3322,8 +3450,10 @@ public sealed class MailboxSynchronizerTests
         RawMimeMemoryBudget? rawMimeMemoryBudget = null,
         StoredContentCeiling? storedContentCeiling = null,
         IOwnerStoredContentLedger? ownerContentLedger = null,
-        SpamClassificationSettings? classificationSettings = null)
+        SpamClassificationSettings? classificationSettings = null,
+        MailFolderResolution? runFolder = null)
     {
+        var folder = runFolder ?? InboxFolder;
         var checkpointStore = Substitute.For<ISynchronizationCheckpointStore>();
         var metadataRepository = Substitute.For<IEmailMetadataRepository>();
         var persistenceSessionFactory = Substitute.For<IPersistenceSessionFactory>();
@@ -3343,10 +3473,10 @@ public sealed class MailboxSynchronizerTests
             return persistenceSession;
         });
         checkpointStore
-            .GetCheckpointAsync(Arg.Any<MailAccountIdentity>(), InboxFolder.Id, Arg.Any<CancellationToken>())
+            .GetCheckpointAsync(Arg.Any<MailAccountIdentity>(), folder.Id, Arg.Any<CancellationToken>())
             .Returns(storedCheckpoint ?? SynchronizationCheckpoint.None(uidValidity));
         sessionFactory
-            .OpenReadOnlyAsync(Arg.Any<MailAccountId>(), InboxFolder, Arg.Any<MailTransportSecurityPolicy>(), Arg.Any<CancellationToken>())
+            .OpenReadOnlyAsync(Arg.Any<MailAccountId>(), folder, Arg.Any<MailTransportSecurityPolicy>(), Arg.Any<CancellationToken>())
             .Returns(session);
         session.GetUidValidityAsync(Arg.Any<CancellationToken>()).Returns(uidValidity);
         session
@@ -3456,7 +3586,8 @@ public sealed class MailboxSynchronizerTests
                 MintedMessageId,
                 "Subject",
                 new DateTimeOffset(2026, 8, 19, 8, 0, 0, TimeSpan.Zero),
-                128);
+                128,
+                IsRemotelySeen: false);
 
             var checkpointStore = Substitute.For<ISynchronizationCheckpointStore>();
             checkpointStore

--- a/backend/tests/Application.UnitTests/Synchronization/MailboxSynchronizerTests.cs
+++ b/backend/tests/Application.UnitTests/Synchronization/MailboxSynchronizerTests.cs
@@ -2749,6 +2749,7 @@ public sealed class MailboxSynchronizerTests
 
         // Assert
         Assert.Equal(1, result.StoredEmailCount);
+        Assert.Equal(0, result.ArrivedEmailCount);
         await context.AssertJoinedToTheSendAsync();
     }
 
@@ -2768,6 +2769,7 @@ public sealed class MailboxSynchronizerTests
 
         // Assert
         Assert.Equal(1, result.StoredEmailCount);
+        Assert.Equal(0, result.ArrivedEmailCount);
         await context.AssertJoinedToTheSendAsync();
     }
 
@@ -2785,26 +2787,6 @@ public sealed class MailboxSynchronizerTests
         Assert.Equal(1, result.StoredEmailCount);
         Assert.Equal(1, result.ArrivedEmailCount);
         await context.AssertStoredAsArrivingMailAsync();
-    }
-
-    /// <summary>
-    /// The owner wrote it, so nothing about it reached them. A copy MailFathom filed lands in a folder like any other
-    /// message and carries whatever flags the server gave it, which is why the filing record rather than the folder or
-    /// the flag is what keeps it out of the count.
-    /// </summary>
-    [Fact]
-    public async Task SynchronizeAsync_ACopyThisDeploymentFiled_IsNeverReportedAsArrivedMail()
-    {
-        // Arrange
-        var context = new FiledCopyContext(uid: ImapUid.Create(34));
-        context.FileCopyAtPlacement();
-
-        // Act
-        var result = await context.SynchronizeAsync();
-
-        // Assert
-        Assert.Equal(1, result.StoredEmailCount);
-        Assert.Equal(0, result.ArrivedEmailCount);
     }
 
     /// <summary>Answers as a deployment that has never filed a copy of its own outgoing mail, which is most of them.</summary>

--- a/backend/tests/Infrastructure.UnitTests/Mail/MailKit/MailKitImapMailboxSessionTests.cs
+++ b/backend/tests/Infrastructure.UnitTests/Mail/MailKit/MailKitImapMailboxSessionTests.cs
@@ -206,6 +206,75 @@ public sealed class MailKitImapMailboxSessionTests
         Assert.Equal(new DateTimeOffset(2026, 7, 24, 6, 30, 0, TimeSpan.Zero), metadata.SentAt);
     }
 
+    /// <summary>
+    /// The seen state rides the discovery fetch, so a run knows what the server had marked read without a second round
+    /// trip. The requested items are asserted for the reason the reconciliation fetch asserts its own: every item here
+    /// is answered out of the envelope and folder state, and adding a body or header item would set <c>\Seen</c> on
+    /// every message a run discovers.
+    /// </summary>
+    [Theory]
+    [InlineData(MessageFlags.Seen, true)]
+    [InlineData(MessageFlags.None, false)]
+    public async Task GetEmailBatchAfterAsync_ServerReportsFlags_CarriesTheSeenStateWithoutFetchingItSeparately(
+        MessageFlags flags,
+        bool expectedIsRemotelySeen)
+    {
+        // Arrange
+        using var resilience = CreateSingleAttemptResilience();
+        var client = new FakeImapClient();
+        var folder = CreateSelectedFolder();
+        var uid = new UniqueId(10);
+        var summary = CreateSummary(uid);
+        summary.Flags.Returns(flags);
+        folder.UidNext.Returns(new UniqueId(11));
+        folder.SearchAsync(Arg.Any<SearchQuery>(), Arg.Any<CancellationToken>()).Returns([uid]);
+        folder.FetchAsync(
+            Arg.Any<IList<UniqueId>>(),
+            Arg.Any<IFetchRequest>(),
+            Arg.Any<CancellationToken>()).Returns([summary]);
+        await using var session = await OpenSessionAsync(resilience, client, folder);
+
+        // Act
+        var batch = await session.GetEmailBatchAfterAsync(null, 100, MailSynchronizationWindow.Unbounded, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(expectedIsRemotelySeen, Assert.Single(batch.Emails).IsRemotelySeen);
+        Assert.Equal(MailKitImapMailboxSession.DiscoverySummaryItems, RequestedFetchItems(folder));
+        await folder.DidNotReceive().StoreAsync(Arg.Any<IList<UniqueId>>(), Arg.Any<IStoreFlagsRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// A server that answered without <c>FLAGS</c> said nothing about whether the message had been read, and the safe
+    /// reading of that silence is the one that reports less: an arrival stated about mail somebody already read is the
+    /// defect the flag exists to remove.
+    /// </summary>
+    [Fact]
+    public async Task GetEmailBatchAfterAsync_ServerAnswersWithoutFlags_TreatsTheMessageAsAlreadyRead()
+    {
+        // Arrange
+        using var resilience = CreateSingleAttemptResilience();
+        var client = new FakeImapClient();
+        var folder = CreateSelectedFolder();
+        var uid = new UniqueId(10);
+
+        // Built before the stubbing rather than inside it: constructing a substitute configures NSubstitute's ambient
+        // call context, which would consume the call the Returns below is meant to answer.
+        var flaglessSummary = CreateSummary(uid);
+        folder.UidNext.Returns(new UniqueId(11));
+        folder.SearchAsync(Arg.Any<SearchQuery>(), Arg.Any<CancellationToken>()).Returns([uid]);
+        folder.FetchAsync(
+            Arg.Any<IList<UniqueId>>(),
+            Arg.Any<IFetchRequest>(),
+            Arg.Any<CancellationToken>()).Returns([flaglessSummary]);
+        await using var session = await OpenSessionAsync(resilience, client, folder);
+
+        // Act
+        var batch = await session.GetEmailBatchAfterAsync(null, 100, MailSynchronizationWindow.Unbounded, CancellationToken.None);
+
+        // Assert
+        Assert.True(Assert.Single(batch.Emails).IsRemotelySeen);
+    }
+
     /// <summary>A half-established connection is unusable, so it is closed rather than asked for a graceful logout it may never answer.</summary>
     [Fact]
     public async Task OpenReadOnlyAsync_FolderOpenFails_AbandonsTheConnectionWithoutASecondCommand()

--- a/backend/tests/Infrastructure.UnitTests/Persistence/Emails/StoredEmailMetadataMappingTests.cs
+++ b/backend/tests/Infrastructure.UnitTests/Persistence/Emails/StoredEmailMetadataMappingTests.cs
@@ -630,7 +630,7 @@ public sealed class StoredEmailMetadataMappingTests
         };
 
     private static RemoteEmailMetadata CreateRemoteMetadata(string internetMessageId) =>
-        new(OccurrenceId, internetMessageId, "Quarterly report", SentAt, SizeOctets: 4096);
+        new(OccurrenceId, internetMessageId, "Quarterly report", SentAt, SizeOctets: 4096, IsRemotelySeen: false);
 
     private static EmailOccurrenceId OccurrenceId => EmailOccurrenceId.Create(
         MailAccountId.Create("primary"),

--- a/backend/tests/IntegrationTests/Persistence/SyntheticEmail.cs
+++ b/backend/tests/IntegrationTests/Persistence/SyntheticEmail.cs
@@ -66,12 +66,14 @@ internal static class SyntheticEmail
     /// <param name="occurrenceId">The occurrence the summary describes.</param>
     /// <param name="subject">The subject, which is how a test recognizes its own row.</param>
     /// <param name="sizeOctets">The size the server reported.</param>
+    /// <param name="isRemotelySeen">Whether the server had marked the message read, which decides whether a run reports it as arrival.</param>
     /// <returns>The remote summary.</returns>
     internal static RemoteEmailMetadata RemoteMetadataOf(
         EmailOccurrenceId occurrenceId,
         string subject,
-        long sizeOctets = 2048) =>
-        new(occurrenceId, $"{subject}@mailfathom.test", subject, SentAt, sizeOctets);
+        long sizeOctets = 2048,
+        bool isRemotelySeen = false) =>
+        new(occurrenceId, $"{subject}@mailfathom.test", subject, SentAt, sizeOctets, isRemotelySeen);
 
     /// <summary>The address every extraction reports as the sender unless a test names another.</summary>
     internal const string DefaultSenderAddress = "sender@mailfathom.test";

--- a/docs/architecture/arrival-pipeline.md
+++ b/docs/architecture/arrival-pipeline.md
@@ -135,8 +135,8 @@ The last step of that sequence belongs to no arrival either, and is drawn nowher
 passes have finished, the run tells the account's owner what happened to it — mail arrived, a credential was refused,
 some folders did not finish. It is stated per run rather than per message, which is why it cannot sit on this page's
 graph: what it reports is the run's own outcome, and the count it carries is how much of what the passes above stored
-was mail arriving for the person — the inbox, unread on the server, and not a copy of the owner's own outgoing message
-— rather than anything derived from one message. It is the weakest link in the sequence exactly as the drain is, and for
+was mail arriving for the person — the inbox, unread on the server, and nothing MailFathom itself placed there —
+rather than anything derived from one message. It is the weakest link in the sequence exactly as the drain is, and for
 a stronger reason — a run whose whole point was to fetch mail must not be failed by the record saying it did.
 [What a run tells the person whose mailbox it is](../features/imap-synchronization.md#what-a-run-tells-the-person-whose-mailbox-it-is)
 describes it; nothing else on this page concerns it either.

--- a/docs/architecture/arrival-pipeline.md
+++ b/docs/architecture/arrival-pipeline.md
@@ -134,8 +134,9 @@ described; nothing else on this page concerns it.
 The last step of that sequence belongs to no arrival either, and is drawn nowhere above for the same reason: once the
 passes have finished, the run tells the account's owner what happened to it — mail arrived, a credential was refused,
 some folders did not finish. It is stated per run rather than per message, which is why it cannot sit on this page's
-graph: what it reports is the run's own outcome, and the count it carries is how many messages the passes above stored
-rather than anything derived from one of them. It is the weakest link in the sequence exactly as the drain is, and for
+graph: what it reports is the run's own outcome, and the count it carries is how much of what the passes above stored
+was mail arriving for the person — the inbox, unread on the server, and not a copy of the owner's own outgoing message
+— rather than anything derived from one message. It is the weakest link in the sequence exactly as the drain is, and for
 a stronger reason — a run whose whole point was to fetch mail must not be failed by the record saying it did.
 [What a run tells the person whose mailbox it is](../features/imap-synchronization.md#what-a-run-tells-the-person-whose-mailbox-it-is)
 describes it; nothing else on this page concerns it either.

--- a/docs/architecture/stored-email-schema.md
+++ b/docs/architecture/stored-email-schema.md
@@ -316,7 +316,7 @@ cannot both read nothing and then collide on the key. Erasing an owner takes the
 
 ## What happened while nobody was looking
 
-`notifications` holds what a person is told about — a synchronization run that committed new mail, and the system
+`notifications` holds what a person is told about — a synchronization run that brought them mail, and the system
 conditions that run distinguishes. It belongs to the deployment rather than to a device, because the read state has to
 be the same in both heads and on a second machine, and because most of what produces a row is visible only to the
 service.
@@ -360,9 +360,12 @@ a digest of itself rather than truncated, because two accounts sharing a long pr
 condition and silence each other's statements; the same identifier is left off the row's source line entirely, since a
 label that cannot be shown is better absent than shown as an account nobody configured.
 
-**A notification is kept for ninety days after the thing it describes happened.** The bound is the record's own rather
+**A notification is kept for thirty days after the thing it describes happened.** The bound is the record's own rather
 than an operator's setting, because a notification is the client's working state rather than a history a deployment
 undertakes to hold, and the sweep rides each account's own synchronization run beside the audit-trail retention passes.
+A month is what a working set is: long enough that somebody back from leave still finds what happened while they were
+away, and short enough that the table never becomes the thing the bound exists to prevent — three months of a person's
+arrivals is their mailbox in miniature.
 
 ## What an owner signs in with
 
@@ -1473,7 +1476,7 @@ and the folder alias, never a subject, an address, a file name, or a line of wha
 mutation history: a row says that something reached this person's mailbox and when, without saying what. It therefore
 inherits the source message's obligations wherever it names one, and the cascade from `stored_emails` is what makes that
 structural — a notification offering to open a message that has been erased is exactly the row that must not survive.
-What the rows naming no message carry instead is a bound of the record's own: ninety days from the instant described,
+What the rows naming no message carry instead is a bound of the record's own: thirty days from the instant described,
 swept on each account's own run. Nothing in the table reaches a log, a metric, a trace, or an exception message; the
 owner's generated identifier and the account alias are what a failure names, and they are the two values that are not
 personal data.

--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -176,13 +176,29 @@ are reported and nothing else is:
 
 | What the run observed | What it says | Where it leads |
 | --- | --- | --- |
-| It committed new mail | One notification for the run, carrying the count — never one per message | The mailbox |
+| Mail arrived for the person | One notification for the run, carrying the count — never one per message | The mailbox |
 | It ended with folders it did not finish | How many of how many, and that MailFathom will try again | Nowhere |
 | A mail server refused this account's credential | That the account needs signing in again and is no longer being fetched | The settings |
 
+**Arrival is narrower than what a run stored, and the run decides it where it stores rather than by a query
+afterwards.** A message counts as arrival when all three of these hold, and it is not arrival when any one of them
+fails:
+
+| The run stored it | Why it decides arrival |
+| --- | --- |
+| in a folder whose role is the inbox | Mail the run brought into an archive, a sent folder, or a junk folder is mail it fetched rather than mail waiting for somebody. A server-side rule delivering into a custom folder is real mail arriving, and whether MailFathom says so is a question left open rather than answered here |
+| while the server had not marked it `\Seen` | The person read it somewhere else, so it is news to nobody. The flag is the one the server reported when it described the message, which rides the discovery fetch and costs no second round trip and no write |
+| and no filing record says MailFathom put it there | A copy MailFathom filed of the owner's own outgoing message arrives on the same path as anything else and can carry any flags at all, so the filing record rather than the folder or the flag is what keeps it out |
+
+Everything else a run stores is still stored, still indexed, and still searchable; it is only the sentence about
+arrival that it is left out of. A mailbox's first runs therefore backfill years of history without announcing it, which
+is what the narrowing is chiefly for.
+
 **One notification for the run is the rule rather than this worker's choice.** A run that commits forty messages is one
 arrival to somebody who was away, and forty rows would bury every other kind of notification under one mailbox's
-traffic. A run that committed nothing, and a run that finished every folder it scheduled, say nothing at all.
+traffic. A run whose arrival count is zero says nothing at all — a run that stored nothing, a run that stored only
+outside the inbox, and a run that stored only mail already read are the same silence — and neither does a run that
+finished every folder it scheduled.
 
 **A condition already standing unread is not said twice.** Each notification names the condition it was raised for, and
 the schema refuses a second unread row for the same one — so an account whose credential is refused on every run for a
@@ -194,7 +210,7 @@ says is that mail arrived rather than how much is waiting, which the mailbox its
 
 **Nothing in a notification is read from mail.** A count, an account identifier, and a fixed sentence are what a row
 carries, so no subject, address, body fragment, filename, or credential material can reach it. What makes it derived
-personal data anyway is that it says something reached this person's mailbox and when, which the ninety-day retention
+personal data anyway is that it says something reached this person's mailbox and when, which the thirty-day retention
 bound and the two cascades answer for; the bound is swept on each account's own run beside the audit-trail retention
 passes.
 

--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -188,7 +188,7 @@ fails:
 | --- | --- |
 | in a folder whose role is the inbox | Mail the run brought into an archive, a sent folder, or a junk folder is mail it fetched rather than mail waiting for somebody. A server-side rule delivering into a custom folder is real mail arriving, and whether MailFathom says so is a question left open rather than answered here |
 | while the server had not marked it `\Seen` | The person read it somewhere else, so it is news to nobody. The flag is the one the server reported when it described the message, which rides the discovery fetch and costs no second round trip and no write |
-| and no filing record says MailFathom put it there | A copy MailFathom filed of the owner's own outgoing message arrives on the same path as anything else and can carry any flags at all, so the filing record rather than the folder or the flag is what keeps it out |
+| and MailFathom did not put it there itself | Two of its own acts land a message in a folder like any other arrival: a copy it filed of the owner's own outgoing message, which the person wrote, and a copy a rule made into a folder mapped as the inbox, which carries the source's flags and would otherwise announce the message it was copied from. Each is recognized by the record of the act rather than by the folder or the flag, and the run already suppresses the appearance each of them raises |
 
 Everything else a run stores is still stored, still indexed, and still searchable; it is only the sentence about
 arrival that it is left out of. A mailbox's first runs therefore backfill years of history without announcing it, which

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -1540,7 +1540,7 @@ mailbox. It is [the preferences routes](#the-preferences-routes)' reasoning rath
 [the mutation routes](#the-mutation-routes)' — a person whose mail accounts an administrator maintains does not hold a
 write grant and still has to be able to clear their own bell.
 
-**A notification is kept for three months and no longer**, and one pointing at a message is erased with that message.
+**A notification is kept for thirty days and no longer**, and one pointing at a message is erased with that message.
 Both are the record's own bounds rather than these routes', so a centre that reaches back no further has aged out
 rather than lost anything.
 


### PR DESCRIPTION
## What this changes

A synchronization run reported as arrived mail everything it stored — every folder, every flag, and its own filed
copies — so *"40 new messages arrived"* stated what the fetcher did rather than what was waiting for a person, and a
backfill announced several hundred messages that were years old. The count is now narrowed at the point the run stores,
and the notification retention window moves from ninety days to thirty.

### Arrival is decided where the run stores, not by a query afterwards

`MailboxSynchronizationResult` gains `ArrivedEmailCount` beside `StoredEmailCount`. It counts an occurrence when all
three hold, and never otherwise:

- the folder's role is the inbox — `folderRole` already reaches `MailboxSynchronizer` as a `MailFolderSpecialUse?`;
- the server had not marked the message `\Seen` when it described it;
- no filing record says MailFathom put it there, which is what keeps a copy of the owner's own outgoing message out
  whatever folder it landed in and whatever flags it carries.

`AccountSynchronizationSupervisor` sums that count instead of `StoredEmailCount`, so the number reaching
`SynchronizationNotifications.ReportArrivedMailAsync` already means arrived mail and no consumer reconstructs the rule.
A run whose arrival count is zero raises nothing, exactly as a run that stored nothing does today.

### The seen state rides the discovery fetch

`RemoteEmailMetadata` carries `IsRemotelySeen`, filled from `MessageSummaryItems.Flags` added to the discovery fetch —
which the adapter now names as `DiscoverySummaryItems`, beside `ReconciliationSummaryItems` and under the same
read-only invariant. `FLAGS` is answered out of folder state, so the fetch costs no second round trip and cannot set
`\Seen`; a test asserts the requested items against that constant and that no `StoreAsync` was issued. A server that
answers without `FLAGS` is read as already-read, because an arrival stated about mail somebody already opened is the
defect being removed.

The row's own `IsRemotelySeen` column is deliberately untouched: it is still written by the reconciliation pass, and
moving that write is a change to stored-mail behaviour this issue does not take.

### Retention

`NotificationRetention.Window` is thirty days, still a constant with no operator setting behind it, still swept by the
pass that rides each account's run. Only the number and the prose defending it change.

## Tests

- `MailboxSynchronizerTests` — unread inbox mail reports as arrival; mail the server had marked read does not; mail
  stored outside the inbox does not; a copy MailFathom filed does not, while a message no filing accounts for does.
- `MailKitImapMailboxSessionTests` — the seen state reaches the metadata for both flag states, the requested items are
  exactly `DiscoverySummaryItems`, no flag is written back, and a flagless answer reads as already-read.
- `NotificationRetentionTests` — the window is thirty days, asserted as the number, because every other test there
  reads it symbolically and would pass if it moved.

## Documentation

`docs/features/imap-synchronization.md` gains the three-part condition table and the thirty-day bound;
`docs/architecture/stored-email-schema.md` and `docs/architecture/arrival-pipeline.md` no longer say the count is
everything the passes stored.

## Verification

`scripts/verify-full.sh` — passed. `scripts/check-docs-licenses`: docs pass, changelog n/a, licenses n/a (no
dependency moved).

Closes #1637
