### PR TITLE
[#1514] Put a reader back before the list asks for anything, and wait for the line the keyboard lands on

### DIFF
--- a/frontend/src/Client.App/src/messageList/MessageList.test.tsx
+++ b/frontend/src/Client.App/src/messageList/MessageList.test.tsx
@@ -247,6 +247,51 @@ describe('MessageList', () => {
         expect(requests[0]?.path).toContain('cursor=where-they-were');
     });
 
+    it('reads nothing above the page it continued into, which nobody scrolled to', async () => {
+        rememberListing(session.baseAddress, everything, {
+            order: 'newestFirst',
+            filters: openingListing.filters,
+            cursor: 'where-they-were',
+            readAs: 'forward',
+            rowInPage: rowsPerPage - 1,
+        });
+
+        const { transport, requests } = recording(
+            pageOf(
+                Array.from({ length: rowsPerPage }, (_, at) => message(at)),
+                { previousCursor: 'the-page-above' },
+            ),
+        );
+
+        renderList(transport);
+        await rows();
+
+        expect(requests.map((asked) => asked.path).filter((path) => path.includes('direction=backward'))).toStrictEqual(
+            [],
+        );
+    });
+
+    it('keeps reading past a page that answered with no rows and a cursor onward', async () => {
+        const requests: ClientRequest[] = [];
+        const transport: MailFathomTransport = (request) => {
+            requests.push(request);
+
+            return Promise.resolve({
+                status: 200,
+                headers: {},
+                body:
+                    requests.length === 1
+                        ? pageOf([], { nextCursor: 'the-page-after' })
+                        : pageOf([message(0)], { previousCursor: 'the-page-above' }),
+            });
+        };
+
+        renderList(transport);
+        await rows();
+
+        expect(requests[1]?.path).toContain('cursor=the-page-after');
+    });
+
     it('says what failed and offers the way out of the one failure a second attempt answers', async () => {
         renderList(answering('', 503));
 

--- a/frontend/src/Client.App/src/messageList/MessageList.tsx
+++ b/frontend/src/Client.App/src/messageList/MessageList.tsx
@@ -123,12 +123,18 @@ export function MessageList({
     const [pressed, setPressed] = useState<{ readonly row: number; readonly at: MenuPoint } | null>(null);
     const [questioned, setQuestioned] = useState<readonly ActedMessage[]>([]);
 
+    // Whether the reader has been put back where they were. State rather than a ref, because what depends on it is what
+    // the list asks the deployment for, and that is worked out during render: a list restored into a page it opened
+    // from a cursor spends the commit before the scroller is moved with its window at the leading end of that page,
+    // which is where the read below would ask for the page before it. Nobody scrolled there, and a hundred rows joining
+    // above the reader between two frames is a reader taken a page back up the folder.
+    const [restored, setRestored] = useState(false);
+
     const scroller = useRef<HTMLDivElement>(null);
     const deleting = useRef<HTMLDialogElement>(null);
     const filing = useRef<HTMLDialogElement>(null);
     const elements = useRef(new Map<number, HTMLLIElement>());
     const dragging = useRef(false);
-    const restored = useRef(false);
     const wantsFocus = useRef(false);
 
     const rowCount = rowCountOf(held);
@@ -151,13 +157,20 @@ export function MessageList({
     //
     // It is `null` for a list that wants nothing, which is also how a read in flight reads: the answer is what changes
     // it, so nothing has to be kept saying whether one is out. A network gap and a failure both make it `null`, which
-    // ends the read they interrupted rather than letting it outlive them.
+    // ends the read they interrupted rather than letting it outlive them. It is `null` on the one commit between the
+    // first page arriving and the reader being put back into it as well, for the reason `restored` above gives: what
+    // the window says on that commit is where the list drew before it was placed rather than where it is, and a page
+    // asked for on that reading is a page nobody scrolled to. A list standing on no rows is placed by that same
+    // reading — there is nowhere to put anybody back into, and it is what a page that answered with nothing but a
+    // cursor onward leaves, which is a list that has to keep reading rather than one waiting to be placed.
     const wanted =
         !online || failure !== null
             ? null
             : held.slots.length === 0
               ? { cursor: opening.cursor, direction: opening.readAs, refilling: null }
-              : wantedFor(held, drawn.first, lastDrawn);
+              : restored || rowCount === 0
+                ? wantedFor(held, drawn.first, lastDrawn)
+                : null;
 
     // Named apart so the effect below depends on what the request *is* rather than on the object naming it. A fresh
     // object every render would put a request on the wire every render; these three change only when the page wanted
@@ -249,9 +262,16 @@ export function MessageList({
         // The reader is put back where they were once there is something to put them back into, and once only: every
         // later scroll is theirs. The measured height rather than the one in state, because both happen on this commit
         // and the one in state is a render behind.
-        if (!restored.current && rowCount > 0) {
-            restored.current = true;
-            element.scrollTop = offsetOfRow(opening.rowInPage, measured > 0 ? measured : rowHeight);
+        if (!restored && rowCount > 0) {
+            const placed = offsetOfRow(opening.rowInPage, measured > 0 ? measured : rowHeight);
+
+            // The window is moved with the scroller rather than left to the scroll event the assignment raises. That
+            // event is delivered on the browser's own schedule, and the render that lets the read below go out again
+            // is this one — so a window still reading zero here is a page asked for from where the list was before it
+            // was placed. The event still arrives and still carries this offset, which sets no state a second time.
+            element.scrollTop = placed;
+            setScrollTop(placed);
+            setRestored(true);
         }
 
         if (wantsFocus.current && focusedIsDrawn) {
@@ -262,7 +282,7 @@ export function MessageList({
                 wantsFocus.current = false;
             }
         }
-    }, [viewport, rowHeight, rowCount, drawn.first, opening.rowInPage, focusedRow, focusedIsDrawn]);
+    }, [viewport, rowHeight, rowCount, drawn.first, opening.rowInPage, focusedRow, focusedIsDrawn, restored]);
 
     // A window resized changes how many rows the list draws, and a resize is not a commit. The scroller's own size is
     // read on the commit that follows, which is what this asks for.
@@ -354,7 +374,7 @@ export function MessageList({
         // made rather than a position they drifted to: leaving the moment after making it keeps it.
         rememberListing(session.baseAddress, scope, restarted);
         setOpening(restarted);
-        restored.current = false;
+        setRestored(false);
         setListing(chosen);
         setHeld(nothingHeld);
         setFailure(null);

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -681,6 +681,13 @@ test('moves a keyboard through a narrow window in the order the window shows', a
     // the space at the top of the window. Only a browser answers this: jsdom has no sequential focus navigation.
     // The freshness line is the first thing the space holds, and it is a disclosure onto the account-by-account
     // reading of the same sentence — so it is where a keyboard arrives before any of the controls beneath it.
+    //
+    // Waited for before the first key rather than after it: until the accounts have answered, that line is a sentence
+    // saying the deployment is being reached, which is text rather than a disclosure and takes no focus at all. A Tab
+    // pressed then lands on the control below it and stays there, and every assertion after it would be reading a tab
+    // order the window was not yet showing.
+    await expect(page.getByText('Every account is up to date.')).toBeVisible();
+
     await page.keyboard.press('Tab');
     await expect(page.getByText('Every account is up to date.')).toBeFocused();
 


### PR DESCRIPTION
Both browser-suite failures #1514 tracks are diagnosed, and neither turned out to be the same kind of defect.

## The reload failure is the client's restoration

A list restored from a cursor **asks the deployment for the page above the one it opened into**, and that page is prepended over the reader.

`opening` names a cursor and a row inside it. On the commit where that page arrives, the scroller has not been moved yet, so `scrollTop` still reads zero and the window is at the leading end of the page — and `wantedFor` reads `firstRow <= 0` as *the reader has scrolled to the top of what is held*, so the list asks for the page before it. That request goes out on **every** restore; it is deterministic rather than rare, and it was measured here:

```
asked=[".../emails?...direction=forward&cursor=100",
       ".../emails?...direction=backward&cursor=100"]
```

Whether it does any harm is the race. The scroll event the restore's `element.scrollTop` assignment raises is delivered on the browser's own schedule; when it lands first, the window moves, the read is abandoned, and nothing is visible. When the answer lands first, a hundred rows join above the reader and every row index shifts by one page — which is exactly the runner's report, `Message 157` expected against `Message 57` received, one page and no other distance.

The fix is that the list asks for nothing between the first page arriving and the reader being put back into it, and that being put back moves the window with the scroller rather than waiting for an event:

- `restored` becomes state rather than a ref, because what depends on it is what the list asks for, and that is worked out during render.
- The restore sets `scrollTop` alongside `element.scrollTop`, so the render that lets reads resume is the one that already knows where the list is.
- A list standing on no rows counts as placed, so a page that answers with nothing but a cursor onward is still read past rather than leaving the list waiting to be placed. That case has a test of its own; without the clause it hangs.

After it, the restore issues the forward read alone and the reader lands where they left, ten runs out of ten.

## The keyboard-order failure is the spec's waiting

The first `Tab` was pressed before the window was showing the tab order being asserted. Until the accounts answer, the freshness line reads *Reaching your deployment…* and is plain text — not a `<summary>`, and not focusable. A `Tab` pressed then goes to the searchbox below it and stays there, which is why the locator resolves the right element fourteen times and it is never focused. Measured with a passive `focusin` recorder, which is why the diagnosis holds: the failing runs end `… DIV|Reaching your deployment… , INPUT|` and the passing ones `… , SUMMARY|Every account is up to date.`

The spec now waits for that line before the first key. Nothing in the client changed for it: the tab order was always right, and the test was reading it a beat early.

`frontend/tests/AGENTS.md` § *The browser suite* is untouched, and nothing gained a retry.

## Verification

- The keyboard test **10/10** and the reload test **10/10** in back-to-back local loops. The keyboard one failed 3/3 in that same loop before this change, which is the measurement #1514 named as the cheapest proof.
- Both new unit tests were confirmed to fail without their half of the fix.
- `pnpm test` 2698 passed; `pnpm test:browser` 45 passed; `scripts/verify-full.sh` passed.

Closes #1514

https://claude.ai/code/session_01SRiFzGLJhGDsL7jYfKDkAN
