### PR TITLE
[#1616] Compose the shell at the design's three widths, and answer the back gesture in one place

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -154,15 +154,16 @@ exists at all and on what terms — one debug-signed APK, left on the run that b
 comes either from a nightly run or from `pnpm android:build` on somebody's own machine.
 Everything else under `gen/` is ignored; this one is tracked, because the decisions in it have nowhere else to live:
 
-| The decision                        | Where it is written                                                                                     | What it says                                                                                                                                                                                     |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| The application identifier          | `bundle.identifier` in `tauri.conf.json`, and nowhere else                                              | `io.github.krzysztof318.mailfathom` — the same one the desktop head carries, because it is one application                                                                                       |
-| The oldest release it installs on   | `bundle.android.minSdkVersion` in `tauri.conf.json`, and `minSdk` in `gen/android/app/build.gradle.kts` | 24, which is Tauri's own floor for the target. Gradle reads the second; the first is what a regeneration would render into it, and the two move together or the key is fiction                   |
-| What it asks the platform for       | `uses-permission` in `AndroidManifest.xml`                                                              | `INTERNET`, and nothing else. A notification permission arrives with the notification                                                                                                            |
-| What the APK's libraries resolve to | `dependencyLocking` in `gen/android/build.gradle.kts`, and `gen/android/app/gradle.lockfile` beside it  | The 80 artifacts behind the five declarations, fixed rather than resolved afresh on every build — `./gradlew :app:dependencies --write-locks` is what rewrites it                                |
-| What it refuses to let leave        | `android:allowBackup` and `res/xml/data_extraction_rules.xml`                                           | Both halves off: the cloud backup, and the device-to-device transfer that the attribute alone stops governing at API 31                                                                          |
-| Which platforms may open a link     | `platforms` in `capabilities/open-a-link.json`                                                          | Every platform this crate can be built for, named rather than left to the default of all of them — which is wider than what a release publishes, and narrower by iOS, for which no head is built |
-| The version the artifact reports    | `<VersionPrefix>` in `Version.props`, merged in by `run-tauri.ts`                                       | The same number as everything else, which is why `android init` runs through the wrapper too — the CLI reads `Cargo.toml` for it otherwise, and that states none                                 |
+| The decision                        | Where it is written                                                                                     | What it says                                                                                                                                                                                                                     |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| The application identifier          | `bundle.identifier` in `tauri.conf.json`, and nowhere else                                              | `io.github.krzysztof318.mailfathom` — the same one the desktop head carries, because it is one application                                                                                                                       |
+| The oldest release it installs on   | `bundle.android.minSdkVersion` in `tauri.conf.json`, and `minSdk` in `gen/android/app/build.gradle.kts` | 24, which is Tauri's own floor for the target. Gradle reads the second; the first is what a regeneration would render into it, and the two move together or the key is fiction                                                   |
+| What it asks the platform for       | `uses-permission` in `AndroidManifest.xml`                                                              | `INTERNET`, and nothing else. A notification permission arrives with the notification                                                                                                                                            |
+| What the APK's libraries resolve to | `dependencyLocking` in `gen/android/build.gradle.kts`, and `gen/android/app/gradle.lockfile` beside it  | The 80 artifacts behind the five declarations, fixed rather than resolved afresh on every build — `./gradlew :app:dependencies --write-locks` is what rewrites it                                                                |
+| What it refuses to let leave        | `android:allowBackup` and `res/xml/data_extraction_rules.xml`                                           | Both halves off: the cloud backup, and the device-to-device transfer that the attribute alone stops governing at API 31                                                                                                          |
+| Where the back gesture goes         | `handleBackNavigation` in `MainActivity.kt`                                                             | Turned back on, which Tauri's own activity turns off: the gesture reaches the page as `popstate`, so all three heads answer it with the one mechanism the frame above carries and nothing in the client asks which head it is on |
+| Which platforms may open a link     | `platforms` in `capabilities/open-a-link.json`                                                          | Every platform this crate can be built for, named rather than left to the default of all of them — which is wider than what a release publishes, and narrower by iOS, for which no head is built                                 |
+| The version the artifact reports    | `<VersionPrefix>` in `Version.props`, merged in by `run-tauri.ts`                                       | The same number as everything else, which is why `android init` runs through the wrapper too — the CLI reads `Cargo.toml` for it otherwise, and that states none                                                                 |
 
 `tauri android init` **writes no file that already exists**, which is what makes both halves of that arrangement work
 and is the whole argument for committing rather than regenerating. Running it on a fresh clone restores whatever the
@@ -323,9 +324,22 @@ question, their scope, and their selection across. Only **Mail** is built — `s
 `implementedSpaces` — and the other six are present, named as placeholders, and say in a sentence that there is nothing
 behind them yet. They are drawn rather than hidden because the design project is what the client is measured against
 and it shows all seven; a rail with three destinations would be a different product from the one that was designed.
-The frame is one tree laid out two ways by the width it is given — a navigation rail beside the workspace at or above
-the `workspace` breakpoint, bottom navigation under a stack of screens below it — and nothing in it reads which head or
-which platform it is running on.
+The frame is one tree laid out by the width it is given, and nothing in it reads which head or which platform it is
+running on. Three `@theme` breakpoints decide it, and between them they give the four compositions the design project
+frames: below `workspace` the destinations are a bottom bar under a single pane, and every side panel is a drawer;
+from `workspace` up they are the rail beside the workspace again; from `panes` up the list and the message stand side
+by side; and from `desktop` up the mailboxes gain a column of their own beside them and the toolbar gives every
+control its name in words. The fold is a composition of its own out of that arithmetic rather than a case anything
+branches on — two panes, drawers, and a mailbox column still behind a control.
+
+The **back gesture** is answered by the same frame, and on all three heads by one mechanism: `src/shell/screenLayers.ts`
+records what stands over the screen as each surface opens, `src/shellOperations/backNavigation.ts` keeps one history
+entry per layer standing, and `src/App.tsx` unwinds them topmost first before the address moves at all. So a press closes a
+drawer, a dialog, a menu, or the message drawn in front of the list, one layer at a time, and only a screen with
+nothing over it lets the gesture leave the client. Taking the navigation to another destination closes every one of
+them instead of leaving a layer behind. Android reaches that through the committed `MainActivity`, which turns
+`handleBackNavigation` back on so the gesture arrives in the page as `popstate` exactly as it does in a browser —
+which is why no module here asks which head it is on.
 
 Two questions are answered before the frame is drawn at all: which deployment this client belongs to, and who is
 asking it. `src/signIn/` is where both are, as one form rather than two screens, because a person was handed the

--- a/frontend/src-tauri/gen/android/app/src/main/java/io/github/krzysztof318/mailfathom/MainActivity.kt
+++ b/frontend/src-tauri/gen/android/app/src/main/java/io/github/krzysztof318/mailfathom/MainActivity.kt
@@ -4,6 +4,19 @@ import android.os.Bundle
 import androidx.activity.enableEdgeToEdge
 
 class MainActivity : TauriActivity() {
+  /**
+   * Hands the system back gesture to the page rather than to the activity, which is the whole of what this head does
+   * about it. Tauri's own activity turns this off, so back finishes the application from wherever a reader happens to
+   * be — a conversation, a drawer, an open dialog — and there is nothing the client could answer instead. Turned on,
+   * the WebView consumes one session-history entry per press and only finishes the activity once there is none left,
+   * which is exactly what a browser does with the same gesture.
+   *
+   * That is why nothing in `frontend/src/` branches on this head for it: the shell is configured to deliver back the
+   * way every other head already delivers it, and `Client.App/src/shellOperations/backNavigation.ts` is the one
+   * implementation all three share.
+   */
+  override val handleBackNavigation: Boolean = true
+
   override fun onCreate(savedInstanceState: Bundle?) {
     enableEdgeToEdge()
     super.onCreate(savedInstanceState)

--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -1863,3 +1863,51 @@ describe('App telemetry', () => {
         expect(recording.events.filter((event) => event === 'session_started')).toHaveLength(1);
     });
 });
+
+// The shell composes two things no surface can compose for itself: which of them the back gesture reaches, and what
+// leaving for another destination does to all of them. Both are asserted here rather than beside a surface, because
+// what they are about is the arrangement rather than any one surface in it.
+describe('App shell layers', () => {
+    it('closes what stands over the screen before the back gesture leaves it, one layer to a press', async () => {
+        renderApp();
+        await framed();
+        openSettings();
+
+        expect(screen.getByRole('dialog', { name: 'Settings' })).toBeDefined();
+
+        act(() => {
+            window.history.back();
+        });
+
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog', { name: 'Settings' })).toBeNull();
+        });
+    });
+
+    it('leaves nothing standing over the screen when the navigation goes to another destination', async () => {
+        renderApp();
+        await framed();
+        openSettings();
+
+        await goTo('Mail');
+
+        expect(screen.queryByRole('dialog', { name: 'Settings' })).toBeNull();
+    });
+
+    // The reading column goes with them, and for a second reason as well: what stands in it is a step the back gesture
+    // has to unwind, so a message left open under another space is a press spent on something nobody can see.
+    it('takes the message being read off the screen when the navigation goes to another destination', async () => {
+        renderApp(servedFrom, heldCredential, deploymentDrawingAMessage());
+        await framed();
+        await goTo('Mail');
+
+        const list = await screen.findByRole('listbox', { name: 'Messages' });
+        fireEvent.pointerDown(within(list).getByRole('option', { name: /Quarterly invoice/ }));
+        expect(await screen.findByText('A drawn message.')).toBeDefined();
+
+        await goTo('Discover');
+        await goTo('Mail');
+
+        expect(screen.queryByText('A drawn message.')).toBeNull();
+    });
+});

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -66,7 +66,9 @@ import { LanguageChoice, ThemeChoice } from './shell/Preferences';
 import { Space } from './shell/Space';
 import { SpaceNavigation } from './shell/SpaceNavigation';
 import { useConnection } from './shell/useConnection';
-import { useCoarsePointer, useWideEnoughForTabs, useWideWorkspace } from './shell/useWideWorkspace';
+import { useBackNavigation } from './shellOperations/backNavigation';
+import { ScreenLayersContext, useScreenLayerStack } from './shell/screenLayers';
+import { useCoarsePointer, useDesktopComposition, useTwoPanes, useWideWorkspace } from './shell/useWideWorkspace';
 import { userNameIn } from './signIn/credentialEntry';
 import { CredentialNotices, type CredentialNotice } from './signIn/CredentialNotices';
 import type { CredentialStore } from './signIn/credentialStore';
@@ -308,8 +310,8 @@ export function App({
     // Whether the person is working in tabs, which is the two halves of that question and nothing else: what they set,
     // and a window with room for a row of tabs above the columns. Below that width the mode is inert rather than off —
     // the switch stays in the menu and says so — so narrowing returns the pane layout and widening returns the strip.
-    const wideEnoughForTabs = useWideEnoughForTabs();
-    const inTabs = preferences.openMailInTabs && wideEnoughForTabs;
+    const desktopComposition = useDesktopComposition();
+    const inTabs = preferences.openMailInTabs && desktopComposition;
     const openTabs = useOpenTabs(inTabs);
 
     // Who the person is, asked on the same three conditions and for the same reasons. It is read here rather than in
@@ -391,6 +393,74 @@ export function App({
         notifications.show,
         notifications.hide,
     );
+
+    // Everything standing over the screen, so that the back gesture reaches the topmost one and moving to another
+    // destination leaves none of them behind. Held here for the reason the composer and the blocking surface are: a
+    // drawer in the Mail space, a menu on the rail, a sheet at the foot of a phone, and a confirmation opened from any
+    // of them have no common parent below this, and what the shell asks of them is asked of all of them at once.
+    const layers = useScreenLayerStack();
+    const twoPanes = useTwoPanes();
+
+    // What is standing in front of what a reader was last looking at, which is what the back gesture unwinds before it
+    // moves anywhere. The surfaces in the reading column count at every width, because each of them genuinely covers
+    // what it was opened from; the message covering the list counts only where the composition shows one pane, since
+    // that is the only composition where opening one took the other off the screen.
+    //
+    // One list rather than a count beside a chain of branches, because how many steps stand there and what each of
+    // them does to go away are one fact read twice. A press that unwinds two of them at once is what makes the
+    // difference: asking the workspace again for the second step would answer with the surface the first has already
+    // taken away, this event holding the revision that closed one no more than it holds the one that opened it.
+    const inFrontOfTheList = [
+        workspace.attachment === null ? null : openTabs.closeAttachment,
+        workspace.fullHtml === null ? null : openTabs.closeFullHtml,
+        twoPanes || (workspace.selection === null && workspace.conversation === null)
+            ? null
+            : () => {
+                  revise({ selection: null, conversation: null });
+              },
+    ].filter((close) => close !== null);
+
+    useBackNavigation(layers.depth + inFrontOfTheList.length, (used) => {
+        let left = used;
+
+        while (left > 0 && layers.closeTop()) {
+            left -= 1;
+        }
+
+        // Topmost first, which is the order the list is written in: a file stands in front of the message it was
+        // opened from, and that message in front of the list it was opened from.
+        for (const close of inFrontOfTheList.slice(0, left)) {
+            close();
+        }
+    });
+
+    // Moving to another destination closes what was standing over the one being left, so that coming back to it gives
+    // that screen rather than the layer somebody had over it. A layer that survived would be one they cannot get rid of
+    // without finding its own close control, which on a phone is where it is hardest to find.
+    //
+    // The reading column's own surfaces go with them, and for a second reason as well as that one: they are steps the
+    // back gesture has to unwind, and a step left standing while another space is on the screen is a press that closes
+    // something nobody can see instead of leaving the space they are in.
+    const destination = useRef(space);
+    const { closeAttachment, closeFullHtml } = openTabs;
+
+    // The first destination is arrived at rather than moved to: the space is unknown until the session says which ones
+    // this credential is offered, so the client's own opening screen would otherwise read as somewhere it had been
+    // taken away from — and would clear a reader's place the moment a reload restored it.
+    useEffect(() => {
+        const left = destination.current;
+
+        destination.current = space;
+
+        if (left === null || left === space) {
+            return;
+        }
+
+        layers.closeEvery();
+        closeAttachment();
+        closeFullHtml();
+        revise({ selection: null, conversation: null });
+    }, [space, layers, closeAttachment, closeFullHtml, revise]);
 
     function signedIn(reached: DeploymentAddress, presented: string): void {
         if (adopted === null) {
@@ -499,129 +569,125 @@ export function App({
     }
 
     return (
-        // Above every screen that would act on one, because what changed is the deployment's statement rather than any
-        // one screen's: the tree, the list, and the bell each subscribe to the kinds they draw, and a second connection
-        // per screen would be several sockets saying the same thing.
-        <SignalledChangesContext value={signalledChanges}>
-            {/* Above everything that changes a mailbox, because following a change is not the business of whichever
+        // Above every surface that can stand over the screen, which is every one of them: what the back gesture reaches
+        // and what a change of destination closes are questions about the frame rather than about whichever surface is
+        // on top. It is not above the sign-in screen, because that screen stands in front of the frame rather than
+        // inside it and opens nothing over itself.
+        <ScreenLayersContext value={layers}>
+            {/* Above every screen that would act on one, because what changed is the deployment's statement rather than
+            any one screen's: the tree, the list, and the bell each subscribe to the kinds they draw, and a second
+            connection per screen would be several sockets saying the same thing. */}
+            <SignalledChangesContext value={signalledChanges}>
+                {/* Above everything that changes a mailbox, because following a change is not the business of whichever
             screen asked for one: what is waiting, what the deployment refused, and what only a person can settle are
             one queue whoever produced the change. */}
-            <PendingChangesProvider session={session} transport={readMail}>
-                {/* Above the frame rather than inside a space, because three unrelated places below read what has been
+                <PendingChangesProvider session={session} transport={readMail}>
+                    {/* Above the frame rather than inside a space, because three unrelated places below read what has been
             marked: the row that draws a message, the folder tree that counts unread mail, and the body that marks one
             on being drawn. What it holds goes with the credential, exactly as the workspace does. */}
-                <ReadMarkingProvider session={session} transport={readMail} marking={markingRead}>
-                    {/* Above the frame for the same reason: which of the two reading surfaces a message opens on decides
+                    <ReadMarkingProvider session={session} transport={readMail} marking={markingRead}>
+                        {/* Above the frame for the same reason: which of the two reading surfaces a message opens on decides
                 how every message anywhere below is drawn, and the two components that read it — the body and the
                 control on the message head — sit several levels under the reading pane and under the conversation
                 alike. */}
-                    <EmbeddedHtmlMessagesContext value={preferences.embeddedHtmlMessages}>
-                        {/* Above the frame for the reason the marking is, and above the acts because the acts read it: what the
+                        <EmbeddedHtmlMessagesContext value={preferences.embeddedHtmlMessages}>
+                            {/* Above the frame for the reason the marking is, and above the acts because the acts read it: what the
             list has drawn is where a message belongs, and every act on one has to name that. It holds nothing that is
             drawn, so nothing below re-renders because of it. */}
-                        <ListedMailProvider>
-                            {/* Above the frame as well, because four surfaces reach the same five acts — the toolbar over what is
+                            <ListedMailProvider>
+                                {/* Above the frame as well, because four surfaces reach the same five acts — the toolbar over what is
             open, the bar over a selection, the row that draws one as pending, and the message somebody swiped — and a
             second implementation of *archive* is how two of them come to file mail differently. */}
-                            <MailboxActsProvider
-                                session={readsMail ? session : null}
-                                transport={readMail}
-                                online={connection.online}
-                                flags={writesFlags}
-                                moves={filesMail}
-                            >
-                                {/* Above the frame rather than inside the mail space, because what is being written outlives moving
+                                <MailboxActsProvider
+                                    session={readsMail ? session : null}
+                                    transport={readMail}
+                                    online={connection.online}
+                                    flags={writesFlags}
+                                    moves={filesMail}
+                                >
+                                    {/* Above the frame rather than inside the mail space, because what is being written outlives moving
             between the spaces, and because the three controls that ask for it are each several components below here.
             Writing is offered where the credential may file a draft; one that may not is told so by the strip above
             rather than by a screen that refuses every act. */}
-                                <ComposingContext value={composing}>
-                                    {/* Above the frame as well, and for a stronger reason than the composer's: what it draws covers
+                                    <ComposingContext value={composing}>
+                                        {/* Above the frame as well, and for a stronger reason than the composer's: what it draws covers
                 everything below it, and the operations that ask for it — a mailbox migration, a bulk change, an
                 export — each begin somewhere different and none of them is the parent of what has to be covered. The
                 surface itself is the platform's own modal dialog, so where it sits in the document decides nothing
                 about where it is drawn; it stands first here because it stands in front of everything. */}
-                                    <BlockingContext value={blocking}>
-                                        <BlockingOverlay operation={blockedOn} />
+                                        <BlockingContext value={blocking}>
+                                            <BlockingOverlay operation={blockedOn} />
 
-                                        {/* Beside them for the composer's own reason, one component further down: the row that opens a
+                                            {/* Beside them for the composer's own reason, one component further down: the row that opens a
                     file a message carries sits three components below the frame that owns what is open, and none of
                     the three between them has a reason to name a file it never opens. */}
-                                        <OpenAttachmentContext value={openTabs.openAttachment}>
-                                            <div className="flex h-dvh flex-col bg-rail pt-safe-top pr-safe-right pb-safe-bottom pl-safe-left workspace:flex-row">
-                                                <div
-                                                    ref={workspaceRegion}
-                                                    tabIndex={-1}
-                                                    className="flex min-h-0 min-w-0 flex-1 flex-col bg-page"
-                                                >
-                                                    {/* Inside the frame as well as on the sign-in screen, because a credential that could not be kept is
+                                            <OpenAttachmentContext value={openTabs.openAttachment}>
+                                                <div className="flex h-dvh flex-col bg-rail pt-safe-top pr-safe-right pb-safe-bottom pl-safe-left workspace:flex-row">
+                                                    <div
+                                                        ref={workspaceRegion}
+                                                        tabIndex={-1}
+                                                        className="flex min-h-0 min-w-0 flex-1 flex-col bg-page"
+                                                    >
+                                                        {/* Inside the frame as well as on the sign-in screen, because a credential that could not be kept is
                     learned about at the moment somebody successfully signed in — which is the one of these sentences
                     whose reader is already past that screen. Beside it, and in the same strip, is what this credential
                     may not do: both are statements about the credential rather than about anything it read. */}
-                                                    {notices.length === 0 && withheld.length === 0 ? null : (
-                                                        <div className="flex flex-col gap-2 border-b border-line-soft bg-panel px-4 py-2 workspace:px-8">
-                                                            <CredentialNotices notices={notices} />
-                                                            <GrantNotice withheld={withheld} />
-                                                        </div>
-                                                    )}
+                                                        {notices.length === 0 && withheld.length === 0 ? null : (
+                                                            <div className="flex flex-col gap-2 border-b border-line-soft bg-panel px-4 py-2 workspace:px-8">
+                                                                <CredentialNotices notices={notices} />
+                                                                <GrantNotice withheld={withheld} />
+                                                            </div>
+                                                        )}
 
-                                                    {/* The region the space is drawn in is there before the deployment says which space that is, so
+                                                        {/* The region the space is drawn in is there before the deployment says which space that is, so
                     nothing on the screen moves under a reader when the answer arrives. Until it does, what stands in
                     the region is what the connection says — reaching, retrying, offline, or refused — because that is
                     the only thing on the screen there is to read, and the way out of a deployment that never answers
                     has to be somewhere. */}
-                                                    {space === null ? (
-                                                        <main className="flex-1 px-4 py-6 workspace:px-8">
-                                                            <ConnectionSummary connection={connection} />
-                                                        </main>
-                                                    ) : (
-                                                        <Space
-                                                            space={space}
-                                                            // Who is signed in, taken apart in the one module that composes a credential and never here.
-                                                            // A screen never sees the credential; what it is handed is the name the deployment knows the
-                                                            // person by, which is what a preference kept per person on this machine is written under.
-                                                            person={userNameIn(authorization)}
-                                                            // Asking is what the field is for, so a credential that may not ask is not shown one. It is
-                                                            // absent rather than disabled: a control nobody can use says less about why than the sentence
-                                                            // above does. Where it stands is the space's decision, which is why it is handed in rather
-                                                            // than drawn here.
-                                                            intent={
-                                                                // Not while a message is being written: what stands at the foot of that column then is
-                                                                // the composer's own footer, and two rows of controls under one column is two answers
-                                                                // to what the primary act is.
-                                                                written === null &&
-                                                                deploymentSession !== null &&
-                                                                offers(deploymentSession, 'askMail') ? (
-                                                                    <IntentField accounts={mailAccounts} />
-                                                                ) : null
-                                                            }
-                                                            status={<ConnectionSummary connection={connection} />}
-                                                            folders={
-                                                                session === null || !readsMail ? null : (
-                                                                    <FolderTree
-                                                                        session={session}
-                                                                        transport={readMail}
-                                                                        online={connection.online}
-                                                                    />
-                                                                )
-                                                            }
-                                                            list={
-                                                                session === null || !readsMail ? null : (
-                                                                    // Both keyed by the scope, so pointing at another mailbox starts a list and a search
-                                                                    // rather than resetting either: every value below belongs to one mailbox read one way,
-                                                                    // and a search carries the mailbox it was made in as a filter it would go on showing.
-                                                                    // Searching stands above the list rather than beside it because it is where somebody
-                                                                    // reaches for it — looking at a folder, with the message not in front of them — and
-                                                                    // what it finds is drawn in the same column with the same row.
-                                                                    <MailSearch
-                                                                        key={scopeKey(workspace.scope)}
-                                                                        session={session}
-                                                                        transport={readMail}
-                                                                        scope={workspace.scope}
-                                                                        accounts={mailAccounts}
-                                                                        online={connection.online}
-                                                                        onOpen={openTabs.openMail}
-                                                                    >
-                                                                        <MessageList
+                                                        {space === null ? (
+                                                            <main className="flex-1 px-4 py-6 workspace:px-8">
+                                                                <ConnectionSummary connection={connection} />
+                                                            </main>
+                                                        ) : (
+                                                            <Space
+                                                                space={space}
+                                                                // Who is signed in, taken apart in the one module that composes a credential and never here.
+                                                                // A screen never sees the credential; what it is handed is the name the deployment knows the
+                                                                // person by, which is what a preference kept per person on this machine is written under.
+                                                                person={userNameIn(authorization)}
+                                                                // Asking is what the field is for, so a credential that may not ask is not shown one. It is
+                                                                // absent rather than disabled: a control nobody can use says less about why than the sentence
+                                                                // above does. Where it stands is the space's decision, which is why it is handed in rather
+                                                                // than drawn here.
+                                                                intent={
+                                                                    // Not while a message is being written: what stands at the foot of that column then is
+                                                                    // the composer's own footer, and two rows of controls under one column is two answers
+                                                                    // to what the primary act is.
+                                                                    written === null &&
+                                                                    deploymentSession !== null &&
+                                                                    offers(deploymentSession, 'askMail') ? (
+                                                                        <IntentField accounts={mailAccounts} />
+                                                                    ) : null
+                                                                }
+                                                                status={<ConnectionSummary connection={connection} />}
+                                                                folders={
+                                                                    session === null || !readsMail ? null : (
+                                                                        <FolderTree
+                                                                            session={session}
+                                                                            transport={readMail}
+                                                                            online={connection.online}
+                                                                        />
+                                                                    )
+                                                                }
+                                                                list={
+                                                                    session === null || !readsMail ? null : (
+                                                                        // Both keyed by the scope, so pointing at another mailbox starts a list and a search
+                                                                        // rather than resetting either: every value below belongs to one mailbox read one way,
+                                                                        // and a search carries the mailbox it was made in as a filter it would go on showing.
+                                                                        // Searching stands above the list rather than beside it because it is where somebody
+                                                                        // reaches for it — looking at a folder, with the message not in front of them — and
+                                                                        // what it finds is drawn in the same column with the same row.
+                                                                        <MailSearch
                                                                             key={scopeKey(workspace.scope)}
                                                                             session={session}
                                                                             transport={readMail}
@@ -629,108 +695,118 @@ export function App({
                                                                             accounts={mailAccounts}
                                                                             online={connection.online}
                                                                             onOpen={openTabs.openMail}
-                                                                        />
-                                                                    </MailSearch>
-                                                                )
-                                                            }
-                                                            tabs={
-                                                                /* A map of what is open, so it is drawn only where there is something to map: an empty
+                                                                        >
+                                                                            <MessageList
+                                                                                key={scopeKey(workspace.scope)}
+                                                                                session={session}
+                                                                                transport={readMail}
+                                                                                scope={workspace.scope}
+                                                                                accounts={mailAccounts}
+                                                                                online={connection.online}
+                                                                                onOpen={openTabs.openMail}
+                                                                            />
+                                                                        </MailSearch>
+                                                                    )
+                                                                }
+                                                                tabs={
+                                                                    /* A map of what is open, so it is drawn only where there is something to map: an empty
                                    strip over an empty pane would say the same thing twice. */
-                                                                inTabs && openTabs.tabs.length > 0 ? (
-                                                                    <TabStrip
-                                                                        tabs={openTabs.tabs}
-                                                                        active={openTabs.active}
-                                                                        onActivate={openTabs.activate}
-                                                                        onClose={openTabs.close}
-                                                                        onCloseEverything={openTabs.closeEverything}
-                                                                    />
-                                                                ) : null
-                                                            }
-                                                            mail={
-                                                                // A message being written stands where one being read stands, which is the design
-                                                                // project's composition rather than a window over it — and what is open is still open
-                                                                // underneath, so closing the composer is a return rather than a second thing to find.
-                                                                // Keyed by what is being written, so asking for an answer while a message of its own is
-                                                                // open starts that answer rather than pouring it into the fields already on the screen.
-                                                                written === null || session === null ? (
-                                                                    whatIsOpen()
-                                                                ) : (
-                                                                    <Composer
-                                                                        key={openingKey(written)}
-                                                                        session={session}
-                                                                        transport={readMail}
-                                                                        accounts={mailAccounts}
-                                                                        opening={written}
-                                                                        online={connection.online}
-                                                                        onClosed={composing.close}
-                                                                    />
-                                                                )
-                                                            }
-                                                        />
-                                                    )}
-                                                </div>
+                                                                    inTabs && openTabs.tabs.length > 0 ? (
+                                                                        <TabStrip
+                                                                            tabs={openTabs.tabs}
+                                                                            active={openTabs.active}
+                                                                            onActivate={openTabs.activate}
+                                                                            onClose={openTabs.close}
+                                                                            onCloseEverything={openTabs.closeEverything}
+                                                                        />
+                                                                    ) : null
+                                                                }
+                                                                mail={
+                                                                    // A message being written stands where one being read stands, which is the design
+                                                                    // project's composition rather than a window over it — and what is open is still open
+                                                                    // underneath, so closing the composer is a return rather than a second thing to find.
+                                                                    // Keyed by what is being written, so asking for an answer while a message of its own is
+                                                                    // open starts that answer rather than pouring it into the fields already on the screen.
+                                                                    written === null || session === null ? (
+                                                                        whatIsOpen()
+                                                                    ) : (
+                                                                        <Composer
+                                                                            key={openingKey(written)}
+                                                                            session={session}
+                                                                            transport={readMail}
+                                                                            accounts={mailAccounts}
+                                                                            opening={written}
+                                                                            online={connection.online}
+                                                                            onClosed={composing.close}
+                                                                        />
+                                                                    )
+                                                                }
+                                                            />
+                                                        )}
+                                                    </div>
 
-                                                {/* Navigation is last in the document because the keyboard follows the document rather than the layout,
+                                                    {/* Navigation is last in the document because the keyboard follows the document rather than the layout,
                 and the narrow composition puts it at the bottom of the screen: written the other way round, a reader
                 tabbing into a narrow window would reach the bottom bar before the header above it. The wide
                 composition then carries the one mismatch CSS cannot remove — a rail drawn on the left out of a node
                 that comes last — because no single document order matches both shapes, and content before navigation
                 is the direction a skip link exists to manufacture rather than the one it works around. */}
-                                                <SpaceNavigation
-                                                    offered={offeredSpaces}
-                                                    current={space}
-                                                    onPointerDown={swipe.onNavigationPointerDown}
-                                                    onClickCapture={swipe.onNavigationClickCapture}
-                                                    notifications={
-                                                        // Offered on the grant the routes are admitted under, and absent
-                                                        // rather than inert without it: a bell that could never answer is
-                                                        // a control saying less about why than not drawing it does.
-                                                        readsMail ? (
-                                                            <NotificationBell
-                                                                unreadCount={notifications.unreadCount}
-                                                                shown={notifications.shown}
-                                                                onPress={
-                                                                    notifications.shown
-                                                                        ? notifications.hide
-                                                                        : notifications.show
-                                                                }
+                                                    <SpaceNavigation
+                                                        offered={offeredSpaces}
+                                                        current={space}
+                                                        onPointerDown={swipe.onNavigationPointerDown}
+                                                        onClickCapture={swipe.onNavigationClickCapture}
+                                                        notifications={
+                                                            // Offered on the grant the routes are admitted under, and absent
+                                                            // rather than inert without it: a bell that could never answer is
+                                                            // a control saying less about why than not drawing it does.
+                                                            readsMail ? (
+                                                                <NotificationBell
+                                                                    unreadCount={notifications.unreadCount}
+                                                                    shown={notifications.shown}
+                                                                    onPress={
+                                                                        notifications.shown
+                                                                            ? notifications.hide
+                                                                            : notifications.show
+                                                                    }
+                                                                />
+                                                            ) : null
+                                                        }
+                                                        account={
+                                                            <AccountMenu
+                                                                accounts={mailAccounts}
+                                                                deploymentVersion={deploymentSession?.version ?? null}
+                                                                telemetryForwarding={telemetryForwardedBy(
+                                                                    deploymentSession,
+                                                                    baseAddress,
+                                                                )}
+                                                                preferences={preferences}
+                                                                profile={profile}
+                                                                onSignOut={signOut}
                                                             />
-                                                        ) : null
-                                                    }
-                                                    account={
-                                                        <AccountMenu
-                                                            accounts={mailAccounts}
-                                                            deploymentVersion={deploymentSession?.version ?? null}
-                                                            telemetryForwarding={telemetryForwardedBy(
-                                                                deploymentSession,
-                                                                baseAddress,
-                                                            )}
-                                                            preferences={preferences}
-                                                            profile={profile}
-                                                            onSignOut={signOut}
-                                                        />
-                                                    }
-                                                />
+                                                        }
+                                                    />
 
-                                                {/* Outside the frame's own columns because it stands over all of them,
+                                                    {/* Outside the frame's own columns because it stands over all of them,
                                                 and inside the frame because it goes with the credential: it is the
                                                 platform's own modal dialog, so where it sits in the document decides
                                                 nothing about where it is drawn. It is mounted whether or not it is
                                                 open, which is what lets it travel on and off the screen rather than
                                                 appearing and disappearing. */}
-                                                {readsMail ? (
-                                                    <NotificationCentre centre={notifications} swipe={swipe} />
-                                                ) : null}
-                                            </div>
-                                        </OpenAttachmentContext>
-                                    </BlockingContext>
-                                </ComposingContext>
-                            </MailboxActsProvider>
-                        </ListedMailProvider>
-                    </EmbeddedHtmlMessagesContext>
-                </ReadMarkingProvider>
-            </PendingChangesProvider>
-        </SignalledChangesContext>
+                                                    {readsMail ? (
+                                                        <NotificationCentre centre={notifications} swipe={swipe} />
+                                                    ) : null}
+                                                </div>
+                                            </OpenAttachmentContext>
+                                        </BlockingContext>
+                                    </ComposingContext>
+                                </MailboxActsProvider>
+                            </ListedMailProvider>
+                        </EmbeddedHtmlMessagesContext>
+                    </ReadMarkingProvider>
+                </PendingChangesProvider>
+            </SignalledChangesContext>
+        </ScreenLayersContext>
     );
 }
 

--- a/frontend/src/Client.App/src/composer/DiscardConfirmation.test.tsx
+++ b/frontend/src/Client.App/src/composer/DiscardConfirmation.test.tsx
@@ -2,25 +2,45 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, renderHook, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { LocalizationProvider } from '../localization/Localization';
+import { ScreenLayersContext, useScreenLayerStack, type ScreenLayers } from '../shell/screenLayers';
 import { DiscardConfirmation } from './DiscardConfirmation';
 
 function drawConfirmation(written: boolean): {
     discarded: ReturnType<typeof vi.fn>;
     kept: ReturnType<typeof vi.fn>;
+    shell: { readonly current: ScreenLayers };
 } {
     const discarded = vi.fn();
     const kept = vi.fn();
 
+    // The shell around it, because the composer is what the back gesture meets while it is open and this component is
+    // where that is recorded. Its three functions are the same ones for the life of the stack, so the value handed to
+    // the provider stays current however the count moves.
+    const { result } = renderHook(() => useScreenLayerStack());
+
     render(
         <LocalizationProvider>
-            <DiscardConfirmation written={written} onDiscard={discarded} onKeep={kept} />
+            <ScreenLayersContext value={result.current}>
+                <DiscardConfirmation written={written} onDiscard={discarded} onKeep={kept} />
+            </ScreenLayersContext>
         </LocalizationProvider>,
     );
 
-    return { discarded, kept };
+    return { discarded, kept, shell: result };
+}
+
+/** One press of the back gesture, which is what the shell answers with the topmost surface it holds. */
+function theGestureIsUsed(shell: { readonly current: ScreenLayers }): boolean {
+    let reached = false;
+
+    act(() => {
+        reached = shell.current.closeTop();
+    });
+
+    return reached;
 }
 
 function close(): void {
@@ -86,5 +106,38 @@ describe('DiscardConfirmation', () => {
 
         expect(discarded).not.toHaveBeenCalled();
         expect(kept).not.toHaveBeenCalled();
+    });
+
+    // The back gesture reaches the same decision the control does rather than a shorter one, which is the whole reason
+    // this component registers itself: a message with words in it is never given up by a gesture.
+    it('puts the question on the screen when the back gesture reaches the composer', () => {
+        const { discarded, shell } = drawConfirmation(true);
+
+        expect(theGestureIsUsed(shell)).toBe(true);
+
+        expect(screen.getByRole('dialog').hasAttribute('open')).toBe(true);
+        expect(discarded).not.toHaveBeenCalled();
+    });
+
+    it('closes on the gesture without asking where there is nothing to lose', () => {
+        const { discarded, shell } = drawConfirmation(false);
+
+        theGestureIsUsed(shell);
+
+        expect(discarded).toHaveBeenCalledTimes(1);
+        expect(screen.queryByRole('dialog')).toBeNull();
+    });
+
+    // The press that asked the question was spent on the composer, which is still on the screen behind it — so once
+    // that question has been answered the next press has to find the composer there rather than fall past it.
+    it('meets the gesture again once the question it asked has been answered', () => {
+        const { shell } = drawConfirmation(true);
+
+        theGestureIsUsed(shell);
+        fireEvent.click(screen.getByRole('button', { name: 'Back to writing' }));
+
+        expect(screen.queryByRole('dialog')).toBeNull();
+        expect(theGestureIsUsed(shell)).toBe(true);
+        expect(screen.getByRole('dialog').hasAttribute('open')).toBe(true);
     });
 });

--- a/frontend/src/Client.App/src/composer/DiscardConfirmation.tsx
+++ b/frontend/src/Client.App/src/composer/DiscardConfirmation.tsx
@@ -2,10 +2,11 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { Confirmation } from '../confirmation/Confirmation';
 import { Icon } from '../controls/Icon';
 import { useLocalization } from '../localization/useLocalization';
+import { useScreenLayer } from '../shell/screenLayers';
 
 // Closing the composer, and the question in front of it where closing would cost something. Discarding mail somebody
 // wrote is destructive, so the question names what goes and offers the way out of losing it; a message with nothing in
@@ -34,6 +35,28 @@ export function DiscardConfirmation({
 }) {
     const { translate } = useLocalization();
     const asked = useRef<HTMLDialogElement>(null);
+    const [timesAsked, setTimesAsked] = useState(0);
+
+    // Leaving the composer, whichever way somebody asked to: the control below, and the back gesture, which reaches
+    // the same decision rather than a shorter one. A message with words in it is never given up by a gesture — what
+    // back does then is put the question on the screen, exactly as pressing the control does.
+    function leave(): void {
+        if (written) {
+            setTimesAsked((times) => times + 1);
+            asked.current?.showModal();
+        } else {
+            onDiscard();
+        }
+    }
+
+    // The composer stands where a message being read stands, and it is what the back gesture meets first while it is
+    // open: this component is on the screen for exactly as long as the composer is, which is what makes it the place
+    // that registers one.
+    //
+    // A press that reached it and got the question rather than the composer closing is the one case that has to be
+    // recorded again, which is what the count is for: the composer is still on the screen behind the question, so the
+    // press that answers the question has to find it there.
+    useScreenLayer(true, leave, timesAsked);
 
     return (
         <>
@@ -42,13 +65,7 @@ export function DiscardConfirmation({
                 aria-label={translate('compose.close')}
                 title={translate('compose.close')}
                 className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted transition hover:bg-hover hover:text-text"
-                onClick={() => {
-                    if (written) {
-                        asked.current?.showModal();
-                    } else {
-                        onDiscard();
-                    }
-                }}
+                onClick={leave}
             >
                 <Icon name="close" className="size-4.5" />
             </button>

--- a/frontend/src/Client.App/src/confirmation/Confirmation.test.tsx
+++ b/frontend/src/Client.App/src/confirmation/Confirmation.test.tsx
@@ -3,9 +3,10 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { useRef } from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, renderHook, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { LocalizationProvider } from '../localization/Localization';
+import { ScreenLayersContext, useScreenLayerStack, type ScreenLayers } from '../shell/screenLayers';
 import { storeLocale } from '../localization/locale';
 import { Confirmation, type Reversal, type WayOut } from './Confirmation';
 
@@ -57,6 +58,7 @@ function drawConfirmation(
     acted: ReturnType<typeof vi.fn>;
     leftAside: ReturnType<typeof vi.fn>;
     keptAsTheyWere: ReturnType<typeof vi.fn>;
+    shell: { readonly current: ScreenLayers };
 } {
     const acted = vi.fn();
     const leftAside = vi.fn();
@@ -66,21 +68,45 @@ function drawConfirmation(
     // to run and look exactly like one that resolved to nothing at all.
     const keptAsTheyWere = vi.fn();
 
+    // The shell around it, because the question records itself as standing over whatever asked it for as long as it
+    // is open. Its three functions are the same ones for the life of the stack, so the value handed to the provider
+    // stays current however the count moves.
+    const { result } = renderHook(() => useScreenLayerStack());
+
     render(
         <LocalizationProvider>
-            <Asking
-                reversal={reversal}
-                cautions={cautions}
-                ways={[
-                    { said: 'Keep them where they are', manner: 'back', run: keptAsTheyWere },
-                    { said: 'Leave a copy', manner: 'aside', run: leftAside },
-                    { said: 'Move them', manner: 'act', run: acted },
-                ]}
-            />
+            <ScreenLayersContext value={result.current}>
+                <Asking
+                    reversal={reversal}
+                    cautions={cautions}
+                    ways={[
+                        { said: 'Keep them where they are', manner: 'back', run: keptAsTheyWere },
+                        { said: 'Leave a copy', manner: 'aside', run: leftAside },
+                        { said: 'Move them', manner: 'act', run: acted },
+                    ]}
+                />
+            </ScreenLayersContext>
         </LocalizationProvider>,
     );
 
-    return { acted, leftAside, keptAsTheyWere };
+    return { acted, leftAside, keptAsTheyWere, shell: result };
+}
+
+/**
+ * The question as the platform would report it once it is open, which jsdom reports of nothing.
+ *
+ * The component reads whether it is open off the element's own toggle rather than holding a second copy, and jsdom
+ * fires none and declares no `ToggleEvent` — so the one property read off it is put on an ordinary event.
+ */
+function theQuestionIsOpened(): void {
+    const asked = screen.getByRole('dialog', { hidden: true });
+    const opening = new Event('toggle');
+
+    Object.defineProperty(opening, 'newState', { value: 'open' });
+
+    act(() => {
+        asked.dispatchEvent(opening);
+    });
 }
 
 function ask(): void {
@@ -242,5 +268,25 @@ describe('Confirmation', () => {
 
         expect(named === null ? null : document.getElementById(named)?.textContent).toBe(question);
         expect(described === null ? null : document.getElementById(described)?.textContent).toContain(consequence);
+    });
+
+    // The question stands over whatever asked it, so the back gesture answers this before it reaches anything behind
+    // it: back on a confirmation is the same as Escape on one, which is leaving without choosing a way out.
+    it('closes without choosing a way out when the back gesture reaches it', () => {
+        const { acted, leftAside, keptAsTheyWere, shell } = drawConfirmation();
+
+        ask();
+        theQuestionIsOpened();
+
+        expect(shell.current.depth).toBe(1);
+
+        act(() => {
+            shell.current.closeTop();
+        });
+
+        expect(screen.getByRole('dialog', { hidden: true }).hasAttribute('open')).toBe(false);
+        expect(acted).not.toHaveBeenCalled();
+        expect(leftAside).not.toHaveBeenCalled();
+        expect(keptAsTheyWere).not.toHaveBeenCalled();
     });
 });

--- a/frontend/src/Client.App/src/confirmation/Confirmation.tsx
+++ b/frontend/src/Client.App/src/confirmation/Confirmation.tsx
@@ -2,11 +2,12 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import { useId, type ReactNode, type RefObject } from 'react';
+import { useId, useState, type ReactNode, type RefObject } from 'react';
 import { Icon } from '../controls/Icon';
 import type { IconName } from '../controls/icons';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
+import { useScreenLayer } from '../shell/screenLayers';
 import { mannerDrawn, type Manner } from './wayOutShapes';
 
 // The one question this client puts in front of an act that leaves the deployment, and the vocabulary every screen asks
@@ -117,6 +118,15 @@ export function Confirmation({
     const { locale, translate } = useLocalization();
     const asks = useId();
     const explains = useId();
+    const [standing, setStanding] = useState(false);
+
+    // The question stands over whatever asked it, so the back gesture answers this before it reaches anything behind
+    // it: back on a confirmation is the same as Escape on one, which is leaving without choosing a way out. It is
+    // registered from the platform's own toggle rather than from a value the callers set, for the reason the ref is
+    // theirs to begin with — nothing here holds a second copy of whether the question is open.
+    useScreenLayer(standing, () => {
+        asked.current?.close();
+    });
 
     // Which way out was pressed travels the way the platform carries it, in the return value, so that closing by any
     // route — a press, Escape, the backdrop — arrives in one place with focus already restored.
@@ -132,6 +142,9 @@ export function Confirmation({
             aria-labelledby={asks}
             aria-describedby={explains}
             className="m-auto w-110 max-w-full rounded-2xl border border-line bg-panel p-5 text-text shadow-dialog backdrop:bg-scrim"
+            onToggle={(event) => {
+                setStanding(event.newState === 'open');
+            }}
             onClose={(closing) => {
                 const dialog = closing.currentTarget;
                 const way = chosen(dialog.returnValue);

--- a/frontend/src/Client.App/src/contextMenu/ContextMenu.test.tsx
+++ b/frontend/src/Client.App/src/contextMenu/ContextMenu.test.tsx
@@ -2,9 +2,10 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, renderHook, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { LocalizationProvider } from '../localization/Localization';
+import { ScreenLayersContext, useScreenLayerStack, type ScreenLayers } from '../shell/screenLayers';
 import { ContextMenu, type ContextMenuItem } from './ContextMenu';
 
 const archiving = vi.fn();
@@ -15,12 +16,26 @@ const items: readonly ContextMenuItem[] = [
     { icon: 'delete', label: 'Delete', destroys: true, choose: vi.fn() },
 ];
 
-function menuOver(closed: () => void = vi.fn()): void {
+function menuOver(closed: () => void = vi.fn()): { readonly current: ScreenLayers } {
+    // The shell around it, because the menu records itself as standing over the screen for as long as it is drawn.
+    // Its three functions are the same ones for the life of the stack, so the value handed to the provider stays
+    // current however the count moves.
+    const { result } = renderHook(() => useScreenLayerStack());
+
     render(
         <LocalizationProvider>
-            <ContextMenu header="Contract annex — signatures" at={{ x: 40, y: 60 }} items={items} onClose={closed} />
+            <ScreenLayersContext value={result.current}>
+                <ContextMenu
+                    header="Contract annex — signatures"
+                    at={{ x: 40, y: 60 }}
+                    items={items}
+                    onClose={closed}
+                />
+            </ScreenLayersContext>
         </LocalizationProvider>,
     );
+
+    return result;
 }
 
 function walked(): HTMLElement[] {
@@ -132,5 +147,21 @@ describe('ContextMenu', () => {
 
         expect(archiving).toHaveBeenCalledOnce();
         expect(closed).toHaveBeenCalledOnce();
+    });
+
+    // It stands over whatever it was opened on, so the back gesture closes it before it navigates and a change of
+    // destination leaves none of it behind. It is on the screen for exactly as long as it is drawn, which is why the
+    // registration is unconditional rather than following a state of its own.
+    it('closes when the back gesture reaches it, rather than standing over the next screen', () => {
+        const closed = vi.fn();
+        const shell = menuOver(closed);
+
+        expect(shell.current.depth).toBe(1);
+
+        act(() => {
+            shell.current.closeTop();
+        });
+
+        expect(closed).toHaveBeenCalled();
     });
 });

--- a/frontend/src/Client.App/src/contextMenu/ContextMenu.tsx
+++ b/frontend/src/Client.App/src/contextMenu/ContextMenu.tsx
@@ -5,6 +5,7 @@
 import { useEffect, useId, useLayoutEffect, useRef, useState, type KeyboardEvent } from 'react';
 import { Icon } from '../controls/Icon';
 import type { IconName } from '../controls/icons';
+import { useScreenLayer } from '../shell/screenLayers';
 import { useWideWorkspace } from '../shell/useWideWorkspace';
 import { placedWithin, type MenuPoint } from './menuPlacement';
 
@@ -89,6 +90,11 @@ export function ContextMenu({
     useEffect(() => {
         walkable(panel.current)[0]?.focus();
     }, []);
+
+    // It stands over the row it was opened from, so the back gesture closes it before it does anything else — the same
+    // way out Escape and a press outside it take. The component is on the screen only while the menu is, which is why
+    // it is registered unconditionally.
+    useScreenLayer(true, onClose);
 
     // Closed by a press outside it rather than by the click that follows one. The tap ending a long press arrives as a
     // click with no press of its own behind it, so a menu listening for that would close under the finger that had

--- a/frontend/src/Client.App/src/controls/controlShapes.ts
+++ b/frontend/src/Client.App/src/controls/controlShapes.ts
@@ -2,7 +2,7 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-// The six shapes a control takes in the design project, stated once for the two components that draw one: the control
+// The seven shapes a control takes in the design project, stated once for the two components that draw one: the control
 // that does something and the control that stands for something the client cannot do yet. They are here rather than in
 // either of those because a shape written twice is how the same button comes to look like two buttons — and because a
 // module Vite hot-reloads may export components alone, which is what keeps this table out of the component files.
@@ -11,13 +11,19 @@
 // drawn as. They are shapes of their own rather than a colour passed in, because what changes is every colour the
 // control has: a control that took `text-text-soft` from the table and a foreground from its caller would be two
 // utilities of one property fighting over which of them the stylesheet emitted last.
+//
+// Two more are the same pairing again for the width a strip has: the design draws the toolbar's controls as words
+// beside their symbols only where there is a mailbox column beside them, and as symbols alone at every narrower
+// composition. So `symbol` is what `labelled` narrows to, and `primarySymbol` is what `primary` narrows to.
 
-export type ControlShape = 'labelled' | 'symbol' | 'primary' | 'floating' | 'onAccent' | 'onAccentSymbol';
+export type ControlShape =
+    'labelled' | 'symbol' | 'primary' | 'primarySymbol' | 'floating' | 'onAccent' | 'onAccentSymbol';
 
 export const controlShapes: Readonly<Record<ControlShape, string>> = {
     labelled: 'gap-1.75 rounded-lg px-2.75 py-1.75 text-base text-text-soft hover:bg-hover',
     symbol: 'size-9.5 justify-center rounded-lg text-text-soft hover:bg-hover',
     primary: 'gap-1.75 rounded-lg bg-accent px-3.25 py-2 text-base font-semibold text-on-accent shadow-raised',
+    primarySymbol: 'size-9.5 justify-center rounded-lg bg-accent text-on-accent shadow-raised',
     floating: 'size-13.5 justify-center rounded-4xl bg-accent text-on-accent shadow-overlay',
     onAccent: 'gap-1.75 rounded-lg px-2.75 py-1.75 text-base text-on-accent hover:bg-accent-strong',
     onAccentSymbol: 'size-9.5 justify-center rounded-lg text-on-accent hover:bg-accent-strong',

--- a/frontend/src/Client.App/src/mailSpace/MailSpace.test.tsx
+++ b/frontend/src/Client.App/src/mailSpace/MailSpace.test.tsx
@@ -3,10 +3,11 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { useEffect } from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, renderHook, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ComposingContext, type Composing } from '../composer/useComposing';
 import { LocalizationProvider } from '../localization/Localization';
+import { ScreenLayersContext, useScreenLayerStack, type ScreenLayers } from '../shell/screenLayers';
 import { WorkspaceProvider } from '../workspace/Workspace';
 import { useWorkspace, type Workspace } from '../workspace/useWorkspace';
 import { listWidthStep, readListWidth, startingListWidth, storeListWidth } from './listWidth';
@@ -27,20 +28,63 @@ const declaredMatchMedia = Object.getOwnPropertyDescriptor(window, 'matchMedia')
 const declaredShowModal = Object.getOwnPropertyDescriptor(HTMLDialogElement.prototype, 'showModal');
 const declaredClose = Object.getOwnPropertyDescriptor(HTMLDialogElement.prototype, 'close');
 
-function atWidth(wide: boolean): void {
+// The three breakpoints answer separately, which is what makes the four compositions distinguishable here at all: the
+// space asks whether there is room for two panes, whether the mailboxes have a column, and whether the toolbar is drawn,
+// and each is its own width. The query carries that width, so it is read out of the query rather than from a table this
+// file would have to keep in step with the stylesheet. A query naming no width is not one of the three and matches
+// nothing. The listeners are kept because a composition also changes under a window somebody drags, which is what
+// `theWindowBecomes` below is: the same screen, told it has another width.
+let watching: (() => void)[] = [];
+let room = 0;
+
+function atWidth(pixels: number): void {
+    watching = [];
+    room = pixels;
+
     Object.defineProperty(window, 'matchMedia', {
         configurable: true,
-        value: (query: string) => ({
-            matches: wide,
-            media: query,
-            addEventListener: () => undefined,
-            removeEventListener: () => undefined,
-        }),
+        value: (query: string) => {
+            const named = /([\d.]+)rem/.exec(query)?.[1];
+
+            return {
+                matches: named !== undefined && room >= Number(named) * 16,
+                media: query,
+                addEventListener: (_: string, watch: () => void) => {
+                    watching.push(watch);
+                },
+                removeEventListener: (_: string, watch: () => void) => {
+                    watching = watching.filter((watched) => watched !== watch);
+                },
+            };
+        },
     });
 }
 
+/** A window dragged to another width, which is the one thing a composition changes on while a screen stays put. */
+function theWindowBecomes(pixels: number): void {
+    room = pixels;
+
+    act(() => {
+        for (const watch of [...watching]) {
+            watch();
+        }
+    });
+}
+
+// The four widths the design project frames its compositions at, named here so a test says which composition it is
+// about rather than repeating a number.
+const phone = 390;
+const fold = 884;
+const tablet = 1024;
+const desktop = 1440;
+
 // The drawer is the platform's own modal dialog, which jsdom implements none of: opening and closing it are recorded
 // as the `open` attribute the platform would set and clear, which is what every assertion below reads.
+//
+// Closing also fires the `close` event, because that is what the space listens to rather than a value of its own —
+// whichever way out was taken, the control inside the drawer, Escape, or the folder that was picked in it. A double
+// that only flipped the attribute would leave every one of those paths asserting a screen the component's own state
+// had stopped agreeing with.
 function withModalDialogs(): void {
     Object.defineProperty(HTMLDialogElement.prototype, 'showModal', {
         configurable: true,
@@ -51,7 +95,12 @@ function withModalDialogs(): void {
     Object.defineProperty(HTMLDialogElement.prototype, 'close', {
         configurable: true,
         value(this: HTMLDialogElement) {
+            if (!this.hasAttribute('open')) {
+                return;
+            }
+
             this.removeAttribute('open');
+            this.dispatchEvent(new Event('close'));
         },
     });
 }
@@ -93,37 +142,46 @@ const nothingBeingWritten = {
 };
 
 function renderSpace(
-    wide: boolean,
+    pixels: number,
     opening: Partial<Workspace> = {},
     person: string | null = 'reader',
     composing: Composing = nothingBeingWritten,
-): void {
-    atWidth(wide);
+): { readonly current: ScreenLayers } {
+    atWidth(pixels);
     withModalDialogs();
+
+    // The shell the space is drawn inside, so what it opens over the screen is recorded where the back gesture would
+    // find it. Its three functions are the same ones for the life of the stack, so the value handed to the provider
+    // stays current however the count moves.
+    const { result } = renderHook(() => useScreenLayerStack());
 
     render(
         <LocalizationProvider>
-            <WorkspaceProvider>
-                <ComposingContext value={composing}>
-                    <Opening change={opening} />
-                    <MailSpace
-                        folders={
-                            <>
-                                <p>{handedTheFolders}</p>
-                                <ChooseInbox />
-                            </>
-                        }
-                        list={<p>{handedTheList}</p>}
-                        mail={<p>{handedToMail}</p>}
-                        tabs={<p>{handedTheTabs}</p>}
-                        intent={<p>{handedTheIntent}</p>}
-                        status={<p>{handedTheStatus}</p>}
-                        person={person}
-                    />
-                </ComposingContext>
-            </WorkspaceProvider>
+            <ScreenLayersContext value={result.current}>
+                <WorkspaceProvider>
+                    <ComposingContext value={composing}>
+                        <Opening change={opening} />
+                        <MailSpace
+                            folders={
+                                <>
+                                    <p>{handedTheFolders}</p>
+                                    <ChooseInbox />
+                                </>
+                            }
+                            list={<p>{handedTheList}</p>}
+                            mail={<p>{handedToMail}</p>}
+                            tabs={<p>{handedTheTabs}</p>}
+                            intent={<p>{handedTheIntent}</p>}
+                            status={<p>{handedTheStatus}</p>}
+                            person={person}
+                        />
+                    </ComposingContext>
+                </WorkspaceProvider>
+            </ScreenLayersContext>
         </LocalizationProvider>,
     );
+
+    return result;
 }
 
 // The two things the space does differently once writing a message is on offer: the corner control becomes one that
@@ -159,13 +217,13 @@ describe('MailSpace, wide', () => {
     it('puts a grip on the boundary, at the width this person last settled on', () => {
         storeListWidth('karolina', 420);
 
-        renderSpace(true, {}, 'karolina');
+        renderSpace(desktop, {}, 'karolina');
 
         expect(screen.getByRole('separator', { name: 'Message list width' }).getAttribute('aria-valuenow')).toBe('420');
     });
 
     it('opens at the starting width for somebody who has settled on none', () => {
-        renderSpace(true, {}, 'marta');
+        renderSpace(desktop, {}, 'marta');
 
         expect(screen.getByRole('separator', { name: 'Message list width' }).getAttribute('aria-valuenow')).toBe(
             String(startingListWidth),
@@ -173,7 +231,7 @@ describe('MailSpace, wide', () => {
     });
 
     it('keeps the width a reader moves the grip to, and offers it back on the next start', () => {
-        renderSpace(true, {}, 'karolina');
+        renderSpace(desktop, {}, 'karolina');
 
         fireEvent.keyDown(screen.getByRole('separator', { name: 'Message list width' }), { key: 'ArrowRight' });
 
@@ -184,7 +242,7 @@ describe('MailSpace, wide', () => {
     });
 
     it('moves the boundary while the grip is being dragged, and settles where it was let go', () => {
-        renderSpace(true, {}, 'karolina');
+        renderSpace(desktop, {}, 'karolina');
 
         const grip = screen.getByRole('separator', { name: 'Message list width' });
         fireEvent.pointerDown(grip, { pointerId: 1, clientX: 600 });
@@ -199,7 +257,7 @@ describe('MailSpace, wide', () => {
     });
 
     it('draws the three columns side by side, with the toolbar over them', () => {
-        renderSpace(true);
+        renderSpace(desktop);
 
         expect(screen.getByRole('toolbar', { name: 'Mail actions' })).toBeDefined();
         expect(screen.getByRole('complementary', { name: 'Folders and filters' })).toBeDefined();
@@ -211,7 +269,7 @@ describe('MailSpace, wide', () => {
     });
 
     it('puts the connection at the foot of the mailbox column and the question at the foot of the reading column', () => {
-        renderSpace(true);
+        renderSpace(desktop);
 
         expect(screen.getByRole('complementary').contains(screen.getByText(handedTheStatus))).toBe(true);
         expect(screen.getByRole('region', { name: 'What is open' }).contains(screen.getByText(handedTheIntent))).toBe(
@@ -220,7 +278,7 @@ describe('MailSpace, wide', () => {
     });
 
     it('folds the mailbox column to a rail and opens it again, from a control named for each', () => {
-        renderSpace(true);
+        renderSpace(desktop);
 
         fireEvent.click(screen.getByRole('button', { name: 'Collapse the mailbox column' }));
 
@@ -234,7 +292,7 @@ describe('MailSpace, wide', () => {
     });
 
     it('keeps the mailboxes in the folded rail, and drops what a rail has no room to say', () => {
-        renderSpace(true);
+        renderSpace(desktop);
 
         fireEvent.click(screen.getByRole('button', { name: 'Collapse the mailbox column' }));
 
@@ -244,7 +302,7 @@ describe('MailSpace, wide', () => {
     });
 
     it('draws the AI filters as symbols in the folded rail, where their names would not fit', () => {
-        renderSpace(true);
+        renderSpace(desktop);
 
         fireEvent.click(screen.getByRole('button', { name: 'Collapse the mailbox column' }));
 
@@ -256,7 +314,7 @@ describe('MailSpace, wide', () => {
     });
 
     it('draws every action of the toolbar, each saying in its own name why it cannot act here', () => {
-        renderSpace(true);
+        renderSpace(desktop);
 
         const toolbar = screen.getByRole('toolbar', { name: 'Mail actions' });
 
@@ -282,7 +340,7 @@ describe('MailSpace, wide', () => {
     });
 
     it('puts the strip of what is open above the toolbar, over the whole width', () => {
-        renderSpace(true);
+        renderSpace(desktop);
 
         const strip = screen.getByText(handedTheTabs);
 
@@ -292,7 +350,7 @@ describe('MailSpace, wide', () => {
     });
 
     it('offers the three AI filters as what the product will have rather than as working controls', () => {
-        renderSpace(true);
+        renderSpace(desktop);
 
         const filters = screen.getByRole('region', { name: 'AI filters' });
 
@@ -302,19 +360,19 @@ describe('MailSpace, wide', () => {
 
 describe('MailSpace, narrow', () => {
     it('draws no grip, because one column at a time has no boundary to move', () => {
-        renderSpace(false);
+        renderSpace(phone);
 
         expect(screen.queryByRole('separator', { name: 'Message list width' })).toBeNull();
     });
 
     it('draws no strip of what is open, there being no room above one column for a row of tabs', () => {
-        renderSpace(false);
+        renderSpace(phone);
 
         expect(screen.queryByText(handedTheTabs)).toBeNull();
     });
 
     it('draws the list alone while nothing is open, with the mailboxes behind a control and no toolbar', () => {
-        renderSpace(false);
+        renderSpace(phone);
 
         expect(screen.getByText(handedTheList)).toBeDefined();
         expect(screen.queryByText(handedToMail)).toBeNull();
@@ -324,14 +382,14 @@ describe('MailSpace, narrow', () => {
     });
 
     it('draws a corner control that works where writing a message is on offer', () => {
-        renderSpace(false, {}, 'reader', writingIsOffered);
+        renderSpace(phone, {}, 'reader', writingIsOffered);
 
         expect(screen.getByRole('button', { name: 'New message' })).toBeDefined();
         expect(screen.queryByRole('button', { name: 'New message — not built yet' })).toBeNull();
     });
 
     it('brings the reading column in front of the list for a message being written, as it does for one being read', () => {
-        renderSpace(false, {}, 'reader', somethingBeingWritten);
+        renderSpace(phone, {}, 'reader', somethingBeingWritten);
 
         expect(screen.getByText(handedToMail)).toBeDefined();
         expect(screen.queryByText(handedTheList)).toBeNull();
@@ -341,7 +399,7 @@ describe('MailSpace, narrow', () => {
     });
 
     it('opens the mailboxes in a drawer that closes from its own control', () => {
-        renderSpace(false);
+        const shell = renderSpace(phone);
 
         fireEvent.click(screen.getByRole('button', { name: 'Folders and filters' }));
         const drawer = screen.getByRole('dialog', { name: 'Folders and filters' });
@@ -352,23 +410,59 @@ describe('MailSpace, narrow', () => {
 
         fireEvent.click(screen.getByRole('button', { name: 'Close the folders' }));
 
+        // The shell's record of it goes with the drawer itself: a step left on the stack is a press of the back
+        // gesture spent closing something that is no longer there.
         expect(drawer.hasAttribute('open')).toBe(false);
+        expect(shell.current.depth).toBe(0);
+    });
+
+    // A window widened past the room for a mailbox column takes the drawer off the screen with it, and nothing it
+    // would have closed by fires: the element is simply gone. What must not be left behind is the shell's record of
+    // it, which is a step the back gesture would spend on a surface nobody can see.
+    it('leaves nothing standing over the screen once the window widens to a mailbox column', () => {
+        const shell = renderSpace(tablet);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Folders and filters' }));
+        expect(shell.current.depth).toBe(1);
+
+        theWindowBecomes(desktop);
+
+        expect(shell.current.depth).toBe(0);
     });
 
     it('closes the drawer once a scope is chosen in it, because the mail is behind it', () => {
-        renderSpace(false);
+        const shell = renderSpace(phone);
 
         fireEvent.click(screen.getByRole('button', { name: 'Folders and filters' }));
         const drawer = screen.getByRole('dialog', { name: 'Folders and filters' });
         expect(drawer.hasAttribute('open')).toBe(true);
+        expect(shell.current.depth).toBe(1);
 
         fireEvent.click(screen.getByRole('button', { name: chooseTheInbox }));
 
         expect(drawer.hasAttribute('open')).toBe(false);
+        expect(shell.current.depth).toBe(0);
+    });
+
+    // The back gesture is the third way out of it, and the only one that reaches the drawer through the shell rather
+    // than through a control on the screen. What it closes is the same element by the same method, which is what the
+    // registration holds.
+    it('closes the drawer when the back gesture reaches it', () => {
+        const shell = renderSpace(phone);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Folders and filters' }));
+        const drawer = screen.getByRole('dialog', { name: 'Folders and filters' });
+
+        act(() => {
+            shell.current.closeTop();
+        });
+
+        expect(drawer.hasAttribute('open')).toBe(false);
+        expect(shell.current.depth).toBe(0);
     });
 
     it('puts the message in front of the list once one is open, and returns to the list from it', () => {
-        renderSpace(false, { selection: 'stored-1' });
+        renderSpace(phone, { selection: 'stored-1' });
 
         expect(screen.getByText(handedToMail)).toBeDefined();
         expect(screen.queryByText(handedTheList)).toBeNull();
@@ -381,10 +475,58 @@ describe('MailSpace, narrow', () => {
     });
 
     it('puts focus at the start of the list on the way back, which is a view change', () => {
-        renderSpace(false, { selection: 'stored-1' });
+        renderSpace(phone, { selection: 'stored-1' });
 
         fireEvent.click(screen.getByRole('button', { name: 'Back to the list' }));
 
         expect(document.activeElement).toBe(screen.getByRole('region', { name: 'Message list' }));
+    });
+});
+
+// The four compositions the design project frames, each at the width it frames it at. Three separate questions decide
+// them rather than one asked three ways, so the fold and the tablet are stated as cases of their own: both carry two
+// panes and keep the mailboxes behind a control, which is neither the phone's composition nor the desktop's.
+describe('MailSpace, in the four compositions', () => {
+    it('shows the list alone at a phone width, with a message coming in front of it rather than beside it', () => {
+        renderSpace(phone, { selection: 'stored-1' });
+
+        expect(screen.getByText(handedToMail)).toBeDefined();
+        expect(screen.queryByText(handedTheList)).toBeNull();
+    });
+
+    it('shows the list and the message together at the fold, which is above the width one pane stops at', () => {
+        renderSpace(fold, { selection: 'stored-1' });
+
+        expect(screen.getByText(handedTheList)).toBeDefined();
+        expect(screen.getByText(handedToMail)).toBeDefined();
+        expect(screen.queryByRole('button', { name: 'Back to the list' })).toBeNull();
+    });
+
+    it('keeps the mailboxes behind a control at the fold, there being no room for a column of them', () => {
+        renderSpace(fold);
+
+        expect(screen.getByRole('button', { name: 'Folders and filters' })).toBeDefined();
+        expect(screen.queryByRole('complementary', { name: 'Folders and filters' })).toBeNull();
+    });
+
+    it('keeps the mailboxes behind a control at a tablet width as well, which is the same composition', () => {
+        renderSpace(tablet);
+
+        expect(screen.getByText(handedTheList)).toBeDefined();
+        expect(screen.getByText(handedToMail)).toBeDefined();
+        expect(screen.getByRole('button', { name: 'Folders and filters' })).toBeDefined();
+    });
+
+    it('gives the mailboxes a column of their own at a desktop width, rather than a control that opens one', () => {
+        renderSpace(desktop);
+
+        expect(screen.getByRole('complementary', { name: 'Folders and filters' })).toBeDefined();
+        expect(screen.queryByRole('button', { name: 'Folders and filters' })).toBeNull();
+    });
+
+    it('draws the strip of what is open only in the desktop composition, which is the only one with room above two columns', () => {
+        renderSpace(tablet);
+
+        expect(screen.queryByText(handedTheTabs)).toBeNull();
     });
 });

--- a/frontend/src/Client.App/src/mailSpace/MailSpace.tsx
+++ b/frontend/src/Client.App/src/mailSpace/MailSpace.tsx
@@ -8,7 +8,8 @@ import { Control } from '../controls/Control';
 import { Icon } from '../controls/Icon';
 import { PlannedControl } from '../controls/PlannedControl';
 import { useLocalization } from '../localization/useLocalization';
-import { useWideWorkspace } from '../shell/useWideWorkspace';
+import { useScreenLayer } from '../shell/screenLayers';
+import { useDesktopComposition, useTwoPanes, useWideWorkspace } from '../shell/useWideWorkspace';
 import { scopeKey } from '../workspace/mailScope';
 import { useWorkspace } from '../workspace/useWorkspace';
 import { AiFilters } from './AiFilters';
@@ -19,18 +20,28 @@ import { SelectionBar } from './SelectionBar';
 
 // The Mail space as the design project composes it, out of the three regions a mail client is: the mailboxes, the list
 // of what is in the one that is scoped, and what is open from it. What this component owns is the composition alone —
-// each region is handed in already built — and the composition is two shapes out of one tree, decided by the width the
-// space has been given rather than by which head it runs on.
+// each region is handed in already built — and the composition comes out of one tree, decided by the width the space
+// has been given rather than by which head it runs on.
 //
-// Wide, it is the toolbar over three columns: a mailbox column that folds to a strip, the list at the width the design
-// gives it, and the reading pane taking the rest. Narrow, it is one column at a time: the list first, with the mailboxes
-// behind a control and the message in front of the list once one is open, and a way back from each. Nothing is hidden
-// by the width alone; what the narrow shape cannot show at once is reached rather than dropped.
+// **Three widths decide it, and they are three separate questions rather than one asked three ways.** The design
+// project's prototype asks exactly these, and `shell/useWideWorkspace.ts` is where each is asked once:
 //
-// Where focus goes when the narrow shape changes what it shows is this component's too: a message coming in front of
-// the list is a view change, and so is going back, and a reader on a keyboard is put at the start of what replaced what
-// they were on rather than left on an element that is no longer there. A resize that changes the shape is not, so the
-// width changing moves nothing.
+// - *Two panes or one.* Below that width the space draws the list **or** what is open and never both, so a row that is
+//   not on the screen is not in the document either; above it the two stand side by side with a boundary to move.
+// - *The mailbox column or a drawer.* Only the desktop composition has room for a third column, so at the tablet and
+//   the fold the mailboxes stand in a drawer over the space, reached from a control in the list's own header.
+// - *The toolbar at all*, which is the phone question: bottom navigation already spends the foot of a phone-width
+//   window, and the toolbar's acts are on the selection bar and the message's own head there.
+//
+// So the four compositions the project frames fall out of those three: the phone has one pane, a drawer and no toolbar;
+// the fold and the tablet have two panes, a drawer and a toolbar; the desktop has two panes, the mailbox column and the
+// tab strip. Nothing is hidden by the width alone; what a narrower composition cannot show at once is reached rather
+// than dropped.
+//
+// Where focus goes when the single-pane shape changes what it shows is this component's too: a message coming in front
+// of the list is a view change, and so is going back, and a reader on a keyboard is put at the start of what replaced
+// what they were on rather than left on an element that is no longer there. A resize that changes the shape is not, so
+// the width changing moves nothing.
 //
 // How the wide shape divides its width between the list and the pane is the reader's, and this is where that lives: it
 // is the composition's own number rather than either column's, and only the shape that draws both columns has a
@@ -87,7 +98,10 @@ export function MailSpace({
     const { workspace, revise } = useWorkspace();
     const composing = useComposing();
     const wide = useWideWorkspace();
+    const twoPanes = useTwoPanes();
+    const desktop = useDesktopComposition();
     const [listWidth, setListWidth] = useState(() => readListWidth(person));
+    const [drawerOpen, setDrawerOpen] = useState(false);
     const drawer = useRef<HTMLDialogElement>(null);
     const listColumn = useRef<HTMLElement>(null);
     const readingColumn = useRef<HTMLElement>(null);
@@ -95,7 +109,7 @@ export function MailSpace({
     // What is being written stands where what is being read stands, so the narrow shape brings the reading column
     // in front of the list for a message somebody is writing exactly as it does for one they opened.
     const readingInFront =
-        !wide && (workspace.selection !== null || workspace.conversation !== null || composing.opening !== null);
+        !twoPanes && (workspace.selection !== null || workspace.conversation !== null || composing.opening !== null);
 
     // Read from the workspace rather than held here, because the column is not the only thing that draws differently
     // once it is folded: the tree inside it draws a symbol where it drew a name, and the tree is a region handed in
@@ -113,7 +127,7 @@ export function MailSpace({
         const listed = listColumn.current;
         const reading = readingColumn.current;
 
-        if (!wide || listed === null || reading === null || typeof ResizeObserver !== 'function') {
+        if (!twoPanes || listed === null || reading === null || typeof ResizeObserver !== 'function') {
             return;
         }
 
@@ -131,20 +145,20 @@ export function MailSpace({
         return () => {
             watched.disconnect();
         };
-    }, [wide]);
+    }, [twoPanes]);
 
     // Focus is placed on the shape changing what it shows, and not on the width changing the shape: both are recorded
     // and only the first moves anything. A ref rather than state, because what it holds is what was last drawn.
-    const shown = useRef({ wide, readingInFront });
+    const shown = useRef({ twoPanes, readingInFront });
 
     useEffect(() => {
         const before = shown.current;
-        shown.current = { wide, readingInFront };
+        shown.current = { twoPanes, readingInFront };
 
-        if (before.wide === wide && before.readingInFront !== readingInFront) {
+        if (before.twoPanes === twoPanes && before.readingInFront !== readingInFront) {
             (readingInFront ? readingColumn : listColumn).current?.focus();
         }
-    }, [wide, readingInFront]);
+    }, [twoPanes, readingInFront]);
 
     // The drawer is a way to point at a mailbox, so pointing at one closes it: a reader who chose a folder wants the
     // folder's mail, which is behind the drawer they chose it in. The dialog is the platform's own, so closing it puts
@@ -158,6 +172,25 @@ export function MailSpace({
             drawer.current?.close();
         }
     }, [scope]);
+
+    // The drawer belongs to the two compositions with no room for a mailbox column, so a window widened past that room
+    // takes it off the screen without any way out of it firing `close`. What it was is given up as the composition
+    // changes rather than in an effect answering that it did: the width is what caused it, so a render answers it and
+    // nothing is left standing for a frame. Narrowing again therefore finds a drawer that is shut, which is what it is.
+    const [composedForDesktop, setComposedForDesktop] = useState(desktop);
+
+    if (composedForDesktop !== desktop) {
+        setComposedForDesktop(desktop);
+        setDrawerOpen(false);
+    }
+
+    // The drawer stands over the space rather than beside it, so the back gesture closes it before it takes a message
+    // off the screen, and taking the navigation to another destination leaves none of it behind. Whether it is open is
+    // held here because the platform publishes no such value: `close` is the one event every way out of it fires — the
+    // control inside it, Escape, and the back gesture alike — so this cannot disagree with what is on the screen.
+    useScreenLayer(drawerOpen, () => {
+        drawer.current?.close();
+    });
 
     function goBackToList(): void {
         revise({ selection: null, conversation: null });
@@ -174,7 +207,7 @@ export function MailSpace({
 
     return (
         <div className="flex min-h-0 flex-1 flex-col">
-            {wide ? tabs : null}
+            {desktop ? tabs : null}
 
             {/* The bar replaces the toolbar while messages are picked out, which is the design project's composition:
                 one strip saying what the next press is about. It stands at every width because the narrow shape has no
@@ -182,7 +215,7 @@ export function MailSpace({
             {workspace.selected.length > 0 ? <SelectionBar /> : wide ? <MailToolbar /> : null}
 
             <div className="flex min-h-0 flex-1">
-                {wide ? (
+                {desktop ? (
                     <aside
                         aria-label={translate('mailboxes.open')}
                         className={`flex shrink-0 flex-col border-e border-line bg-sunken ${folded ? 'w-mailboxes-folded' : 'w-mailboxes'}`}
@@ -205,8 +238,13 @@ export function MailSpace({
                 ) : (
                     <dialog
                         ref={drawer}
+                        onClose={() => {
+                            setDrawerOpen(false);
+                        }}
                         aria-label={translate('mailboxes.open')}
-                        className="fixed inset-y-0 left-0 m-0 h-full max-h-none w-drawer max-w-full border-0 border-e border-line bg-sunken p-0 text-text shadow-overlay backdrop:bg-scrim"
+                        // It stands in the platform's top layer, which the frame's own safe-area padding is not around,
+                        // so a drawer running the height of the screen carries the insets it crosses itself.
+                        className="fixed inset-y-0 left-0 m-0 h-full max-h-none w-drawer max-w-full border-0 border-e border-line bg-sunken p-0 pt-safe-top pb-safe-bottom pl-safe-left text-text shadow-overlay backdrop:bg-scrim"
                     >
                         <div className="flex h-full flex-col">
                             <Mailboxes
@@ -227,12 +265,12 @@ export function MailSpace({
                     </dialog>
                 )}
 
-                {wide || !readingInFront ? (
+                {twoPanes || !readingInFront ? (
                     <section
                         ref={listColumn}
                         tabIndex={-1}
                         aria-label={translate('mail.listColumn')}
-                        className={`flex min-h-0 min-w-0 flex-col bg-panel ${wide ? '' : 'flex-1'}`}
+                        className={`flex min-h-0 min-w-0 flex-col bg-panel ${twoPanes ? '' : 'flex-1'}`}
                         /* The one width in the client a person sets rather than the design, which is why it is drawn
                            from a value instead of a utility. The narrow shape has no boundary to move, so it takes the
                            whole column and this says nothing about it.
@@ -240,15 +278,16 @@ export function MailSpace({
                            anything has measured this one, and a column that refuses to give way in that frame would
                            push the message off the side. Flexbox holds it inside the window until the measurement
                            below brings it back to a width that fits. */
-                        style={wide ? { width: `${String(listWidth)}px` } : undefined}
+                        style={twoPanes ? { width: `${String(listWidth)}px` } : undefined}
                     >
-                        {wide ? null : (
+                        {desktop ? null : (
                             <div className="flex items-center px-2 pt-2">
                                 <ColumnControl
                                     label={translate('mailboxes.open')}
                                     icon="menu"
                                     onActivate={() => {
                                         drawer.current?.showModal();
+                                        setDrawerOpen(true);
                                     }}
                                 />
                             </div>
@@ -256,13 +295,13 @@ export function MailSpace({
 
                         {list}
 
-                        {wide ? null : intent}
+                        {twoPanes ? null : intent}
                     </section>
                 ) : null}
 
                 {/* The boundary is only there where both columns are: one column at a time has nothing between them,
                     and the line the grip draws is the border the list would otherwise carry. */}
-                {wide ? (
+                {twoPanes ? (
                     <ListWidthGrip
                         width={listWidth}
                         onWidth={(moved) => {
@@ -277,14 +316,14 @@ export function MailSpace({
                     />
                 ) : null}
 
-                {wide || readingInFront ? (
+                {twoPanes || readingInFront ? (
                     <section
                         ref={readingColumn}
                         tabIndex={-1}
                         aria-label={translate('mail.readingColumn')}
                         className="flex min-h-0 min-w-0 flex-1 flex-col bg-panel"
                     >
-                        {wide ? null : (
+                        {twoPanes ? null : (
                             <div className="flex items-center px-2 pt-2">
                                 <button
                                     type="button"
@@ -310,7 +349,7 @@ export function MailSpace({
 
             {/* Composing stands on the list in the narrow shape, where the toolbar carrying it is not drawn: the one
                 thing a phone-width reader reaches for from the list, at the corner a thumb reaches. */}
-            {wide || readingInFront ? null : composing.offered ? (
+            {twoPanes || readingInFront ? null : composing.offered ? (
                 <Control
                     label={translate('mail.compose')}
                     icon="edit_square"

--- a/frontend/src/Client.App/src/mailSpace/MailToolbar.test.tsx
+++ b/frontend/src/Client.App/src/mailSpace/MailToolbar.test.tsx
@@ -4,7 +4,7 @@
 
 import { useEffect } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Composing } from '../composer/useComposing';
 import { ComposingContext } from '../composer/useComposing';
 import { LocalizationProvider } from '../localization/Localization';
@@ -15,6 +15,34 @@ import { useWorkspace } from '../workspace/useWorkspace';
 import { MailToolbar } from './MailToolbar';
 
 const messageId = '00000000-0000-4000-8000-000000000000';
+
+// jsdom has no width, so the composition the strip is drawn in is answered here. A runtime that cannot answer at all
+// reads as the widest, which is what every test below that says nothing about a width is asking about.
+const declaredMatchMedia = Object.getOwnPropertyDescriptor(window, 'matchMedia');
+
+function atWidth(pixels: number): void {
+    Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        value: (query: string) => {
+            const named = /([\d.]+)rem/.exec(query)?.[1];
+
+            return {
+                matches: named !== undefined && pixels >= Number(named) * 16,
+                media: query,
+                addEventListener: () => undefined,
+                removeEventListener: () => undefined,
+            };
+        },
+    });
+}
+
+afterEach(() => {
+    if (declaredMatchMedia === undefined) {
+        Reflect.deleteProperty(window, 'matchMedia');
+    } else {
+        Object.defineProperty(window, 'matchMedia', declaredMatchMedia);
+    }
+});
 
 const place = { storedEmailId: messageId, account: 'work', folder: 'work-inbox' };
 
@@ -130,6 +158,26 @@ describe('MailToolbar', () => {
 
         expect(performed).not.toHaveBeenCalled();
         expect(screen.getByRole('heading', { name: 'Delete 1 message?' })).toBeDefined();
+    });
+
+    it('draws each control as its symbol alone where there is no room for a mailbox column beside it', () => {
+        atWidth(1024);
+
+        drawToolbar(true, messageId, actsOffering(vi.fn()));
+
+        for (const name of ['New message', 'Reply', 'Archive']) {
+            expect(screen.getByRole('button', { name }).textContent).toBe('');
+        }
+    });
+
+    it('gives every control its name in words in the composition wide enough to read them', () => {
+        atWidth(1440);
+
+        drawToolbar(true, messageId, actsOffering(vi.fn()));
+
+        for (const name of ['New message', 'Reply', 'Archive']) {
+            expect(screen.getByRole('button', { name }).textContent).toBe(name);
+        }
     });
 
     it('asks about no message at all while nothing is open, rather than about the last one that was', () => {

--- a/frontend/src/Client.App/src/mailSpace/MailToolbar.tsx
+++ b/frontend/src/Client.App/src/mailSpace/MailToolbar.tsx
@@ -5,12 +5,14 @@
 import type { MailDraftAnswer } from '@mailfathom/client-backend';
 import { useComposing } from '../composer/useComposing';
 import { Control } from '../controls/Control';
+import type { ControlShape } from '../controls/controlShapes';
 import type { IconName } from '../controls/icons';
 import { PlannedControl } from '../controls/PlannedControl';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
 import { MailboxActControls } from '../mailboxActs/MailboxActControls';
 import { actedMessages, useListedMail } from '../messageList/useListedMail';
+import { useDesktopComposition } from '../shell/useWideWorkspace';
 import { useWorkspace } from '../workspace/useWorkspace';
 
 // The strip the design project draws across the top of the Mail space: composing, and the eight things a person does
@@ -21,6 +23,12 @@ import { useWorkspace } from '../workspace/useWorkspace';
 // components below the frame that knows either, and neither is this strip's to own: the mail space already reads the
 // workspace, the composer is asked for from three unrelated places, which is what `useComposing` exists for, and where
 // the open message belongs is the list's, which is what `useListedMail` exists for.
+//
+// **How wide a control is drawn is the strip's own question**, and it is asked here rather than passed in for the same
+// reason: the design gives every control its name in words only in the composition that has room for a mailbox column
+// beside them, and draws the symbols alone at the tablet, the fold, and anywhere narrower. Nine names across a strip
+// that is already sharing its width with two panes is a strip that scrolls sideways, which is the one thing a toolbar
+// may not do.
 
 // Answering a message: which of the three answers each control writes, and the symbol and name the design gives it.
 const answers: readonly { readonly answer: MailDraftAnswer; readonly icon: IconName; readonly label: MessageKey }[] = [
@@ -35,6 +43,9 @@ export function MailToolbar() {
     const composing = useComposing();
     const listed = useListedMail();
     const open = workspace.selection;
+    const desktop = useDesktopComposition();
+    const composeShape: ControlShape = desktop ? 'primary' : 'primarySymbol';
+    const actShape: ControlShape = desktop ? 'labelled' : 'symbol';
 
     return (
         <div
@@ -46,13 +57,13 @@ export function MailToolbar() {
                 <Control
                     label={translate('mail.compose')}
                     icon="edit_square"
-                    shape="primary"
+                    shape={composeShape}
                     onPress={() => {
                         composing.compose({ kind: 'new' });
                     }}
                 />
             ) : (
-                <PlannedControl label={translate('mail.compose')} icon="edit_square" shape="primary" />
+                <PlannedControl label={translate('mail.compose')} icon="edit_square" shape={composeShape} />
             )}
 
             <span aria-hidden="true" className="mx-0.5 w-px self-stretch bg-line" />
@@ -66,7 +77,7 @@ export function MailToolbar() {
                         key={answering.icon}
                         label={translate(answering.label)}
                         icon={answering.icon}
-                        shape="symbol"
+                        shape={actShape}
                         onPress={() => {
                             composing.compose({ kind: 'answer', answers: answering.answer, storedEmailId: open });
                         }}
@@ -76,14 +87,14 @@ export function MailToolbar() {
                         key={answering.icon}
                         label={translate(answering.label)}
                         icon={answering.icon}
-                        shape="symbol"
+                        shape={actShape}
                     />
                 ),
             )}
 
             {/* The five that change the mailbox, over the one message that is open. With nothing open each of them
                 says so rather than being left out, for the reason the three answers above are drawn either way. */}
-            <MailboxActControls messages={open === null ? [] : actedMessages(listed, [open])} shape="symbol" />
+            <MailboxActControls messages={open === null ? [] : actedMessages(listed, [open])} shape={actShape} />
         </div>
     );
 }

--- a/frontend/src/Client.App/src/notifications/NotificationCentre.test.tsx
+++ b/frontend/src/Client.App/src/notifications/NotificationCentre.test.tsx
@@ -2,10 +2,11 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, renderHook, screen, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ClientNotification } from '@mailfathom/client-backend';
 import { LocalizationProvider } from '../localization/Localization';
+import { ScreenLayersContext, useScreenLayerStack, type ScreenLayers } from '../shell/screenLayers';
 import { NotificationCentre } from './NotificationCentre';
 import type { NotificationCentre as Centre } from './useNotificationCentre';
 import type { PanelSwipe } from './usePanelSwipe';
@@ -69,12 +70,21 @@ function centre(held: Partial<Centre> = {}): Centre {
     };
 }
 
-function panel(held: Partial<Centre> = {}): void {
+function panel(held: Partial<Centre> = {}): { readonly current: ScreenLayers } {
+    // The shell around it, because the panel records itself as standing over the screen while it is shown. Its three
+    // functions are the same ones for the life of the stack, so the value handed to the provider stays current
+    // however the count moves.
+    const { result } = renderHook(() => useScreenLayerStack());
+
     render(
         <LocalizationProvider>
-            <NotificationCentre centre={centre(held)} swipe={swipe} />
+            <ScreenLayersContext value={result.current}>
+                <NotificationCentre centre={centre(held)} swipe={swipe} />
+            </ScreenLayersContext>
         </LocalizationProvider>,
     );
+
+    return result;
 }
 
 /** The row naming this notification, which is the list item its title sits in. */
@@ -295,5 +305,26 @@ describe('NotificationCentre', () => {
 
         expect(screen.queryByRole('menuitem', { name: 'Open the source' })).toBeNull();
         expect(screen.getByRole('menuitem', { name: 'Mark as unread' })).toBeDefined();
+    });
+
+    // The panel covers what it was opened over, so the back gesture reaches it before it navigates and a change of
+    // destination leaves it behind. It is the panel's own way out that is recorded rather than a second one, which is
+    // what makes the gesture clear what was picked as well as close the panel.
+    it('leaves by its own way out when the back gesture reaches it', () => {
+        const shell = panel();
+
+        expect(shell.current.depth).toBe(1);
+
+        act(() => {
+            shell.current.closeTop();
+        });
+
+        expect(acts.hide).toHaveBeenCalled();
+    });
+
+    it('records nothing over the screen while the centre is not being shown', () => {
+        const shell = panel({ shown: false });
+
+        expect(shell.current.depth).toBe(0);
     });
 });

--- a/frontend/src/Client.App/src/notifications/NotificationCentre.tsx
+++ b/frontend/src/Client.App/src/notifications/NotificationCentre.tsx
@@ -10,6 +10,7 @@ import { Icon } from '../controls/Icon';
 import type { MenuPoint } from '../contextMenu/menuPlacement';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
+import { useScreenLayer } from '../shell/screenLayers';
 import { useCurrentMinute } from './notificationAge';
 import { NotificationRow } from './NotificationRow';
 import { NotificationRowMenu } from './NotificationRowMenu';
@@ -99,6 +100,13 @@ export function NotificationCentre({
         }
     }, [centre.shown]);
 
+    // It covers the screen it was opened over, so the back gesture closes it before it navigates anywhere and taking
+    // the navigation to another destination leaves it behind. What closing it does is the panel's own way out, which
+    // clears what was picked and any menu standing on it as well.
+    useScreenLayer(centre.shown, () => {
+        leave();
+    });
+
     const drawn = filter === 'unread' ? centre.notifications.filter((row) => !row.read) : centre.notifications;
     const picked = selected.filter((id) => centre.notifications.some((row) => row.id === id));
 
@@ -127,7 +135,10 @@ export function NotificationCentre({
             // The two compositions are the design project's own: a sheet that stops above the bottom navigation in a
             // narrow window, and a panel standing beside the rail in a wide one. Where it comes from differs with it,
             // which is what the two motions and the two closed positions below say.
-            className={`fixed inset-x-0 top-0 bottom-navigation m-0 hidden h-auto max-h-none w-auto max-w-none open:flex flex-col overflow-visible rounded-t-4xl border-line bg-panel text-text shadow-dialog backdrop:bg-scrim workspace:end-auto workspace:bottom-0 workspace:start-rail workspace:w-notifications workspace:rounded-none workspace:border-e ${
+            // The panel is in the platform's top layer, where the frame's safe-area padding is not around it: the top
+            // inset is padded away inside it, and the bottom one is a margin because what the sheet stops above is the
+            // bottom navigation, which the frame has already lifted clear of the gesture bar.
+            className={`fixed inset-x-0 top-0 bottom-navigation m-0 mb-safe-bottom hidden h-auto max-h-none w-auto max-w-none open:flex flex-col overflow-visible rounded-t-4xl border-line bg-panel pt-safe-top text-text shadow-dialog backdrop:bg-scrim workspace:end-auto workspace:bottom-0 workspace:start-rail workspace:w-notifications workspace:rounded-none workspace:border-e ${
                 swipe.dragging
                     ? 'transition-none'
                     : swipe.springing

--- a/frontend/src/Client.App/src/routing/useSpace.test.ts
+++ b/frontend/src/Client.App/src/routing/useSpace.test.ts
@@ -1,0 +1,51 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useSpace } from './useSpace';
+
+// The address bar is the one copy of which space is being shown, and correcting an address nobody answers is the one
+// write this hook makes to it. What is asserted here is that the correction leaves the entry otherwise as it found it:
+// the shell marks the entry showing with how many steps the back gesture has to unwind, and an address rewritten with
+// nothing in its place would spend one of those presses on an entry that no longer says what it is for.
+
+const stepsTaken = 'mailfathom.back';
+
+beforeEach(() => {
+    window.history.replaceState(null, '', '/');
+});
+
+describe('useSpace', () => {
+    it('answers with the space the address names, where it names one this credential is offered', () => {
+        window.history.replaceState(null, '', '#/mail');
+
+        const { result } = renderHook(() => useSpace(['discover', 'mail']));
+
+        expect(result.current).toBe('mail');
+    });
+
+    it('writes the space it fell back to into an address that named none', () => {
+        const { result } = renderHook(() => useSpace(['discover', 'mail']));
+
+        expect(result.current).toBe('discover');
+        expect(window.location.hash).toBe('#/discover');
+    });
+
+    it('carries the shell’s own mark across the address it corrects', () => {
+        window.history.replaceState({ [stepsTaken]: 2 }, '', '#/nowhere');
+
+        renderHook(() => useSpace(['discover', 'mail']));
+
+        expect(window.location.hash).toBe('#/discover');
+        expect(window.history.state).toStrictEqual({ [stepsTaken]: 2 });
+    });
+
+    it('answers with nothing where the grant carries no space at all, and writes no address', () => {
+        const { result } = renderHook(() => useSpace([]));
+
+        expect(result.current).toBeNull();
+        expect(window.location.hash).toBe('');
+    });
+});

--- a/frontend/src/Client.App/src/routing/useSpace.ts
+++ b/frontend/src/Client.App/src/routing/useSpace.ts
@@ -37,9 +37,13 @@ export function useSpace(offered: readonly Space[]): Space | null {
     // Replaced rather than pushed: a first load at the root, or a fragment nobody answers, would otherwise leave the
     // back gesture landing on an address that immediately corrects itself again. Nothing is written while the offered
     // spaces are unknown, so an address somebody arrived at survives the session being read.
+    //
+    // Whatever state the entry already carried is written back with it rather than replaced by nothing: an entry the
+    // shell marked is one press of the back gesture, and correcting the address on it would spend that press on an
+    // entry that no longer says what it is for. `shellOperations/backNavigation.ts` is what puts a mark there.
     useEffect(() => {
         if (space !== null && named !== space) {
-            window.history.replaceState(null, '', addressOf(space));
+            window.history.replaceState(window.history.state, '', addressOf(space));
         }
     }, [address, named, space]);
 

--- a/frontend/src/Client.App/src/settings/Settings.tsx
+++ b/frontend/src/Client.App/src/settings/Settings.tsx
@@ -10,6 +10,7 @@ import { VersionLine } from '../controls/VersionLine';
 import type { TelemetryForwarding } from '../deployment/telemetryForwarding';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
+import { useScreenLayer } from '../shell/screenLayers';
 import type { ClientPreferencesInForce } from '../preferences/useClientPreferences';
 import type { OwnProfileInForce } from '../profile/useOwnProfile';
 import { LanguageSegments } from '../shell/Preferences';
@@ -65,7 +66,12 @@ export function Settings({
     /** What the deployment answered it is running, or `null` while nothing has answered, for the line at the foot. */
     readonly deploymentVersion: string | null;
 
-    readonly onClose: () => void;
+    /**
+     * Leaves this screen, and says which of the two ways out did it: `false` for a control on the screen, Escape, or
+     * one press of the back gesture, and `true` for the shell clearing everything on the way to another destination.
+     * The menu this was opened from is put back by the first and by none of the second.
+     */
+    readonly onClose: (clearingTheScreen: boolean) => void;
 }) {
     const { translate } = useLocalization();
     const panel = useRef<HTMLDialogElement>(null);
@@ -79,12 +85,29 @@ export function Settings({
         panel.current?.showModal();
     }, []);
 
+    // It stands over whichever screen opened it, so the back gesture closes it before it navigates anywhere, and going
+    // to another destination leaves it behind rather than over the screen somebody arrives at.
+    // Which of the two asked, carried across the element's own `close` event, which says nothing about why it fired.
+    // Every way out of this screen arrives at `onClose` through that one event — which is what keeps this screen with
+    // one path out — so the answer is put down here and read on the other side of it.
+    const clearingTheScreen = useRef(false);
+
+    useScreenLayer(true, (clearing) => {
+        clearingTheScreen.current = clearing;
+        panel.current?.close();
+    });
+
     return (
         <dialog
             ref={panel}
             aria-labelledby={named}
-            onClose={onClose}
-            className="m-0 h-full max-h-full w-full max-w-full rounded-none border-0 bg-panel p-0 text-base text-text backdrop:bg-scrim open:flex open:flex-col workspace:m-auto workspace:h-settings-card workspace:w-settings workspace:rounded-3xl workspace:border workspace:border-line workspace:shadow-dialog"
+            onClose={() => {
+                onClose(clearingTheScreen.current);
+            }}
+            // The insets are the screen's here rather than the frame's: a modal dialog stands in the platform's own top
+            // layer, so the padding the frame carries is not around it and a full-bleed settings screen would run under
+            // a cutout and under the gesture bar. The card composition has the frame around it again and takes none.
+            className="m-0 h-full max-h-full w-full max-w-full rounded-none border-0 bg-panel p-0 pt-safe-top pr-safe-right pb-safe-bottom pl-safe-left text-base text-text backdrop:bg-scrim open:flex open:flex-col workspace:m-auto workspace:h-settings-card workspace:w-settings workspace:rounded-3xl workspace:border workspace:border-line workspace:p-0 workspace:shadow-dialog"
         >
             <div className="flex items-center gap-3 border-b border-line bg-sunken px-3.5 pt-3.5 pb-3 workspace:pt-2.5 workspace:pb-2.5">
                 <h2 id={named} className="text-2xl font-semibold workspace:text-md">

--- a/frontend/src/Client.App/src/shell/AccountMenu.test.tsx
+++ b/frontend/src/Client.App/src/shell/AccountMenu.test.tsx
@@ -2,7 +2,7 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, renderHook, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { MailAccount } from '@mailfathom/client-backend';
 import type { TelemetryForwarding } from '../deployment/telemetryForwarding';
@@ -14,6 +14,7 @@ import { WorkspaceProvider } from '../workspace/Workspace';
 import type { MailScope } from '../workspace/mailScope';
 import { useWorkspace } from '../workspace/useWorkspace';
 import { AccountMenu } from './AccountMenu';
+import { ScreenLayersContext, useScreenLayerStack, type ScreenLayers } from './screenLayers';
 
 function mailbox(id: string, displayName: string): MailAccount {
     return {
@@ -120,19 +121,26 @@ function renderMenu({
     readonly profile?: OwnProfileInForce;
     readonly onSignOut?: () => void;
     readonly scope?: MailScope | null;
-} = {}): void {
+} = {}): { readonly current: ScreenLayers } {
+    // The shell around it, because the menu records itself as standing over the screen while it is open. Its three
+    // functions are the same ones for the life of the stack, so the value handed to the provider stays current
+    // however the count moves.
+    const { result } = renderHook(() => useScreenLayerStack());
+
     render(
         <LocalizationProvider>
             <ThemeProvider>
                 <WorkspaceProvider>
-                    <AccountMenu
-                        accounts={accounts}
-                        deploymentVersion={deploymentVersion}
-                        telemetryForwarding={telemetryForwarding}
-                        preferences={preferences}
-                        profile={profile}
-                        onSignOut={onSignOut}
-                    />
+                    <ScreenLayersContext value={result.current}>
+                        <AccountMenu
+                            accounts={accounts}
+                            deploymentVersion={deploymentVersion}
+                            telemetryForwarding={telemetryForwarding}
+                            preferences={preferences}
+                            profile={profile}
+                            onSignOut={onSignOut}
+                        />
+                    </ScreenLayersContext>
                     <ScopeProbe />
                     {scope === null ? null : <ScopeAs scope={scope} />}
                 </WorkspaceProvider>
@@ -143,6 +151,37 @@ function renderMenu({
     if (scope !== null) {
         scopeAsTheTreeWould();
     }
+
+    return result;
+}
+
+/**
+ * The menu as the platform would report it once it is open, which jsdom reports of nothing.
+ *
+ * `hidePopover` is what the shell closes it by and jsdom declares neither it nor `showPopover`, so the one the menu
+ * would have is recorded; the toggle is the platform saying the state changed, which is what the component reads
+ * rather than holding an opinion of its own. jsdom declares no `ToggleEvent` either, so the one thing read off it is
+ * put on an ordinary event.
+ */
+function theMenuIsOpened(): ReturnType<typeof vi.fn> {
+    const menu = document.getElementById('account-menu');
+    const hidden = vi.fn();
+
+    if (menu === null) {
+        throw new Error('The menu was not drawn.');
+    }
+
+    Object.defineProperty(menu, 'hidePopover', { configurable: true, value: hidden });
+
+    const opening = new Event('toggle');
+
+    Object.defineProperty(opening, 'newState', { value: 'open' });
+
+    act(() => {
+        menu.dispatchEvent(opening);
+    });
+
+    return hidden;
 }
 
 // jsdom draws a popover closed and never opens one — it implements neither the invoker nor `showPopover` — so what is
@@ -342,5 +381,72 @@ describe('AccountMenu', () => {
         fireEvent.click(screen.getByRole('radio', { name: 'Dark', hidden: true }));
 
         expect(chooseTheme).toHaveBeenCalledWith('dark');
+    });
+
+    // The menu stands over whichever screen the rail is beside, so the back gesture closes it before it navigates and
+    // taking the navigation to another destination leaves none of it behind. Both are one registration, and whether it
+    // is open stays the platform's answer — which is what the toggle below stands for.
+    it('closes the menu when the back gesture reaches it, rather than leaving it over the next screen', () => {
+        const shell = renderMenu();
+        const hidden = theMenuIsOpened();
+
+        expect(shell.current.depth).toBe(1);
+
+        act(() => {
+            shell.current.closeTop();
+        });
+
+        expect(hidden).toHaveBeenCalled();
+    });
+
+    it('records nothing over the screen while the menu has not been opened', () => {
+        const shell = renderMenu();
+
+        expect(shell.current.depth).toBe(0);
+    });
+
+    // Opening the settings screen folds this menu away, and leaving that screen by a way out of it puts the menu back
+    // on the row it was opened from. Clearing the screen is the one case that must not: putting it back there would
+    // open a menu over the space somebody has just arrived at, with focus moved into it, which is the trap clearing
+    // the screen exists to prevent.
+    it('leaves the menu folded away when the shell clears the screen from behind the settings screen', () => {
+        const shell = renderMenu();
+        const menu = document.getElementById('account-menu');
+        const reopened = vi.fn();
+
+        if (menu === null) {
+            throw new Error('The menu was not drawn.');
+        }
+
+        Object.defineProperty(menu, 'hidePopover', { configurable: true, value: vi.fn() });
+        Object.defineProperty(menu, 'showPopover', { configurable: true, value: reopened });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Settings', hidden: true }));
+        expect(screen.getByRole('dialog', { name: 'Settings' })).toBeDefined();
+
+        act(() => {
+            shell.current.closeEvery();
+        });
+
+        expect(screen.queryByRole('dialog', { name: 'Settings' })).toBeNull();
+        expect(reopened).not.toHaveBeenCalled();
+    });
+
+    it('puts the menu back where the settings screen was left by a way out of that screen', () => {
+        renderMenu();
+        const menu = document.getElementById('account-menu');
+        const reopened = vi.fn();
+
+        if (menu === null) {
+            throw new Error('The menu was not drawn.');
+        }
+
+        Object.defineProperty(menu, 'hidePopover', { configurable: true, value: vi.fn() });
+        Object.defineProperty(menu, 'showPopover', { configurable: true, value: reopened });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Settings', hidden: true }));
+        fireEvent.click(screen.getByRole('button', { name: 'Close settings' }));
+
+        expect(reopened).toHaveBeenCalled();
     });
 });

--- a/frontend/src/Client.App/src/shell/AccountMenu.tsx
+++ b/frontend/src/Client.App/src/shell/AccountMenu.tsx
@@ -15,6 +15,7 @@ import { Settings } from '../settings/Settings';
 import { accountInScope, scopeOfAccount } from '../workspace/mailScope';
 import { useWorkspace } from '../workspace/useWorkspace';
 import { TabModeSwitch, ThemeSegments } from './Preferences';
+import { useScreenLayer } from './screenLayers';
 import { useWideWorkspace } from './useWideWorkspace';
 
 // The menu at the foot of the rail, which is where the design project puts everything that is about the person rather
@@ -67,6 +68,7 @@ export function AccountMenu({
     const { translate } = useLocalization();
     const wide = useWideWorkspace();
     const [settingsOpen, setSettingsOpen] = useState(false);
+    const [standing, setStanding] = useState(false);
     const menu = useRef<HTMLDivElement>(null);
     const settingsRow = useRef<HTMLButtonElement>(null);
 
@@ -79,11 +81,28 @@ export function AccountMenu({
         setSettingsOpen(true);
     }
 
-    function closeSettings(): void {
+    // The menu comes back where the screen behind it was left by a way out of that screen — a control, Escape, or one
+    // press of the back gesture — and does not where the shell cleared everything on the way to another destination.
+    // Putting it back there would open a menu over the space somebody has just arrived at, with focus moved into it,
+    // which is the one thing clearing the screen exists to prevent.
+    function closeSettings(clearingTheScreen: boolean): void {
         setSettingsOpen(false);
+
+        if (clearingTheScreen) {
+            return;
+        }
+
         menu.current?.showPopover();
         settingsRow.current?.focus();
     }
+
+    // The menu stands over whichever screen the rail is beside, so the back gesture closes it before it navigates and
+    // taking the navigation to another destination leaves none of it behind. Whether it is open stays the platform's
+    // answer for the reason above: what is recorded here is the way to close it, never a second opinion about whether
+    // it is.
+    useScreenLayer(standing, () => {
+        menu.current?.hidePopover();
+    });
 
     return (
         <>
@@ -111,6 +130,9 @@ export function AccountMenu({
                 ref={menu}
                 id="account-menu"
                 popover="auto"
+                onToggle={(event) => {
+                    setStanding(event.newState === 'open');
+                }}
                 aria-label={translate('shell.accountMenu')}
                 className="inset-x-4 top-auto bottom-22 m-0 overflow-hidden rounded-2xl border border-line bg-panel p-0 text-base text-text shadow-overlay workspace:inset-x-auto workspace:bottom-4.5 workspace:left-26.5 workspace:w-54"
             >

--- a/frontend/src/Client.App/src/shell/Preferences.tsx
+++ b/frontend/src/Client.App/src/shell/Preferences.tsx
@@ -10,7 +10,7 @@ import { isOfferedLocale, localeNames, locales } from '../localization/locale';
 import { useLocalization } from '../localization/useLocalization';
 import { isThemeChoice, themeChoices } from '../theme/themeChoice';
 import { useTheme } from '../theme/useTheme';
-import { useWideEnoughForTabs } from './useWideWorkspace';
+import { useDesktopComposition } from './useWideWorkspace';
 
 // The settings a person reaches without leaving the screen they are on. Two of them follow the person and are held on
 // the deployment — the theme and the tab mode — and one follows the machine, which is the language: what a client is
@@ -85,7 +85,7 @@ export function ThemeSegments({ onChoose }: { readonly onChoose: (choice: (typeo
  */
 export function TabModeSwitch({ on, onChange }: { readonly on: boolean; readonly onChange: (on: boolean) => void }) {
     const { translate } = useLocalization();
-    const wideEnough = useWideEnoughForTabs();
+    const wideEnough = useDesktopComposition();
 
     return (
         <label className={`${settingRow} ${wideEnough ? 'cursor-pointer hover:bg-hover' : 'opacity-50'}`}>

--- a/frontend/src/Client.App/src/shell/SpaceOverflow.test.tsx
+++ b/frontend/src/Client.App/src/shell/SpaceOverflow.test.tsx
@@ -2,10 +2,11 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { act, render, renderHook, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 import { LocalizationProvider } from '../localization/Localization';
 import type { Space } from '../routing/spaces';
+import { ScreenLayersContext, useScreenLayerStack, type ScreenLayers } from './screenLayers';
 import { SpaceOverflow } from './SpaceOverflow';
 
 // jsdom draws a closed popover hidden and opens none — it implements neither the invoker nor `showPopover` — so what
@@ -15,12 +16,51 @@ import { SpaceOverflow } from './SpaceOverflow';
 
 const handedTheAccount = 'The account control this sheet was handed.';
 
-function renderOverflow(spaces: readonly Space[] = ['tasks', 'cases'], current: Space | null = null): void {
+function renderOverflow(
+    spaces: readonly Space[] = ['tasks', 'cases'],
+    current: Space | null = null,
+): { readonly current: ScreenLayers } {
+    const { result } = renderHook(() => useScreenLayerStack());
+
     render(
         <LocalizationProvider>
-            <SpaceOverflow spaces={spaces} current={current} account={<button>{handedTheAccount}</button>} />
+            <ScreenLayersContext value={result.current}>
+                <SpaceOverflow spaces={spaces} current={current} account={<button>{handedTheAccount}</button>} />
+            </ScreenLayersContext>
         </LocalizationProvider>,
     );
+
+    return result;
+}
+
+/**
+ * The sheet as the platform would report it once it is open, which jsdom reports of nothing.
+ *
+ * `hidePopover` is what the shell closes it by and jsdom declares neither it nor `showPopover`, so the one the sheet
+ * would have is recorded; the toggle is the platform saying the state changed, which is what the component reads
+ * rather than holding an opinion of its own.
+ */
+function theSheetIsOpened(): ReturnType<typeof vi.fn> {
+    const sheet = document.getElementById('space-overflow');
+    const hidden = vi.fn();
+
+    if (sheet === null) {
+        throw new Error('The sheet was not drawn.');
+    }
+
+    Object.defineProperty(sheet, 'hidePopover', { configurable: true, value: hidden });
+
+    // jsdom declares no `ToggleEvent`, so the one thing the component reads off it is put on an ordinary event: what
+    // a popover reports is the state it moved to, and that is the whole of what is asked here.
+    const opening = new Event('toggle');
+
+    Object.defineProperty(opening, 'newState', { value: 'open' });
+
+    act(() => {
+        sheet.dispatchEvent(opening);
+    });
+
+    return hidden;
 }
 
 describe('SpaceOverflow', () => {
@@ -78,5 +118,20 @@ describe('SpaceOverflow', () => {
 
         expect(document.getElementById('space-overflow')?.contains(account)).toBe(true);
         expect(lastRow?.compareDocumentPosition(account)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    });
+
+    // The sheet stands over the screen, so the back gesture reaches it before it navigates and a change of destination
+    // leaves none of it behind. Both are one registration, and this is what proves it was made at all.
+    it('closes the sheet when the back gesture reaches it, rather than leaving it over the next screen', () => {
+        const shell = renderOverflow();
+        const hidden = theSheetIsOpened();
+
+        expect(shell.current.depth).toBe(1);
+
+        act(() => {
+            shell.current.closeTop();
+        });
+
+        expect(hidden).toHaveBeenCalled();
     });
 });

--- a/frontend/src/Client.App/src/shell/SpaceOverflow.tsx
+++ b/frontend/src/Client.App/src/shell/SpaceOverflow.tsx
@@ -5,8 +5,9 @@
 import { Icon } from '../controls/Icon';
 import { useLocalization } from '../localization/useLocalization';
 import { addressOf, implementedSpaces, spaceLabels, type Space } from '../routing/spaces';
+import { useScreenLayer } from './screenLayers';
 import { spaceIcons } from './spaceIcons';
-import type { ReactNode } from 'react';
+import { useRef, useState, type ReactNode } from 'react';
 
 // The fifth place in the bottom bar, and what stands behind it. A narrow window has room for five items and the design
 // project spends them on three spaces, the bell, and this — so what does not fit is reached rather than dropped, which
@@ -46,6 +47,16 @@ export function SpaceOverflow({
     // `aria-current="true"` rather than `page`, which is the row inside the sheet — this says *the current one of these
     // five places*, which is what it is.
     const holdsCurrent = current !== null && spaces.includes(current);
+    const opened = useRef<HTMLDivElement>(null);
+    const [standing, setStanding] = useState(false);
+
+    // The sheet stands over the screen, so the back gesture closes it before it navigates anywhere and taking the bar
+    // to another destination leaves none of it behind. Whether it is open is read from the platform rather than held
+    // as a second copy of it: the control that names it is what opens and closes it, and the toggle below is the
+    // platform saying which of the two just happened.
+    useScreenLayer(standing, () => {
+        opened.current?.hidePopover();
+    });
 
     return (
         <>
@@ -66,8 +77,12 @@ export function SpaceOverflow({
             {/* No display utility on the sheet itself, for the reason the account menu's own popover carries none: the
                 platform hides a closed popover from its own stylesheet, and a utility here would outrank that. */}
             <div
+                ref={opened}
                 id={sheet}
                 popover="auto"
+                onToggle={(event) => {
+                    setStanding(event.newState === 'open');
+                }}
                 aria-label={translate('shell.more')}
                 // Dimmed behind, which the design project draws and which is what says the sheet is the whole of what
                 // is being answered right now. The platform paints it: a popover has a `::backdrop` of its own exactly

--- a/frontend/src/Client.App/src/shell/screenLayers.test.tsx
+++ b/frontend/src/Client.App/src/shell/screenLayers.test.tsx
@@ -1,0 +1,202 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { useState } from 'react';
+import { act, fireEvent, render, renderHook, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ScreenLayersContext, useScreenLayer, useScreenLayerStack, type ScreenLayers } from './screenLayers';
+
+// One surface standing over the screen, drawn as what a reader would see of it and left by a control of its own. It is
+// a paragraph and a button rather than a dialog because what is proven here is the order the shell closes them in, and
+// jsdom implements none of the platform's own top layer — so the element is whatever the surface would have been.
+function Standing({
+    name,
+    leaving,
+    open,
+    onClose,
+}: {
+    readonly name: string;
+    readonly leaving: string;
+    readonly open: boolean;
+    readonly onClose: () => void;
+}) {
+    useScreenLayer(open, onClose);
+
+    return open ? (
+        <div>
+            <p>{name}</p>
+            <button type="button" onClick={onClose}>
+                {leaving}
+            </button>
+        </div>
+    ) : null;
+}
+
+// Not catalogue entries: each stands for a surface the shell would have drawn, and what they say is what a test reads.
+const drawer = 'The mailboxes in a drawer';
+const leaveTheDrawer = 'Close the drawer';
+const question = 'A question asked over the drawer';
+const leaveTheQuestion = 'Close the question';
+
+// The composer's own shape: closing it with something written in it asks a question rather than taking it away, so the
+// surface is still on the screen after the press that reached it and has to be recorded again.
+function Asking() {
+    const [timesAsked, setTimesAsked] = useState(0);
+
+    useScreenLayer(
+        true,
+        () => {
+            setTimesAsked((times) => times + 1);
+        },
+        timesAsked,
+    );
+
+    // How many times it has been asked, drawn on its own: this surface is the whole of what a test renders here, so
+    // the count is unambiguous without a sentence around it.
+    return <p>{String(timesAsked)}</p>;
+}
+
+/** A drawer with a question standing over it, which is the arrangement every ordering behaviour is asked about. */
+function Surfaces({
+    layers,
+    drawerOpen = true,
+    questionOpen = true,
+}: {
+    readonly layers: ScreenLayers;
+    readonly drawerOpen?: boolean;
+    readonly questionOpen?: boolean;
+}) {
+    const [drawerStanding, setDrawerStanding] = useState(drawerOpen);
+    const [questionStanding, setQuestionStanding] = useState(questionOpen);
+
+    return (
+        <ScreenLayersContext value={layers}>
+            <Standing
+                name={drawer}
+                leaving={leaveTheDrawer}
+                open={drawerStanding}
+                onClose={() => {
+                    setDrawerStanding(false);
+                }}
+            />
+            <Standing
+                name={question}
+                leaving={leaveTheQuestion}
+                open={questionStanding}
+                onClose={() => {
+                    setQuestionStanding(false);
+                }}
+            />
+        </ScreenLayersContext>
+    );
+}
+
+// The stack is built through its own hook and the surfaces are drawn under it, so that a test can ask the shell to
+// close one the way the back gesture does rather than the way a control does. Its three functions are the same ones for
+// the life of the stack, so the value handed to the provider stays current however the count moves.
+function shellWith(standing: { readonly drawerOpen?: boolean; readonly questionOpen?: boolean } = {}): ScreenLayers {
+    const { result } = renderHook(() => useScreenLayerStack());
+
+    render(<Surfaces layers={result.current} {...standing} />);
+
+    return result.current;
+}
+
+describe('useScreenLayerStack', () => {
+    it('counts nothing standing over a screen nobody has opened anything on', () => {
+        const { result } = renderHook(() => useScreenLayerStack());
+
+        expect(result.current.depth).toBe(0);
+    });
+
+    it('answers that there was nothing to close where nothing stands over the screen', () => {
+        const { result } = renderHook(() => useScreenLayerStack());
+        let closed = true;
+
+        act(() => {
+            closed = result.current.closeTop();
+        });
+
+        expect(closed).toBe(false);
+    });
+});
+
+describe('useScreenLayer', () => {
+    it('closes the surface opened last, which is the one standing on top', () => {
+        const layers = shellWith();
+
+        act(() => {
+            layers.closeTop();
+        });
+
+        expect(screen.queryByText(question)).toBeNull();
+        expect(screen.getByText(drawer)).toBeTruthy();
+    });
+
+    it('closes one surface per step, so the one underneath is reached by the step after it', () => {
+        const layers = shellWith();
+
+        act(() => {
+            layers.closeTop();
+        });
+        act(() => {
+            layers.closeTop();
+        });
+
+        expect(screen.queryByText(drawer)).toBeNull();
+    });
+
+    it('closes every surface at once, which is what going to another destination does to them', () => {
+        const layers = shellWith();
+
+        act(() => {
+            layers.closeEvery();
+        });
+
+        expect(screen.queryByText(drawer)).toBeNull();
+        expect(screen.queryByText(question)).toBeNull();
+    });
+
+    it('stops counting a surface that was closed by its own control', () => {
+        const { result } = renderHook(() => useScreenLayerStack());
+        render(<Surfaces layers={result.current} />);
+
+        fireEvent.click(screen.getByRole('button', { name: leaveTheQuestion }));
+
+        expect(result.current.depth).toBe(1);
+    });
+
+    it('registers nothing for a surface that is mounted while it is closed', () => {
+        const { result } = renderHook(() => useScreenLayerStack());
+        render(<Surfaces layers={result.current} drawerOpen={false} questionOpen={false} />);
+
+        expect(result.current.depth).toBe(0);
+    });
+
+    // The press is spent on the surface it reached, so a surface that answered with a question rather than by going
+    // away has to be recorded afresh — otherwise the press after it goes straight past a composer still on the screen.
+    it('records a surface again where closing it asked a question instead of taking it away', () => {
+        const { result } = renderHook(() => useScreenLayerStack());
+        render(
+            <ScreenLayersContext value={result.current}>
+                <Asking />
+            </ScreenLayersContext>,
+        );
+
+        act(() => {
+            result.current.closeTop();
+        });
+        act(() => {
+            result.current.closeTop();
+        });
+
+        expect(screen.getByText('2')).toBeTruthy();
+    });
+
+    it('leaves a surface drawn with no shell around it unchanged, rather than refusing to draw it', () => {
+        render(<Standing name={question} leaving={leaveTheQuestion} open onClose={() => undefined} />);
+
+        expect(screen.getByText(question)).toBeTruthy();
+    });
+});

--- a/frontend/src/Client.App/src/shell/screenLayers.ts
+++ b/frontend/src/Client.App/src/shell/screenLayers.ts
@@ -1,0 +1,154 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+
+// What stands over the screen, in the order it was opened. A drawer, a dialog, a popover, and an overflow sheet are
+// each one of these, and the shell has two questions about them that no single one of them can answer for itself:
+// **which is on top**, so the back gesture closes that one and no other, and **are any of them still open**, so moving
+// to another destination can leave none of them behind.
+//
+// The platform keeps a stack of its own — a modal dialog and a popover both stand in the top layer, and Escape unwinds
+// it one element at a time — but it publishes neither the order nor a way to unwind it from code. So the order is
+// recorded here as each surface opens, and each surface stays the one thing that knows how to close itself: what is
+// registered is a way to close it rather than the element, which is what lets a drawer that is a `dialog`, a menu that
+// is a popover, and a confirmation that asks a question before it goes all live in one stack.
+//
+// It is a stack rather than a set because that is the whole of what it is for: `closeTop` is one press of the back
+// gesture, and `closeEvery` is a person taking the bottom navigation somewhere else — a layer that survived that is a
+// layer they cannot get rid of without finding its own close control, which on a phone is the trap the rule against it
+// exists to prevent.
+//
+// **One surface deliberately registers nothing**, and it is the blocking overlay: an operation that has to finish
+// before the client is usable again is not something a gesture may dismiss, and it carries its own way to stop what it
+// is waiting on. A surface that back must not close is a surface that is not a layer.
+//
+// The array is a ref rather than state because `closeTop` is answered inside one event and its answer decides what the
+// next line does: unwinding two of them in one press has to reach two different surfaces, and a component's own state
+// has not settled by then. The count beside it is state, because what re-renders on it is the shell arithmetic that
+// decides how many history entries the back gesture has to consume.
+
+/** One thing standing over the screen, held as the way to close it. */
+interface OpenLayer {
+    readonly close: (clearingTheScreen: boolean) => void;
+}
+
+/** The layers standing over the screen, and what the shell does to them. */
+export interface ScreenLayers {
+    /** How many stand over the screen now. */
+    readonly depth: number;
+
+    /**
+     * Records one while it is open. The returned function withdraws it, and withdrawing twice is a no-op.
+     *
+     * What is recorded is told which of the two asked, because going away means different things in them: one press
+     * of the back gesture leaves a surface with whatever it stood on still on the screen, and clearing the screen
+     * leaves nothing at all — so a surface that puts something back as it goes has to know not to.
+     */
+    readonly opened: (close: (clearingTheScreen: boolean) => void) => () => void;
+
+    /** Closes the one on top, answering whether there was one to close. */
+    readonly closeTop: () => boolean;
+
+    /** Closes every one of them, the top first. */
+    readonly closeEvery: () => void;
+}
+
+export const ScreenLayersContext = createContext<ScreenLayers | null>(null);
+
+/** Builds the stack the shell supplies, which the composition root does once. */
+export function useScreenLayerStack(): ScreenLayers {
+    const open = useRef<OpenLayer[]>([]);
+    const [depth, setDepth] = useState(0);
+
+    // Each of the three is built once and never again, because a surface registers itself against `opened` and would
+    // withdraw and register afresh on every change of depth if that function were composed per render — which is a
+    // registration that removes itself while the stack is being read.
+    const opened = useCallback((close: (clearingTheScreen: boolean) => void) => {
+        const layer: OpenLayer = { close };
+
+        open.current = [...open.current, layer];
+        setDepth(open.current.length);
+
+        return () => {
+            const left = open.current.filter((standing) => standing !== layer);
+
+            if (left.length !== open.current.length) {
+                open.current = left;
+                setDepth(left.length);
+            }
+        };
+    }, []);
+
+    const closeTop = useCallback(() => {
+        const top = open.current.at(-1);
+
+        if (top === undefined) {
+            return false;
+        }
+
+        // Taken off the stack before it is asked to close rather than after, because closing is what a surface does to
+        // its own state and that has not settled inside this event: two steps unwound together would otherwise both
+        // reach the same surface and leave the one beneath it standing.
+        open.current = open.current.slice(0, -1);
+        setDepth(open.current.length);
+        top.close(false);
+
+        return true;
+    }, []);
+
+    const closeEvery = useCallback(() => {
+        const standing = open.current;
+
+        open.current = [];
+        setDepth(0);
+
+        for (const layer of [...standing].reverse()) {
+            layer.close(true);
+        }
+    }, []);
+
+    return useMemo(() => ({ depth, opened, closeTop, closeEvery }), [depth, opened, closeTop, closeEvery]);
+}
+
+/**
+ * Records a surface as standing over the screen for as long as it is open, so that the back gesture reaches it and a
+ * change of destination closes it.
+ *
+ * A surface drawn with no shell around it registers nothing and is otherwise unchanged, which is the one place this
+ * differs from the client's other contexts and is deliberate rather than lax. What the shell supplies here is a service
+ * to a surface rather than a value it renders from: the sign-in screen stands in front of the frame and opens nothing
+ * over itself, and a test drawing one surface alone is looking at that surface rather than at a shell. Refusing to draw
+ * in either case would be refusing over something neither of them has any use for.
+ *
+ * @param open Whether the surface is on the screen. A surface mounted while closed registers nothing.
+ * @param close What closing it does, which is the surface's own way out rather than a second implementation of it. It
+ *   is told whether the shell is clearing the screen rather than answering one press, which a surface only reads where
+ *   the two differ — putting back what it was opened from is the case that has one.
+ * @param restoredBy A value that changes whenever closing this surface put a question in front of it instead of
+ *   taking it off the screen. `closeTop` spends the registration on the press that reached it, so a surface still
+ *   standing afterwards has to be recorded again or the next press would go straight past it.
+ */
+export function useScreenLayer(open: boolean, close: (clearingTheScreen: boolean) => void, restoredBy?: unknown): void {
+    const layers = useContext(ScreenLayersContext);
+    const closing = useRef(close);
+
+    // The stack holds one function for the life of the registration, and this is what keeps that function current:
+    // what closing a surface does is written where the surface is drawn, and every render may compose it afresh.
+    useEffect(() => {
+        closing.current = close;
+    });
+
+    const opened = layers?.opened;
+
+    useEffect(() => {
+        if (!open || opened === undefined) {
+            return;
+        }
+
+        return opened((clearingTheScreen) => {
+            closing.current(clearingTheScreen);
+        });
+    }, [open, opened, restoredBy]);
+}

--- a/frontend/src/Client.App/src/shell/useWideWorkspace.test.tsx
+++ b/frontend/src/Client.App/src/shell/useWideWorkspace.test.tsx
@@ -4,7 +4,7 @@
 
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { useCoarsePointer } from './useWideWorkspace';
+import { useCoarsePointer, useDesktopComposition, useTwoPanes, useWideWorkspace } from './useWideWorkspace';
 
 // What the pointer can do is the half of a composition a stylesheet cannot answer, because it decides whether a
 // listener is bound at all. It is stated here the way `theme/Theme.test.tsx` states a machine's appearance: a query
@@ -70,5 +70,43 @@ describe('useCoarsePointer', () => {
         theDeviceIsPickedUp(true);
 
         expect(result.current).toBe(true);
+    });
+});
+
+// The three widths themselves, at the four sizes the design project frames a composition at. jsdom lays nothing out
+// and declares no custom property, so each query is answered from the width alone and the hooks fall back to the
+// stylesheet's own numbers — which is exactly what is being asserted, those numbers being the boundaries.
+function atWidth(pixels: number): void {
+    Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        value: (query: string) => {
+            const named = /([\d.]+)rem/.exec(query)?.[1];
+
+            return {
+                media: query,
+                matches: named !== undefined && pixels >= Number(named) * 16,
+                addEventListener: () => undefined,
+                removeEventListener: () => undefined,
+            };
+        },
+    });
+}
+
+describe('the widths a composition changes at', () => {
+    it.each([
+        ['the phone', 390, false, false, false],
+        ['the fold', 884, true, true, false],
+        ['the tablet', 1024, true, true, false],
+        ['the desktop', 1440, true, true, true],
+    ])('composes %s as the design project frames it', (_, pixels, workspace, panes, desktop) => {
+        atWidth(pixels);
+
+        const composition = renderHook(() => ({
+            workspace: useWideWorkspace(),
+            panes: useTwoPanes(),
+            desktop: useDesktopComposition(),
+        }));
+
+        expect(composition.result.current).toEqual({ workspace, panes, desktop });
     });
 });

--- a/frontend/src/Client.App/src/shell/useWideWorkspace.ts
+++ b/frontend/src/Client.App/src/shell/useWideWorkspace.ts
@@ -4,7 +4,7 @@
 
 import { useSyncExternalStore } from 'react';
 
-// The two widths a component has to ask about rather than compose against. A stylesheet answers a width question for
+// The three widths a component has to ask about rather than compose against. A stylesheet answers a width question for
 // anything CSS can lay out two ways from one tree, and that is almost everything; what it cannot do is decide *which*
 // of two screens is in the document, or whether a control is one a person may operate at all.
 //
@@ -65,30 +65,46 @@ function pointerIsCoarse() {
 
 // Built once each, because `useSyncExternalStore` compares the two functions it is handed by identity and a pair
 // rebuilt per render would resubscribe on every one of them.
-const workspaceWidth = widthAtLeast('--breakpoint-workspace', '48.75rem');
-const tabsWidth = widthAtLeast('--breakpoint-tabs', '73.75rem');
+const workspaceWidth = widthAtLeast('--breakpoint-workspace', '43.75rem');
+const paneWidth = widthAtLeast('--breakpoint-panes', '51.25rem');
+const desktopWidth = widthAtLeast('--breakpoint-desktop', '73.75rem');
 const coarsePointer = pointerIsCoarse();
 
 /**
- * Whether the window is at or above the width the workspace opens out at, kept current as it is resized across that
+ * Whether the window is at or above the width the phone shape stops at, kept current as it is resized across that
  * breakpoint.
  *
- * The narrow Mail space is what needs asking: it draws the list or the message and never both, so a row that is not on
- * the screen is not in the document either.
+ * What needs asking rather than composing is where a surface stands at all: bottom navigation is a row of five places
+ * and a rail is a column of nine, and a sheet rising from the foot of the window is a different element from a panel
+ * beside the rail.
  */
 export function useWideWorkspace(): boolean {
     return useSyncExternalStore(workspaceWidth.watch, workspaceWidth.matches);
 }
 
 /**
- * Whether the window is wide enough for the tab mode to be worth offering.
+ * Whether the window has room for the list and the message side by side, kept current as it is resized across that
+ * breakpoint.
  *
- * It is a second and wider breakpoint than the workspace's, because a rail beside two columns fits long before a row
- * of tabs above them does. Below it the switch is inert rather than absent: a control that vanished by width alone
- * would leave somebody who had turned it on with no way to reach it, and the row says why instead.
+ * The single-pane Mail space is what needs asking: it draws the list or the message and never both, so a row that is
+ * not on the screen is not in the document either — and going between them is navigation the back gesture returns
+ * through rather than a layout that changed.
  */
-export function useWideEnoughForTabs(): boolean {
-    return useSyncExternalStore(tabsWidth.watch, tabsWidth.matches);
+export function useTwoPanes(): boolean {
+    return useSyncExternalStore(paneWidth.watch, paneWidth.matches);
+}
+
+/**
+ * Whether the window is in the desktop composition rather than the tablet one.
+ *
+ * It is the widest of the three, and the design project draws three things at it together: the mailbox column stands
+ * beside the list rather than in a drawer over it, the toolbar's controls carry their labels, and the tab mode is
+ * worth offering at all — a row of tabs above the columns needs room a rail beside two of them does not. Below it the
+ * tab switch is inert rather than absent: a control that vanished by width alone would leave somebody who had turned
+ * it on with no way to reach it, and the row says why instead.
+ */
+export function useDesktopComposition(): boolean {
+    return useSyncExternalStore(desktopWidth.watch, desktopWidth.matches);
 }
 
 /**

--- a/frontend/src/Client.App/src/shellOperations/backNavigation.test.ts
+++ b/frontend/src/Client.App/src/shellOperations/backNavigation.test.ts
@@ -1,0 +1,173 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useBackNavigation } from './backNavigation';
+
+// The session history is the one thing outside React this hook synchronizes with, and jsdom's own is a real stack this
+// suite cannot rewind without waiting on it — `history.back()` there is asynchronous and delivers nothing a test can
+// await. So the three calls that matter are recorded and the entry showing is stated directly, which is what a press of
+// the back gesture actually leaves behind: an earlier entry, with whatever it was marked with.
+//
+// Nothing here mentions a head. The gesture arrives as `popstate` in the browser, in the desktop shell's WebView, and
+// on Android — where the head's own activity hands it to the page rather than finishing the application — so what is
+// proven below is proven for all three at once.
+
+const declaredState = Object.getOwnPropertyDescriptor(window.history, 'state');
+
+let pushed: unknown[] = [];
+let replaced: unknown[] = [];
+let travelled: number[] = [];
+let showing: unknown = null;
+
+function theEntryShowing(state: unknown): void {
+    showing = state;
+}
+
+function theGestureIsUsed(): void {
+    act(() => {
+        window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+}
+
+beforeEach(() => {
+    pushed = [];
+    replaced = [];
+    travelled = [];
+    showing = null;
+
+    Object.defineProperty(window.history, 'state', {
+        configurable: true,
+        get: () => showing,
+    });
+
+    vi.spyOn(window.history, 'pushState').mockImplementation((state: unknown) => {
+        pushed.push(state);
+        showing = state;
+    });
+
+    vi.spyOn(window.history, 'replaceState').mockImplementation((state: unknown) => {
+        replaced.push(state);
+        showing = state;
+    });
+
+    vi.spyOn(window.history, 'go').mockImplementation((delta?: number) => {
+        travelled.push(delta ?? 0);
+    });
+});
+
+afterEach(() => {
+    if (declaredState === undefined) {
+        Reflect.deleteProperty(window.history, 'state');
+    } else {
+        Object.defineProperty(window.history, 'state', declaredState);
+    }
+
+    vi.restoreAllMocks();
+});
+
+describe('useBackNavigation', () => {
+    it('leaves the history alone while nothing stands over the screen', () => {
+        renderHook(() => {
+            useBackNavigation(0, () => undefined);
+        });
+
+        expect(pushed).toEqual([]);
+    });
+
+    it('adds one entry for the gesture to consume as something opens over the screen', () => {
+        const { rerender } = renderHook(
+            ({ steps }) => {
+                useBackNavigation(steps, () => undefined);
+            },
+            { initialProps: { steps: 0 } },
+        );
+
+        rerender({ steps: 1 });
+
+        expect(pushed).toHaveLength(1);
+    });
+
+    it('adds one entry per step, so two surfaces take two presses to unwind', () => {
+        const { rerender } = renderHook(
+            ({ steps }) => {
+                useBackNavigation(steps, () => undefined);
+            },
+            { initialProps: { steps: 0 } },
+        );
+
+        rerender({ steps: 2 });
+
+        expect(pushed).toHaveLength(2);
+    });
+
+    it('unwinds one step for the entry the gesture consumed', () => {
+        const unwound = vi.fn();
+
+        renderHook(() => {
+            useBackNavigation(2, unwound);
+        });
+
+        theEntryShowing({ 'mailfathom.back': 1 });
+        theGestureIsUsed();
+
+        expect(unwound).toHaveBeenCalledExactlyOnceWith(1);
+    });
+
+    // In one call rather than in two: what the second of them would take away depends on the first having happened,
+    // and the screen it would be asked against is the screen as it stood before either.
+    it('unwinds everything standing over the screen where the gesture landed past all of it', () => {
+        const unwound = vi.fn();
+
+        renderHook(() => {
+            useBackNavigation(2, unwound);
+        });
+
+        theEntryShowing(null);
+        theGestureIsUsed();
+
+        expect(unwound).toHaveBeenCalledExactlyOnceWith(2);
+    });
+
+    it('unwinds nothing where the gesture left as many entries as there are steps', () => {
+        const unwound = vi.fn();
+
+        renderHook(() => {
+            useBackNavigation(1, unwound);
+        });
+
+        theGestureIsUsed();
+
+        expect(unwound).not.toHaveBeenCalled();
+    });
+
+    it('gives the spare entry back where a surface was closed by its own control instead', () => {
+        const { rerender } = renderHook(
+            ({ steps }) => {
+                useBackNavigation(steps, () => undefined);
+            },
+            { initialProps: { steps: 0 } },
+        );
+
+        rerender({ steps: 1 });
+        rerender({ steps: 0 });
+
+        expect(travelled).toEqual([-1]);
+    });
+
+    // A reload is the one time the entry showing describes a screen that no longer exists: the marks were written by
+    // the client that was thrown away, and the one that came back has nothing standing over it. Giving those entries
+    // up would walk the reader backwards out of the client on a reload, so the entry is re-marked instead.
+    it('re-marks the entry a reload arrived on rather than giving its entries back', () => {
+        theEntryShowing({ 'mailfathom.back': 3 });
+
+        renderHook(() => {
+            useBackNavigation(0, () => undefined);
+        });
+
+        expect(travelled).toEqual([]);
+        expect(replaced).toEqual([{ 'mailfathom.back': 0 }]);
+    });
+});

--- a/frontend/src/Client.App/src/shellOperations/backNavigation.ts
+++ b/frontend/src/Client.App/src/shellOperations/backNavigation.ts
@@ -1,0 +1,123 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { useEffect, useRef } from 'react';
+
+// Going back, which on Android is a system gesture, on the web is the browser's own control, and on the desktop is
+// whatever the window manager offers — and which is one thing in this client rather than three, because all three
+// arrive as the same event.
+//
+// **It is a shell operation and it sits here for that reason**, ADR 0027 § _The no-platform-branch rule holds, and the
+// shell is the only seam a head operation crosses_ naming the back gesture the third member of this directory, beside
+// where the credential is kept and how a system notification is raised.
+// What it resolves, though, is that there is nothing left to choose between: the Android shell is asked to hand the
+// gesture to the page it is showing — `handleBackNavigation` in the head's own activity — which is what a browser
+// already does, so back arrives in all three heads as one entry coming off the session history. So this module reads
+// no shell command, offers no context, and publishes one hook; a second implementation to pick between would be an
+// indirection with one implementation, which is the abstraction `frontend/src/AGENTS.md` refuses. What makes the
+// difference between the heads disappear is the shell being configured rather than the application being told which
+// shell it is in, and the desktop and web heads gained the behaviour without a line written for either.
+//
+// **What is unwound, and in what order.** Whatever stands on top of the screen goes first — an overflow sheet, a
+// popover, a drawer, a dialog — one per press, from `shell/screenLayers.ts`. Only with nothing standing over it does
+// back move inside the screen, which in the single-pane composition is a message going back to the list it was opened
+// from. Only with nothing left to go back to at all does it reach the platform, which then does what it does with an
+// application at its root: on Android it leaves, in a browser it goes wherever the tab was before.
+//
+// **How a press reaches us.** Neither a layer nor the pane is an address — nothing about mail is written where it
+// outlives the process, and a message identifier in a history entry is exactly that, kept by the browser's own store
+// under [ADR 0028](../../../../../docs/decisions/0028-no-mail-on-the-device-and-an-honest-client-with-no-route-to-its-deployment.md).
+// So what is pushed is an entry at the address already showing, marked with how many steps stand over the screen at
+// that point. Back consumes one of those marks, the page is told, and the number the mark carries says how many steps
+// to unwind; the address never changes, so the space the reader is in is the space the address names throughout.
+//
+// The marks are pushed and given up by one effect rather than by whoever opened a surface, which is what keeps them
+// honest: a surface closed by its own control leaves one step fewer than the history holds, and the same effect gives
+// the spare entry back. Nothing else in the client writes history state, and `routing/useSpace.ts` carries a mark
+// across the one address it rewrites rather than replacing it with nothing.
+
+const stepsTaken = 'mailfathom.back';
+
+/** Whatever the entry showing carries, as something a mark can be written beside rather than over. */
+function asState(state: unknown): Record<string, unknown> {
+    return typeof state === 'object' && state !== null ? (state as Record<string, unknown>) : {};
+}
+
+/** How many steps the entry showing says stand over the screen, which is none for an entry nothing marked. */
+function markedSteps(): number {
+    const state: unknown = window.history.state;
+
+    if (typeof state !== 'object' || state === null || !(stepsTaken in state)) {
+        return 0;
+    }
+
+    const marked: unknown = (state as Record<string, unknown>)[stepsTaken];
+
+    return typeof marked === 'number' && Number.isInteger(marked) && marked > 0 ? marked : 0;
+}
+
+/**
+ * Keeps the session history holding one entry per step the back gesture has to unwind, and unwinds them as it is used.
+ *
+ * @param steps How many things stand between the reader and the screen underneath — every open layer, plus the pane
+ *   standing in front of the list where the composition shows one at a time.
+ * @param unwind Takes that many of them away, the topmost first, in one call. It is handed the count rather than
+ *   called once per step because closing one of them is a revision the caller's own event does not yet hold, so a
+ *   second call would answer against the screen as it stood before the first.
+ */
+export function useBackNavigation(steps: number, unwind: (used: number) => void): void {
+    const standing = useRef(steps);
+    const unwinding = useRef(unwind);
+    const reconciled = useRef(false);
+
+    useEffect(() => {
+        standing.current = steps;
+        unwinding.current = unwind;
+    });
+
+    // The history is brought into step with the screen rather than written by whoever changed it: a surface that opened
+    // needs an entry to consume, and one closed by its own control leaves an entry nobody will. Both are the same
+    // difference read in opposite directions, which is why one effect answers both.
+    //
+    // The first reading of it is the exception, and it is a reload: the entry showing keeps whatever mark it carried
+    // before the page was thrown away, while the client that came back has nothing standing over its screen. Giving
+    // those entries up would be a reload that walks the reader backwards out of the client, so the entry is re-marked
+    // for the screen actually being drawn and the entries behind it are left where they are.
+    useEffect(() => {
+        const marked = markedSteps();
+
+        if (steps > marked) {
+            for (let step = marked + 1; step <= steps; step += 1) {
+                window.history.pushState({ [stepsTaken]: step }, '');
+            }
+        } else if (steps < marked) {
+            if (reconciled.current) {
+                window.history.go(steps - marked);
+            } else {
+                window.history.replaceState({ ...asState(window.history.state), [stepsTaken]: steps }, '');
+            }
+        }
+
+        reconciled.current = true;
+    }, [steps]);
+
+    useEffect(() => {
+        function backWasUsed(): void {
+            // What the entry now showing says stands over the screen, against what actually does. A press that landed
+            // on an address of ours rather than on a mark says nothing stands over it, which is the same arithmetic:
+            // an unmarked entry is zero steps.
+            const used = standing.current - markedSteps();
+
+            if (used > 0) {
+                unwinding.current(used);
+            }
+        }
+
+        window.addEventListener('popstate', backWasUsed);
+
+        return () => {
+            window.removeEventListener('popstate', backWasUsed);
+        };
+    }, []);
+}

--- a/frontend/src/Client.App/src/signIn/SignIn.tsx
+++ b/frontend/src/Client.App/src/signIn/SignIn.tsx
@@ -106,15 +106,16 @@ const lifetimeMessages: Readonly<Record<CredentialLifetime, MessageKey>> = {
 // to the accent and the tint widens behind it — and it is written with `focus-within` on the box rather than on the
 // input, because the box is what the reveal control and the port hint stand inside.
 //
-// Everything that changes below the compact breakpoint is the same decision made twice: a control a finger has to hit
-// is taller than one a pointer has to hit, and a field a phone keyboard would zoom the page into is one set below the
-// size that browser treats as readable. So the generous size is the base and the compact one is the variant, which is
-// the direction a mobile-first breakpoint reads in.
+// Everything that changes below the workspace breakpoint is the same decision made twice: a control a finger has to
+// hit is taller than one a pointer has to hit, and a field a phone keyboard would zoom the page into is one set below
+// the size that browser treats as readable. So the generous size is the base and the tighter one is the variant, which
+// is the direction a mobile-first breakpoint reads in. It is the same width the workspace stops taking a phone's shape
+// at, which is why this screen names that breakpoint rather than one of its own.
 const fieldBox =
     'flex items-center gap-2 rounded-xl border border-line-strong bg-panel px-3 transition focus-within:border-accent focus-within:ring-3 focus-within:ring-accent-soft';
 
 const fieldInput =
-    'min-h-13 min-w-0 flex-1 bg-transparent text-xl text-text outline-none compact:min-h-11 compact:text-md';
+    'min-h-13 min-w-0 flex-1 bg-transparent text-xl text-text outline-none workspace:min-h-11 workspace:text-md';
 
 const fieldLabel = 'text-sm font-medium text-text-soft';
 
@@ -460,7 +461,7 @@ export function SignIn({
                             aria-label={translate(
                                 revealed ? 'signIn.hidePasswordControl' : 'signIn.revealPasswordControl',
                             )}
-                            className="-me-2 flex min-h-12 shrink-0 items-center rounded-lg px-3 text-md text-muted transition hover:bg-hover hover:text-text compact:min-h-8 compact:px-2 compact:text-sm"
+                            className="-me-2 flex min-h-12 shrink-0 items-center rounded-lg px-3 text-md text-muted transition hover:bg-hover hover:text-text workspace:min-h-8 workspace:px-2 workspace:text-sm"
                             type="button"
                             onClick={() => {
                                 setRevealed(!revealed);
@@ -501,7 +502,7 @@ export function SignIn({
 
                 <div className="flex items-center gap-3">
                     <button
-                        className="flex min-h-13 flex-1 items-center justify-center gap-2 rounded-full bg-accent px-4 text-lg font-semibold text-on-accent transition hover:bg-accent-strong disabled:opacity-70 compact:min-h-11.5 compact:text-md"
+                        className="flex min-h-13 flex-1 items-center justify-center gap-2 rounded-full bg-accent px-4 text-lg font-semibold text-on-accent transition hover:bg-accent-strong disabled:opacity-70 workspace:min-h-11.5 workspace:text-md"
                         disabled={presenting}
                         ref={submit}
                         type="submit"

--- a/frontend/src/Client.App/src/styles.css
+++ b/frontend/src/Client.App/src/styles.css
@@ -188,29 +188,36 @@
     --radius-3xl: 0.875rem;
     --radius-4xl: 1.125rem;
 
-    /* The width the workspace itself changes at: below it the workspace is a stack of screens under bottom
-       navigation, and at or above it a rail beside columns. Declared here so the point where narrow stops is one
-       decision rather than one per screen. The number is the project's, and it is a width rather than a device. */
-    --breakpoint-workspace: 48.75rem;
+    /* The three widths the shell is composed at, and they are the design project's own numbers rather than three
+       roundings of one idea. The project's prototype asks exactly these three questions of the width it was given, and
+       the client asks them under these names — so the four compositions the project frames fall out of the same
+       arithmetic rather than out of a breakpoint that happens to sit near each of them.
 
-    /* The second width the client changes at, and it belongs to one screen: the sign-in split stands as two
-       columns above it and stacks below it, which is wider than the workspace opens out at because a claim beside a
-       form needs more room than a rail beside a list. Declared here for the same reason the first one is. */
+       The first is where the phone shape stops. Below it the shell lays out in the reverse direction: the rail leaves
+       the side and becomes bottom navigation across the foot of the window, a sheet rises from the bottom instead of a
+       panel standing beside the rail, and a form is drawn for a finger rather than for a pointer — taller controls, and
+       fields at the size a phone browser treats as readable rather than one it zooms the page in to reach. The sign-in
+       screen turns its density at this same width, which is why it is one token: two names for 700 pixels is two
+       decisions free to disagree about which shape a window is in. */
+    --breakpoint-workspace: 43.75rem;
+
+    /* The second is where the space stops showing one pane at a time. Below it the Mail space draws the list *or* the
+       message and never both, and moving between them is navigation the back gesture returns through; at or above it
+       the two stand side by side and there is a boundary between them to move. It is wider than the first because a
+       window can carry a rail long before it can carry two columns beside one. */
+    --breakpoint-panes: 51.25rem;
+
+    /* The third is where the desktop composition begins, and it is one width with three consequences the project draws
+       together: the mailbox column stands beside the list rather than in a drawer over it, the toolbar's controls carry
+       their labels rather than standing as symbols alone, and the tab mode is worth offering at all — a row of tabs
+       above the columns needs room a rail beside two of them does not. Below it the shell is the tablet composition,
+       whatever the pointer driving it turns out to be. */
+    --breakpoint-desktop: 73.75rem;
+
+    /* The one width outside that scheme, and it belongs to one screen: the sign-in split stands as two columns above it
+       and stacks below it, which is wider than the workspace opens out at because a claim beside a form needs more room
+       than a rail beside a list. It is the sign-in artboard's own number rather than a fourth shell composition. */
     --breakpoint-split: 58.75rem;
-
-    /* The third, and the only one that decides whether a control may be operated rather than how something is
-       laid out: below it the tab mode is inert, because a row of tabs above the columns needs room a rail beside two
-       of them does not. Declared here for the same reason the other two are — a screen reaching for a width of its own
-       is the same drift as one reaching for a colour. */
-    --breakpoint-tabs: 73.75rem;
-
-    /* The fourth and last, and the only one about density rather than composition: at and above it a form is drawn for
-       a pointer, and below it the same form grows — taller controls a finger can hit, and fields at the size a phone
-       browser treats as readable rather than one it zooms the page in to reach. It is narrower than every other
-       breakpoint here because it is not a layout at all: a window can stack the sign-in screen's two halves and still
-       be driven with a mouse. The sign-in screen is the only one that reads it today, which is where the project draws
-       the change; it is a width rather than a device, exactly as the three above are. */
-    --breakpoint-compact: 43.75rem;
 
     /* One row of the message list. Declared here rather than in the list because it is a density decision like any
        other — and because the list is arithmetic over it: the window that keeps a mailbox of two hundred thousand

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -1397,10 +1397,11 @@ test('draws every row of the list at one height, which is what the window is ari
 });
 
 test('draws the three columns of the Mail space without the page scrolling sideways', async ({ page }) => {
-    // The width the composition opens out at, which is where the three columns have the least room they will ever
-    // have: any narrower and they are a stack instead. A column that held its width here rather than giving way is
-    // what would push the page wider than the window, and only a browser answers that — jsdom computes no geometry.
-    await page.setViewportSize({ width: 780, height: 800 });
+    // The width the third column arrives at, which is where the three of them have the least room they will ever have:
+    // one pixel narrower and the mailboxes are a drawer instead. A column that held its width here rather than giving
+    // way is what would push the page wider than the window, and only a browser answers that — jsdom computes no
+    // geometry.
+    await page.setViewportSize({ width: 1180, height: 800 });
 
     // With a message open, so the third column is the pane a reader actually gets rather than the note standing in
     // for it: the pane is the column that has to give way, and an empty one proves nothing about a filled one.


### PR DESCRIPTION
## What this changes

The client had one composition breakpoint where the design project's prototype has three, so the fold and the tablet
fell out of the desktop's range rather than being drawn as the cases the project frames. This replaces that with the
prototype's own arithmetic and answers the back gesture on all three heads.

**The three widths, and the four compositions they give.** `styles.css` now declares `--breakpoint-workspace` (700),
`--breakpoint-panes` (820) and `--breakpoint-desktop` (1180) — the prototype's own numbers — and
`shell/useWideWorkspace.ts` publishes one hook per width: `useWideWorkspace`, the new `useTwoPanes`, and
`useDesktopComposition` in place of `useWideEnoughForTabs`. The phone gets bottom navigation, one pane and a mailbox
drawer; the fold and the tablet get two panes, a drawer and the toolbar; the desktop gets the mailbox column, the tab
strip and a toolbar whose controls carry their names. `--breakpoint-compact` is gone: it was a second name for 700, and
the sign-in screen reads `workspace` instead. `--breakpoint-split` stays as the sign-in artboard's own number.

**What stands over the screen is recorded.** `shell/screenLayers.ts` is a stack every surface registers itself in while
it is open — the mailbox drawer, the settings screen, the notification centre, the overflow sheet, the account menu, a
row's context menu, a confirmation, and the composer's discard question. The blocking overlay deliberately registers
nothing: an operation that must finish is not something a gesture may dismiss.

**The back gesture is a shell operation with one implementation, and that is the finding.**
`shellOperations/backNavigation.ts` keeps one history entry per layer standing and unwinds them as the gesture consumes
them; `App.tsx` closes the topmost layer, then the attachment, then the sender's own markup, then the message drawn in
front of the list, and only then lets the platform have the press. Taking the navigation to another destination closes
every layer at once.

ADR 0027 § *The no-platform-branch rule holds* places the back gesture in `shellOperations/` beside the credential store
and the system notification, and this module is there. What it resolves, though, is that **there is nothing left to
choose between**: the committed `MainActivity` turns `handleBackNavigation` back on — Tauri's own activity turns it off —
so the gesture arrives in the page as `popstate` exactly as a browser's back does, and the desktop and web heads gained
the behaviour with no line written for either. The ADR's premise for the seam is that the shell contributes an event the
application cannot observe for itself; on this head, configuring the shell is what makes that untrue. So the module reads
no shell command and publishes one hook rather than an interface with a single implementation, which
`frontend/src/AGENTS.md` refuses. **If that reading is wrong, the correction is an amendment to 0027 rather than a
change here**, and it is called out for that reason.

Nothing about mail reaches an address or a history entry, under ADR 0028: what is pushed is an entry at the address
already showing, marked with how many steps stand over the screen.

**The toolbar's labels follow the composition.** The design draws every control's name in words only in the desktop
composition and the symbols alone at the tablet and the fold, which the client did not — so `controlShapes.ts` gains
`primarySymbol` and `MailToolbar` picks its two shapes from `useDesktopComposition`.

**Safe-area insets on the three surfaces that escape the frame.** The frame already pads all four insets, but a modal
dialog stands in the platform's top layer where that padding is not around it: the settings screen, the mailbox drawer,
and the notification centre now carry the insets they cross.

## Held against the design project

Two screenshots per composition, at 390×844, 884×832, 1024×768 and 1440×900, the first three with a coarse pointer. The
shell matches at all four: the bottom bar and its five places at the phone, the labelled rail from 700 up, two panes
from 820 up, the mailbox drawer below 1180 and the column above it, and the toolbar's two forms. At the desktop the
toolbar's nine controls carry the design's own words in the design's own order.

Every difference that remains belongs to a screen rather than to the shell, and each is named here:

- **The list header** is three rows in the client — the drawer control, the search field with its button, then the filter
  control — where the design draws one row carrying all four. It differs the same way at every width, so it is the
  search bar's own composition rather than anything this change decides.
- **The message row** draws initials, the sender's domain and the flag and attachment symbols where the design draws a
  round portrait, an unread count, and an AI summary line. That is the row issues' and the AI stage's.
- **The question at the foot** carries a mailbox-scope select the design does not draw, and the design's own reads
  differently once a message is open and carries scope chips at the desktop. AI stage.
- **The mailbox column** draws the account and folder tree where the design draws saved views above per-account trees.
- **Two labels differ in wording.** The bottom bar's bell reads *Powiadomienia* where the design reads *Alerty*, and the
  rail's seventh place reads *Osoby* where the design reads *Kontakty*. Both are single catalogue entries, and both were
  left alone deliberately: the bell's visible label is also its accessible name and the notification centre's, settled
  against the design by #1608 a day ago, and the People space's name belongs to #1558. Changing either here would be
  this issue overruling a sibling's contract on a glance at one artboard.

## Acceptance

- [x] Four compositions at the widths the design frames them at, the fold as its own case
- [x] The rail becomes the bottom bar; the destinations it drops are behind *Więcej*
- [x] One pane below 820, reversible, with the address and the history agreeing
- [x] Side panels as drawers below 1180, focus moved in and returned by the platform's own modal dialog
- [x] Safe-area insets across the shell, including the three top-layer surfaces the frame's padding does not reach
- [x] The back gesture navigates inside the client, resolved at the composition root, with nothing branching on the head
- [x] Back closes the topmost layer first, one per press, and only an empty screen lets it leave
- [x] Another destination closes every layer over the screen
- [x] Unit tests beside their sources, driven by viewport rather than by head
- [x] Two screenshots per composition, every difference named above

## Verification

`scripts/verify-full.sh` green. `pnpm android:build` run by hand, which is what a change reaching `src-tauri/` owes and
no gate covers.

Closes #1616
