### PR TITLE
[#1666] Tell a traversal this hook asked for from a press of the back gesture

### DIFF
--- a/frontend/src/Client.App/src/shellOperations/backNavigation.test.ts
+++ b/frontend/src/Client.App/src/shellOperations/backNavigation.test.ts
@@ -157,6 +157,74 @@ describe('useBackNavigation', () => {
         expect(travelled).toEqual([-1]);
     });
 
+    // One surface replacing another dips the count for a single render: the menu folds away as the screen its own row
+    // opened arrives, and the platform's own toggle event puts the two in separate renders. The entry that dip gives
+    // back is a traversal of ours, and it reaches this hook as the same event a press of the gesture does — read as a
+    // press it would close the screen that had just opened, which is the flake this test exists for.
+    it('does not read the entry it gave back as a press of the gesture', () => {
+        const unwound = vi.fn();
+
+        const { rerender } = renderHook(
+            ({ steps }) => {
+                useBackNavigation(steps, unwound);
+            },
+            { initialProps: { steps: 1 } },
+        );
+
+        rerender({ steps: 0 });
+        rerender({ steps: 1 });
+
+        expect(travelled).toEqual([-1]);
+
+        theEntryShowing(null);
+        theGestureIsUsed();
+
+        expect(unwound).not.toHaveBeenCalled();
+    });
+
+    // And the history is left holding an entry for the surface still standing, so the next press has one to consume: a
+    // traversal answered by swallowing alone would leave the screen a step ahead of the history for good.
+    it('marks the entry again for the surface the dip left standing', () => {
+        const { rerender } = renderHook(
+            ({ steps }) => {
+                useBackNavigation(steps, () => undefined);
+            },
+            { initialProps: { steps: 1 } },
+        );
+
+        rerender({ steps: 0 });
+        rerender({ steps: 1 });
+
+        theEntryShowing(null);
+        theGestureIsUsed();
+
+        expect(pushed).toEqual([{ 'mailfathom.back': 1 }, { 'mailfathom.back': 1 }]);
+    });
+
+    // The count is spent on the traversal it was kept for and on nothing after it, so the press that follows one is
+    // still a press.
+    it('unwinds the press that follows a traversal of its own', () => {
+        const unwound = vi.fn();
+
+        const { rerender } = renderHook(
+            ({ steps }) => {
+                useBackNavigation(steps, unwound);
+            },
+            { initialProps: { steps: 1 } },
+        );
+
+        rerender({ steps: 0 });
+        rerender({ steps: 1 });
+
+        theEntryShowing(null);
+        theGestureIsUsed();
+
+        theEntryShowing(null);
+        theGestureIsUsed();
+
+        expect(unwound).toHaveBeenCalledExactlyOnceWith(1);
+    });
+
     // A reload is the one time the entry showing describes a screen that no longer exists: the marks were written by
     // the client that was thrown away, and the one that came back has nothing standing over it. Giving those entries
     // up would walk the reader backwards out of the client on a reload, so the entry is re-marked instead.

--- a/frontend/src/Client.App/src/shellOperations/backNavigation.ts
+++ b/frontend/src/Client.App/src/shellOperations/backNavigation.ts
@@ -32,10 +32,17 @@ import { useEffect, useRef } from 'react';
 // that point. Back consumes one of those marks, the page is told, and the number the mark carries says how many steps
 // to unwind; the address never changes, so the space the reader is in is the space the address names throughout.
 //
-// The marks are pushed and given up by one effect rather than by whoever opened a surface, which is what keeps them
-// honest: a surface closed by its own control leaves one step fewer than the history holds, and the same effect gives
+// The marks are pushed and given up in one place rather than by whoever opened a surface, which is what keeps them
+// honest: a surface closed by its own control leaves one step fewer than the history holds, and the same place gives
 // the spare entry back. Nothing else in the client writes history state, and `routing/useSpace.ts` carries a mark
 // across the one address it rewrites rather than replacing it with nothing.
+//
+// **Giving an entry back is itself a traversal**, so it arrives as the very event a press of the gesture arrives as,
+// and the two cannot be told apart from what the history says — both leave an entry marked with fewer steps than the
+// screen holds. So the traversals asked for here are counted, and one of them is answered by finishing the
+// reconciliation rather than by unwinding anything. Without that, a surface replacing another — a menu folding away as
+// the screen its own row opened arrives — dips the count for the single render between the two, and the entry that dip
+// gives back comes back as a press that closes the screen which had just opened.
 
 const stepsTaken = 'mailfathom.back';
 
@@ -58,6 +65,38 @@ function markedSteps(): number {
 }
 
 /**
+ * Brings the session history into step with the screen, answering whether it asked for a traversal to do it.
+ *
+ * A surface that opened needs an entry to consume, and one closed by its own control leaves an entry nobody will —
+ * both are the same difference read in opposite directions, which is why one function answers both.
+ *
+ * @param standingSteps How many things stand between the reader and the screen underneath.
+ * @param arrivedOnAReload Whether this is the first reading, which is the one time the entry showing describes a
+ *   screen that no longer exists: its mark was written by the client that was thrown away, while the one that came
+ *   back has nothing standing over it. Giving those entries up would walk the reader backwards out of the client on a
+ *   reload, so the entry is re-marked for the screen actually being drawn and the ones behind it are left alone.
+ */
+function reconcileHistory(standingSteps: number, arrivedOnAReload: boolean): boolean {
+    const marked = markedSteps();
+
+    if (standingSteps > marked) {
+        for (let step = marked + 1; step <= standingSteps; step += 1) {
+            window.history.pushState({ [stepsTaken]: step }, '');
+        }
+    } else if (standingSteps < marked) {
+        if (arrivedOnAReload) {
+            window.history.replaceState({ ...asState(window.history.state), [stepsTaken]: standingSteps }, '');
+        } else {
+            window.history.go(standingSteps - marked);
+
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
  * Keeps the session history holding one entry per step the back gesture has to unwind, and unwinds them as it is used.
  *
  * @param steps How many things stand between the reader and the screen underneath — every open layer, plus the pane
@@ -70,33 +109,16 @@ export function useBackNavigation(steps: number, unwind: (used: number) => void)
     const standing = useRef(steps);
     const unwinding = useRef(unwind);
     const reconciled = useRef(false);
+    const travelling = useRef(0);
 
     useEffect(() => {
         standing.current = steps;
         unwinding.current = unwind;
     });
 
-    // The history is brought into step with the screen rather than written by whoever changed it: a surface that opened
-    // needs an entry to consume, and one closed by its own control leaves an entry nobody will. Both are the same
-    // difference read in opposite directions, which is why one effect answers both.
-    //
-    // The first reading of it is the exception, and it is a reload: the entry showing keeps whatever mark it carried
-    // before the page was thrown away, while the client that came back has nothing standing over its screen. Giving
-    // those entries up would be a reload that walks the reader backwards out of the client, so the entry is re-marked
-    // for the screen actually being drawn and the entries behind it are left where they are.
     useEffect(() => {
-        const marked = markedSteps();
-
-        if (steps > marked) {
-            for (let step = marked + 1; step <= steps; step += 1) {
-                window.history.pushState({ [stepsTaken]: step }, '');
-            }
-        } else if (steps < marked) {
-            if (reconciled.current) {
-                window.history.go(steps - marked);
-            } else {
-                window.history.replaceState({ ...asState(window.history.state), [stepsTaken]: steps }, '');
-            }
+        if (reconcileHistory(steps, !reconciled.current)) {
+            travelling.current += 1;
         }
 
         reconciled.current = true;
@@ -104,6 +126,19 @@ export function useBackNavigation(steps: number, unwind: (used: number) => void)
 
     useEffect(() => {
         function backWasUsed(): void {
+            // A traversal this hook asked for, answered by finishing what it interrupted rather than by unwinding
+            // anything: nobody went back through the screen. The last of them reconciles, because until they have all
+            // landed the entry showing is not yet the one the last of them will leave.
+            if (travelling.current > 0) {
+                travelling.current -= 1;
+
+                if (travelling.current === 0 && reconcileHistory(standing.current, false)) {
+                    travelling.current += 1;
+                }
+
+                return;
+            }
+
             // What the entry now showing says stands over the screen, against what actually does. A press that landed
             // on an address of ours rather than on a mark says nothing stands over it, which is the same arithmetic:
             // an unmarked entry is zero steps.


### PR DESCRIPTION
## What this changes

The two browser tests that reach the settings surface through `openSettings` failed intermittently on the runner,
on `main` as well as on an unrelated pull request. The cause is not the settings screen, the account menu, or a slow
render — it is `useBackNavigation` reading a traversal of its own as a press of the back gesture, and unwinding a
layer nobody asked it to.

**What is not in the document when the assertion reads, and why.** The hook keeps one history entry per step the
gesture has to unwind, and reconciles the history against `layers.depth` whenever that number changes. When one
surface replaces another, the number *dips* for a single render: opening the settings screen hides the account-menu
popover, and the platform's `toggle` event — which is what withdraws the menu's layer — is queued as a task, so it
lands in a different render from the one that registered the settings dialog. The hook sees the count fall, gives the
spare entry back with `window.history.go(-1)`, and that traversal is asynchronous. By the time its `popstate` lands
the count has risen again, and the handler's arithmetic — *what the screen holds, against what the entry showing
says* — reads exactly what a genuine press reads. So it unwinds the top layer, which is the surface that had just
opened.

Both faces the issue records are that one bug landing at two depths:

- opening the screen (`depth` 2 → 1 → 2) unwinds the **settings dialog**, so `getByRole('dialog', { name: 'Settings' })` finds nothing;
- leaving it on Escape (`depth` 1 → 0 → 1) unwinds the **account menu**, so `getByRole('button', { name: 'Settings' })` finds nothing.

Whether it fails at all turns on whether that `popstate` lands before or after the render that puts the count back —
two tasks, ordered by how busy the machine is. That is why it passes locally and fails on the runner.

**The fix** is to tell the two apart, which nothing in the history can do: a traversal this hook asked for and a press
of the gesture both leave an entry marked with fewer steps than the screen holds. So the traversals it asks for are
counted, and one arriving is answered by finishing the reconciliation it interrupted rather than by unwinding
anything. Finishing it matters as much as swallowing it — a traversal answered by swallowing alone would leave the
screen one step ahead of the history for good, and the next real press would go straight past the surface standing.

No timeout is raised, no retry is added, and no locator is loosened. The reconciliation moved out of the component to
a module-level function, because it reads the standing count from a ref rather than from the render that scheduled
it, and both callers want that.

## Evidence

The three new unit tests fail on the previous implementation and pass on this one.

In the browser, the two tests were run 12 times each under six busy cores:

- on the pre-fix build, **6 of 24 failed**, both faces, with the signatures the issue records;
- on this build, **74 of 74 passed** across two runs at that load, and the full browser suite is 48 of 48.

## Acceptance

- [x] The cause is named: the settings dialog, or the account menu behind it, is unwound by `useBackNavigation`
      answering its own `history.go()` as a press of the back gesture. The click that should have put the element in
      the document did — a `popstate` took it out again a task later.
- [x] Both tests pass on repeated runs with no added retry and no raised timeout.
- [x] Both tests are unchanged, so the assertions they make are unchanged: the dialog is the whole screen in a
      single-pane window, and Escape hands focus back to the row that opened it.

Closes #1666
