### PR TITLE
[#1742] Refuse an HTTP/3 profile nothing can discover, and document HTTP/3 on the client endpoint

### DIFF
--- a/backend/src/Host/Configuration/Endpoints/TransportHttpsEndpointOptions.cs
+++ b/backend/src/Host/Configuration/Endpoints/TransportHttpsEndpointOptions.cs
@@ -50,8 +50,8 @@ internal sealed class TransportHttpsEndpointOptions
     /// <summary>Gets or sets the HTTP versions this profile serves, or <see langword="null" /> to serve the default HTTP/1.1 and HTTP/2.</summary>
     /// <remarks>
     /// Nullable rather than a pre-filled list, because the configuration binder adds to a collection it finds rather
-    /// than replacing it: a default of HTTP/1.1 and HTTP/2 written here would leave an operator who configured HTTP/3
-    /// alone serving all three. Absent therefore means the default and an explicitly empty list is a configuration
+    /// than replacing it: a default of HTTP/1.1 and HTTP/2 written here would leave an operator who named HTTP/1.1 and
+    /// HTTP/3 serving all three. Absent therefore means the default and an explicitly empty list is a configuration
     /// error, which are two different mistakes and are reported as such.
     /// </remarks>
     public IList<TransportHttpProtocol>? HttpProtocols { get; set; }
@@ -158,6 +158,18 @@ internal sealed class TransportHttpsEndpointOptions
         if (configured.Distinct().Count() != configured.Count)
         {
             yield return $"{settingPath} — an HTTP version is listed more than once; each version is served or it is not, so a repeat says nothing a single entry does not.";
+        }
+
+        // HTTP/3 is a version a client arrives at rather than one it dials: Kestrel advertises the QUIC socket in an
+        // alt-svc header carried on a TCP connection, and the client moves across on a later request. A profile serving
+        // it alone has no such connection to advertise from, so nothing discovers the endpoint — and it has no version
+        // left to answer on where a network drops UDP, which is the fallback the advertisement exists to preserve.
+        if (undefined.Length == 0
+            && configured.Contains(TransportHttpProtocol.Http3)
+            && !configured.Contains(TransportHttpProtocol.Http1)
+            && !configured.Contains(TransportHttpProtocol.Http2))
+        {
+            yield return $"{settingPath} — '{nameof(TransportHttpProtocol.Http3)}' is the only version this profile serves, and a client reaches HTTP/3 by upgrading from a connection that advertised it rather than by dialling it; name '{nameof(TransportHttpProtocol.Http1)}' or '{nameof(TransportHttpProtocol.Http2)}' beside it, so the endpoint can be discovered and still answers where QUIC does not get through.";
         }
 
         // Reported rather than silently dropped: an operator who asked for HTTP/3 and got HTTP/2 would read a working

--- a/backend/src/Host/Security/Transport/TransportHttpsEndpointBinder.cs
+++ b/backend/src/Host/Security/Transport/TransportHttpsEndpointBinder.cs
@@ -114,8 +114,9 @@ internal static class TransportHttpsEndpointBinder
             authenticationOptions.RemoteCertificateValidationCallback = static (_, _, _, _) => true;
         }
 
-        // Left unset rather than set empty when this listener negotiates nothing over TLS, which is an HTTP/3-only
-        // profile: its versions travel over QUIC, and an empty offer is not the same statement as making none.
+        // Left unset rather than set empty, because an empty offer is not the same statement as making none. Validation
+        // refuses the profile that would reach this with nothing to negotiate — HTTP/3 without an older version beside
+        // it — so what remains here is the binder declining to assert a version list it does not have.
         if (NegotiableProtocols(servedProtocols) is { Count: > 0 } applicationProtocols)
         {
             authenticationOptions.ApplicationProtocols = applicationProtocols;

--- a/backend/tests/Host.UnitTests/Configuration/Endpoints/TransportHttpsOptionsTests.cs
+++ b/backend/tests/Host.UnitTests/Configuration/Endpoints/TransportHttpsOptionsTests.cs
@@ -210,7 +210,47 @@ public sealed class TransportHttpsOptionsTests
     {
         // Arrange
         var profile = Profile();
+        profile.HttpProtocols = [TransportHttpProtocol.Http1, TransportHttpProtocol.Http2, TransportHttpProtocol.Http3];
+
+        // Act, Assert
+        Assert.Empty(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true));
+    }
+
+    /// <summary>Nothing would advertise the QUIC socket, so the profile binds a listener no client can arrive at and has no version left when UDP is dropped.</summary>
+    [Fact]
+    public void FindConfigurationErrors_Http3WithNoVersionBesideIt_IsRefused()
+    {
+        // Arrange
+        var profile = Profile();
         profile.HttpProtocols = [TransportHttpProtocol.Http3];
+
+        // Act
+        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true));
+
+        // Assert
+        Assert.StartsWith($"{SectionPath}:Endpoints:0:HttpProtocols", error, StringComparison.Ordinal);
+        Assert.Contains("Http3", error, StringComparison.Ordinal);
+    }
+
+    /// <summary>One connection a client can start on is all the advertisement needs, so HTTP/1.1 alone discharges the requirement.</summary>
+    [Fact]
+    public void FindConfigurationErrors_Http3BesideHttp1Alone_IsAccepted()
+    {
+        // Arrange
+        var profile = Profile();
+        profile.HttpProtocols = [TransportHttpProtocol.Http1, TransportHttpProtocol.Http3];
+
+        // Act, Assert
+        Assert.Empty(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true));
+    }
+
+    /// <summary>And so does HTTP/2 alone, which is the version the advertisement most often travels on.</summary>
+    [Fact]
+    public void FindConfigurationErrors_Http3BesideHttp2Alone_IsAccepted()
+    {
+        // Arrange
+        var profile = Profile();
+        profile.HttpProtocols = [TransportHttpProtocol.Http2, TransportHttpProtocol.Http3];
 
         // Act, Assert
         Assert.Empty(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true));

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -1,6 +1,6 @@
 # The client endpoint
 
-<!-- describes: backend/src/AppHost/Program.cs, backend/src/AppHost/OrchestrationContract.cs, backend/src/Host/Configuration/Endpoints/ClientEndpointOptions.cs, backend/src/Host/Configuration/Endpoints/ClientApplicationOptions.cs, backend/src/Host/Api/ClientApiEndpoints.cs, backend/src/Host/Api/ClientMailAccountsEndpoint.cs, backend/src/Host/Api/ClientMailFoldersEndpoint.cs, backend/src/Host/Api/ClientMailTimelineEndpoint.cs, backend/src/Host/Api/ClientMailThreadEndpoint.cs, backend/src/Host/Api/ClientMailMessageEndpoint.cs, backend/src/Host/Api/ClientMailBodyEndpoint.cs, backend/src/Host/Api/ClientMailAttachmentEndpoint.cs, backend/src/Host/Api/AttachmentContentResponse.cs, backend/src/Host/Api/ProtectedResourceMetadataEndpoint.cs, backend/src/Host/Security/Endpoints/ClientTransportSecurityExtensions.cs, backend/src/Host/Hosting/ClientApplicationFiles.cs, backend/src/Host/Hosting/Warnings/ClientTransportSecurityWarning.cs, backend/src/Host/Hosting/Warnings/PasswordClearTextTransportWarning.cs, backend/src/Host/Api/ClientOwnerRecordEndpoint.cs, backend/src/Host/Api/ClientPortraitEndpoint.cs, backend/src/Host/Api/ClientDisplayNameEndpoint.cs, backend/src/Host/Configuration/OwnerSettings/Administration/OwnDisplayName.cs, backend/src/Host/Api/ClientMailMutationsEndpoint.cs, backend/src/Host/Api/ClientDraftEndpoints.cs, backend/src/Host/Api/ClientDraftResponses.cs, backend/src/Host/Api/ClientOutboxEndpoints.cs, backend/src/Host/Api/ClientNotificationEndpoints.cs, backend/src/Host/Api/ClientTelemetryEndpoint.cs, backend/src/Host/Api/ClientCitationEndpoint.cs, backend/src/Host/Api/ClientDiscoveryRunEndpoints.cs, backend/src/Host/Observability/ClientTelemetry/** -->
+<!-- describes: backend/src/AppHost/Program.cs, backend/src/AppHost/OrchestrationContract.cs, backend/src/Host/Configuration/Endpoints/ClientEndpointOptions.cs, backend/src/Host/Configuration/Endpoints/ClientApplicationOptions.cs, backend/src/Host/Configuration/Endpoints/TransportHttpsEndpointOptions.cs, backend/src/Host/Api/ClientApiEndpoints.cs, backend/src/Host/Api/ClientMailAccountsEndpoint.cs, backend/src/Host/Api/ClientMailFoldersEndpoint.cs, backend/src/Host/Api/ClientMailTimelineEndpoint.cs, backend/src/Host/Api/ClientMailThreadEndpoint.cs, backend/src/Host/Api/ClientMailMessageEndpoint.cs, backend/src/Host/Api/ClientMailBodyEndpoint.cs, backend/src/Host/Api/ClientMailAttachmentEndpoint.cs, backend/src/Host/Api/AttachmentContentResponse.cs, backend/src/Host/Api/ProtectedResourceMetadataEndpoint.cs, backend/src/Host/Security/Endpoints/ClientTransportSecurityExtensions.cs, backend/src/Host/Hosting/ClientApplicationFiles.cs, backend/src/Host/Hosting/Warnings/ClientTransportSecurityWarning.cs, backend/src/Host/Hosting/Warnings/PasswordClearTextTransportWarning.cs, backend/src/Host/Api/ClientOwnerRecordEndpoint.cs, backend/src/Host/Api/ClientPortraitEndpoint.cs, backend/src/Host/Api/ClientDisplayNameEndpoint.cs, backend/src/Host/Configuration/OwnerSettings/Administration/OwnDisplayName.cs, backend/src/Host/Api/ClientMailMutationsEndpoint.cs, backend/src/Host/Api/ClientDraftEndpoints.cs, backend/src/Host/Api/ClientDraftResponses.cs, backend/src/Host/Api/ClientOutboxEndpoints.cs, backend/src/Host/Api/ClientNotificationEndpoints.cs, backend/src/Host/Api/ClientTelemetryEndpoint.cs, backend/src/Host/Api/ClientCitationEndpoint.cs, backend/src/Host/Api/ClientDiscoveryRunEndpoints.cs, backend/src/Host/Observability/ClientTelemetry/** -->
 
 Where the MailFathom client reaches the service, what a deployment has to enable before it answers, and what a person's
 mail client presents to get in.
@@ -2060,6 +2060,71 @@ surfaces': material that is missing, expired, or issued for another domain fails
 than binding a listener that then refuses every connection. The startup record names each profile it loaded and the
 section it was configured under, so `ClientEndpoint:Https` is what an operator reads this endpoint's profiles back
 from; [rotating a server certificate](secret-rotation.md) is what renewing one takes.
+
+### HTTP/3, and what turns it on
+
+A profile serves HTTP/1.1 and HTTP/2, and nothing else unless it says so. `ClientEndpoint:Https:Endpoints:<n>:HttpProtocols`
+is where it says so, and HTTP/3 is opt-in on this surface exactly as it is on the other two —
+[`HttpProtocols`](configuration-endpoints.md#tls-termination--mcpendpointhttpsendpointsn) carries the key and its whole rule, and
+this section is what it means for the surface a browser calls:
+
+```jsonc
+{
+  "ClientEndpoint": {
+    "Transport": "HttpsOnly",
+    "Https": {
+      "Endpoints": [
+        {
+          "Name": "client",
+          "Domain": "mail.example.test",
+          "HttpProtocols": ["Http1", "Http2", "Http3"],
+          "ServerCertificate": { "Bundle": { "Path": "/run/secrets/client-tls.pfx" } }
+        }
+      ]
+    }
+  }
+}
+```
+
+Three things about that set are not a matter of taste. The host has to provide QUIC, and one that cannot fails startup
+rather than serving HTTP/2 under a configuration that named HTTP/3. `Http1` or `Http2` has to stand beside `Http3`,
+because a client reaches HTTP/3 by upgrading from a connection that advertised it and an HTTP/3-only profile is
+therefore a listener nothing discovers — startup refuses that too. And the TLS floor the profile states governs the
+other versions alone: QUIC always uses TLS 1.3, whatever `MinimumTlsVersion` says.
+
+### The client does nothing about it, and that is the whole of its half
+
+**Choosing a version is the browser's, not the application's.** The client puts every request on the wire through one
+`fetch` call, and `fetch` exposes no HTTP version — no request option sets one, no response field reports one, and there
+is nothing a caller could pass. So the client contains no code about HTTP/3, and it is not missing any: the upgrade from
+the first TCP connection, the fallback to HTTP/2 when QUIC does not get through, and the per-origin memory of which
+answered are all the user agent's, and they work for this deployment the moment a profile serves the version.
+
+What that costs is one round trip on a cold origin. The first request a browser makes to a deployment it has never seen
+goes over TCP whatever the endpoint offers, because the `alt-svc` header advertising the QUIC socket travels on the
+answer to it. A deployment that wants the very first connection to be QUIC publishes a DNS `HTTPS` record for the name,
+with `alpn="h3"`; that is a record in the operator's own zone rather than a setting here, and nothing about it changes
+what this endpoint serves.
+
+**The desktop head inherits its platform's answer.** It draws the same bundle in a system WebView, so which versions it
+speaks are that WebView's: WebView2 on Windows is Chromium and does HTTP/3, and WebKitGTK on Linux does not. Neither is
+a posture this deployment configures, and neither changes what a client can reach — a head without HTTP/3 keeps using
+HTTP/2 against the same profile, which is the fallback the older version beside it exists to hold open.
+
+### Which deployment shape serves it
+
+**MailFathom serves HTTP/3 where MailFathom terminates TLS**, which is a host process configured with the profile above
+on a machine providing QUIC. That is the shape this section is written for.
+
+**Every published container shape delegates it**, and this is an arrangement rather than a gap. The image speaks plain
+HTTP and terminates no TLS of its own — [Kubernetes](deployment-kubernetes.md), [Compose](deployment-compose.md), and
+[Quadlet](deployment-quadlet.md) each put a TLS-terminating ingress or reverse proxy in front of it, which is also the
+only place a certificate has to exist. HTTP/3 requires HTTPS, so in those shapes it is the ingress that offers it to a
+browser, configured there beside the certificate an operator already manages. Consistent with that, the image carries no
+QUIC library and no deployment asset here publishes a UDP port: a container asked to serve HTTP/3 itself would fail
+startup on the missing QUIC transport rather than bind a socket nothing could reach. Enabling HTTP/3 at the ingress
+needs nothing from this section, and the client behaves the same way behind it — the ingress advertises, the browser
+upgrades, and MailFathom answers HTTP/1.1 on the hop it was always answering.
 
 ## Serving the client from the deployment
 

--- a/docs/operations/configuration-endpoints.md
+++ b/docs/operations/configuration-endpoints.md
@@ -228,7 +228,7 @@ profile **takes over the host's listeners**: only the profiles' sockets are open
 | `…:BindAddress` | string | `0.0.0.0` | An IP address | restart |
 | `…:Port` | int | `8443` | 1 – 65535 | restart |
 | `…:MinimumTlsVersion` | enum | `Tls12` | `Tls12`, `Tls13` | restart |
-| `…:HttpProtocols` | enum list | `Http1`, `Http2` | `Http1`, `Http2`, `Http3`; selecting `Http3` where the platform provides no QUIC fails startup rather than falling back | restart |
+| `…:HttpProtocols` | enum list | `Http1`, `Http2` | `Http1`, `Http2`, `Http3`; selecting `Http3` where the platform provides no QUIC fails startup rather than falling back, and naming it without `Http1` or `Http2` beside it fails startup because nothing would advertise it | restart |
 | `…:ServerCertificate` | certificate block | — | Required; see below | restart; renewal behind unchanged references — see [secret rotation](secret-rotation.md#renewing-an-mcp-server-certificate) |
 
 A certificate block names either `Bundle` (one PKCS#12 secret block, optionally with a nested `Password`) or the pair
@@ -362,7 +362,7 @@ the MCP endpoint's grants come from, because the client reads the mail an agent 
 | `ClientEndpoint:Transport` | enum | `Http` | `Http`, `HttpAndHttps`, `HttpsOnly` — the same setting the other endpoints carry, read the same way | restart |
 | `ClientEndpoint:Authentication` | list of methods | empty | Same shape and rules as [`McpEndpoint:Authentication:<n>`](#the-accepted-methods--mcpendpointauthenticationn), with two additions: every `OAuth` block's `Resource` must end in `/api/client`, because that is where these routes answer and what the client appends to find the metadata document; and a client assertion presented here names the audience `urn:mailfathom:client` | restart; material per request |
 | `ClientEndpoint:Cors` | block | every origin | Same shape and rules as [`McpEndpoint:Cors`](#browser-origins--mcpendpointcors), configured separately. The setting a browser-hosted client cannot start without — see [browser origins](client-endpoint.md#browser-origins) | restart |
-| `ClientEndpoint:Https:Endpoints:<n>` | list of profiles | empty | Same shape and rules as `McpEndpoint:Https:Endpoints:<n>`, read under the two `Transport` modes that terminate TLS | restart; material per handshake |
+| `ClientEndpoint:Https:Endpoints:<n>` | list of profiles | empty | Same shape and rules as [`McpEndpoint:Https:Endpoints:<n>`](#tls-termination--mcpendpointhttpsendpointsn), read under the two `Transport` modes that terminate TLS. [HTTP/3 on this surface](client-endpoint.md#http3-and-what-turns-it-on) is what `HttpProtocols` means for a browser | restart; material per handshake |
 | `ClientEndpoint:Https:Redirect` | block | on | Same shape and rules as `McpEndpoint:Https:Redirect`; its socket is this surface's own `BindAddress` and `Port` | restart |
 | `ClientEndpoint:RateLimiting` | block | bounded | Same shape, defaults, and rules as [`McpEndpoint:RateLimiting`](#rate-limiting) above; applied whether or not it is written | restart |
 | `ClientEndpoint:RequestTimeout` | block | bounded | Same shape, defaults, and rules as [`McpEndpoint:RequestTimeout`](#request-timeout) above; applied whether or not it is written | restart |

--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -1127,7 +1127,7 @@ needs a handshake this process terminated, and configuring one here is how it ge
 | `BindAddress` | `0.0.0.0` | The IP address to bind; `::` binds IPv6 |
 | `Port` | `8443` | The TCP port to bind |
 | `MinimumTlsVersion` | `Tls12` | `Tls12` or `Tls13` |
-| `HttpProtocols` | absent — HTTP/1.1 and HTTP/2 | Any of `Http1`, `Http2`, `Http3` |
+| `HttpProtocols` | absent — HTTP/1.1 and HTTP/2 | Any of `Http1`, `Http2`, `Http3`, and never `Http3` on its own |
 | `ServerCertificate` | required | `Bundle`, or `CertificateChain` beside `PrivateKey` |
 
 ### Configuring a profile takes over the host's listeners
@@ -1314,6 +1314,23 @@ needs; install the platform's QUIC support or remove the version rather than hav
 ```
 
 Selecting HTTP/3 does not change the TLS floor for the other versions. QUIC always uses TLS 1.3 of its own accord.
+
+**HTTP/3 is a version a client arrives at rather than one it dials**, which is why it is never configured on its own. A
+client opens a TCP connection, reads the `alt-svc` header Kestrel adds to the answer once HTTP/3 is served, and moves to
+QUIC on a later request; nothing about the QUIC socket is discoverable without that first connection. Naming `Http3`
+with neither `Http1` nor `Http2` beside it therefore binds a listener nothing reaches, and it also removes the version
+the endpoint would have answered on where a firewall or a middlebox drops UDP — which is the fallback the advertisement
+exists to preserve. Startup refuses it:
+
+```text
+McpEndpoint:Https:Endpoints:0:HttpProtocols — 'Http3' is the only version this profile serves, and a client reaches
+HTTP/3 by upgrading from a connection that advertised it rather than by dialling it; name 'Http1' or 'Http2' beside it,
+so the endpoint can be discovered and still answers where QUIC does not get through.
+```
+
+So the serving set for a deployment offering HTTP/3 is `Http1`, `Http2`, and `Http3` together, and the order it is
+written in decides nothing: which version a given exchange uses is settled by ALPN on the TLS connection and by the
+advertisement afterwards, never by the configuration's order.
 
 ### What startup proves before a listener opens
 


### PR DESCRIPTION
Closes #1742

HTTP/3 was already a value every HTTPS profile accepted, off by default, refused where the host provides no QUIC, and
correctly left out of the ALPN offer because QUIC carries it on a socket of its own. What was missing was the rule that
makes it reachable and any statement of it on the surface a browser actually calls.

## What changed

**A profile serving HTTP/3 with nothing beside it is refused at startup.** A client reaches HTTP/3 by upgrading from a
TCP connection that advertised it in `alt-svc`, so `HttpProtocols: ["Http3"]` binds a QUIC listener nothing can
discover — and it removes the version the endpoint would have answered on where a network drops UDP, which is the
fallback the advertisement exists to preserve. It joins the four refusals the section already makes about this setting:
an empty list, an undefined member, a repeated version, and HTTP/3 on a host without QUIC. Upstream states the same rule
twice, as *"apps configured to take advantage of HTTP/3 should be designed to also support HTTP/1.1 and HTTP/2"* and
*"because not all routers, firewalls, and proxies properly support HTTP/3, configure HTTP/3 together with HTTP/1.1 and
HTTP/2"*.

**`docs/operations/client-endpoint.md` gained the section that surface never had.** It documents `HttpProtocols` for the
client endpoint — the default, the worked configuration, the QUIC requirement, the older version that has to stand
beside it, and that QUIC uses TLS 1.3 whatever `MinimumTlsVersion` states — and then the two things an operator reading
it actually needs beyond the key.

The first is that **the client does nothing about HTTP/3, and is not missing anything by doing nothing**. `fetch`
exposes no HTTP version: no request option sets one, no response field reports one. So the upgrade, the fallback, and
the per-origin memory of which versions answered are the user agent's, they work the moment a profile serves the
version, and the client contains no code about the subject. The section records the two platform facts that come with
that — a browser's first connection to a cold origin is TCP whatever the endpoint offers, unless a DNS `HTTPS` record
advertises `alpn="h3"`, and the desktop head inherits its WebView's answer, which is Chromium on Windows and WebKitGTK
on Linux.

The second is **which deployment shape serves HTTP/3 from MailFathom and which delegates it**. A host process
terminating TLS itself serves it. Every published container shape delegates it to the ingress or reverse proxy that
already terminates TLS in front of it, which is why the image carries no QUIC library and no deployment asset publishes
a UDP port — an arrangement rather than a gap, and now a stated one.

`configuration-endpoints.md` carries the new constraint on the key and links the `ClientEndpoint:Https:Endpoints` row to
the shared rule; `mcp-endpoint.md` carries the discovery rule and its refusal message beside the existing QUIC one.

## Two comments this change made false, corrected in it

`TransportHttpsEndpointBinder` left `ApplicationProtocols` unset when a listener negotiates nothing over TLS, and its
comment named an HTTP/3-only profile as the case it exists for — a shape validation now refuses. The guard stays and the
comment now says what it is actually holding. `TransportHttpsEndpointOptions.HttpProtocols` used "configured HTTP/3
alone" as the worked example of the binder-append hazard its nullability guards against; the example moved to a set that
is still valid.

## What this deliberately does not do

Adding `libmsquic` to the chiseled runtime image, publishing UDP ports through `deploy/`, and a chart value for either
are one decision with a supply-chain review of its own, taken against deployment shapes that today terminate no TLS at
all. Nothing under `frontend/` changed, because the code that would change is code that should not exist.

## Breaking change

`…:Https:Endpoints:<n>:HttpProtocols` naming `Http3` with neither `Http1` nor `Http2` beside it now fails startup rather
than binding. A deployment configured that way had no client that could reach it, so the operator's action is to add
`Http1` or `Http2` to the list — which is the configuration that makes the endpoint work rather than a workaround for
the refusal. No default changes and no other value is affected.

## Verification

`scripts/verify-full.sh`, and the new rule is covered by four unit tests beside the existing `HttpProtocols` cases:
HTTP/3 alone refused, HTTP/3 with HTTP/1.1, with HTTP/2, and with both accepted.

---

- Issue: https://github.com/Krzysztof318/MailFathom/issues/1742
