### PR TITLE
[#1741] Serve the desktop and mobile head an origin they can be named by

### DIFF
--- a/backend/src/Host/Configuration/Access/TransportCorsOptions.cs
+++ b/backend/src/Host/Configuration/Access/TransportCorsOptions.cs
@@ -12,9 +12,10 @@ namespace MailFathom.Host.Configuration.Access;
 /// <remarks>
 /// <para>
 /// One section shared by the three surfaces a browser can reach, because the question and its three postures are the
-/// same for each: the MCP endpoint, whose browser clients are MCP hosts running in a page; the client endpoint, whose
-/// WebAssembly head calls it from a page origin; and the administrative endpoint, which a page can call the same way.
-/// Each surface binds its own copy, so none of the three's origins reach the others' traffic.
+/// same for each: the MCP endpoint, whose browser clients are MCP hosts running in a page; the client endpoint, which
+/// every MailFathom head calls from an origin — the page a deployment serves from its own origin, and a downloaded
+/// desktop or mobile head from the one its shell served the bundle from; and the administrative endpoint, which a page
+/// can call the same way. Each surface binds its own copy, so none of the three's origins reach the others' traffic.
 /// </para>
 /// <para>
 /// Allowing every origin is the default because a surface is not protected by who is calling it — it is protected by
@@ -117,7 +118,7 @@ internal sealed class TransportCorsOptions
 
             if (!BrowserOriginPolicy.TryNormalize(configuredOrigin, out var normalizedOrigin))
             {
-                yield return $"{settingPath} — '{configuredOrigin}' is not an origin; write a scheme, a host, and a port where the port is not the scheme's default, and nothing else.";
+                yield return $"{settingPath} — '{configuredOrigin}' is not an origin this surface can be called from; write 'http', 'https', or 'tauri' for a downloaded head, then a host, then a port where the port is not the scheme's default, and nothing else.";
             }
             else if (!claimedOrigins.Add(normalizedOrigin))
             {

--- a/backend/src/Host/Security/Endpoints/ClientTransportSecurityExtensions.cs
+++ b/backend/src/Host/Security/Endpoints/ClientTransportSecurityExtensions.cs
@@ -130,8 +130,14 @@ internal static class ClientTransportSecurityExtensions
     /// <remarks>
     /// <para>
     /// A policy that names no origin at all is the deliberate third posture rather than an oversight: it advertises
-    /// nothing to a browser, which is what a deployment whose client is a desktop or mobile head — neither of which is
-    /// subject to CORS — wants.
+    /// nothing to a browser, which is what a deployment whose only client is the page it serves itself wants, since a
+    /// same-origin request is never subject to CORS at all.
+    /// </para>
+    /// <para>
+    /// It is not what a deployment reached by a downloaded head wants. Both native heads render in a webview, which
+    /// enforces CORS exactly as a browser does against the origin their shell served the bundle from, so a head is a
+    /// browser origin to list rather than a client this policy is silent about — and one that answers no preflight
+    /// reports a deployment that never answered rather than a policy that refused it.
     /// </para>
     /// <para>
     /// Credentials are never allowed, under any policy. A browser that could attach an ambient cookie would let a page

--- a/backend/src/Infrastructure/Security/Transport/BrowserOriginPolicy.cs
+++ b/backend/src/Infrastructure/Security/Transport/BrowserOriginPolicy.cs
@@ -23,6 +23,17 @@ namespace MailFathom.Infrastructure.Security.Transport;
 /// </remarks>
 public sealed class BrowserOriginPolicy
 {
+    /// <summary>The scheme a client rendering in a native shell's own webview serves its document from, and therefore the scheme of the origin it sends.</summary>
+    /// <remarks>
+    /// A downloaded head is not exempt from CORS — its webview enforces it exactly as a browser does, against the
+    /// origin the shell served the bundle from. Tauri serves that bundle over a custom protocol, so the Linux desktop
+    /// head sends <c>tauri://localhost</c>; Windows and Android tunnel the same protocol over
+    /// <c>http://tauri.localhost</c>, which is an ordinary <c>http</c> origin and needs nothing of its own here.
+    /// Admitting the custom-protocol scheme is what lets a deployment name the head it serves instead of opening the
+    /// surface to every origin, which was the only posture that reached the first of those at all.
+    /// </remarks>
+    private const string NativeShellScheme = "tauri";
+
     private readonly HashSet<string> allowedOrigins;
 
     private BrowserOriginPolicy(bool allowsAnyOrigin, IEnumerable<string> allowedOrigins)
@@ -38,7 +49,9 @@ public sealed class BrowserOriginPolicy
     /// <remarks>
     /// It refuses every request carrying an <c>Origin</c> and serves every request carrying none, so what it excludes is
     /// browsers rather than clients. That is the accurate posture for a deployment whose only consumers are agents and
-    /// command-line clients, and it is the one posture a list of origins cannot express.
+    /// command-line clients, and it is the one posture a list of origins cannot express. A page a deployment serves
+    /// itself is unaffected, being same-origin and therefore never subject to CORS at all; a head somebody downloaded
+    /// is not, and this posture refuses it, which is why <see cref="NativeShellScheme" /> exists to be listed.
     /// </remarks>
     public static BrowserOriginPolicy ServingNoBrowserOrigin { get; } = new(allowsAnyOrigin: false, []);
 
@@ -76,6 +89,12 @@ public sealed class BrowserOriginPolicy
     /// than a set of special cases, and so <c>https://Client.Example.Test:443/</c> and <c>https://client.example.test</c>
     /// cannot be two different entries in one list. A path, a query, a fragment, or user information means the operator
     /// wrote a URL where an origin belongs, and is refused rather than silently discarded.
+    /// <para>
+    /// Three schemes are admitted rather than the two a page on the web can be served from: <c>http</c>, <c>https</c>,
+    /// and the <see cref="NativeShellScheme" /> a downloaded head sends. The list is closed rather than open so a
+    /// scheme nobody here serves — a typo, or another framework's protocol — is a startup error naming the entry,
+    /// instead of a line that binds and then matches nothing a client ever sends.
+    /// </para>
     /// </remarks>
     public static bool TryNormalize(string? configuredValue, out string normalizedOrigin)
     {
@@ -93,7 +112,9 @@ public sealed class BrowserOriginPolicy
             && string.IsNullOrEmpty(origin.UserInfo);
 
         if (!carriesOnlyAnAuthority
-            || (origin.Scheme != Uri.UriSchemeHttp && origin.Scheme != Uri.UriSchemeHttps))
+            || (origin.Scheme != Uri.UriSchemeHttp
+                && origin.Scheme != Uri.UriSchemeHttps
+                && origin.Scheme != NativeShellScheme))
         {
             return false;
         }

--- a/backend/tests/Host.UnitTests/Configuration/Access/TransportCorsOptionsTests.cs
+++ b/backend/tests/Host.UnitTests/Configuration/Access/TransportCorsOptionsTests.cs
@@ -46,6 +46,25 @@ public sealed class TransportCorsOptionsTests
             policy.AllowedOrigins.Order(StringComparer.Ordinal));
     }
 
+    /// <summary>An operator serving a downloaded head names its custom-protocol origin, which has to validate as an origin rather than as the startup error it used to be.</summary>
+    [Fact]
+    public void ToOriginPolicy_TheOriginOfADownloadedHead_IsAcceptedBesideAPageOrigin()
+    {
+        // Arrange
+        var options = new TransportCorsOptions();
+        options.AllowedOrigins.Add("https://mail.example.test");
+        options.AllowedOrigins.Add("tauri://localhost");
+
+        // Act
+        var policy = options.ToOriginPolicy();
+
+        // Assert
+        Assert.Empty(options.FindConfigurationErrors());
+        Assert.Equal(
+            ["https://mail.example.test", "tauri://localhost"],
+            policy.AllowedOrigins.Order(StringComparer.Ordinal));
+    }
+
     /// <summary>An empty list is the third posture rather than a mistake: no browser is served, and every client that sends no origin still is.</summary>
     [Fact]
     public void ToOriginPolicy_AnEmptyList_ServesNoBrowserAndEveryClientThatSendsNoOrigin()

--- a/backend/tests/Host.UnitTests/Security/Endpoints/ClientTransportSecurityExtensionsTests.cs
+++ b/backend/tests/Host.UnitTests/Security/Endpoints/ClientTransportSecurityExtensionsTests.cs
@@ -72,7 +72,9 @@ public sealed class ClientTransportSecurityExtensionsTests
 
         // Assert
         Assert.False(policy.AllowAnyOrigin);
-        Assert.Equal(["tauri://localhost", "http://tauri.localhost"], policy.Origins);
+        Assert.Equal(
+            ["http://tauri.localhost", "tauri://localhost"],
+            policy.Origins.Order(StringComparer.Ordinal));
     }
 
     /// <summary>An emptied list advertises nothing to a browser, which is what a deployment whose only client is the page it serves itself wants.</summary>

--- a/backend/tests/Host.UnitTests/Security/Endpoints/ClientTransportSecurityExtensionsTests.cs
+++ b/backend/tests/Host.UnitTests/Security/Endpoints/ClientTransportSecurityExtensionsTests.cs
@@ -54,7 +54,28 @@ public sealed class ClientTransportSecurityExtensionsTests
         Assert.True(ClientCorsPolicyOf(endpointSettings).AllowAnyOrigin);
     }
 
-    /// <summary>An emptied list advertises nothing to a browser, which is what a deployment whose client is a desktop or mobile head wants.</summary>
+    /// <summary>
+    /// Both native heads render in a webview and enforce CORS against the origin their shell served the bundle from, so
+    /// the custom-protocol origin three of the five platforms send has to reach the policy intact — otherwise the only
+    /// posture serving those heads is every origin.
+    /// </summary>
+    [Fact]
+    public void AddClientTransportSecurity_TheOriginOfADownloadedHead_ReachesThePolicyUnchanged()
+    {
+        // Arrange
+        var endpointSettings = EnabledEndpoint();
+        endpointSettings.Cors.AllowedOrigins.Add("tauri://localhost");
+        endpointSettings.Cors.AllowedOrigins.Add("http://tauri.localhost");
+
+        // Act
+        var policy = ClientCorsPolicyOf(endpointSettings);
+
+        // Assert
+        Assert.False(policy.AllowAnyOrigin);
+        Assert.Equal(["tauri://localhost", "http://tauri.localhost"], policy.Origins);
+    }
+
+    /// <summary>An emptied list advertises nothing to a browser, which is what a deployment whose only client is the page it serves itself wants.</summary>
     [Fact]
     public void AddClientTransportSecurity_AnEmptiedOriginList_AdvertisesNothingToABrowser()
     {

--- a/backend/tests/Infrastructure.UnitTests/Security/Transport/BrowserOriginPolicyTests.cs
+++ b/backend/tests/Infrastructure.UnitTests/Security/Transport/BrowserOriginPolicyTests.cs
@@ -27,6 +27,22 @@ public sealed class BrowserOriginPolicyTests
         Assert.Equal(expectedOrigin, normalizedOrigin);
     }
 
+    /// <summary>A downloaded head is served over a custom protocol on Linux, macOS, and iOS, so its origin is the one an operator has to be able to list.</summary>
+    [Theory]
+    [InlineData("tauri://localhost", "tauri://localhost")]
+    [InlineData("TAURI://LocalHost", "tauri://localhost")]
+    [InlineData("tauri://localhost/", "tauri://localhost")]
+    [InlineData("http://tauri.localhost", "http://tauri.localhost")]
+    public void TryNormalize_TheOriginANativeHeadSends_IsAcceptedAndNormalized(string configuredValue, string expectedOrigin)
+    {
+        // Arrange, Act
+        var normalized = BrowserOriginPolicy.TryNormalize(configuredValue, out var normalizedOrigin);
+
+        // Assert
+        Assert.True(normalized);
+        Assert.Equal(expectedOrigin, normalizedOrigin);
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]
@@ -39,7 +55,10 @@ public sealed class BrowserOriginPolicyTests
     [InlineData("https://user@client.example.test")]
     [InlineData("ftp://client.example.test")]
     [InlineData("file:///etc/hosts")]
-    public void TryNormalize_AnythingThatIsNotAnHttpOrigin_IsRefused(string? configuredValue)
+    [InlineData("capacitor://localhost")]
+    [InlineData("tauri:localhost")]
+    [InlineData("tauri://localhost/index.html")]
+    public void TryNormalize_AnythingThatIsNotAnOriginThisSurfaceIsCalledFrom_IsRefused(string? configuredValue)
     {
         // Arrange, Act
         var normalized = BrowserOriginPolicy.TryNormalize(configuredValue, out var normalizedOrigin);
@@ -87,6 +106,19 @@ public sealed class BrowserOriginPolicyTests
         Assert.True(policy.Permits("https://client.example.test"));
         Assert.True(policy.Permits("https://other-client.example.test"));
         Assert.False(policy.Permits("https://attacker.example.test"));
+    }
+
+    /// <summary>Naming the head's own origin is what a deployment serving one does instead of opening the surface to every origin.</summary>
+    [Fact]
+    public void Permits_TheListedOriginOfANativeHead_IsServedAndNoOtherCustomProtocolOriginIs()
+    {
+        // Arrange
+        var policy = BrowserOriginPolicy.Restricting(["tauri://localhost"]);
+
+        // Act, Assert
+        Assert.True(policy.Permits("tauri://localhost"));
+        Assert.False(policy.Permits("tauri://attacker.example.test"));
+        Assert.False(policy.Permits("http://tauri.localhost"));
     }
 
     /// <summary>A page served over plain HTTP is a different origin from the same host over HTTPS, and so is a different port.</summary>

--- a/backend/tests/Infrastructure.UnitTests/Security/Transport/BrowserOriginPolicyTests.cs
+++ b/backend/tests/Infrastructure.UnitTests/Security/Transport/BrowserOriginPolicyTests.cs
@@ -27,7 +27,7 @@ public sealed class BrowserOriginPolicyTests
         Assert.Equal(expectedOrigin, normalizedOrigin);
     }
 
-    /// <summary>A downloaded head is served over a custom protocol on Linux, macOS, and iOS, so its origin is the one an operator has to be able to list.</summary>
+    /// <summary>The desktop head on Linux is served over a custom protocol, so its origin is the one an operator has to be able to list.</summary>
     [Theory]
     [InlineData("tauri://localhost", "tauri://localhost")]
     [InlineData("TAURI://LocalHost", "tauri://localhost")]

--- a/deploy/compose/config/10-mailfathom.json.example
+++ b/deploy/compose/config/10-mailfathom.json.example
@@ -81,6 +81,8 @@
   // writes the first two. It provisions no credential, because the page it prepares reads its own sample data and
   // calls nothing yet. The empty origin list is the same posture as the endpoint below and for the same reason: the
   // page this deployment serves is same-origin, so no browser origin beyond it has any business calling the surface.
+  // A downloaded desktop or Android head is such an origin — `tauri://localhost` or `http://tauri.localhost`, which
+  // its webview enforces exactly as a browser would — so a deployment reached by one lists it here instead.
   //
   // "ClientEndpoint": {
   //   "Enabled": true,

--- a/deploy/helm/mailfathom/values.yaml
+++ b/deploy/helm/mailfathom/values.yaml
@@ -596,10 +596,11 @@ service:
 # own configuration section enabled it: `/mcp` to `McpEndpoint`, `/api/admin` to `AdminEndpoint`, and `/api/client` to
 # `ClientEndpoint`. Publishing a path whose section is off routes to a listener that answers 404, and enabling a section
 # without publishing its path leaves it reachable only inside the cluster — which is a legitimate posture for the
-# administrative surface and never one for the client, whose caller is somebody's own machine. A browser-hosted client
-# also needs `ClientEndpoint:Cors:AllowedOrigins` to name the origin the page is served from, since the ingress answers
-# no preflight on the application's behalf — unless the page is the one this deployment serves itself, which is same
-# origin and therefore no preflight at all.
+# administrative surface and never one for the client, whose caller is somebody's own machine. Every client but the page
+# this deployment serves itself also needs `ClientEndpoint:Cors:AllowedOrigins` to name the origin it calls from, since
+# the ingress answers no preflight on the application's behalf: a page served elsewhere by its own origin, and a
+# downloaded desktop or Android head by `tauri://localhost` or `http://tauri.localhost`, which its webview enforces
+# exactly as a browser would. The deployment's own page is same origin and therefore no preflight at all.
 #
 # With `client.enabled` on, publish `/` as well: that is where the page is, on the same host it calls.
 ingress:

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -1,6 +1,6 @@
 # The client endpoint
 
-<!-- describes: backend/src/AppHost/Program.cs, backend/src/AppHost/OrchestrationContract.cs, backend/src/Host/Configuration/Endpoints/ClientEndpointOptions.cs, backend/src/Host/Configuration/Endpoints/ClientApplicationOptions.cs, backend/src/Host/Configuration/Endpoints/TransportHttpsEndpointOptions.cs, backend/src/Host/Api/ClientApiEndpoints.cs, backend/src/Host/Api/ClientMailAccountsEndpoint.cs, backend/src/Host/Api/ClientMailFoldersEndpoint.cs, backend/src/Host/Api/ClientMailTimelineEndpoint.cs, backend/src/Host/Api/ClientMailThreadEndpoint.cs, backend/src/Host/Api/ClientMailMessageEndpoint.cs, backend/src/Host/Api/ClientMailBodyEndpoint.cs, backend/src/Host/Api/ClientMailAttachmentEndpoint.cs, backend/src/Host/Api/AttachmentContentResponse.cs, backend/src/Host/Api/ProtectedResourceMetadataEndpoint.cs, backend/src/Host/Security/Endpoints/ClientTransportSecurityExtensions.cs, backend/src/Host/Hosting/ClientApplicationFiles.cs, backend/src/Host/Hosting/Warnings/ClientTransportSecurityWarning.cs, backend/src/Host/Hosting/Warnings/PasswordClearTextTransportWarning.cs, backend/src/Host/Api/ClientUserRecordEndpoint.cs, backend/src/Host/Api/ClientPortraitEndpoint.cs, backend/src/Host/Api/ClientDisplayNameEndpoint.cs, backend/src/Host/Configuration/UserSettings/Administration/OwnDisplayName.cs, backend/src/Host/Api/ClientMailMutationsEndpoint.cs, backend/src/Host/Api/ClientDraftEndpoints.cs, backend/src/Host/Api/ClientDraftResponses.cs, backend/src/Host/Api/ClientOutboxEndpoints.cs, backend/src/Host/Api/ClientNotificationEndpoints.cs, backend/src/Host/Api/ClientTelemetryEndpoint.cs, backend/src/Host/Api/ClientCitationEndpoint.cs, backend/src/Host/Api/ClientDiscoveryRunEndpoints.cs, backend/src/Host/Observability/ClientTelemetry/** -->
+<!-- describes: backend/src/AppHost/Program.cs, backend/src/AppHost/OrchestrationContract.cs, backend/src/Host/Configuration/Endpoints/ClientEndpointOptions.cs, backend/src/Host/Configuration/Endpoints/ClientApplicationOptions.cs, backend/src/Host/Configuration/Endpoints/TransportHttpsEndpointOptions.cs, backend/src/Host/Api/ClientApiEndpoints.cs, backend/src/Host/Api/ClientMailAccountsEndpoint.cs, backend/src/Host/Api/ClientMailFoldersEndpoint.cs, backend/src/Host/Api/ClientMailTimelineEndpoint.cs, backend/src/Host/Api/ClientMailThreadEndpoint.cs, backend/src/Host/Api/ClientMailMessageEndpoint.cs, backend/src/Host/Api/ClientMailBodyEndpoint.cs, backend/src/Host/Api/ClientMailAttachmentEndpoint.cs, backend/src/Host/Api/AttachmentContentResponse.cs, backend/src/Host/Api/ProtectedResourceMetadataEndpoint.cs, backend/src/Host/Security/Endpoints/ClientTransportSecurityExtensions.cs, backend/src/Infrastructure/Security/Transport/BrowserOriginPolicy.cs, backend/src/Host/Hosting/ClientApplicationFiles.cs, backend/src/Host/Hosting/Warnings/ClientTransportSecurityWarning.cs, backend/src/Host/Hosting/Warnings/PasswordClearTextTransportWarning.cs, backend/src/Host/Api/ClientUserRecordEndpoint.cs, backend/src/Host/Api/ClientPortraitEndpoint.cs, backend/src/Host/Api/ClientDisplayNameEndpoint.cs, backend/src/Host/Configuration/UserSettings/Administration/OwnDisplayName.cs, backend/src/Host/Api/ClientMailMutationsEndpoint.cs, backend/src/Host/Api/ClientDraftEndpoints.cs, backend/src/Host/Api/ClientDraftResponses.cs, backend/src/Host/Api/ClientOutboxEndpoints.cs, backend/src/Host/Api/ClientNotificationEndpoints.cs, backend/src/Host/Api/ClientTelemetryEndpoint.cs, backend/src/Host/Api/ClientCitationEndpoint.cs, backend/src/Host/Api/ClientDiscoveryRunEndpoints.cs, backend/src/Host/Observability/ClientTelemetry/** -->
 
 Where the MailFathom client reaches the service, what a deployment has to enable before it answers, and what a person's
 mail client presents to get in.
@@ -1983,8 +1983,8 @@ must prove, and why the advertised scope list is longer than the checked one, is
 
 ## Browser origins
 
-A WebAssembly head calls this surface from a page, and a preflight this endpoint cannot answer is a client that never
-starts. The same setting exists on the MCP and administrative endpoints, configured separately.
+Every MailFathom head calls this surface from an origin, and a preflight this endpoint cannot answer is a client that
+never starts. The same setting exists on the MCP and administrative endpoints, configured separately.
 
 | `ClientEndpoint:Cors:AllowedOrigins` | What the endpoint answers |
 | --- | --- |
@@ -1995,10 +1995,48 @@ starts. The same setting exists on the MCP and administrative endpoints, configu
 
 The permissive default is deliberate, for the reason [the MCP endpoint's is](mcp-endpoint.md#cors-and-the-origin-header):
 a surface is protected by the credential a caller presents rather than by which page it was called from, and a first run
-that failed a preflight would look like a broken deployment. Narrow it to the origin your own head is served from once
-you know what that is. The empty list is the third posture rather than an oversight — it advertises nothing to a
-browser, which is what a deployment whose client is a desktop or mobile head wants, since neither is subject to CORS at
-all.
+that failed a preflight would look like a broken deployment. Narrow it to the origins your own heads are served from
+once you know what those are — the next section is what a downloaded one sends.
+
+**The empty list is the third posture rather than an oversight, and it fits exactly one deployment: the one whose only
+client is the page it serves itself.** That page is same-origin, so it is never subject to CORS at all and goes on
+working while every other browser origin is refused; so does every non-browser caller, which sends no `Origin`. **It
+does not fit a deployment reached by a downloaded head**, which sends an origin of its own and is refused by it.
+
+### The origin a downloaded head sends
+
+A desktop or mobile head is not exempt from CORS. Both render in a webview — WebKitGTK or WebView2 on the desktop,
+Chromium's on Android — which enforces CORS exactly as a browser does, against the origin the shell served the bundle
+from. That origin is never the deployment's, so it is named here or the head is not served:
+
+| The head | The origin it sends |
+| --- | --- |
+| The desktop head on Linux | `tauri://localhost` |
+| The desktop head on Windows, and the Android head | `http://tauri.localhost` |
+
+Both are accepted as entries. The custom-protocol one is the reason this setting takes a scheme beyond `http` and
+`https` at all: without it, the only posture that served a Linux desktop head was `["*"]`, which is every origin on the
+internet rather than the one head an operator meant. Nothing else is accepted — a scheme MailFathom serves no head from
+is a startup error naming the entry rather than a line that binds and then matches nothing.
+
+```json
+{
+  "ClientEndpoint": {
+    "Cors": {
+      "AllowedOrigins": [
+        "https://mail.example.test",
+        "tauri://localhost",
+        "http://tauri.localhost"
+      ]
+    }
+  }
+}
+```
+
+**A refusal here does not look like a refusal.** The response carries no `Access-Control-Allow-Origin`, so the webview
+rejects the fetch before the client sees a status, and nothing reaches this endpoint's logs — the head reports that the
+deployment did not answer, on its sign-in screen, before a password has been typed. A deployment whose page signs in
+while a downloaded head calls it silent is this setting before it is anything else.
 
 The policy allows `GET` and `POST`, the `Authorization`, `Content-Type`, `Accept`, and `traceparent` request headers,
 and exposes `WWW-Authenticate` so a page can read the challenge that tells it where to authorize and `Retry-After` so a
@@ -2159,7 +2197,8 @@ the client in front of the sign-in the endpoint already required.
 
 Serving it from the same origin as the surface it calls is the point of serving it here at all: the page then needs no
 cross-origin permission and `Cors:AllowedOrigins` has nothing to say about it. A client downloaded and installed rather
-than served reaches the same routes from an origin of its own and does need one.
+than served reaches the same routes from an origin of its own and does need one — [the origin a downloaded head
+sends](#the-origin-a-downloaded-head-sends) is which.
 
 **Clear text is refused rather than warned about**, and that is the one difference from every other posture on this
 page. A page is what a person types their credential into, so a deployment that serves it over a socket this process

--- a/docs/operations/configuration-endpoints.md
+++ b/docs/operations/configuration-endpoints.md
@@ -210,8 +210,9 @@ expiry, and replay identifier an assertion carries, none of which is a setting �
 | --- | --- | --- | --- | --- |
 | `…:AllowedOrigins` | string list | absent = every origin | `*` for every origin, a list for exactly those, an empty list for none | restart |
 
-The default is deliberately the permissive one — an `Origin` header only exists in browsers, and a native client is
-unaffected — but a deployment reachable from a browser should narrow it.
+The default is deliberately the permissive one — an `Origin` header only exists in browsers, and a client that is not
+one is unaffected — but a deployment reachable from a browser should narrow it. A client rendering in a webview *is* a
+browser here, whatever it was installed as, so narrowing means listing its origin rather than leaving it out.
 [CORS and the `Origin` header](mcp-endpoint.md#cors-and-the-origin-header) explains what the check does and does not
 protect.
 
@@ -361,7 +362,7 @@ the MCP endpoint's grants come from, because the client reads the mail an agent 
 | `ClientEndpoint:Port` | int | `8080` | 1–65535. The other two request-serving endpoints' default as well — see [sharing a socket](#sharing-a-socket) | restart |
 | `ClientEndpoint:Transport` | enum | `Http` | `Http`, `HttpAndHttps`, `HttpsOnly` — the same setting the other endpoints carry, read the same way | restart |
 | `ClientEndpoint:Authentication` | list of methods | empty | Same shape and rules as [`McpEndpoint:Authentication:<n>`](#the-accepted-methods--mcpendpointauthenticationn), with two additions: every `OAuth` block's `Resource` must end in `/api/client`, because that is where these routes answer and what the client appends to find the metadata document; and a client assertion presented here names the audience `urn:mailfathom:client` | restart; material per request |
-| `ClientEndpoint:Cors` | block | every origin | Same shape and rules as [`McpEndpoint:Cors`](#browser-origins--mcpendpointcors), configured separately. The setting a browser-hosted client cannot start without — see [browser origins](client-endpoint.md#browser-origins) | restart |
+| `ClientEndpoint:Cors` | block | every origin | Same shape and rules as [`McpEndpoint:Cors`](#browser-origins--mcpendpointcors), configured separately. The setting no client but the page this deployment serves itself can start without, a downloaded head included — see [browser origins](client-endpoint.md#browser-origins) and [the origin a downloaded head sends](client-endpoint.md#the-origin-a-downloaded-head-sends) | restart |
 | `ClientEndpoint:Https:Endpoints:<n>` | list of profiles | empty | Same shape and rules as [`McpEndpoint:Https:Endpoints:<n>`](#tls-termination--mcpendpointhttpsendpointsn), read under the two `Transport` modes that terminate TLS. [HTTP/3 on this surface](client-endpoint.md#http3-and-what-turns-it-on) is what `HttpProtocols` means for a browser | restart; material per handshake |
 | `ClientEndpoint:Https:Redirect` | block | on | Same shape and rules as `McpEndpoint:Https:Redirect`; its socket is this surface's own `BindAddress` and `Port` | restart |
 | `ClientEndpoint:RateLimiting` | block | bounded | Same shape, defaults, and rules as [`McpEndpoint:RateLimiting`](#rate-limiting) above; applied whether or not it is written | restart |

--- a/docs/operations/deployment-kubernetes.md
+++ b/docs/operations/deployment-kubernetes.md
@@ -308,7 +308,7 @@ Every one of those is a MailFathom setting rather than a chart value, so turning
 | TLS terminated by the pod itself | `McpEndpoint:Https:Endpoints` | [HTTPS and your own domain](mcp-endpoint.md#https-and-your-own-domain) |
 | Client certificates | `McpEndpoint:ClientCertificateProfiles` | [Client certificates](mcp-endpoint.md#client-certificates) |
 | Rate limits | `McpEndpoint:RateLimiting`, and `AdminEndpoint:RateLimiting` or `ClientEndpoint:RateLimiting` for the other surfaces | [Rate limiting](mcp-endpoint.md#rate-limiting) |
-| The surface the MailFathom client reaches | `ClientEndpoint`, whose `Cors:AllowedOrigins` names the origin a browser-hosted client is served from | [The client endpoint](client-endpoint.md) |
+| The surface the MailFathom client reaches | `ClientEndpoint`, whose `Cors:AllowedOrigins` names the origin every client but this deployment's own page calls from, a downloaded head included | [The client endpoint](client-endpoint.md) |
 | The client itself, served as a page | `client.enabled`, which is a chart value rather than a ConfigMap entry — see [serving the client](#serving-the-client) | [Serving the client from the deployment](client-endpoint.md#serving-the-client-from-the-deployment) |
 
 The ingress row is the one an OAuth deployment should not skip, and it narrows rather than enables. The controller

--- a/docs/operations/desktop-client.md
+++ b/docs/operations/desktop-client.md
@@ -97,6 +97,14 @@ head is, in full, is that record; how one is built is
 
 ## Pointing the client at a deployment
 
+**The deployment has to allow this client's origin first**, and a deployment serving only its own page does not. This
+head renders in a webview, which enforces CORS exactly as a browser does against the origin the shell served the bundle
+from — `tauri://localhost` on Linux, `http://tauri.localhost` on Windows — so the deployment's
+`ClientEndpoint:Cors:AllowedOrigins` names that origin, or answers nothing this client can read. It looks like a
+deployment that is down rather than one that refused: the sign-in screen reports that the deployment did not answer,
+before a password has been typed, and nothing reaches the deployment's logs. [The origin a downloaded head
+sends](client-endpoint.md#the-origin-a-downloaded-head-sends) is the operator's half of it.
+
 The web head is served by its deployment and needs to be told nothing. The desktop head is served by nobody, so it asks
 for an address on the sign-in screen — and where somebody hands this application to other people, they can state that
 address once instead, so nobody is asked for it at all. Two settings do that, and both are read at start.

--- a/docs/operations/desktop-client.md
+++ b/docs/operations/desktop-client.md
@@ -1,6 +1,6 @@
 # The desktop client
 
-<!-- describes: .github/workflows/build-desktop-client.yml, frontend/src-tauri/**, frontend/src/Client.App/src/shellOperations/configuredConnection.ts, frontend/src/Client.App/src/deployment/adoptedDeployment.ts -->
+<!-- describes: .github/workflows/build-desktop-client.yml, frontend/src-tauri/**, frontend/src/Client.App/src/shellOperations/configuredConnection.ts, frontend/src/Client.App/src/deployment/adoptedDeployment.ts, backend/src/Infrastructure/Security/Transport/BrowserOriginPolicy.cs -->
 
 What a release publishes for somebody who wants MailFathom's client as an application on their own machine rather than
 as a page a deployment serves: which platforms, in which formats, what each installer does, and what none of them does.

--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -989,7 +989,10 @@ agents and command-line tools states it and serves no browser anything.
 
 An origin is a scheme, a host, and a port where the port is not the scheme's default — nothing else. A path, a query, a
 fragment, or user information means a URL was written where an origin belongs and is refused at startup, as is a value
-that is not an origin at all. Entries are normalized to the form a browser sends, so `https://Client.Example.Test:443/`
+that is not an origin at all. Three schemes are accepted, on this endpoint and the other two alike: `http`, `https`, and
+the `tauri` a downloaded MailFathom head is served from — [the origin a downloaded head
+sends](client-endpoint.md#the-origin-a-downloaded-head-sends) is where the last one matters. Anything else is refused
+at startup rather than bound and then never matched. Entries are normalized to the form a browser sends, so `https://Client.Example.Test:443/`
 and `https://client.example.test` are one entry and listing both is refused rather than quietly collapsed.
 
 `*` beside a real origin is refused at startup. It states two policies at once, and guessing would either widen a


### PR DESCRIPTION
A deployment reached by a downloaded head could not be configured to serve it, and two of the three places that
describe the setting said no configuration was needed at all. Both halves are here.

## What was wrong

**Neither native head is exempt from CORS.** Both render in a webview, which enforces it exactly as a browser does
against the origin the shell served the bundle from. Three places said otherwise:

- `docs/operations/client-endpoint.md` § *Browser origins* presented the empty list as what a deployment whose client
  is a desktop or mobile head wants;
- the `ConfigureCorsPolicy` remarks in `ClientTransportSecurityExtensions` said the same thing in the code;
- `docs/operations/configuration-endpoints.md` said an `Origin` header only exists in browsers and a native client is
  unaffected.

The same page already had it right 100 lines further down, in § *Serving the client page*, which is the contradiction
the issue opens with. An operator following the first three narrows the list to `[]` for exactly the deployment that
then stops working — and the failure is silent: the response carries no `Access-Control-Allow-Origin`, the fetch
rejects with a `TypeError` before the client sees a status, nothing reaches the endpoint's logs, and the head reports
that the deployment did not answer.

**The origin could not be written down at all on Linux.** `BrowserOriginPolicy.TryNormalize` accepted `http` and
`https` and refused every other scheme, so a `tauri://localhost` entry was a startup configuration error. Per Tauri's
own configuration reference (`useHttpsScheme`: *"Sets whether the custom protocols should use `https://<scheme>.localhost`
instead of the default `http://<scheme>.localhost` on Windows and Android"*, contrasted there with the
`<scheme>://localhost` protocols on macOS and Linux), the origins MailFathom's own published heads send are:

| The head | The origin it sends |
| --- | --- |
| The desktop head on Linux | `tauri://localhost` |
| The desktop head on Windows, and the Android head | `http://tauri.localhost` |

The second was already expressible. The first was not, so the only posture that served a Linux desktop head was
`["*"]` — every origin on the internet — which the documentation presents as the permissive default to be narrowed
away rather than as the one setting that platform requires.

## What this changes

- **`TryNormalize` admits `tauri` beside `http` and `https`.** The list stays closed rather than becoming open, so a
  scheme MailFathom serves no head from is still a startup error naming the entry instead of a line that binds and then
  matches nothing a client ever sends. `.NET`'s `Uri` normalizes the custom-protocol origin with no special casing —
  case, trailing slash, path, and userinfo all behave as they do for an `http` one — and ASP.NET Core's
  `WithOrigins` carries the string through to `IsOriginAllowed` unchanged, which the new
  `ClientTransportSecurityExtensionsTests` case asserts against the real policy.
- **The empty list is described as what it is.** It fits the deployment whose only client is the page it serves itself,
  which is same-origin and therefore never subject to CORS, plus every non-browser caller. It does not fit a downloaded
  head, and now says so — in § *Browser origins*, in the `ConfigureCorsPolicy` remarks, and in
  `BrowserOriginPolicy.ServingNoBrowserOrigin`'s own remarks.
- **A new § *The origin a downloaded head sends*** on the client endpoint page carries the table above, a worked
  `AllowedOrigins` example, and why the refusal reads as an unreachable server rather than as a policy.
- **The setting reaches the places an operator actually meets it**: `docs/operations/desktop-client.md`
  § *Pointing the client at a deployment* now opens with it, and the Compose configuration example and the chart's
  `values.yaml` — both of which recommended or described the empty list — name the downloaded head as an origin that
  has to be listed instead.
- **The shared scheme rule is stated where the shared setting is documented.** `TryNormalize` backs all three surfaces,
  so `docs/operations/mcp-endpoint.md` § *CORS and the `Origin` header* names the three accepted schemes rather than
  letting the client page imply a rule of its own.

## What it does not change

No configuration key, no default, and no behaviour for a value that was already valid: the accepted set widens, so
every configuration that started before this starts after it. Not a break against any of ADR 0004's four surfaces, and
no changelog entry is owed.

## Verification

`scripts/verify-full.sh` — green. The new coverage is `BrowserOriginPolicyTests` (normalization of the custom-protocol
origin, its refusals, and `Permits` over a listed one), `TransportCorsOptionsTests` (the entry validates and maps
beside a page origin), and `ClientTransportSecurityExtensionsTests` (both head origins reach the registered CORS policy
unchanged). `scripts/review-obligations.sh` reports every changed source file covered.

Closes #1741
