### PR TITLE
[#1745] Read a message and its body in one round trip instead of two

### DIFF
--- a/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.test.tsx
+++ b/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.test.tsx
@@ -2,7 +2,7 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import type { ClientRequest, ClientResponse, ClientSession, MailFathomTransport } from '@mailfathom/client-backend';
 import { LocalizationProvider } from '../localization/Localization';
@@ -73,6 +73,25 @@ function deploymentServing(markup: unknown = asSent): { transport: MailFathomTra
     };
 }
 
+/**
+ * A deployment that has taken both requests and answered neither, recording what each of them asked for.
+ *
+ * It is how a read still in flight is seen at all: every other assertion here waits on an answer, and a read that
+ * never answers has nothing but the record to be seen by.
+ */
+function deploymentAnsweringNothing(): { transport: MailFathomTransport; asked: ClientRequest[] } {
+    const asked: ClientRequest[] = [];
+
+    return {
+        asked,
+        transport: (request) => {
+            asked.push(request);
+
+            return new Promise<ClientResponse>(() => undefined);
+        },
+    };
+}
+
 /** Draws the surface, and answers with the way to hand it a network that came or went afterwards. */
 async function drawing(
     transport: MailFathomTransport,
@@ -113,6 +132,22 @@ describe('FullHtmlSurface', () => {
         expect(asked.map((request) => request.path).filter((path) => path.includes('/body'))).toEqual([
             `${session.baseAddress}/api/client/messages/${messageId}/body?fullHtml=true`,
         ]);
+    });
+
+    // The head and the markup are two answers that need nothing from each other, so neither read waits on the other
+    // having settled: both leave for the deployment when the surface opens. Proven against a deployment answering
+    // neither, both paths reaching it while nothing has come back being the whole of what "at once" can mean here.
+    it('asks for the head and the markup at once, neither waiting on the other to answer', async () => {
+        const { transport, asked } = deploymentAnsweringNothing();
+
+        await drawing(transport);
+
+        await waitFor(() => {
+            expect([...new Set(asked.map((request) => request.path))].sort()).toEqual([
+                `${session.baseAddress}/api/client/messages/${messageId}`,
+                `${session.baseAddress}/api/client/messages/${messageId}/body?fullHtml=true`,
+            ]);
+        });
     });
 
     it('names the message it is showing, and who sent it and when', async () => {

--- a/frontend/src/Client.App/src/messageBody/Message.test.tsx
+++ b/frontend/src/Client.App/src/messageBody/Message.test.tsx
@@ -9,6 +9,7 @@ import type { ClientResponse, ClientSession, MailFathomTransport } from '@mailfa
 import { LocalizationProvider } from '../localization/Localization';
 import { EmbeddedHtmlMessagesContext } from '../preferences/messageView';
 import { Message } from './Message';
+import { useMessageBody } from './useMessageBody';
 
 // The transport is handed in, so nothing here replaces a module: the request, the parsing, and the failure mapping
 // stay the real ones, and only the answer they are given is the test's.
@@ -75,6 +76,27 @@ function readsAsked(): string[] {
     return [...new Set(asked)];
 }
 
+// A surface reading one message, which is what every test below is holding: the read is started where the surface
+// mounts and the component under test draws what it produced, exactly as the reading pane and a conversation do it.
+function ReadMessage({
+    storedEmailId,
+    quotedHistoryOnRequest = false,
+    onBodyDrawn = () => undefined,
+}: {
+    readonly storedEmailId: string;
+    readonly quotedHistoryOnRequest?: boolean;
+    readonly onBodyDrawn?: () => void;
+}) {
+    return (
+        <Message
+            body={useMessageBody(session, transport, storedEmailId, true)}
+            storedEmailId={storedEmailId}
+            quotedHistoryOnRequest={quotedHistoryOnRequest}
+            onBodyDrawn={onBodyDrawn}
+        />
+    );
+}
+
 function readingOneMessage(storedEmailId = 'stub-message') {
     return render(reading(storedEmailId));
 }
@@ -83,7 +105,7 @@ function reading(storedEmailId: string) {
     return (
         <StrictMode>
             <LocalizationProvider>
-                <Message session={session} transport={transport} storedEmailId={storedEmailId} />
+                <ReadMessage storedEmailId={storedEmailId} />
             </LocalizationProvider>
         </StrictMode>
     );
@@ -94,7 +116,7 @@ function readingInAConversation() {
     return render(
         <StrictMode>
             <LocalizationProvider>
-                <Message session={session} transport={transport} storedEmailId="stub-message" quotedHistoryOnRequest />
+                <ReadMessage storedEmailId="stub-message" quotedHistoryOnRequest />
             </LocalizationProvider>
         </StrictMode>,
     );
@@ -105,12 +127,7 @@ function readingReported(onBodyDrawn: () => void, storedEmailId = 'stub-message'
     return (
         <StrictMode>
             <LocalizationProvider>
-                <Message
-                    session={session}
-                    transport={transport}
-                    storedEmailId={storedEmailId}
-                    onBodyDrawn={onBodyDrawn}
-                />
+                <ReadMessage storedEmailId={storedEmailId} onBodyDrawn={onBodyDrawn} />
             </LocalizationProvider>
         </StrictMode>
     );
@@ -122,7 +139,7 @@ function readingUnder(embeddedHtmlMessages: boolean) {
         <StrictMode>
             <LocalizationProvider>
                 <EmbeddedHtmlMessagesContext value={embeddedHtmlMessages}>
-                    <Message session={session} transport={transport} storedEmailId="stub-message" />
+                    <ReadMessage storedEmailId="stub-message" />
                 </EmbeddedHtmlMessagesContext>
             </LocalizationProvider>
         </StrictMode>

--- a/frontend/src/Client.App/src/messageBody/Message.tsx
+++ b/frontend/src/Client.App/src/messageBody/Message.tsx
@@ -2,33 +2,21 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import { useEffect, useRef, useState } from 'react';
-import {
-    readMailBody,
-    type ClientFailureReason,
-    type ClientResult,
-    type ClientSession,
-    type MailBody,
-    type MailFathomTransport,
-} from '@mailfathom/client-backend';
+import { useEffect, useRef } from 'react';
+import type { ClientFailureReason } from '@mailfathom/client-backend';
 import { SecondaryButton } from '../controls/SecondaryButton';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
-import { useEmbeddedHtmlMessages } from '../preferences/messageView';
 import { MessageBody } from './MessageBody';
+import type { MessageBodyRead } from './useMessageBody';
 
-// One message's body, read and drawn. Which message that is, and everything the reading pane lays out around it, is
-// `readingPane/ReadingPane.tsx`'s; what this owns is the body read itself, the reader's own ask for pictures from the
-// sender, the five states a surface that waits owes somebody, and the width all of it is read at.
+// One message's body, drawn. Which message that is, and everything a surface lays out around it, is that surface's;
+// the read itself is `messageBody/useMessageBody.ts`'s, started where the surface mounted rather than here. What this
+// owns is the five states a surface that waits owes somebody, and the width all of it is read at.
 //
-// Asking for pictures re-reads that one message with the ask in the query, and neither this component nor anything
-// beneath it writes the answer down: leaving the message and coming back asks again, which is the whole of what
-// ADR 0024 permits to be remembered.
-//
-// **Which of the two reading surfaces a message is drawn on is asked here rather than passed in**, because this is
-// where the read is composed: the sender's own markup is a second thing the body route answers, so the setting is part
-// of what is being asked for rather than something the drawing decides afterwards. That is also what keeps the
-// representation off every other read — a client in the reduced view never asks for it.
+// **The read is handed in rather than made here**, which is what lets the reading pane start it at the moment somebody
+// opened the message rather than at the moment its description answered: this component is drawn inside the branch
+// that already holds that description, so a read owned here would be a second round trip waiting on the first.
 
 const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
     unauthenticated: 'failure.unauthenticated',
@@ -37,58 +25,11 @@ const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
     unreadable: 'failure.unreadable',
 };
 
-/** What is being read: which message, under which asks, and which attempt at it. A change to any of them may read. */
-interface Read {
-    readonly storedEmailId: string;
-    readonly remotePictures: boolean;
-
-    /** Whether this read asks for the sender's own markup, which only the embedded view does. */
-    readonly markup: boolean;
-
-    readonly attempt: number;
-}
-
-interface Answered {
-    readonly read: Read;
-    readonly result: ClientResult<MailBody>;
-}
-
-/**
- * The answer a read may still be drawn under, which is not every answer this component happens to be holding.
- *
- * It has to be this message's, and it has to have asked for no more than the current read does: a caller that leaves a
- * message whose pictures were asked for and comes back before the next read answers would otherwise redraw the remote
- * sources under a visit where nobody asked, and tell the sender the message was opened again. The other direction is
- * kept deliberately — a message read without the pictures stays on the screen while the ask for them is in flight.
- */
-function drawableUnder(answer: Answered | null, read: Read): Answered | null {
-    if (answer?.read.storedEmailId !== read.storedEmailId) {
-        return null;
-    }
-
-    return answer.read.remotePictures && !read.remotePictures ? null : answer;
-}
-
-/**
- * Whether the answer in hand already covers what the current read asks for, and there is therefore nothing to fetch.
- *
- * The markup is the one ask an older answer may satisfy in one direction only: an answer read with it carries the
- * reduced tree as well, so changing the view back draws what is already here, while an answer read without it has
- * nothing for the embedded view to draw and has to be read again. That is what makes changing the view twice cost one
- * read rather than two, and it is why the read carries the ask rather than the setting deciding after the fact.
- */
-function covers(had: Read | undefined, wants: Read): boolean {
-    return (
-        had?.storedEmailId === wants.storedEmailId &&
-        had.attempt === wants.attempt &&
-        had.remotePictures === wants.remotePictures &&
-        (had.markup || !wants.markup)
-    );
-}
-
 interface MessageToDraw {
-    readonly session: ClientSession;
-    readonly transport: MailFathomTransport;
+    /** The message's body as the surface is holding it, which is what this component draws the states of. */
+    readonly body: MessageBodyRead;
+
+    /** Which message that read belongs to, which is what makes the words on the screen one message's rather than any. */
     readonly storedEmailId: string;
 
     /** Whether the conversation this message quoted is folded away until a reader asks for it, which a thread does. */
@@ -106,7 +47,7 @@ interface MessageToDraw {
      * Asking for the sender's pictures re-reads the same message and says nothing again, because the reader did not
      * open it twice.
      */
-    readonly onBodyDrawn?: () => void;
+    readonly onBodyDrawn: () => void;
 }
 
 // The measure a message is read at is the surface's rather than this component's, which is why nothing here writes
@@ -114,72 +55,12 @@ interface MessageToDraw {
 // message's content and ranges it left against the list it was opened from, and a conversation binds a whole message —
 // head and words together — and centres the column in the pane. A ceiling stated here would have made the second of
 // those unreachable, since a ceiling inside a narrower one is the narrower one.
-export function Message({
-    session,
-    transport,
-    storedEmailId,
-    quotedHistoryOnRequest = false,
-    onBodyDrawn,
-}: MessageToDraw) {
+export function Message({ body, storedEmailId, quotedHistoryOnRequest = false, onBodyDrawn }: MessageToDraw) {
     const { translate } = useLocalization();
-    const embeddedHtml = useEmbeddedHtmlMessages();
-    const [read, setRead] = useState<Read>({ storedEmailId, remotePictures: false, markup: embeddedHtml, attempt: 0 });
-
-    // The answer carries the read it came from, so whether one is still in flight is computed rather than kept beside
-    // it: two pieces of state that must agree is one piece of state and a function, and the answer to a previous read
-    // is never drawn under the current one.
-    const [answer, setAnswer] = useState<Answered | null>(null);
-
-    // The ask belongs to the one message it was made for, so a message changing under this component is not state to
-    // carry over — the next message would otherwise be read with `remoteImages=true` although nobody asked for its
-    // pictures, telling its sender it was opened. React's answer to a prop that invalidates state is to adjust it
-    // during render rather than in an effect, which is why this is an assignment and not a second read.
-    if (read.storedEmailId !== storedEmailId) {
-        setRead({ storedEmailId, remotePictures: false, markup: embeddedHtml, attempt: 0 });
-    } else if (read.markup !== embeddedHtml) {
-        // The view changed under a message already on the screen. That is a changed ask rather than a changed message,
-        // so the pictures and the attempt stay where they are — and the read below is skipped entirely where what is
-        // held already carries what the new view draws.
-        setRead({ ...read, markup: embeddedHtml });
-    }
-
-    // What still has to be read, or `null` where the answer in hand already covers it. Written as the effect's own
-    // dependency rather than as a guard inside it, so that an answer arriving is what stops the next read rather than
-    // a condition evaluated over state the effect would have to depend on to see.
-    const outstanding = covers(answer?.read, read) ? null : read;
-
-    useEffect(() => {
-        if (outstanding === null) {
-            return;
-        }
-
-        let listening = true;
-
-        const ask = { remoteImages: outstanding.remotePictures, fullHtml: outstanding.markup };
-
-        void readMailBody(session, transport, outstanding.storedEmailId, ask).then((answered) => {
-            if (listening) {
-                setAnswer({ read: outstanding, result: answered });
-            }
-        });
-
-        return () => {
-            listening = false;
-        };
-    }, [session, transport, outstanding]);
-
-    const held = drawableUnder(answer, read);
-    const reading = outstanding !== null;
-
-    // Which read is in flight, rather than whether one is. Only the ask for the sender's pictures has a surface that
-    // reports it — the button somebody pressed, with the wait beneath it — so a read begun by anything else, and
-    // changing the view over an open message is one, would otherwise put "Loading them…" under a button nobody
-    // touched. What separates the two is that the answer being drawn was read without the pictures.
-    const askingForPictures = outstanding !== null && outstanding.remotePictures && !held?.read.remotePictures;
 
     // Which message's words are actually on the screen, which is the whole of what opening one means here — `null`
     // while a read is in flight and for a read that failed, because neither put anything in front of anybody.
-    const drawn = held?.result.outcome === 'read' ? held.read.storedEmailId : null;
+    const drawn = body.drawn?.outcome === 'read' ? storedEmailId : null;
 
     // The message this component has already reported as drawn. A ref rather than a flag in state because it has to
     // survive `StrictMode` invoking the effect below twice on mount, for the reason the reading pane's own focus guard
@@ -189,43 +70,38 @@ export function Message({
     useEffect(() => {
         if (drawn !== null && reported.current !== drawn) {
             reported.current = drawn;
-            onBodyDrawn?.();
+            onBodyDrawn();
         }
     }, [drawn, onBodyDrawn]);
 
     // A message already drawn stays on the screen while a re-read runs, because replacing it with one line drops the
     // focus of whoever clicked and moves everything below their cursor on an interaction that changes no words. A
     // failure has nothing worth keeping, so a read started from one says it started.
-    if (held === null || (reading && held.result.outcome === 'failed')) {
+    if (body.drawn === null || (body.reading && body.drawn.outcome === 'failed')) {
         return <p className="text-sm text-muted">{translate('body.reading')}</p>;
     }
 
-    if (held.result.outcome === 'failed') {
+    if (body.drawn.outcome === 'failed') {
+        const failure = body.drawn.failure;
+
         return (
             <div className="flex flex-col items-start gap-2">
                 <p className="text-sm text-warning">
-                    {translate('body.failed', { reason: translate(failureLabels[held.result.failure.reason]) })}
+                    {translate('body.failed', { reason: translate(failureLabels[failure.reason]) })}
                 </p>
 
                 {/* Reading again is the way out of exactly one of the four failures, for the reason
                     `shell/ConnectionSummary.tsx` gives: the other three repeat identically on a second attempt. */}
-                {held.result.failure.reason === 'unavailable' ? (
-                    <SecondaryButton
-                        label={translate('connection.retry')}
-                        onActivate={() => {
-                            setRead({ ...read, attempt: read.attempt + 1 });
-                        }}
-                    />
+                {failure.reason === 'unavailable' ? (
+                    <SecondaryButton label={translate('connection.retry')} onActivate={body.readAgain} />
                 ) : null}
 
                 {/* A failed ask for the sender's pictures has a second way out, which is not reloading the page: the
                     message read without them is one this deployment already answered with. */}
-                {read.remotePictures ? (
+                {body.askedForPictures ? (
                     <SecondaryButton
                         label={translate('body.showWithoutRemotePictures')}
-                        onActivate={() => {
-                            setRead({ ...read, remotePictures: false, attempt: read.attempt + 1 });
-                        }}
+                        onActivate={body.showWithoutRemotePictures}
                     />
                 ) : null}
             </div>
@@ -234,16 +110,11 @@ export function Message({
 
     return (
         <MessageBody
-            body={held.result.value}
-            asking={askingForPictures}
-            /* Both halves rather than the setting alone: the view has to be the one in force *and* the answer on the
-               screen has to be one that was read under it, so a message drawn from an earlier answer stays the reduced
-               tree until the representation arrives instead of reporting markup nobody fetched. */
-            embeddedHtml={read.markup && held.read.markup}
+            body={body.drawn.value}
+            asking={body.askingForPictures}
+            embeddedHtml={body.embeddedHtml}
             quotedHistoryOnRequest={quotedHistoryOnRequest}
-            onShowRemotePictures={() => {
-                setRead({ ...read, remotePictures: true });
-            }}
+            onShowRemotePictures={body.showRemotePictures}
         />
     );
 }

--- a/frontend/src/Client.App/src/messageBody/useMessageBody.ts
+++ b/frontend/src/Client.App/src/messageBody/useMessageBody.ts
@@ -1,0 +1,215 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { useEffect, useState } from 'react';
+import {
+    readMailBody,
+    type ClientResult,
+    type ClientSession,
+    type MailBody,
+    type MailFathomTransport,
+} from '@mailfathom/client-backend';
+import { useEmbeddedHtmlMessages } from '../preferences/messageView';
+
+// Reading one message's body: the read itself, the reader's own ask for pictures from the sender, and which of the
+// answers this client is holding may actually be drawn. What is done with it is `messageBody/Message.tsx`'s.
+//
+// **It is a hook rather than state inside that component because a surface has to be able to start this read before it
+// has anything to draw it under.** The reading pane draws the body inside the branch that already holds the message's
+// description, so a read owned by the component in that branch could not begin until the description had answered —
+// two round trips one after the other for two answers that need nothing from each other. A caller starting the read
+// where it mounts rather than where it draws is what makes the pair concurrent, and it is why the read is separable
+// from the drawing at all.
+//
+// **Whether the read is wanted at all is the caller's to say**, and the two surfaces answer it for different reasons: a
+// conversation of thirty messages holds thirty heads and one open body, so a collapsed message wants none of this, and
+// the reading pane wants nothing while the machine has no network. What a read that is not wanted leaves standing is a
+// body already drawn — nothing about it stopped being true — and never a failure, so wanting the read again is what
+// recovers from one rather than a reader pressing through a refusal that belonged to a wait they have left.
+//
+// Asking for pictures re-reads that one message with the ask in the query, and nothing beneath this writes the answer
+// down: leaving the message and coming back asks again, which is the whole of what ADR 0024 permits to be remembered.
+//
+// **Which of the two reading surfaces a message is drawn on is asked here rather than passed in**, because this is
+// where the read is composed: the sender's own markup is a second thing the body route answers, so the setting is part
+// of what is being asked for rather than something the drawing decides afterwards. That is also what keeps the
+// representation off every other read — a client in the reduced view never asks for it.
+
+/** What is being read: which message, under which asks, and which attempt at it. A change to any of them may read. */
+interface Read {
+    readonly storedEmailId: string;
+    readonly remotePictures: boolean;
+
+    /** Whether this read asks for the sender's own markup, which only the embedded view does. */
+    readonly markup: boolean;
+
+    readonly attempt: number;
+}
+
+interface Answered {
+    readonly read: Read;
+    readonly result: ClientResult<MailBody>;
+}
+
+/** One message's body as this client is holding it: what may be drawn, what is still being read, and the ways on. */
+export interface MessageBodyRead {
+    /** The answer that may be drawn now, or `null` while nothing this hook holds may be. */
+    readonly drawn: ClientResult<MailBody> | null;
+
+    /** Whether a read is in flight, which is a different question from whether anything may be drawn. */
+    readonly reading: boolean;
+
+    /** Whether the read in flight is the reader's own ask for the sender's pictures, which has a surface reporting it. */
+    readonly askingForPictures: boolean;
+
+    /** Whether the current ask carries the sender's pictures, which is what a failed one offers a way back from. */
+    readonly askedForPictures: boolean;
+
+    /** Whether what is drawn may be shown as the sender's own markup: the view in force, and the ask it was read under. */
+    readonly embeddedHtml: boolean;
+
+    readonly readAgain: () => void;
+    readonly showRemotePictures: () => void;
+    readonly showWithoutRemotePictures: () => void;
+}
+
+/** What a message is opened under, which is nothing it inherits from the message read before it. */
+function opening(storedEmailId: string, markup: boolean): Read {
+    return { storedEmailId, remotePictures: false, markup, attempt: 0 };
+}
+
+/**
+ * The answer a read may still be drawn under, which is not every answer this hook happens to be holding.
+ *
+ * It has to be this message's, and it has to have asked for no more than the current read does: a caller that leaves a
+ * message whose pictures were asked for and comes back before the next read answers would otherwise redraw the remote
+ * sources under a visit where nobody asked, and tell the sender the message was opened again. The other direction is
+ * kept deliberately — a message read without the pictures stays on the screen while the ask for them is in flight.
+ */
+function drawableUnder(answer: Answered | null, read: Read): Answered | null {
+    if (answer?.read.storedEmailId !== read.storedEmailId) {
+        return null;
+    }
+
+    return answer.read.remotePictures && !read.remotePictures ? null : answer;
+}
+
+/**
+ * Whether the answer in hand already covers what the current read asks for, and there is therefore nothing to fetch.
+ *
+ * The markup is the one ask an older answer may satisfy in one direction only: an answer read with it carries the
+ * reduced tree as well, so changing the view back draws what is already here, while an answer read without it has
+ * nothing for the embedded view to draw and has to be read again. That is what makes changing the view twice cost one
+ * read rather than two, and it is why the read carries the ask rather than the setting deciding after the fact.
+ */
+function covers(had: Read | undefined, wants: Read): boolean {
+    return (
+        had?.storedEmailId === wants.storedEmailId &&
+        had.attempt === wants.attempt &&
+        had.remotePictures === wants.remotePictures &&
+        (had.markup || !wants.markup)
+    );
+}
+
+/**
+ * Reads one message's body, where the surface asking for it wants it read.
+ *
+ * Called where the surface mounts rather than where the body is drawn, so that the read starts at the moment the
+ * message was opened rather than at the moment something else has answered.
+ *
+ * @param wanted Whether a read may be made at all: this message is the one being shown, and the deployment is reachable.
+ */
+export function useMessageBody(
+    session: ClientSession,
+    transport: MailFathomTransport,
+    storedEmailId: string,
+    wanted: boolean,
+): MessageBodyRead {
+    const embeddedHtml = useEmbeddedHtmlMessages();
+    const [read, setRead] = useState<Read>(() => opening(storedEmailId, embeddedHtml));
+
+    // The answer carries the read it came from, so whether one is still in flight is computed rather than kept beside
+    // it: two pieces of state that must agree is one piece of state and a function, and the answer to a previous read
+    // is never drawn under the current one.
+    const [answer, setAnswer] = useState<Answered | null>(null);
+
+    // The ask belongs to the one message it was made for, so a message changing under this hook is not state to carry
+    // over — the next message would otherwise be read with `remoteImages=true` although nobody asked for its pictures,
+    // telling its sender it was opened. React's answer to a prop that invalidates state is to adjust it during render
+    // rather than in an effect, which is why this is an assignment and not a second read.
+    if (read.storedEmailId !== storedEmailId) {
+        setRead(opening(storedEmailId, embeddedHtml));
+    } else if (read.markup !== embeddedHtml) {
+        // The view changed under a message already on the screen. That is a changed ask rather than a changed message,
+        // so the pictures and the attempt stay where they are — and the read below is skipped entirely where what is
+        // held already carries what the new view draws.
+        setRead({ ...read, markup: embeddedHtml });
+    }
+
+    // A refusal that stood while the read was wanted has nothing left to say once it is not, so it goes with the wait
+    // rather than standing in front of whoever comes back to the message. Adjusted during render for the reason the
+    // assignment above is, and it settles in one pass: what it clears is what its own condition reads.
+    if (!wanted && answer?.result.outcome === 'failed') {
+        setAnswer(null);
+    }
+
+    // What still has to be read, or `null` where no read is wanted and where the answer in hand already covers it.
+    // Written as the effect's own dependency rather than as a guard inside it, so that an answer arriving is what
+    // stops the next read rather than a condition evaluated over state the effect would have to depend on to see.
+    const outstanding = !wanted || covers(answer?.read, read) ? null : read;
+
+    useEffect(() => {
+        if (outstanding === null) {
+            return;
+        }
+
+        let listening = true;
+
+        const ask = { remoteImages: outstanding.remotePictures, fullHtml: outstanding.markup };
+
+        void readMailBody(session, transport, outstanding.storedEmailId, ask).then((answered) => {
+            if (listening) {
+                setAnswer({ read: outstanding, result: answered });
+            }
+        });
+
+        return () => {
+            listening = false;
+        };
+    }, [session, transport, outstanding]);
+
+    const held = drawableUnder(answer, read);
+
+    return {
+        drawn: held?.result ?? null,
+        reading: outstanding !== null,
+
+        // Which read is in flight, rather than whether one is. Only the ask for the sender's pictures has a surface
+        // that reports it — the button somebody pressed, with the wait beneath it — so a read begun by anything else,
+        // and changing the view over an open message is one, would otherwise put "Loading them…" under a button
+        // nobody touched. What separates the two is that the answer being drawn was read without the pictures.
+        askingForPictures: outstanding !== null && outstanding.remotePictures && !held?.read.remotePictures,
+
+        askedForPictures: read.remotePictures,
+
+        // Both halves rather than the setting alone: the view has to be the one in force *and* the answer on the
+        // screen has to be one that was read under it, so a message drawn from an earlier answer stays the reduced
+        // tree until the representation arrives instead of reporting markup nobody fetched.
+        embeddedHtml: read.markup && (held?.read.markup ?? false),
+
+        readAgain: () => {
+            setRead((current) => ({ ...current, attempt: current.attempt + 1 }));
+        },
+
+        showRemotePictures: () => {
+            setRead((current) => ({ ...current, remotePictures: true }));
+        },
+
+        // A failed ask for the sender's pictures has a way out that is not reloading the page: the message read
+        // without them is one this deployment already answered with.
+        showWithoutRemotePictures: () => {
+            setRead((current) => ({ ...current, remotePictures: false, attempt: current.attempt + 1 }));
+        },
+    };
+}

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
@@ -98,8 +98,17 @@ function deploymentDescribing(described = description(), status = 200): MailFath
     };
 }
 
-/** A deployment that has taken the request and not answered it, which is what a surface that waits is proven against. */
-const answersNothing: MailFathomTransport = () => new Promise<ClientResponse>(() => undefined);
+/**
+ * A deployment that has taken the request and not answered it, which is what a surface that waits is proven against.
+ *
+ * It records what it was asked for, which is what makes a read that is in flight visible at all: an answer is what
+ * every other assertion here waits on, and a read that never answers has nothing but the record to be seen by.
+ */
+const answersNothing: MailFathomTransport = (request) => {
+    asked.push(request);
+
+    return new Promise<ClientResponse>(() => undefined);
+};
 
 function drawing(
     transport: MailFathomTransport,
@@ -210,6 +219,34 @@ describe('ReadingPane', () => {
         expect(await screen.findByRole('heading', { name: 'Quarterly invoice', level: 2 })).toBeDefined();
     });
 
+    // The body is read on the same terms as the description now that both leave together, and the network going is
+    // one of them: a refusal the gap itself caused is not something to leave a reader pressing through under a
+    // message that is otherwise on the screen, so it goes with the gap and the words arrive on their own afterwards.
+    it('reads the body again once the network is back, rather than standing on the refusal the gap caused', async () => {
+        let bodyStatus = 503;
+
+        const transport: MailFathomTransport = (request) => {
+            asked.push(request);
+
+            const answer: ClientResponse = request.path.includes('/body')
+                ? { status: bodyStatus, body: bodyStatus === 200 ? bodyAsWords : '', headers: {} }
+                : { status: 200, body: description(), headers: {} };
+
+            return Promise.resolve(answer);
+        };
+
+        const { rerender } = render(paneReading(transport, true));
+        await screen.findByText('The message could not be read: unavailable.');
+
+        rerender(paneReading(transport, false));
+        expect(screen.queryByText('The message could not be read: unavailable.')).toBeNull();
+
+        bodyStatus = 200;
+        rerender(paneReading(transport, true));
+
+        expect(await screen.findByText('The invoice is attached.')).toBeDefined();
+    });
+
     it('draws the headers and the body of the message it read', async () => {
         drawing(deploymentDescribing());
 
@@ -229,7 +266,24 @@ describe('ReadingPane', () => {
         // the body is a second read that has not necessarily been made by then. Reading the record at that moment is
         // what reports one route where there are two, on a machine loaded enough to put the two commits apart.
         await waitFor(() => {
-            expect([...new Set(asked.map((request) => request.path))]).toEqual([
+            expect([...new Set(asked.map((request) => request.path))].sort()).toEqual([
+                `https://mail.example.invalid/api/client/messages/${messageId}`,
+                `https://mail.example.invalid/api/client/messages/${messageId}/body`,
+            ]);
+        });
+    });
+
+    // The two reads need nothing from each other — the identity both of them carry is the one the reader pressed — so
+    // neither is allowed to wait on the other having settled. Proven against a deployment that answers neither: both
+    // paths reaching it while nothing has come back is the whole of what "at the same time" can mean here, and it is
+    // what the pane could not do while the body was read by the component drawn under the description's own answer.
+    it('asks for the description and the body at once, neither waiting on the other to answer', async () => {
+        asked.length = 0;
+
+        drawing(answersNothing);
+
+        await waitFor(() => {
+            expect([...new Set(asked.map((request) => request.path))].sort()).toEqual([
                 `https://mail.example.invalid/api/client/messages/${messageId}`,
                 `https://mail.example.invalid/api/client/messages/${messageId}/body`,
             ]);

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
@@ -25,6 +25,7 @@ import { useSignalledChanges } from '../signals/signalledChanges';
 import { useOpenAttachment } from '../workspace/openAttachment';
 import { useWorkspace } from '../workspace/useWorkspace';
 import { Message } from '../messageBody/Message';
+import { useMessageBody } from '../messageBody/useMessageBody';
 import { BackToList } from '../mailSpace/BackToList';
 import { NothingOpen } from '../mailSpace/NothingOpen';
 import { useTwoPanes } from '../shell/useWideWorkspace';
@@ -40,7 +41,10 @@ import { SenderVerdict } from './SenderVerdict';
 //
 // Two reads stand behind it and that is deliberate rather than incidental. The description and the body are separately
 // expensive, so the header block is drawn the moment the first answers and the body says it is still reading underneath
-// it; that is this screen's partial state rather than a gap in it.
+// it; that is this screen's partial state rather than a gap in it. **Both are started at the moment the message was
+// opened**, neither waiting on the other to settle: the identity both of them need is what the reader pressed, so a
+// body read owned by the component drawn inside the description's own branch would have spent a second round trip —
+// and the derivation every request on this surface pays — for an answer that needed nothing from the first.
 //
 // Neither of those reads writes to a mailbox, and that is the property ADR 0007 bought as a property of the types: both
 // are `GET`s against the local copy, and the route that serves a body holds no write session to reach a mail server
@@ -158,6 +162,11 @@ function OpenMessage({
     const [read, setRead] = useState<Read>({ storedEmailId, attempt: 0, quietly: false });
     const [answer, setAnswer] = useState<Answered | null>(null);
     const [connected, setConnected] = useState(online);
+
+    // The body's own read, started here rather than inside the component that draws it, which is what makes the pair
+    // concurrent: this component mounts when the message is opened, and the branch drawing the body exists only once
+    // the description has answered.
+    const bodyRead = useMessageBody(session, transport, storedEmailId, online);
 
     // The opener is a new function on every render, so it is held rather than named as a dependency below: the effect
     // that follows a citation reacts to the citation and to the answer, and naming this would run it once per render.
@@ -457,8 +466,7 @@ function OpenMessage({
                             description above already says which account and folder the message is counted in, which is
                             what a folder's unread count is corrected by. */}
                         <Message
-                            session={session}
-                            transport={transport}
+                            body={bodyRead}
                             storedEmailId={storedEmailId}
                             onBodyDrawn={() => {
                                 markRead({

--- a/frontend/src/Client.App/src/thread/ThreadMessage.test.tsx
+++ b/frontend/src/Client.App/src/thread/ThreadMessage.test.tsx
@@ -138,6 +138,23 @@ describe('ThreadMessage', () => {
         expect(screen.queryByRole('button', { name: 'Open this message on its own' })).toBeNull();
     });
 
+    // The words are what the read costs, and a conversation of thirty messages draws thirty heads: so a collapsed
+    // message reaches the deployment for nothing at all, and pressing it is what asks. The record is what proves it —
+    // a message drawing no words could be one whose read is merely still in flight.
+    it('reads nothing from the deployment while it is collapsed', () => {
+        drawing(message(), { collapsed: true });
+
+        expect(asked).toEqual([]);
+    });
+
+    it('reads the body from the deployment once it is open', () => {
+        drawing(message());
+
+        expect(asked.map((request) => request.path)).toEqual([
+            `${session.baseAddress}/api/client/messages/a-message/body`,
+        ]);
+    });
+
     it('opens and closes from its head, which is the control the design draws it as', () => {
         const toggled = vi.fn();
 

--- a/frontend/src/Client.App/src/thread/ThreadMessage.tsx
+++ b/frontend/src/Client.App/src/thread/ThreadMessage.tsx
@@ -12,6 +12,7 @@ import { SenderAvatar } from '../controls/SenderAvatar';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
 import { Message } from '../messageBody/Message';
+import { useMessageBody } from '../messageBody/useMessageBody';
 import { drawnUnread, useReadMarking } from '../readMarking/useReadMarking';
 import type { ArrivalMark } from './threadOpening';
 
@@ -80,6 +81,10 @@ export function ThreadMessage({
     const email = message.email;
     const sender = email.senderDisplayName ?? email.senderAddress ?? translate('list.senderUnknown');
 
+    // A collapsed message wants no read, which is what keeps a conversation of thirty heads to one body: the head is
+    // drawn from what the conversation already answered with, and pressing it is what asks for the words.
+    const body = useMessageBody(session, transport, email.id, !collapsed);
+
     // What the deployment last reported, less what this client has marked read since — the same reading the list's own
     // row draws from, because the two are the same message in two places and a reader who opened it here would
     // otherwise find it still unread there.
@@ -140,8 +145,7 @@ export function ThreadMessage({
                             decides for itself draws more than the latest message — the rest are collapsed until
                             pressed, which is a gesture the reader makes knowing whose message it opens. */}
                         <Message
-                            session={session}
-                            transport={transport}
+                            body={body}
                             storedEmailId={email.id}
                             quotedHistoryOnRequest
                             onBodyDrawn={() => {


### PR DESCRIPTION
## What changed

Opening a message issued two round trips one after the other, although neither answer needed anything from the other. `readingPane/ReadingPane.tsx` read the description, and `<Message>` — which read the body — was rendered inside the branch that already held that answer, so the body request could not start until the description had settled. The identity both reads need is what the reader pressed.

The body read moves out of `messageBody/Message.tsx` into `messageBody/useMessageBody.ts`, a hook a **surface calls where it mounts rather than where it draws**. `OpenMessage` now starts both reads at the moment the message is opened, and `Message` draws whichever answer is in hand — the header block still appears as soon as the description answers, with the body saying it is reading underneath it, and a description that arrived first is no longer held back.

The hook is told whether a read is wanted at all, and the two surfaces answer that for different reasons: the reading pane wants nothing while the machine has no network, and a conversation wants nothing for a collapsed message — which is what keeps a thread of thirty heads to one body, and what the pane's old gate got for free by not mounting `<Message>` at all.

## Acceptance

- **Both requests in flight before either answers** — `ReadingPane.test.tsx`, against a deployment that answers neither: both paths reach it while nothing has come back.
- **The pane draws what has arrived** — unchanged; the header block is drawn from the description alone and the body reports its own wait, which the existing state tests still cover.
- **A message change and a signalled re-read still cancel and replace** — a changed `storedEmailId` resets the ask and discards the read in flight; a signalled re-read still re-reads the description alone, as it did before.
- **The ask travels with the read** — the sender's pictures and the markup view are still resolved where the read is composed, and a message opened after another inherits neither.
- **`fullHtml/FullHtmlSurface.tsx` starts its pair the same way** — it already did: its two effects both run on mount, so the issue's reading that it carries the same chain was wrong. It gains the test that says so rather than a change.
- **A unit test asserts both are in flight** — one on each surface.

## What this costs, stated rather than left to be found

- A refusal the network gap itself caused now goes with the gap for the body as it already did for the description, so **offline, a drawn header can stand over "Reading the message…"** until the network returns, at which point the body reads itself. That is the pane's own offline posture — a reader who lost their network is not left pressing through a refusal — and the frame above already says the machine is offline.
- A message whose **description fails still spends one body request**, which is inherent to asking both at once.

## Verification

- `scripts/verify-full.sh` — passed (client flow; 299 workflow assertions, 3028 client tests, `src/messageBody` at 98.63% statements).
- `useMessageBody.ts` has no test file beside it: it is exercised through `Message.test.tsx`, which mounts it via a surface stand-in, and through both surfaces' own tests.
- No visual change, so no design capture is owed: the states, the composition, and the copy are the ones already drawn.

Closes #1745
