### PR TITLE
[#1729] Draw the sender's HTML and an opened file as a window over the message outside tabs

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -504,7 +504,9 @@ request. A row that ever stops being one height is the argument for reopening th
 degrading quietly.
 
 `src/fullHtml/` is the second surface [ADR 0024](../docs/decisions/0024-rendering-mail-in-the-client-as-a-closed-document-tree.md)
-takes, and it stands in front of the message the same way a conversation does. What the reading pane draws is a closed
+takes, and where somebody works in tabs it opens as a tab of its own. Where they do not it is drawn in a window over
+the message — `mailSpace/SurfaceWindow.tsx`, the platform's own modal dialog, so the message they were reading is still
+where they left it when the window goes. What the reading pane draws is a closed
 document tree; what this draws is the markup the sender actually wrote, and two different mechanisms are what make that
 safe rather than one. The frame it is drawn in carries a `sandbox` attribute naming neither `allow-scripts` nor
 `allow-same-origin`, so nothing in the markup runs whatever the markup holds; and what is drawn in it is the
@@ -521,7 +523,8 @@ letting a call site suppress the rule.
 
 A file a message carries opens on a third surface, in the same place and by the same rule: `readingPane/Attachment.tsx`
 is the row that describes it, and `readingPane/AttachmentView.tsx` is what a press on it opens — a tab of its own where
-somebody works in tabs, and standing in front of the message where they do not. Opening and downloading are two controls
+somebody works in tabs, and the same window over the message where they do not, drawn at the size the design project
+gives a file rather than markup. Opening and downloading are two controls
 on that row rather than one, because they are two acts: the chip opens the file inside the client and the control at its
 end writes it to the person's machine, so looking at something never costs a trip to a downloads folder. It reads the one route the download
 already used, `/api/client/messages/{storedEmailId}/attachments/{position}`, under the size the message declared, so

--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -191,10 +191,10 @@ describe('App', () => {
         });
     });
 
-    // The message this one opens belongs to no conversation, which is deliberate: what is being proven is leaving the
-    // sender's own view, and a threaded message would draw the way into the conversation beside it — a second surface
-    // for every query here to walk past, in the heaviest test this suite has.
-    it('returns to the message from the sender own markup, and places the reader in it', async () => {
+    // The message this one opens belongs to no conversation, which is deliberate: what is being proven is the shape the
+    // sender's own view is drawn in, and a threaded message would draw the way into the conversation beside it — a
+    // second surface for every query here to walk past, in the heaviest test this suite has.
+    it('draws the sender own markup in a window over the message where the person does not work in tabs', async () => {
         renderApp(servedFrom, heldCredential, deploymentDrawingAMessage());
         await framed();
 
@@ -206,18 +206,42 @@ describe('App', () => {
         fireEvent.click(await screen.findByRole('button', { name: 'Show the full HTML version' }));
         fireEvent.click(screen.getByRole('button', { name: 'Show the HTML' }));
 
-        const surface = await screen.findByRole('region', { name: "The sender's own version of this message" });
+        const standing = await screen.findByRole('dialog', { name: "The sender's own version of this message" });
+        const surface = within(standing).getByRole('region', { name: "The sender's own version of this message" });
+
+        // The message is where it was rather than replaced by the surface, which is the whole of what a window over it
+        // means: the reading column goes on drawing what the reader was reading.
+        expect(screen.getByText('A drawn message.')).toBeDefined();
+
+        // Opening it is a view change, so the reader is placed in what was opened. Where that focus goes when the
+        // window closes is the platform's own — the browser suite is where a real modal can be asked.
+        await waitFor(() => {
+            expect(document.activeElement).toBe(surface);
+        });
 
         fireEvent.click(within(surface).getByRole('button', { name: 'Close this view' }));
 
-        expect(await screen.findByText('A drawn message.')).toBeDefined();
+        expect(screen.queryByRole('dialog')).toBeNull();
+        expect(screen.getByText('A drawn message.')).toBeDefined();
+    });
 
-        // The same rule the conversation above is held to, and the one the two surfaces would otherwise disagree on:
-        // what decides it is that *something* was in front of the message rather than which of the two it was, so a
-        // reader leaving this one is placed exactly as a reader leaving that one is.
-        await waitFor(() => {
-            expect(document.activeElement).toBe(screen.getByRole('article', { name: /Quarterly invoice/ }));
-        });
+    it('draws the sender own markup in the reading column where the person works in tabs', async () => {
+        renderApp(servedFrom, heldCredential, deploymentWorkingInTabs());
+        await framed();
+
+        await goTo('Mail');
+
+        const list = await screen.findByRole('listbox', { name: 'Messages' });
+        fireEvent.pointerDown(within(list).getByRole('option', { name: /Quarterly invoice/ }));
+
+        fireEvent.click(await screen.findByRole('button', { name: 'Show the full HTML version' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Show the HTML' }));
+
+        // A tab of its own, so it takes the column the message had rather than standing in a window over it — which is
+        // the mode deciding the shape, and the one difference between this test and the one above.
+        expect(await screen.findByRole('region', { name: "The sender's own version of this message" })).toBeDefined();
+        expect(screen.queryByRole('dialog')).toBeNull();
+        expect(screen.queryByText('A drawn message.')).toBeNull();
     });
 
     // Three things decide whether opening a message marks it read, and all three are the frame's: the reader's own

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -36,6 +36,7 @@ import { FullHtmlSurface } from './fullHtml/FullHtmlSurface';
 import type { MessageKey } from './localization/en';
 import { useLocalization } from './localization/useLocalization';
 import { NothingOpen } from './mailSpace/NothingOpen';
+import { SurfaceWindow } from './mailSpace/SurfaceWindow';
 import { TabStrip } from './mailSpace/TabStrip';
 import { useOpenTabs } from './mailSpace/useOpenTabs';
 import { MailboxActsProvider } from './mailboxActs/MailboxActs';
@@ -402,17 +403,19 @@ export function App({
     const twoPanes = useTwoPanes();
 
     // What is standing in front of what a reader was last looking at, which is what the back gesture unwinds before it
-    // moves anywhere. The surfaces in the reading column count at every width, because each of them genuinely covers
-    // what it was opened from; the message covering the list counts only where the composition shows one pane, since
-    // that is the only composition where opening one took the other off the screen.
+    // moves anywhere. The two surfaces count here only where they are tabs in the reading column: where somebody does
+    // not work in tabs each is drawn in a window over the message, and a window registers itself as a screen layer the
+    // way every other modal surface does — so counting it here as well would spend two presses on one window. The
+    // message covering the list counts only where the composition shows one pane, since that is the only composition
+    // where opening one took the other off the screen.
     //
     // One list rather than a count beside a chain of branches, because how many steps stand there and what each of
     // them does to go away are one fact read twice. A press that unwinds two of them at once is what makes the
     // difference: asking the workspace again for the second step would answer with the surface the first has already
     // taken away, this event holding the revision that closed one no more than it holds the one that opened it.
     const inFrontOfTheList = [
-        workspace.attachment === null ? null : openTabs.closeAttachment,
-        workspace.fullHtml === null ? null : openTabs.closeFullHtml,
+        inTabs && workspace.attachment !== null ? openTabs.closeAttachment : null,
+        inTabs && workspace.fullHtml !== null ? openTabs.closeFullHtml : null,
         twoPanes || (workspace.selection === null && workspace.conversation === null)
             ? null
             : () => {
@@ -538,6 +541,7 @@ export function App({
                     attachment={workspace.attachment}
                     storedEmailId={workspace.selection}
                     online={connection.online}
+                    inTabs={inTabs}
                     expandWholeThread={preferences.expandWholeThread}
                     onShowFullHtml={openTabs.openFullHtml}
                     onCloseFullHtml={openTabs.closeFullHtml}
@@ -847,6 +851,7 @@ function OpenMail({
     attachment,
     storedEmailId,
     online,
+    inTabs,
     expandWholeThread,
     onShowFullHtml,
     onCloseFullHtml,
@@ -863,9 +868,18 @@ function OpenMail({
     readonly onCloseFullHtml: () => void;
     readonly onCloseAttachment: () => void;
 
+    /**
+     * Whether the person is working in tabs, which is what decides the shape either surface is drawn in rather than
+     * which of them was opened: a tab in the reading column where they are, and a window over the message where they
+     * are not.
+     */
+    readonly inTabs: boolean;
+
     /** Whether the reader asked for conversations to open with every message drawn, which only the conversation reads. */
     readonly expandWholeThread: boolean;
 }) {
+    const { translate } = useLocalization();
+
     // Whether the pane below is being arrived at rather than landed on. Closing whatever stood in front of the message
     // swaps this position from one component to the other, so the pane mounts afresh exactly as it does on a cold start
     // and cannot tell the two apart from anything it holds itself — this is the only place that saw the surface go.
@@ -876,7 +890,11 @@ function OpenMail({
     // The question is *whether something was in front* rather than which of the three it was, so the conversation, the
     // markup surface, and the file are one value here. Asking it per surface is how closing the second one would leave
     // focus on a control that has just been unmounted, while closing the first placed it correctly.
-    const covered = conversation !== null || fullHtml !== null || attachment !== null;
+    //
+    // Neither surface is in front of the pane where they are drawn as windows: the pane goes on standing underneath one
+    // and is never unmounted by it, and what places focus as the window goes is the platform handing it back to the
+    // control that opened it. Counting it here as well would have the pane take focus off that control.
+    const covered = conversation !== null || (inTabs && (fullHtml !== null || attachment !== null));
     const [wasCovered, setWasCovered] = useState(covered);
     const [arriving, setArriving] = useState(false);
 
@@ -885,51 +903,78 @@ function OpenMail({
         setArriving(!covered);
     }
 
-    // Keyed by the file, so opening a second one from the same message is a surface of its own rather than the first
-    // one adjusted — which is what keeps a read of one file from drawing into the screen that asked for another.
-    if (attachment !== null) {
-        return (
-            <AttachmentView
-                key={attachmentKey(attachment)}
-                session={session}
-                opened={attachment}
-                online={online}
-                onClose={onCloseAttachment}
-            />
-        );
+    // Which surface is open, what it is drawn as, and what it comes to — written once, because the two shapes below
+    // differ in where the surface stands rather than in what it is. Keyed by what was opened, so opening a second file
+    // from the same message is a surface of its own rather than the first one adjusted — which is what keeps a read of
+    // one file from drawing into the screen that asked for another.
+    const opened =
+        attachment !== null
+            ? {
+                  drawn: 'file' as const,
+                  label: attachment.attachment.fileName ?? translate('attachment.unnamed'),
+                  onClosed: onCloseAttachment,
+                  draw: (close: () => void) => (
+                      <AttachmentView
+                          key={attachmentKey(attachment)}
+                          session={session}
+                          opened={attachment}
+                          online={online}
+                          onClose={close}
+                      />
+                  ),
+              }
+            : fullHtml !== null
+              ? {
+                    drawn: 'markup' as const,
+                    label: translate('fullHtml.surface'),
+                    onClosed: onCloseFullHtml,
+                    draw: (close: () => void) => (
+                        <FullHtmlSurface
+                            key={fullHtml}
+                            session={session}
+                            transport={transport}
+                            storedEmailId={fullHtml}
+                            online={online}
+                            onClose={close}
+                        />
+                    ),
+                }
+              : null;
+
+    // In tabs the surface *is* the reading column, because a tab of its own is what it was opened as and the message it
+    // came from is a tab beside it. Closing it is the workspace letting go of it, there being no window to leave.
+    if (inTabs && opened !== null) {
+        return opened.draw(opened.onClosed);
     }
 
-    if (fullHtml !== null) {
-        return (
-            <FullHtmlSurface
-                key={fullHtml}
-                session={session}
-                transport={transport}
-                storedEmailId={fullHtml}
-                online={online}
-                onClose={onCloseFullHtml}
-            />
-        );
-    }
+    return (
+        <>
+            {conversation === null ? (
+                <ReadingPane
+                    session={session}
+                    transport={transport}
+                    storedEmailId={storedEmailId}
+                    online={online}
+                    onShowFullHtml={onShowFullHtml}
+                    arriving={arriving}
+                />
+            ) : (
+                <Thread
+                    key={conversationKey(conversation)}
+                    session={session}
+                    transport={transport}
+                    conversation={conversation}
+                    online={online}
+                    expandWholeThread={expandWholeThread}
+                />
+            )}
 
-    return conversation === null ? (
-        <ReadingPane
-            session={session}
-            transport={transport}
-            storedEmailId={storedEmailId}
-            online={online}
-            onShowFullHtml={onShowFullHtml}
-            arriving={arriving}
-        />
-    ) : (
-        <Thread
-            key={conversationKey(conversation)}
-            session={session}
-            transport={transport}
-            conversation={conversation}
-            online={online}
-            expandWholeThread={expandWholeThread}
-        />
+            {opened === null ? null : (
+                <SurfaceWindow label={opened.label} drawn={opened.drawn} onClosed={opened.onClosed}>
+                    {opened.draw}
+                </SurfaceWindow>
+            )}
+        </>
     );
 }
 

--- a/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.tsx
+++ b/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.tsx
@@ -24,9 +24,11 @@ import { useLocalization } from '../localization/useLocalization';
 import { MessageMarkupFrame } from '../messageBody/MessageMarkupFrame';
 
 // The second surface ADR 0024 takes: what the sender actually sent, drawn away from the reading pane for the reader
-// whose message reduced badly. It is a surface rather than a dialog — the content area where a message is read, or a
-// tab of its own where somebody works in tabs — and what it composes is the head the design project draws, the frame
-// beneath it, and the footer that says what is actually holding each promise.
+// whose message reduced badly. **It composes what stands in it and never where it stands** — the head the design
+// project draws, the frame beneath it, and the footer that says what is actually holding each promise. Where it is
+// drawn is the composition root's: a tab of its own where somebody works in tabs, and `mailSpace/SurfaceWindow.tsx`
+// over the message where they do not. So nothing here opens, closes, or traps anything; what it is handed is the way
+// out of wherever it was put, and it calls that.
 //
 // **The footer states two guarantees and attributes each to what holds it**, per #1483. The frame is what stops the
 // markup running. The representation is what stops it reporting: no sandboxing flag governs what a framed document
@@ -84,7 +86,7 @@ export function FullHtmlSurface({
     /** Whether this machine has a network, which is a different thing from the deployment refusing to answer. */
     readonly online: boolean;
 
-    /** Leaves the surface, which returns to whatever the reading column was drawing before it. */
+    /** Leaves the surface, which returns to the message it was opened from however this one was put on the screen. */
     readonly onClose: () => void;
 }) {
     const { locale, translate } = useLocalization();

--- a/frontend/src/Client.App/src/mailSpace/SurfaceWindow.test.tsx
+++ b/frontend/src/Client.App/src/mailSpace/SurfaceWindow.test.tsx
@@ -1,0 +1,85 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { fireEvent, render, renderHook, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ScreenLayersContext, useScreenLayerStack } from '../shell/screenLayers';
+import { SurfaceWindow } from './SurfaceWindow';
+
+// What this suite can say and what it cannot is the division `settings/Settings.test.tsx` works under: jsdom carries
+// the element and its `close` event, and carries none of what a modal actually is — the top layer, the backdrop, the
+// focus trap, and the focus handed back as it closes. So what is proven here is that every way out of the window leads
+// through the element, which is what earns the platform those four; the browser suite is where they are asked of a
+// real one. The two sizes the design draws are in the token layer and are held against the design by a parity capture,
+// jsdom computing no styles at all.
+
+// The surface standing in the window is a stand-in rather than either of the two real ones, because what this file is
+// about is the window: a real surface would bring a read, a transport, and every state of its own to a test that
+// asserts nothing about any of them. Its words are named here rather than translated for the same reason — nobody
+// reads them, and the catalogue describes what somebody reads.
+const named = 'What stands in it';
+const wayOut = 'Close this view';
+
+function drawWindow(onClosed: () => void): { readonly closeTop: () => boolean; readonly depth: () => number } {
+    const { result } = renderHook(() => useScreenLayerStack());
+
+    render(
+        <ScreenLayersContext value={result.current}>
+            <SurfaceWindow label={named} drawn="markup" onClosed={onClosed}>
+                {(close) => (
+                    <section aria-label={named}>
+                        <button type="button" onClick={close}>
+                            {wayOut}
+                        </button>
+                    </section>
+                )}
+            </SurfaceWindow>
+        </ScreenLayersContext>,
+    );
+
+    return { closeTop: () => result.current.closeTop(), depth: () => result.current.depth };
+}
+
+function theWindow(): HTMLElement {
+    return screen.getByRole('dialog', { name: named });
+}
+
+describe('SurfaceWindow', () => {
+    it('opens as a modal dialog named for what stands in it, rather than as a panel drawn to look like one', () => {
+        drawWindow(vi.fn());
+
+        expect(theWindow().hasAttribute('open')).toBe(true);
+    });
+
+    it('draws the surface it was given inside that window', () => {
+        drawWindow(vi.fn());
+
+        expect(within(theWindow()).getByRole('button', { name: wayOut })).toBeDefined();
+    });
+
+    it('answers the surface own way out through the element, so the platform hands focus back', () => {
+        const closed = vi.fn();
+
+        drawWindow(closed);
+
+        const standing = theWindow();
+
+        fireEvent.click(screen.getByRole('button', { name: wayOut }));
+
+        expect(standing.hasAttribute('open')).toBe(false);
+        expect(closed).toHaveBeenCalledTimes(1);
+    });
+
+    it('stands over the screen as one layer, so one press of the back gesture closes it and no more', () => {
+        const closed = vi.fn();
+        const layers = drawWindow(closed);
+        const standing = theWindow();
+
+        expect(layers.depth()).toBe(1);
+        expect(layers.closeTop()).toBe(true);
+
+        expect(standing.hasAttribute('open')).toBe(false);
+        expect(closed).toHaveBeenCalledTimes(1);
+    });
+});

--- a/frontend/src/Client.App/src/mailSpace/SurfaceWindow.tsx
+++ b/frontend/src/Client.App/src/mailSpace/SurfaceWindow.tsx
@@ -1,0 +1,88 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
+import { useScreenLayer } from '../shell/screenLayers';
+
+// The other shape the two surfaces opened from a message take, and the one `useOpenTabs.ts` describes as standing *in
+// front of* the message rather than beside it: where somebody does not work in tabs, the sender's own markup and an
+// opened file are drawn in a window over the message instead of taking the reading column. The message they were opened
+// from is therefore still where it was when the window goes, which is the whole reason the design project draws one.
+//
+// It is a `dialog` opened as a modal rather than a panel drawn to look like one, for the reason `settings/Settings.tsx`
+// gives about the same choice: focus moves in and is kept, Escape leaves it, the page behind it is out of reach, and
+// closing hands focus back to the control that opened it — five obligations the element already holds and a
+// hand-written trap would be a second, worse implementation of.
+//
+// **Every way out therefore leaves through the element's own `close`.** The surface inside is handed the way to close
+// this window rather than the way to clear what the workspace holds, so its close control, Escape, and the back gesture
+// all arrive at one event and the platform restores focus on each of them. Taking the surface off the screen from
+// underneath instead would remove an open modal from the document, which closes it and hands focus to nothing.
+//
+// Three compositions, and none of them is asked for in code: the design project draws the window over a scrim where
+// there is room for two panes, the whole screen between that width and the phone shape, and the whole screen stopping
+// above the bottom navigation on a phone. All three are the width variants on the element itself.
+
+/** Which of the two windows the design project draws. It is a size and nothing else. */
+export type SurfaceWindowKind = 'markup' | 'file';
+
+// The project draws the two at two sizes rather than at one, and each stops short of the viewport by the room the
+// project leaves around it — which is what the tokens carry, so this names them rather than composing a size here.
+const windowSizes: Readonly<Record<SurfaceWindowKind, string>> = {
+    markup: 'panes:h-markup-window-tall panes:w-markup-window',
+    file: 'panes:h-file-window-tall panes:w-file-window',
+};
+
+export function SurfaceWindow({
+    label,
+    drawn,
+    onClosed,
+    children,
+}: {
+    /** What this window is, for a reader who meets it as a dialog before they meet what is inside it. */
+    readonly label: string;
+
+    /** Which of the two the design project draws, which decides the size and nothing else. */
+    readonly drawn: SurfaceWindowKind;
+
+    /** What the window having closed comes to, which is the workspace letting go of the surface that stood in it. */
+    readonly onClosed: () => void;
+
+    /** The surface itself, handed the one way out of this window. */
+    readonly children: (close: () => void) => ReactNode;
+}) {
+    // The element is held as state rather than in a ref because the way out of this window is handed *to* the surface
+    // inside it, which happens while this component renders — and a ref is a value a render may not read. What that
+    // costs is one further render as the element arrives, which is the render that then opens it.
+    const [standing, setStanding] = useState<HTMLDialogElement | null>(null);
+
+    // The one way out, and every other one leads here: the surface's own close control, Escape, and the back gesture
+    // all arrive at the element's `close` so the platform hands focus back on each of them.
+    const close = useCallback(() => {
+        standing?.close();
+    }, [standing]);
+
+    // The one imperative browser API this surface synchronizes with, which is the whole of what an effect is for. It
+    // runs when the element arrives, and the element is in the document exactly as long as the window is open.
+    useEffect(() => {
+        standing?.showModal();
+    }, [standing]);
+
+    // It stands over the message, so the back gesture closes it before it navigates anywhere, and going to another
+    // destination leaves it behind rather than over the screen somebody arrives at.
+    useScreenLayer(true, close);
+
+    return (
+        <dialog
+            ref={setStanding}
+            aria-label={label}
+            onClose={onClosed}
+            // The insets are the screen's here rather than the frame's, exactly as they are for the settings surface: a
+            // modal dialog stands in the platform's own top layer, so the padding the frame carries is not around it.
+            className={`fixed inset-x-0 top-0 bottom-navigation m-0 mb-safe-bottom h-auto max-h-none w-auto max-w-none overflow-hidden rounded-none border-0 bg-panel p-0 text-text open:flex open:flex-col workspace:bottom-0 workspace:mb-0 panes:inset-0 panes:m-auto panes:rounded-window panes:border panes:border-line panes:shadow-dialog panes:backdrop:bg-scrim ${windowSizes[drawn]}`}
+        >
+            {children(close)}
+        </dialog>
+    );
+}

--- a/frontend/src/Client.App/src/mailSpace/useOpenTabs.ts
+++ b/frontend/src/Client.App/src/mailSpace/useOpenTabs.ts
@@ -57,12 +57,12 @@ export interface OpenTabsInForce {
     readonly closeFullHtml: () => void;
 
     /**
-     * Opens one file a message carries, in the reading column.
+     * Opens one file a message carries.
      *
-     * In a tab of its own where the person works in tabs, so the message it was opened from stays open beside it. Where
-     * they do not, it stands in front of that message exactly as a conversation does — which is the one place this
-     * differs from opening a message, and it differs because a file is opened *from* what is on the screen rather than
-     * instead of it: replacing the one tab there is would close the message the reader is going back to.
+     * In a tab of its own in the reading column where the person works in tabs, so the message it was opened from stays
+     * open beside it. Where they do not, it stands in front of that message in a window over it — which is the one
+     * place this differs from opening a message, and it differs because a file is opened *from* what is on the screen
+     * rather than instead of it: replacing the one tab there is would close the message the reader is going back to.
      */
     readonly openAttachment: (opened: OpenedAttachment) => void;
 
@@ -166,8 +166,8 @@ export function useOpenTabs(inTabs: boolean): OpenTabsInForce {
         },
 
         // The surface is a tab of its own only where a person works in tabs. Where they do not there is one reading
-        // column and nothing to put a second tab beside, so the surface stands in front of the message the way a
-        // conversation does — which is what makes closing it a return to that message rather than to nothing.
+        // column and nothing to put a second tab beside, so the surface stands in front of the message in a window over
+        // it — which is what makes closing it a return to that message rather than to nothing.
         openFullHtml: (storedEmailId, subject) => {
             if (!inTabs) {
                 revise({ fullHtml: storedEmailId });

--- a/frontend/src/Client.App/src/readingPane/AttachmentView.tsx
+++ b/frontend/src/Client.App/src/readingPane/AttachmentView.tsx
@@ -21,9 +21,10 @@ import { sizeOf } from '../localization/octets';
 import { kindOf } from './fileKind';
 import { shownAttachment, type NotShown } from './shownAttachment';
 
-// One file a message carries, opened inside the client instead of saved. It stands where the message was — in the
-// reading column, as the fourth kind of tab the design project draws — and closing it is a return to that message
-// rather than a way out of the client.
+// One file a message carries, opened inside the client instead of saved. It stands with the message — in the reading
+// column as the fourth kind of tab the design project draws where somebody works in tabs, and over the message in
+// `mailSpace/SurfaceWindow.tsx` where they do not — and closing it is a return to that message rather than a way out of
+// the client. Which of the two it is put in is the composition root's, so nothing here asks.
 //
 // **What it shows is decided before anything is fetched**, by `shownAttachment.ts` beside it, which is where the two
 // shapes this client draws and the reasoning behind each of them live. A file of any other kind, and a file of either

--- a/frontend/src/Client.App/src/styles.css
+++ b/frontend/src/Client.App/src/styles.css
@@ -188,6 +188,12 @@
     --radius-3xl: 0.875rem;
     --radius-4xl: 1.125rem;
 
+    /* The one corner outside that ladder, and it belongs to two surfaces: the window a message's own markup and an
+       opened file stand in over the message. The design project cuts both at a corner of its own rather than at the
+       one it gives a card, so the value is named here for the surfaces that read it instead of being rounded onto the
+       nearest rung — a rung the ladder does not have. */
+    --radius-window: 0.8125rem;
+
     /* The three widths the shell is composed at, and they are the design project's own numbers rather than three
        roundings of one idea. The project's prototype asks exactly these three questions of the width it was given, and
        the client asks them under these names — so the four compositions the project frames fall out of the same
@@ -267,6 +273,17 @@
        Below the workspace breakpoint neither is read, because the surface is the screen. */
     --spacing-settings: 28.75rem;
     --spacing-settings-card: min(78vh, 37.5rem);
+
+    /* The two windows that stand over the message where somebody does not work in tabs — the sender's own markup and an
+       opened file — in the composition where each is a window rather than the whole screen. Each is a width and a
+       height the design project draws it at, and each stops short of the viewport by the room the project leaves around
+       it, so the window never runs to the edge of the screen it is centred on. The two are separate names rather than
+       one because the project draws them at two sizes; below the pane breakpoint neither is read, the surface being the
+       screen there. */
+    --spacing-markup-window: min(62.5rem, calc(100% - 3.25rem));
+    --spacing-markup-window-tall: min(90vh, calc(100% - 3.25rem));
+    --spacing-file-window: min(58.75rem, calc(100% - 3.5rem));
+    --spacing-file-window-tall: min(88vh, calc(100% - 3.5rem));
 
     /* The share of the sign-in screen its brand column takes above the split breakpoint, which the design draws as a
        proportion of the window rather than as a width — so the column and the form beside it keep their ratio at

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -903,13 +903,17 @@ test('describes an attached file before it is fetched, and fetches it only when 
 test('opens an attached file inside the client rather than handing it to the machine', async ({ page }) => {
     await openTheFirstMessage(page);
 
-    await page.getByRole('button', { name: 'Open orders.csv' }).click();
+    const openTheFile = page.getByRole('button', { name: 'Open orders.csv' });
 
-    // The file is drawn in the reading column under its own name, which is the whole of what opening one means: the
-    // person reads it where they were reading the message, and nothing was written to their machine to get there.
+    await openTheFile.click();
+
+    // The file is drawn under its own name in a window over the message, which is the whole of what opening one means
+    // where somebody does not work in tabs: the person reads it where they were reading the message, the message is
+    // still there underneath, and nothing was written to their machine to get there.
     const viewer = page.getByRole('region', { name: 'orders.csv' });
     await expect(viewer.getByRole('heading', { name: 'orders.csv' })).toBeVisible();
     await expect(viewer.getByText(/kettle,1/u)).toBeVisible();
+    await expect(page.getByRole('article', messageRegion)).toBeVisible();
 
     // Only a browser can say the octets the built bundle read were decoded rather than drawn as a download: jsdom has
     // no download of its own to distinguish it from.
@@ -918,6 +922,7 @@ test('opens an attached file inside the client rather than handing it to the mac
     await viewer.getByRole('button', { name: 'Close orders.csv' }).click();
 
     await expect(page.getByRole('article', messageRegion)).toBeVisible();
+    await expect(openTheFile).toBeFocused();
 });
 
 test('presents the credential the bundle composed when it fetches an attached file', async ({ page }) => {
@@ -1001,32 +1006,49 @@ test('runs nothing the markup carries, and reaches no host but its own until the
     await showTheSenderMarkup(page);
     await expect(page.locator(`iframe[title="${markupFrame}"]`)).toBeVisible();
 
+    // Scoped to the surface, because the message it stands over is still drawn underneath and offers the same ask: the
+    // window is what the reader is looking at, and it is that one's promise being asserted.
+    const surface = page.getByRole('region', { name: "The sender's own version of this message" });
+
     // The script inside the frame fetches from a host of its own, so a request to it would be that script having run.
     // The picture's host is the other half: the representation carries no address for it until the reader asks, so a
     // frame that fetched one would be drawing markup this client composed rather than the one it was served. The
     // sentence under the frame is the design project's own wording of that promise, which #1693 brought the surface to.
-    await expect(page.getByText(/scripts and remote content are blocked/)).toBeVisible();
+    await expect(surface.getByText(/scripts and remote content are blocked/)).toBeVisible();
     expect([...hosts]).not.toContain(messages.senderScriptHost);
     expect([...hosts]).not.toContain(messages.senderPictureHost);
 
-    await page.getByRole('button', { name: 'Load pictures from the sender' }).click();
+    await surface.getByRole('button', { name: 'Load pictures from the sender' }).click();
 
     // Asking is what makes the request, on this surface exactly as in the pane. The script is unaffected by it: the
     // consent restores addresses and never restores anything that runs.
-    await expect(page.getByText(/their servers can tell it was opened/)).toBeVisible();
+    await expect(surface.getByText(/their servers can tell it was opened/)).toBeVisible();
     await expect.poll(() => [...hosts]).toContain(messages.senderPictureHost);
     expect([...hosts]).not.toContain(messages.senderScriptHost);
 });
 
+// What only a browser can say about the shape the two surfaces take where somebody does not work in tabs: the design
+// project draws each as a window over the message, and a window is the platform's own modal — which jsdom carries the
+// element of and none of the behaviour of. So the focus handed back as it closes is asserted here and nowhere else.
 test('leaves the markup surface for the message it was opened from, and asks again next time', async ({ page }) => {
     await openTheFirstMessage(page);
+
+    const showTheMarkup = page.getByRole('button', { name: 'Show the full HTML version' });
+
     await showTheSenderMarkup(page);
     await expect(page.locator(`iframe[title="${markupFrame}"]`)).toBeVisible();
+
+    // The message is still where it was rather than replaced, which is what a window over it means.
+    await expect(page.getByRole('heading', messageHeading)).toBeVisible();
 
     await page.getByRole('button', { name: 'Close this view' }).click();
 
     await expect(page.getByRole('heading', messageHeading)).toBeVisible();
     await expect(page.locator(`iframe[title="${markupFrame}"]`)).toHaveCount(0);
+
+    // Closing a modal hands focus back to what opened it, and that is the whole reason every way out of the window
+    // leaves through the element rather than by taking the surface off the screen from underneath it.
+    await expect(showTheMarkup).toBeFocused();
 
     // Nothing on either side wrote the answer down, so the control asks again rather than reopening what was shown.
     await page.getByRole('button', { name: 'Show the full HTML version' }).click();


### PR DESCRIPTION
Closes #1729

Where somebody works in tabs, the sender's own markup and an opened file keep opening as tabs of their own and nothing about them moves. Where they do not, each was taking the reading column: opening one replaced the message it was opened from, so the reader lost what they were reading in order to look at part of it. The design project draws a window over the message instead, and this is that window.

## What it is

`mailSpace/SurfaceWindow.tsx` is one component both surfaces stand in, and it is the platform's own `dialog` opened with `showModal()` — the same choice `settings/Settings.tsx` and `fullHtml/ShowFullHtml.tsx` make, for the same reason. Focus moves in and is kept, Escape leaves it, the page behind it is out of reach, and closing hands focus back to the control that opened it. Five obligations the element already holds, and a hand-written trap would be a second, worse implementation of each. It registers with `useScreenLayer`, so the back gesture closes it before it navigates and a change of destination leaves it behind.

**Every way out leaves through the element's own `close`.** The surface inside is handed the way to close the window rather than the way to clear what the workspace holds, so its close control, Escape, and the back gesture all arrive at one `close` event and the platform restores focus on each. Taking the surface off the screen from underneath instead would remove an open modal from the document, which closes it and hands focus to nothing. That is why the surface is given a render prop rather than rendered directly.

Three compositions, all of them width variants on the element, and all three the design project's own — read out of the prototype rather than chosen here:

| Width | What is drawn |
|---|---|
| Below 700 | The whole screen, stopping above the bottom navigation |
| 700 to 819 | The whole screen |
| 820 and up | A window centred over the scrim, at the size the project draws for markup and the other one it draws for a file |

## What moved with it

- `App.tsx` decides the shape from `inTabs` and nothing else. In tabs the surface *is* the reading column; outside them the reading pane or the thread goes on drawing underneath and the window stands over it.
- The two surfaces stop counting in `inFrontOfTheList`, the back-gesture arithmetic, where they are windows — a window is already a screen layer, and counting it twice would spend two presses on one window.
- `covered` — what tells the reading pane it is being arrived at rather than landed on — stops counting them for the same reason. The pane is never unmounted by a window, and what places focus as the window goes is the platform handing it back to the control that opened it; a pane taking focus would take it off that control.
- Four size tokens and one radius join the token layer, because a value is written there and nowhere else. `--radius-window` is the corner the project cuts both windows at, which is not a rung the radius ladder has.

## Verification

- The unit suite covers both halves of the mode decision — a window over a message still drawn, and a tab in the reading column with no dialog — plus the window's own four behaviours over a stand-in surface: it opens as a modal named for what stands in it, it draws what it was given, the surface's own way out goes through the element, and it stands as exactly one screen layer.
- The browser suite is where a real modal is asked the thing jsdom carries none of: the focus handed back to the control that opened it, for both surfaces. Its markup spec is now scoped to the surface region, because the message underneath offers the same "load pictures" control and a page-wide query matched both — a genuine consequence of the message still being there.
- The `full-html` parity pair was captured at both compositions the manifest names. The window's frame, its position and size, its head, its foot, and the scrim match the design; what still differs is the mail inside it and the shell behind the scrim, which are two different mock corpora rather than anything a client change reaches, and the remote-picture control in the foot, which this issue puts out of scope.

Nothing about what either surface shows changed, and the design project was read and not written to.
