### PR TITLE
[#1744] Serve the client endpoint's responses compressed

### DIFF
--- a/backend/src/Host/HostComposition.cs
+++ b/backend/src/Host/HostComposition.cs
@@ -1334,6 +1334,7 @@ internal static class HostComposition
         if (clientEndpointSettings.Enabled)
         {
             builder.Services.AddClientTransportSecurity(clientEndpointSettings);
+            builder.Services.AddClientResponseCompression();
             AddClientTelemetryProxy(builder);
             AddClientSignalChannel(builder);
             // What puts a Discover run on a scope of its own and keeps it running past the request that asked for it.

--- a/backend/src/Host/HostPipeline.cs
+++ b/backend/src/Host/HostPipeline.cs
@@ -89,6 +89,14 @@ internal static class HostPipeline
 
         if (composition.Client.Enabled)
         {
+            // Behind the isolation above, so a listener that does not serve the client surface never wraps a response
+            // stream, and ahead of every route that writes one. What it is deliberately behind is the exception
+            // handler, whose document is written from upstream and therefore travels uncompressed: a body nobody asked
+            // for is not worth a compression pass. It scopes itself to this surface's paths rather than being branched
+            // on here, because what it must not reach is the signal hub, which is a client path as well;
+            // ClientResponseCompression holds that reading and the BREACH one beside it.
+            app.UseClientResponseCompression();
+
             // What lets the signal hub accept an upgrade at all, and behind the isolation above so a listener that does
             // not serve the client surface never reaches it. It is added on whether this deployment serves the client
             // rather than beside the routes, because middleware is the process's pipeline and a route is not.

--- a/backend/src/Host/Hosting/Startup/ClientResponseCompression.cs
+++ b/backend/src/Host/Hosting/Startup/ClientResponseCompression.cs
@@ -1,0 +1,96 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Host.Configuration.Endpoints;
+using MailFathom.Host.Signals;
+
+namespace MailFathom.Host.Hosting.Startup;
+
+/// <summary>Compresses what the client endpoint serves, in whichever encoding the caller offered.</summary>
+/// <remarks>
+/// <para>
+/// The bodies this surface serves are JSON that repeats itself — a mail list is a hundred rows of the same field names
+/// around a few kilobytes of subject and preview text — and it travelled uncompressed, so a page cost six times the
+/// bytes it had to. Nothing in front of a deployment fixes that on its behalf: <c>deploy/</c> ships arrangements with
+/// no reverse proxy at all, so a surface that does not compress its own responses is one that ships uncompressed.
+/// </para>
+/// <para>
+/// <b>Why BREACH does not apply here, which is what
+/// <see cref="Microsoft.AspNetCore.ResponseCompression.ResponseCompressionOptions.EnableForHttps" /> is off by
+/// default for.</b> The attack recovers a secret from a compressed body by measuring how the body's length moves as an
+/// attacker-chosen string is reflected into it, and it needs three things at once. It needs the victim's browser to
+/// attach a credential to a request the attacker caused: this surface authenticates by header — a bearer token, an API
+/// key, or a client assertion the page attaches itself — and never by cookie, so a cross-site request reaches it with
+/// no credential and is answered as an anonymous one. It needs a caller-supplied value reflected into the same body as
+/// the secret: no response composed here carries one, the search route being the closest and deliberately not echoing
+/// the query it was asked. And the refusals that do quote a caller's value back are served as
+/// <c>application/problem+json</c>, which is not among the media types compressed below.
+/// </para>
+/// <para>
+/// What is compressed is the framework's default set — JSON, text, XML, CSS, JavaScript, and WebAssembly — which is
+/// also what keeps an already-compressed payload from being compressed twice: an attachment download and a portrait
+/// travel under the media type their content declares, and a JPEG, a PDF, or a ZIP is not in that set. The compression
+/// level is the framework's default of <see cref="System.IO.Compression.CompressionLevel.Fastest" /> for both
+/// providers rather than a tuned one, because the ratio past it is a few percent and the cost is the request's own
+/// latency, which is the thing this exists to reduce.
+/// </para>
+/// <para>
+/// The encoding is negotiated rather than fixed: the framework reads <c>Accept-Encoding</c>, serves <c>br</c> to a
+/// caller that offered it and <c>gzip</c> to one that offered only that, and serves a caller that offered neither the
+/// body unchanged.
+/// </para>
+/// </remarks>
+internal static class ClientResponseCompression
+{
+    /// <summary>Registers the compression this surface's responses are served under.</summary>
+    /// <param name="services">The container to add to.</param>
+    /// <returns>The container, so composition reads as one sequence.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// Registered on whether this deployment serves the client surface, because it is the only surface that reaches
+    /// the middleware — the MCP and administrative surfaces are a separate reading, and
+    /// <see cref="ServedByThisSurface" /> is what keeps them out of it.
+    /// </remarks>
+    internal static IServiceCollection AddClientResponseCompression(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        // Over HTTPS as well as over clear text, on the reading above. Left at its default, the middleware would
+        // compress nothing at all in the deployment shape this was written for, since a surface a browser reaches is
+        // one an operator is told to serve over TLS.
+        return services.AddResponseCompression(options => options.EnableForHttps = true);
+    }
+
+    /// <summary>Puts the compression in front of the routes this surface serves, and in front of nothing else.</summary>
+    /// <param name="app">The application pipeline being composed.</param>
+    /// <returns>The same application instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="app" /> is <see langword="null" />.</exception>
+    internal static IApplicationBuilder UseClientResponseCompression(this IApplicationBuilder app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        return app.UseWhen(
+            static context => ServedByThisSurface(context.Request.Path),
+            compressed => compressed.UseResponseCompression());
+    }
+
+    /// <summary>Whether a path is one whose response this compresses.</summary>
+    /// <param name="path">The path the request asked for.</param>
+    /// <returns><see langword="true" /> where the path is a client route other than the signal hub.</returns>
+    /// <remarks>
+    /// Matched by segment, so a path such as <c>/api/clients</c> is not mistaken for one of these, which is how the
+    /// isolation middleware matches the same prefix.
+    /// <para>
+    /// The signal hub is excluded rather than left to the media types: what travels there is a connection rather than a
+    /// response, and a transport SignalR negotiates down to — long polling answers <c>text/plain</c>, which is in the
+    /// compressed set — would have each poll buffered for compression instead of delivered as it is written. Nothing
+    /// is lost by leaving it out, a signal being a few dozen bytes. The route that mints the hub's tickets sits under
+    /// the same prefix and is excluded with it, which is the right side to err on: it is the one answer on this surface
+    /// that is itself a credential, and it is two hundred bytes.
+    /// </para>
+    /// </remarks>
+    internal static bool ServedByThisSurface(PathString path) =>
+        path.StartsWithSegments(ClientEndpointOptions.RoutePrefix)
+        && !path.StartsWithSegments(ClientSignalEndpoints.HubPath);
+}

--- a/backend/tests/Host.UnitTests/Hosting/Startup/ClientResponseCompressionTests.cs
+++ b/backend/tests/Host.UnitTests/Hosting/Startup/ClientResponseCompressionTests.cs
@@ -1,0 +1,175 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text;
+using MailFathom.Host.Api;
+using MailFathom.Host.Configuration.Endpoints;
+using MailFathom.Host.Hosting.Startup;
+using MailFathom.Host.Signals;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Hosting.Startup;
+
+/// <summary>Covers what the client endpoint compresses, in which encoding, and what it leaves alone.</summary>
+/// <remarks>
+/// Asserted through the composed middleware rather than through the options it was registered with, because what an
+/// operator is promised is a response that arrives compressed: an encoding the framework negotiates away, a media type
+/// that turns out not to be in the compressed set, or a scheme the middleware refuses to compress over would each
+/// leave every option correct and every response the size it was.
+/// <para>
+/// The bodies below repeat themselves the way the surface's own do — a mail list is the same field names around a
+/// hundred rows — so that a body that was compressed is recognizable as one by its length rather than by the header
+/// alone.
+/// </para>
+/// </remarks>
+public sealed class ClientResponseCompressionTests
+{
+    private const string TimelinePath = ClientEndpointOptions.RoutePrefix
+        + ClientMailTimelineEndpoint.MailTimelineRoute;
+
+    private static readonly byte[] TimelinePage = Encoding.UTF8.GetBytes(
+        $$"""{"emails":[{{string.Join(
+            ",",
+            Enumerable.Range(0, 100).Select(static row =>
+                $$"""{"id":"{{row}}","subject":"Quarterly report","preview":"Please find the figures attached.","unread":false}"""))}}],"pageSize":100}""");
+
+    /// <summary>What a mail list costs a reader on a request that offered an encoding, which is the whole of this issue.</summary>
+    /// <remarks>
+    /// The <c>Vary</c> header is asserted here rather than beside the uncompressed case because that is where it
+    /// decides something: a cache that kept this body without it would hand a Brotli page to the next caller, whatever
+    /// that caller offered.
+    /// </remarks>
+    [Fact]
+    public async Task Response_ATimelinePageForARequestOfferingBrotli_IsServedCompressed()
+    {
+        // Act
+        var served = await ServeAsync(TimelinePath, "application/json; charset=utf-8", "br, gzip");
+
+        // Assert
+        Assert.Equal("br", served.Encoding);
+        Assert.True(
+            served.Length < TimelinePage.Length,
+            $"the page travelled as {served.Length} bytes of an uncompressed {TimelinePage.Length}");
+        Assert.Contains("Accept-Encoding", served.Vary, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>A caller that cannot read Brotli is served what it can read rather than what this deployment prefers.</summary>
+    [Fact]
+    public async Task Response_ARequestOfferingOnlyGzip_IsServedGzipRatherThanBrotli()
+    {
+        // Act
+        var served = await ServeAsync(TimelinePath, "application/json; charset=utf-8", "gzip");
+
+        // Assert
+        Assert.Equal("gzip", served.Encoding);
+        Assert.True(served.Length < TimelinePage.Length);
+    }
+
+    /// <summary>A caller that offered nothing is answered with the bytes it asked for.</summary>
+    [Fact]
+    public async Task Response_ARequestOfferingNoEncoding_IsServedUnchanged()
+    {
+        // Act
+        var served = await ServeAsync(TimelinePath, "application/json; charset=utf-8", acceptEncoding: null);
+
+        // Assert
+        Assert.Null(served.Encoding);
+        Assert.Equal(TimelinePage.Length, served.Length);
+    }
+
+    /// <summary>An attachment is octets somebody else already compressed, and a second pass over them costs latency to make them longer.</summary>
+    [Theory]
+    [InlineData("application/pdf")]
+    [InlineData("image/jpeg")]
+    [InlineData("application/zip")]
+    [InlineData("application/problem+json")]
+    public async Task Response_AMediaTypeOutsideTheCompressedSet_IsServedUnchanged(string contentType)
+    {
+        // Act
+        var served = await ServeAsync(ClientEndpointOptions.RoutePrefix + "/emails/1/attachments/2", contentType, "br, gzip");
+
+        // Assert
+        Assert.Null(served.Encoding);
+        Assert.Equal(TimelinePage.Length, served.Length);
+    }
+
+    /// <summary>The live channel is a connection rather than a response, so nothing buffers its writes to compress them — and the route that mints its tickets is under the same prefix.</summary>
+    [Theory]
+    [InlineData(ClientSignalEndpoints.HubPath)]
+    [InlineData(ClientEndpointOptions.RoutePrefix + ClientSignalEndpoints.TicketRoute)]
+    public async Task Response_TheSignalChannel_IsServedUncompressed(string path)
+    {
+        // Act
+        var served = await ServeAsync(path, "text/plain", "br, gzip");
+
+        // Assert
+        Assert.Null(served.Encoding);
+    }
+
+    /// <summary>The other two surfaces are a separate reading, and a path that merely begins with the same letters is not this one.</summary>
+    [Theory]
+    [InlineData("/mcp")]
+    [InlineData("/api/admin/accounts")]
+    [InlineData("/api/clients")]
+    [InlineData("/health/ready")]
+    public async Task Response_APathThisSurfaceDoesNotServe_IsServedUncompressed(string path)
+    {
+        // Act
+        var served = await ServeAsync(path, "application/json; charset=utf-8", "br, gzip");
+
+        // Assert
+        Assert.Null(served.Encoding);
+    }
+
+    /// <summary>Serves one body through the composed pipeline and reports what reached the wire.</summary>
+    private static async Task<ServedResponse> ServeAsync(string path, string contentType, string? acceptEncoding)
+    {
+        // Logging is the one registration the framework's own middleware asks for and the composition under test does
+        // not make: a host has it before any surface is composed.
+        var services = new ServiceCollection()
+            .AddLogging()
+            .AddClientResponseCompression()
+            .BuildServiceProvider();
+
+        var pipeline = new ApplicationBuilder(services)
+            .UseClientResponseCompression()
+            .Use(_ => async context =>
+            {
+                context.Response.ContentType = contentType;
+
+                await context.Response.Body.WriteAsync(TimelinePage);
+            })
+            .Build();
+
+        using var body = new MemoryStream();
+        var context = new DefaultHttpContext { RequestServices = services };
+
+        // The scheme the surface is served over where a browser reaches it, which is what the registration turns
+        // compression on for and therefore the one this has to assert under.
+        context.Request.Scheme = "https";
+        context.Request.Path = path;
+        context.Response.Body = body;
+
+        if (acceptEncoding is not null)
+        {
+            context.Request.Headers.AcceptEncoding = acceptEncoding;
+        }
+
+        await pipeline(context);
+
+        return new ServedResponse(
+            context.Response.Headers.ContentEncoding.ToString() is { Length: > 0 } encoding ? encoding : null,
+            context.Response.Headers.Vary.ToString(),
+            body.Length);
+    }
+
+    /// <summary>What one response put on the wire.</summary>
+    /// <param name="Encoding">The encoding it was served under, or <see langword="null" /> where it carried none.</param>
+    /// <param name="Vary">What the response says its shape depends on.</param>
+    /// <param name="Length">The octets that travelled.</param>
+    private sealed record ServedResponse(string? Encoding, string Vary, long Length);
+}

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -1,6 +1,6 @@
 # The client endpoint
 
-<!-- describes: backend/src/AppHost/Program.cs, backend/src/AppHost/OrchestrationContract.cs, backend/src/Host/Configuration/Endpoints/ClientEndpointOptions.cs, backend/src/Host/Configuration/Endpoints/ClientApplicationOptions.cs, backend/src/Host/Configuration/Endpoints/TransportHttpsEndpointOptions.cs, backend/src/Host/Api/ClientApiEndpoints.cs, backend/src/Host/Api/ClientMailAccountsEndpoint.cs, backend/src/Host/Api/ClientMailFoldersEndpoint.cs, backend/src/Host/Api/ClientMailTimelineEndpoint.cs, backend/src/Host/Api/ClientMailThreadEndpoint.cs, backend/src/Host/Api/ClientMailMessageEndpoint.cs, backend/src/Host/Api/ClientMailBodyEndpoint.cs, backend/src/Host/Api/ClientMailAttachmentEndpoint.cs, backend/src/Host/Api/AttachmentContentResponse.cs, backend/src/Host/Api/ProtectedResourceMetadataEndpoint.cs, backend/src/Host/Security/Endpoints/ClientTransportSecurityExtensions.cs, backend/src/Infrastructure/Security/Transport/BrowserOriginPolicy.cs, backend/src/Host/Hosting/ClientApplicationFiles.cs, backend/src/Host/Hosting/Warnings/ClientTransportSecurityWarning.cs, backend/src/Host/Hosting/Warnings/PasswordClearTextTransportWarning.cs, backend/src/Host/Api/ClientUserRecordEndpoint.cs, backend/src/Host/Api/ClientPortraitEndpoint.cs, backend/src/Host/Api/ClientDisplayNameEndpoint.cs, backend/src/Host/Configuration/UserSettings/Administration/OwnDisplayName.cs, backend/src/Host/Api/ClientMailMutationsEndpoint.cs, backend/src/Host/Api/ClientDraftEndpoints.cs, backend/src/Host/Api/ClientDraftResponses.cs, backend/src/Host/Api/ClientOutboxEndpoints.cs, backend/src/Host/Api/ClientNotificationEndpoints.cs, backend/src/Host/Api/ClientTelemetryEndpoint.cs, backend/src/Host/Api/ClientCitationEndpoint.cs, backend/src/Host/Api/ClientDiscoveryRunEndpoints.cs, backend/src/Host/Observability/ClientTelemetry/** -->
+<!-- describes: backend/src/AppHost/Program.cs, backend/src/AppHost/OrchestrationContract.cs, backend/src/Host/Configuration/Endpoints/ClientEndpointOptions.cs, backend/src/Host/Configuration/Endpoints/ClientApplicationOptions.cs, backend/src/Host/Configuration/Endpoints/TransportHttpsEndpointOptions.cs, backend/src/Host/Api/ClientApiEndpoints.cs, backend/src/Host/Api/ClientMailAccountsEndpoint.cs, backend/src/Host/Api/ClientMailFoldersEndpoint.cs, backend/src/Host/Api/ClientMailTimelineEndpoint.cs, backend/src/Host/Api/ClientMailThreadEndpoint.cs, backend/src/Host/Api/ClientMailMessageEndpoint.cs, backend/src/Host/Api/ClientMailBodyEndpoint.cs, backend/src/Host/Api/ClientMailAttachmentEndpoint.cs, backend/src/Host/Api/AttachmentContentResponse.cs, backend/src/Host/Api/ProtectedResourceMetadataEndpoint.cs, backend/src/Host/Security/Endpoints/ClientTransportSecurityExtensions.cs, backend/src/Infrastructure/Security/Transport/BrowserOriginPolicy.cs, backend/src/Host/Hosting/ClientApplicationFiles.cs, backend/src/Host/Hosting/Startup/ClientResponseCompression.cs, backend/src/Host/Hosting/Warnings/ClientTransportSecurityWarning.cs, backend/src/Host/Hosting/Warnings/PasswordClearTextTransportWarning.cs, backend/src/Host/Api/ClientUserRecordEndpoint.cs, backend/src/Host/Api/ClientPortraitEndpoint.cs, backend/src/Host/Api/ClientDisplayNameEndpoint.cs, backend/src/Host/Configuration/UserSettings/Administration/OwnDisplayName.cs, backend/src/Host/Api/ClientMailMutationsEndpoint.cs, backend/src/Host/Api/ClientDraftEndpoints.cs, backend/src/Host/Api/ClientDraftResponses.cs, backend/src/Host/Api/ClientOutboxEndpoints.cs, backend/src/Host/Api/ClientNotificationEndpoints.cs, backend/src/Host/Api/ClientTelemetryEndpoint.cs, backend/src/Host/Api/ClientCitationEndpoint.cs, backend/src/Host/Api/ClientDiscoveryRunEndpoints.cs, backend/src/Host/Observability/ClientTelemetry/** -->
 
 Where the MailFathom client reaches the service, what a deployment has to enable before it answers, and what a person's
 mail client presents to get in.
@@ -2062,6 +2062,39 @@ whether it is taken out of service.
 **Neither reaches [the signal channel's hub](#the-signal-channel)**, which is mapped outside this surface's route group
 for that reason, and both reach the route that mints its tickets — so a client reconnecting in a loop is bounded by the
 minting it cannot avoid rather than by a timeout on the connection itself.
+
+## What travels compressed
+
+**A response is compressed when the request offered an encoding this deployment can produce, and is served unchanged
+when it did not.** Nothing configures it: there is no key, no switch, and no per-route opt-out. A caller that sends
+`Accept-Encoding: br, gzip` is answered with `content-encoding: br`, one that offers `gzip` alone is answered with
+`gzip` rather than with an encoding it cannot read, and one that offers neither is answered with the bytes it asked
+for. Every compressed response carries `Vary: Accept-Encoding`, so a cache in front of the deployment keeps one body
+per encoding rather than handing a Brotli page to a client that never offered it.
+
+It matters most where it is least visible from: a hundred-row mail list is around 75 kB of JSON that repeats its own
+field names, and it travels several times smaller than that. On a local or intranet deployment the difference is
+nothing; on a phone it is most of the time a folder takes to open.
+
+**What is compressed is JSON, text, XML, CSS, JavaScript, and WebAssembly**, which is the framework's default set.
+Everything else travels as it arrived, which is what keeps an [attachment](#the-attachment-route) or a
+[portrait](#the-portrait-routes) from being compressed a second time: a JPEG, a PDF, and a ZIP are octets somebody else
+already compressed, and a pass over them costs latency to produce a slightly longer body. The
+[signal channel](#the-signal-channel) is excluded as well, for the reason the limits and the ceiling exclude it — what
+travels there is a connection rather than a response — and so is the route that mints its tickets, which is the one
+answer here that is itself a credential and is a couple of hundred bytes either way.
+
+**This is the client endpoint alone.** The MCP surface and the administrative surface serve their responses
+uncompressed, and whether they want the same treatment is a separate reading rather than an oversight.
+
+**It applies over HTTPS as well as over clear text**, which the framework does not do by default, because compressing a
+response over TLS is what BREACH exploits. The attack recovers a secret from a compressed body by watching how the
+body's length moves as an attacker-chosen string is reflected into it, and it needs the victim's browser to attach a
+credential to a request the attacker caused. This surface authenticates by header — the token, key, or assertion the
+page attaches itself — and never by cookie, so a cross-site request arrives here with no credential and is answered as
+an anonymous one. Nor does any response here reflect a caller-supplied value back: the [search route](#the-mail-search-route)
+is the closest and deliberately does not echo the query it was asked, and the refusals that do quote a caller's value
+are served as `application/problem+json`, which is outside the compressed set above.
 
 ## Transport security
 


### PR DESCRIPTION
## What this changes

The client endpoint served every response uncompressed. A hundred-row `/api/client/emails` page is around 75 kB of
JSON that repeats its own field names, and it was byte-identical whether or not the request offered an encoding.
Nothing in front of a deployment covered for it either, since `deploy/` ships arrangements with no reverse proxy at
all — so the surface a phone reads mail over was shipping uncompressed by construction.

`ClientResponseCompression` registers the framework's response compression on whether this deployment serves the
client surface, and puts the middleware in front of that surface's own paths and nothing else. The encoding is
negotiated rather than fixed: `br` to a caller that offered it, `gzip` to one that offered only that, and the body
unchanged to one that offered neither, with `Vary: Accept-Encoding` on everything compressed.

## Why it is enabled over HTTPS, which the framework refuses by default

`EnableForHttps` is off by default because of BREACH, and the file states in place why the attack does not reach this
surface. It needs the victim's browser to attach a credential to a request the attacker caused: this endpoint
authenticates by header — the bearer token, API key, or client assertion the page attaches itself — and never by
cookie, so a cross-site request arrives with no credential and is answered as an anonymous one. It needs a
caller-supplied value reflected into the same body as the secret: no response composed here carries one, the search
route being the closest and deliberately not echoing the query it was asked. And the refusals that do quote a
caller's value are served as `application/problem+json`, which is outside the compressed media types.

## What is left alone

- **The framework's default media types** are what is compressed — JSON, text, XML, CSS, JavaScript, WebAssembly —
  which is also what keeps an already-compressed payload from a second pass: an attachment download and a portrait
  travel under the media type their content declares, and a JPEG, a PDF, or a ZIP is not in that set.
- **The signal hub**, and the route that mints its tickets under the same prefix. What travels there is a connection
  rather than a response, and a transport SignalR negotiates down to would have each poll buffered instead of
  delivered as it is written; the ticket is the one answer on this surface that is itself a credential, and it is a
  couple of hundred bytes either way.
- **The MCP and administrative surfaces**, which the issue puts out of scope, and **the client bundle**, which is
  served ahead of surface isolation by the static-file middleware and is a build-time precompression question rather
  than a per-request one. Neither is an oversight; both are a separate reading.
- **The exception handler's document**, which is written from upstream of the middleware. A body nobody asked for is
  not worth a compression pass.

The compression level is the framework's default of `Fastest` for both providers: the ratio past it is a few percent
and the cost is the request's own latency, which is the thing this exists to reduce.

## Public surfaces

None of the four moved. No route, no configuration key, no tool argument, and no column — there is deliberately no
switch, because there is no per-deployment decision here to expose. `http-api-contract.json` is unchanged, which the
gate confirms.

## Tests

`ClientResponseCompressionTests` drives the composed middleware rather than reading the options it was registered
with, because what is promised is a response that arrives compressed: a negotiated-away encoding, a media type that
turns out not to be in the set, or a scheme the middleware refuses to compress over would each leave every option
correct and every response the size it was. Thirteen cases: a timeline page under `br` and under `gzip` alone, one
offering nothing, four media types outside the set, the hub and its ticket route, and four paths this surface does not
serve.

## Verification

- `scripts/verify-fast.sh` — 15 023 tests, 0 failed.
- `scripts/verify-full.sh` — exit 0, 299 contracts passed.
- `scripts/review-obligations.sh` — read; `docs/operations/client-endpoint.md` carries the new section and its
  `describes:` marker now names the new file.

Closes #1744
