### PR TITLE
[#1700] Give the client one corpus of example mail, imported by every suite that needs it

### DIFF
--- a/docs/architecture/solution-structure.md
+++ b/docs/architecture/solution-structure.md
@@ -184,7 +184,10 @@ real browser, which is what answers the questions jsdom structurally cannot — 
 a document with a history, and the requests a page actually issued; it belongs to neither package, imports neither, and
 therefore does live under `frontend/tests/`, beside the contract governing both.
 [`frontend/tests/AGENTS.md`](https://github.com/Krzysztof318/MailFathom/blob/main/frontend/tests/AGENTS.md) is that
-contract.
+contract. `frontend/tests/fixtures/` beside them is the third thing in that directory and belongs to neither package
+either: one corpus of invented example mail, exported as values, which whatever needs a populated screen imports rather
+than writing out again — the browser suite reaches it with Playwright's own routing, and a unit test would hand it to a
+transport function.
 
 What the workspace builds is a directory of static files under `frontend/src/Client.App/dist/` and nothing else, so no
 Node process joins any deployment shape.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -332,7 +332,13 @@ produces, and the requests the page actually issued. It needs a browser of its o
 `pnpm exec playwright install chromium` — which is why neither verification gate runs it and the pipeline does, on every
 pull request that reaches this stack. Its configuration is `playwright.config.ts` and its specs are under `tests/`.
 
-[`tests/AGENTS.md`](tests/AGENTS.md) is where both suites' policy is decided, including which check belongs to which.
+`tests/fixtures/` beside them is one corpus of example mail — the session, the accounts and folders, the mail, the
+conversations, the drafts, the notifications, and what a change answers with — imported by whatever needs a populated
+screen rather than written out again per check. It is data and no consumer of it is assumed: the browser suite reaches
+it with `page.route`, and a unit test would hand it to a transport function.
+
+[`tests/AGENTS.md`](tests/AGENTS.md) is where both suites' policy is decided, including which check belongs to which,
+and where the corpus's own rules are.
 
 ## Whitespace is decided in `.editorconfig`
 

--- a/frontend/tests/AGENTS.md
+++ b/frontend/tests/AGENTS.md
@@ -19,9 +19,10 @@ question is answered again rather than reworded.
   could reach one only through a relative path out of the package, which is the one thing that boundary exists to
   refuse. A test inside the package inherits it instead: a `Client.Backend` test cannot import React, exactly as its
   source cannot, and nothing has to check that it did not.
-- `frontend/tests/` therefore holds this file and the browser suite beside it, and nothing else. A unit test written
-  here would resolve neither package, which is the whole of the argument above; the browser suite is what can live here
-  precisely because it imports neither — it drives a built bundle over HTTP rather than importing a module out of one.
+- `frontend/tests/` therefore holds this file, the browser suite beside it, and [the corpus](#the-corpus) both suites
+  read — and nothing else. A unit test written here would resolve neither package, which is the whole of the argument
+  above; the browser suite is what can live here precisely because it imports neither — it drives a built bundle over
+  HTTP rather than importing a module out of one, and the corpus is data rather than a test.
 - **The two suites are told apart by the name.** A unit test is `*.test.ts` or `*.test.tsx` beside its source; a browser
   spec is `*.spec.ts` under this directory. Each runner's default finds its own and neither finds the other's, so a file
   named for the wrong one silently joins the wrong suite — and a browser spec run by Vitest would fail on an import
@@ -102,6 +103,39 @@ question is answered again rather than reworded.
   was handed.
 - No mock service worker, no request-interception package, and no local HTTP server. A real exchange belongs to the
   browser suite below.
+- **What is faked is the boundary; what travels over it is [the corpus](#the-corpus).** The section below is where the
+  example mail itself is decided, and the two rules do not overlap: this one says nothing may stand between the client
+  and its transport, and that one says the values handed to whatever does stand there are written once.
+
+## The corpus
+
+`fixtures/` is one corpus of example mail, and it is what every client check reads. It exists because the same shapes
+were being invented in three places at once — the browser suite, a throwaway spec, and whatever a session wrote before
+it could take a screenshot — and three copies of one corpus is three places to be wrong about a contract the service
+owns. Reaching a populated screen is most of the work in a client task, and it is work that had already been done.
+
+- **It is data, never routing.** It exports values, and every consumer decides how they reach the client: `page.route`
+  in the browser suite, a transport function in a unit test. Nothing in it parses a request, names a route, or knows
+  what a `fetch` is. Where an answer genuinely depends on what was asked for — how far into a folder somebody has read,
+  whether the reader asked for a sender's pictures — it is stated as a function of that question and the consumer
+  decides what was asked; that is still data, and it is the only shape a mailbox of two hundred thousand messages has.
+- **It states what the service answers, not what the client parses.** No file in it imports a type from
+  `@mailfathom/client-backend`. A fixture typed by the parser that reads it would agree with that parser by
+  construction and say nothing about the deployment, which is the one thing a fixture is for.
+- **Every message body carries a `plainText` object.** It is not an alternative representation a sender may have
+  omitted: it is what MailFathom derived, present on every readable body whatever the message carried. A `null` there
+  is refused by `mailBody.ts` before any screen sees it, and what a reader meets instead is the pane saying the message
+  could not be read — which reads as a defect in the client and is a malformed fixture. What the message route's own
+  `body.plainText` says is a different thing, and it is a `boolean`: whether the _message_ carried a text part.
+- **It covers the states a screen has to be looked at in, not only the resting one.** An empty folder, a message whose
+  sender wrote no text part, a conversation long enough that the screen folds it, a mailbox whose synchronization is
+  failing, and a mailbox that is behind are each in it, because none of them can be reached from the resting corpus by
+  scrolling or clicking and each is a screen somebody has to be able to draw.
+- **Nothing in it is anybody's.** Every address, name, subject, and sentence is invented, and the hosts are reserved
+  names — `.invalid` and `.example` — so no fixture can reach a machine that exists. That is the same rule
+  `frontend/AGENTS.md` states about a capture of a signed-in client, read from the other end.
+- **The browser suite is the proof that it is sufficient.** `client.spec.ts` declares no fixture of its own, so a shape
+  the corpus states wrongly fails a committed suite rather than one session's scratch file.
 
 ## A localized screen
 

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -4,7 +4,11 @@
 
 import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
-import { expect, test, type Browser, type Locator, type Page } from '@playwright/test';
+import { expect, test, type Browser, type Locator, type Page, type Route } from '@playwright/test';
+
+import * as deployment from './fixtures/deployment';
+import * as mail from './fixtures/mail';
+import * as messages from './fixtures/messages';
 
 // What the unit suite structurally cannot answer, asked of the directory of static files `pnpm build` writes, in a
 // browser: the bundle is the built one rather than the source, the document is a real one with a history, the window
@@ -25,223 +29,23 @@ const narrowWindow = { width: 380, height: 720 };
 // breakpoint, so what is measured against it is what the artboard shows.
 const phoneWindow = { width: 390, height: 844 };
 
-// What the deployment the preview server stands in for answers. It accepts any credential presented to it, because
-// what this suite proves about signing in is the composing, the sending, and the keeping — which of two passwords a
-// service accepts is the service's own decision and is proven where that decision is made.
-// The grant it reports is what decides which spaces the client offers, so it names both the client acts on: a session
-// answer without them would open a frame with Discover and the intent field absent, which is a different screen from
-// the one every test below is about.
-const sessionAnswer = {
-    service: 'MailFathom',
-    version: declaredVersion,
-    permissions: ['mailfathom.mail.read', 'mailfathom.mail.ask'],
-    telemetry: true,
-};
-
-const mailAccounts = {
-    synchronizationEnabled: true,
-    accounts: [
-        {
-            id: 'work',
-            displayName: 'Work',
-            synchronizationState: 'Synchronized',
-            lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
-            behind: false,
-        },
-    ],
-};
-
-// The tree the Mail space is scoped by, standing in for what the folders route answers. One mailbox with an inbox and
-// a folder nested where a mail server nests one, which is what the reload below is read against.
-const mailFolders = {
-    synchronizationEnabled: true,
-    accounts: [
-        {
-            account: mailAccounts.accounts[0],
-            folders: [
-                {
-                    alias: 'INBOX',
-                    role: 'Inbox',
-                    path: ['INBOX'],
-                    storedEmailCount: 4213,
-                    unreadEmailCount: 12,
-                    synchronizationState: 'Synchronized',
-                    lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
-                    behind: false,
-                },
-                {
-                    alias: 'ARCHIVE-2024',
-                    role: null,
-                    path: ['Archive', '2024'],
-                    storedEmailCount: 980,
-                    unreadEmailCount: 0,
-                    synchronizationState: 'Synchronized',
-                    lastSynchronizedAt: '2026-08-31T09:00:00+00:00',
-                    behind: false,
-                },
-            ],
-        },
-    ],
-};
-
-// The password this suite signs in with, and the RFC 7617 value the client is expected to compose out of it. Neither
-// belongs to anybody: the deployment is the preview server, and nothing here reaches a machine holding real mail.
-const userName = 'owner';
-const password = 'open sesame';
-const expectedAuthorization = 'Basic b3duZXI6b3BlbiBzZXNhbWU=';
-
-// The message the Mail space draws, standing in for one a deployment would hold, and the closest thing this suite has
-// to a mailbox. Nothing in it comes from a real one and nothing in it names a host this page could actually reach: the
-// blocks are chosen so that each the catalogue holds is drawn at least once, and so that the two things a sender may
-// try are visible — markup written as text, and a link whose words name one place while its target names another.
+// What this suite answers the client with is the corpus under `frontend/tests/fixtures/`, imported rather than
+// declared here: it is the same example mail every client check reads, so a shape that drifts from the service is
+// wrong in one place rather than in as many places as have written their own. `frontend/tests/AGENTS.md` § *The
+// corpus* holds what belongs in it, and this suite importing it is the first proof that it is sufficient.
 //
-// A one-pixel transparent picture stands in for a part the message carried itself; `pictures.invalid` stands in for one
-// it asked to be fetched, and is the host the assertions below watch for.
-const transparentPicture = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+// The session answer is the one value with anything spread over it. Its version is the one field only a build knows,
+// so the corpus states a placeholder and this suite substitutes what it read above; everything else is taken as the
+// corpus states it, the grant that decides which spaces the client offers included.
+const sessionAnswer = { ...deployment.sessionAnswer, version: declaredVersion };
 
-function run(text: string, overrides: Readonly<Record<string, unknown>> = {}) {
-    return { text, emphasis: 'None', foreground: null, link: null, ...overrides };
-}
+// The heading the corpus message carries. The sender wrote it as their own first-level heading, and two levels above
+// it are already taken — the space's own title and the subject the reading pane draws — so the pane draws it two
+// deeper, which is the assertion in the level rather than an accident of the fixture.
+const messageHeading = { name: messages.newsletterHeading, level: 3 } as const;
 
-function messageBlocks(pictureSource: string) {
-    return [
-        { type: 'heading', version: 1, level: 1, content: [run('This week at Example')], alignment: 'Start' },
-        {
-            type: 'paragraph',
-            version: 1,
-            content: [
-                run('A sender may write '),
-                run('<script>alert(1)</script>', { emphasis: 'Bold, Monospace' }),
-                run(' and it stays words.'),
-            ],
-            alignment: 'Inherited',
-        },
-        {
-            type: 'paragraph',
-            version: 1,
-            content: [
-                run('example.invalid', {
-                    link: {
-                        target: 'https://offers.invalid/claim',
-                        host: 'offers.invalid',
-                        asciiHost: null,
-                        deception: 'DisplayedHostDiffers',
-                        isWorthWarningAbout: true,
-                    },
-                }),
-            ],
-            alignment: 'Inherited',
-        },
-        {
-            type: 'image',
-            version: 1,
-            image: { source: pictureSource, alternativeText: 'The Example mark', width: 32, height: 32 },
-            link: null,
-            alignment: 'Center',
-        },
-        {
-            type: 'quote',
-            version: 1,
-            depth: 1,
-            blocks: [
-                { type: 'paragraph', version: 1, content: [run('You wrote: send me the list.')], alignment: 'Start' },
-            ],
-        },
-        { type: 'separator', version: 1 },
-        { type: 'preformatted', version: 1, text: '  order  quantity\n  kettle 1' },
-    ];
-}
-
-// The sender's own markup, as the self-contained representation serves it: the pictures inlined and every remote
-// address gone, unless the reader asked for this one message's pictures.
-//
-// It carries a script deliberately, which the representation itself never would. What that stands in for is the second
-// mechanism ADR 0024 keeps on this surface: the frame permits no script whatever the markup holds, so a representation
-// that ever stopped removing one would still not run it. The script fetches from a host of its own, so a browser says
-// whether it ran without anything having to read inside a frame it cannot reach into.
-function senderMarkup(remoteImages: boolean): string {
-    const picture = remoteImages ? 'https://pictures.invalid/mark.png' : transparentPicture;
-
-    return (
-        '<html><body><h1>This week at Example</h1>' +
-        '<script>new Image().src = "https://ranscript.invalid/beacon.png";</script>' +
-        `<img src="${picture}" alt="A mark">` +
-        '</body></html>'
-    );
-}
-
-function messageBody(remoteImages: boolean, fullHtml: boolean): string {
-    return JSON.stringify({
-        storedEmailId: '00000000-0000-4000-8000-000000000000',
-        availability: 'Readable',
-        plainText: {
-            text: 'A newsletter, as words.\n\nRead it at example.invalid.',
-            originalCharacterCount: 48,
-            truncation: 'None',
-        },
-        document: {
-            schemaVersion: 1,
-            blocks: messageBlocks(remoteImages ? 'https://pictures.invalid/mark.png' : transparentPicture),
-            refusal: 'None',
-            removedRemoteReferenceCount: remoteImages ? 0 : 3,
-            retainedRemoteImageCount: remoteImages ? 1 : 0,
-            inlineImageCount: remoteImages ? 0 : 1,
-            undrawnInlineImageCount: 0,
-            truncated: false,
-        },
-        selfContainedHtml: fullHtml
-            ? { text: senderMarkup(remoteImages), originalCharacterCount: 320, truncation: 'None' }
-            : null,
-        remoteImagesRequested: remoteImages,
-    });
-}
-
-// The heading the message below carries. The sender wrote it as their own first-level heading, and two levels above it
-// are already taken — the space's own title and the subject the reading pane draws — so the pane draws it two deeper,
-// which is the assertion in the level rather than an accident of the fixture.
-const messageHeading = { name: 'This week at Example', level: 3 } as const;
-
-/** The subject the message below carries, which is what names the region the pane draws it in. */
-const messageRegion = { name: 'A newsletter from Example' } as const;
-
-/** What the attachment below holds, small enough to state here and large enough to arrive in more than nothing. */
-const attachedOctets = 'order,quantity\nkettle,1\n';
-
-/** What the message route answers with: everything the pane draws around a body it never carries. */
-const messageDescription = JSON.stringify({
-    storedEmailId: '00000000-0000-4000-8000-000000000000',
-    account: 'work',
-    folder: 'INBOX',
-    threadId: null,
-    sizeOctets: 40_960,
-    headers: {
-        subject: messageRegion.name,
-        sentAt: '2026-08-31T09:41:00+00:00',
-        receivedAt: '2026-08-31T09:41:10+00:00',
-        participants: [
-            { role: 'From', address: 'news@example.invalid', displayName: 'Example' },
-            { role: 'To', address: 'reader@example.invalid', displayName: null },
-        ],
-        messageId: 'abc@example.invalid',
-        inReplyTo: null,
-        references: [],
-    },
-    body: { availability: 'Readable', plainText: true, html: true },
-    sender: { authorAuthentication: 'Authenticated', deploymentTrust: 'Unknown', authenticatedDomain: null },
-    attachments: [
-        {
-            position: 0,
-            fileName: 'orders.csv',
-            wasFileNameNormalized: false,
-            mediaType: 'text/csv',
-            sizeOctets: attachedOctets.length,
-        },
-    ],
-    carried: null,
-    unread: true,
-    flagged: false,
-    answered: false,
-});
+/** The subject that message carries, which is what names the region the pane draws it in. */
+const messageRegion = { name: messages.newsletterSubject } as const;
 
 interface Box {
     readonly x: number;
@@ -271,9 +75,7 @@ async function boxOf(element: Locator): Promise<Box> {
  * bundle exactly as it would be against a service.
  */
 async function servedByADeployment(page: Page): Promise<void> {
-    await page.route('**/api/client/messages/*', (route) =>
-        route.fulfill({ status: 200, contentType: 'application/json', body: messageDescription }),
-    );
+    await page.route('**/api/client/messages/*', (route) => answering(route, messages.newsletterMessage));
 
     // The one route that answers with octets rather than with JSON, which is what makes a real download something this
     // suite can watch: the built bundle composes the request, sends it with the credential it holds, reads the stream,
@@ -282,22 +84,16 @@ async function servedByADeployment(page: Page): Promise<void> {
         route.fulfill({
             status: 200,
             contentType: 'text/csv',
-            body: attachedOctets,
+            body: messages.attachedOctets,
         }),
     );
 
-    // The one route this fixture answers from state rather than from a constant. What the client is asked to prove
+    // The one route this suite answers from state rather than from the corpus. What the client is asked to prove
     // about the two preferences held on the deployment is that a choice made in one session is in force in the next,
     // and a route answering a fixed document would prove the read alone while quietly passing a client that wrote
-    // nothing at all.
-    let held = {
-        telemetryEnabled: true,
-        theme: 'system',
-        openMailInTabs: false,
-        markReadOnOpen: true,
-        expandWholeThread: false,
-        embeddedHtmlMessages: false,
-    };
+    // nothing at all — so the corpus states what a deployment holds before anything was chosen, and this holds what
+    // was chosen since.
+    let held = { ...deployment.clientPreferences };
 
     await page.route('**/api/client/preferences', (route) => {
         if (route.request().method() === 'POST') {
@@ -310,92 +106,45 @@ async function servedByADeployment(page: Page): Promise<void> {
     // Who the signed-in person is, which the frame reads for the account menu and the settings screen. The portrait is
     // answered as none: what a stored one costs this suite is a second binary fixture, and every assertion below is
     // about the name and the screen around it rather than about the octets.
-    await page.route('**/api/client/display-name', (route) =>
-        route.fulfill({
-            status: 200,
-            contentType: 'application/json',
-            body: JSON.stringify({ displayName: 'Ada Lovelace', changeable: true }),
-        }),
-    );
+    await page.route('**/api/client/display-name', (route) => answering(route, deployment.ownDisplayName));
 
     await page.route('**/api/client/portrait', (route) => route.fulfill({ status: 204 }));
 
-    await page.route('**/api/client/session', (route) =>
-        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(sessionAnswer) }),
-    );
+    await page.route('**/api/client/session', (route) => answering(route, sessionAnswer));
 
-    await page.route('**/api/client/accounts', (route) =>
-        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mailAccounts) }),
-    );
+    await page.route('**/api/client/accounts', (route) => answering(route, deployment.mailAccounts));
 
-    await page.route('**/api/client/folders', (route) =>
-        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mailFolders) }),
-    );
+    await page.route('**/api/client/folders', (route) => answering(route, deployment.mailFolders));
 
-    await page.route('**/api/client/emails*', (route) =>
-        route.fulfill({
-            status: 200,
-            contentType: 'application/json',
-            body: timelinePage(new URL(route.request().url())),
-        }),
-    );
+    // Where in the folder the client asked to read is in the query and nowhere else, so this is where it is read: the
+    // corpus states a page of the mailbox given the row it starts at, and reading a request is this suite's half.
+    await page.route('**/api/client/emails*', (route) => {
+        const asked = new URL(route.request().url()).searchParams;
+        const cursor = Number(asked.get('cursor') ?? '0');
+        const from = asked.get('direction') === 'backward' ? cursor - mail.rowsPerPage : cursor;
 
-    // The one route whose answer depends on what the client asked for: the reader's ask for the sender's pictures is
-    // in the query and nowhere else, so answering it here is what lets this suite watch a request leave for the
-    // sender's host — and watch it not leave before the ask.
-    await page.route('**/api/client/messages/*/body*', (route) =>
-        route.fulfill({
-            status: 200,
-            contentType: 'application/json',
-            body: messageBody(
-                new URL(route.request().url()).searchParams.get('remoteImages') === 'true',
-                new URL(route.request().url()).searchParams.get('fullHtml') === 'true',
-            ),
-        }),
-    );
+        return answering(route, mail.timelinePage(from));
+    });
+
+    // The other route whose answer depends on what the client asked for: the reader's ask for the sender's pictures is
+    // in the query too, so answering it here is what lets this suite watch a request leave for the sender's host — and
+    // watch it not leave before the ask.
+    await page.route('**/api/client/messages/*/body*', (route) => {
+        const asked = new URL(route.request().url()).searchParams;
+
+        return answering(
+            route,
+            messages.newsletterBody({
+                remoteImages: asked.get('remoteImages') === 'true',
+                fullHtml: asked.get('fullHtml') === 'true',
+            }),
+        );
+    });
 }
 
-// How many messages the mailbox behind the routing holds, which is the number `frontend/src/AGENTS.md` names as the
-// one the client actually has to render. Nothing here is anybody's mail: every row is generated from its own number.
-const mailboxSize = 214_000;
-const rowsPerPage = 100;
-
-/**
- * One page of the mailbox, keyset-paged the way the client surface pages it.
- *
- * The cursor is the row the page starts at, written as text, because what this suite proves about a cursor is that the
- * client holds one and continues from it — what a deployment encodes in one is the deployment's own business.
- */
-function timelinePage(url: URL): string {
-    const asked = Number(url.searchParams.get('cursor') ?? '0');
-    const backward = url.searchParams.get('direction') === 'backward';
-    const from = Math.max(backward ? asked - rowsPerPage : asked, 0);
-    const rows = Math.min(rowsPerPage, mailboxSize - from);
-
-    return JSON.stringify({
-        emails: Array.from({ length: rows }, (_, at) => ({
-            id: `message-${String(from + at)}`,
-            account: 'work',
-            folder: 'INBOX',
-            threadId: null,
-            subject: `Message ${String(from + at)}`,
-            receivedAt: '2026-08-31T09:41:00+00:00',
-            sentAt: null,
-            senderAddress: `writer-${String(from + at)}@nordwind.example`,
-            senderDisplayName: `Writer ${String(from + at)}`,
-            toAddresses: ['owner@example.invalid'],
-            unread: at % 3 === 0,
-            flagged: false,
-            answered: false,
-            hasAttachments: at % 5 === 0,
-            attachmentCount: at % 5 === 0 ? 1 : 0,
-            sizeOctets: 4_096,
-            preview: `The opening of message ${String(from + at)}.`,
-        })),
-        nextCursor: from + rows >= mailboxSize ? null : String(from + rows),
-        previousCursor: from === 0 ? null : String(from),
-        pageSize: rowsPerPage,
-    });
+/** One value of the corpus put on the wire as the deployment behind the preview server would answer with it. */
+function answering(route: Route, answered: unknown): Promise<void> {
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(answered) });
 }
 
 /**
@@ -443,8 +192,8 @@ async function readOnward(page: Page, list: Locator): Promise<void> {
 }
 
 async function signIn(page: Page): Promise<void> {
-    await page.getByRole('textbox', { name: 'Login' }).fill(userName);
-    await page.getByLabel('Password', { exact: true }).fill(password);
+    await page.getByRole('textbox', { name: 'Login' }).fill(deployment.userName);
+    await page.getByLabel('Password', { exact: true }).fill(deployment.password);
     await page.getByRole('button', { name: 'Connect' }).click();
 
     await expect(page.getByRole('navigation', { name: 'Spaces' })).toBeVisible();
@@ -577,7 +326,7 @@ test('sends the password as one Basic header the bundle composed, on every reque
     // the bundler has been over it, and what a screen sends is not what a component was handed in jsdom.
     expect(presented.length).toBeGreaterThan(0);
     for (const [route, authorization] of presented) {
-        expect(authorization, `no credential on ${route}`).toBe(expectedAuthorization);
+        expect(authorization, `no credential on ${route}`).toBe(deployment.expectedAuthorization);
     }
 });
 
@@ -1180,14 +929,14 @@ test('presents the credential the bundle composed when it fetches an attached fi
     await page.route('**/api/client/messages/*/attachments/*', async (route) => {
         presented.push(route.request().headers()['authorization']);
 
-        await route.fulfill({ status: 200, contentType: 'text/csv', body: attachedOctets });
+        await route.fulfill({ status: 200, contentType: 'text/csv', body: messages.attachedOctets });
     });
 
     const offered = page.waitForEvent('download');
     await page.getByRole('button', { name: 'Download orders.csv' }).click();
     await offered;
 
-    expect(presented).toStrictEqual([expectedAuthorization]);
+    expect(presented).toStrictEqual([deployment.expectedAuthorization]);
 });
 
 test('fetches nothing from the sender until the reader asks, and asks again next time', async ({ page }) => {
@@ -1202,14 +951,14 @@ test('fetches nothing from the sender until the reader asks, and asks again next
     const askForPictures = page.getByRole('button', { name: 'Load pictures from the sender' });
     await expect(askForPictures).toBeVisible();
     await expect(page.getByText('References removed: 3')).toBeVisible();
-    expect([...hosts]).not.toContain('pictures.invalid');
+    expect([...hosts]).not.toContain(messages.senderPictureHost);
 
     await askForPictures.click();
 
     // Asking is what makes the request, and it is the only thing that does. The address never reached the document
     // before this click, so there was nothing for a rendering defect to fetch.
     await expect(page.getByText('Pictures are being loaded from the sender for this message.')).toBeVisible();
-    await expect.poll(() => [...hosts]).toContain('pictures.invalid');
+    await expect.poll(() => [...hosts]).toContain(messages.senderPictureHost);
 
     await page.reload();
 
@@ -1255,16 +1004,16 @@ test('runs nothing the markup carries, and reaches no host but its own until the
     // The picture's host is the other half: the representation carries no address for it until the reader asks, so a
     // frame that fetched one would be drawing markup this client composed rather than the one it was served.
     await expect(page.getByText(/permits no script at all/)).toBeVisible();
-    expect([...hosts]).not.toContain('ranscript.invalid');
-    expect([...hosts]).not.toContain('pictures.invalid');
+    expect([...hosts]).not.toContain(messages.senderScriptHost);
+    expect([...hosts]).not.toContain(messages.senderPictureHost);
 
     await page.getByRole('button', { name: 'Load pictures from the sender' }).click();
 
     // Asking is what makes the request, on this surface exactly as in the pane. The script is unaffected by it: the
     // consent restores addresses and never restores anything that runs.
     await expect(page.getByText(/their servers can tell it was opened/)).toBeVisible();
-    await expect.poll(() => [...hosts]).toContain('pictures.invalid');
-    expect([...hosts]).not.toContain('ranscript.invalid');
+    await expect.poll(() => [...hosts]).toContain(messages.senderPictureHost);
+    expect([...hosts]).not.toContain(messages.senderScriptHost);
 });
 
 test('leaves the markup surface for the message it was opened from, and asks again next time', async ({ page }) => {

--- a/frontend/tests/fixtures/changes.ts
+++ b/frontend/tests/fixtures/changes.ts
@@ -1,0 +1,118 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+// A change travels in two directions on this surface, and this file holds both ends of it.
+//
+// Outward: the client submits a batch of flag or folder changes and the deployment writes down a record per value,
+// which is what the mutation answers below are. Inward: the deployment says something changed while somebody had the
+// client open, which is what the signal payloads below are. They sit together because a screen reads them against each
+// other — a row that has just been marked read locally and a `mail.changed` naming the same message are the same event
+// arriving twice, and a fixture stating one without the other could not be looked at in that state.
+
+import { markupOnlyId, newsletterId } from './messages';
+
+/** What a submitted batch of flag changes answers with: one result per message, and a record per value inside it. */
+export const flagsRecorded = {
+    results: [
+        {
+            storedEmailId: newsletterId,
+            outcome: 'recorded',
+            detail: null,
+            changes: [
+                { mutation: 'set-seen', recordId: '00000000-0000-4000-8000-0000000000a1', state: 'pending' },
+                { mutation: 'add-keywords', recordId: '00000000-0000-4000-8000-0000000000a2', state: 'pending' },
+            ],
+        },
+    ],
+};
+
+/**
+ * What a batch answers with when one of its messages did not apply.
+ *
+ * A refusal about one message is that message's own result rather than the request's, so a batch composed from a list
+ * that has moved on since the screen drew it reports exactly which entries did not apply and writes the rest down —
+ * which is the state a screen has to be looked at in and the one a fixture of nothing but successes never reaches.
+ */
+export const movesPartlyRecorded = {
+    results: [
+        {
+            storedEmailId: newsletterId,
+            outcome: 'recorded',
+            detail: null,
+            changes: [{ mutation: 'relocate', recordId: '00000000-0000-4000-8000-0000000000a3', state: 'pending' }],
+        },
+        { storedEmailId: markupOnlyId, outcome: 'message-not-found', detail: null, changes: [] },
+    ],
+};
+
+/**
+ * Where the caller's own changes stand, read back.
+ *
+ * The three rows are the three answers a screen says something different about: one still converging against a mailbox
+ * that is being retried, one that reached the server, and one whose placement command went out and whose answer never
+ * came back — the last being the only field here a person acts on rather than waits through.
+ */
+export const mutationRecords = {
+    changes: [
+        {
+            recordId: '00000000-0000-4000-8000-0000000000a1',
+            storedEmailId: newsletterId,
+            mutation: 'set-seen',
+            state: 'converging',
+            outcomeUnknown: false,
+            attemptCount: 2,
+            lastFailure: 22001,
+            recordedAt: '2026-08-31T09:00:00+00:00',
+            stateChangedAt: '2026-08-31T09:04:00+00:00',
+        },
+        {
+            recordId: '00000000-0000-4000-8000-0000000000a2',
+            storedEmailId: newsletterId,
+            mutation: 'add-keywords',
+            state: 'completed',
+            outcomeUnknown: false,
+            attemptCount: 1,
+            lastFailure: null,
+            recordedAt: '2026-08-31T09:00:00+00:00',
+            stateChangedAt: '2026-08-31T09:01:00+00:00',
+        },
+        {
+            recordId: '00000000-0000-4000-8000-0000000000a3',
+            storedEmailId: newsletterId,
+            mutation: 'relocate',
+            state: 'converging',
+            outcomeUnknown: true,
+            attemptCount: 3,
+            lastFailure: 22001,
+            recordedAt: '2026-08-31T09:02:00+00:00',
+            stateChangedAt: '2026-08-31T09:06:00+00:00',
+        },
+    ],
+};
+
+/** The ticket one signal connection is opened against, and when presenting it stops working. */
+export const signalTicket = {
+    ticket: '00000000-0000-4000-8000-0000000000b0',
+    expiresAt: '2026-08-31T10:41:00+00:00',
+};
+
+/**
+ * The five payloads a deployment sends over the channel, one of each kind.
+ *
+ * A signal is an instruction to look again rather than something to keep, so nothing here carries mail: what each says
+ * is which folder, which mailbox, or which messages to re-read over the routes the client already reads.
+ */
+export const signals = {
+    mailArrived: { kind: 'mail.arrived', account: 'work', folder: 'INBOX', count: 3 },
+    mailChanged: { kind: 'mail.changed', account: 'work', folder: 'INBOX', emails: [newsletterId, markupOnlyId] },
+    foldersChanged: { kind: 'folders.changed', account: 'work' },
+    notificationRaised: {
+        kind: 'notification.raised',
+        notificationKind: 'Mail',
+        headline: 'Nordwind wrote about the racking quote',
+        secondLine: 'Booked for the ninth. The crew will need the yard for a morning.',
+        count: 2,
+    },
+    accountState: { kind: 'account.state', account: 'club' },
+};

--- a/frontend/tests/fixtures/deployment.ts
+++ b/frontend/tests/fixtures/deployment.ts
@@ -1,0 +1,158 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+// What a deployment says about itself, about the person signed in to it, and about the mailboxes it reads for them —
+// everything the client asks for before it has drawn a single message.
+//
+// `frontend/tests/AGENTS.md` § *The corpus* holds what the whole of it is and what may go in it. What this file adds
+// is the two states an account can be looked at in beside the resting one: a mailbox whose synchronization is failing,
+// and a mailbox the deployment has not caught up with. They are a page of their own rather than extra entries in the
+// resting page, because the resting page is what a screen is looked at in when nothing is wrong, and an account in
+// trouble changes what every summary above it says.
+
+/** The name typed into the sign-in screen, which belongs to nobody: it reaches a preview server or a fake transport. */
+export const userName = 'owner';
+
+/** @see userName */
+export const password = 'open sesame';
+
+/** The RFC 7617 value a client composes out of the two above, which is what a request on this surface presents. */
+export const expectedAuthorization = 'Basic b3duZXI6b3BlbiBzZXNhbWU=';
+
+/**
+ * What the session route answers, which is what decides how much of the client is offered at all.
+ *
+ * The grant names both permissions the client acts on: an answer without them opens a frame with Discover and the
+ * intent field absent, which is a different screen from the one most checks are about.
+ *
+ * **`version` is the one field a consumer replaces rather than reads.** Only a build knows what version it was built
+ * from, and a corpus stating one would be a second copy of `Version.props` going stale in a directory nothing reads it
+ * from — so a check proving anything about the version spreads the number it read over this value, and every other
+ * check takes it as it stands.
+ */
+export const sessionAnswer = {
+    service: 'MailFathom',
+    version: '0.0.0',
+    permissions: ['mailfathom.mail.read', 'mailfathom.mail.ask'],
+    telemetry: true,
+};
+
+/** Who the signed-in person is, as the frame reads it for the account menu and the settings screen. */
+export const ownDisplayName = { displayName: 'Iris Marlow', changeable: true };
+
+/** What the preferences route answers before anything has been chosen, which is every default the deployment holds. */
+export const clientPreferences = {
+    telemetryEnabled: true,
+    theme: 'system',
+    openMailInTabs: false,
+    markReadOnOpen: true,
+    expandWholeThread: false,
+    embeddedHtmlMessages: false,
+};
+
+/** The mailbox everything else in the corpus belongs to, up to date and with nothing to say about itself. */
+export const workAccount = {
+    id: 'work',
+    displayName: 'Work',
+    synchronizationState: 'Synchronized',
+    lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
+    behind: false,
+};
+
+/** A mailbox whose synchronization is failing, which is what a screen draws its own failure sentence from. */
+export const failingAccount = {
+    id: 'club',
+    displayName: 'Club',
+    synchronizationState: 'Failing',
+    lastSynchronizedAt: '2026-08-30T18:12:00+00:00',
+    behind: true,
+};
+
+/**
+ * A mailbox that is reachable and not up to date, which is the state the resting one and the failing one both miss.
+ *
+ * It is worth its own entry because a screen says something different about it: nothing is wrong with the account, so
+ * what a reader is owed is that some of their mail has not arrived yet rather than that the deployment cannot reach it.
+ */
+export const accountBehind = {
+    id: 'personal',
+    displayName: 'Personal',
+    synchronizationState: 'Synchronized',
+    lastSynchronizedAt: '2026-08-31T06:02:00+00:00',
+    behind: true,
+};
+
+/** What the accounts route answers at rest: one mailbox, up to date, with nothing to report. */
+export const mailAccounts = {
+    synchronizationEnabled: true,
+    accounts: [workAccount],
+};
+
+/** What the accounts route answers when the deployment has something to say about two of the three mailboxes. */
+export const troubledAccounts = {
+    synchronizationEnabled: true,
+    accounts: [workAccount, failingAccount, accountBehind],
+};
+
+const inbox = {
+    alias: 'INBOX',
+    role: 'Inbox',
+    path: ['INBOX'],
+    storedEmailCount: 4213,
+    unreadEmailCount: 12,
+    synchronizationState: 'Synchronized',
+    lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
+    behind: false,
+};
+
+// A folder nested where a mail server nests one, which is what a tree that has been expanded and collapsed is read
+// against. It carries no role, because most folders on a real server carry none.
+const archive2024 = {
+    alias: 'ARCHIVE-2024',
+    role: null,
+    path: ['Archive', '2024'],
+    storedEmailCount: 980,
+    unreadEmailCount: 0,
+    synchronizationState: 'Synchronized',
+    lastSynchronizedAt: '2026-08-31T09:00:00+00:00',
+    behind: false,
+};
+
+/** A folder holding nothing, which is the state a message list has to be looked at in and cannot reach by scrolling. */
+export const emptyFolder = {
+    alias: 'RECEIPTS',
+    role: null,
+    path: ['Receipts'],
+    storedEmailCount: 0,
+    unreadEmailCount: 0,
+    synchronizationState: 'Synchronized',
+    lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
+    behind: false,
+};
+
+/** What the folders route answers at rest: one mailbox with an inbox and a folder nested under another. */
+export const mailFolders = {
+    synchronizationEnabled: true,
+    accounts: [{ account: workAccount, folders: [inbox, archive2024] }],
+};
+
+/**
+ * What the folders route answers for {@link troubledAccounts}, so a tree can be looked at in the states above.
+ *
+ * The failing mailbox carries a folder that is behind as well as an account that is: a tree draws both, and a fixture
+ * that only set the account's state would leave the row a reader actually points at saying nothing.
+ */
+export const troubledFolders = {
+    synchronizationEnabled: true,
+    accounts: [
+        { account: workAccount, folders: [inbox, archive2024, emptyFolder] },
+        {
+            account: failingAccount,
+            folders: [
+                { ...inbox, storedEmailCount: 61, unreadEmailCount: 4, synchronizationState: 'Failing', behind: true },
+            ],
+        },
+        { account: accountBehind, folders: [{ ...inbox, storedEmailCount: 812, unreadEmailCount: 0, behind: true }] },
+    ],
+};

--- a/frontend/tests/fixtures/drafts.ts
+++ b/frontend/tests/fixtures/drafts.ts
@@ -1,0 +1,75 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+// What the owner is writing, and what becomes of one of them when it is sent.
+//
+// A draft here is the one in the owner's own drafts folder, so there is nothing held only in the client for a fixture
+// to stand in for: what a save answers with is the record itself, and that is what these values are.
+
+/** The identity the draft below is addressed by, everywhere the corpus names one draft. */
+export const draftId = '00000000-0000-4000-8000-0000000000d0';
+
+/** A message of the author's own, addressed to two people and carrying one staged file. */
+export const draft = {
+    draftId,
+    account: 'work',
+    subject: 'The yard on the ninth',
+    recipients: [
+        { role: 'To', address: 'sales@nordwind.example', displayName: 'Nordwind' },
+        { role: 'Cc', address: 'yard@example.invalid', displayName: null },
+    ],
+    attachments: [
+        {
+            attachmentId: '00000000-0000-4000-8000-0000000000d1',
+            fileName: 'yard.pdf',
+            mediaType: 'application/pdf',
+            sizeOctets: 18_432,
+        },
+    ],
+    revision: 3,
+    sizeOctets: 21_504,
+};
+
+/**
+ * A second draft, written as an answer to stored mail rather than as a message of its own.
+ *
+ * It is worth stating because the two are one type with two halves, and a screen listing them draws the same row for
+ * both: what separates them is what the deployment derived — the subject and the threading — rather than anything the
+ * author typed twice.
+ */
+export const answeringDraft = {
+    draftId: '00000000-0000-4000-8000-0000000000d2',
+    account: 'work',
+    subject: 'Re: The racking quote',
+    recipients: [{ role: 'To', address: 'sales@nordwind.example', displayName: 'Nordwind' }],
+    attachments: [],
+    revision: 1,
+    sizeOctets: 1_120,
+};
+
+/**
+ * What is unsent, newest first, as the records themselves rather than as a listing.
+ *
+ * The envelope a listing puts them in is left to whoever routes it, because nothing in `Client.Backend` reads that
+ * route yet — and a corpus that invented one would be a shape nobody could check against the service, which is the
+ * failure this whole directory exists to end rather than to move.
+ */
+export const drafts = [answeringDraft, draft];
+
+/** What a save answers with, which is the record wrapped the way the surface is documented as free to wrap it. */
+export const savedDraft = { draft };
+
+/** What a send answers with once the message is queued: an identity to watch in the outbox and nothing else. */
+export const queuedSend = { outgoingEmail: '00000000-0000-4000-8000-0000000000e0' };
+
+/**
+ * What a send answers with when a rule of the deployment refused the message that was written.
+ *
+ * The code is what a client matches rather than the sentence beside it: the sentence is written for an operator and is
+ * not a contract, so a fixture whose refusal was recognised by its wording would prove a client nobody wrote.
+ */
+export const refusedSend = {
+    errorCode: 59_001,
+    detail: 'The content scanner refused this message.',
+};

--- a/frontend/tests/fixtures/mail.ts
+++ b/frontend/tests/fixtures/mail.ts
@@ -1,0 +1,245 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+// The mailbox as rows: one page of a folder, one page of a search, and one conversation. The three are together because
+// they are one shape — the service publishes a search result as a list row with two fields added, and a conversation's
+// `email` as that same row field for field — so a fixture that stated them apart would be three copies of one thing
+// drifting away from each other.
+//
+// Nothing here parses a request. Where an answer depends on what was asked for — how far into the folder somebody has
+// read — the corpus states it as a function of that question, and the consumer routing it decides what was asked.
+
+import { markupOnlyId, markupOnlySubject, newsletterId, newsletterSubject } from './messages';
+
+/**
+ * How many messages the folder behind the corpus holds.
+ *
+ * It is the number `frontend/src/AGENTS.md` names as the one the client actually has to render, which is why the rows
+ * are generated from their own position rather than written out: a fixture of two hundred and fourteen thousand
+ * literals would prove the same thing and be unreadable, and nothing in one row is anybody's mail.
+ */
+export const mailboxSize = 214_000;
+
+/** How many rows one page of the folder holds, which is what a cursor moves by. */
+export const rowsPerPage = 100;
+
+/** The conversation every corpus message that belongs to one belongs to. */
+export const conversationId = '00000000-0000-4000-8000-0000000000c0';
+
+function timelineRow(at: number) {
+    return {
+        id: `message-${String(at)}`,
+        account: 'work',
+        folder: 'INBOX',
+        threadId: null,
+        subject: `Message ${String(at)}`,
+        receivedAt: '2026-08-31T09:41:00+00:00',
+        sentAt: null,
+        senderAddress: `writer-${String(at)}@nordwind.example`,
+        senderDisplayName: `Writer ${String(at)}`,
+        toAddresses: ['owner@example.invalid'],
+        unread: at % 3 === 0,
+        flagged: false,
+        answered: false,
+        hasAttachments: at % 5 === 0,
+        attachmentCount: at % 5 === 0 ? 1 : 0,
+        sizeOctets: 4_096,
+        preview: `The opening of message ${String(at)}.`,
+    };
+}
+
+/**
+ * One page of the folder, keyset-paged the way the client surface pages it.
+ *
+ * The cursor is the row the page starts at, written as text, because what a check about a cursor proves is that the
+ * client holds one and continues from it — what a deployment encodes in one is the deployment's own business.
+ *
+ * @param from The row the page starts at, which is what a cursor names.
+ */
+export function timelinePage(from: number) {
+    const start = Math.max(from, 0);
+    const rows = Math.max(Math.min(rowsPerPage, mailboxSize - start), 0);
+
+    return {
+        emails: Array.from({ length: rows }, (_, at) => timelineRow(start + at)),
+        nextCursor: start + rows >= mailboxSize ? null : String(start + rows),
+        previousCursor: start === 0 ? null : String(start),
+        pageSize: rowsPerPage,
+    };
+}
+
+/**
+ * What a folder holding nothing answers with.
+ *
+ * A screen cannot be scrolled into this state, so it is stated rather than derived: an empty folder says why it is
+ * empty and what would fill it, and that sentence is only ever seen by a check that asked for this page.
+ */
+export const emptyFolderPage = {
+    emails: [],
+    nextCursor: null,
+    previousCursor: null,
+    pageSize: rowsPerPage,
+};
+
+// The message the conversation below opens with, named here because a search finds it too: one message written in two
+// places would be the drift this directory exists to end, in miniature.
+const rackingQuote = {
+    id: '00000000-0000-4000-8000-0000000000c1',
+    subject: 'The racking quote',
+    preview: 'Two prices, one for the shallow bays and one for the deep ones.',
+};
+
+/**
+ * What the search route answers, ranked both ways.
+ *
+ * The three rows are the three things `matchedBy` separates, because a screen draws each differently: a result found by
+ * its words carries the extracts around them, one found by meaning alone carries none and would otherwise read as an
+ * unexplained row, and one both rankings found carries both claims.
+ */
+export const searchResults = {
+    results: [
+        {
+            ...timelineRow(0),
+            id: newsletterId,
+            subject: newsletterSubject,
+            senderAddress: 'news@example.invalid',
+            senderDisplayName: 'Example',
+            preview: 'A newsletter, as words.',
+            snippets: ['The **renewal** falls due at the end of the month'],
+            matchedBy: 'BothRankings',
+        },
+        {
+            ...timelineRow(1),
+            id: markupOnlyId,
+            subject: markupOnlySubject,
+            senderAddress: 'dispatch@kettles.invalid',
+            senderDisplayName: 'Kettles',
+            preview: 'Your order left this morning and should reach you on Thursday.',
+            snippets: ['what the **renewal** covers'],
+            matchedBy: 'LexicalRanking',
+        },
+        {
+            ...timelineRow(2),
+            id: rackingQuote.id,
+            threadId: conversationId,
+            subject: rackingQuote.subject,
+            senderAddress: 'sales@nordwind.example',
+            senderDisplayName: 'Nordwind',
+            preview: rackingQuote.preview,
+            snippets: [],
+            matchedBy: 'SemanticRanking',
+        },
+    ],
+    nextCursor: null,
+    pageSize: 20,
+    retrievalMode: 'Hybrid',
+    semanticSearch: 'Available',
+    includedJunkMail: false,
+};
+
+/** What a search that matched nothing answers with, which is a page rather than a refusal. */
+export const noSearchResults = {
+    results: [],
+    nextCursor: null,
+    pageSize: 20,
+    retrievalMode: 'Hybrid',
+    semanticSearch: 'Available',
+    includedJunkMail: false,
+};
+
+const conversationRows = [
+    {
+        id: rackingQuote.id,
+        answersRow: null,
+        folder: 'INBOX',
+        subject: rackingQuote.subject,
+        sentAt: '2026-08-28T08:12:00+00:00',
+        senderAddress: 'sales@nordwind.example',
+        senderDisplayName: 'Nordwind',
+        preview: rackingQuote.preview,
+    },
+    {
+        id: '00000000-0000-4000-8000-0000000000c2',
+        answersRow: 0,
+        folder: 'SENT',
+        subject: 'Re: The racking quote',
+        sentAt: '2026-08-28T09:40:00+00:00',
+        senderAddress: 'owner@example.invalid',
+        senderDisplayName: 'Iris Marlow',
+        preview: 'Does the deeper price include the fixings?',
+    },
+    {
+        id: '00000000-0000-4000-8000-0000000000c3',
+        answersRow: 1,
+        folder: 'INBOX',
+        subject: 'Re: The racking quote',
+        sentAt: '2026-08-29T07:55:00+00:00',
+        senderAddress: 'sales@nordwind.example',
+        senderDisplayName: 'Nordwind',
+        preview: 'It does, and the delivery is inside the same figure.',
+    },
+    {
+        id: '00000000-0000-4000-8000-0000000000c4',
+        answersRow: 2,
+        folder: 'SENT',
+        subject: 'Re: The racking quote',
+        sentAt: '2026-08-29T16:04:00+00:00',
+        senderAddress: 'owner@example.invalid',
+        senderDisplayName: 'Iris Marlow',
+        preview: 'Then take the deeper bays. I will confirm the dates on Monday.',
+    },
+    {
+        id: '00000000-0000-4000-8000-0000000000c5',
+        answersRow: 3,
+        folder: 'INBOX',
+        subject: 'Re: The racking quote',
+        sentAt: '2026-08-31T08:03:00+00:00',
+        senderAddress: 'sales@nordwind.example',
+        senderDisplayName: 'Nordwind',
+        preview: 'Booked for the ninth. The crew will need the yard for a morning.',
+    },
+];
+
+/**
+ * One conversation, long enough that a screen collapses it.
+ *
+ * The screen shows the latest message and folds every earlier one behind a control naming how many there are, so a
+ * conversation of two would draw the collapsed history and prove nothing about it. Five is the shortest one where the
+ * fold is worth reading: four messages behind the control, in both folders the exchange ran through.
+ */
+export const conversation = {
+    threadId: conversationId,
+    messages: conversationRows.map((row, position) => ({
+        position,
+        answeredId: row.answersRow === null ? null : (conversationRows[row.answersRow]?.id ?? null),
+        email: {
+            id: row.id,
+            account: 'work',
+            folder: row.folder,
+            threadId: conversationId,
+            subject: row.subject,
+            receivedAt: row.sentAt,
+            sentAt: row.sentAt,
+            senderAddress: row.senderAddress,
+            senderDisplayName: row.senderDisplayName,
+            toAddresses: [row.folder === 'SENT' ? 'sales@nordwind.example' : 'owner@example.invalid'],
+            unread: false,
+            flagged: false,
+            answered: false,
+            hasAttachments: false,
+            attachmentCount: 0,
+            sizeOctets: 3_120,
+            preview: row.preview,
+        },
+    })),
+    participants: [
+        { address: 'sales@nordwind.example', displayName: 'Nordwind', messageCount: 3 },
+        { address: 'owner@example.invalid', displayName: 'Iris Marlow', messageCount: 2 },
+    ],
+    messageCount: conversationRows.length,
+    moreMessagesNotAssembled: false,
+    moreParticipantsNotNamed: false,
+    nextCursor: null,
+    pageSize: 25,
+};

--- a/frontend/tests/fixtures/messages.ts
+++ b/frontend/tests/fixtures/messages.ts
@@ -1,0 +1,255 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+// One message as a reading pane draws it: what the message route answers around a body, what the body route answers as
+// the body, the sender's own markup behind that, and the octets of the one file it carries.
+//
+// **Every body here carries a `plainText` object, and a `null` there is refused rather than tolerated.** The body route
+// answers both renderings together — the document, and the same message as words — because a pane needs the second
+// whenever the first is refused, so `plainText` is not an alternative representation the sender may have omitted: it is
+// what MailFathom derived, present on every readable body whatever the sender sent. A fixture writing `null` into it is
+// refused by `mailBody.ts` before any screen sees it, and what a reader then meets is the pane saying the message could
+// not be read — which reads as a defect in the client and is a malformed fixture. {@link markupOnlyMessage} below is the
+// case that would tempt one: a sender who wrote no text part at all, whose message route answer says exactly that and
+// whose body still carries the words.
+
+/** The identity the newsletter is addressed by, everywhere the corpus names one message. */
+export const newsletterId = '00000000-0000-4000-8000-000000000000';
+
+/** @see markupOnlyMessage */
+export const markupOnlyId = '00000000-0000-4000-8000-000000000001';
+
+/** The subject the newsletter carries, which is what names the region a pane draws it in. */
+export const newsletterSubject = 'A newsletter from Example';
+
+/** The sender's own first-level heading inside the newsletter, which a pane draws deeper than they wrote it. */
+export const newsletterHeading = 'This week at Example';
+
+/** @see markupOnlyMessage */
+export const markupOnlySubject = 'Your order is on its way';
+
+/** What the one attached file holds — small enough to state here, and large enough to arrive as more than nothing. */
+export const attachedOctets = 'order,quantity\nkettle,1\n';
+
+/** A one-pixel transparent picture, standing in for a part a message carried itself rather than asked to be fetched. */
+export const transparentPicture = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+
+/** The host a message asks its pictures to be fetched from, which is what a check watching for a leak watches for. */
+export const senderPictureHost = 'pictures.invalid';
+
+/** The address of the picture the newsletter asks for, retained only where the reader asked for the sender's pictures. */
+export const senderPicture = `https://${senderPictureHost}/mark.png`;
+
+/** The host the script inside the sender's markup fetches from, so a request to it is that script having run. */
+export const senderScriptHost = 'ranscript.invalid';
+
+function run(text: string, overrides: Readonly<Record<string, unknown>> = {}) {
+    return { text, emphasis: 'None', foreground: null, link: null, ...overrides };
+}
+
+/**
+ * The newsletter as a closed document tree.
+ *
+ * The blocks are chosen so each identity the contract carries is drawn at least once, and so the two things a sender
+ * may try are both visible: markup written as text, and a link whose words name one place while its target names
+ * another.
+ *
+ * @param pictureSource What the picture block resolves to — the message's own inlined copy, or the sender's address
+ * where the reader asked for it.
+ */
+export function newsletterBlocks(pictureSource: string) {
+    return [
+        { type: 'heading', version: 1, level: 1, content: [run(newsletterHeading)], alignment: 'Start' },
+        {
+            type: 'paragraph',
+            version: 1,
+            content: [
+                run('A sender may write '),
+                run('<script>alert(1)</script>', { emphasis: 'Bold, Monospace' }),
+                run(' and it stays words.'),
+            ],
+            alignment: 'Inherited',
+        },
+        {
+            type: 'paragraph',
+            version: 1,
+            content: [
+                run('example.invalid', {
+                    link: {
+                        target: 'https://offers.invalid/claim',
+                        host: 'offers.invalid',
+                        asciiHost: null,
+                        deception: 'DisplayedHostDiffers',
+                        isWorthWarningAbout: true,
+                    },
+                }),
+            ],
+            alignment: 'Inherited',
+        },
+        {
+            type: 'image',
+            version: 1,
+            image: { source: pictureSource, alternativeText: 'The Example mark', width: 32, height: 32 },
+            link: null,
+            alignment: 'Center',
+        },
+        {
+            type: 'quote',
+            version: 1,
+            depth: 1,
+            blocks: [
+                { type: 'paragraph', version: 1, content: [run('You wrote: send me the list.')], alignment: 'Start' },
+            ],
+        },
+        { type: 'separator', version: 1 },
+        { type: 'preformatted', version: 1, text: '  order  quantity\n  kettle 1' },
+    ];
+}
+
+/**
+ * The sender's own markup, as the self-contained representation serves it: pictures inlined and remote addresses gone,
+ * unless the reader asked for this one message's pictures.
+ *
+ * It carries a script deliberately, which the representation itself never would. What that stands in for is the second
+ * mechanism ADR 0024 keeps on this surface — the frame permits no script whatever the markup holds, so a representation
+ * that ever stopped removing one would still not run it. The script fetches from a host of its own, so a browser says
+ * whether it ran without anything having to read inside a frame it cannot reach into.
+ */
+export function senderMarkup(remoteImages: boolean): string {
+    const picture = remoteImages ? senderPicture : transparentPicture;
+
+    return (
+        `<html><body><h1>${newsletterHeading}</h1>` +
+        `<script>new Image().src = "https://${senderScriptHost}/beacon.png";</script>` +
+        `<img src="${picture}" alt="A mark">` +
+        '</body></html>'
+    );
+}
+
+/**
+ * What the body route answers for the newsletter.
+ *
+ * Both flags are questions the reader asked rather than anything the corpus decides, which is why they are parameters:
+ * asking for the sender's pictures restores the addresses the representation had removed, and asking for their own
+ * markup adds a third rendering beside the two every read carries. Nothing here reads a request — a consumer that
+ * routes this decides what was asked and says so.
+ */
+export function newsletterBody({ remoteImages = false, fullHtml = false } = {}) {
+    return {
+        storedEmailId: newsletterId,
+        availability: 'Readable',
+        plainText: {
+            text: 'A newsletter, as words.\n\nRead it at example.invalid.',
+            originalCharacterCount: 48,
+            truncation: 'None',
+        },
+        document: {
+            schemaVersion: 1,
+            blocks: newsletterBlocks(remoteImages ? senderPicture : transparentPicture),
+            refusal: 'None',
+            removedRemoteReferenceCount: remoteImages ? 0 : 3,
+            retainedRemoteImageCount: remoteImages ? 1 : 0,
+            inlineImageCount: remoteImages ? 0 : 1,
+            undrawnInlineImageCount: 0,
+            truncated: false,
+        },
+        selfContainedHtml: fullHtml
+            ? { text: senderMarkup(remoteImages), originalCharacterCount: 320, truncation: 'None' }
+            : null,
+        remoteImagesRequested: remoteImages,
+    };
+}
+
+/** What the message route answers for the newsletter: everything a pane draws around a body it never carries. */
+export const newsletterMessage = {
+    storedEmailId: newsletterId,
+    account: 'work',
+    folder: 'INBOX',
+    threadId: null,
+    sizeOctets: 40_960,
+    headers: {
+        subject: newsletterSubject,
+        sentAt: '2026-08-31T09:41:00+00:00',
+        receivedAt: '2026-08-31T09:41:10+00:00',
+        participants: [
+            { role: 'From', address: 'news@example.invalid', displayName: 'Example' },
+            { role: 'To', address: 'reader@example.invalid', displayName: null },
+        ],
+        messageId: 'abc@example.invalid',
+        inReplyTo: null,
+        references: [],
+    },
+    body: { availability: 'Readable', plainText: true, html: true },
+    sender: { authorAuthentication: 'Authenticated', deploymentTrust: 'Unknown', authenticatedDomain: null },
+    attachments: [
+        {
+            position: 0,
+            fileName: 'orders.csv',
+            wasFileNameNormalized: false,
+            mediaType: 'text/csv',
+            sizeOctets: attachedOctets.length,
+        },
+    ],
+    carried: null,
+    unread: true,
+    flagged: false,
+    answered: false,
+};
+
+/**
+ * A message whose sender wrote no plain text part at all, which is the state the module note above is about.
+ *
+ * `body.plainText` is `false` here because that field says what the *message* carried, and this one carried markup and
+ * nothing else. What the body route answers for it still carries a `plainText` object — {@link markupOnlyBody} — because
+ * that is what MailFathom derived from the markup rather than what the sender attached.
+ */
+export const markupOnlyMessage = {
+    ...newsletterMessage,
+    storedEmailId: markupOnlyId,
+    sizeOctets: 12_288,
+    headers: {
+        ...newsletterMessage.headers,
+        subject: markupOnlySubject,
+        sentAt: '2026-08-30T14:20:00+00:00',
+        receivedAt: '2026-08-30T14:20:06+00:00',
+        participants: [
+            { role: 'From', address: 'dispatch@kettles.invalid', displayName: 'Kettles' },
+            { role: 'To', address: 'reader@example.invalid', displayName: null },
+        ],
+        messageId: 'def@kettles.invalid',
+    },
+    body: { availability: 'Readable', plainText: false, html: true },
+    attachments: [],
+    unread: false,
+};
+
+/** @see markupOnlyMessage */
+export const markupOnlyBody = {
+    storedEmailId: markupOnlyId,
+    availability: 'Readable',
+    plainText: {
+        text: 'Your order left this morning and should reach you on Thursday.',
+        originalCharacterCount: 62,
+        truncation: 'None',
+    },
+    document: {
+        schemaVersion: 1,
+        blocks: [
+            {
+                type: 'paragraph',
+                version: 1,
+                content: [run('Your order left this morning and should reach you on Thursday.')],
+                alignment: 'Inherited',
+            },
+        ],
+        refusal: 'None',
+        removedRemoteReferenceCount: 0,
+        retainedRemoteImageCount: 0,
+        inlineImageCount: 0,
+        undrawnInlineImageCount: 0,
+        truncated: false,
+    },
+    selfContainedHtml: null,
+    remoteImagesRequested: false,
+};

--- a/frontend/tests/fixtures/notifications.ts
+++ b/frontend/tests/fixtures/notifications.ts
@@ -1,0 +1,64 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+// What happened to the person while nobody was looking at their screen, and what each of the two ways of marking one
+// read answers with.
+//
+// The three targets are all stated, because which one a producer chose is what a row is drawn by: a notification
+// leading to a message, one leading to a screen, and one leading nowhere are three different rows rather than one row
+// with a field that is sometimes absent.
+
+import { newsletterId } from './messages';
+
+/** The identity the unread notification below is addressed by. */
+export const notificationId = '00000000-0000-4000-8000-0000000000f0';
+
+/** One page of the centre, newest first, holding one row of each kind of target and both read states. */
+export const notificationPage = {
+    notifications: [
+        {
+            id: notificationId,
+            kind: 'Mail',
+            title: 'Nordwind wrote about the racking quote',
+            body: 'Booked for the ninth. The crew will need the yard for a morning.',
+            source: 'Work',
+            target: { kind: 'Message', messageId: newsletterId },
+            occurredAt: '2026-08-31T08:03:00+00:00',
+            read: false,
+        },
+        {
+            id: '00000000-0000-4000-8000-0000000000f1',
+            kind: 'System',
+            title: 'The Club mailbox is refusing its credential',
+            body: 'Nothing has been read from it since Sunday evening.',
+            source: 'Club',
+            target: { kind: 'Screen', screen: 'Settings' },
+            occurredAt: '2026-08-30T18:12:00+00:00',
+            read: false,
+        },
+        {
+            id: '00000000-0000-4000-8000-0000000000f2',
+            kind: 'Task',
+            title: 'Four messages were filed into Receipts',
+            body: '',
+            source: null,
+            target: { kind: 'Nothing' },
+            occurredAt: '2026-08-29T11:00:00+00:00',
+            read: true,
+        },
+    ],
+    nextCursor: null,
+};
+
+/** What a centre with nothing in it answers with, which a panel says something of its own about. */
+export const emptyNotificationPage = { notifications: [], nextCursor: null };
+
+/** What the count route answers on its own, which is the whole of what the bell draws. */
+export const unreadNotificationCount = { unreadCount: 2 };
+
+/** What marking {@link notificationId} read answers with: the row's new state, and what it leaves on the bell. */
+export const notificationMarkedRead = { id: notificationId, read: true, unreadCount: 1 };
+
+/** What marking the whole centre read answers with, which a client redraws both the panel and the bell from. */
+export const everyNotificationMarkedRead = { markedRead: 2, unreadCount: 0 };


### PR DESCRIPTION
Closes #1700

The browser suite carried its own mail inline. A session answer, one account, two folders, a
generated timeline, one message and its body were all declared in `client.spec.ts` beside the checks
that read them — fine for one suite and wrong for two, because the second one to need a populated
screen invents a mailbox of its own and the two drift apart with nothing to notice.

`frontend/tests/fixtures/` is now one corpus, and it is **data rather than routing**: every module
exports values and none of them knows what a `page.route` or a transport function is, so a unit test
reaches it exactly as the browser suite does. Each consumer decides how the values get to the client.

## What the corpus holds

Split by what each module is about rather than by which check reads it:

- `deployment.ts` — the deployment and the person: the credential and the `Authorization` header it
  produces, the session answer, the display name, the client preferences, the accounts and the
  folder tree. The resting tree is byte-identical to what the spec declared before, so nothing it
  asserts moved.
- `messages.ts` — one message drawn every way the reader draws it: the document tree, the sender's
  own markup, remote images asked for and withheld, an attachment, and the message that carries no
  plain text part at all.
- `mail.ts` — the mailbox as rows. One shape covers the timeline, a search result and a
  conversation's messages, because the service publishes a search result as a list row plus two
  fields and a conversation's `email` as that same row field for field. `timelinePage(from)` answers
  a cursor rather than a fixed page, so paging forward and backward is the corpus's arithmetic rather
  than the spec's.
- `drafts.ts`, `notifications.ts`, `changes.ts` — a draft and an answer to one, a notification page
  covering all three target shapes and both read states, and both directions a change travels: the
  mutation answers, the record states, and one payload of each of the five signal kinds.

It covers the states a screen has to be looked at in and the resting one does not show: an **empty
folder**, a **message with no plain text alternative**, a **thread long enough to collapse** (five
messages, four of them behind the fold `Thread.tsx` draws), a **synchronization that failed**, and an
**account behind**.

Every message body carries a `plainText` object, and `messages.ts` says why rather than leaving the
next reader to decide: `mailBody.ts` refuses a `null` there and the reader is told the message could
not be read, so a fixture with a `null` in it would be exercising the failure path while looking like
an ordinary message. The `plainText` on the *message* route is a different thing — a `boolean` saying
whether the message carried a text part — and the module says that too, because the two names are one
transposition apart.

Nothing in it is anybody's. Every address is under a reserved name (`.invalid`, `.example`), and
every person, subject and sentence is invented.

## What is deliberately not here

- No unit test imports it yet. The two Vitest projects are rooted at `src/Client.Backend` and
  `src/Client.App`, so an import of `../../../../tests/fixtures/…` would cross the package boundary
  that layout exists to refuse; the issue's own scope is the corpus, not its consumers.
- No module imports a type from `@mailfathom/client-backend`. The corpus states what the service
  answers with, which is what a fake is for — typing it against what the client parses would make a
  mistake in the parser invisible.
- The draft listing is a bare array rather than an envelope: nothing in `Client.Backend` reads that
  route yet, and inventing an envelope would be exactly the drift this directory exists to end.
- `sessionAnswer.version` is `'0.0.0'` and the consumer substitutes it. Only a build knows the real
  one, and `AGENTS.md` allows nobody to retype it.

## The browser suite is red, and not from this change

`Frontend / Check, build, and test the client` will fail on three checks that fail on `main` as well:
the markup-frame sentence, a `Reply — not built yet` name that now resolves to two controls, and the
phone composition's `New message`. They were reproduced against `origin/main` with an unmodified
`client.spec.ts`, twice, with identical results; #1710's own client job is recorded as `FAILURE` and
was merged over, so the required check has been red on every client change since. They are #1715 and
are not this pull request's to fix.

## Verification

- `scripts/verify-fast.sh` and `scripts/verify-full.sh` pass over the pushed tree; the client unit
  suite is 2916 tests and unchanged in what it asserts.
- `pnpm test:browser` gives the same 45 passed / 3 failed against this branch as against
  `origin/main` with the spec reverted and the corpus removed — the three are the #1715 failures and
  nothing else moved.
- `$check-docs-licenses`: docs `pass`, changelog `n/a`, licenses `n/a` — no dependency is added,
  upgraded or newly used, so no register row, no census and no bundled notice moves.
