### PR TITLE
[#1681] Read a Strict-conformance Open XML document instead of reporting it as a scan

### DIFF
--- a/backend/src/Infrastructure/Documents/OpenXmlAttachmentTextReader.cs
+++ b/backend/src/Infrastructure/Documents/OpenXmlAttachmentTextReader.cs
@@ -2,6 +2,7 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Collections.Frozen;
 using System.Globalization;
 using System.IO.Compression;
 using System.Text;
@@ -28,9 +29,31 @@ namespace MailFathom.Infrastructure.Documents;
 /// </remarks>
 internal sealed partial class OpenXmlAttachmentTextReader(AttachmentTextExtractionOptions options)
 {
-    private const string WordprocessingNamespace = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
-    private const string SpreadsheetNamespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
-    private const string DrawingNamespace = "http://schemas.openxmlformats.org/drawingml/2006/main";
+    /// <summary>The namespaces a word-processing part writes its text in, one per conformance class.</summary>
+    /// <remarks>
+    /// ISO 29500 defines two conformance classes, and a package written under the Strict one declares every part in a
+    /// namespace of its own. Matching only the Transitional namespace would walk a Strict document correctly, recognize
+    /// nothing in it, and report the empty result as a page carrying no text layer — which is how this reader reports a
+    /// scan, so a caller acting on <c>PagesWithoutText</c> would be told a specific wrong thing rather than nothing.
+    /// The admission is a set per format so that a further conformance class is one entry rather than an edit at each
+    /// comparison site.
+    /// </remarks>
+    private static readonly FrozenSet<string> WordprocessingNamespaces = FrozenSet.Create(
+        StringComparer.Ordinal,
+        "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
+        "http://purl.oclc.org/ooxml/wordprocessingml/main");
+
+    /// <summary>The namespaces a workbook's parts are written in, one per conformance class.</summary>
+    private static readonly FrozenSet<string> SpreadsheetNamespaces = FrozenSet.Create(
+        StringComparer.Ordinal,
+        "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
+        "http://purl.oclc.org/ooxml/spreadsheetml/main");
+
+    /// <summary>The namespaces a slide writes its text in, one per conformance class.</summary>
+    private static readonly FrozenSet<string> DrawingNamespaces = FrozenSet.Create(
+        StringComparer.Ordinal,
+        "http://schemas.openxmlformats.org/drawingml/2006/main",
+        "http://purl.oclc.org/ooxml/drawingml/main");
 
     private const string WordDocumentPart = "word/document.xml";
     private const string SharedStringsPart = "xl/sharedStrings.xml";
@@ -104,7 +127,7 @@ internal sealed partial class OpenXmlAttachmentTextReader(AttachmentTextExtracti
 
         using (var reader = this.parts.OpenPart(document, budget))
         {
-            carriedText = this.ReadRunsInto(reader, WordprocessingNamespace, text, cancellationToken);
+            carriedText = this.ReadRunsInto(reader, WordprocessingNamespaces, text, cancellationToken);
         }
 
         foreach (var part in SurroundingWordParts(archive))
@@ -113,7 +136,7 @@ internal sealed partial class OpenXmlAttachmentTextReader(AttachmentTextExtracti
 
             using var reader = this.parts.OpenPart(part, budget);
 
-            carriedText |= this.ReadRunsInto(reader, WordprocessingNamespace, text, cancellationToken);
+            carriedText |= this.ReadRunsInto(reader, WordprocessingNamespaces, text, cancellationToken);
         }
 
         return new ExtractedAttachmentText(text.ToText(), PageCount: 1, carriedText ? [] : [1]);
@@ -155,7 +178,7 @@ internal sealed partial class OpenXmlAttachmentTextReader(AttachmentTextExtracti
 
             using (var reader = this.parts.OpenPart(slide, budget))
             {
-                carriedText = this.ReadRunsInto(reader, DrawingNamespace, text, cancellationToken);
+                carriedText = this.ReadRunsInto(reader, DrawingNamespaces, text, cancellationToken);
             }
 
             if (!carriedText)
@@ -240,7 +263,7 @@ internal sealed partial class OpenXmlAttachmentTextReader(AttachmentTextExtracti
     /// </remarks>
     private bool ReadRunsInto(
         XmlReader reader,
-        string textNamespace,
+        FrozenSet<string> textNamespaces,
         BoundedTextAccumulator text,
         CancellationToken cancellationToken)
     {
@@ -262,7 +285,7 @@ internal sealed partial class OpenXmlAttachmentTextReader(AttachmentTextExtracti
 
             switch (reader.NodeType)
             {
-                case XmlNodeType.Element when reader.NamespaceURI == textNamespace:
+                case XmlNodeType.Element when textNamespaces.Contains(reader.NamespaceURI):
                     ReadRunElement(reader, text, ref insideRun, ref propertiesDepth);
                     break;
 
@@ -275,7 +298,7 @@ internal sealed partial class OpenXmlAttachmentTextReader(AttachmentTextExtracti
 
                     break;
 
-                case XmlNodeType.EndElement when reader.NamespaceURI == textNamespace:
+                case XmlNodeType.EndElement when textNamespaces.Contains(reader.NamespaceURI):
                     if (reader.LocalName == "t")
                     {
                         insideRun = false;
@@ -358,7 +381,7 @@ internal sealed partial class OpenXmlAttachmentTextReader(AttachmentTextExtracti
         {
             switch (reader.NodeType)
             {
-                case XmlNodeType.Element when reader.NamespaceURI == SpreadsheetNamespace:
+                case XmlNodeType.Element when SpreadsheetNamespaces.Contains(reader.NamespaceURI):
                     if (reader.LocalName == "si")
                     {
                         item.Clear();
@@ -383,7 +406,7 @@ internal sealed partial class OpenXmlAttachmentTextReader(AttachmentTextExtracti
 
                     break;
 
-                case XmlNodeType.EndElement when reader.NamespaceURI == SpreadsheetNamespace:
+                case XmlNodeType.EndElement when SpreadsheetNamespaces.Contains(reader.NamespaceURI):
                     if (reader.LocalName == "t")
                     {
                         insideRun = false;
@@ -416,7 +439,7 @@ internal sealed partial class OpenXmlAttachmentTextReader(AttachmentTextExtracti
         while (this.parts.ReadNode(reader, cancellationToken))
         {
             if (reader.NodeType != XmlNodeType.Element
-                || reader.NamespaceURI != SpreadsheetNamespace
+                || !SpreadsheetNamespaces.Contains(reader.NamespaceURI)
                 || reader.LocalName != "c"
                 || reader.IsEmptyElement)
             {
@@ -468,7 +491,7 @@ internal sealed partial class OpenXmlAttachmentTextReader(AttachmentTextExtracti
         {
             switch (cell.NodeType)
             {
-                case XmlNodeType.Element when cell.NamespaceURI == SpreadsheetNamespace:
+                case XmlNodeType.Element when SpreadsheetNamespaces.Contains(cell.NamespaceURI):
                     insideValue = cell.LocalName == "v" && !cell.IsEmptyElement;
                     insideInlineRun = cell.LocalName == "t" && !cell.IsEmptyElement;
                     break;
@@ -485,7 +508,7 @@ internal sealed partial class OpenXmlAttachmentTextReader(AttachmentTextExtracti
 
                     break;
 
-                case XmlNodeType.EndElement when cell.NamespaceURI == SpreadsheetNamespace:
+                case XmlNodeType.EndElement when SpreadsheetNamespaces.Contains(cell.NamespaceURI):
                     insideValue &= cell.LocalName != "v";
                     insideInlineRun &= cell.LocalName != "t";
                     break;

--- a/backend/tests/Infrastructure.UnitTests/Documents/BoundedAttachmentTextExtractorTests.cs
+++ b/backend/tests/Infrastructure.UnitTests/Documents/BoundedAttachmentTextExtractorTests.cs
@@ -98,6 +98,30 @@ public sealed class BoundedAttachmentTextExtractorTests
         Assert.Equal(1, result.Text?.PageCount);
     }
 
+    /// <summary>
+    /// The same document saved under ISO 29500 Strict declares another namespace and is otherwise identical, so it
+    /// reads back the same words. Matching Transitional alone would have answered with empty text and named the body as
+    /// a page carrying none, which is how this reader reports a scan — a specific wrong thing rather than nothing.
+    /// </summary>
+    [Fact]
+    public async Task ExtractTextAsync_AStrictWordDocument_ReadsItAsItsTransitionalEquivalent()
+    {
+        // Arrange
+        await using var attachment = new FakeOpenedEmailAttachment(
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "terms.docx",
+            DocumentFixtures.StrictWordDocument("Clause one", "Clause two"));
+
+        // Act
+        var result = await ExtractAsync(attachment);
+
+        // Assert
+        Assert.Equal(AttachmentTextExtractionOutcome.Extracted, result.Outcome);
+        Assert.Equal("Clause one\nClause two", result.Text?.Text);
+        Assert.Equal(1, result.Text?.PageCount);
+        Assert.Empty(result.Text?.PagesWithoutText ?? [0]);
+    }
+
     /// <summary>A presentation is read one page per slide, and an empty slide is named like an empty page.</summary>
     [Fact]
     public async Task ExtractTextAsync_APresentation_ReadsOnePagePerSlideAndNamesTheEmptyOne()
@@ -107,6 +131,26 @@ public sealed class BoundedAttachmentTextExtractorTests
             "application/vnd.openxmlformats-officedocument.presentationml.presentation",
             "deck.pptx",
             DocumentFixtures.Presentation("Opening", string.Empty, "Closing"));
+
+        // Act
+        var result = await ExtractAsync(attachment);
+
+        // Assert
+        Assert.Equal(AttachmentTextExtractionOutcome.Extracted, result.Outcome);
+        Assert.Equal("Opening\nClosing", result.Text?.Text);
+        Assert.Equal(3, result.Text?.PageCount);
+        Assert.Equal([2], result.Text?.PagesWithoutText);
+    }
+
+    /// <summary>A deck saved under ISO 29500 Strict reads back the same slides, and still names the empty one.</summary>
+    [Fact]
+    public async Task ExtractTextAsync_AStrictPresentation_ReadsItAsItsTransitionalEquivalent()
+    {
+        // Arrange
+        await using var attachment = new FakeOpenedEmailAttachment(
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            "deck.pptx",
+            DocumentFixtures.StrictPresentation("Opening", string.Empty, "Closing"));
 
         // Act
         var result = await ExtractAsync(attachment);
@@ -130,6 +174,29 @@ public sealed class BoundedAttachmentTextExtractorTests
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
             "ledger.xlsx",
             DocumentFixtures.Workbook(["Invoice", "Roof repair"], []));
+
+        // Act
+        var result = await ExtractAsync(attachment);
+
+        // Assert
+        Assert.Equal(AttachmentTextExtractionOutcome.Extracted, result.Outcome);
+        Assert.Equal("Invoice\nRoof repair", result.Text?.Text);
+        Assert.Equal(2, result.Text?.PageCount);
+        Assert.Equal([2], result.Text?.PagesWithoutText);
+    }
+
+    /// <summary>
+    /// A workbook saved under ISO 29500 Strict resolves the same table: the string table, the sheets, and the cells
+    /// each declare the Strict namespace, so admitting it at one comparison site and not the others would read nothing.
+    /// </summary>
+    [Fact]
+    public async Task ExtractTextAsync_AStrictWorkbook_ReadsItAsItsTransitionalEquivalent()
+    {
+        // Arrange
+        await using var attachment = new FakeOpenedEmailAttachment(
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "ledger.xlsx",
+            DocumentFixtures.StrictWorkbook(["Invoice", "Roof repair"], []));
 
         // Act
         var result = await ExtractAsync(attachment);
@@ -699,6 +766,32 @@ public sealed class BoundedAttachmentTextExtractorTests
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             "nested.docx",
             DocumentFixtures.DeeplyNestedWordDocument(depth: 40));
+
+        // Act
+        var result = await ExtractAsync(attachment, bounds);
+
+        // Assert
+        Assert.Equal(AttachmentTextExtractionOutcome.ContainerBoundExceeded, result.Outcome);
+    }
+
+    /// <summary>
+    /// A Strict package is the same archive of the same parts, so every bound around the walk holds over it unchanged.
+    /// The depth ceiling stands for all of them: it fires inside the walk rather than before it, so it is the one an
+    /// admitted second namespace could conceivably have widened.
+    /// </summary>
+    [Fact]
+    public async Task ExtractTextAsync_AStrictPartNestedPastTheDepthCeiling_ReportsTheContainerBound()
+    {
+        // Arrange
+        var bounds = new AttachmentTextExtractionOptions
+        {
+            MaxElementDepth = 8,
+        };
+
+        await using var attachment = new FakeOpenedEmailAttachment(
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "nested.docx",
+            DocumentFixtures.StrictDeeplyNestedWordDocument(depth: 40));
 
         // Act
         var result = await ExtractAsync(attachment, bounds);

--- a/backend/tests/Infrastructure.UnitTests/Documents/DocumentFixtures.cs
+++ b/backend/tests/Infrastructure.UnitTests/Documents/DocumentFixtures.cs
@@ -25,6 +25,10 @@ internal static class DocumentFixtures
     private const string SpreadsheetNamespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
     private const string DrawingNamespace = "http://schemas.openxmlformats.org/drawingml/2006/main";
 
+    private const string StrictWordprocessingNamespace = "http://purl.oclc.org/ooxml/wordprocessingml/main";
+    private const string StrictSpreadsheetNamespace = "http://purl.oclc.org/ooxml/spreadsheetml/main";
+    private const string StrictDrawingNamespace = "http://purl.oclc.org/ooxml/drawingml/main";
+
     private const string OfficeNamespace = "urn:oasis:names:tc:opendocument:xmlns:office:1.0";
     private const string OpenDocumentTextNamespace = "urn:oasis:names:tc:opendocument:xmlns:text:1.0";
     private const string OpenDocumentTableNamespace = "urn:oasis:names:tc:opendocument:xmlns:table:1.0";
@@ -55,16 +59,18 @@ internal static class DocumentFixtures
     /// <summary>Builds a word-processing package whose body carries the paragraphs given.</summary>
     /// <param name="paragraphs">The paragraphs, in order.</param>
     /// <returns>The package's octets.</returns>
-    public static byte[] WordDocument(params string[] paragraphs)
-    {
-        var body = string.Concat(paragraphs.Select(paragraph =>
-            $"<w:p><w:r><w:t>{Escaped(paragraph)}</w:t></w:r></w:p>"));
+    public static byte[] WordDocument(params string[] paragraphs) =>
+        WordDocumentIn(WordprocessingNamespace, paragraphs);
 
-        return Package(("word/document.xml", $"""
-            <?xml version="1.0" encoding="UTF-8"?>
-            <w:document xmlns:w="{WordprocessingNamespace}"><w:body>{body}</w:body></w:document>
-            """));
-    }
+    /// <summary>Builds the ISO 29500 Strict equivalent of <see cref="WordDocument(string[])" />.</summary>
+    /// <param name="paragraphs">The paragraphs, in order.</param>
+    /// <returns>The package's octets.</returns>
+    /// <remarks>
+    /// Strict differs from Transitional here in nothing but the namespace its parts declare — same archive, same part
+    /// names, same element names — which is what makes the pair a fair test of the admission rather than of the walk.
+    /// </remarks>
+    public static byte[] StrictWordDocument(params string[] paragraphs) =>
+        WordDocumentIn(StrictWordprocessingNamespace, paragraphs);
 
     /// <summary>Builds a word-processing package holding one part whose markup is given verbatim.</summary>
     /// <param name="documentXml">The markup <c>word/document.xml</c> carries.</param>
@@ -74,38 +80,26 @@ internal static class DocumentFixtures
     /// <summary>Builds a presentation package whose slides carry the lines given for each of them.</summary>
     /// <param name="slides">One entry per slide, each the line that slide carries, or empty for a slide with no text.</param>
     /// <returns>The package's octets.</returns>
-    public static byte[] Presentation(params string[] slides) => Package(
-        [
-            .. slides.Select((line, index) => (
-                $"ppt/slides/slide{(index + 1).ToString(CultureInfo.InvariantCulture)}.xml",
-                $"""
-                 <?xml version="1.0" encoding="UTF-8"?>
-                 <sld xmlns:a="{DrawingNamespace}"><a:p>{(line.Length == 0 ? string.Empty : $"<a:r><a:t>{Escaped(line)}</a:t></a:r>")}</a:p></sld>
-                 """)),
-        ]);
+    public static byte[] Presentation(params string[] slides) =>
+        PresentationIn(DrawingNamespace, slides);
+
+    /// <summary>Builds the ISO 29500 Strict equivalent of <see cref="Presentation(string[])" />.</summary>
+    /// <param name="slides">One entry per slide, each the line that slide carries, or empty for a slide with no text.</param>
+    /// <returns>The package's octets.</returns>
+    public static byte[] StrictPresentation(params string[] slides) =>
+        PresentationIn(StrictDrawingNamespace, slides);
 
     /// <summary>Builds a workbook whose sheets hold the cells given for each of them, through the shared string table.</summary>
     /// <param name="sheets">One entry per sheet, each the cell values that sheet holds in order.</param>
     /// <returns>The package's octets.</returns>
-    public static byte[] Workbook(params string[][] sheets)
-    {
-        var sharedStrings = sheets.SelectMany(sheet => sheet).Distinct(StringComparer.Ordinal).ToList();
+    public static byte[] Workbook(params string[][] sheets) =>
+        WorkbookIn(SpreadsheetNamespace, sheets);
 
-        var table = $"""
-            <?xml version="1.0" encoding="UTF-8"?>
-            <sst xmlns="{SpreadsheetNamespace}">{string.Concat(sharedStrings.Select(value => $"<si><t>{Escaped(value)}</t></si>"))}</sst>
-            """;
-
-        var parts = sheets.Select((sheet, index) => (
-            $"xl/worksheets/sheet{(index + 1).ToString(CultureInfo.InvariantCulture)}.xml",
-            $"""
-             <?xml version="1.0" encoding="UTF-8"?>
-             <worksheet xmlns="{SpreadsheetNamespace}"><sheetData><row>{string.Concat(sheet.Select(value =>
-                 $"""<c t="s"><v>{sharedStrings.IndexOf(value).ToString(CultureInfo.InvariantCulture)}</v></c>"""))}</row></sheetData></worksheet>
-             """));
-
-        return Package([("xl/sharedStrings.xml", table), .. parts]);
-    }
+    /// <summary>Builds the ISO 29500 Strict equivalent of <see cref="Workbook(string[][])" />.</summary>
+    /// <param name="sheets">One entry per sheet, each the cell values that sheet holds in order.</param>
+    /// <returns>The package's octets.</returns>
+    public static byte[] StrictWorkbook(params string[][] sheets) =>
+        WorkbookIn(StrictSpreadsheetNamespace, sheets);
 
     /// <summary>Builds an OpenDocument text package whose body carries the paragraphs given.</summary>
     /// <param name="paragraphs">The paragraphs, in order.</param>
@@ -163,16 +157,19 @@ internal static class DocumentFixtures
     /// <summary>Nests an element tree the given number of levels deep inside a word-processing document.</summary>
     /// <param name="depth">How many levels to nest.</param>
     /// <returns>The package's octets.</returns>
-    public static byte[] DeeplyNestedWordDocument(int depth)
-    {
-        var opened = string.Concat(Enumerable.Repeat("<w:tbl><w:tr><w:tc>", depth));
-        var closed = string.Concat(Enumerable.Repeat("</w:tc></w:tr></w:tbl>", depth));
+    public static byte[] DeeplyNestedWordDocument(int depth) =>
+        DeeplyNestedWordDocumentIn(WordprocessingNamespace, depth);
 
-        return WordDocumentPart($"""
-            <?xml version="1.0" encoding="UTF-8"?>
-            <w:document xmlns:w="{WordprocessingNamespace}"><w:body>{opened}<w:p><w:r><w:t>deep</w:t></w:r></w:p>{closed}</w:body></w:document>
-            """);
-    }
+    /// <summary>Builds the ISO 29500 Strict equivalent of <see cref="DeeplyNestedWordDocument(int)" />.</summary>
+    /// <param name="depth">How many levels to nest.</param>
+    /// <returns>The package's octets.</returns>
+    /// <remarks>
+    /// A Strict package is the same zip archive of the same parts, so every bound around the walk is reached the same
+    /// way — which is what this fixture is for: admitting a second namespace must widen what is read, not what is
+    /// refused.
+    /// </remarks>
+    public static byte[] StrictDeeplyNestedWordDocument(int depth) =>
+        DeeplyNestedWordDocumentIn(StrictWordprocessingNamespace, depth);
 
     /// <summary>Builds a word-processing package whose one part inflates to the given number of characters.</summary>
     /// <param name="characters">How many characters the part's single run holds.</param>
@@ -307,6 +304,62 @@ internal static class DocumentFixtures
         }
 
         return offsets;
+    }
+
+    /// <summary>Builds a word-processing package whose parts declare the namespace given.</summary>
+    private static byte[] WordDocumentIn(string namespaceUri, string[] paragraphs)
+    {
+        var body = string.Concat(paragraphs.Select(paragraph =>
+            $"<w:p><w:r><w:t>{Escaped(paragraph)}</w:t></w:r></w:p>"));
+
+        return WordDocumentPart($"""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <w:document xmlns:w="{namespaceUri}"><w:body>{body}</w:body></w:document>
+            """);
+    }
+
+    /// <summary>Builds a presentation package whose slides declare the namespace given.</summary>
+    private static byte[] PresentationIn(string namespaceUri, string[] slides) => Package(
+        [
+            .. slides.Select((line, index) => (
+                $"ppt/slides/slide{(index + 1).ToString(CultureInfo.InvariantCulture)}.xml",
+                $"""
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <sld xmlns:a="{namespaceUri}"><a:p>{(line.Length == 0 ? string.Empty : $"<a:r><a:t>{Escaped(line)}</a:t></a:r>")}</a:p></sld>
+                 """)),
+        ]);
+
+    /// <summary>Builds a workbook whose string table and sheets declare the namespace given.</summary>
+    private static byte[] WorkbookIn(string namespaceUri, string[][] sheets)
+    {
+        var sharedStrings = sheets.SelectMany(sheet => sheet).Distinct(StringComparer.Ordinal).ToList();
+
+        var table = $"""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <sst xmlns="{namespaceUri}">{string.Concat(sharedStrings.Select(value => $"<si><t>{Escaped(value)}</t></si>"))}</sst>
+            """;
+
+        var parts = sheets.Select((sheet, index) => (
+            $"xl/worksheets/sheet{(index + 1).ToString(CultureInfo.InvariantCulture)}.xml",
+            $"""
+             <?xml version="1.0" encoding="UTF-8"?>
+             <worksheet xmlns="{namespaceUri}"><sheetData><row>{string.Concat(sheet.Select(value =>
+                 $"""<c t="s"><v>{sharedStrings.IndexOf(value).ToString(CultureInfo.InvariantCulture)}</v></c>"""))}</row></sheetData></worksheet>
+             """));
+
+        return Package([("xl/sharedStrings.xml", table), .. parts]);
+    }
+
+    /// <summary>Nests an element tree inside a word-processing document declaring the namespace given.</summary>
+    private static byte[] DeeplyNestedWordDocumentIn(string namespaceUri, int depth)
+    {
+        var opened = string.Concat(Enumerable.Repeat("<w:tbl><w:tr><w:tc>", depth));
+        var closed = string.Concat(Enumerable.Repeat("</w:tc></w:tr></w:tbl>", depth));
+
+        return WordDocumentPart($"""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <w:document xmlns:w="{namespaceUri}"><w:body>{opened}<w:p><w:r><w:t>deep</w:t></w:r></w:p>{closed}</w:body></w:document>
+            """);
     }
 
     /// <summary>Wraps a body in the one content part an OpenDocument package holds everything in.</summary>

--- a/docs/features/attachment-text-extraction.md
+++ b/docs/features/attachment-text-extraction.md
@@ -91,13 +91,12 @@ page with no text layer is the exact target an optical-character-recognition pas
 are reported as a list rather than as a flag on the document — a scanned page bound into an otherwise textual report is
 the ordinary case. No optical character recognition happens here; that is a decision of its own and this is not it.
 
-**One kind of document answers that way without being a scan, and there is currently no telling the two apart.** Only
-the ISO 29500 **Transitional** namespaces are read, which is what an office suite writes unless somebody explicitly
-chooses otherwise. A **Strict** `.docx`, `.xlsx`, or `.pptx` uses different namespaces, so it walks to completion with
-no run recognized and comes back as `Extracted` with empty text and every page listed as carrying none — the answer this
-page has just called a scan. It is rare and it is a defect rather than a design: #1681 is where it is tracked, and until
-it closes, a document reported as carrying no text may be one whose words were never looked for. The three OpenDocument
-formats have no such split and are unaffected.
+**Both ISO 29500 conformance classes are read, so that answer means a scan and nothing else.** The standard defines a
+**Transitional** class, which is what an office suite writes unless somebody explicitly chooses otherwise, and a
+**Strict** class, whose parts declare a namespace of their own. Each of the three formats admits both, so a Strict
+`.docx`, `.xlsx`, or `.pptx` yields the text its Transitional equivalent does rather than walking to completion with no
+run recognized. A conformance class is the only thing that differs between the two: same archive, same part names, same
+elements, and therefore the same bounds. The three OpenDocument formats have no such split and never did.
 
 The order pages are reported in has its own limit. A presentation's slides and a workbook's sheets are read in the order
 their parts are *named*, and neither format records order there — a deck or a workbook somebody reordered before sending


### PR DESCRIPTION
## What changed

`OpenXmlAttachmentTextReader` matched the ISO 29500 **Transitional** namespaces and only those, so a **Strict** `.docx`, `.xlsx`, or `.pptx` walked to completion, recognized nothing, and was answered as `Extracted` with empty text and every page listed as carrying none — which is exactly how this reader reports a **scan**. The document did not merely go unread: it was reported as a specific other thing, and a caller acting on `PagesWithoutText` — today #1555, later an optical-character-recognition pass — would draw the wrong conclusion about it.

Each format now admits both conformance classes:

| Format | Transitional | Strict |
| --- | --- | --- |
| word-processing | `…openxmlformats.org/wordprocessingml/2006/main` | `…purl.oclc.org/ooxml/wordprocessingml/main` |
| spreadsheet | `…openxmlformats.org/spreadsheetml/2006/main` | `…purl.oclc.org/ooxml/spreadsheetml/main` |
| drawing (a deck's text) | `…openxmlformats.org/drawingml/2006/main` | `…purl.oclc.org/ooxml/drawingml/main` |

## How

The three namespace constants become one `FrozenSet<string>` per format, so the comparison sites across the word-processing walk, the presentation walk, the shared-string walk, the cell walk, and the cell-value subtree read are set membership rather than `==`. A fourth namespace is one entry rather than an edit at each site. `ReadRunsInto` takes the set its caller's format admits, which is what already let one walk serve both word-processing and presentation markup.

## Bounds are unaffected, and that is asserted rather than assumed

A Strict package is the same zip archive of the same parts under the same names — the conformance class changes what a part *declares*, not what the archive *is*. So the part count, the inflation total, the per-part ratio, and the element depth are reached identically. The depth ceiling stands for all of them in the suite because it is the one that fires *inside* the walk, so it is the only bound an admitted second namespace could conceivably have widened: `ExtractTextAsync_AStrictPartNestedPastTheDepthCeiling_ReportsTheContainerBound` proves it still reports `ContainerBoundExceeded`.

A document that genuinely carries no text still reports as a scan. The fix narrows what an empty result means rather than removing the case.

## Tests

`DocumentFixtures` composes a Strict fixture per format — and a Strict deeply-nested one — by parameterizing the namespace of the builders the Transitional fixtures already used, so the pair differs in nothing else. Four tests sit beside their Transitional equivalents:

- `ExtractTextAsync_AStrictWordDocument_ReadsItAsItsTransitionalEquivalent`
- `ExtractTextAsync_AStrictPresentation_ReadsItAsItsTransitionalEquivalent`
- `ExtractTextAsync_AStrictWorkbook_ReadsItAsItsTransitionalEquivalent`
- `ExtractTextAsync_AStrictPartNestedPastTheDepthCeiling_ReportsTheContainerBound`

## Documentation

`docs/features/attachment-text-extraction.md` carried a paragraph stating that only Transitional is read and that a Strict document therefore comes back looking like a scan, naming this issue as where it was tracked. That paragraph is now false and was rewritten to state that both conformance classes are read, so `Extracted` with no text means a scan and nothing else.

## Verification

`scripts/verify-full.sh` — 14205 tests passed, aggregate line coverage 95.32% against the 85% floor, `Formatted 0 of 4302 files`, 288 workflow contracts passed.

## Contract impact

None. No MCP tool contract, configuration key, database column, or deployment contract moves; the change is what the reader recognizes inside a document it already accepted.

Closes #1681
