### PR TITLE
[#1664] Raise a browser notification on the web head, through the operation the desktop head already resolves

### DIFF
--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -1806,6 +1806,14 @@ TLS-terminating reverse proxy and wrong anywhere else, so startup says so:
 - an endpoint serving [the page](#serving-the-client-from-the-deployment) over clear text an operator explicitly
   permitted reports that separately, at every startup, naming the permission rather than assuming it is still true.
 
+**One thing the page itself does less of over clear text**, and no setting turns it back on: a browser withholds the
+Notifications API outside a secure context, so a client reached over plain `http` at anything but `localhost` raises no
+system notification while its window is behind another, draws no switch for one on its settings screen, and asks nobody
+for permission. It is the browser's own rule rather than this deployment's, it is decided by the address a person
+opened rather than by any configuration here, and the client reports the operation as one this run does not carry —
+which is the same thing it says on a desktop shell that linked no notification plugin. A deployment that wants the
+client to notify therefore serves the page over `https`, which is what the redirect above already is for.
+
 All three are warnings rather than refusals, because a loopback bind, a private network, and a proxy that terminates
 TLS are each a deployment where one of them is the right answer, and only an operator knows which they have. Serving
 the page is the one part that is refused rather than warned about, for the reason the next section gives — and that

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -125,7 +125,19 @@ build time, so linking it would change what `gen/android/app/gradle.lockfile` fi
 that verifies that file. The phone's own notification is
 [#1616](https://github.com/Krzysztof318/MailFathom/issues/1616), which grants the capability, declares the runtime
 permission, and rewrites the lock file together; until then the Android head meets an operation that reports itself
-unoffered, exactly as the web head does.
+unoffered.
+
+**The web head raises one too, and through this same operation rather than beside it.** A browser has the
+Notifications API of its own, so `shellOperations/systemNotifier.ts` resolves a second implementation where no shell
+announced itself, and everything above it — the settings switch, the count and kind an arrival is reduced to, the rule
+that says nothing while the window has focus — is what it already was. Three things are the browser's own and are the
+whole of what differs. Permission is asked from the settings switch rather than from an arrival, because a browser
+wants a gesture behind the prompt and cannot re-ask a person who has said no. The API is withheld entirely outside a
+secure context, so a page served over plain `http` at anything but `localhost` carries no such operation and draws no
+switch — [the client endpoint's page](../docs/operations/client-endpoint.md) is where an operator reads that. And
+somebody acting on one arrives by a different route: the shell says it out loud over its own event, while the browser
+reports it on the notification itself, so the web head satisfies `whenActedOn` out of `Notification.onclick` and adds
+bringing the window to the front, which the shell's own event arrives too late to need.
 
 | What                                                                | Where it is decided                                                                                                                                                                                    |
 | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/frontend/src/AGENTS.md
+++ b/frontend/src/AGENTS.md
@@ -195,6 +195,21 @@ that would decide nothing — which is how a surface adapts to an absent operati
 did not need: a shell announcing itself says nothing about a plugin only some targets link, so the question is whether
 the binding that plugin installs is there. And an operation a head does not carry is an answer of its own rather than a
 refusal — a refusal was given by somebody and is kept, an absent operation was decided by nobody and is kept nowhere.
+
+**The same module is also the worked example of a shell operation a head other than a shell can satisfy**, which is
+what stops "shell operation" from meaning "the desktop one does it and the rest do without". A browser has the
+Notifications API, so `systemNotifier.ts` resolves a second implementation of the _same_ operation where no shell
+announced itself — and the settings row, the privacy bound, the device switch, and the focus rule are unchanged, because
+none of them ever asked which head was underneath. Three rules come out of it and hold for the next such module.
+**The order the implementations are asked in is part of the resolution**, since the desktop plugin installs its own
+replacement for the platform binding: the shell is asked first, or a browser question would answer for a head the
+plugin was already answering for. **What a head can do before anybody is asked is part of the operation's own type**,
+which is why this one answers a standing beside a way to ask — a browser needs a gesture behind its prompt and cannot
+re-ask somebody who refused, so a switch that assumed a default would draw a promise the head could not keep, and only
+the operation knows which case it is in. And **one member is satisfied by whatever each head actually has**, rather
+than gaining a second member per head: `whenActedOn` is a shell event on the desktop and `Notification.onclick` in a
+browser, and the caller subscribes once without learning which. That the two arrive by different mechanisms is the
+implementations' business; that they arrive at all is the operation's.
 `Client.App/src/signIn/credentialStore.ts` is the other one today and predates the directory, so it still sits beside
 the sign-in screen; moving it is a change of its own rather than a side effect of adding the second. What is refused
 above is a component, a hook, or a screen asking the question itself, and that refusal is unchanged by either

--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -390,9 +390,11 @@ const deliversNothing: AttachmentExchange = {
 
 const uploadsNothing: AttachmentUpload = () => Promise.resolve(null);
 
-/** The head a test runs in: one that offered no system notification, which is the web head and what jsdom is. */
+/** The head a test runs in: one that offered no system notification, which is what jsdom is with no binding on it. */
 const raisesNothing: SystemNotifier = {
     offered: false,
+    standing: 'unasked',
+    permit: () => Promise.resolve('unasked'),
     raise: () => Promise.resolve('unavailable'),
     whenActedOn: () => () => undefined,
 };

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -182,6 +182,8 @@ export const en = {
     'settings.raiseSystemNotifications': 'Notify me on this machine',
     'settings.raiseSystemNotificationsExplanation':
         'When the window is not in front of you, this machine says how much arrived and of what kind — never who wrote or what about.',
+    'settings.systemNotificationsRefused':
+        'This browser has been told to block notifications from here. Allow them in its own site settings, and this switch will work again.',
     'settings.privacy': 'Privacy',
     'settings.telemetryWithheld': 'Do not send telemetry',
     'settings.telemetryExplanation': 'Error diagnostics and usage statistics stay on this device.',

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -184,6 +184,8 @@ export const pl: Catalogue = {
     'settings.raiseSystemNotifications': 'Powiadamiaj mnie na tym urządzeniu',
     'settings.raiseSystemNotificationsExplanation':
         'Gdy okno nie jest przed Tobą, to urządzenie mówi, ile rzeczy przyszło i jakiego rodzaju — nigdy od kogo ani w jakiej sprawie.',
+    'settings.systemNotificationsRefused':
+        'Ta przeglądarka ma zablokowane powiadomienia z tej strony. Zezwól na nie w jej własnych ustawieniach witryny, a przełącznik znów zadziała.',
     'settings.privacy': 'Prywatność',
     'settings.telemetryWithheld': 'Nie wysyłaj danych telemetrycznych',
     'settings.telemetryExplanation': 'Diagnostyka błędów i statystyki użycia zostają na tym urządzeniu.',

--- a/frontend/src/Client.App/src/notifications/useNotificationCentre.test.tsx
+++ b/frontend/src/Client.App/src/notifications/useNotificationCentre.test.tsx
@@ -138,6 +138,8 @@ const shell: SystemNotifier = {
     get offered() {
         return head.offered;
     },
+    standing: 'permitted',
+    permit: () => Promise.resolve('permitted'),
     raise: (said) => {
         if (head.answers !== 'raised') {
             return Promise.resolve(head.answers);

--- a/frontend/src/Client.App/src/notifications/useNotificationCentre.ts
+++ b/frontend/src/Client.App/src/notifications/useNotificationCentre.ts
@@ -252,10 +252,12 @@ export function useNotificationCentre(
         [session, transport, onFollow],
     );
 
-    // What the operating system is told, which is the whole of the desktop head's half of an arrival. Three things
-    // decide whether anything is said at all, and each of them is a different question: whether a shell offered the
+    // What the operating system is told, which is the whole of an arrival's half outside the window. Three things
+    // decide whether anything is said at all, and each of them is a different question: whether this head offered the
     // operation, whether this machine was left raising them, and whether somebody is already looking at the window —
-    // a notification raised over a window somebody is reading is the client interrupting itself.
+    // a notification raised over a window somebody is reading is the client interrupting itself. None of the three is
+    // a question about which head this is: a desktop shell and a browser both answer the first, and everything below
+    // reads the same way in either.
     //
     // `document.hasFocus()` rather than `visibilityState`, and the difference is the case this exists for: a desktop
     // window standing behind another is visible and unfocused, which is exactly when nobody is looking at it.

--- a/frontend/src/Client.App/src/settings/Settings.test.tsx
+++ b/frontend/src/Client.App/src/settings/Settings.test.tsx
@@ -506,7 +506,7 @@ describe('Settings', () => {
         expect(window.localStorage.getItem(deviceKeys.systemNotifications)).toBe('true');
     });
 
-    it('says so in the row where the answer to that question was no, and stops offering the switch', async () => {
+    it('says so in the row where the answer to that question was no, and leaves the switch off', async () => {
         renderSettings({ head: asksFirst('refused') });
         openApplication();
 
@@ -516,7 +516,7 @@ describe('Settings', () => {
         });
 
         expect(screen.getByText(/told to block notifications/u)).toBeTruthy();
-        expect(screen.getByRole('switch', { name: /Notify me on this machine/u })).toHaveProperty('disabled', true);
+        expect(screen.getByRole('switch', { name: /Notify me on this machine/u })).toHaveProperty('checked', false);
         expect(window.localStorage.getItem(deviceKeys.systemNotifications)).toBe('false');
     });
 
@@ -553,7 +553,27 @@ describe('Settings', () => {
         });
 
         expect(screen.getByText(/told to block notifications/u)).toBeTruthy();
-        expect(screen.getByRole('switch', { name: /Notify me on this machine/u })).toHaveProperty('disabled', true);
+        expect(screen.getByRole('switch', { name: /Notify me on this machine/u })).toHaveProperty('checked', false);
+    });
+
+    it('recovers on the gesture once the browser has been told to allow them after all', async () => {
+        const browser = asksFirst('permitted');
+        browser.toldToBlockThem();
+        renderSettings({ head: browser });
+        openApplication();
+
+        expect(screen.getByText(/told to block notifications/u)).toBeTruthy();
+
+        // What the row promises in words is that this switch works again once the browser has been told, and the
+        // gesture is what reads that: nothing announces a permission granted from the browser's own site settings, so a
+        // row that disabled itself here would be the one state on this screen nothing on this screen could leave.
+        await act(async () => {
+            fireEvent.click(screen.getByRole('switch', { name: /Notify me on this machine/u }));
+            await Promise.resolve();
+        });
+
+        expect(screen.getByRole('switch', { name: /Notify me on this machine/u })).toHaveProperty('checked', true);
+        expect(screen.queryByText(/told to block notifications/u)).toBeNull();
     });
 
     it('reports a browser already told to block them without putting the question to it again', () => {
@@ -561,7 +581,7 @@ describe('Settings', () => {
         openApplication();
 
         expect(screen.getByText(/told to block notifications/u)).toBeTruthy();
-        expect(screen.getByRole('switch', { name: /Notify me on this machine/u })).toHaveProperty('disabled', true);
+        expect(screen.getByRole('switch', { name: /Notify me on this machine/u })).toHaveProperty('checked', false);
     });
 
     it('closes from its own control, which is the way out that does not need a keyboard', () => {

--- a/frontend/src/Client.App/src/settings/Settings.test.tsx
+++ b/frontend/src/Client.App/src/settings/Settings.test.tsx
@@ -11,7 +11,11 @@ import { chooseSystemNotifications } from '../preferences/systemNotifications';
 import type { ClientPreferencesInForce } from '../preferences/useClientPreferences';
 import type { OwnProfileInForce } from '../profile/useOwnProfile';
 import { deviceKeys } from '../device/deviceStore';
-import { SystemNotifierContext, type SystemNotifier } from '../shellOperations/systemNotifier';
+import {
+    SystemNotifierContext,
+    type NotificationStanding,
+    type SystemNotifier,
+} from '../shellOperations/systemNotifier';
 import { Settings } from './Settings';
 
 const settings: ClientPreferencesInForce = {
@@ -75,17 +79,52 @@ function renderSettings({
     );
 }
 
-/** The web head, where nothing offered the operation and the row therefore has nothing to decide. */
+/** A head that offered nothing, which is a page served outside a secure context and a shell with no plugin linked. */
 const raisesNothing: SystemNotifier = {
     offered: false,
+    standing: 'unasked',
+    permit: () => Promise.resolve('unasked'),
     raise: () => Promise.resolve('unavailable'),
     whenActedOn: () => () => undefined,
 };
 
-/** A head that offered it, which is the desktop one. */
+/** A head that offered it and grants on demand, which is the desktop one. */
 const raisesThem: SystemNotifier = {
     offered: true,
+    standing: 'permitted',
+    permit: () => Promise.resolve('permitted'),
     raise: () => Promise.resolve('raised'),
+    whenActedOn: () => () => undefined,
+};
+
+/**
+ * A head that offered it and has to ask somebody first, which is what a browser is.
+ *
+ * @param answered What the person says to the browser's own dialog when the switch puts it in front of them.
+ */
+function asksFirst(answered: NotificationStanding): SystemNotifier & { asked: () => number } {
+    let asked = 0;
+
+    return {
+        offered: true,
+        standing: 'unasked',
+        permit: () => {
+            asked += 1;
+
+            return Promise.resolve(answered);
+        },
+        raise: () => Promise.resolve(answered === 'permitted' ? 'raised' : 'unavailable'),
+        whenActedOn: () => () => undefined,
+        asked: () => asked,
+    };
+}
+
+/** A browser that has already been told to block them, which no gesture on this row can put a question to again. */
+const alreadyRefused: SystemNotifier = {
+    offered: true,
+    standing: 'refused',
+    permit: () => Promise.resolve('refused'),
+    raise: () => Promise.resolve('refused'),
     whenActedOn: () => () => undefined,
 };
 
@@ -430,6 +469,62 @@ describe('Settings', () => {
         });
 
         expect(screen.getByRole('switch', { name: /Notify me on this machine/u })).toHaveProperty('checked', false);
+    });
+
+    it('draws the switch off on a head nobody has been asked in, however the device was left', () => {
+        renderSettings({ head: asksFirst('permitted') });
+        openApplication();
+
+        expect(screen.getByRole('switch', { name: /Notify me on this machine/u })).toHaveProperty('checked', false);
+    });
+
+    it('asks from the gesture, and a grant leaves the switch on and the answer on the device', async () => {
+        const browser = asksFirst('permitted');
+        renderSettings({ head: browser });
+        openApplication();
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('switch', { name: /Notify me on this machine/u }));
+            await Promise.resolve();
+        });
+
+        expect(browser.asked()).toBe(1);
+        expect(screen.getByRole('switch', { name: /Notify me on this machine/u })).toHaveProperty('checked', true);
+        expect(window.localStorage.getItem(deviceKeys.systemNotifications)).toBe('true');
+    });
+
+    it('says so in the row where the answer to that question was no, and stops offering the switch', async () => {
+        renderSettings({ head: asksFirst('refused') });
+        openApplication();
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('switch', { name: /Notify me on this machine/u }));
+            await Promise.resolve();
+        });
+
+        expect(screen.getByText(/told to block notifications/u)).toBeTruthy();
+        expect(screen.getByRole('switch', { name: /Notify me on this machine/u })).toHaveProperty('disabled', true);
+        expect(window.localStorage.getItem(deviceKeys.systemNotifications)).toBe('false');
+    });
+
+    it('writes nothing on the device where the question reached nobody, which nobody decided', async () => {
+        renderSettings({ head: asksFirst('unasked') });
+        openApplication();
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('switch', { name: /Notify me on this machine/u }));
+            await Promise.resolve();
+        });
+
+        expect(window.localStorage.getItem(deviceKeys.systemNotifications)).toBeNull();
+    });
+
+    it('reports a browser already told to block them without putting the question to it again', () => {
+        renderSettings({ head: alreadyRefused });
+        openApplication();
+
+        expect(screen.getByText(/told to block notifications/u)).toBeTruthy();
+        expect(screen.getByRole('switch', { name: /Notify me on this machine/u })).toHaveProperty('disabled', true);
     });
 
     it('closes from its own control, which is the way out that does not need a keyboard', () => {

--- a/frontend/src/Client.App/src/settings/Settings.test.tsx
+++ b/frontend/src/Client.App/src/settings/Settings.test.tsx
@@ -100,22 +100,35 @@ const raisesThem: SystemNotifier = {
 /**
  * A head that offered it and has to ask somebody first, which is what a browser is.
  *
+ * Its standing is read rather than fixed, exactly as the real one reads `Notification.permission` on every ask: what a
+ * browser will do is decided in the browser, so the answer moves when the question is put to it and `toldToBlockThem`
+ * moves it the way an address bar does, with nothing announcing either.
+ *
  * @param answered What the person says to the browser's own dialog when the switch puts it in front of them.
  */
-function asksFirst(answered: NotificationStanding): SystemNotifier & { asked: () => number } {
+function asksFirst(
+    answered: NotificationStanding,
+): SystemNotifier & { asked: () => number; toldToBlockThem: () => void } {
     let asked = 0;
+    let stands: NotificationStanding = 'unasked';
 
     return {
         offered: true,
-        standing: 'unasked',
+        get standing() {
+            return stands;
+        },
         permit: () => {
             asked += 1;
+            stands = answered;
 
             return Promise.resolve(answered);
         },
         raise: () => Promise.resolve(answered === 'permitted' ? 'raised' : 'unavailable'),
         whenActedOn: () => () => undefined,
         asked: () => asked,
+        toldToBlockThem: () => {
+            stands = 'refused';
+        },
     };
 }
 
@@ -517,6 +530,30 @@ describe('Settings', () => {
         });
 
         expect(window.localStorage.getItem(deviceKeys.systemNotifications)).toBeNull();
+    });
+
+    it('follows the head where a permission is taken back underneath an open dialog', async () => {
+        const browser = asksFirst('permitted');
+        renderSettings({ head: browser });
+        openApplication();
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole('switch', { name: /Notify me on this machine/u }));
+            await Promise.resolve();
+        });
+
+        expect(screen.getByRole('switch', { name: /Notify me on this machine/u })).toHaveProperty('checked', true);
+
+        // Nobody tells this screen either of these two things: the browser is told to block them from its own address
+        // bar, and the next arrival it refuses is what turns the choice off from `useNotificationCentre.ts`. A standing
+        // copied at mount would leave the ordinary explanation and a switch to move over a machine that raises nothing.
+        browser.toldToBlockThem();
+        act(() => {
+            chooseSystemNotifications(false);
+        });
+
+        expect(screen.getByText(/told to block notifications/u)).toBeTruthy();
+        expect(screen.getByRole('switch', { name: /Notify me on this machine/u })).toHaveProperty('disabled', true);
     });
 
     it('reports a browser already told to block them without putting the question to it again', () => {

--- a/frontend/src/Client.App/src/settings/Settings.tsx
+++ b/frontend/src/Client.App/src/settings/Settings.tsx
@@ -305,13 +305,47 @@ function Application({
 // rather than passed down — and read through a subscription rather than copied, because the person moving the switch is
 // not the only writer: an arrival the operating system refuses turns it off from `useNotificationCentre.ts`, and a copy
 // taken at mount would still read *on* underneath somebody with this dialog open.
+//
+// **Moving the switch on is the gesture the permission is asked from**, which is why this row asks rather than the
+// arrival that would use it: a browser refuses the prompt outright unless somebody's own action led to it, and a
+// dialog an arrival raised would land over whatever they were reading. Nothing here knows that a browser is what is
+// underneath — it asks the operation where it stands and asks it to ask, and a head that grants unconditionally
+// answers both without a dialog appearing at all.
+//
+// The switch says what this machine will actually do, which is the choice *and* the permission: a head nobody has been
+// asked in yet draws off however the device store reads, because a control saying *on* over a machine that will raise
+// nothing is the one state worse than an absent row. Only a refusal is explained in words, because it is the only one
+// of the three the switch cannot undo — the browser has to be told from its own address bar.
 function SystemNotifications() {
     const { translate } = useLocalization();
     const notifier = useSystemNotifier();
     const raising = useSystemNotificationsChosen();
 
+    // Seeded from what the head already stood at and moved by what it answers, because the operation resolves once at
+    // the composition root and cannot redraw a screen when somebody answers its dialog.
+    const [standing, setStanding] = useState(notifier.standing);
+
     if (!notifier.offered) {
         return null;
+    }
+
+    function choose(on: boolean): void {
+        if (!on) {
+            chooseSystemNotifications(false);
+
+            return;
+        }
+
+        void notifier.permit().then((answered) => {
+            setStanding(answered);
+
+            // Only an answer somebody gave is written. `unasked` is a question that reached nobody — a prompt the
+            // browser dismissed without deciding, or a shell command that threw — and writing *off* for it would leave
+            // a switch to undo on a machine that was never asked anything.
+            if (answered !== 'unasked') {
+                chooseSystemNotifications(answered === 'permitted');
+            }
+        });
     }
 
     return (
@@ -324,11 +358,15 @@ function SystemNotifications() {
                 <span className="flex min-w-0 flex-1 flex-col gap-0.75">
                     {translate('settings.raiseSystemNotifications')}
                     <span className="text-xs text-muted">
-                        {translate('settings.raiseSystemNotificationsExplanation')}
+                        {translate(
+                            standing === 'refused'
+                                ? 'settings.systemNotificationsRefused'
+                                : 'settings.raiseSystemNotificationsExplanation',
+                        )}
                     </span>
                 </span>
 
-                <Switch on={raising} onChange={chooseSystemNotifications} />
+                <Switch on={raising && standing === 'permitted'} disabled={standing === 'refused'} onChange={choose} />
             </label>
         </>
     );

--- a/frontend/src/Client.App/src/settings/Settings.tsx
+++ b/frontend/src/Client.App/src/settings/Settings.tsx
@@ -321,9 +321,15 @@ function SystemNotifications() {
     const notifier = useSystemNotifier();
     const raising = useSystemNotificationsChosen();
 
-    // Seeded from what the head already stood at and moved by what it answers, because the operation resolves once at
-    // the composition root and cannot redraw a screen when somebody answers its dialog.
-    const [standing, setStanding] = useState(notifier.standing);
+    // Read on every render rather than copied, for the same reason the switch above it is: this screen is not the only
+    // writer. An arrival the head refuses turns the choice off from `useNotificationCentre.ts`, and a permission taken
+    // back from the browser's own address bar is written by nobody at all — a value seeded at mount would go on
+    // explaining a machine that will now raise nothing as one the switch can still turn back on.
+    const standing = notifier.standing;
+
+    // Nothing announces that answer, so the one moment this screen knows a redraw is owed is the moment it asked: the
+    // head resolves its own dialog long after the gesture, and only a state change puts the answer on the screen.
+    const [, redrawOnceTheHeadAnswers] = useState(0);
 
     if (!notifier.offered) {
         return null;
@@ -337,7 +343,7 @@ function SystemNotifications() {
         }
 
         void notifier.permit().then((answered) => {
-            setStanding(answered);
+            redrawOnceTheHeadAnswers((asked) => asked + 1);
 
             // Only an answer somebody gave is written. `unasked` is a question that reached nobody — a prompt the
             // browser dismissed without deciding, or a shell command that threw — and writing *off* for it would leave

--- a/frontend/src/Client.App/src/settings/Settings.tsx
+++ b/frontend/src/Client.App/src/settings/Settings.tsx
@@ -315,7 +315,13 @@ function Application({
 // The switch says what this machine will actually do, which is the choice *and* the permission: a head nobody has been
 // asked in yet draws off however the device store reads, because a control saying *on* over a machine that will raise
 // nothing is the one state worse than an absent row. Only a refusal is explained in words, because it is the only one
-// of the three the switch cannot undo — the browser has to be told from its own address bar.
+// of the three that cannot be undone from this row — the browser has to be told first, from its own site settings.
+//
+// It is explained rather than disabled, and the switch stays live under the explanation, because the row promises in
+// words that it will work again once the browser has been told. The gesture is what re-reads the answer: `permit()`
+// asks the head where it stands before it asks anybody anything, so moving the switch on a browser still refusing puts
+// no dialog in front of anyone and moving it on one told to allow them since is what notices. Disabling it would leave
+// the one state the row's own sentence says is recoverable as the one state nothing on the screen can recover from.
 function SystemNotifications() {
     const { translate } = useLocalization();
     const notifier = useSystemNotifier();
@@ -372,7 +378,7 @@ function SystemNotifications() {
                     </span>
                 </span>
 
-                <Switch on={raising && standing === 'permitted'} disabled={standing === 'refused'} onChange={choose} />
+                <Switch on={raising && standing === 'permitted'} onChange={choose} />
             </label>
         </>
     );

--- a/frontend/src/Client.App/src/shellOperations/systemNotifier.test.ts
+++ b/frontend/src/Client.App/src/shellOperations/systemNotifier.test.ts
@@ -14,6 +14,10 @@ import { systemNotifierForThisApplication } from './systemNotifier';
 // `window.Notification` before the bundle runs and the binding goes through that. Raising is this shell's own command
 // and the click it reports is this shell's own event, so both go through the global Tauri API instead. A fake of
 // either one alone would prove nothing about what this module calls, so what stands in below is both.
+//
+// The browser is stood up out of the platform's own three parts — the constructor, the record, and the request — since
+// that is exactly what the plugin's replacement is a replacement *for*. What separates the two heads in every test
+// below is therefore whether a shell announced itself, which is the question the module actually asks.
 
 const tauriBridge = '__TAURI_INTERNALS__';
 
@@ -87,10 +91,67 @@ function shellAnswering(answer: 'granted' | 'denied'): Shell {
     return shell;
 }
 
+/** One notification as this module holds it, which is the two parts it sets on what the constructor returned. */
+interface Raised {
+    onclick?: () => void;
+    close?: () => void;
+}
+
+/** A browser's own Notifications API, as a page reaches it where no shell replaced the binding. */
+interface Browser {
+    /** Every notification the browser was asked to construct, as it would have received it. */
+    readonly raised: { title: string | undefined; body: string | undefined }[];
+
+    /** How many times permission was asked for, which is what "asked from the gesture, once" is measured as. */
+    asked: number;
+
+    /** The last one constructed, so what a click on it does can be provoked. */
+    last: Raised | null;
+}
+
+/**
+ * Installs the browser's own `Notification`, answering the permission question the way one would.
+ *
+ * @param standing What the record reads before anything asks, which is the browser's own `permission`.
+ * @param answer What is answered when somebody is asked, or `null` where the call itself fails.
+ */
+function browserAnswering(standing: NotificationPermission, answer: NotificationPermission | null): Browser {
+    const browser: Browser = { raised: [], asked: 0, last: null };
+
+    const binding = function (this: Raised, title: string, options?: { body?: string }) {
+        browser.raised.push({ title, body: options?.body });
+        this.close = () => undefined;
+        browser.last = this;
+    } as unknown as typeof window.Notification;
+
+    Reflect.set(binding, 'permission', standing);
+    Reflect.set(binding, 'requestPermission', () => {
+        browser.asked += 1;
+
+        if (answer === null) {
+            return Promise.reject(new Error('The browser answered nothing at all.'));
+        }
+
+        Reflect.set(binding, 'permission', answer);
+
+        return Promise.resolve(answer);
+    });
+
+    Reflect.set(window, 'Notification', binding);
+
+    return browser;
+}
+
+/** Whether the page is in a secure context, which is the one condition a browser withholds the whole API outside of. */
+function servedSecurely(secure: boolean): void {
+    Object.defineProperty(globalThis, 'isSecureContext', { configurable: true, value: secure });
+}
+
 afterEach(() => {
     Reflect.deleteProperty(globalThis, tauriBridge);
     Reflect.deleteProperty(window, '__TAURI__');
     Reflect.deleteProperty(window, 'Notification');
+    servedSecurely(false);
 });
 
 describe('systemNotifierForThisApplication', () => {
@@ -103,11 +164,13 @@ describe('systemNotifierForThisApplication', () => {
         await expect(notifier.raise('2 new messages')).resolves.toBe('unavailable');
     });
 
-    it('offers nothing where no shell announced itself, so the web head raises nothing and asks nothing', async () => {
+    it('offers nothing where neither a shell nor a browser carries the operation at all', async () => {
         const notifier = systemNotifierForThisApplication();
 
         expect(notifier.offered).toBe(false);
+        expect(notifier.standing).toBe('unasked');
         await expect(notifier.raise('2 new messages')).resolves.toBe('unavailable');
+        await expect(notifier.permit()).resolves.toBe('unasked');
     });
 
     it('subscribes to nothing where no shell offered the operation, and stopping that subscription is safe', () => {
@@ -171,5 +234,187 @@ describe('systemNotifierForThisApplication', () => {
         expect([first, second]).toEqual(['refused', 'refused']);
         expect(shell.asked).toBe(1);
         expect(shell.raised).toEqual([]);
+    });
+
+    it('stands permitted on a shell head, which grants on demand rather than putting a dialog in front of anybody', () => {
+        shellAnswering('granted');
+
+        expect(systemNotifierForThisApplication().standing).toBe('permitted');
+    });
+
+    it('asks the shell once between the settings switch and an arrival', async () => {
+        const shell = shellAnswering('granted');
+        const notifier = systemNotifierForThisApplication();
+
+        await expect(notifier.permit()).resolves.toBe('permitted');
+        await notifier.raise('2 new messages');
+
+        expect(shell.asked).toBe(1);
+    });
+
+    it('reports the shell refusing to the switch that asked, which is the Android head under #1616', async () => {
+        shellAnswering('denied');
+
+        await expect(systemNotifierForThisApplication().permit()).resolves.toBe('refused');
+    });
+});
+
+describe('systemNotifierForThisApplication in a browser', () => {
+    it('offers the operation where the page is served securely and the browser carries the API', () => {
+        servedSecurely(true);
+        browserAnswering('default', 'granted');
+
+        const notifier = systemNotifierForThisApplication();
+
+        expect(notifier.offered).toBe(true);
+        expect(notifier.standing).toBe('unasked');
+    });
+
+    it('offers nothing outside a secure context, which is a client endpoint served over plain http', async () => {
+        servedSecurely(false);
+        browserAnswering('granted', 'granted');
+
+        const notifier = systemNotifierForThisApplication();
+
+        expect(notifier.offered).toBe(false);
+        await expect(notifier.raise('2 new messages')).resolves.toBe('unavailable');
+    });
+
+    it('stands refused where the browser has already been told to block them, and puts no second question to it', async () => {
+        servedSecurely(true);
+        const browser = browserAnswering('denied', 'granted');
+
+        const notifier = systemNotifierForThisApplication();
+
+        expect(notifier.standing).toBe('refused');
+        await expect(notifier.permit()).resolves.toBe('refused');
+        expect(browser.asked).toBe(0);
+    });
+
+    it('asks the browser from the gesture, and once however many gestures are made', async () => {
+        servedSecurely(true);
+        const browser = browserAnswering('default', 'granted');
+        const notifier = systemNotifierForThisApplication();
+
+        const answers = await Promise.all([notifier.permit(), notifier.permit()]);
+
+        expect(answers).toEqual(['permitted', 'permitted']);
+        expect(browser.asked).toBe(1);
+    });
+
+    it('reads a prompt somebody closed without answering as unasked rather than as a refusal', async () => {
+        servedSecurely(true);
+        browserAnswering('default', 'default');
+
+        await expect(systemNotifierForThisApplication().permit()).resolves.toBe('unasked');
+    });
+
+    it('asks again on a second gesture where the first prompt was closed without an answer', async () => {
+        servedSecurely(true);
+        const browser = browserAnswering('default', 'default');
+        const notifier = systemNotifierForThisApplication();
+
+        await notifier.permit();
+        await notifier.permit();
+
+        expect(browser.asked).toBe(2);
+    });
+
+    it('reads the standing at each ask, so a dialog reopened after a grant draws what the browser now holds', async () => {
+        servedSecurely(true);
+        browserAnswering('default', 'granted');
+        const notifier = systemNotifierForThisApplication();
+
+        expect(notifier.standing).toBe('unasked');
+        await notifier.permit();
+
+        expect(notifier.standing).toBe('permitted');
+    });
+
+    it('holds no grant, so permission taken back from the address bar is answered rather than the old yes', async () => {
+        servedSecurely(true);
+        browserAnswering('default', 'granted');
+        const notifier = systemNotifierForThisApplication();
+
+        await expect(notifier.permit()).resolves.toBe('permitted');
+        Reflect.set(window.Notification, 'permission', 'denied');
+
+        await expect(notifier.permit()).resolves.toBe('refused');
+        expect(notifier.standing).toBe('refused');
+    });
+
+    it('keeps a browser that answered nothing unasked, so nothing is written on the device for it', async () => {
+        servedSecurely(true);
+        browserAnswering('default', null);
+
+        await expect(systemNotifierForThisApplication().permit()).resolves.toBe('unasked');
+    });
+
+    it('raises nothing and asks nobody where an arrival lands before anybody was asked', async () => {
+        servedSecurely(true);
+        const browser = browserAnswering('default', 'granted');
+
+        const raised = await systemNotifierForThisApplication().raise('2 new messages');
+
+        expect(raised).toBe('unavailable');
+        expect(browser.asked).toBe(0);
+        expect(browser.raised).toEqual([]);
+    });
+
+    it('raises one carrying the sentence and no second line, once the browser has allowed it', async () => {
+        servedSecurely(true);
+        const browser = browserAnswering('granted', 'granted');
+
+        const raised = await systemNotifierForThisApplication().raise('2 new messages');
+
+        expect(raised).toBe('raised');
+        expect(browser.raised).toEqual([{ title: '2 new messages', body: undefined }]);
+    });
+
+    it('reports somebody acting on one by bringing the window to the front, and stops when the subscription does', async () => {
+        servedSecurely(true);
+        const browser = browserAnswering('granted', 'granted');
+        const front = vi.spyOn(window, 'focus').mockImplementation(() => undefined);
+        const acted = vi.fn();
+        const notifier = systemNotifierForThisApplication();
+
+        const stop = notifier.whenActedOn(acted);
+        await notifier.raise('2 new messages');
+        browser.last?.onclick?.();
+
+        expect(front).toHaveBeenCalledOnce();
+        expect(acted).toHaveBeenCalledOnce();
+
+        stop();
+        browser.last?.onclick?.();
+
+        expect(acted).toHaveBeenCalledOnce();
+
+        front.mockRestore();
+    });
+
+    it('reports a browser that exposes the constructor and refuses to construct one as carrying no answer', async () => {
+        servedSecurely(true);
+        const refusing = function () {
+            throw new Error('A service worker has to show one here.');
+        } as unknown as typeof window.Notification;
+
+        Reflect.set(refusing, 'permission', 'granted');
+        Reflect.set(refusing, 'requestPermission', () => Promise.resolve('granted'));
+        Reflect.set(window, 'Notification', refusing);
+
+        await expect(systemNotifierForThisApplication().raise('2 new messages')).resolves.toBe('unavailable');
+    });
+
+    it('reads the browser record at each arrival, so permission withdrawn mid-run stops raising them', async () => {
+        servedSecurely(true);
+        const browser = browserAnswering('granted', 'granted');
+        const notifier = systemNotifierForThisApplication();
+
+        await notifier.raise('2 new messages');
+        Reflect.set(window.Notification, 'permission', 'denied');
+
+        await expect(notifier.raise('1 task reminder')).resolves.toBe('refused');
+        expect(browser.raised).toHaveLength(1);
     });
 });

--- a/frontend/src/Client.App/src/shellOperations/systemNotifier.ts
+++ b/frontend/src/Client.App/src/shellOperations/systemNotifier.ts
@@ -11,17 +11,32 @@ import { isPermissionGranted, requestPermission } from '@tauri-apps/plugin-notif
 // context. No component, hook, or screen asks which head it is running on — they ask whether the operation is offered,
 // which is a question about this run rather than about an operating system.
 //
+// **A browser is one of the heads that can answer it**, which is the part #1609 left for #1664. The Notifications API
+// is the operating system's own surface reached from a page rather than a second mechanism beside the shell's, so a
+// web head resolves to a second implementation of this same operation and nothing above learns that it did. What
+// separates the two is asked in order: a shell that linked the notification plugin answers first, because that plugin
+// installs its own replacement for `window.Notification` before the bundle runs, and a browser question put first
+// would reach the replacement while believing it had reached the browser.
+//
 // **What it may carry is a count and a kind, and that bound is the reason this module exists at all.** A notification
 // lands in the operating system's own action centre and on its lock screen, which is storage MailFathom cannot retain,
 // redact, or erase — so a sender, a subject, a fragment of a body, an attachment name, and an address each stay behind
 // the click. `notifications/arrivalCounts.ts` is what reduces an arrival to the two numbers this is allowed to say, and
 // it is asserted there rather than here, because a bound proved at the edge is a bound one caller can still walk past.
+// A browser notification lands in exactly the same places, so it is the same bound rather than a second one.
 //
 // **The permission is asked once and its refusal is final.** The plugin's own desktop path grants unconditionally, so
 // on Windows and Linux this resolves to a grant the first time it is asked; a head that refuses — Android, once #1616
 // links the plugin and grants it the capability — answers `refused` for the rest of the run and is never asked again.
 // What the caller does with that refusal is turn the behaviour off on this device, which is
 // `preferences/systemNotifications.ts`.
+//
+// **Who is asked, and when, is where the two heads genuinely differ.** The plugin grants without a dialog, so a shell
+// head may be asked by the first arrival and nobody notices. A browser puts a dialog in front of a person, several
+// browsers refuse the call unless a gesture they made led to it, and a browser standing at `denied` cannot be asked
+// again from script at all. So the ask is an operation of its own — `permit` — called where a gesture exists, which is
+// the settings switch, and `raise` asks nobody anything. What a head already stands able to do before that gesture is
+// `standing`, which is what lets the switch draw the truth rather than a default the web head could not keep.
 //
 // **A refusal and an absent operation are not the same answer**, which is what makes the answer three values rather
 // than two. A refusal was given by somebody and is kept; an operation this head never carried was decided by nobody
@@ -32,8 +47,10 @@ import { isPermissionGranted, requestPermission } from '@tauri-apps/plugin-notif
 // plugin's, because it is the half whose answer differs between heads and the half the phone will need. Raising is
 // this shell's own command, because the plugin's desktop path reports no click: it hands the notification to
 // `notify_rust` and drops the handle, so a person who clicks the thing the client showed them lands nowhere.
-// `src-tauri/src/notifications.rs` keeps that handle instead, which is what makes the third member below possible —
+// `src-tauri/src/notifications.rs` keeps that handle instead, which is what makes `whenActedOn` below possible —
 // somebody acting on a notification is an event the shell says out loud, and a head that raises none says nothing.
+// A browser needs no such split: `Notification.onclick` is the platform's own, so the web head satisfies that same
+// member out of the notifications it raised rather than out of a bridge.
 
 /**
  * What raising one ended as, which is three answers rather than two because two of them are not the same fact.
@@ -43,15 +60,39 @@ import { isPermissionGranted, requestPermission } from '@tauri-apps/plugin-notif
  */
 export type NotificationRaised = 'raised' | 'refused' | 'unavailable';
 
+/**
+ * What this head stands able to do before anybody has been asked anything, which is what a switch draws rather than
+ * guesses.
+ *
+ * `permitted` is a head that would reach the operating system if it raised one now — a shell whose plugin grants on
+ * demand, or a browser somebody has already allowed. `refused` was said by somebody, and asking again reaches nobody.
+ * `unasked` is a question nobody has put yet, and it is the one of the three a gesture can still change.
+ */
+export type NotificationStanding = 'permitted' | 'refused' | 'unasked';
+
 /** Raising a system notification, and whether the head this bundle is running in can raise one at all. */
 export interface SystemNotifier {
     /**
      * Whether this head carries the operation, which is the whole of what decides the client's behaviour here.
      *
-     * Where it is `false` there is no operation, no setting to draw, and nothing to ask permission for: the web head
-     * behaves exactly as it did before this existed, and so does a head whose shell linked no notification plugin.
+     * Where it is `false` there is no operation, no setting to draw, and nothing to ask permission for: a head whose
+     * shell linked no notification plugin behaves exactly as it did before this existed, and so does a page served
+     * outside a secure context, where the browser withholds the API rather than refusing a call into it.
      */
     readonly offered: boolean;
+
+    /** What this head already stands able to do, which the settings switch draws and never has to ask to find out. */
+    readonly standing: NotificationStanding;
+
+    /**
+     * Asks whoever decides, and answers what they said.
+     *
+     * It is called from a gesture and from nowhere else, because a browser refuses the prompt outright unless one was
+     * made — and because a dialog an arrival raised is a dialog raised over whatever somebody was reading. Asking
+     * twice is asking once, except where the question reached nobody: a prompt somebody closed without answering is
+     * put again by the next gesture.
+     */
+    readonly permit: () => Promise<NotificationStanding>;
 
     /**
      * Raises one notification saying the sentence given, answering what became of it.
@@ -72,6 +113,15 @@ export interface SystemNotifier {
     readonly whenActedOn: (act: () => void) => () => void;
 }
 
+/** What the browser's three permission words mean here, which are the same three facts under other names. */
+function standingFromBrowser(permission: NotificationPermission): NotificationStanding {
+    if (permission === 'granted') {
+        return 'permitted';
+    }
+
+    return permission === 'denied' ? 'refused' : 'unasked';
+}
+
 /** What the shell calls the event, which is the one name this module and `src-tauri/src/notifications.rs` share. */
 const actedOn = 'system-notification-acted-on';
 
@@ -89,12 +139,18 @@ export function useSystemNotifier(): SystemNotifier {
 
 /** Resolves the operation for the head this bundle is running in, which is the whole of the composition. */
 export function systemNotifierForThisApplication(): SystemNotifier {
-    return shellOffersNotifying() ? raisedThroughTheShell() : raisesNothing;
+    if (shellOffersNotifying()) {
+        return raisedThroughTheShell();
+    }
+
+    return browserOffersNotifying() ? raisedThroughTheBrowser() : raisesNothing;
 }
 
 /** What a head that offered no such command answers, and what every caller reads before it asks for anything. */
 const raisesNothing: SystemNotifier = {
     offered: false,
+    standing: 'unasked',
+    permit: () => Promise.resolve('unasked'),
     raise: () => Promise.resolve('unavailable'),
     whenActedOn: () => () => undefined,
 };
@@ -113,11 +169,26 @@ function shellOffersNotifying(): boolean {
     return Object.hasOwn(globalThis, '__TAURI_INTERNALS__') && typeof globalThis.Notification === 'function';
 }
 
+// The same question of the browser, and it is two questions for a reason of its own. A browser withholds the API
+// entirely outside a secure context, and this repository permits a client endpoint served without TLS where a
+// deployment declared it — so a page reached over plain `http` at anything but `localhost` carries no such operation,
+// which is the answer a head that linked no plugin gives and is drawn the same way. `isSecureContext` is the browser's
+// own reading of that condition, the localhost exemption included, so nothing here parses an address.
+function browserOffersNotifying(): boolean {
+    return globalThis.isSecureContext && typeof globalThis.Notification === 'function';
+}
+
 /**
  * The operation the shell answers, holding the permission answer for the run.
  *
- * The answer is held as the promise rather than as its value, so two arrivals landing in the same tick ask the
- * operating system once between them instead of racing to open two of its dialogs.
+ * The answer is held as the promise rather than as its value, so two arrivals landing in the same tick — or an arrival
+ * and somebody moving the settings switch — ask the operating system once between them instead of racing to open two
+ * of its dialogs.
+ *
+ * It stands `permitted` before anybody is asked, which is what the plugin's desktop path makes true: it grants
+ * unconditionally, so a switch drawn off until somebody had answered a dialog that never appears would describe a
+ * machine that does not exist. A head that does refuse — Android, once #1616 links the plugin — says so at the first
+ * arrival, and `useNotificationCentre.ts` is what writes that refusal onto the device.
  */
 function raisedThroughTheShell(): SystemNotifier {
     let permitted: Promise<NotificationRaised> | null = null;
@@ -130,6 +201,8 @@ function raisedThroughTheShell(): SystemNotifier {
 
     return {
         offered: true,
+        standing: 'permitted',
+        permit: async () => standingFromRaising(await permission()),
         raise: async (said) => {
             const answer = await permission();
 
@@ -161,6 +234,86 @@ function raisedThroughTheShell(): SystemNotifier {
 }
 
 /**
+ * The operation the browser answers, which puts a question to nobody until a gesture does.
+ *
+ * **`Notification.permission` is read at every call and held nowhere**, because it is the browser's own record and
+ * somebody may change it from the address bar while the client is open. A copy taken once would be a client insisting
+ * it had been refused by a person who has since allowed it — and the settings dialog is remounted every time it is
+ * opened, so a copy taken at composition would also be redrawing app-start truth over an answer given since. What is
+ * held is only the prompt itself, and only for as long as one is actually open.
+ *
+ * The act somebody takes on one is held here rather than reached for at each raise, because that is the shape the
+ * shell established and the caller subscribes once: every notification this raises is wired to whatever is listening
+ * when it is raised, so a head with nothing subscribed raises one that does nothing when clicked.
+ */
+function raisedThroughTheBrowser(): SystemNotifier {
+    let asking: Promise<NotificationStanding> | null = null;
+    let acted: (() => void) | null = null;
+
+    return {
+        offered: true,
+
+        get standing() {
+            return standingFromBrowser(Notification.permission);
+        },
+
+        // The prompt is held only while it is open, so two gestures in the same moment raise one dialog between them
+        // and nothing is remembered once it closes. Every answer is then re-derived from the browser's own record on
+        // the next gesture — including a grant, because a person may take one back from the address bar, and a held
+        // *yes* is how this client would come to write **on** onto a device the browser has since refused. Asking
+        // again costs no second dialog: a browser standing at anything but `default` answers without opening one.
+        permit: async () => {
+            asking ??= askTheBrowser();
+
+            try {
+                return await asking;
+            } finally {
+                asking = null;
+            }
+        },
+
+        raise: (said) => {
+            // Never a prompt. An arrival is not a gesture, so a browser nobody has put the question to yet answers
+            // `unavailable` rather than a refusal — which is kept nowhere, for the reason an absent operation is:
+            // nobody decided it.
+            const standing = standingFromBrowser(Notification.permission);
+
+            if (standing !== 'permitted') {
+                return Promise.resolve(standing === 'refused' ? 'refused' : 'unavailable');
+            }
+
+            try {
+                const raised = new Notification(said);
+
+                // Bringing the window to the front is the browser's half of answering a click, and is this head's
+                // alone: the shell's own event arrives at a window the operating system has already raised.
+                raised.onclick = () => {
+                    window.focus();
+                    raised.close();
+                    acted?.();
+                };
+
+                return Promise.resolve('raised');
+            } catch {
+                // A browser that exposes the constructor and refuses to construct one, which is what Chrome on Android
+                // does — it wants a service worker to show it instead. Nobody decided that either.
+                return Promise.resolve('unavailable');
+            }
+        },
+
+        whenActedOn: (act) => {
+            acted = act;
+
+            return () => {
+                if (acted === act) {
+                    acted = null;
+                }
+            };
+        },
+    };
+}
+
+/**
  * Asks the operating system once, and separates the two ways of not being allowed.
  *
  * A grant or a refusal is an answer somebody gave, so `denied` is theirs to keep. A call that throws is not an answer
@@ -177,4 +330,38 @@ async function askOnce(): Promise<NotificationRaised> {
     } catch {
         return 'unavailable';
     }
+}
+
+/**
+ * Puts the browser's question to whoever is in front of it, once.
+ *
+ * A browser standing at `denied` is not asked: the specification has the call resolve `denied` without a prompt, and
+ * reading the record first is what makes that a stated rule of this module rather than a behaviour inherited from one.
+ *
+ * **A prompt somebody closed without answering resolves `default`, and that is not a refusal.** Chrome's dialog has a
+ * dismissal beside its two answers, and reading it as *no* would write the permanent off onto the device on behalf of
+ * a person who said nothing — which is the same mistake as reading an absent operation as one. So the browser's three
+ * answers are carried across as three, and only `denied` is somebody's decision.
+ */
+async function askTheBrowser(): Promise<NotificationStanding> {
+    const standing = standingFromBrowser(Notification.permission);
+
+    if (standing !== 'unasked') {
+        return standing;
+    }
+
+    try {
+        return standingFromBrowser(await Notification.requestPermission());
+    } catch {
+        return 'unasked';
+    }
+}
+
+/** What a raise's three answers say about where a head stands, which is the same fact asked a different way. */
+function standingFromRaising(raised: NotificationRaised): NotificationStanding {
+    if (raised === 'raised') {
+        return 'permitted';
+    }
+
+    return raised === 'refused' ? 'refused' : 'unasked';
 }


### PR DESCRIPTION
Closes #1664

#1609 gave the desktop head a system notification and left the web head resolving an operation that does nothing, so a browser tab open behind another window said nothing when mail arrived. The browser has the same surface the operating system does, so this reaches it through the seam #1609 built rather than through a second mechanism beside it.

## What moved

**One module, one more implementation.** `Client.App/src/shellOperations/systemNotifier.ts` now resolves a browser implementation of the *same* operation where no shell announced itself and the browser exposes the Notifications API in a secure context. The composition root, the settings row, the privacy bound in `arrivalCounts.ts`, the device switch, and the rule that says nothing while the window has focus are unchanged — none of them ever asked which head was underneath, so none of them learned that a second one can now notify.

**The order the two are asked in is part of the resolution.** The desktop plugin installs its own replacement for `window.Notification` before the bundle runs, so the shell is asked first; a browser question put first would answer for a head the plugin was already answering for.

**Two members carry what a browser needs and a shell does not.** `standing` says what the head can already do before anybody is asked — `permitted`, `refused`, or `unasked` — and `permit()` asks. The ask is called from the settings switch and from nowhere else, because a browser refuses the prompt unless a gesture led to it and a dialog raised by an arrival lands over whatever somebody was reading. `raise` asks nobody anything: a browser standing at `default` answers `unavailable`, which is kept nowhere for the same reason an absent operation is.

**The switch draws what the machine will actually do**, which is the choice *and* the permission. A head nobody has been asked in yet draws off however the device store reads, because a control saying *on* over a machine that will raise nothing is worse than an absent row. A shell head stands `permitted` before anybody is asked, which is what the plugin's desktop path makes true, so the desktop row is drawn exactly as it was.

**A capability one head has and another lacks is handed down as a value rather than branched on.** A click is answerable in a browser and not by `tauri-plugin-notification` (#1658), so `raise` takes what a click should do — the act the centre's own rows already take — and the head that cannot report one never calls it. On the web head a click brings the window to the front and opens the notification centre.

**Outside a secure context the operation is unoffered**: no settings row, no permission prompt, nothing raised. That is the browser's own rule about a client endpoint served over plain `http` at anything but `localhost`, and it is the same answer a shell that linked no notification plugin gives.

## What it carries

A count and a kind, in the reader's language, and nothing else. `arrivalCounts.ts` is unchanged and is still where that bound is enforced and proven; a browser notification lands in the same action centre and on the same lock screen as a desktop one, so it is the same bound rather than a second one. Verified in a real browser: what the browser was handed was `{ title: '1 new message' }` with no options at all — no body, no sender, no subject, no source.

## Verified in a real browser

`playwright-cli` alone could not answer this: `chromium_headless_shell`, which Playwright launches by default, reports `Notification.permission` as `denied` even after the permission is granted, while `requestPermission()` in the same page resolves `granted`. Under the full `chromium` channel both agree. Against the built bundle served over a real origin, with a throwaway spec deleted before the gates ran:

- the page reports `isSecureContext: true`, `typeof Notification === 'function'`, and no Tauri bridge, so the web head resolves the browser implementation;
- with no permission granted the settings row is drawn with the switch off;
- with permission granted the switch draws on, and an arrival landing while `document.hasFocus()` is false makes the browser construct exactly one notification carrying the sentence and no options;
- dispatching a click on that notification opens the notification centre;
- a browser that refuses at the prompt swaps the row's explanation for the refusal copy and disables the switch.

## One correction found while reviewing

A prompt somebody closes without answering resolves `default`, and reading that as a refusal would write the permanent off onto the device on behalf of a person who said nothing. The browser's three answers are carried across as three, only `denied` is somebody's decision, and a dismissal leaves the prompt unheld so a second gesture asks again.

## The design

The row itself is what #1609 shipped against the design project and is unchanged in shape. The refused state is a screen the project does not draw — it is a browser-only condition that did not exist when the prototype was made — so the copy is new here and the correction has been handed to the owner rather than invented in the project.

## Breaking changes

None. No configuration key, database column, MCP tool argument, or deployment contract moves. No new dependency: the Notifications API is a platform capability, so no closure moved and `THIRD_PARTY_LICENSES.md` is unaffected.

## Verification

`scripts/verify-full.sh` — passed, 288 contracts, 0 failed. Client suite 2880 tests across 169 files. `$check-docs-licenses` — Docs pass, Changelog n/a, Licenses n/a.
