### PR TITLE
[#1739] Read folder participation from the owners' accounts beside the deployment's section

### DIFF
--- a/backend/src/Host/Configuration/Mail/Readers/ConfiguredMailFolders.cs
+++ b/backend/src/Host/Configuration/Mail/Readers/ConfiguredMailFolders.cs
@@ -19,13 +19,23 @@ internal static class ConfiguredMailFolders
     /// <param name="settings">The snapshot the folders are read from.</param>
     /// <returns>One entry per usable configured folder.</returns>
     /// <remarks>
+    /// <para>
     /// It walks <see cref="MailSynchronizationAccountOptions.EffectiveFolders" /> rather than the configured list, so an
     /// account that configures no folder answers for the inbox mapping it is actually run with. An entry whose alias or
     /// account identifier is unusable is skipped: startup validation refuses that configuration, and inventing an
     /// identity for it here would attach one folder's decision to a name no operator wrote.
+    /// </para>
+    /// <para>
+    /// Both places a mailbox is declared are read, exactly as <see cref="Rules.DeclaredMailAccounts.ReadFrom(MailSynchronizationOptions)" />
+    /// reads them: the deployment's own section, and each served owner's accounts. A deployment declaring owners is
+    /// refused a non-empty <c>MailSynchronization:Accounts</c>, so reading only the first leaves such a deployment with
+    /// no mapped folder at all — every folder unmapped, no folder visible to a tool, and mail it has already stored
+    /// reported as an empty mailbox.
+    /// </para>
     /// </remarks>
     internal static IEnumerable<ConfiguredFolder> Of(MailSynchronizationOptions settings) =>
-        Of(settings.Accounts ?? []);
+        Of((settings.Accounts ?? [])
+            .Concat(settings.ServedOwners?.SelectMany(static owner => owner.MailAccounts) ?? []));
 
     /// <summary>Reads one set of account declarations as the pair of identity and participation the ports answer with.</summary>
     /// <param name="accounts">The declarations, which may be one owner's own rather than the whole deployment's.</param>

--- a/backend/tests/Host.UnitTests/Configuration/Mail/MailFolderParticipationOptionsTests.cs
+++ b/backend/tests/Host.UnitTests/Configuration/Mail/MailFolderParticipationOptionsTests.cs
@@ -2,12 +2,15 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Folders;
 using MailFathom.Host.Configuration.Mail;
 using MailFathom.Host.Configuration.Mail.Readers;
+using MailFathom.Host.Configuration.OwnerSettings;
 using MailFathom.Infrastructure.Mail;
 using MailFathom.Infrastructure.Secrets.Discovery;
+using MailFathom.TestSupport;
 using Xunit;
 
 namespace MailFathom.Host.UnitTests.Configuration.Mail;
@@ -409,8 +412,88 @@ public sealed class MailFolderParticipationOptionsTests
         Assert.Equal([MailFolderAlias.Create("PRIMARY-MAIL")], ConfiguredMailFolders.InboxAliasesOf(options.Accounts));
     }
 
+    /// <summary>
+    /// A deployment declaring its mailboxes under an owner is refused a deployment section, so a reader that read only
+    /// that section reported every folder as unmapped and hid mail the deployment had already stored.
+    /// </summary>
+    [Fact]
+    public void GetParticipation_AFolderDeclaredUnderAnOwner_AnswersForThatFolderRatherThanUnmapped()
+    {
+        // Arrange
+        var options = OwnerDeclaring(CreateAccount(new MailFolderMappingOptions
+        {
+            Alias = "archive",
+            RemotePath = "Archive",
+        }));
+        var archive = new MailFolderIdentity(Primary, MailFolderAlias.Create("ARCHIVE"));
+
+        // Act
+        var participation = options.Readers.FolderParticipation.GetParticipation(Primary, MailFolderAlias.Create("ARCHIVE"));
+
+        // Assert
+        Assert.Equal(MailFolderParticipation.Full, participation);
+        Assert.Equal([archive], options.Readers.FolderParticipation.FoldersMapped);
+        Assert.Equal([archive], options.Readers.FolderParticipation.FoldersSynchronized);
+        Assert.Equal([archive], options.Readers.FolderParticipation.FoldersVisibleToTools);
+        Assert.Equal([archive], options.Readers.FolderParticipation.FoldersGeneratingEmbeddings);
+    }
+
+    /// <summary>The junk catalog reads the same entries, so an owner-declared junk folder is withheld as a mapped one is.</summary>
+    [Fact]
+    public void JunkFolders_AFolderDeclaredUnderAnOwner_NamesThatFolder()
+    {
+        // Arrange
+        var options = OwnerDeclaring(CreateAccount(new MailFolderMappingOptions
+        {
+            Alias = "junk",
+            SpecialUse = "Junk",
+        }));
+
+        // Act, Assert
+        Assert.Equal([new MailFolderIdentity(Primary, MailFolderAlias.Create("JUNK"))], options.Readers.JunkFolderCatalog.JunkFolders);
+        Assert.True(options.Readers.JunkFolderCatalog.IsJunkFolder(Primary, MailFolderAlias.Create("JUNK")));
+    }
+
+    /// <summary>A folder is identified by its account beside its alias, so one owner's folder never enters another owner's scope.</summary>
+    [Fact]
+    public void FoldersVisibleToTools_TwoOwnersDeclaringTheSameAlias_KeepsEachFolderToItsOwnAccount()
+    {
+        // Arrange
+        var options = new MailSynchronizationOptions().WithServedOwners(
+        [
+            Owner(SyntheticMailOwner.Deployment, CreateAccount(new MailFolderMappingOptions { Alias = "private", RemotePath = "Private" })),
+            Owner(
+                SyntheticMailOwner.Another,
+                CreateAccount("secondary", new MailFolderMappingOptions
+                {
+                    Alias = "private",
+                    RemotePath = "Private",
+                    VisibleToTools = false,
+                })),
+        ]);
+
+        // Act
+        var visible = options.Readers.FolderParticipation.FoldersVisibleToTools;
+
+        // Assert
+        Assert.Equal([new MailFolderIdentity(Primary, MailFolderAlias.Create("PRIVATE"))], visible);
+        Assert.False(options
+            .Readers.FolderParticipation.GetParticipation(MailAccountId.Create("secondary"), MailFolderAlias.Create("PRIVATE"))
+            .IsVisibleToTools);
+    }
+
     private static MailSynchronizationOptions OptionsFor(MailSynchronizationAccountOptions account) =>
         new() { Accounts = [account] };
+
+    private static MailSynchronizationOptions OwnerDeclaring(MailSynchronizationAccountOptions account) =>
+        new MailSynchronizationOptions().WithServedOwners([Owner(SyntheticMailOwner.Deployment, account)]);
+
+    private static ServedMailOwner Owner(MailOwnerId owner, MailSynchronizationAccountOptions account) =>
+        new(
+            owner,
+            "the owner this deployment serves",
+            MailOwnerAccountSource.OwnerDocument,
+            [account]);
 
     private static MailSynchronizationAccountOptions CreateAccount(params MailFolderMappingOptions[] folders) =>
         CreateAccount("primary", folders);


### PR DESCRIPTION
## What changed

`ConfiguredMailFolders.Of(MailSynchronizationOptions)` read `MailSynchronization:Accounts` alone. A deployment that declares its mailboxes under an owner is *refused* a non-empty `MailSynchronization:Accounts`, so that reader answered with no folder at all for exactly the deployment shape the feature exists for.

It now reads both places a mailbox is declared — the deployment's own section and each served owner's `MailAccounts` — in the shape `DeclaredMailAccounts.ReadFrom(MailSynchronizationOptions)` already uses. That is one `Concat` in the shared overload every folder surface routes through, so `FoldersMapped`, `FoldersSynchronized`, `FoldersVisibleToTools`, `FoldersGeneratingEmbeddings`, `GetParticipation`, and `ConfiguredJunkMailFolderCatalog` are all corrected at once rather than caller by caller.

The roster carries no accounts for an owner whose source is `DeploymentSection`, so a deployment configuring `MailSynchronization:Accounts` reads exactly as it did and no folder is counted twice.

## Downstream

Nothing else changed. The client folder list, the account freshness state, `mfctl mailbox status`, and the MCP tools' scope all narrow through `FoldersVisibleToTools` or the same reader, so a scope that admits nothing was the whole of what made stored mail read as an empty mailbox and a synchronized account read as `NeverSynchronized`. The synchronizer was always correct and is untouched.

## Tests

Three added to `MailFolderParticipationOptionsTests`:

- an owner-declared folder answers its own participation and appears in all four lists rather than reading `Unmapped`;
- the junk catalog names an owner-declared junk folder;
- two owners declaring the same alias keep each folder to its own account, so one owner's folder never enters another's scope.

Not covered here: the read path end to end against committed synchronization progress. A folder identity is the whole of what the scope resolver was missing, and the surfaces above resolve it through this reader, so that case is one the integration suite reaches with a real database rather than one a unit test can state.

## Verification

`scripts/verify-fast.sh` — passed, 14946 tests. The full gate runs in CI; this was asked for as an urgent fix.

Closes #1739

- Issue: https://github.com/Krzysztof318/MailFathom/issues/1739