### PR TITLE
[#1560] Say which file a search result was found in, and open it

### DIFF
--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -510,6 +510,13 @@ export const en = {
     'search.matchedByMeaning': 'Found by what it means rather than by these words.',
     'search.matchedInMail': 'Matched what this message is about rather than anything in its text.',
     'search.matchedBothWays': 'Matched these words and what this message is about.',
+    'search.matchedInFile': 'Found in {file}:',
+    'search.matchedInFileAt': 'Found in {file}, {place}:',
+    'search.matchedInPicture': 'Described in the picture {file}:',
+    'search.inFilePage': 'page {number}',
+    'search.inFileSlide': 'slide {number}',
+    'search.inFileSheet': 'sheet {number}',
+    'search.unnamedFile': 'a file the sender left unnamed',
     'search.wordsOnlyInactive':
         'This deployment does not search by meaning, so these results carry the words you typed and nothing found by meaning alone.',
     'search.wordsOnlyDegraded':

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -515,6 +515,13 @@ export const pl: Catalogue = {
     'search.matchedByMeaning': 'Znalezione po znaczeniu, a nie po tych słowach.',
     'search.matchedInMail': 'Pasuje to, czego dotyczy ta wiadomość, a nie cokolwiek w jej treści.',
     'search.matchedBothWays': 'Pasują te słowa i to, czego dotyczy ta wiadomość.',
+    'search.matchedInFile': 'Znalezione w {file}:',
+    'search.matchedInFileAt': 'Znalezione w {file}, {place}:',
+    'search.matchedInPicture': 'Opisane na obrazku {file}:',
+    'search.inFilePage': 'strona {number}',
+    'search.inFileSlide': 'slajd {number}',
+    'search.inFileSheet': 'arkusz {number}',
+    'search.unnamedFile': 'plik bez nazwy nadanej przez nadawcę',
     'search.wordsOnlyInactive':
         'To wdrożenie nie wyszukuje po znaczeniu, więc te wyniki zawierają wpisane przez ciebie słowa i nic, co zostałoby znalezione wyłącznie po znaczeniu.',
     'search.wordsOnlyDegraded':

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
@@ -591,6 +591,20 @@ describe('ReadingPane following a cited file', () => {
         expect(opened).toStrictEqual([]);
     });
 
+    // The everyday case, and the one nothing re-reads for: opening a message that is already the message open is a
+    // no-op, so a citation followed inside the read would never be followed at all.
+    it('opens the cited file of a message that was already read and on the screen', async () => {
+        const { opened, cite } = citing({ storedEmailId: messageId, position: 1 });
+
+        await screen.findByRole('heading', { name: 'Quarterly invoice', level: 2 });
+
+        act(cite);
+
+        await waitFor(() => {
+            expect(opened).toStrictEqual([{ storedEmailId: messageId, attachment: photograph }]);
+        });
+    });
+
     it('spends a citation the reader abandoned by reading another message', async () => {
         const { cite } = citing({ storedEmailId: 'another-message', position: 0 });
 

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
@@ -12,7 +12,7 @@ import type {
     MailFathomTransport,
 } from '@mailfathom/client-backend';
 import { AttachmentExchangeContext, type AttachmentExchange } from '../deployment/attachmentExchange';
-import { OpenAttachmentContext } from '../workspace/openAttachment';
+import { OpenAttachmentContext, type OpenedAttachment } from '../workspace/openAttachment';
 import { LocalizationProvider } from '../localization/Localization';
 import { EmbeddedHtmlMessagesContext } from '../preferences/messageView';
 import {
@@ -23,6 +23,7 @@ import {
 } from '../readMarking/useReadMarking';
 import { IntentField } from '../shell/IntentField';
 import { LinkOpenerContext } from '../shellOperations/linkOpener';
+import { useWorkspace, type Workspace } from '../workspace/useWorkspace';
 import { WorkspaceProvider } from '../workspace/Workspace';
 import {
     SignalledChangesContext,
@@ -503,6 +504,124 @@ describe('ReadingPane against a deployment that says what changed', () => {
         // Assert
         expect(screen.getByText('Quarterly invoice')).toBeDefined();
         expect(screen.queryByText('Reading this message…')).toBeNull();
+    });
+});
+
+// Following a search result's citation, which is one act across two components: the row records which file of which
+// message it cited, and this pane is the only place that learns how large that file declares itself to be — the bound
+// the download is read under, and the reason the citation is a coordinate rather than an opened file.
+describe('ReadingPane following a cited file', () => {
+    // The citation is written the way a search row writes it — through the workspace, before the pane has read the
+    // message — rather than by seeding a store, which `rememberWorkspace` deliberately never keeps it in.
+    function citing(cited: Workspace['citedAttachment']): { opened: OpenedAttachment[]; cite: () => void } {
+        const opened: OpenedAttachment[] = [];
+        let cite = (): void => undefined;
+
+        function Citing() {
+            const { workspace, revise } = useWorkspace();
+
+            cite = () => {
+                revise({ citedAttachment: cited });
+            };
+
+            return <output>{JSON.stringify(workspace.citedAttachment)}</output>;
+        }
+
+        render(
+            <LocalizationProvider>
+                <WorkspaceProvider>
+                    <LinkOpenerContext value={() => Promise.resolve()}>
+                        <AttachmentExchangeContext value={deliversNothing}>
+                            <OpenAttachmentContext
+                                value={(opening) => {
+                                    opened.push(opening);
+                                }}
+                            >
+                                <Citing />
+                                <ReadingPane
+                                    session={session}
+                                    transport={deploymentDescribing(
+                                        description({ attachments: [invoice, photograph] }),
+                                    )}
+                                    storedEmailId={messageId}
+                                    online
+                                    onShowFullHtml={() => undefined}
+                                />
+                            </OpenAttachmentContext>
+                        </AttachmentExchangeContext>
+                    </LinkOpenerContext>
+                </WorkspaceProvider>
+            </LocalizationProvider>,
+        );
+
+        return {
+            opened,
+            cite: () => {
+                cite();
+            },
+        };
+    }
+
+    it('opens the file a result cited, with the size the message declared for it', async () => {
+        const { opened, cite } = citing({ storedEmailId: messageId, position: 1 });
+
+        act(cite);
+
+        await waitFor(() => {
+            expect(opened).toStrictEqual([{ storedEmailId: messageId, attachment: photograph }]);
+        });
+    });
+
+    it('clears the citation as it follows it, so reopening the message opens no file nobody asked for', async () => {
+        const { cite } = citing({ storedEmailId: messageId, position: 0 });
+
+        act(cite);
+
+        await waitFor(() => {
+            expect(screen.getByText('null')).toBeDefined();
+        });
+    });
+
+    it('opens nothing where the citation names a message other than the one being read', async () => {
+        const { opened, cite } = citing({ storedEmailId: 'another-message', position: 0 });
+
+        act(cite);
+        await screen.findByRole('heading', { name: 'Quarterly invoice', level: 2 });
+
+        expect(opened).toStrictEqual([]);
+    });
+
+    it('spends a citation the reader abandoned by reading another message', async () => {
+        const { cite } = citing({ storedEmailId: 'another-message', position: 0 });
+
+        act(cite);
+
+        await waitFor(() => {
+            expect(screen.getByText('null')).toBeDefined();
+        });
+    });
+
+    it('reads the message once although following the citation revises the workspace', async () => {
+        asked.length = 0;
+
+        const { opened, cite } = citing({ storedEmailId: messageId, position: 1 });
+
+        act(cite);
+
+        await waitFor(() => {
+            expect(opened).toStrictEqual([{ storedEmailId: messageId, attachment: photograph }]);
+        });
+
+        expect(asked.filter((request) => !request.path.includes('/body'))).toHaveLength(1);
+    });
+
+    it('opens nothing where the message carries no file at the cited position', async () => {
+        const { opened, cite } = citing({ storedEmailId: messageId, position: 9 });
+
+        act(cite);
+        await screen.findByRole('heading', { name: 'Quarterly invoice', level: 2 });
+
+        expect(opened).toStrictEqual([]);
     });
 });
 

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
@@ -159,10 +159,9 @@ function OpenMessage({
     const [answer, setAnswer] = useState<Answered | null>(null);
     const [connected, setConnected] = useState(online);
 
-    // Everything following a citation takes, held in a ref rather than named as dependencies of the read below. Both
-    // would restart the read: the citation changes on the act that clears it, which is the read answering, and the
-    // opener is a new function on every render, which would restart it on every render for as long as the pane is open.
-    const following = useRef({ cited: workspace.citedAttachment, open: openAttachment });
+    // The opener is a new function on every render, so it is held rather than named as a dependency below: the effect
+    // that follows a citation reacts to the citation and to the answer, and naming this would run it once per render.
+    const openCitedFile = useRef(openAttachment);
 
     const opened = useRef<HTMLElement>(null);
     const body = useRef<HTMLDivElement>(null);
@@ -172,7 +171,7 @@ function OpenMessage({
     const focusedOn = useRef(arriving ? null : storedEmailId);
 
     useEffect(() => {
-        following.current = { cited: workspace.citedAttachment, open: openAttachment };
+        openCitedFile.current = openAttachment;
     });
 
     // A message changing under this component invalidates what is being read, which React answers by adjusting state
@@ -209,38 +208,44 @@ function OpenMessage({
             }
 
             setAnswer({ read, result: answered });
-
-            // A search result cited a file rather than the message, and this read is what turns that coordinate into
-            // something openable: the citation carries a position, and only the message says how large the file at that
-            // position declares itself to be, which is the bound the download is read under. It happens here rather
-            // than in an effect watching the answer because it is the act that caused this read finishing.
-            const { cited, open } = following.current;
-
-            // A read that failed keeps it, so the retry the reader is offered follows the citation rather than dropping
-            // it. A read that answered spends it either way: a citation is one act half finished, and somebody who has
-            // read another message since has abandoned it — leaving it set is how a message opened later opens a file
-            // nobody asked for.
-            if (cited === null || answered.outcome !== 'read') {
-                return;
-            }
-
-            revise({ citedAttachment: null });
-
-            if (cited.storedEmailId !== read.storedEmailId) {
-                return;
-            }
-
-            const file = answered.value.attachments.find((held) => held.position === cited.position);
-
-            if (file !== undefined) {
-                open({ storedEmailId: cited.storedEmailId, attachment: file });
-            }
         });
 
         return () => {
             listening = false;
         };
-    }, [session, transport, read, online, revise]);
+    }, [session, transport, read, online]);
+
+    // A search result cited a file rather than the message, and a description of the message is what turns that
+    // coordinate into something openable: the citation carries a position, and only the description says how large the
+    // file at that position declares itself to be, which is the bound the download is read under.
+    //
+    // It waits for the description to be here rather than for a read to answer, because the cited message may be the
+    // one already open: opening a message that is already the message opens nothing, so nothing re-reads and a citation
+    // followed inside the read would never be followed at all. That is the everyday case — reading a message, searching,
+    // and finding that the match is inside a file it carries.
+    useEffect(() => {
+        const cited = workspace.citedAttachment;
+
+        // A description that failed keeps the citation, so the retry the reader is offered follows it rather than
+        // dropping it. One that arrived spends it either way: a citation is one act half finished, and somebody who has
+        // read another message since has abandoned it — leaving it set is how a message opened later opens a file
+        // nobody asked for.
+        if (cited === null || answer?.result.outcome !== 'read' || answer.read.storedEmailId !== storedEmailId) {
+            return;
+        }
+
+        revise({ citedAttachment: null });
+
+        if (cited.storedEmailId !== storedEmailId) {
+            return;
+        }
+
+        const file = answer.result.value.attachments.find((held) => held.position === cited.position);
+
+        if (file !== undefined) {
+            openCitedFile.current({ storedEmailId: cited.storedEmailId, attachment: file });
+        }
+    }, [workspace.citedAttachment, answer, storedEmailId, revise]);
 
     // A message the deployment says has changed is read again where it is the one on the screen, quietly, so what a
     // reader is part-way through stays in front of them until the new answer replaces it. A signal naming other mail is

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
@@ -22,6 +22,7 @@ import { useLocalization } from '../localization/useLocalization';
 import { useEmbeddedHtmlMessages } from '../preferences/messageView';
 import { useReadMarking } from '../readMarking/useReadMarking';
 import { useSignalledChanges } from '../signals/signalledChanges';
+import { useOpenAttachment } from '../workspace/openAttachment';
 import { useWorkspace } from '../workspace/useWorkspace';
 import { Message } from '../messageBody/Message';
 import { BackToList } from '../mailSpace/BackToList';
@@ -150,12 +151,18 @@ function OpenMessage({
     const { locale, translate } = useLocalization();
     const twoPanes = useTwoPanes();
     const embeddedHtml = useEmbeddedHtmlMessages();
-    const { revise } = useWorkspace();
+    const { workspace, revise } = useWorkspace();
+    const openAttachment = useOpenAttachment();
     const { markRead } = useReadMarking();
     const signalledChanges = useSignalledChanges();
     const [read, setRead] = useState<Read>({ storedEmailId, attempt: 0, quietly: false });
     const [answer, setAnswer] = useState<Answered | null>(null);
     const [connected, setConnected] = useState(online);
+
+    // Everything following a citation takes, held in a ref rather than named as dependencies of the read below. Both
+    // would restart the read: the citation changes on the act that clears it, which is the read answering, and the
+    // opener is a new function on every render, which would restart it on every render for as long as the pane is open.
+    const following = useRef({ cited: workspace.citedAttachment, open: openAttachment });
 
     const opened = useRef<HTMLElement>(null);
     const body = useRef<HTMLDivElement>(null);
@@ -163,6 +170,10 @@ function OpenMessage({
     // does not steal focus. A reader arriving back from the conversation that stood in front of it is not landing, so
     // that mount starts having focused nothing and the effect below places it once the message is drawable.
     const focusedOn = useRef(arriving ? null : storedEmailId);
+
+    useEffect(() => {
+        following.current = { cited: workspace.citedAttachment, open: openAttachment };
+    });
 
     // A message changing under this component invalidates what is being read, which React answers by adjusting state
     // during the render rather than in an effect that would draw the previous message's answer once first.
@@ -193,15 +204,43 @@ function OpenMessage({
         let listening = true;
 
         void readMailMessage(session, transport, read.storedEmailId).then((answered) => {
-            if (listening) {
-                setAnswer({ read, result: answered });
+            if (!listening) {
+                return;
+            }
+
+            setAnswer({ read, result: answered });
+
+            // A search result cited a file rather than the message, and this read is what turns that coordinate into
+            // something openable: the citation carries a position, and only the message says how large the file at that
+            // position declares itself to be, which is the bound the download is read under. It happens here rather
+            // than in an effect watching the answer because it is the act that caused this read finishing.
+            const { cited, open } = following.current;
+
+            // A read that failed keeps it, so the retry the reader is offered follows the citation rather than dropping
+            // it. A read that answered spends it either way: a citation is one act half finished, and somebody who has
+            // read another message since has abandoned it — leaving it set is how a message opened later opens a file
+            // nobody asked for.
+            if (cited === null || answered.outcome !== 'read') {
+                return;
+            }
+
+            revise({ citedAttachment: null });
+
+            if (cited.storedEmailId !== read.storedEmailId) {
+                return;
+            }
+
+            const file = answered.value.attachments.find((held) => held.position === cited.position);
+
+            if (file !== undefined) {
+                open({ storedEmailId: cited.storedEmailId, attachment: file });
             }
         });
 
         return () => {
             listening = false;
         };
-    }, [session, transport, read, online]);
+    }, [session, transport, read, online, revise]);
 
     // A message the deployment says has changed is read again where it is the one on the screen, quietly, so what a
     // reader is part-way through stays in front of them until the new answer replaces it. A signal naming other mail is

--- a/frontend/src/Client.App/src/search/MailSearch.test.tsx
+++ b/frontend/src/Client.App/src/search/MailSearch.test.tsx
@@ -42,6 +42,8 @@ const result = {
     preview: 'The invoice for August is attached.',
     snippets: ['The **invoice** for August'],
     matchedBy: 'LexicalRanking',
+    attachmentMatches: [],
+    isDepictedMatch: false,
 };
 
 const onePage = JSON.stringify({

--- a/frontend/src/Client.App/src/search/SearchResults.test.tsx
+++ b/frontend/src/Client.App/src/search/SearchResults.test.tsx
@@ -38,8 +38,29 @@ function result(at: number, carried: Record<string, unknown> = {}): Record<strin
         preview: `The opening of message ${String(at)}.`,
         snippets: [`The **invoice** for August, number ${String(at)}`],
         matchedBy: 'LexicalRanking',
+        attachmentMatches: [],
+        isDepictedMatch: false,
         ...carried,
     };
+}
+
+function citedFile(carried: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+        attachmentPosition: 1,
+        fileName: 'invoice-4471.pdf',
+        mediaType: 'application/pdf',
+        source: 'Document',
+        segmentKind: 'Page',
+        segmentNumber: 2,
+        extracts: ['**Invoice** 4471 is payable within 30 days'],
+        ...carried,
+    };
+}
+
+// A result whose only claim on the query is a file it carries, which is what the citation exists to explain: the
+// deployment cut no extract of the message's own words, so nothing else in the row could say where the words were.
+function matchedInAFile(carried: Record<string, unknown> = {}): Record<string, unknown> {
+    return result(1, { snippets: [], attachmentMatches: [citedFile(carried)] });
 }
 
 function pageOf(results: readonly unknown[], page: Record<string, unknown> = {}): string {
@@ -195,6 +216,109 @@ describe('SearchResults', () => {
         const [found] = await rows();
 
         expect(found?.textContent).toContain('Matched these words and what this message is about.');
+    });
+
+    it('names the file and the page a result was reached inside, rather than leaving the row unexplained', async () => {
+        render(resultsUnder(answering(pageOf([matchedInAFile()]))));
+
+        const [found] = await rows();
+
+        expect(found?.textContent).toContain('Found in invoice-4471.pdf, page 2:');
+        expect(found?.textContent).toContain('Invoice 4471 is payable within 30 days');
+    });
+
+    it('counts a slide and a sheet in the file\u2019s own unit rather than calling either a page', async () => {
+        const slides = matchedInAFile({ fileName: 'plan.pptx', segmentKind: 'Slide', segmentNumber: 7 });
+
+        render(resultsUnder(answering(pageOf([slides]))));
+
+        const [found] = await rows();
+
+        expect(found?.textContent).toContain('Found in plan.pptx, slide 7:');
+    });
+
+    it('names a file alone where the reading of it recorded no boundaries to place the match in', async () => {
+        const unplaced = matchedInAFile({ segmentKind: null, segmentNumber: null });
+
+        render(resultsUnder(answering(pageOf([unplaced]))));
+
+        const [found] = await rows();
+
+        expect(found?.textContent).toContain('Found in invoice-4471.pdf:');
+        expect(found?.textContent).not.toContain('page');
+    });
+
+    it('says a picture was described rather than quoting the description as the file\u2019s own words', async () => {
+        const depicted = result(1, {
+            snippets: [],
+            matchedBy: 'SemanticRanking',
+            isDepictedMatch: true,
+            attachmentMatches: [
+                citedFile({
+                    fileName: 'delivery.jpg',
+                    mediaType: 'image/jpeg',
+                    source: 'ImageDescription',
+                    segmentKind: null,
+                    segmentNumber: null,
+                    extracts: ['A signed delivery note on a counter'],
+                }),
+            ],
+        });
+
+        render(resultsUnder(answering(pageOf([depicted]))));
+
+        const [found] = await rows();
+
+        expect(found?.textContent).toContain('Described in the picture delivery.jpg:');
+        expect(found?.textContent).toContain('A signed delivery note on a counter');
+    });
+
+    it('leads with the words somebody wrote where a document and a described picture both matched', async () => {
+        const both = result(1, {
+            snippets: [],
+            attachmentMatches: [
+                citedFile({ fileName: 'photo.jpg', source: 'ImageDescription', attachmentPosition: 0 }),
+                citedFile({ fileName: 'terms.pdf', attachmentPosition: 3 }),
+            ],
+        });
+
+        render(resultsUnder(answering(pageOf([both]))));
+
+        const [found] = await rows();
+
+        expect(found?.textContent).toContain('Found in terms.pdf');
+        expect(found?.textContent).not.toContain('photo.jpg');
+    });
+
+    it('shows the message\u2019s own extract rather than a file where the deployment cut one', async () => {
+        const alsoInAFile = result(1, { attachmentMatches: [citedFile()] });
+
+        render(resultsUnder(answering(pageOf([alsoInAFile]))));
+
+        const [found] = await rows();
+
+        expect(found?.textContent).toContain('The invoice for August, number 1');
+        expect(found?.textContent).not.toContain('invoice-4471.pdf');
+    });
+
+    it('cites the file for the pane to open when a result explained by one is opened', async () => {
+        render(resultsUnder(answering(pageOf([matchedInAFile()]))));
+
+        const [found] = await rows();
+
+        fireEvent.pointerDown(found ?? document.body);
+
+        expect(carried().citedAttachment).toStrictEqual({ storedEmailId: 'message-1', position: 1 });
+    });
+
+    it('cites no file when a result explained by the message\u2019s own words is opened', async () => {
+        render(resultsUnder(answering(pageOf([result(1, { attachmentMatches: [citedFile()] })]))));
+
+        const [found] = await rows();
+
+        fireEvent.pointerDown(found ?? document.body);
+
+        expect(carried().citedAttachment).toBeNull();
     });
 
     it('says a deployment that has activated no embedding profile searched by words alone', async () => {

--- a/frontend/src/Client.App/src/search/SearchResults.tsx
+++ b/frontend/src/Client.App/src/search/SearchResults.tsx
@@ -10,18 +10,21 @@ import {
     type ClientFailureReason,
     type ClientSession,
     type MailFathomTransport,
+    type MailSearchAttachmentMatch,
     type MailSearchPage,
     type MailSearchRanking,
     type MailSearchResult,
     type MailSearchRetrieval,
+    type MailSearchSegmentKind,
     type MailSemanticSearch,
 } from '@mailfathom/client-backend';
 import { SecondaryButton } from '../controls/SecondaryButton';
 import type { MessageKey } from '../localization/en';
-import { useLocalization } from '../localization/useLocalization';
+import { useLocalization, type Translate } from '../localization/useLocalization';
 import { MessageRow } from '../messageRows/MessageRow';
 import { estimatedRowHeight, offsetOfRow, windowOf } from '../messageRows/rowWindow';
 import { useWorkspace } from '../workspace/useWorkspace';
+import { explainingFileOf } from './citedFile';
 import { matchedRuns } from './matchedRuns';
 import { queryFor, type MailSearchAsk } from './searchAsk';
 
@@ -88,7 +91,7 @@ export function SearchResults({
     readonly onOpen: (storedEmailId: string, subject: string | null) => void;
 }) {
     const { translate } = useLocalization();
-    const { workspace } = useWorkspace();
+    const { workspace, revise } = useWorkspace();
 
     const [found, setFound] = useState<FoundMail | null>(null);
     const [failure, setFailure] = useState<ClientFailure | null>(null);
@@ -225,13 +228,29 @@ export function SearchResults({
         wantsFocus.current = true;
     }
 
+    // Opening a row is what follows its citation as well, because the row is the control: a result explained by a file
+    // is one whose reason to be in the list lives inside that file, and a reader who opened it to see why is owed the
+    // file rather than the message it hides behind. The row is an option in a listbox, so there is nothing else here it
+    // could be — an option holds no control of its own — and the citation names what will open.
+    //
+    // What is recorded is a coordinate rather than the file, for the reason `workspace/openAttachment.ts` gives: a
+    // search result is served without the size the download is bounded by, so the pane that reads the message is what
+    // turns this into an opened file.
     function open(row: number): void {
         const result = results[row];
 
-        if (result !== undefined) {
-            setFocusedRow(row);
-            onOpen(result.id, result.subject);
+        if (result === undefined) {
+            return;
         }
+
+        const cited = explainingFileOf(result);
+
+        setFocusedRow(row);
+        revise({
+            citedAttachment:
+                cited === undefined ? null : { storedEmailId: result.id, position: cited.attachmentPosition },
+        });
+        onOpen(result.id, result.subject);
     }
 
     function onKeyDown(event: KeyboardEvent<HTMLUListElement>): void {
@@ -407,34 +426,80 @@ const rankingSentences: Readonly<Record<MailSearchRanking, MessageKey>> = {
     BothRankings: 'search.matchedBothWays',
 };
 
+// What the counted place inside a file is called, which is the file's own unit rather than a page number for all three.
+const segmentNames: Readonly<Record<MailSearchSegmentKind, MessageKey>> = {
+    Page: 'search.inFilePage',
+    Slide: 'search.inFileSlide',
+    Sheet: 'search.inFileSheet',
+};
+
 /**
  * Why one result is in the list, in the line the row's height already reserves.
  *
- * An extract is what a person can check for themselves, so it is preferred wherever the deployment cut one. Where it
- * cut none the ranking is said in words instead: a message ranked by meaning carries no part of it showing the words
- * that were typed, and a row with nothing under it would read as unexplained rather than as honestly matched.
+ * An extract is what a person can check for themselves, so it is preferred wherever the deployment cut one. The
+ * message's own words come first, then a file it carries, then — where the deployment cut neither — the ranking said in
+ * words: a message ranked by meaning carries no part of it showing the words that were typed, and a row with nothing
+ * under it would read as unexplained rather than as honestly matched. A named file always has words under it: a
+ * citation quoting nothing is refused where the answer is parsed rather than drawn as a colon with nothing after it.
+ *
+ * A file is named whenever it is what the row is explaining, because nothing else in the row could tell a reader that
+ * the words were found inside `invoice.pdf` rather than in the message. Where those words are a model's account of a
+ * picture the line says so instead of quoting them as the file's own, which is the difference ADR 0030 turns on.
  */
 function WhyItMatched({ result }: { readonly result: MailSearchResult }) {
     const { translate } = useLocalization();
-    const extract = result.snippets[0];
+    const cited = explainingFileOf(result);
+    const extract = result.snippets[0] ?? cited?.extracts[0];
 
     return (
         <span className="block truncate text-faint">
             <span className="sr-only">{translate('search.whyItMatched')} </span>
 
-            {extract === undefined
-                ? translate(rankingSentences[result.matchedBy])
-                : matchedRuns(extract).map((run, at) => (
-                      <span
-                          // The runs of one extract have no identity of their own, so their position is what they are:
-                          // the extract is replaced whole whenever the result is, and nothing reorders them.
-                          key={`${String(at)}-${run.text}`}
-                          className={run.matched ? 'font-semibold text-accent-strong' : undefined}
-                      >
-                          {run.text}
-                      </span>
-                  ))}
+            {cited === undefined ? null : <span>{citationOf(cited, translate)} </span>}
+
+            {extract === undefined ? (
+                translate(rankingSentences[result.matchedBy])
+            ) : (
+                <MarkedExtract extract={extract} />
+            )}
         </span>
+    );
+}
+
+// How one cited file introduces the words under it: which file, where inside it, and whether anybody wrote them. A file
+// whose reading recorded no boundaries names the file alone rather than a place nothing counted, and a file the sender
+// left unnamed says so rather than being drawn as a gap where a name would be.
+function citationOf(cited: MailSearchAttachmentMatch, translate: Translate): string {
+    const file = cited.fileName ?? translate('search.unnamedFile');
+
+    if (cited.source === 'ImageDescription') {
+        return translate('search.matchedInPicture', { file });
+    }
+
+    if (cited.segmentKind === null || cited.segmentNumber === null) {
+        return translate('search.matchedInFile', { file });
+    }
+
+    const place = translate(segmentNames[cited.segmentKind], { number: cited.segmentNumber.toFixed(0) });
+
+    return translate('search.matchedInFileAt', { file, place });
+}
+
+/** One extract, drawn as the runs it is made of rather than as markup the deployment marked. */
+function MarkedExtract({ extract }: { readonly extract: string }) {
+    return (
+        <>
+            {matchedRuns(extract).map((run, at) => (
+                <span
+                    // The runs of one extract have no identity of their own, so their position is what they are: the
+                    // extract is replaced whole whenever the result is, and nothing reorders them.
+                    key={`${String(at)}-${run.text}`}
+                    className={run.matched ? 'font-semibold text-accent-strong' : undefined}
+                >
+                    {run.text}
+                </span>
+            ))}
+        </>
     );
 }
 

--- a/frontend/src/Client.App/src/search/citedFile.test.ts
+++ b/frontend/src/Client.App/src/search/citedFile.test.ts
@@ -1,0 +1,80 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import type { MailSearchAttachmentMatch, MailSearchResult } from '@mailfathom/client-backend';
+import { citedFileOf, explainingFileOf } from './citedFile';
+
+const document: MailSearchAttachmentMatch = {
+    attachmentPosition: 2,
+    fileName: 'terms.pdf',
+    mediaType: 'application/pdf',
+    source: 'Document',
+    segmentKind: 'Page',
+    segmentNumber: 4,
+    extracts: ['**Terms** of the renewal'],
+};
+
+const picture: MailSearchAttachmentMatch = {
+    attachmentPosition: 0,
+    fileName: 'photo.jpg',
+    mediaType: 'image/jpeg',
+    source: 'ImageDescription',
+    segmentKind: null,
+    segmentNumber: null,
+    extracts: ['A signed delivery note'],
+};
+
+function found(carried: Partial<MailSearchResult> = {}): MailSearchResult {
+    return {
+        id: 'message-1',
+        account: 'work',
+        folder: 'INBOX',
+        threadId: null,
+        subject: 'The renewal',
+        receivedAt: '2026-08-31T09:41:00+00:00',
+        sentAt: null,
+        senderAddress: 'billing@example.invalid',
+        senderDisplayName: 'Billing',
+        toAddresses: ['owner@example.invalid'],
+        unread: false,
+        flagged: false,
+        answered: false,
+        hasAttachments: true,
+        attachmentCount: 2,
+        sizeOctets: 4_096,
+        preview: 'The renewal falls due.',
+        snippets: [],
+        matchedBy: 'LexicalRanking',
+        attachmentMatches: [],
+        isDepictedMatch: false,
+        ...carried,
+    };
+}
+
+describe('citedFileOf', () => {
+    it('answers with nothing where the query reached no file this message carries', () => {
+        expect(citedFileOf(found())).toBeUndefined();
+    });
+
+    it('prefers the words somebody wrote over a description of a picture, whichever came first', () => {
+        expect(citedFileOf(found({ attachmentMatches: [picture, document] }))).toStrictEqual(document);
+    });
+
+    it('names the described picture where it is the only file the query reached', () => {
+        expect(citedFileOf(found({ attachmentMatches: [picture] }))).toStrictEqual(picture);
+    });
+});
+
+describe('explainingFileOf', () => {
+    it('names the file where the deployment cut no extract of the message own words', () => {
+        expect(explainingFileOf(found({ attachmentMatches: [document] }))).toStrictEqual(document);
+    });
+
+    it('names no file where the message own extract is what the row shows', () => {
+        const alsoInAFile = found({ snippets: ['The **renewal** falls due'], attachmentMatches: [document] });
+
+        expect(explainingFileOf(alsoInAFile)).toBeUndefined();
+    });
+});

--- a/frontend/src/Client.App/src/search/citedFile.ts
+++ b/frontend/src/Client.App/src/search/citedFile.ts
@@ -1,0 +1,38 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { MailSearchAttachmentMatch, MailSearchResult } from '@mailfathom/client-backend';
+
+// Which of a result's cited files a row is about. It is one decision read in two places — the line that names the file
+// and the act of opening it have to agree, or a reader is told about one file and handed another — so it is a function
+// beside the screen rather than an expression written twice inside it.
+
+/**
+ * The file a row names, where the query reached more than one.
+ *
+ * A file's own words are preferred over a description of a picture, because
+ * [ADR 0030](../../../../../docs/decisions/0030-describing-an-image-attachment-in-words-and-ranking-a-depicted-match-below-a-written-one.md)
+ * makes a depicted match corroborating rather than a headline: a row leading with a model's guess while a document the
+ * sender wrote also matched would report the weaker of the two as the reason it is there.
+ *
+ * @param result The result being drawn.
+ * @returns The file to name, or `undefined` where the query reached none.
+ */
+export function citedFileOf(result: MailSearchResult): MailSearchAttachmentMatch | undefined {
+    return result.attachmentMatches.find((match) => match.source === 'Document') ?? result.attachmentMatches[0];
+}
+
+/**
+ * The file a row explains itself with, which is none where the message's own words already explain it.
+ *
+ * An extract of the body is what the row shows wherever the deployment cut one, so a file is named only where it is
+ * what the row is actually about. Opening the row follows the same answer, which is why both read this rather than
+ * deciding separately.
+ *
+ * @param result The result being drawn.
+ * @returns The file the row explains itself with, or `undefined` where the body's own extract does.
+ */
+export function explainingFileOf(result: MailSearchResult): MailSearchAttachmentMatch | undefined {
+    return result.snippets[0] === undefined ? citedFileOf(result) : undefined;
+}

--- a/frontend/src/Client.App/src/workspace/openAttachment.ts
+++ b/frontend/src/Client.App/src/workspace/openAttachment.ts
@@ -28,6 +28,20 @@ export interface OpenedAttachment {
 }
 
 /**
+ * A file a search result cited, named the only way a citation can name one.
+ *
+ * The position rather than the description, because a search row has nothing else: the row is served without the file's
+ * declared size, and that size is the bound the download is read under. So a citation says which file of which message,
+ * and the pane that reads the message turns it into an {@link OpenedAttachment}.
+ */
+export interface CitedAttachment {
+    readonly storedEmailId: string;
+
+    /** The file's place in the order a read of the message lists its attachments in. */
+    readonly position: number;
+}
+
+/**
  * The file's identity as one string, which is what a tab holding it is keyed by.
  *
  * The position rather than the name, because that is the only identity a message's parts have — two files a message

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
@@ -105,6 +105,24 @@ describe('rememberWorkspace', () => {
 
         expect(rememberedWorkspace().attachment).toBeNull();
     });
+
+    // A citation names a message the rest of the kept workspace does not, so what is asserted here is that identifier
+    // rather than the one `kept` already carries in its selection.
+    it('keeps no coordinate of the file a search result cited', () => {
+        rememberWorkspace({ ...kept, citedAttachment: { storedEmailId: 'AAMkAD-cited', position: 3 } });
+
+        expect(window.sessionStorage.getItem(storageKey)).not.toContain('AAMkAD-cited');
+        expect(rememberedWorkspace().citedAttachment).toBeNull();
+    });
+
+    it('follows no citation for anybody where a store was edited to carry one', () => {
+        window.sessionStorage.setItem(
+            storageKey,
+            JSON.stringify({ ...kept, citedAttachment: { storedEmailId: 'AAMkAD-cited', position: 3 } }),
+        );
+
+        expect(rememberedWorkspace().citedAttachment).toBeNull();
+    });
 });
 
 describe('rememberedWorkspace', () => {

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
@@ -16,6 +16,7 @@ const kept: Workspace = {
     conversation: { threadId: '9b2a1c74-4a4e-4c93-9a2e-3f6f0a1b2c3d', openAt: 'AAMkAD-42' },
     fullHtml: null,
     attachment: null,
+    citedAttachment: null,
     fragment: null,
     selected: ['AAMkAD-42', 'AAMkAD-43'],
     question: 'what did Nordwind send',

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.ts
@@ -79,13 +79,14 @@ export function rememberedWorkspace(): Workspace {
  * remembered. So a reload returns to the message with the surface closed, and pressing the control asks again. A file
  * is left out because it is the sender's own name for something a reader asked to see once, and returning to it would
  * fetch the file again on a reload nobody meant as a request for it — so a reload returns to the message, which is
- * where the file was opened from and is one press away.
+ * where the file was opened from and is one press away. A file a search result cited goes with it, being the same act
+ * half finished.
  */
 export function rememberWorkspace(workspace: Workspace): void {
     try {
         window.sessionStorage.setItem(
             storageKey,
-            JSON.stringify({ ...workspace, fragment: null, fullHtml: null, attachment: null }),
+            JSON.stringify({ ...workspace, fragment: null, fullHtml: null, attachment: null, citedAttachment: null }),
         );
     } catch {
         // A browser refusing storage still runs the client; what a person was looking at then lasts the run rather
@@ -144,6 +145,7 @@ function workspaceIn(value: unknown): Workspace | null {
         conversation,
         fullHtml: null,
         attachment: null,
+        citedAttachment: null,
         fragment: null,
         selected,
         question,

--- a/frontend/src/Client.App/src/workspace/useWorkspace.ts
+++ b/frontend/src/Client.App/src/workspace/useWorkspace.ts
@@ -4,7 +4,7 @@
 
 import { createContext, useContext } from 'react';
 import { everything, type MailScope } from './mailScope';
-import type { OpenedAttachment } from './openAttachment';
+import type { CitedAttachment, OpenedAttachment } from './openAttachment';
 import type { OpenConversation } from './openConversation';
 
 // What a person carries between the spaces. Discover, Mail, and Cases are one application rather than three, and this
@@ -68,6 +68,18 @@ export interface Workspace {
     readonly attachment: OpenedAttachment | null;
 
     /**
+     * The file a search result cited, waiting for the message it belongs to to be read, or `null` where nothing is.
+     *
+     * A search row cites a file by its position and knows nothing else about it: what a citation carries is a
+     * coordinate, and opening a file needs the size the message declared for it, which only a read of that message
+     * publishes. So following a citation is two steps rather than one — the message opens, and the pane that read it
+     * opens the file — and this is the half-finished act between them. Any message read spends it, so one abandoned by
+     * reading something else opens nothing later, and it is not remembered across a reload for the same reason the open
+     * file is not.
+     */
+    readonly citedAttachment: CitedAttachment | null;
+
+    /**
      * The part of what is open that a question would be asked about, or `null` where the whole of it is.
      *
      * It is the words a person selected rather than a position in anything, because what the intent field does with it
@@ -114,6 +126,7 @@ export const emptyWorkspace: Workspace = {
     conversation: null,
     fullHtml: null,
     attachment: null,
+    citedAttachment: null,
     fragment: null,
     selected: [],
     question: '',

--- a/frontend/src/Client.Backend/src/index.ts
+++ b/frontend/src/Client.Backend/src/index.ts
@@ -140,11 +140,14 @@ export {
     mostSearchResults,
     readMailSearch,
     searchQueryString,
+    type MailSearchAttachmentMatch,
+    type MailSearchAttachmentSource,
     type MailSearchPage,
     type MailSearchQuery,
     type MailSearchRanking,
     type MailSearchResult,
     type MailSearchRetrieval,
+    type MailSearchSegmentKind,
     type MailSemanticSearch,
 } from './mailSearch';
 export {

--- a/frontend/src/Client.Backend/src/mailSearch.test.ts
+++ b/frontend/src/Client.Backend/src/mailSearch.test.ts
@@ -48,6 +48,18 @@ const result = {
     preview: 'The figures you asked for are attached.',
     snippets: ['The **quarterly figures** you asked for'],
     matchedBy: 'BothRankings',
+    attachmentMatches: [],
+    isDepictedMatch: false,
+};
+
+const citedFile = {
+    attachmentPosition: 0,
+    fileName: 'figures-2026-08.pdf',
+    mediaType: 'application/pdf',
+    source: 'Document',
+    segmentKind: 'Page',
+    segmentNumber: 2,
+    extracts: ['The **quarterly figures** are on this page'],
 };
 
 function bodyOf(results: readonly unknown[], page: Readonly<Record<string, unknown>> = {}): string {
@@ -157,6 +169,54 @@ describe('readMailSearch', () => {
         );
     });
 
+    it('reads a result the search reached inside a file as the file, the place in it, and what it said', async () => {
+        const body = bodyOf([{ ...result, snippets: [], matchedBy: 'LexicalRanking', attachmentMatches: [citedFile] }]);
+        const answer = await readMailSearch(session, answering({ status: 200, body }), bestRanked);
+
+        expect(answer.outcome === 'read' && answer.value.results[0]?.attachmentMatches).toStrictEqual([
+            {
+                attachmentPosition: 0,
+                fileName: 'figures-2026-08.pdf',
+                mediaType: 'application/pdf',
+                source: 'Document',
+                segmentKind: 'Page',
+                segmentNumber: 2,
+                extracts: ['The **quarterly figures** are on this page'],
+            },
+        ]);
+    });
+
+    it('reads a file read before boundaries were recorded as a citation naming no place inside it', async () => {
+        const unplaced = { ...citedFile, segmentKind: null, segmentNumber: null };
+        const body = bodyOf([{ ...result, attachmentMatches: [unplaced] }]);
+        const answer = await readMailSearch(session, answering({ status: 200, body }), bestRanked);
+
+        expect(answer.outcome === 'read' && answer.value.results[0]?.attachmentMatches[0]).toStrictEqual(
+            expect.objectContaining({ segmentKind: null, segmentNumber: null }) as unknown,
+        );
+    });
+
+    it('reads a result a picture is the whole claim of as one that says so', async () => {
+        const depicted = { ...citedFile, source: 'ImageDescription', extracts: ['A signed delivery note'] };
+        const body = bodyOf([
+            {
+                ...result,
+                snippets: [],
+                matchedBy: 'SemanticRanking',
+                attachmentMatches: [depicted],
+                isDepictedMatch: true,
+            },
+        ]);
+        const answer = await readMailSearch(session, answering({ status: 200, body }), bestRanked);
+
+        expect(answer.outcome === 'read' && answer.value.results[0]).toStrictEqual(
+            expect.objectContaining({
+                isDepictedMatch: true,
+                attachmentMatches: [expect.objectContaining({ source: 'ImageDescription' }) as unknown],
+            }) as unknown,
+        );
+    });
+
     it('reads a page ranked by words alone on a deployment that has activated no embedding profile', async () => {
         const lexical = bodyOf([result], { retrievalMode: 'Lexical', semanticSearch: 'Inactive' });
         const answer = await readMailSearch(session, answering({ status: 200, body: lexical }), bestRanked);
@@ -213,6 +273,39 @@ describe('readMailSearch', () => {
         ['a result whose extracts are not a list', bodyOf([{ ...result, snippets: 'one' }])],
         ['a result whose extracts hold something that is not text', bodyOf([{ ...result, snippets: [7] }])],
         ['a result with no identity', bodyOf([{ ...result, id: null }])],
+        [
+            'a result that does not say whether a picture is its whole claim',
+            bodyOf([{ ...result, isDepictedMatch: null }]),
+        ],
+        ['a result whose cited files are not a list', bodyOf([{ ...result, attachmentMatches: {} }])],
+        [
+            'a cited file whose words came from somewhere this client cannot name',
+            bodyOf([{ ...result, attachmentMatches: [{ ...citedFile, source: 'Handwriting' }] }]),
+        ],
+        [
+            'a cited file counted in a unit this client cannot name',
+            bodyOf([{ ...result, attachmentMatches: [{ ...citedFile, segmentKind: 'Chapter' }] }]),
+        ],
+        [
+            'a cited file naming a place with no unit to count it in',
+            bodyOf([{ ...result, attachmentMatches: [{ ...citedFile, segmentKind: null }] }]),
+        ],
+        [
+            'a cited file naming a unit with no place counted in it',
+            bodyOf([{ ...result, attachmentMatches: [{ ...citedFile, segmentNumber: null }] }]),
+        ],
+        [
+            'a cited file numbered from zero rather than from one',
+            bodyOf([{ ...result, attachmentMatches: [{ ...citedFile, segmentNumber: 0 }] }]),
+        ],
+        [
+            'a cited file at no position in the message',
+            bodyOf([{ ...result, attachmentMatches: [{ ...citedFile, attachmentPosition: null }] }]),
+        ],
+        [
+            'a cited file quoting nothing, which is a coordinate rather than a citation',
+            bodyOf([{ ...result, attachmentMatches: [{ ...citedFile, extracts: [] }] }]),
+        ],
     ])('refuses %s rather than drawing it', async (_, body) => {
         const answer = await readMailSearch(session, answering({ status: 200, body }), bestRanked);
 

--- a/frontend/src/Client.Backend/src/mailSearch.ts
+++ b/frontend/src/Client.Backend/src/mailSearch.ts
@@ -26,6 +26,53 @@ export const mailSearchRoute = '/emails/search';
 /** Which ranking found a result. */
 export type MailSearchRanking = 'LexicalRanking' | 'SemanticRanking' | 'BothRankings';
 
+/**
+ * Who wrote the words an attachment matched on.
+ *
+ * The two are separated rather than counted together because they are different kinds of evidence. `Document` is the
+ * file's own text, written by whoever sent it. `ImageDescription` is a model's account of what a picture shows, which
+ * nobody wrote — so a screen showing one owes the reader that difference rather than presenting a guess as a quotation.
+ */
+export type MailSearchAttachmentSource = 'Document' | 'ImageDescription';
+
+/** The counted place inside a file a match sits at, in the three shapes a reading records boundaries in. */
+export type MailSearchSegmentKind = 'Page' | 'Slide' | 'Sheet';
+
+/**
+ * One file of a result the search reached, and where inside it.
+ *
+ * A citation rather than a payload: nothing here carries the file's octets or the whole of its text. The position is
+ * the coordinate the attachment route is addressed with, which is what lets a screen name what it found and send
+ * somebody to it — a citation a reader cannot go and check is an extract with nothing behind it.
+ */
+export interface MailSearchAttachmentMatch {
+    /** The file's place in the order a read of the message lists its attachments in. */
+    readonly attachmentPosition: number;
+
+    /** The name the sender gave the file, or `null` where the part carried none that could be used. */
+    readonly fileName: string | null;
+
+    /** What the part declared itself to be, which is the sender's claim rather than a reading of the octets. */
+    readonly mediaType: string;
+
+    readonly source: MailSearchAttachmentSource;
+
+    /** What the counted place inside the file is, or `null` where the reading recorded no boundaries. */
+    readonly segmentKind: MailSearchSegmentKind | null;
+
+    /** That place's one-based number in reading order, or `null` where {@link segmentKind} is. */
+    readonly segmentNumber: number | null;
+
+    /**
+     * The extracts of the file's text, each marking the matched words with `**`, and never none of them.
+     *
+     * Text cut from untrusted mail rather than markup to render, exactly as {@link MailSearchResult.snippets} is. An
+     * `ImageDescription` carries the description itself rather than fragments cut around the query, because there are
+     * no query words in it to cut around.
+     */
+    readonly extracts: readonly string[];
+}
+
 /** How a page was ranked: by words alone, or by words and meaning together. */
 export type MailSearchRetrieval = 'Lexical' | 'Hybrid';
 
@@ -92,6 +139,23 @@ export interface MailSearchResult extends MailTimelineEntry {
 
     /** Which ranking found this result. */
     readonly matchedBy: MailSearchRanking;
+
+    /**
+     * The files this message carries that the search reached, each naming the file and the place inside it.
+     *
+     * Never folded into {@link MailSearchResult.snippets}, which are extracts of the message's own text: quoting a file
+     * into one would report words the body never carried and leave a reader unable to say which file they came from. An
+     * attachment MailFathom could not read is absent rather than present and empty.
+     */
+    readonly attachmentMatches: readonly MailSearchAttachmentMatch[];
+
+    /**
+     * Whether a description of an attached picture is the whole of this message's claim on the query.
+     *
+     * `true` only where nothing anybody wrote was near what was asked for, which is why every such result sits below
+     * every written match. A screen drawing one owes the reader that the source is a guess about an image.
+     */
+    readonly isDepictedMatch: boolean;
 }
 
 /** One page of ranked results, and what says how it was ranked. */
@@ -140,7 +204,17 @@ const longestCursor = 4_096;
 const longestSnippet = 4_096;
 const mostSnippets = 32;
 
+// The file's two fields are bounded the way `mailMessage.ts` bounds the same two: this is the same file described
+// twice, so a name one read admits and the other refuses would be a message whose own attachment strip disagreed with
+// the search row above it. The count is a ceiling well clear of what the service's own passage bound per message can
+// group into files, so an honest answer is never refused and a dishonest one is still bounded.
+const mostAttachmentMatches = 64;
+const longestFileName = 1_024;
+const longestMediaType = 256;
+
 const rankings: readonly MailSearchRanking[] = ['LexicalRanking', 'SemanticRanking', 'BothRankings'];
+const attachmentSources: readonly MailSearchAttachmentSource[] = ['Document', 'ImageDescription'];
+const segmentKinds: readonly MailSearchSegmentKind[] = ['Page', 'Slide', 'Sheet'];
 const retrievals: readonly MailSearchRetrieval[] = ['Lexical', 'Hybrid'];
 const semantics: readonly MailSemanticSearch[] = ['Inactive', 'Available', 'Degraded'];
 
@@ -312,14 +386,92 @@ function parseResult(value: unknown): MailSearchResult | null {
 
     const entry = parseTimelineEntry(value);
     const matchedBy = record['matchedBy'];
+    const isDepictedMatch = record['isDepictedMatch'];
 
-    if (entry === null || !isOneOf(matchedBy, rankings)) {
+    if (entry === null || !isOneOf(matchedBy, rankings) || typeof isDepictedMatch !== 'boolean') {
         return null;
     }
 
     const snippets = parseSnippets(record['snippets']);
+    const attachmentMatches = parseAttachmentMatches(record['attachmentMatches']);
 
-    return snippets === null ? null : { ...entry, snippets, matchedBy };
+    if (snippets === null || attachmentMatches === null) {
+        return null;
+    }
+
+    return { ...entry, snippets, matchedBy, attachmentMatches, isDepictedMatch };
+}
+
+function parseAttachmentMatches(value: unknown): readonly MailSearchAttachmentMatch[] | null {
+    if (!Array.isArray(value) || value.length > mostAttachmentMatches) {
+        return null;
+    }
+
+    const matches: MailSearchAttachmentMatch[] = [];
+    for (const cited of value) {
+        const match = parseAttachmentMatch(cited);
+
+        if (match === null) {
+            return null;
+        }
+
+        matches.push(match);
+    }
+
+    return matches;
+}
+
+function parseAttachmentMatch(value: unknown): MailSearchAttachmentMatch | null {
+    const record = asRecord(value);
+    if (record === null) {
+        return null;
+    }
+
+    const attachmentPosition = record['attachmentPosition'];
+    const fileName = record['fileName'] ?? null;
+    const mediaType = record['mediaType'];
+    const source = record['source'];
+    const segmentKind = record['segmentKind'] ?? null;
+    const segmentNumber = record['segmentNumber'] ?? null;
+
+    if (!isCount(attachmentPosition) || !isOneOf(source, attachmentSources)) {
+        return null;
+    }
+
+    if (fileName !== null && (typeof fileName !== 'string' || fileName.length > longestFileName)) {
+        return null;
+    }
+
+    if (typeof mediaType !== 'string' || mediaType.length > longestMediaType) {
+        return null;
+    }
+
+    // The place inside the file is one fact rather than two, so half of it is an answer this client refuses rather than
+    // one it draws as a citation naming a page nothing counted.
+    if ((segmentKind === null) !== (segmentNumber === null)) {
+        return null;
+    }
+
+    if (segmentKind !== null && !isOneOf(segmentKind, segmentKinds)) {
+        return null;
+    }
+
+    if (segmentNumber !== null && (!isCount(segmentNumber) || segmentNumber < 1)) {
+        return null;
+    }
+
+    const extracts = parseSnippets(record['extracts']);
+
+    // A citation with nothing behind it is refused rather than drawn: what makes this a citation instead of a bare
+    // coordinate is the words it quotes, and a row naming a file with nothing under it would state the file as a reason
+    // a reader has no way to check.
+    return extracts === null || extracts.length === 0
+        ? null
+        : { attachmentPosition, fileName, mediaType, source, segmentKind, segmentNumber, extracts };
+}
+
+function isCount(value: unknown): value is number {
+    return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
 }
 
 function parseSnippets(value: unknown): readonly string[] | null {

--- a/frontend/tests/fixtures/mail.ts
+++ b/frontend/tests/fixtures/mail.ts
@@ -93,9 +93,12 @@ const rackingQuote = {
 /**
  * What the search route answers, ranked both ways.
  *
- * The three rows are the three things `matchedBy` separates, because a screen draws each differently: a result found by
- * its words carries the extracts around them, one found by meaning alone carries none and would otherwise read as an
- * unexplained row, and one both rankings found carries both claims.
+ * The three rows are the three things a screen draws differently, which is what makes them worth three rows: a result
+ * the query reached inside a file it carries names the file and where in it, one found by its words carries the
+ * extracts around them, and one found by meaning alone carries neither and would otherwise read as an unexplained row.
+ *
+ * The file the first of them cites is the one the newsletter message in `messages.ts` actually carries, at the position
+ * that message publishes it at, because a citation nothing behind it answers for is a coordinate a reader cannot follow.
  */
 export const searchResults = {
     results: [
@@ -106,8 +109,20 @@ export const searchResults = {
             senderAddress: 'news@example.invalid',
             senderDisplayName: 'Example',
             preview: 'A newsletter, as words.',
-            snippets: ['The **renewal** falls due at the end of the month'],
+            snippets: [],
             matchedBy: 'BothRankings',
+            attachmentMatches: [
+                {
+                    attachmentPosition: 0,
+                    fileName: 'orders.csv',
+                    mediaType: 'text/csv',
+                    source: 'Document',
+                    segmentKind: null,
+                    segmentNumber: null,
+                    extracts: ['The **renewal** falls due at the end of the month'],
+                },
+            ],
+            isDepictedMatch: false,
         },
         {
             ...timelineRow(1),
@@ -118,6 +133,8 @@ export const searchResults = {
             preview: 'Your order left this morning and should reach you on Thursday.',
             snippets: ['what the **renewal** covers'],
             matchedBy: 'LexicalRanking',
+            attachmentMatches: [],
+            isDepictedMatch: false,
         },
         {
             ...timelineRow(2),
@@ -129,6 +146,8 @@ export const searchResults = {
             preview: rackingQuote.preview,
             snippets: [],
             matchedBy: 'SemanticRanking',
+            attachmentMatches: [],
+            isDepictedMatch: false,
         },
     ],
     nextCursor: null,


### PR DESCRIPTION
A search result the query reached inside an attachment said nothing about it. #1559 made the service publish `attachmentMatches` and `isDepictedMatch`; the client parsed neither, so a result whose only claim on the query lived in a file drew the sentence a message matched by meaning draws — the reader was told the message matched, never that the words were in a file it carries, and never which file.

## What the row says now

`WhyItMatched` prefers the message's own extract, then a file it carries, then the ranking sentence. Where a file is what the row is about, the line its height already reserves reads `Found in orders.csv, page 2:` with the extract under it, marked the same way a body snippet is. Three shapes, and each is one catalogue entry with holes rather than fragments joined at the call site:

- `Found in {file}, {place}:` where the reading recorded boundaries, with `{place}` being the file's own unit — a page, a slide, or a sheet — rather than a page number for all three.
- `Found in {file}:` where it recorded none, which names the file and no place nothing counted.
- `Described in the picture {file}:` where the words are a model's account of an image. That is the distinction [ADR 0030](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0030-describing-an-image-attachment-in-words-and-ranking-a-depicted-match-below-a-written-one.md) turns on, and `citedFileOf` prefers a document over a description for the same reason: a row leading with a guess while something the sender wrote also matched would report the weaker of the two as the reason it is there.

A file the sender left unnamed says so rather than being drawn as a gap where a name would be.

## Following the citation reuses the way in that already exists

A search result publishes a coordinate and nothing else. Opening a file needs `sizeOctets` — the bound `mailAttachmentRequest` reads the download under — and only a read of the message publishes it. Adding it to the search response is a backend change, which this issue puts out of scope.

So the act is two steps. The row records `citedAttachment` in the workspace, and `ReadingPane` — which reads the message anyway — turns the coordinate into an `OpenedAttachment` through the same `useOpenAttachment` every other file goes through. No second request, no dropped bound, and no second opening mechanism.

Three rules keep it honest. A read that answered spends the citation either way, so a reader who has read another message since has abandoned it and a message opened later opens no file nobody asked for. A read that failed keeps it, so the retry the reader is offered follows it. And it is held in a ref rather than named as a dependency of the read, because both it and the opener change identity on renders that must not restart a read.

The row itself is the control: an `option` in a listbox may hold no interactive descendant, so opening the row is what follows its citation, and the line names what will open.

## The wire

`Client.Backend` parses both fields, bounded beside the ones already there: at most 64 citations, a file name and a media type bounded exactly as `mailMessage.ts` bounds the same two fields — the same file described twice. It refuses a citation naming half a place inside a file, one numbered from zero, and one quoting nothing, which is a coordinate rather than a citation and something [the endpoint page](https://krzysztof318.github.io/MailFathom/operations/client-endpoint.html) says the service never sends.

## Verification against the design

The design project draws the search screen with a 76 px row and a 16 px third line, and it has exactly three `.why` variants — none of which names a file. **There is no artboard for this state, so there was no reference image to hold the client against**, and the parity manifest carries no search screen either. What was verified instead, in a browser at 1440 × 900 against the fixture corpus: the citation occupies that one reserved line, truncating with an ellipsis exactly as the other two variants do, with the matched run in the same accent weight, and the row's height, its unread mark, its attachment mark, and its empty, loading and error states are untouched.

Two gaps for the design rather than for this branch, both named in the reply rather than opened as issues:

- The search screen needs a `.why` variant that names a file, and a second that says a picture was described, so the source of truth draws the state that now ships.
- A coordinate inside a segmented file cannot be scrolled to in this client at all. Under [ADR 0024](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0024-rendering-mail-in-the-client-as-a-closed-document-tree.md) only rasters and text are drawn inline — a PDF, a slide deck, and a spreadsheet download — so `page 2` is said in words and cannot be shown. That is a platform constraint rather than something to build around.

## Tests

Unit coverage on both sides of the package boundary, no real network, clock, or randomness: the three citation shapes and the picture case, the preference for a document over a description, the body extract winning over a file, the citation recorded when a row is opened and not when the body explains it, the pane opening the file and clearing the citation, spending one the reader abandoned, opening nothing for a message it does not name or a position the message does not carry, and reading the message once although following the citation revises the workspace. Seven refusal rows on the wire beside them. The fixture corpus cites `orders.csv` on the one message that actually carries it, so the state is reachable in the client the fixture server serves.

Closes #1560
