### PR TITLE
[#1545] Compose every AI operation as one Agent Framework agent, with an instruction envelope around each

### DIFF
--- a/backend/src/AI/AiServiceCollectionExtensions.cs
+++ b/backend/src/AI/AiServiceCollectionExtensions.cs
@@ -164,12 +164,20 @@ public static class AiServiceCollectionExtensions
     /// It adds no transport of its own — a run's requests go to the same endpoint under the same bounds as any other chat
     /// request, so it sends over the client that registration named.
     /// </para>
+    /// <para>
+    /// The instruction envelope every composed agent is wrapped in is registered here rather than by the composition
+    /// root, because it is what this boundary composes with rather than something a deployment declares. It is added
+    /// only if nothing registered one already, so an implementation supplying a person's language or a deployment's own
+    /// wording replaces the empty default by registering before this runs, with whatever lifetime its answer varies
+    /// over.
+    /// </para>
     /// </remarks>
     public static IServiceCollection AddMailAnsweringAgent(this IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(services);
 
         services.TryAddSingleton<OpenAiCompatibleClientFactory>();
+        services.TryAddSingleton<IAgentInstructionEnvelope, EmptyAgentInstructionEnvelope>();
         services.AddScoped<IMailQuestionAnswerer, MailAnsweringAgent>();
 
         return services;

--- a/backend/src/AI/Orchestration/AgentComposition.cs
+++ b/backend/src/AI/Orchestration/AgentComposition.cs
@@ -1,0 +1,76 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.AI.Chat;
+using MailFathom.AI.ProviderAdapters;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace MailFathom.AI.Orchestration;
+
+/// <summary>Composes every AI operation this product runs as one Agent Framework agent.</summary>
+/// <remarks>
+/// <para>
+/// One composition rather than a chat call written beside each feature, because what makes an operation safe is a
+/// property of the composition rather than of its prose. An instruction cannot be reached from a tool result because of
+/// where each is placed; the tool set <em>is</em> the capability, so an operation that only reads composes no mutating
+/// tool; every call passes through whichever client the caller wrapped, which is where a run's spend is counted; and
+/// what a run reports about cost, cancellation, and the model is what
+/// <see href="https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0022-what-an-ai-run-reports-about-cost-cancellation-and-the-model.md">ADR 0022</see>
+/// says. A feature composing its own call would re-decide all four in silence, once per feature.
+/// </para>
+/// <para>
+/// The instruction is carried as the agent's own rather than written into a message, which is what keeps it in a
+/// position no tool result can be placed in. Its three parts are concatenated and nothing else happens to them: there
+/// is no substitution syntax, no placeholder, and no separator, so an empty envelope composes the operation's
+/// instruction byte for byte.
+/// </para>
+/// <para>
+/// The envelope is asked at composition rather than read once at start, so an implementation whose answer varies per
+/// person or per request changes what a run sends without any operation changing.
+/// </para>
+/// <para>
+/// What the envelope adds rides inside the same instruction every turn carries, so it is sent through the client the
+/// caller composed and counted by whatever that client counts. There is no path by which the envelope reaches a
+/// provider outside what the run reports as spent.
+/// </para>
+/// </remarks>
+internal static class AgentComposition
+{
+    /// <summary>Composes one operation's agent over one chat client.</summary>
+    /// <param name="chatClient">The provider-neutral client every turn of the run is sent through, already carrying whatever the caller wrapped it in.</param>
+    /// <param name="plan">The validated declaration: the generation parameters one call runs with.</param>
+    /// <param name="operation">The operation being composed: its name, its own instruction, and its tool set.</param>
+    /// <param name="envelope">Supplies the text placed before and after the operation's instruction.</param>
+    /// <param name="loggerFactory">Creates the loggers the framework's own components record through.</param>
+    /// <returns>The composed agent.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    internal static ChatClientAgent Compose(
+        IChatClient chatClient,
+        ChatGenerationPlan plan,
+        AgentOperation operation,
+        IAgentInstructionEnvelope envelope,
+        ILoggerFactory loggerFactory)
+    {
+        ArgumentNullException.ThrowIfNull(chatClient);
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(operation);
+        ArgumentNullException.ThrowIfNull(envelope);
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+
+        var chatOptions = ChatGenerationParameterMapping.ToChatOptions(plan);
+
+        chatOptions.Instructions = string.Concat(envelope.Preamble, operation.Instruction, envelope.Postamble);
+        chatOptions.Tools = [.. operation.Tools];
+
+        var options = new ChatClientAgentOptions
+        {
+            Name = operation.Name,
+            ChatOptions = chatOptions,
+        };
+
+        return new ChatClientAgent(chatClient, options, loggerFactory);
+    }
+}

--- a/backend/src/AI/Orchestration/AgentComposition.cs
+++ b/backend/src/AI/Orchestration/AgentComposition.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 
 namespace MailFathom.AI.Orchestration;
 
-/// <summary>Composes every AI operation this product runs as one Agent Framework agent.</summary>
+/// <summary>Composes an AI operation as an Agent Framework agent, and is the one place any agent here is composed.</summary>
 /// <remarks>
 /// <para>
 /// One composition rather than a chat call written beside each feature, because what makes an operation safe is a
@@ -30,6 +30,11 @@ namespace MailFathom.AI.Orchestration;
 /// <para>
 /// The envelope is asked at composition rather than read once at start, so an implementation whose answer varies per
 /// person or per request changes what a run sends without any operation changing.
+/// </para>
+/// <para>
+/// What comes here is an operation composed as an agent, which is not the same set as every call this product makes to
+/// a model. A single judgement carrying its own instruction, offering no tool, and running no loop composes no agent at
+/// all and reaches the chat client directly — <see cref="Retrieval.ModelJudgedKnowledgeSearch" /> is that shape today.
 /// </para>
 /// <para>
 /// What the envelope adds rides inside the same instruction every turn carries, so it is sent through the client the

--- a/backend/src/AI/Orchestration/AgentComposition.cs
+++ b/backend/src/AI/Orchestration/AgentComposition.cs
@@ -43,7 +43,7 @@ internal static class AgentComposition
     /// <param name="chatClient">The provider-neutral client every turn of the run is sent through, already carrying whatever the caller wrapped it in.</param>
     /// <param name="plan">The validated declaration: the generation parameters one call runs with.</param>
     /// <param name="operation">The operation being composed: its name, its own instruction, and its tool set.</param>
-    /// <param name="envelope">Supplies the text placed before and after the operation's instruction.</param>
+    /// <param name="instructionEnvelope">Supplies the text placed before and after the operation's instruction.</param>
     /// <param name="loggerFactory">Creates the loggers the framework's own components record through.</param>
     /// <returns>The composed agent.</returns>
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
@@ -51,18 +51,21 @@ internal static class AgentComposition
         IChatClient chatClient,
         ChatGenerationPlan plan,
         AgentOperation operation,
-        IAgentInstructionEnvelope envelope,
+        IAgentInstructionEnvelope instructionEnvelope,
         ILoggerFactory loggerFactory)
     {
         ArgumentNullException.ThrowIfNull(chatClient);
         ArgumentNullException.ThrowIfNull(plan);
         ArgumentNullException.ThrowIfNull(operation);
-        ArgumentNullException.ThrowIfNull(envelope);
+        ArgumentNullException.ThrowIfNull(instructionEnvelope);
         ArgumentNullException.ThrowIfNull(loggerFactory);
 
         var chatOptions = ChatGenerationParameterMapping.ToChatOptions(plan);
 
-        chatOptions.Instructions = string.Concat(envelope.Preamble, operation.Instruction, envelope.Postamble);
+        chatOptions.Instructions = string.Concat(
+            instructionEnvelope.Preamble,
+            operation.Instruction,
+            instructionEnvelope.Postamble);
         chatOptions.Tools = [.. operation.Tools];
 
         var options = new ChatClientAgentOptions

--- a/backend/src/AI/Orchestration/AgentOperation.cs
+++ b/backend/src/AI/Orchestration/AgentOperation.cs
@@ -1,0 +1,24 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using Microsoft.Extensions.AI;
+
+namespace MailFathom.AI.Orchestration;
+
+/// <summary>What one AI operation is, apart from the endpoint it runs against and the parameters it runs with.</summary>
+/// <remarks>
+/// <para>
+/// The three things an operation decides for itself. Everything else an agent is composed from — the chat client, the
+/// generation parameters, the envelope around the instruction — is the same for every operation and is supplied by
+/// <see cref="AgentComposition" />.
+/// </para>
+/// <para>
+/// <see cref="Tools" /> is the capability rather than a description of one: an operation that only reads declares no
+/// tool that mutates a mailbox, and there is nothing else it would have to say so in.
+/// </para>
+/// </remarks>
+/// <param name="Name">What a run of this operation reports itself as.</param>
+/// <param name="Instruction">What the operation tells the model about its task, before the envelope is placed around it.</param>
+/// <param name="Tools">Everything the operation may do besides answer, which for a reading operation is what it may look up.</param>
+internal sealed record AgentOperation(string Name, string Instruction, IReadOnlyList<AITool> Tools);

--- a/backend/src/AI/Orchestration/EmptyAgentInstructionEnvelope.cs
+++ b/backend/src/AI/Orchestration/EmptyAgentInstructionEnvelope.cs
@@ -1,0 +1,19 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.AI.Orchestration;
+
+/// <summary>Wraps every operation's instruction in nothing, which is what this build ships.</summary>
+/// <remarks>
+/// The registered default, and the thing that makes the seam free: a composition over this produces the operation's own
+/// instruction byte for byte, so no run pays for a wrapper nobody has written yet.
+/// </remarks>
+internal sealed class EmptyAgentInstructionEnvelope : IAgentInstructionEnvelope
+{
+    /// <inheritdoc />
+    public string Preamble => string.Empty;
+
+    /// <inheritdoc />
+    public string Postamble => string.Empty;
+}

--- a/backend/src/AI/Orchestration/IAgentInstructionEnvelope.cs
+++ b/backend/src/AI/Orchestration/IAgentInstructionEnvelope.cs
@@ -1,0 +1,45 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.AI.Orchestration;
+
+/// <summary>Supplies the text every composed agent's own instruction is wrapped in.</summary>
+/// <remarks>
+/// <para>
+/// One seam for what is true of every AI operation rather than of one of them: the language a person reads, a
+/// deployment's own wording, anything else that would otherwise have to be written into each instruction in the tree
+/// and kept in step with the others. What ships is the seam and an implementation returning nothing, so composing an
+/// agent today produces exactly the instruction the operation carries.
+/// </para>
+/// <para>
+/// Consulted once per composition rather than once per process, which is what lets an implementation return different
+/// text per person or per request without any agent changing. An implementation is therefore registered with whatever
+/// lifetime its answer varies over, and must be cheap enough to be asked at the start of every run.
+/// </para>
+/// <para>
+/// There is no substitution syntax, no placeholder, and no configuration key: whatever is returned is text, and the
+/// composition puts one part before the operation's instruction and the other after it.
+/// </para>
+/// <para>
+/// **Neither half may carry mail content, an address, or anything else personal.** The envelope is composed into the
+/// instruction, which every turn of every run sends to the provider, so an implementation reading a mailbox to fill it
+/// would put that mail in the one position <see cref="MailAnsweringInstructions" /> exists to keep it out of. What
+/// belongs here is what the deployment or the person chose to say about how they are addressed, and nothing derived
+/// from mail.
+/// </para>
+/// <para>
+/// An operation recording which policy a run was conducted under records the version of its own instruction, which is
+/// the composed one exactly while this stays empty. The first implementation that returns anything therefore has to
+/// decide what such a record names, because an audited answer produced under a wrapper the record does not mention is a
+/// record that misstates its own policy.
+/// </para>
+/// </remarks>
+public interface IAgentInstructionEnvelope
+{
+    /// <summary>Gets the text placed before the operation's own instruction, or an empty string to place none.</summary>
+    string Preamble { get; }
+
+    /// <summary>Gets the text placed after the operation's own instruction, or an empty string to place none.</summary>
+    string Postamble { get; }
+}

--- a/backend/src/AI/Orchestration/MailAnsweringAgent.cs
+++ b/backend/src/AI/Orchestration/MailAnsweringAgent.cs
@@ -30,11 +30,18 @@ namespace MailFathom.AI.Orchestration;
 /// question rather than at the next restart, and one caller's retrieved mail cannot outlive the call that retrieved it.
 /// </para>
 /// <para>
-/// A prompt this run sends is composed from three things and no others: the instruction, which is a constant of this
-/// build; the question, which is guarded here; and the extracts a lookup returns, which are guarded where the retrieval
-/// writes them. Guarding the composed conversation instead would rescan every earlier turn on every turn, and would
-/// leave the guarantee resting on which content kinds a framework release happens to publish rather than on where mail
-/// enters the run.
+/// A prompt this run sends is composed from three things and no others: the instruction, which is this build's own text
+/// wrapped by <see cref="IAgentInstructionEnvelope" />; the question, which is guarded here; and the extracts a lookup
+/// returns, which are guarded where the retrieval writes them. Guarding the composed conversation instead would rescan
+/// every earlier turn on every turn, and would leave the guarantee resting on which content kinds a framework release
+/// happens to publish rather than on where mail enters the run.
+/// </para>
+/// <para>
+/// The instruction is not scanned, and what makes that safe is the envelope's own contract rather than the text being
+/// fixed at compile time: neither half of it may carry mail content, an address, or anything else personal, so nothing
+/// an implementation supplies is untrusted input in the sense the guard exists for. An implementation that filled it
+/// from a mailbox would be the defect, and scanning here would not repair it — it would put mail into the position the
+/// instruction occupies and then check it for secrets.
 /// </para>
 /// </remarks>
 internal sealed class MailAnsweringAgent : IMailQuestionAnswerer
@@ -128,8 +135,8 @@ internal sealed class MailAnsweringAgent : IMailQuestionAnswerer
         observation.RecordComposition(endpoint.Alias, MailAnsweringInstructions.Version);
 
         // The question is one turn, so the bound on what one call may carry is the bound on the question. What the
-        // retrieval adds beside it is bounded where the passages are built, and the run's instruction is a constant of
-        // this build rather than anything a caller composes.
+        // retrieval adds beside it is bounded where the passages are built, and the run's instruction is this build's
+        // own text inside the envelope registration supplied rather than anything a caller composes.
         ChatRequestBounds.Require(
             [new ChatMessage(ChatRole.User, question.Text.Value)],
             this.plan.MaximumMessagesPerRequest,

--- a/backend/src/AI/Orchestration/MailAnsweringAgent.cs
+++ b/backend/src/AI/Orchestration/MailAnsweringAgent.cs
@@ -49,6 +49,7 @@ internal sealed class MailAnsweringAgent : IMailQuestionAnswerer
     private readonly IAiProviderHealthRecorder healthRecorder;
     private readonly IMailAnsweringSpendLedger spendLedger;
     private readonly SensitiveContentEgressGuard egressGuard;
+    private readonly IAgentInstructionEnvelope instructionEnvelope;
     private readonly ILoggerFactory loggerFactory;
     private readonly ILogger<MailAnsweringAgent> logger;
 
@@ -63,6 +64,7 @@ internal sealed class MailAnsweringAgent : IMailQuestionAnswerer
     /// <param name="healthRecorder">Records what each call established about the provider.</param>
     /// <param name="spendLedger">Counts what every call of this run added to the current period.</param>
     /// <param name="egressGuard">Scans the question and every retrieved extract before either reaches the provider.</param>
+    /// <param name="instructionEnvelope">Supplies the text every composed agent's instruction is wrapped in, asked once per run.</param>
     /// <param name="loggerFactory">Creates the loggers the framework's own components record through.</param>
     /// <param name="logger">Records the outcome without recording any question, answer, or passage.</param>
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
@@ -77,6 +79,7 @@ internal sealed class MailAnsweringAgent : IMailQuestionAnswerer
         IAiProviderHealthRecorder healthRecorder,
         IMailAnsweringSpendLedger spendLedger,
         SensitiveContentEgressGuard egressGuard,
+        IAgentInstructionEnvelope instructionEnvelope,
         ILoggerFactory loggerFactory,
         ILogger<MailAnsweringAgent> logger)
     {
@@ -90,6 +93,7 @@ internal sealed class MailAnsweringAgent : IMailQuestionAnswerer
         ArgumentNullException.ThrowIfNull(healthRecorder);
         ArgumentNullException.ThrowIfNull(spendLedger);
         ArgumentNullException.ThrowIfNull(egressGuard);
+        ArgumentNullException.ThrowIfNull(instructionEnvelope);
         ArgumentNullException.ThrowIfNull(loggerFactory);
         ArgumentNullException.ThrowIfNull(logger);
 
@@ -103,6 +107,7 @@ internal sealed class MailAnsweringAgent : IMailQuestionAnswerer
         this.healthRecorder = healthRecorder;
         this.spendLedger = spendLedger;
         this.egressGuard = egressGuard;
+        this.instructionEnvelope = instructionEnvelope;
         this.loggerFactory = loggerFactory;
         this.logger = logger;
     }
@@ -184,7 +189,12 @@ internal sealed class MailAnsweringAgent : IMailQuestionAnswerer
             question.Text.Value,
             cancellationToken);
 
-        var agent = MailAnsweringAgentComposition.Compose(chatClient, this.plan, retrieval, this.loggerFactory);
+        var agent = MailAnsweringAgentComposition.Compose(
+            chatClient,
+            this.plan,
+            retrieval,
+            this.instructionEnvelope,
+            this.loggerFactory);
         var response = await agent.RunAsync(questionText, session: null, options: null, cancellationToken);
         var report = retrieval.Report;
 

--- a/backend/src/AI/Orchestration/MailAnsweringAgentComposition.cs
+++ b/backend/src/AI/Orchestration/MailAnsweringAgentComposition.cs
@@ -15,8 +15,9 @@ namespace MailFathom.AI.Orchestration;
 /// <para>
 /// What is here is what answering decides for itself: its name, its instruction, and its one tool.
 /// <see cref="AgentComposition" /> is what turns those into an agent, and everything true of every operation — where
-/// the instruction is carried, the envelope around it, the parameters each turn runs with — is stated there rather than
-/// again here.
+/// the instruction is carried, the <see cref="IAgentInstructionEnvelope" /> wrapped around it, the parameters each turn
+/// runs with — is stated there rather than again here. The word <em>envelope</em> below keeps the meaning this file
+/// already gave it, which is the element the retrieval formats an extract into.
 /// </para>
 /// <para>
 /// The composition is separate from what opens the provider connection, so what the agent is can be exercised over a
@@ -49,7 +50,7 @@ internal static class MailAnsweringAgentComposition
     /// <param name="chatClient">The provider-neutral client every turn of the run is sent through.</param>
     /// <param name="plan">The validated declaration: the generation parameters one call runs with.</param>
     /// <param name="retrieval">The mail this run may reach, already bound to the caller's scope.</param>
-    /// <param name="envelope">Supplies the text placed before and after this operation's instruction.</param>
+    /// <param name="instructionEnvelope">Supplies the text placed before and after this operation's instruction.</param>
     /// <param name="loggerFactory">Creates the loggers the framework's own components record through.</param>
     /// <returns>The composed agent.</returns>
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
@@ -57,7 +58,7 @@ internal static class MailAnsweringAgentComposition
         IChatClient chatClient,
         ChatGenerationPlan plan,
         ScopedMailKnowledgeRetrieval retrieval,
-        IAgentInstructionEnvelope envelope,
+        IAgentInstructionEnvelope instructionEnvelope,
         ILoggerFactory loggerFactory)
     {
         ArgumentNullException.ThrowIfNull(retrieval);
@@ -70,6 +71,6 @@ internal static class MailAnsweringAgentComposition
             MailAnsweringInstructions.Text,
             [retrieval.CreateSearchTool()]);
 
-        return AgentComposition.Compose(chatClient, plan, operation, envelope, loggerFactory);
+        return AgentComposition.Compose(chatClient, plan, operation, instructionEnvelope, loggerFactory);
     }
 }

--- a/backend/src/AI/Orchestration/MailAnsweringAgentComposition.cs
+++ b/backend/src/AI/Orchestration/MailAnsweringAgentComposition.cs
@@ -3,7 +3,6 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.AI.Chat;
-using MailFathom.AI.ProviderAdapters;
 using MailFathom.AI.Retrieval;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
@@ -11,8 +10,14 @@ using Microsoft.Extensions.Logging;
 
 namespace MailFathom.AI.Orchestration;
 
-/// <summary>Composes the agent that answers a question about the mailbox.</summary>
+/// <summary>Declares the agent that answers a question about the mailbox, and composes it like every other operation.</summary>
 /// <remarks>
+/// <para>
+/// What is here is what answering decides for itself: its name, its instruction, and its one tool.
+/// <see cref="AgentComposition" /> is what turns those into an agent, and everything true of every operation — where
+/// the instruction is carried, the envelope around it, the parameters each turn runs with — is stated there rather than
+/// again here.
+/// </para>
 /// <para>
 /// The composition is separate from what opens the provider connection, so what the agent is can be exercised over a
 /// substituted chat client and no network: the tool loop, the scope the retrieval is bound to, and the parameters the
@@ -44,6 +49,7 @@ internal static class MailAnsweringAgentComposition
     /// <param name="chatClient">The provider-neutral client every turn of the run is sent through.</param>
     /// <param name="plan">The validated declaration: the generation parameters one call runs with.</param>
     /// <param name="retrieval">The mail this run may reach, already bound to the caller's scope.</param>
+    /// <param name="envelope">Supplies the text placed before and after this operation's instruction.</param>
     /// <param name="loggerFactory">Creates the loggers the framework's own components record through.</param>
     /// <returns>The composed agent.</returns>
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
@@ -51,30 +57,19 @@ internal static class MailAnsweringAgentComposition
         IChatClient chatClient,
         ChatGenerationPlan plan,
         ScopedMailKnowledgeRetrieval retrieval,
+        IAgentInstructionEnvelope envelope,
         ILoggerFactory loggerFactory)
     {
-        ArgumentNullException.ThrowIfNull(chatClient);
-        ArgumentNullException.ThrowIfNull(plan);
         ArgumentNullException.ThrowIfNull(retrieval);
-        ArgumentNullException.ThrowIfNull(loggerFactory);
-
-        var chatOptions = ChatGenerationParameterMapping.ToChatOptions(plan);
-
-        // Carried as the run's instruction rather than written into a message, which is what keeps it in a position no
-        // retrieved extract can be placed in.
-        chatOptions.Instructions = MailAnsweringInstructions.Text;
 
         // The one tool, and the only route by which mail reaches the model. It is offered as a tool rather than through
         // the framework's text-search context provider because that provider publishes a query and nothing else, and
         // the narrowing a lookup needs is the greater part of what makes an answer reach the mail a search would.
-        chatOptions.Tools = [retrieval.CreateSearchTool()];
+        var operation = new AgentOperation(
+            AgentName,
+            MailAnsweringInstructions.Text,
+            [retrieval.CreateSearchTool()]);
 
-        var options = new ChatClientAgentOptions
-        {
-            Name = AgentName,
-            ChatOptions = chatOptions,
-        };
-
-        return new ChatClientAgent(chatClient, options, loggerFactory);
+        return AgentComposition.Compose(chatClient, plan, operation, envelope, loggerFactory);
     }
 }

--- a/backend/tests/AI.UnitTests/AiServiceCollectionExtensionsTests.cs
+++ b/backend/tests/AI.UnitTests/AiServiceCollectionExtensionsTests.cs
@@ -4,6 +4,7 @@
 
 using MailFathom.AI.Chat;
 using MailFathom.AI.Embeddings;
+using MailFathom.AI.Orchestration;
 using MailFathom.AI.ProviderAdapters;
 using MailFathom.AI.Providers;
 using MailFathom.AI.UnitTests.TestDoubles;
@@ -274,6 +275,27 @@ public sealed class AiServiceCollectionExtensionsTests
         Assert.NotSame(
             scope.ServiceProvider.GetRequiredService<IMailQuestionAnswerer>(),
             otherScope.ServiceProvider.GetRequiredService<IMailQuestionAnswerer>());
+    }
+
+    /// <summary>
+    /// The empty envelope is a default rather than a fixture: a deployment supplying a person's language registers its
+    /// own before this runs and keeps it, which is the whole of what makes the seam worth having.
+    /// </summary>
+    [Fact]
+    public void AddMailAnsweringAgent_WhereAnInstructionEnvelopeIsAlreadyRegistered_KeepsIt()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var declared = Substitute.For<IAgentInstructionEnvelope>();
+        services.AddSingleton(declared);
+
+        // Act
+        services.AddMailAnsweringAgent();
+
+        // Assert
+        using var provider = services.BuildServiceProvider();
+
+        Assert.Same(declared, provider.GetRequiredService<IAgentInstructionEnvelope>());
     }
 
     [Fact]

--- a/backend/tests/AI.UnitTests/Orchestration/AgentCompositionTests.cs
+++ b/backend/tests/AI.UnitTests/Orchestration/AgentCompositionTests.cs
@@ -1,0 +1,168 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.AI.Orchestration;
+using MailFathom.AI.UnitTests.TestDoubles;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace MailFathom.AI.UnitTests.Orchestration;
+
+/// <summary>Covers the one composition every AI operation is built by: what it names the run, what it offers it, and what instruction it carries.</summary>
+/// <remarks>
+/// Each test runs the composed agent over a substituted chat client and reads what the client was asked to send, so what
+/// is proved is the composition rather than a description of it.
+/// </remarks>
+public sealed class AgentCompositionTests
+{
+    private const string Instruction = "Answer the question you were asked.";
+
+    /// <summary>The whole of what this build ships: a composition over the registered default is the operation's own text.</summary>
+    [Fact]
+    public async Task Compose_TheEmptyEnvelope_CarriesTheOperationsInstructionUnchanged()
+    {
+        // Arrange
+        using var chatClient = ScriptedChatClient.Answering("answered");
+        var agent = AgentComposition.Compose(
+            chatClient,
+            ChatDeclarations.Plan(),
+            new AgentOperation("an-operation", Instruction, []),
+            new EmptyAgentInstructionEnvelope(),
+            NullLoggerFactory.Instance);
+
+        // Act
+        await agent.RunAsync("a question", session: null, options: null, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(Instruction, Assert.Single(chatClient.Calls).Options?.Instructions);
+    }
+
+    /// <summary>Concatenated and nothing else: the operation's text sits between the two halves, with no separator of the composition's own.</summary>
+    [Fact]
+    public async Task Compose_AnEnvelopeSupplyingBothHalves_PlacesThemFirstAndLast()
+    {
+        // Arrange
+        using var chatClient = ScriptedChatClient.Answering("answered");
+        var agent = AgentComposition.Compose(
+            chatClient,
+            ChatDeclarations.Plan(),
+            new AgentOperation("an-operation", Instruction, []),
+            new StubAgentInstructionEnvelope("before. ", " after."),
+            NullLoggerFactory.Instance);
+
+        // Act
+        await agent.RunAsync("a question", session: null, options: null, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(
+            $"before. {Instruction} after.",
+            Assert.Single(chatClient.Calls).Options?.Instructions);
+    }
+
+    /// <summary>Either half stands on its own, so an implementation with something to say in one position says nothing in the other.</summary>
+    [Theory]
+    [InlineData("before. ", "", "before. Answer the question you were asked.")]
+    [InlineData("", " after.", "Answer the question you were asked. after.")]
+    public async Task Compose_AnEnvelopeSupplyingOneHalf_PlacesThatHalfAlone(
+        string preamble,
+        string postamble,
+        string expected)
+    {
+        // Arrange
+        using var chatClient = ScriptedChatClient.Answering("answered");
+        var agent = AgentComposition.Compose(
+            chatClient,
+            ChatDeclarations.Plan(),
+            new AgentOperation("an-operation", Instruction, []),
+            new StubAgentInstructionEnvelope(preamble, postamble),
+            NullLoggerFactory.Instance);
+
+        // Act
+        await agent.RunAsync("a question", session: null, options: null, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(expected, Assert.Single(chatClient.Calls).Options?.Instructions);
+    }
+
+    /// <summary>
+    /// Asked at composition rather than read once at start, which is what lets an implementation vary its answer per
+    /// person or per request without any operation changing.
+    /// </summary>
+    [Fact]
+    public async Task Compose_AnEnvelopeAnsweringDifferentlyEachTime_IsConsultedOncePerComposition()
+    {
+        // Arrange
+        var envelope = new CountingAgentInstructionEnvelope();
+        using var firstClient = ScriptedChatClient.Answering("answered");
+        using var secondClient = ScriptedChatClient.Answering("answered");
+        var operation = new AgentOperation("an-operation", Instruction, []);
+
+        // Act
+        var first = AgentComposition.Compose(
+            firstClient,
+            ChatDeclarations.Plan(),
+            operation,
+            envelope,
+            NullLoggerFactory.Instance);
+        await first.RunAsync("a question", session: null, options: null, TestContext.Current.CancellationToken);
+
+        var second = AgentComposition.Compose(
+            secondClient,
+            ChatDeclarations.Plan(),
+            operation,
+            envelope,
+            NullLoggerFactory.Instance);
+        await second.RunAsync("a question", session: null, options: null, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal($"1. {Instruction}", Assert.Single(firstClient.Calls).Options?.Instructions);
+        Assert.Equal($"2. {Instruction}", Assert.Single(secondClient.Calls).Options?.Instructions);
+    }
+
+    /// <summary>
+    /// The name a run reports and the tool set that is the operation's whole capability, both taken from the operation
+    /// rather than decided by the composition: an operation that only reads is one declaring no tool that mutates.
+    /// </summary>
+    [Fact]
+    public async Task Compose_AnOperation_ReportsItsNameAndOffersItsOwnToolSet()
+    {
+        // Arrange
+        using var chatClient = ScriptedChatClient.Answering("answered");
+        var tool = AIFunctionFactory.Create(() => "nothing", "count_nothing");
+        var agent = AgentComposition.Compose(
+            chatClient,
+            ChatDeclarations.Plan(),
+            new AgentOperation("an-operation", Instruction, [tool]),
+            new EmptyAgentInstructionEnvelope(),
+            NullLoggerFactory.Instance);
+
+        // Act
+        await agent.RunAsync("a question", session: null, options: null, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("an-operation", agent.Name);
+        Assert.Equal(
+            ["count_nothing"],
+            (Assert.Single(chatClient.Calls).Options?.Tools ?? []).Select(offered => offered.Name));
+    }
+
+    /// <summary>An envelope with something to say in both positions.</summary>
+    private sealed class StubAgentInstructionEnvelope(string preamble, string postamble) : IAgentInstructionEnvelope
+    {
+        public string Preamble => preamble;
+
+        public string Postamble => postamble;
+    }
+
+    /// <summary>An envelope whose answer changes on every reading, which is what a per-person implementation would look like from here.</summary>
+    private sealed class CountingAgentInstructionEnvelope : IAgentInstructionEnvelope
+    {
+        private int readings;
+
+        public string Preamble => $"{++this.readings}. ";
+
+        public string Postamble => string.Empty;
+    }
+}

--- a/backend/tests/AI.UnitTests/Orchestration/MailAnsweringAgentCompositionTests.cs
+++ b/backend/tests/AI.UnitTests/Orchestration/MailAnsweringAgentCompositionTests.cs
@@ -267,6 +267,7 @@ public sealed class MailAnsweringAgentCompositionTests
             chatClient,
             plan,
             retrieval,
+            new EmptyAgentInstructionEnvelope(),
             NullLoggerFactory.Instance);
 
         // Act
@@ -354,6 +355,7 @@ public sealed class MailAnsweringAgentCompositionTests
             chatClient,
             plan,
             retrieval,
+            new EmptyAgentInstructionEnvelope(),
             NullLoggerFactory.Instance);
 
         // Act
@@ -517,6 +519,7 @@ public sealed class MailAnsweringAgentCompositionTests
             chatClient,
             ChatDeclarations.Plan(),
             retrieval,
+            new EmptyAgentInstructionEnvelope(),
             NullLoggerFactory.Instance);
 
         // Act
@@ -566,6 +569,7 @@ public sealed class MailAnsweringAgentCompositionTests
             chatClient,
             ChatDeclarations.Plan(),
             retrieval,
+            new EmptyAgentInstructionEnvelope(),
             NullLoggerFactory.Instance);
     }
 }

--- a/backend/tests/AI.UnitTests/Orchestration/MailAnsweringAgentTests.cs
+++ b/backend/tests/AI.UnitTests/Orchestration/MailAnsweringAgentTests.cs
@@ -289,6 +289,7 @@ public sealed class MailAnsweringAgentTests
                 this.HealthRecorder,
                 this.SpendLedger,
                 egressGuard ?? SensitiveContentEgressGuards.Inactive(),
+                new EmptyAgentInstructionEnvelope(),
                 NullLoggerFactory.Instance,
                 NullLogger<MailAnsweringAgent>.Instance);
         }

--- a/backend/tests/AI.UnitTests/Retrieval/PromptInjectionResistanceTests.cs
+++ b/backend/tests/AI.UnitTests/Retrieval/PromptInjectionResistanceTests.cs
@@ -166,6 +166,7 @@ public sealed class PromptInjectionResistanceTests
                 OnePrimaryAccount,
                 new MailAnsweringRunLedger(MailAnsweringRunBounds.Default),
                 SensitiveContentEgressGuards.Inactive()),
+            new EmptyAgentInstructionEnvelope(),
             NullLoggerFactory.Instance);
 
     private static IReadOnlyList<XElement> MessagesIn(string envelope) =>

--- a/backend/tests/IntegrationTests/Orchestration/ComposedMailQuestionAnswerer.cs
+++ b/backend/tests/IntegrationTests/Orchestration/ComposedMailQuestionAnswerer.cs
@@ -59,6 +59,7 @@ internal sealed class ComposedMailQuestionAnswerer(
                 chatClient,
                 plan,
                 retrieval,
+                new EmptyAgentInstructionEnvelope(),
                 NullLoggerFactory.Instance);
 
             var response = await agent.RunAsync(

--- a/docs/features/mail-answering.md
+++ b/docs/features/mail-answering.md
@@ -11,6 +11,44 @@ surface — the arguments, the citations, and when the tool is advertised at all
 much of a mailbox may leave the process to answer it, is [§ What one question may spend](#what-one-question-may-spend)
 below; [`MailAnswering`](../operations/configuration-ai.md#mailanswering) holds the keys.
 
+## Every AI operation is one agent, composed one way
+
+`ask_mail` is a Microsoft Agent Framework agent built over a provider-neutral chat client, and every other thing this
+product does with a model is built the same way, by the same composition. An operation supplies three things and no
+others: the name a run reports itself as, its own instruction, and its tool set.
+Everything else — where the instruction is carried, the generation parameters each turn runs with, the envelope
+described below — is decided once, for all of them.
+
+One composition rather than a chat call written beside each feature, because what makes an operation safe is a property
+of that shape rather than of its prose. An instruction cannot be reached from a tool result because of where each is
+placed; the tool set **is** the capability, so an operation that only reads composes no mutating tool; every call goes
+through the client the run wrapped, which is where its spend is counted; and what a run reports about cost,
+cancellation, and the model is what [ADR 0022](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0022-what-an-ai-run-reports-about-cost-cancellation-and-the-model.md)
+says. A feature composing its own call would re-decide all four in silence, once per feature.
+
+### An envelope around every instruction, empty in this build
+
+What a composed agent sends as its instruction is three parts: a preamble, the operation's own instruction, and a
+postamble. Both outer parts come from one implementation resolved through dependency injection and asked once per
+composition, so an answer that varies per person or per request changes what a run sends without any operation changing.
+
+**This build ships the seam and an implementation that returns nothing**, so the composed instruction is the operation's
+own text byte for byte and no run pays for a wrapper nobody has written yet. What it buys is that adding the language a
+person reads, a deployment's own wording, or anything else true of every operation is one implementation of one
+interface rather than an edit to every instruction in the tree.
+
+There is no template language, no substitution syntax, no prompt store, and no configuration key. Whatever the
+implementation returns is text, and the composition puts one part before the operation's instruction and the other
+after it, with no separator of its own.
+
+**Neither half may carry mail content, an address, or anything else personal.** The envelope is composed into the
+instruction, which is the one position [§ Mail is read as evidence, never as an instruction](#mail-is-read-as-evidence-never-as-an-instruction)
+keeps mail out of, so an implementation filling it from a mailbox would undo that separation. What belongs there is what
+the deployment or the person chose to say about how they are addressed. Whatever it adds rides inside the same
+instruction every turn carries, so it is sent through the same client the run's spend is counted on and is inside what a
+run reports as spent rather than outside it — and it reaches no log and no telemetry event, for the reason
+[§ What never reaches a log](#what-never-reaches-a-log) gives for everything else on this path.
+
 ## The model asks for mail; nothing is pushed at it
 
 Retrieval runs **on demand**. The agent is composed with one tool, `search_mail`, and the model calls it when it decides

--- a/docs/features/mail-answering.md
+++ b/docs/features/mail-answering.md
@@ -13,11 +13,16 @@ below; [`MailAnswering`](../operations/configuration-ai.md#mailanswering) holds 
 
 ## Every AI operation is one agent, composed one way
 
-`ask_mail` is a Microsoft Agent Framework agent built over a provider-neutral chat client, and every other thing this
-product does with a model is built the same way, by the same composition. An operation supplies three things and no
-others: the name a run reports itself as, its own instruction, and its tool set. Everything else — where the instruction
-is carried, the generation parameters each turn runs with, the instruction envelope described below — is decided once,
-for all of them.
+`ask_mail` is a Microsoft Agent Framework agent built over a provider-neutral chat client, and it is composed by the one
+expression every agent this product runs is composed by. An operation supplies three things and no others: the name a
+run reports itself as, its own instruction, and its tool set. Everything else — where the instruction is carried, the
+generation parameters each turn runs with, the instruction envelope described below — is decided once, for all of them.
+
+**Not every model call is an agent, and the ones that are not do not come through here.** The second pass below sends a
+single relevance judgement through the chat client directly: it carries its own instruction, offers no tool, and runs no
+loop, so there is no agent to compose — [§ An optional second pass: the model decides what
+answers](#an-optional-second-pass-the-model-decides-what-answers) is what governs it. `ask_mail` is the one agent this
+build composes; the operations that will join it are the model-invoking work still to be built.
 
 One composition rather than a chat call written beside each feature, because what makes an operation safe is a property
 of that shape rather than of its prose. An instruction cannot be reached from a tool result because of where each is

--- a/docs/features/mail-answering.md
+++ b/docs/features/mail-answering.md
@@ -15,9 +15,9 @@ below; [`MailAnswering`](../operations/configuration-ai.md#mailanswering) holds 
 
 `ask_mail` is a Microsoft Agent Framework agent built over a provider-neutral chat client, and every other thing this
 product does with a model is built the same way, by the same composition. An operation supplies three things and no
-others: the name a run reports itself as, its own instruction, and its tool set.
-Everything else — where the instruction is carried, the generation parameters each turn runs with, the envelope
-described below — is decided once, for all of them.
+others: the name a run reports itself as, its own instruction, and its tool set. Everything else — where the instruction
+is carried, the generation parameters each turn runs with, the instruction envelope described below — is decided once,
+for all of them.
 
 One composition rather than a chat call written beside each feature, because what makes an operation safe is a property
 of that shape rather than of its prose. An instruction cannot be reached from a tool result because of where each is
@@ -26,7 +26,7 @@ through the client the run wrapped, which is where its spend is counted; and wha
 cancellation, and the model is what [ADR 0022](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0022-what-an-ai-run-reports-about-cost-cancellation-and-the-model.md)
 says. A feature composing its own call would re-decide all four in silence, once per feature.
 
-### An envelope around every instruction, empty in this build
+### The instruction envelope, empty in this build
 
 What a composed agent sends as its instruction is three parts: a preamble, the operation's own instruction, and a
 postamble. Both outer parts come from one implementation resolved through dependency injection and asked once per
@@ -41,8 +41,8 @@ There is no template language, no substitution syntax, no prompt store, and no c
 implementation returns is text, and the composition puts one part before the operation's instruction and the other
 after it, with no separator of its own.
 
-**Neither half may carry mail content, an address, or anything else personal.** The envelope is composed into the
-instruction, which is the one position [§ Mail is read as evidence, never as an instruction](#mail-is-read-as-evidence-never-as-an-instruction)
+**Neither half may carry mail content, an address, or anything else personal.** The instruction envelope is composed
+into the instruction, which is the one position [§ Mail is read as evidence, never as an instruction](#mail-is-read-as-evidence-never-as-an-instruction)
 keeps mail out of, so an implementation filling it from a mailbox would undo that separation. What belongs there is what
 the deployment or the person chose to say about how they are addressed. Whatever it adds rides inside the same
 instruction every turn carries, so it is sent through the same client the run's spend is counted on and is inside what a


### PR DESCRIPTION
## What this changes

Every AI operation this product runs is now composed by one expression, and each composed agent's instruction is
wrapped in an envelope supplied through dependency injection. `ask_mail` is retrofitted onto that composition rather
than left beside it as a second path.

- **`AgentComposition.Compose`** builds the `ChatClientAgent` for any operation: the chat client the caller wrapped, the
  generation parameters from a validated `ChatGenerationPlan`, the tool set, the composed instruction, and the name a
  run reports. What made `ask_mail` safe is now a property of the composition rather than of one feature's prose — the
  instruction sits where no tool result can be placed, the tool set *is* the capability, every call passes through the
  client the run's spend is counted on, and what a run reports about cost, cancellation, and the model stays what
  ADR 0022 says.
- **`AgentOperation`** is the three things an operation decides for itself: its name, its own instruction, and its tools.
  Two adjacent strings in a parameter list would have been swappable in silence; the record names them instead.
- **`IAgentInstructionEnvelope`** supplies a preamble and a postamble, asked once per composition rather than once per
  process, so an implementation whose answer varies per person or per request changes what a run sends without any
  operation changing. `EmptyAgentInstructionEnvelope` returns empty for both and is what ships:
  `string.Concat(preamble, instruction, postamble)` over it produces the operation's own text byte for byte. There is no
  substitution syntax, no placeholder, no prompt store, no configuration key, and no separator of the composition's own.
- **`AddMailAnsweringAgent`** registers the default with `TryAddSingleton`, so a deployment supplying a person's language
  registers its own before that call and keeps it — proved by a test rather than only documented.

`MailAnsweringAgentComposition` now holds only what answering decides for itself and delegates the rest. Its behaviour,
its instruction, and every assertion in its existing tests are unchanged; what moved in those files is the arrange line
that now names an envelope.

## Privacy

Neither half of the envelope may carry mail content, an address, or anything personal — the envelope is composed into
the instruction, which is the one position the mail-as-evidence separation keeps mail out of. The default returns empty,
the interface's documentation states that an implementation filling it from a mailbox is what would break that, and
neither half reaches a log or a telemetry event. Whatever an envelope adds rides inside the same instruction every turn
carries, so it is inside what the run reports as spent rather than outside it.

## One thing a later issue inherits

`MailAnsweringRunObservation.RecordComposition` still records `MailAnsweringInstructions.Version`, the digest of the
operation's own instruction — which is the composed instruction exactly while the envelope stays empty. The first
implementation that returns anything has to decide what that audit record names, because an answer produced under a
wrapper the record does not mention is a record that misstates its own policy. That constraint is written into the
interface's remarks so it is met at the point it starts to matter rather than rediscovered.

## Tests

`AgentCompositionTests` covers the empty default composing the operation's instruction unchanged, an envelope supplying
both halves placing them first and last, an envelope supplying one half alone, an envelope consulted once per
composition, and a composed operation reporting its name and offering its own tool set. Each runs the real composed
agent over a substituted chat client and reads what the client was asked to send.

## Verification

- `scripts/verify-full.sh` — passed.
- Coverage: 95.34% aggregate (gate 85%).
- No dependency moved; `Microsoft.Agents.AI` was already pinned.

Closes #1545
