### PR TITLE
[#1617] Compose every screen the client has at the design's four widths, and decide the touch floor once

### DIFF
--- a/frontend/src/AGENTS.md
+++ b/frontend/src/AGENTS.md
@@ -293,6 +293,14 @@ so this is written to be mechanically visible in a diff rather than remembered.
   one shape is how a client stops looking like one product, and it is invisible in review because each diff is fine.
 - **Density and motion are decided once**, in the theme, and a screen does not opt out of either. A duration or an easing
   written into a component is the same drift as a hexadecimal colour.
+- **How small a control may be under a finger is decided once too**, in a base rule in `Client.App/src/styles.css`
+  beside the focus ring, and for the same reason: a floor met by seven control shapes and forty hand-written buttons is
+  a floor most of them eventually stop meeting, and the one that stops is invisible in the diff that stopped it. So a
+  screen writes no `pointer-coarse:` size of its own — what it writes is the measurement the design project gives the
+  control, and the rule lifts whatever falls below the floor. It is stated as a `min-*`, so a control the design already
+  draws large keeps its own size. This is the one place where the two questions § _The two heads_ separates are visible
+  side by side: what a screen composes as follows the width it was given, and how big a target is follows what is
+  driving it.
 - **`prefers-reduced-motion` is honoured**, and that is an accessibility obligation rather than a nicety: motion is
   removed under it, not merely shortened, and any transition conveying meaning still conveys it without the movement.
 - **Everything a screen draws comes out of the bundle, and no screen reaches an external origin for it.** The typeface

--- a/frontend/src/Client.App/src/controls/Organisation.tsx
+++ b/frontend/src/Client.App/src/controls/Organisation.tsx
@@ -8,6 +8,12 @@
 //
 // Shared for the reason `ReceivedAt` and `MessageMarkers` are: the mail list and the conversation say the same thing
 // about the same sender, and two spellings of one host is how they start disagreeing about who wrote.
+//
+// It is drawn in the desktop composition alone, which is where the design project draws it. That is a decision about
+// the composition rather than about the room on the line: the project gives the list the same width at the tablet as
+// at the desktop and still leaves the host off the narrower one, because a column that has given up its mailboxes to a
+// drawer has given up the least-read thing on the row with them. Nothing is lost by width alone — the address is on
+// the message's own head, which is one press away and is where somebody checking who wrote actually looks.
 
 /** Where a sender wrote from, or nothing at all where the address says nothing a reader could use. */
 export function Organisation({ address }: { readonly address: string | null }) {
@@ -17,5 +23,5 @@ export function Organisation({ address }: { readonly address: string | null }) {
         return null;
     }
 
-    return <span className="hidden truncate text-xs text-faint workspace:inline">{address.slice(at + 1)}</span>;
+    return <span className="hidden truncate text-xs text-faint desktop:inline">{address.slice(at + 1)}</span>;
 }

--- a/frontend/src/Client.App/src/controls/SenderAvatar.tsx
+++ b/frontend/src/Client.App/src/controls/SenderAvatar.tsx
@@ -10,12 +10,16 @@ import { initialsOf } from './initials';
 //
 // The signed-in person has a circle of their own in `PersonAvatar.tsx`, because they may have put a picture in it and
 // a sender never has one here: what the two share is the derivation of the letters, which is `initials.ts`.
+//
+// The row's circle is drawn at two sizes for the reason the row itself is two heights: the design project enlarges
+// both at the phone, where the list is the whole screen, and draws them at one size everywhere above it. The card's is
+// one size, because a message's head is the same head at every width.
 
 /** Where the avatar stands: on a row of the list, or at the head of a message drawn as a card. */
 export type SenderAvatarPlace = 'row' | 'card';
 
 const places: Readonly<Record<SenderAvatarPlace, string>> = {
-    row: 'size-5.5 text-2xs',
+    row: 'size-8.5 text-xs workspace:size-5.5 workspace:text-2xs',
     card: 'size-7.5 text-xs',
 };
 

--- a/frontend/src/Client.App/src/controls/SurfaceControl.tsx
+++ b/frontend/src/Client.App/src/controls/SurfaceControl.tsx
@@ -8,10 +8,10 @@ import type { IconName } from './icons';
 // The control the head of a surface, a column, or a dialog carries — closing it, folding it, opening it, downloading
 // what it is showing — drawn as the symbol alone.
 //
-// It is here rather than in any of them because six draw it: the surface that shows a message's own markup, the surface
-// that shows a file the message carries, the mailbox column and the drawer that replaces it, the sheet that asks which
-// folder to file a message in, and the question that asks whether to discard what is being written. Written out by hand
-// it was already two sizes, which is the drift a shared component exists to stop; it is a component of its own rather
+// It is here rather than in any of them because five draw it: the surface that shows a message's own markup and the
+// control on the message's head that opens it, the surface that shows a file the message carries, the mailbox column
+// and the drawer that replaces it, and the sheet that asks which folder to file a message in. Written out by hand it
+// was already two sizes, which is the drift a shared component exists to stop; it is a component of its own rather
 // than an eighth `ControlShape` because what differs from those is the symbol's own size as well as the box around it.
 //
 // The name is on the control rather than beside it, because a head that named every symbol in words would be a second

--- a/frontend/src/Client.App/src/controls/SurfaceControl.tsx
+++ b/frontend/src/Client.App/src/controls/SurfaceControl.tsx
@@ -5,15 +5,20 @@
 import { Icon } from './Icon';
 import type { IconName } from './icons';
 
-// The control a surface's own head carries — closing it, downloading what it is showing — drawn as the symbol alone.
+// The control the head of a surface, a column, or a dialog carries — closing it, folding it, opening it, downloading
+// what it is showing — drawn as the symbol alone.
 //
-// It is here rather than in either surface because both draw it: the surface that shows a message's own markup, and the
-// surface that shows a file the message carries. Written twice it was already two sizes, which is the drift a shared
-// component exists to stop; it is a component of its own rather than a fifth `ControlShape` because what differs from
-// those four is the symbol's own size as well as the box around it.
+// It is here rather than in any of them because six draw it: the surface that shows a message's own markup, the surface
+// that shows a file the message carries, the mailbox column and the drawer that replaces it, the sheet that asks which
+// folder to file a message in, and the question that asks whether to discard what is being written. Written out by hand
+// it was already two sizes, which is the drift a shared component exists to stop; it is a component of its own rather
+// than an eighth `ControlShape` because what differs from those is the symbol's own size as well as the box around it.
 //
 // The name is on the control rather than beside it, because a head that named every symbol in words would be a second
 // toolbar over the thing being read. `title` carries the same words for a pointer.
+//
+// It is drawn at the size the design gives it and grows under a finger to the floor `styles.css` states for every
+// control in the client, which is why no measurement here mentions a pointer.
 
 export function SurfaceControl({
     label,

--- a/frontend/src/Client.App/src/controls/controlShapes.ts
+++ b/frontend/src/Client.App/src/controls/controlShapes.ts
@@ -15,6 +15,11 @@
 // Two more are the same pairing again for the width a strip has: the design draws the toolbar's controls as words
 // beside their symbols only where there is a mailbox column beside them, and as symbols alone at every narrower
 // composition. So `symbol` is what `labelled` narrows to, and `primarySymbol` is what `primary` narrows to.
+//
+// What is deliberately absent is the size a finger needs. Every shape below is drawn at the measure the design project
+// gives it, and the floor a control grows to under a coarse pointer is stated once for the whole client in
+// `styles.css` — a bar met in seven shapes and forty hand-written controls is a bar most of them eventually stop
+// meeting.
 
 export type ControlShape =
     'labelled' | 'symbol' | 'primary' | 'primarySymbol' | 'floating' | 'onAccent' | 'onAccentSymbol';

--- a/frontend/src/Client.App/src/fullHtml/ShowFullHtml.tsx
+++ b/frontend/src/Client.App/src/fullHtml/ShowFullHtml.tsx
@@ -4,6 +4,7 @@
 
 import { useRef } from 'react';
 import { Icon } from '../controls/Icon';
+import { SurfaceControl } from '../controls/SurfaceControl';
 import { useLocalization } from '../localization/useLocalization';
 
 // The control the design project puts on a message's head, and the question it asks before anything is shown. Pressing
@@ -32,17 +33,13 @@ export function ShowFullHtml({ onShow }: { readonly onShow: () => void }) {
 
     return (
         <>
-            <button
-                type="button"
-                aria-label={translate('fullHtml.show')}
-                title={translate('fullHtml.show')}
-                className="flex size-8 shrink-0 items-center justify-center rounded-md text-muted transition hover:bg-hover hover:text-text"
-                onClick={() => {
+            <SurfaceControl
+                label={translate('fullHtml.show')}
+                icon="code"
+                onActivate={() => {
                     asked.current?.showModal();
                 }}
-            >
-                <Icon name="code" className="size-5" />
-            </button>
+            />
 
             <dialog
                 ref={asked}

--- a/frontend/src/Client.App/src/mailSpace/MailSpace.tsx
+++ b/frontend/src/Client.App/src/mailSpace/MailSpace.tsx
@@ -7,6 +7,7 @@ import { useComposing } from '../composer/useComposing';
 import { Control } from '../controls/Control';
 import { Icon } from '../controls/Icon';
 import { PlannedControl } from '../controls/PlannedControl';
+import { SurfaceControl } from '../controls/SurfaceControl';
 import { useLocalization } from '../localization/useLocalization';
 import { useScreenLayer } from '../shell/screenLayers';
 import { useDesktopComposition, useTwoPanes, useWideWorkspace } from '../shell/useWideWorkspace';
@@ -225,7 +226,7 @@ export function MailSpace({
                             status={status}
                             folded={folded}
                             control={
-                                <ColumnControl
+                                <SurfaceControl
                                     label={translate(folded ? 'mailboxes.unfold' : 'mailboxes.fold')}
                                     icon={folded ? 'chevron_right' : 'chevron_left'}
                                     onActivate={() => {
@@ -252,7 +253,7 @@ export function MailSpace({
                                 status={status}
                                 folded={false}
                                 control={
-                                    <ColumnControl
+                                    <SurfaceControl
                                         label={translate('mailboxes.close')}
                                         icon="close"
                                         onActivate={() => {
@@ -282,7 +283,7 @@ export function MailSpace({
                     >
                         {desktop ? null : (
                             <div className="flex items-center px-2 pt-2">
-                                <ColumnControl
+                                <SurfaceControl
                                     label={translate('mailboxes.open')}
                                     icon="menu"
                                     onActivate={() => {
@@ -293,7 +294,34 @@ export function MailSpace({
                             </div>
                         )}
 
-                        {list}
+                        {/* The list and, in the narrow shape, the control that writes a message standing over its
+                            bottom corner. Over the *list* rather than over the window, because the window's own
+                            bottom corner is where the question field and the navigation are: a control placed against
+                            the viewport would sit on top of both, and it would move whenever either changed height.
+                            Positioned against this box instead, it keeps the corner a thumb reaches whatever stands
+                            under it. */}
+                        <div className="relative flex min-h-0 flex-1 flex-col">
+                            {list}
+
+                            {twoPanes || readingInFront ? null : composing.offered ? (
+                                <Control
+                                    label={translate('mail.compose')}
+                                    icon="edit_square"
+                                    shape="floating"
+                                    className="absolute right-4.5 bottom-4.5"
+                                    onPress={() => {
+                                        composing.compose({ kind: 'new' });
+                                    }}
+                                />
+                            ) : (
+                                <PlannedControl
+                                    label={translate('mail.compose')}
+                                    icon="edit_square"
+                                    shape="floating"
+                                    className="absolute right-4.5 bottom-4.5"
+                                />
+                            )}
+                        </div>
 
                         {twoPanes ? null : intent}
                     </section>
@@ -346,27 +374,6 @@ export function MailSpace({
                     </section>
                 ) : null}
             </div>
-
-            {/* Composing stands on the list in the narrow shape, where the toolbar carrying it is not drawn: the one
-                thing a phone-width reader reaches for from the list, at the corner a thumb reaches. */}
-            {twoPanes || readingInFront ? null : composing.offered ? (
-                <Control
-                    label={translate('mail.compose')}
-                    icon="edit_square"
-                    shape="floating"
-                    className="fixed right-4.5 bottom-22"
-                    onPress={() => {
-                        composing.compose({ kind: 'new' });
-                    }}
-                />
-            ) : (
-                <PlannedControl
-                    label={translate('mail.compose')}
-                    icon="edit_square"
-                    shape="floating"
-                    className="fixed right-4.5 bottom-22"
-                />
-            )}
         </div>
     );
 }
@@ -410,28 +417,5 @@ function Mailboxes({
 
             {folded ? null : <div className="border-t border-line px-3.5 py-2.5">{status}</div>}
         </>
-    );
-}
-
-// The one control shape the columns draw: a symbol that folds, opens, or closes a column, named by what it does.
-function ColumnControl({
-    label,
-    icon,
-    onActivate,
-}: {
-    readonly label: string;
-    readonly icon: 'chevron_left' | 'chevron_right' | 'close' | 'menu';
-    readonly onActivate: () => void;
-}) {
-    return (
-        <button
-            type="button"
-            aria-label={label}
-            title={label}
-            className="flex size-8 shrink-0 items-center justify-center rounded-md text-muted transition hover:bg-hover hover:text-text"
-            onClick={onActivate}
-        >
-            <Icon name={icon} className="size-5" />
-        </button>
     );
 }

--- a/frontend/src/Client.App/src/mailboxActs/MoveChoice.tsx
+++ b/frontend/src/Client.App/src/mailboxActs/MoveChoice.tsx
@@ -4,6 +4,7 @@
 
 import { useId, type RefObject } from 'react';
 import { Icon } from '../controls/Icon';
+import { SurfaceControl } from '../controls/SurfaceControl';
 import { useLocalization } from '../localization/useLocalization';
 import type { MoveDestination } from './mailboxDestinations';
 
@@ -61,17 +62,13 @@ export function MoveChoice({
                     {translate('act.moveTitle')}
                 </h2>
 
-                <button
-                    type="button"
-                    aria-label={translate('act.moveClose')}
-                    title={translate('act.moveClose')}
-                    className="flex size-8 shrink-0 items-center justify-center rounded-md text-muted transition hover:bg-hover hover:text-text"
-                    onClick={() => {
+                <SurfaceControl
+                    label={translate('act.moveClose')}
+                    icon="close"
+                    onActivate={() => {
                         asked.current?.close();
                     }}
-                >
-                    <Icon name="close" className="size-5" />
-                </button>
+                />
             </div>
 
             <ul className="flex max-h-96 flex-col overflow-y-auto py-1.5">

--- a/frontend/src/Client.App/src/messageRows/MessageRow.tsx
+++ b/frontend/src/Client.App/src/messageRows/MessageRow.tsx
@@ -33,6 +33,12 @@ import { useRowSwipe, type RowSwipeAct } from './rowSwipe';
 // when, what about, and a line for a sentence about the message rather than from it — why a search result is in the
 // list today, and what MailFathom made of the message when stage 3 lands. A row given none keeps the space, so the row
 // that gains one is this row rather than a taller one.
+//
+// It is the one measurement in the client a composition changes, and the change is the design project's own: the same
+// height at the desktop, the tablet and the fold, and a taller row with a larger circle at the phone, where the list
+// is the whole screen and the row is what a thumb lands on. Both come out of the same tree at the same breakpoint, so
+// the row that grows is this row and not a second one — and the window above it reads what was drawn rather than the
+// token, which is what lets the height change at all.
 
 // What the row says while a change this client asked for has not been seen to have reached the mail server. A mailbox
 // mutation is durable the moment it is written down and converges minutes later, so a row that said nothing would leave
@@ -202,7 +208,7 @@ export function MessageRow({
             //
             // Vertical panning stays the scroller's and everything sideways is the row's, which is what stops a browser
             // from taking the gesture over as a scroll before it has been read.
-            className="relative h-message-row touch-pan-y overflow-hidden border-b border-b-sunken"
+            className="relative h-message-row-narrow touch-pan-y overflow-hidden border-b border-b-sunken workspace:h-message-row"
         >
             {carrying === undefined ? null : (
                 // What the row is being carried off is showing: the act, named and drawn, against the edge the finger

--- a/frontend/src/Client.App/src/readingPane/MessageHeaders.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/MessageHeaders.test.tsx
@@ -44,7 +44,8 @@ function drawing(written: Partial<MailMessageHeaders> = {}, onShowFullHtml: () =
 }
 
 // The width the head composes at is the one thing about it jsdom cannot answer, so a test about either shape states
-// which it is about. A runtime with no `matchMedia` at all reads as wide, which is what the rest of this file inherits.
+// which it is about. Every test that states neither inherits the narrow reading: `vitest.setup.ts` puts a `matchMedia`
+// over jsdom's missing one that answers `false` to every query, so the head composes as it does at the phone.
 const declaredMatchMedia = Object.getOwnPropertyDescriptor(window, 'matchMedia');
 
 function atWorkspaceWidth(wideEnough: boolean): void {

--- a/frontend/src/Client.App/src/readingPane/MessageHeaders.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/MessageHeaders.test.tsx
@@ -43,11 +43,33 @@ function drawing(written: Partial<MailMessageHeaders> = {}, onShowFullHtml: () =
     );
 }
 
+// The width the head composes at is the one thing about it jsdom cannot answer, so a test about either shape states
+// which it is about. A runtime with no `matchMedia` at all reads as wide, which is what the rest of this file inherits.
+const declaredMatchMedia = Object.getOwnPropertyDescriptor(window, 'matchMedia');
+
+function atWorkspaceWidth(wideEnough: boolean): void {
+    Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        value: (query: string) => ({
+            media: query,
+            matches: wideEnough,
+            addEventListener: () => undefined,
+            removeEventListener: () => undefined,
+        }),
+    });
+}
+
 // A zone pinned for one test is put back for the reason a fake clock is released: it is the worker's, not the file's.
 const machineZone = process.env['TZ'];
 
 afterEach(() => {
     process.env['TZ'] = machineZone;
+
+    if (declaredMatchMedia === undefined) {
+        Reflect.deleteProperty(window, 'matchMedia');
+    } else {
+        Object.defineProperty(window, 'matchMedia', declaredMatchMedia);
+    }
 });
 
 describe('MessageHeaders', () => {
@@ -172,5 +194,36 @@ describe('MessageHeaders and the sender own markup', () => {
         );
 
         expect(screen.queryByRole('button', { name: 'Show the full HTML version' })).toBeNull();
+    });
+});
+
+describe('MessageHeaders at the width its column has', () => {
+    // The head is the one place in the reading column a composition changes what is drawn rather than how it is laid
+    // out, so it is asked at both widths: the words go and the control stays, named by what it does either way.
+    it('draws the three acts as words beside their symbols wherever the column is not the whole screen', () => {
+        atWorkspaceWidth(true);
+        drawing();
+
+        expect(screen.getByText('Reply')).toBeDefined();
+        expect(screen.getByText('Forward')).toBeDefined();
+        expect(screen.getByText('Flag')).toBeDefined();
+    });
+
+    it('draws the three acts as symbols alone at the width the column is the whole screen', () => {
+        atWorkspaceWidth(false);
+        drawing();
+
+        expect(screen.queryByText('Reply')).toBeNull();
+        expect(screen.queryByText('Forward')).toBeNull();
+        expect(screen.queryByText('Flag')).toBeNull();
+    });
+
+    it('names each act the same way at either width, so nothing is reachable at one and nameless at the other', () => {
+        atWorkspaceWidth(false);
+        drawing();
+
+        expect(screen.getByRole('button', { name: 'Reply — not built yet' })).toBeDefined();
+        expect(screen.getByRole('button', { name: 'Forward — not built yet' })).toBeDefined();
+        expect(screen.getByRole('button', { name: 'Flag — not built yet' })).toBeDefined();
     });
 });

--- a/frontend/src/Client.App/src/readingPane/MessageHeaders.tsx
+++ b/frontend/src/Client.App/src/readingPane/MessageHeaders.tsx
@@ -3,12 +3,14 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import type { MailMessageHeaders, MailParticipant, MailParticipantRole } from '@mailfathom/client-backend';
+import type { ControlShape } from '../controls/controlShapes';
 import { PlannedControl } from '../controls/PlannedControl';
 import { ShowFullHtml } from '../fullHtml/ShowFullHtml';
 import type { MessageKey } from '../localization/en';
 import { wordInstant } from '../localization/instants';
 import { useLocalization } from '../localization/useLocalization';
 import { useEmbeddedHtmlMessages } from '../preferences/messageView';
+import { useWideWorkspace } from '../shell/useWideWorkspace';
 
 // What a message displays above its body: what it is called, who wrote it, when, and everybody else it names. The
 // author stands on its own line because it is what a reader checks first, and the rest is a disclosure the platform
@@ -25,6 +27,12 @@ import { useEmbeddedHtmlMessages } from '../preferences/messageView';
 // already on the screen under this head, so a control offering to open it would open a second copy of what is being
 // read — which is why it goes rather than being disabled: there is nothing left for it to do rather than something it
 // may not do here.
+//
+// The three narrow to symbols alone at the phone, where the design project draws this head as one compact bar over the
+// message rather than as a title with a row of words beside it. It is the same narrowing the toolbar takes and it is
+// asked here for the same reason it is asked there — the width the head has, not the pointer driving it — but at a
+// different width: a strip sharing its room with two panes runs out of it at the desktop breakpoint, while this head
+// has the whole column and only runs out when the column is the screen.
 //
 // Every value here is text a sender chose. It is drawn as text and never as markup, so a display name written to look
 // like an address, a heading, or a control arrives as the characters it is.
@@ -55,6 +63,8 @@ export function MessageHeaders({
 }) {
     const { locale, translate } = useLocalization();
     const embeddedHtml = useEmbeddedHtmlMessages();
+    const wide = useWideWorkspace();
+    const actShape: ControlShape = wide ? 'labelled' : 'symbol';
 
     const authors = headers.participants.filter((participant) => participant.role === 'From');
     const others = headers.participants.filter((participant) => participant.role !== 'From');
@@ -64,14 +74,14 @@ export function MessageHeaders({
     return (
         <header className="flex flex-col gap-1.5 border-b border-line px-5.5 py-4">
             <div className="flex flex-wrap items-start gap-x-3 gap-y-1.5">
-                <h2 className="min-w-0 flex-1 basis-64 text-3xl font-semibold text-balance">
+                <h2 className="min-w-0 flex-1 basis-64 text-2xl font-semibold text-balance workspace:text-3xl">
                     {headers.subject ?? translate('message.noSubject')}
                 </h2>
 
                 <div className="flex shrink-0 items-center gap-0.5">
-                    <PlannedControl label={translate('mail.reply')} icon="reply" />
-                    <PlannedControl label={translate('mail.forward')} icon="forward" />
-                    <PlannedControl label={translate('mail.flag')} icon="flag" />
+                    <PlannedControl label={translate('mail.reply')} icon="reply" shape={actShape} />
+                    <PlannedControl label={translate('mail.forward')} icon="forward" shape={actShape} />
+                    <PlannedControl label={translate('mail.flag')} icon="flag" shape={actShape} />
                     {embeddedHtml ? null : <ShowFullHtml onShow={onShowFullHtml} />}
                 </div>
             </div>

--- a/frontend/src/Client.App/src/styles.css
+++ b/frontend/src/Client.App/src/styles.css
@@ -219,13 +219,19 @@
        than a rail beside a list. It is the sign-in artboard's own number rather than a fourth shell composition. */
     --breakpoint-split: 58.75rem;
 
-    /* One row of the message list. Declared here rather than in the list because it is a density decision like any
-       other — and because the list is arithmetic over it: the window that keeps a mailbox of two hundred thousand
-       messages costing what a screenful costs measures this value off a rendered row rather than holding a second
-       copy of it. It is three lines and the space around them: who wrote, what about, and a line for a sentence about
-       the message rather than from it — why a search result matched, and what MailFathom made of the message once
-       stage 3 lands. */
-    --spacing-message-row: 4.75rem;
+    /* One row of the message list, in the two heights the design project draws it. Declared here rather than in the
+       list because it is a density decision like any other — and because the list is arithmetic over it: the window
+       that keeps a mailbox of two hundred thousand messages costing what a screenful costs measures this value off a
+       rendered row rather than holding a second copy of it. It is three lines and the space around them: who wrote,
+       what about, and a line for a sentence about the message rather than from it — why a search result matched, and
+       what MailFathom made of the message once stage 3 lands.
+
+       The narrow one is not the wide one loosened by taste: the project draws one height at the desktop, the tablet
+       and the fold alike, and a taller row at the phone, where the list is the whole screen and a row is something a
+       thumb lands on rather than something a cursor points at. So the row is the one place a composition changes a
+       height, and it changes it at the width the phone shape begins at. */
+    --spacing-message-row: 5.6875rem;
+    --spacing-message-row-narrow: 6.875rem;
 
     /* How wide the rail is, how wide the column beside it that holds the mailbox tree is when it is open and when it
        is folded to a strip, and how wide the drawer the narrow shape holds the mailboxes in is. All four are the
@@ -492,6 +498,36 @@
     :focus-visible {
         outline: 2px solid var(--color-accent);
         outline-offset: 2px;
+    }
+
+    /* What a control measures under a finger, decided once here for the same reason the ring above is: a floor met by
+       seven control shapes and forty hand-written buttons is a floor most of them eventually stop meeting, and the one
+       that stops is invisible in the diff that stopped it.
+
+       It is asked of the pointer rather than of the width, and that is the whole distinction this client draws between
+       the two questions. A composition follows the width it was given — the design project frames four of them and
+       every screen composes against those breakpoints. A target follows what is driving it: a touch screen on a
+       desktop is a finger at 1440 pixels and a narrow window on a laptop is a mouse at 390, so neither question
+       answers the other. The design project cannot state this half at all, its prototype having only a width to infer
+       touch from, which is why the number is the platform's rather than an artboard's.
+
+       `min-*` rather than a size, so a control the design already draws large keeps its own measurement and only the
+       ones below the floor are lifted to it. The three input kinds left out are drawn by the browser at a size this
+       would distort rather than enlarge, and the visually hidden ones are not on the screen to be hit. */
+    @media (pointer: coarse) {
+        button:not(.sr-only),
+        summary,
+        select,
+        textarea,
+        [role='button'],
+        [role='tab'],
+        [role='option'],
+        [role='treeitem'],
+        label:has(input),
+        input:not(.sr-only):not([type='checkbox']):not([type='radio']):not([type='range']) {
+            min-width: --spacing(11);
+            min-height: --spacing(11);
+        }
     }
 
     /* An accessibility obligation rather than a nicety: motion is removed under the preference rather than shortened,

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -20,6 +20,11 @@ const declaredVersion = execFileSync(resolve(import.meta.dirname, '../../scripts
 const wideWindow = { width: 1280, height: 720 };
 const narrowWindow = { width: 380, height: 720 };
 
+// The design project's phone frame, which is the composition where the list is the whole screen and the one width at
+// which the row and the head are drawn differently. It is the project's own number rather than a rounding of the
+// breakpoint, so what is measured against it is what the artboard shows.
+const phoneWindow = { width: 390, height: 844 };
+
 // What the deployment the preview server stands in for answers. It accepts any credential presented to it, because
 // what this suite proves about signing in is the composing, the sending, and the keeping — which of two passwords a
 // service accepts is the service's own decision and is proven where that decision is made.
@@ -1394,6 +1399,72 @@ test('draws every row of the list at one height, which is what the window is ari
     // measures rows, which this list deliberately does not carry.
     expect(new Set(heights).size).toBe(1);
     expect(heights[0]).toBeGreaterThan(0);
+});
+
+test('draws the mail screens at the phone composition, with its own row height and nothing over the question', async ({
+    page,
+}) => {
+    // The design project's own phone frame, and the only composition in which the list is the whole screen. Everything
+    // asked below is geometry, which is what puts it here: how tall a row is, what stands over what, and whether the
+    // document has grown wider than the window are three things jsdom answers for nothing.
+    await page.setViewportSize(phoneWindow);
+    await openSignedIn(page, '/#/mail');
+
+    const list = page.getByRole('listbox', { name: 'Messages' });
+    await expect(list.getByRole('option').first()).toBeVisible();
+
+    const phoneRow = await boxOf(list.getByRole('option').first());
+
+    // The control that writes a message stands over the list rather than over the window, so it clears the question
+    // field at the foot of the column whatever that field comes to measure. Placed against the viewport it sat on the
+    // scope beneath the question instead, which put a press meant for the mailbox onto the control that composes.
+    const compose = await boxOf(page.getByRole('button', { name: /^New message/u }));
+    const question = await boxOf(page.getByRole('searchbox', { name: 'Ask your mail' }));
+
+    expect(compose.y + compose.height).toBeLessThanOrEqual(question.y);
+
+    // Nothing has laid out past the window, which is the bar `frontend/src/AGENTS.md` sets at every width. Asked as an
+    // expression for the reason the same question is asked that way at the three-column width above: this suite is
+    // compiled without a DOM declaration, so a closure naming `document` is the one thing that would change that.
+    const overflowing = await page.evaluate<boolean>(
+        'document.documentElement.scrollWidth > document.documentElement.clientWidth',
+    );
+
+    expect(overflowing).toBe(false);
+
+    // The one measurement a composition changes rather than merely rearranges: the design draws a taller row where the
+    // list is the whole screen and one height everywhere above that, so the same row is read at both widths.
+    await page.setViewportSize(wideWindow);
+    await expect(list.getByRole('option').first()).toBeVisible();
+
+    expect(phoneRow.height).toBeGreaterThan((await boxOf(list.getByRole('option').first())).height);
+});
+
+test.describe('driven by a finger', () => {
+    test.use({ hasTouch: true });
+
+    test('draws every control on the mail screens at a size a fingertip can hit', async ({ page }) => {
+        await page.setViewportSize(phoneWindow);
+        await openSignedIn(page, '/#/mail');
+
+        await expect(page.getByRole('listbox', { name: 'Messages' }).getByRole('option').first()).toBeVisible();
+
+        // The floor is asked of the pointer rather than of the width, and `styles.css` is the one place it is stated —
+        // so what this proves is that the statement reaches the whole screen rather than the shapes that remembered it.
+        // Only a browser answers it twice over: the query is the real one, and the size is a measured box.
+        for (const control of await page.getByRole('main').getByRole('button').all()) {
+            const box = await control.boundingBox();
+
+            if (box === null) {
+                continue;
+            }
+
+            expect(
+                Math.min(box.width, box.height),
+                `a control on the Mail space is ${String(box.height)} tall`,
+            ).toBeGreaterThanOrEqual(44);
+        }
+    });
 });
 
 test('draws the three columns of the Mail space without the page scrolling sideways', async ({ page }) => {


### PR DESCRIPTION
Every screen the client already has is now composed at the four widths the design project frames — desktop, tablet, fold, and phone — and the one question the project cannot state is answered beside it: how small a control may be under a finger.

## What the change decides

**Composition follows the width; target size follows `pointer: coarse`.** The two were never the same question and the prototype can only infer the second from the first, having nothing but a width to read. A touch screen on a desktop is a finger at 1440 px and a narrow window on a laptop is a mouse at 390, so the client answers each where it belongs: the composition against the breakpoints already in `styles.css`, and the target size against the pointer, once, in a base rule beside the focus ring.

That rule is a `min-width`/`min-height` floor under `@media (pointer: coarse)`, so a control the design already draws large keeps its own measurement and only the ones below the floor are lifted. It is stated in one place for the reason the focus ring is: a floor met by seven control shapes and forty hand-written buttons is a floor most of them eventually stop meeting, and the one that stops is invisible in the diff that stopped it. `frontend/src/AGENTS.md` § *UI* now says so, and says that a screen writes no `pointer-coarse:` size of its own.

## What moved

- **`styles.css`** carries the two row heights the design project measures — one height at the desktop, the tablet and the fold, a taller row at the phone — and the touch floor above.
- **The message row** takes the narrow height below the workspace breakpoint and the wide one above it. The window's arithmetic is unaffected: it measures a rendered row rather than reading the token, which is what lets the height change at all.
- **The sender's circle** is drawn larger at the phone and at the design's measurement above it.
- **The sender's host** is drawn in the desktop composition alone, which is where the project draws it. That is a composition decision rather than a truncation: the project gives the list the same width at the tablet as at the desktop and still leaves the host off the narrower one. Nothing is lost by width alone — the address is on the message's own head.
- **The message head's three acts** narrow to symbols alone where the reading column is the whole screen, each named identically at either width.
- **The control that writes a message** now stands over the list rather than over the window. Placed against the viewport it sat on top of the mailbox-scope chip beneath the question field at the phone, which put a press meant for the mailbox onto the control that composes; positioned against the list column it clears whatever the question field comes to measure.
- **`SurfaceControl`** is now the one symbol-control shape six callers draw — the markup surface, the attachment surface, the mailbox column, the drawer, the move sheet, and the markup question — replacing four hand-written copies that were already drifting apart.

## Tests

- Three unit tests beside `MessageHeaders.tsx` for the head at either width, stating which width each is about rather than inheriting one.
- Two browser tests: the phone composition — its own row height, the compose control clearing the question, and no horizontal page overflow — and one under `hasTouch`, walking every control on the mail screens and asserting the fingertip floor is met. The second is what proves the base rule reaches the whole screen rather than the shapes that remembered it; only a browser answers the media query and the measured box at once.

## Two differences named and deliberately not fixed

Both were found by holding the design against the running client as images, at each composition, and both are outside this issue.

1. **The rail is 96 px at the tablet and the fold where the design draws 67 px.** The rail belongs to the shell, which #1616 composed and which this issue puts out of scope. It is a single token, and it is worth an issue of its own rather than a drive-by edit here.
2. **The search field, its submit, and the list-settings control stack as three rows where the design draws one.** It is identical at all four widths, so it is a fidelity gap rather than a composition one, and closing it spans `MailSearch`, `MessageList`, and `MailSpace` — a restructure rather than a measurement.

## Verification

- `scripts/verify-full.sh` — passed over exactly this content.
- `pnpm test:browser` — 48 passed, including both new tests, against the built bundle.
- Every composition was screenshotted twice, design and client at the same viewport and the same state, and read region by region. Those captures stay in the session's scratch directory.

Closes #1617

https://claude.ai/code/session_01Pe6m2Na2fX4YFbfFh2R9GC
