### PR TITLE
[#1736] Omit the credentials on every request the client puts on the wire

### DIFF
--- a/frontend/src/Client.App/src/deployment/attachmentExchange.test.ts
+++ b/frontend/src/Client.App/src/deployment/attachmentExchange.test.ts
@@ -2,8 +2,14 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import { describe, expect, it } from 'vitest';
-import { attachmentOctetsOf, deliveryFailureOf, drawnFrom, showingFailureOf } from './attachmentExchange';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+    attachmentExchange,
+    attachmentOctetsOf,
+    deliveryFailureOf,
+    drawnFrom,
+    showingFailureOf,
+} from './attachmentExchange';
 
 // Three things are proven here. What an answer to the attachment route amounts to, asked of an answer this file
 // constructed; what a screen draws those octets as, asked of the octets themselves; and what each outcome becomes in
@@ -11,9 +17,12 @@ import { attachmentOctetsOf, deliveryFailureOf, drawnFrom, showingFailureOf } fr
 // because that reading is what an operator's own dimension is built from, and an outcome mapped to the wrong reason is
 // a dashboard saying a deployment is refusing what it delivered.
 //
-// The `fetch` that produces an answer is not called here and nothing patches it, which `frontend/tests/AGENTS.md`
-// § *What is faked, and where* holds as a rule and `attachmentUpload.ts` beside this module already follows. A real
-// exchange over the wire belongs to the browser suite, which drives the built bundle against a served deployment.
+// Nothing here stands a fake network in front of the `fetch` that produces an answer, which
+// `frontend/tests/AGENTS.md` § *What is faked, and where* holds as a rule and `attachmentUpload.ts` beside this module
+// already follows. A real exchange over the wire belongs to the browser suite, which drives the built bundle against a
+// served deployment. One thing beside those three is asked of the request instead of the answer: the credentials mode the
+// request goes out under, which is a property of what went out rather than of what came back, so `fetch` itself is
+// watched for it — `sendToDeployment.test.ts` states why.
 
 /** An answer whose octets arrive over a stream, which is the shape a ceiling has to hold during rather than after. */
 function answering(status: number, body: Uint8Array = new Uint8Array(0)): Response {
@@ -142,5 +151,30 @@ describe('showingFailureOf', () => {
     // than a person stopping the download is. Counting it would report a working policy as a deployment at fault.
     it('reports a screened file as an answer the client acted on rather than as a failure', () => {
         expect(showingFailureOf({ outcome: 'refused', refusal: 'screened' })).toBeNull();
+    });
+});
+
+describe('attachmentExchange', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('omits the credentials, as every request this client puts on the wire does', async () => {
+        const sent = vi.spyOn(globalThis, 'fetch').mockResolvedValue(answering(200));
+
+        await attachmentExchange.read(
+            {
+                method: 'GET',
+                path: 'https://mail.example/api/client/messages/m1/attachments/a1',
+                headers: { Accept: 'application/octet-stream' },
+            },
+            { as: 'text', charset: 'utf-8' },
+            new AbortController().signal,
+        );
+
+        expect(sent).toHaveBeenCalledWith(
+            'https://mail.example/api/client/messages/m1/attachments/a1',
+            expect.objectContaining({ credentials: 'omit' }),
+        );
     });
 });

--- a/frontend/src/Client.App/src/deployment/attachmentExchange.ts
+++ b/frontend/src/Client.App/src/deployment/attachmentExchange.ts
@@ -11,6 +11,7 @@ import {
 } from '@mailfathom/client-backend';
 import { readBoundedContent } from './boundedBody';
 import { asDataUrl } from './dataUrl';
+import { deploymentCredentials } from './sendToDeployment';
 
 // The two things the client does with one file a message carries: hand it to the person to keep, and show it inside the
 // client. Both are one boundary rather than two — one route, one credential, one bound, one way out — which is why they
@@ -204,6 +205,7 @@ async function fetchedOctets(
         response = await fetch(request.path, {
             method: request.method,
             headers: { ...request.headers },
+            credentials: deploymentCredentials,
             signal: abandoned,
         });
     } catch {

--- a/frontend/src/Client.App/src/deployment/attachmentUpload.test.ts
+++ b/frontend/src/Client.App/src/deployment/attachmentUpload.test.ts
@@ -2,12 +2,15 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import { describe, expect, it } from 'vitest';
-import { answerOf } from './attachmentUpload';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { answerOf, uploadAttachment } from './attachmentUpload';
 
 // What the client decides about an answer to an upload, asked of an answer this file constructed. The request that
-// produces one calls `fetch`, which nothing here patches — `frontend/tests/AGENTS.md` § *What is faked, and where*
-// holds that rule, and it is why the deciding half is a function of its own.
+// produces one calls `fetch`, which nothing here stands a fake network in front of — `frontend/tests/AGENTS.md`
+// § *What is faked, and where* holds that rule, and it is why the deciding half is a function of its own.
+//
+// The one thing asked of the request rather than of the answer is the credentials mode it goes out under, which no
+// constructed `Response` can report; `sendToDeployment.test.ts` states why that is watched on `fetch` itself.
 
 /** An answer whose octets arrive over a stream, which is the shape a ceiling has to hold during rather than after. */
 function answering(body: string, status = 200): Response {
@@ -55,5 +58,30 @@ describe('answerOf', () => {
 
     it('answers nothing for an answer carrying no body at all, rather than reading absence as empty', async () => {
         expect(await answerOf(new Response(null, { status: 204 }), 64)).toMatchObject({ status: 204, body: '' });
+    });
+});
+
+describe('uploadAttachment', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('omits the credentials, as every request this client puts on the wire does', async () => {
+        const sent = vi.spyOn(globalThis, 'fetch').mockResolvedValue(answering('{"attachmentId":"a1"}'));
+
+        await uploadAttachment(
+            {
+                method: 'POST',
+                path: 'https://mail.example/api/client/drafts/d1/attachments',
+                headers: { 'Content-Type': 'text/plain' },
+            },
+            new File(['note'], 'note.txt', { type: 'text/plain' }),
+            new AbortController().signal,
+        );
+
+        expect(sent).toHaveBeenCalledWith(
+            'https://mail.example/api/client/drafts/d1/attachments',
+            expect.objectContaining({ credentials: 'omit' }),
+        );
     });
 });

--- a/frontend/src/Client.App/src/deployment/attachmentUpload.ts
+++ b/frontend/src/Client.App/src/deployment/attachmentUpload.ts
@@ -5,6 +5,7 @@
 import { createContext, useContext } from 'react';
 import { longestResponseBody, type ClientRequest, type ClientResponse } from '@mailfathom/client-backend';
 import { readBoundedContent } from './boundedBody';
+import { deploymentCredentials } from './sendToDeployment';
 
 // Putting one file the author is attaching on the wire. It is the third module in this directory that calls `fetch`
 // and the second that carries octets: `Client.Backend` declares no DOM, so a `File`, a `Blob`, and an `AbortSignal`
@@ -46,6 +47,7 @@ export const uploadAttachment: AttachmentUpload = async (request, file, abandone
         const response = await fetch(request.path, {
             method: request.method,
             headers: { ...request.headers },
+            credentials: deploymentCredentials,
             body: file,
             signal: abandoned,
         });

--- a/frontend/src/Client.App/src/deployment/portraitExchange.test.ts
+++ b/frontend/src/Client.App/src/deployment/portraitExchange.test.ts
@@ -1,0 +1,31 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { portraitExchange } from './portraitExchange';
+
+// The credentials mode this module's two `fetch` calls put on a request, for the reason `sendToDeployment.test.ts`
+// states: it is a property of what went out, so `fetch` is what is watched. Both calls are asserted rather than the
+// read alone, because a write that kept the default would open the browser's dialog over the settings screen exactly
+// as the read would over the sign-in one.
+
+const session = { baseAddress: 'https://mail.example', authorization: 'Basic c2FtcGxl' };
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('portraitExchange', () => {
+    it('omits the credentials on the read and on the write alike', async () => {
+        const sent = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }));
+
+        await portraitExchange.read(session, new AbortController().signal);
+        await portraitExchange.remove(session);
+
+        expect(sent).toHaveBeenCalledTimes(2);
+        for (const [, options] of sent.mock.calls) {
+            expect(options?.credentials).toBe('omit');
+        }
+    });
+});

--- a/frontend/src/Client.App/src/deployment/portraitExchange.ts
+++ b/frontend/src/Client.App/src/deployment/portraitExchange.ts
@@ -15,6 +15,7 @@ import {
 } from '@mailfathom/client-backend';
 import { readBoundedContent } from './boundedBody';
 import { asDataUrl } from './dataUrl';
+import { deploymentCredentials } from './sendToDeployment';
 
 // The third module in this directory that calls `fetch`, and the third for the same reason: `Client.Backend` declares
 // no DOM, so a `Blob`, a `File`, and a `FileReader` can only be named on this side of the boundary. What that package
@@ -87,6 +88,7 @@ async function readPicture(request: ClientRequest, abandoned: AbortSignal): Prom
         response = await fetch(request.path, {
             method: request.method,
             headers: { ...request.headers },
+            credentials: deploymentCredentials,
             signal: abandoned,
         });
     } catch {
@@ -129,7 +131,12 @@ async function stated(request: ClientRequest, body: Blob | null): Promise<Portra
     let response: Response;
 
     try {
-        response = await fetch(request.path, { method: request.method, headers: { ...request.headers }, body });
+        response = await fetch(request.path, {
+            method: request.method,
+            headers: { ...request.headers },
+            credentials: deploymentCredentials,
+            body,
+        });
     } catch {
         return { outcome: 'refused', reason: 'unavailable' };
     }

--- a/frontend/src/Client.App/src/deployment/sendToDeployment.test.ts
+++ b/frontend/src/Client.App/src/deployment/sendToDeployment.test.ts
@@ -1,0 +1,33 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { sendToDeployment } from './sendToDeployment';
+
+// What the transport puts on the request, which is the one thing about this module no constructed `Response` can
+// answer: the credentials mode is a property of what went out rather than of what came back. So `fetch` itself is what
+// is watched here, and it is watched rather than replaced by a fake network — `frontend/tests/AGENTS.md` § *What is
+// faked, and where* refuses the second, and this is the module that calls it. What an answer amounts to is asked of an
+// answer this file could construct, exactly as `attachmentUpload.ts` beside it splits the same question.
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('sendToDeployment', () => {
+    it('omits the credentials, so a challenge reaches the client rather than the browser own dialog', async () => {
+        const sent = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 401 }));
+
+        await sendToDeployment(new AbortController().signal)({
+            method: 'GET',
+            path: 'https://mail.example/api/client/session',
+            headers: { Accept: 'application/json' },
+        });
+
+        expect(sent).toHaveBeenCalledWith(
+            'https://mail.example/api/client/session',
+            expect.objectContaining({ credentials: 'omit' }),
+        );
+    });
+});

--- a/frontend/src/Client.App/src/deployment/sendToDeployment.ts
+++ b/frontend/src/Client.App/src/deployment/sendToDeployment.ts
@@ -18,11 +18,26 @@ import { longestResponseBody, type MailFathomTransport } from '@mailfathom/clien
  */
 export type DeploymentTransport = (abandoned: AbortSignal) => MailFathomTransport;
 
+/**
+ * The credentials mode every request this client puts on the wire is sent under, stated here for all four call sites.
+ *
+ * The client endpoint refuses an uncredentialed request with `401` and names Basic in the challenge, which is what
+ * `signIn.ts` reads to decide whether a password may be sent to an address at all. The Fetch Standard has the user
+ * agent prompt for a username and password on exactly that answer whenever the request included credentials — and the
+ * default `same-origin` includes them for a client served by the deployment it is signing in to, so the browser's own
+ * dialog opens over the sign-in screen at the first request, before a password has been typed once, and the form is
+ * never reached. Omitting them leaves the challenge for the client to read, which is also what this surface already
+ * says about itself: its CORS policy allows no credentials, because the only one it has is the header
+ * `Client.Backend` composed.
+ */
+export const deploymentCredentials: RequestCredentials = 'omit';
+
 /** Puts one request on the wire, and reports what came back without deciding anything about it. */
 export const sendToDeployment: DeploymentTransport = (abandoned) => async (request) => {
     const response = await fetch(request.path, {
         method: request.method,
         headers: { ...request.headers },
+        credentials: deploymentCredentials,
         // `null` rather than the absent property, because the compiler is told an optional property is genuinely
         // absent rather than present and undefined — and `fetch` reads the two the same way.
         body: request.body ?? null,

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -5,7 +5,7 @@
 import { execFileSync } from 'node:child_process';
 import { readdir, readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
-import { expect, test, type Browser, type Locator, type Page, type Route } from '@playwright/test';
+import { expect, test, type Browser, type Locator, type Page, type Request, type Route } from '@playwright/test';
 
 import * as deployment from './fixtures/deployment';
 import * as mail from './fixtures/mail';
@@ -361,6 +361,60 @@ test('asks for the credential again after signing out, including across a reload
 
     await expect(page.getByRole('textbox', { name: 'Login' })).toBeVisible();
     await expect(page.getByRole('navigation', { name: 'Spaces' })).toHaveCount(0);
+});
+
+test('reads a refused password itself rather than letting the browser ask for one', async ({
+    page,
+    context,
+    baseURL,
+}) => {
+    if (baseURL === undefined) {
+        throw new Error('The suite is configured with no base address to set a cookie against.');
+    }
+
+    const prompted: string[] = [];
+    const asked: Request[] = [];
+
+    page.on('dialog', (dialog) => prompted.push(dialog.type()));
+    page.on('request', (request) => {
+        if (new URL(request.url()).pathname === '/api/client/session') {
+            asked.push(request);
+        }
+    });
+
+    // A cookie on the origin the bundle was served from, which is what makes the assertion below about the request's
+    // credentials mode rather than about an origin that happened to have nothing to send. The Fetch Standard gates the
+    // user agent's own credential prompt on the same flag that decides whether this cookie travels, so a request that
+    // carried it is a request the browser would have prompted for.
+    await context.addCookies([{ name: 'mailfathom-probe', value: 'set', url: baseURL }]);
+
+    await servedByADeployment(page);
+
+    // The deployment refuses the password and challenges as MailFathom does wherever it accepts one — Basic named
+    // first, which is what tells the client a password may be sent at all and what separates this refusal from a
+    // deployment offering no password method.
+    await page.route('**/api/client/session', (route) =>
+        route.fulfill({
+            status: 401,
+            headers: { 'www-authenticate': 'Basic realm="MailFathom", charset="UTF-8"' },
+        }),
+    );
+
+    await page.goto('/');
+    await page.getByRole('textbox', { name: 'Login' }).fill(deployment.userName);
+    await page.getByLabel('Password', { exact: true }).fill(deployment.password);
+    await page.getByRole('button', { name: 'Connect' }).click();
+
+    // The screen says what the deployment decided, which is the whole point of the client reading the challenge: a
+    // dialog standing in front of this sentence is one nobody can get past to the form behind it.
+    await expect(page.getByText('The login or the password is not accepted by this deployment.')).toBeVisible();
+
+    expect(asked.length).toBeGreaterThan(0);
+    for (const request of asked) {
+        expect((await request.allHeaders())['cookie']).toBeUndefined();
+    }
+
+    expect(prompted).toStrictEqual([]);
 });
 
 test('opens in Discover, under the version it was built from and the one the deployment answered', async ({ page }) => {


### PR DESCRIPTION
## What changed

Every `fetch` under `frontend/src/Client.App/src/deployment/` now declares `credentials: 'omit'`.

The mode is stated once, as `deploymentCredentials` in `sendToDeployment.ts`, together with the reason: the client endpoint refuses an uncredentialed request with `401` and names Basic in the challenge, and the Fetch Standard has the user agent prompt for a username and password on exactly that answer whenever the request included credentials. The default `same-origin` includes them for a client served by the deployment it is signing in to, so the browser's own dialog opened over the sign-in screen at the first request — `reachDeployment`, which carries no credential deliberately — before a password had been typed once. The four other call sites (`attachmentExchange.ts`, `attachmentUpload.ts`, and both in `portraitExchange.ts`) import that one constant rather than restating it.

Nothing about the service moved. The challenge is what `signIn.ts` reads to tell `credentialRefused` from `basicNotOffered`, and omitting the credentials is what leaves it for the client to read — which is also what this surface already says about itself, its CORS policy allowing no credentials on the grounds that its only credential is the header `Client.Backend` composed.

## How it is proven

- A unit test beside each of the four changed modules asserts the credentials mode the transport puts on the request. It is the one thing about these modules no constructed `Response` can report, so `fetch` itself is watched — a spy on the module's own call, not a fake network standing in for a read, which `frontend/tests/AGENTS.md` § *What is faked, and where* refuses and these files still follow for everything else.
- A browser spec in `frontend/tests/client.spec.ts` signs in against a deployment answering `401` with `Basic realm="MailFathom", charset="UTF-8"`, and asserts that the screen states the refusal itself, that no dialog opened, and that the session requests carried no cookie although one was set on the origin. That last assertion is the real one: the Fetch Standard gates the credential prompt on the same flag that decides whether the cookie travels, so a request carrying it is a request the browser would have prompted for. Reverting the change fails that spec.

## Verification

`scripts/verify-fast.sh` passed; the full gate runs in CI. `pnpm test:browser` was run for the new spec against the built bundle, green with the change and red without it.

`$check-docs-licenses`: no dependency, configuration, protocol, or operational surface moved, and no page's `describes:` marker covers what changed. `CHANGELOG.md` — `n/a`.

Closes #1736
