### PR TITLE
[#1733] Load the client endpoint's TLS certificates from a step a test can reach

### DIFF
--- a/backend/src/Host/HostCertificates.cs
+++ b/backend/src/Host/HostCertificates.cs
@@ -26,16 +26,17 @@ internal static class HostCertificates
     /// <summary>Names the certificate store of every surface this deployment terminates TLS on.</summary>
     /// <param name="surfaces">What the composition settled about the surfaces this deployment serves.</param>
     /// <returns>One service key per store, <see langword="null" /> naming the unkeyed store the protocol surface owns.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="surfaces" /> is <see langword="null" />.</exception>
     /// <remarks>
     /// Separate from <see cref="LoadAsync" /> so that a test can hold this list against the stores
     /// <see cref="HostComposition" /> actually registered. That comparison is the whole guard: a surface added to the
     /// registration and to the handshake lookup but not here fails the suite instead of shipping a mute listener.
+    /// <para>
+    /// The argument is guarded by <see cref="LoadAsync" /> rather than here, because an iterator defers its own guard to
+    /// the first enumeration and would therefore report the fault at whichever line happened to enumerate it.
+    /// </para>
     /// </remarks>
     internal static IEnumerable<object?> TlsTerminatingStoreKeys(ComposedHostSurfaces surfaces)
     {
-        ArgumentNullException.ThrowIfNull(surfaces);
-
         if (surfaces.Mcp is { Enabled: true, TerminatesTls: true })
         {
             yield return null;
@@ -69,6 +70,7 @@ internal static class HostCertificates
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(surfaces);
 
         foreach (var storeKey in TlsTerminatingStoreKeys(surfaces))
         {

--- a/backend/src/Host/HostCertificates.cs
+++ b/backend/src/Host/HostCertificates.cs
@@ -1,0 +1,84 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Host.Security.Endpoints;
+using MailFathom.Host.Security.Transport;
+
+namespace MailFathom.Host;
+
+/// <summary>Loads the TLS material every surface this deployment terminates TLS on will present.</summary>
+/// <remarks>
+/// <para>
+/// A callable step rather than lines in the top-level statements that used to hold it, for the reason
+/// <see cref="HostComposition" /> is one: statements written there cannot be called, so nothing could assert that a
+/// surface whose store the composition registers is a surface the startup path loads. It was not asserted and the
+/// client surface was not loaded — the store was registered and consulted, the listener bound, and every handshake on
+/// its port was refused by a lookup that had never been filled.
+/// </para>
+/// <para>
+/// It runs after the container exists and before the server is started, which is what makes unusable material a startup
+/// failure with nothing listening rather than a listener that binds and then refuses per connection.
+/// </para>
+/// </remarks>
+internal static class HostCertificates
+{
+    /// <summary>Names the certificate store of every surface this deployment terminates TLS on.</summary>
+    /// <param name="surfaces">What the composition settled about the surfaces this deployment serves.</param>
+    /// <returns>One service key per store, <see langword="null" /> naming the unkeyed store the protocol surface owns.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="surfaces" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// Separate from <see cref="LoadAsync" /> so that a test can hold this list against the stores
+    /// <see cref="HostComposition" /> actually registered. That comparison is the whole guard: a surface added to the
+    /// registration and to the handshake lookup but not here fails the suite instead of shipping a mute listener.
+    /// </remarks>
+    internal static IEnumerable<object?> TlsTerminatingStoreKeys(ComposedHostSurfaces surfaces)
+    {
+        ArgumentNullException.ThrowIfNull(surfaces);
+
+        if (surfaces.Mcp is { Enabled: true, TerminatesTls: true })
+        {
+            yield return null;
+        }
+
+        if (surfaces.Admin is { Enabled: true, TerminatesTls: true })
+        {
+            yield return HostComposition.AdminCertificateStoreKey;
+        }
+
+        if (surfaces.Client is { Enabled: true, TerminatesTls: true })
+        {
+            yield return HostComposition.ClientEndpointCertificateStoreKey;
+        }
+    }
+
+    /// <summary>Loads every store above, and the probe surface's own certificate.</summary>
+    /// <param name="services">The built container the stores were registered in.</param>
+    /// <param name="surfaces">What the composition settled about the surfaces this deployment serves.</param>
+    /// <param name="cancellationToken">Cancels the material retrieval.</param>
+    /// <returns>A task that completes once every profile this deployment presents has a usable identity.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The probe certificate is loaded unconditionally because its holder answers for its own surface being unserved or
+    /// clear-text, which the stores above cannot: each of them is one endpoint's material and an endpoint that
+    /// terminates no TLS has none to load.
+    /// </remarks>
+    internal static async Task LoadAsync(
+        IServiceProvider services,
+        ComposedHostSurfaces surfaces,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        foreach (var storeKey in TlsTerminatingStoreKeys(surfaces))
+        {
+            var store = storeKey is null
+                ? services.GetRequiredService<TransportServerCertificateStore>()
+                : services.GetRequiredKeyedService<TransportServerCertificateStore>(storeKey);
+
+            await store.LoadAsync(cancellationToken);
+        }
+
+        await services.GetRequiredService<HealthEndpointCertificate>().LoadAsync(cancellationToken);
+    }
+}

--- a/backend/src/Host/Program.cs
+++ b/backend/src/Host/Program.cs
@@ -7,8 +7,6 @@ using MailFathom.Host.Configuration;
 using MailFathom.Host.Configuration.Provisioning;
 using MailFathom.Host.Configuration.RootSettings;
 using MailFathom.Host.Observability;
-using MailFathom.Host.Security.Endpoints;
-using MailFathom.Host.Security.Transport;
 
 // Composed before anything else, CreateBuilder included, so that a malformed appsettings.json, a failure during
 // composition, and a failed host start are all reported rather than only printed. The pipeline the container owns
@@ -53,22 +51,11 @@ try
     // Before the server starts rather than from a hosted service, because a hosted service could be started after the
     // web host and a certificate proven then would be proven after the listener was already open. A profile whose
     // material is missing, expired, or issued for another domain therefore fails startup with nothing listening.
-    if (composition.Mcp.Enabled && composition.Mcp.TerminatesTls)
-    {
-        await app.Services.GetRequiredService<TransportServerCertificateStore>()
-            .LoadAsync(app.Lifetime.ApplicationStopping);
-    }
-
-    if (composition.Admin.Enabled && composition.Admin.TerminatesTls)
-    {
-        await app.Services.GetRequiredKeyedService<TransportServerCertificateStore>(HostComposition.AdminCertificateStoreKey)
-            .LoadAsync(app.Lifetime.ApplicationStopping);
-    }
-
-    // For the same reason, and with the same outcome: a TLS transport whose material is unusable fails startup with
-    // nothing listening rather than downgrading the probe port to clear text.
-    await app.Services.GetRequiredService<HealthEndpointCertificate>()
-        .LoadAsync(app.Lifetime.ApplicationStopping);
+    //
+    // In one callable place rather than here, for the reason the service graph and the pipeline are: top-level
+    // statements cannot be called, and a surface whose store is registered but never loaded is one no test could have
+    // caught — it binds its listener and refuses every handshake on it.
+    await HostCertificates.LoadAsync(app.Services, composition, app.Lifetime.ApplicationStopping);
 
     // Every middleware and every route this deployment serves, composed in one callable place rather than here, for
     // the reason the service graph is: top-level statements cannot be called, and a misordered pipeline written in

--- a/backend/src/Host/Security/Transport/TransportServerCertificateStore.cs
+++ b/backend/src/Host/Security/Transport/TransportServerCertificateStore.cs
@@ -179,9 +179,17 @@ internal sealed partial class TransportServerCertificateStore : IDisposable
 
     /// <summary>Records that a profile has an identity, and how long that identity lasts.</summary>
     /// <remarks>
+    /// <para>
     /// The profile name and the expiry instant are the whole of it. The subject, the serial number, and the thumbprint
     /// are deliberately absent: they identify the certificate wherever this log is read or shipped, and an operator
     /// renewing it needs to know which profile and by when, not which certificate it was.
+    /// </para>
+    /// <para>
+    /// The section the profile was configured under is named beside them, because one store exists per endpoint and the
+    /// profile name alone is an operator's own word for one of several. Both messages said <c>MCP</c> instead, from when
+    /// that was the only surface terminating TLS, so an administrative or client profile was announced as a protocol
+    /// one — which is the record an operator diagnoses a refused handshake from.
+    /// </para>
     /// </remarks>
     private void ReportLoaded(string profileName, X509Certificate2 leaf)
     {
@@ -189,12 +197,12 @@ internal sealed partial class TransportServerCertificateStore : IDisposable
 
         if (ServerCertificateExpiry.IsExpiringSoon(expiration, this.timeProvider.GetUtcNow()))
         {
-            this.LogServerCertificateExpiringSoon(profileName, expiration);
+            this.LogServerCertificateExpiringSoon(this.configurationSectionPath, profileName, expiration);
 
             return;
         }
 
-        this.LogServerCertificateLoaded(profileName, expiration);
+        this.LogServerCertificateLoaded(this.configurationSectionPath, profileName, expiration);
     }
 
     /// <inheritdoc />
@@ -215,13 +223,21 @@ internal sealed partial class TransportServerCertificateStore : IDisposable
 
     [LoggerMessage(
         Level = LogLevel.Information,
-        Message = "The MCP HTTPS profile {HttpsProfileName} presents a server certificate valid until {ServerCertificateExpiration:u}.")]
-    private partial void LogServerCertificateLoaded(string httpsProfileName, DateTimeOffset serverCertificateExpiration);
+        Message = "The HTTPS profile {HttpsProfileName} configured under {HttpsConfigurationSection} presents a server "
+            + "certificate valid until {ServerCertificateExpiration:u}.")]
+    private partial void LogServerCertificateLoaded(
+        string httpsConfigurationSection,
+        string httpsProfileName,
+        DateTimeOffset serverCertificateExpiration);
 
     [LoggerMessage(
         Level = LogLevel.Warning,
-        Message = "The MCP HTTPS profile {HttpsProfileName} presents a server certificate that expires at {ServerCertificateExpiration:u}. "
+        Message = "The HTTPS profile {HttpsProfileName} configured under {HttpsConfigurationSection} presents a server "
+            + "certificate that expires at {ServerCertificateExpiration:u}. "
             + "Renew it before then: once it expires the profile stops starting, because a certificate outside its validity "
             + "period is refused rather than served.")]
-    private partial void LogServerCertificateExpiringSoon(string httpsProfileName, DateTimeOffset serverCertificateExpiration);
+    private partial void LogServerCertificateExpiringSoon(
+        string httpsConfigurationSection,
+        string httpsProfileName,
+        DateTimeOffset serverCertificateExpiration);
 }

--- a/backend/src/Host/Security/Transport/TransportServerCertificateStore.cs
+++ b/backend/src/Host/Security/Transport/TransportServerCertificateStore.cs
@@ -197,12 +197,12 @@ internal sealed partial class TransportServerCertificateStore : IDisposable
 
         if (ServerCertificateExpiry.IsExpiringSoon(expiration, this.timeProvider.GetUtcNow()))
         {
-            this.LogServerCertificateExpiringSoon(this.configurationSectionPath, profileName, expiration);
+            this.LogServerCertificateExpiringSoon(profileName, this.configurationSectionPath, expiration);
 
             return;
         }
 
-        this.LogServerCertificateLoaded(this.configurationSectionPath, profileName, expiration);
+        this.LogServerCertificateLoaded(profileName, this.configurationSectionPath, expiration);
     }
 
     /// <inheritdoc />
@@ -226,8 +226,8 @@ internal sealed partial class TransportServerCertificateStore : IDisposable
         Message = "The HTTPS profile {HttpsProfileName} configured under {HttpsConfigurationSection} presents a server "
             + "certificate valid until {ServerCertificateExpiration:u}.")]
     private partial void LogServerCertificateLoaded(
-        string httpsConfigurationSection,
         string httpsProfileName,
+        string httpsConfigurationSection,
         DateTimeOffset serverCertificateExpiration);
 
     [LoggerMessage(
@@ -237,7 +237,7 @@ internal sealed partial class TransportServerCertificateStore : IDisposable
             + "Renew it before then: once it expires the profile stops starting, because a certificate outside its validity "
             + "period is refused rather than served.")]
     private partial void LogServerCertificateExpiringSoon(
-        string httpsConfigurationSection,
         string httpsProfileName,
+        string httpsConfigurationSection,
         DateTimeOffset serverCertificateExpiration);
 }

--- a/backend/tests/Host.UnitTests/HostCompositionTests.cs
+++ b/backend/tests/Host.UnitTests/HostCompositionTests.cs
@@ -3,9 +3,11 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Xml.Linq;
 using MailFathom.Application.Access;
 using MailFathom.Application.SensitiveContent.Egress;
+using MailFathom.Host.Configuration.Endpoints;
 using MailFathom.Host.Hosting;
 using MailFathom.Host.Hosting.Startup;
 using MailFathom.Host.Security.Transport;
@@ -110,6 +112,22 @@ public sealed class HostCompositionTests
         new("McpEndpoint:Authentication:0:OAuth:AuthorizationServers:0:Issuer", "https://sso.example.test/realms/mailfathom"),
     ];
 
+    /// <summary>Writes one HTTPS profile under a surface's section, which is what makes that surface terminate TLS.</summary>
+    /// <remarks>
+    /// The material is inline rather than a file, for the reason every other secret in these shapes is: the startup
+    /// validator resolves each reference while the graph is resolved, and a path on the machine running the suite would
+    /// decide whether a shape composes. Nothing here opens the material — a shape composes a service graph and starts no
+    /// server — so what the profile has to be is bindable and valid rather than loadable.
+    /// </remarks>
+    private static KeyValuePair<string, string?>[] HttpsProfile(string sectionName, string profileName, int port) =>
+    [
+        new($"{sectionName}:Https:Endpoints:0:Name", profileName),
+        new($"{sectionName}:Https:Endpoints:0:Domain", $"{profileName}.example.test"),
+        new($"{sectionName}:Https:Endpoints:0:Port", port.ToString(CultureInfo.InvariantCulture)),
+        new($"{sectionName}:Https:Endpoints:0:ServerCertificate:Bundle:Name", $"{profileName}-certificate"),
+        new($"{sectionName}:Https:Endpoints:0:ServerCertificate:Bundle:SecretReference", "plaintext:not-a-real-certificate-bundle"),
+    ];
+
     /// <summary>Each deployment shape, as the configuration an operator would have written to reach it.</summary>
     /// <remarks>
     /// Written as configuration rather than as flags, because that is the input the composition actually reads: the
@@ -134,6 +152,35 @@ public sealed class HostCompositionTests
                 new("ClientEndpoint:Enabled", "true"),
                 new("ClientEndpoint:Port", "8084"),
                 new("ClientEndpoint:Authentication:0:Method", "api-key"),
+            ],
+
+            // The deployment the client surface was refusing every handshake on, and the smallest shape that reaches
+            // the certificate store nobody loaded: one endpoint, terminating its own TLS, with no other surface served.
+            ["client terminating its own tls"] =
+            [
+                new("ClientEndpoint:Enabled", "true"),
+                new("ClientEndpoint:Transport", "HttpsOnly"),
+                new("ClientEndpoint:Authentication:0:Method", "api-key"),
+                .. HttpsProfile(ClientEndpointOptions.SectionName, "client", 8445),
+            ],
+
+            // Every store the composition registers, all three published at once, which is the only shape in which the
+            // registration list and the loading list can be held against each other in full.
+            ["every surface terminating tls"] =
+            [
+                new("McpEndpoint:Enabled", "true"),
+                new("McpEndpoint:Transport", "HttpsOnly"),
+                new("McpEndpoint:Authentication:0:Method", "api-key"),
+                .. HttpsProfile(McpEndpointOptions.SectionName, "mcp", 8443),
+                new("AdminEndpoint:Enabled", "true"),
+                new("AdminEndpoint:Transport", "HttpsOnly"),
+                new("AdminEndpoint:Authentication:0:ApiKey:Name", "operator"),
+                new("AdminEndpoint:Authentication:0:ApiKey:SecretReference", "plaintext:not-a-real-key-either"),
+                .. HttpsProfile(AdminEndpointOptions.SectionName, "admin", 8444),
+                new("ClientEndpoint:Enabled", "true"),
+                new("ClientEndpoint:Transport", "HttpsOnly"),
+                new("ClientEndpoint:Authentication:0:Method", "api-key"),
+                .. HttpsProfile(ClientEndpointOptions.SectionName, "client", 8445),
             ],
 
             // One shape per accepted method, because each registers services the others do not: a password entry adds
@@ -375,6 +422,48 @@ public sealed class HostCompositionTests
         Assert.False(surfaces.Admin.Enabled);
         Assert.NotNull(surfaces.ClientRateLimits);
         Assert.NotNull(surfaces.ClientRequestTimeout);
+    }
+
+    /// <summary>
+    /// The registration and the loading are two lists that nothing else holds against each other. The client surface's
+    /// store was registered here and consulted on every handshake while the startup path loaded only the other two, so
+    /// its listener bound and then refused every connection — with no test naming the store to report the asymmetry.
+    /// A fourth surface added to the registration and not to the loading fails here instead of shipping mute.
+    /// </summary>
+    [Fact]
+    public void TlsTerminatingStoreKeys_NameEveryCertificateStoreTheCompositionRegistered()
+    {
+        // Arrange
+        var builder = ConfiguredBuilder("every surface terminating tls");
+
+        // Act
+        var surfaces = HostComposition.Compose(builder);
+
+        // Assert
+        var registeredStoreKeys = builder.Services
+            .Where(static registration => registration.ServiceType == typeof(TransportServerCertificateStore))
+            .Select(static registration => registration.ServiceKey)
+            .ToHashSet();
+
+        Assert.Equal(registeredStoreKeys, HostCertificates.TlsTerminatingStoreKeys(surfaces).ToHashSet());
+    }
+
+    /// <summary>
+    /// The deployment the defect was observed on: the client endpoint alone, terminating its own TLS. Its store is what
+    /// the handshake callback consults for that listener, so a startup path that names the other two surfaces and not
+    /// this one leaves the client page and every route beneath it unreachable over the only transport it opened.
+    /// </summary>
+    [Fact]
+    public void TlsTerminatingStoreKeys_WithTheClientSurfaceAlone_NameTheClientsOwnStore()
+    {
+        // Arrange
+        var builder = ConfiguredBuilder("client terminating its own tls");
+
+        // Act
+        var storeKeys = HostCertificates.TlsTerminatingStoreKeys(HostComposition.Compose(builder));
+
+        // Assert
+        Assert.Equal([HostComposition.ClientEndpointCertificateStoreKey], storeKeys);
     }
 
     /// <summary>

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -2055,6 +2055,12 @@ the page is the one part that is refused rather than warned about, for the reaso
 refusal is about publishing a page rather than about a credential, which is why a deployment can accept a password on
 this port while still having to declare that the page may be served over it.
 
+**A profile this endpoint terminates TLS with is loaded before the server starts**, on the same terms as the other two
+surfaces': material that is missing, expired, or issued for another domain fails startup with nothing listening, rather
+than binding a listener that then refuses every connection. The startup record names each profile it loaded and the
+section it was configured under, so `ClientEndpoint:Https` is what an operator reads this endpoint's profiles back
+from; [rotating a server certificate](secret-rotation.md) is what renewing one takes.
+
 ## Serving the client from the deployment
 
 **Every published image carries the page**, built into it from the client workspace under `frontend/` and copied

--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -1371,11 +1371,15 @@ Startup records what each profile presents and when it stops working:
 
 ```text
 info: MailFathom.Host.Security.Transport.TransportServerCertificateStore
-      The MCP HTTPS profile public presents a server certificate valid until 2027-01-31 00:00:00Z.
+      The HTTPS profile public configured under McpEndpoint:Https presents a server certificate valid until
+      2027-01-31 00:00:00Z.
 ```
 
 Within thirty days of expiry the same line is a warning instead. Neither carries the certificate's subject, serial
 number, or thumbprint: an operator renewing it needs to know which profile and by when, not which certificate it was.
+The section is named beside the profile because each endpoint that terminates TLS has profiles of its own, and a
+profile name is an operator's own word rather than one that identifies a surface — so the line an operator reads while
+diagnosing the administrative or the client endpoint names that endpoint's own section.
 
 **Replacing certificate material takes a restart.** The profiles are read once while the host is composed, like the rest
 of this section, and the loaded certificates are held for the process lifetime. Renew the material, then restart; startup

--- a/docs/operations/secret-rotation.md
+++ b/docs/operations/secret-rotation.md
@@ -109,9 +109,9 @@ Renew before the certificate expires rather than after. Startup reports the expi
 that line into a warning within thirty days:
 
 ```
-warn: The MCP HTTPS profile public presents a server certificate that expires at 2027-01-31 00:00:00Z. Renew it before
-      then: once it expires the profile stops starting, because a certificate outside its validity period is refused
-      rather than served.
+warn: The HTTPS profile public configured under McpEndpoint:Https presents a server certificate that expires at
+      2027-01-31 00:00:00Z. Renew it before then: once it expires the profile stops starting, because a certificate
+      outside its validity period is refused rather than served.
 ```
 
 Connections already accepted finish on the certificate they negotiated; the restart is what ends them, as it ends every


### PR DESCRIPTION
## What this changes

The client endpoint's certificate store was registered by the composition and consulted by the handshake callback, and
nothing ever loaded it. `Program.cs` loaded two of the three stores — the MCP one and the administrative one — and the
client's stayed at its initial `FrozenDictionary.Empty`, so `Find` answered `null` for every listener and every server
name. `TransportHttpsEndpointBinder.SelectIdentity` reads that `null` as *no profile publishes this name* and throws an
`AuthenticationException`, which ends the connection before a certificate is presented. A deployment with
`ClientEndpoint:Transport` set to `HttpsOnly` or `HttpAndHttps` therefore bound its listener, reported
`Now listening on: https://…`, and refused every handshake on it — the client page and every route under
`/api/client` unreachable over the only transport `HttpsOnly` opens.

Three parts:

- **`HostCertificates` is the loading step**, moved out of the top-level statements that held it. That is the whole
  reason the defect was invisible: `Program.cs` says of its own composition that *top-level statements cannot be
  called*, and the certificate loading was the one composition-root step that stayed in the file that reasoning had
  moved everything else out of. It now runs from one callable place, in the same position in the startup sequence and
  with the same outcome — material that is missing, expired, or issued for another domain fails startup with nothing
  listening.
- **`TlsTerminatingStoreKeys` is separate from `LoadAsync` so a test can hold the two lists against each other.**
  `HostCompositionTests` composes a shape in which all three surfaces terminate TLS, reads every
  `TransportServerCertificateStore` descriptor out of the service collection, and asserts that the set of service keys
  matches the set the startup path loads. A fourth TLS surface added to the registration and to the handshake lookup
  but not to the loading now fails the suite rather than shipping a listener that answers nothing. A second test pins
  the reported deployment — the client endpoint alone, terminating its own TLS — to its own store. Both were confirmed
  to fail against the defect before being committed.
- **The two startup messages name the surface a profile belongs to.** Both read `The MCP HTTPS profile …`, from when
  that was the only surface terminating TLS, so an administrative or client profile was announced as a protocol one —
  which is the record an operator diagnoses a refused handshake from. They now name the configuration section the
  profile was written under, which is one store per endpoint and the identity a profile name alone does not carry.

## Documentation

`docs/operations/mcp-endpoint.md` and `docs/operations/secret-rotation.md` quoted the old line verbatim and now carry
the corrected wording. `docs/operations/client-endpoint.md` gains the paragraph that is now true of that endpoint: a
profile it terminates TLS with is loaded before the server starts, on the same terms as the other two surfaces', and
the startup record names `ClientEndpoint:Https` as the section it was read from. Nothing on those pages described a
handshake that could not have happened — what was missing was the statement of the guarantee, rather than a false one
to remove.

## Verification

`scripts/verify-full.sh` — passed over exactly this content. Both new tests were run against a deliberately broken
`TlsTerminatingStoreKeys` first and both failed, so neither passes vacuously.

## Not covered here

Proving the fixed handshake end to end needs a real TLS connection to a started host, which is the integration suite's
`mailfathom-mtls-host` shape rather than a unit test. The unit guard covers the asymmetry that produced the defect;
whether the handshake then completes is what the certificate store's own contract already guarantees for the two
surfaces that were loading.

Closes #1733
