### PR TITLE
[#1671] Read the navigation box on one side of the composition render

### DIFF
--- a/frontend/tests/AGENTS.md
+++ b/frontend/tests/AGENTS.md
@@ -192,6 +192,14 @@ the answer; dropping it is not, and neither is asserting it in jsdom where it wo
   covers, and it is not this suite.
 - **Nothing here retries.** A check that passes on a second attempt has reported that the client is flaky rather than
   that it works.
+- **A geometry read after `setViewportSize` waits for the composition it is about.** The width is the browser's the
+  moment it is set, and everything a stylesheet lays out from it moves with it — but what a screen _holds_ at a width
+  is `useWideWorkspace` and its two neighbours answering a `matchMedia` change, which is a render a task later. A box
+  read before that render measures the previous composition laid out at the new width, and two boxes read either side
+  of it belong to two different screens, which is what an assertion comparing them reports as a defect in the client.
+  So the wait is an element only the new composition draws — the bottom bar's own overflow control, the mailbox column
+  that stands beside the list — rather than a duration, and the boxes are read after it. An element present in both
+  compositions says nothing about which one drew it and is not that wait.
 - **A failure keeps its trace and its screenshot in `frontend/.playwright/`, which Git ignores and nothing uploads.**
   That is a privacy decision rather than a storage one: the moment this suite drives anything but a routed answer, a
   capture shows somebody's mail and a trace carries the header it was read with, and an artifact anybody with the run's

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -689,6 +689,14 @@ test('puts the navigation beside the workspace in a wide window and under it in 
 
     await page.setViewportSize(narrowWindow);
 
+    // Where the navigation is drawn changes with the width, but what it holds changes with a render: the bar's own
+    // five places are what `useWideWorkspace` answers a `matchMedia` change with, so for one task afterwards the
+    // navigation is still the rail's contents laid out across the foot of the window — 54 pixels taller than the bar,
+    // because the column the rail stacks the bell and the account in is standing in a row. A box read on either side
+    // of that render is a measurement of a different screen, and the pair below is read on one side of it by waiting
+    // for the control only the bar draws.
+    await expect(page.getByRole('button', { name: 'More' })).toBeVisible();
+
     const bottomBar = await boxOf(navigation);
     const narrowSpace = await boxOf(space);
     expect(bottomBar.y).toBeGreaterThanOrEqual(narrowSpace.y + narrowSpace.height);


### PR DESCRIPTION
## What this changes

`puts the navigation beside the workspace in a wide window and under it in a narrow one` failed intermittently on the
runner — most recently on `main` itself, at the merge of #1670. The client is correct; the assertion was reading two
boxes from two different screens.

**What is measured in which shape.** Where the navigation is drawn is CSS at both widths, so it moves the moment the
window does. What it *holds* is not: `useWideWorkspace` answers a `matchMedia` change, and the render that gives the
bar its own five places lands a task later. Until it does, the navigation is the rail's contents laid out across the
foot of the window — every space the session offered, and the column the rail stacks the bell and the account in,
standing in a row. Measured in a browser with that listener deferred, the transitional shape is **124 px tall at
y = 596**; the settled bar is **70 px at y = 650**, in a 720-pixel window.

**Why two reads can straddle it.** The test read the two boxes in two round trips:

```ts
const bottomBar = await boxOf(navigation);
const narrowSpace = await boxOf(space);
```

Two stale reads give 596 against 596 and pass. Two settled reads give 650 against 650 and pass. The runner's failure
was the render landing *between* them: a navigation still in the rail's shape at 596, against a workspace that had
already been given the bar's 70 pixels back and ended at 650 — which is exactly `Expected: >= 650 / Received: 596` in
run `33964289169`. The 54 pixels between the two numbers are the difference between the two navigation shapes, which
is what identifies the render rather than the viewport as the thing being overtaken.

`page.setViewportSize` was ruled out rather than assumed: 4800 resizes under load reported the new `clientWidth` and
the new body box every time.

**The fix** is to read both boxes on one side of that render, by waiting for an element only the narrow composition
draws — the bar's own overflow control. No retry, no raised timeout, and no loosened locator: the assertions the test
makes are unchanged.

**Every other `setViewportSize` followed by a geometry read was checked.** Nine of the twelve set the viewport before
the client is loaded, so the first render is already the composition being measured. Of the two that resize a running
client, this one is the defect; the other is `draws the mail screens at the phone composition` (`client.spec.ts:1443`),
which widens a phone window and re-measures a message row. That one was tested with the same deferred listener and
passes, because the row's height is a stylesheet's answer to the width rather than a JavaScript branch — so nothing
was added there, and the rule now written in `frontend/tests/AGENTS.md` says which of the two cases a future read is
in.

## Evidence

- With the `matchMedia` change listener deferred by 400 ms — the condition that produces the stale shape — the test
  measures the settled bar (`y = 650`, height 70) and passes; before the fix the same probe measured `y = 596`,
  height 124.
- The full browser suite, 48 of 48. Three consecutive runs at eight workers under ten busy cores, 144 of 144. The
  changed test alone at ten workers under that load, 40 of 40.
- `scripts/verify-full.sh`: 288 passed, 0 failed.

## Acceptance

- [x] The cause is named: the navigation is measured in the rail's shape while the workspace is measured in the bar's,
      because the composition render lands between the two reads.
- [x] `client.spec.ts:674` reads both boxes from the settled narrow composition, and the assertions it makes are
      unchanged.
- [x] Every other `setViewportSize` followed by a geometry read is checked, and this body says which of them turned out
      to depend on a render and which are answered by CSS alone.
- [x] The browser suite passes across repeated runs, with nothing retried and no timeout raised.

Closes #1671
