### PR TITLE
[#1753] Draw the unread mark, the open row, and one count where the design puts them

### DIFF
--- a/frontend/src/Client.App/src/folders/FolderRow.tsx
+++ b/frontend/src/Client.App/src/folders/FolderRow.tsx
@@ -143,7 +143,7 @@ export function FolderRow({
                 <span className="min-w-0 flex-1 truncate">{nameOf(row, translate)}</span>
 
                 <State row={row} />
-                <Unread count={row.unreadEmailCount} />
+                <Unread count={row.role === 'Inbox' ? row.unreadEmailCount : null} />
             </span>
 
             {/* A rail has nowhere to put it, and nothing is lost with it: the arrow keys are what fold a row, and the
@@ -209,6 +209,11 @@ function State({ row }: { readonly row: FolderTreeRow }) {
 // What is unread here, of the deployment's own copy rather than of the mailbox, which is what the state beside it
 // says. The words a reader hears are carried, because a bare number on a row is a number of nothing to somebody who
 // cannot see the column it is in. A row with nothing unread carries no number, as the design project draws it.
+//
+// Only an inbox carries one at all. A number on every folder is a column of numbers, and a column of numbers is one
+// nobody reads: what the count is for is the one row somebody is waiting on. Everything else — a sent folder, an
+// archive, a folder with no role, and the headings the accounts are grouped under — carries none, and nothing stands
+// in its place either.
 function Unread({ count }: { readonly count: number | null }) {
     const { locale, translate } = useLocalization();
 

--- a/frontend/src/Client.App/src/folders/FolderTree.test.tsx
+++ b/frontend/src/Client.App/src/folders/FolderTree.test.tsx
@@ -267,10 +267,24 @@ describe('FolderTree', () => {
         expect(row(/^Inbox12 unread/).textContent).not.toContain('4,213');
     });
 
+    // A count belongs to the one row somebody is waiting on, which is the inbox. A number on every row is a column of
+    // numbers nobody reads, so a mailbox, the workspace over all of them, and a folder playing no role each carry none
+    // — and nothing stands in its place either.
+    it('counts what is unread on an inbox and on nothing else', async () => {
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+
+        expect(row(/^Inbox12 unread/).textContent).toContain('12 unread');
+        expect(row(/^Work/).textContent).not.toContain('unread');
+        expect(row(/^All mailboxes/).textContent).not.toContain('unread');
+        expect(row(/^Archiwum/).textContent).not.toContain('unread');
+    });
+
     // A count that still named a message the reader has just opened would disagree with the row drawing that message
     // read, which is the one thing about an unread count somebody notices. Every level of the tree is a sum over the
     // same folders, so the correction is applied once to the folders and each of them answers for it.
-    it('takes what this client has marked read off the folder, its mailbox, and the role across mailboxes', async () => {
+    it('takes what this client has marked read off the folder and off the role across mailboxes', async () => {
         renderTree(
             answering(JSON.stringify(tree)),
             true,
@@ -280,17 +294,15 @@ describe('FolderTree', () => {
         await drawn();
 
         expect(row(/^Inbox10 unread/).textContent).toContain('10 unread');
-        expect(row(/^Work10 unread/).textContent).toContain('10 unread');
         expect(row(/^Inbox13 unread/).textContent).toContain('13 unread');
-        expect(row(/^All mailboxes13 unread/).textContent).toContain('13 unread');
     });
 
-    it('leaves a mailbox this client has marked nothing in exactly as the deployment counted it', async () => {
+    it('leaves an inbox this client has marked nothing in exactly as the deployment counted it', async () => {
         renderTree(answering(JSON.stringify(tree)), true, marked({ account: 'work', folder: 'INBOX' }));
 
         await drawn();
 
-        expect(row(/^Personal/).textContent).toContain('3 unread');
+        expect(row(/^Inbox.*[^0-9]3 unread/).textContent).toContain('3 unread');
     });
 
     it('offers every mailbox at once as the scope everything else is read under', async () => {

--- a/frontend/src/Client.App/src/folders/FolderTree.test.tsx
+++ b/frontend/src/Client.App/src/folders/FolderTree.test.tsx
@@ -46,6 +46,16 @@ const tree = {
                     behind: false,
                 },
                 {
+                    alias: 'ARCHIVE',
+                    role: 'Archive',
+                    path: ['Archive'],
+                    storedEmailCount: 3100,
+                    unreadEmailCount: 7,
+                    synchronizationState: 'Synchronized',
+                    lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
+                    behind: false,
+                },
+                {
                     alias: 'ARCHIVE-2024',
                     role: null,
                     path: ['Archiwum', '2024'],
@@ -279,6 +289,12 @@ describe('FolderTree', () => {
         expect(row(/^Work/).textContent).not.toContain('unread');
         expect(row(/^All mailboxes/).textContent).not.toContain('unread');
         expect(row(/^Archiwum/).textContent).not.toContain('unread');
+
+        // The archive plays a role and holds seven unread, so it is the row that separates "an inbox" from "a folder
+        // the deployment named": a rule reading "any folder with a role" would draw a count here.
+        for (const archive of screen.getAllByRole('treeitem', { name: /^Archive/ })) {
+            expect(archive.textContent).not.toContain('unread');
+        }
     });
 
     // A count that still named a message the reader has just opened would disagree with the row drawing that message

--- a/frontend/src/Client.App/src/messageRows/MessageRow.tsx
+++ b/frontend/src/Client.App/src/messageRows/MessageRow.tsx
@@ -242,7 +242,7 @@ export function MessageRow({
                     selected
                         ? 'border-s-accent bg-accent-soft'
                         : open
-                          ? 'border-s-accent-line bg-accent-soft'
+                          ? 'border-s-accent-strong bg-accent-soft'
                           : 'border-s-transparent bg-panel hover:bg-hover'
                 }`}
                 // The one value here a token cannot hold: how far this row has been carried is a distance a finger
@@ -250,20 +250,12 @@ export function MessageRow({
                 style={swipe.carried === 0 ? undefined : { transform: `translateX(${String(swipe.carried)}px)` }}
             >
                 <div className="flex items-center gap-2">
-                    {/* Unread is drawn as weight and colour, which is how the design project draws it, and said in as
-                        many words for a reader who is not looking at either. Nothing marks the row visually beside
-                        that: a dot ahead of the avatar would inset every unread row a little further than every read
-                        one, which is the one thing a list of rows that have to scan as a column cannot afford. */}
-                    {unread ? <span className="sr-only">{translate('list.unread')}</span> : null}
-
                     <SenderAvatar displayName={email.senderDisplayName} address={email.senderAddress} place="row" />
 
                     {/* Who wrote is read before where they wrote from, so the name keeps up to half the line and the
                         host is what gives way. Half rather than more because the marks and the time hold their own
                         width: a name allowed past it would push the time out of a row that clips rather than wraps. */}
-                    <span
-                        className={`max-w-1/2 shrink-0 truncate text-md font-semibold ${unread ? 'text-text' : 'text-text-soft'}`}
-                    >
+                    <span className="max-w-1/2 shrink-0 truncate text-md font-semibold">
                         {correspondent(email) ?? translate('list.senderUnknown')}
                     </span>
 
@@ -271,12 +263,23 @@ export function MessageRow({
 
                     <MessageMarkers email={email} />
 
+                    {/* Unread, and the whole of what says so. The design project draws the mark here — at the end of
+                        the marks, between the flag and the time, rather than ahead of the avatar, where it would inset
+                        every unread row a little further than every read one, which is the one thing a column that has
+                        to scan cannot afford — and draws the name and the subject of a read row in the same weight and
+                        the same colour as an unread one. So the dot is the mark rather than a second statement beside
+                        a typographic one, and the words beside it are for a reader who is not looking at it. */}
+                    {unread ? (
+                        <span className="shrink-0">
+                            <span aria-hidden="true" className="block size-2 rounded-full bg-accent" />
+                            <span className="sr-only">{translate('list.unread')}</span>
+                        </span>
+                    ) : null}
+
                     <ReceivedAt at={email.receivedAt} />
                 </div>
 
-                <div className={`truncate text-md ${unread ? 'text-text' : 'text-text-soft'}`}>
-                    {email.subject ?? translate('list.noSubject')}
-                </div>
+                <div className="truncate text-md">{email.subject ?? translate('list.noSubject')}</div>
 
                 {/* The reserved line. Hidden from the accessibility tree where it holds nothing, so a row with nothing
                     to say about itself is not announced as one with an empty line in it. */}


### PR DESCRIPTION
Closes #1753.

The owner's read of the running client against the design project found eighteen differences. #1760 groups the work that answers them; this is the first of its children, and it is the three the mail list and the mailbox tree own.

## What moved

**The unread mark.** `MessageRow.tsx` drew unread as weight and colour alone, and its comment said that was how the design drew it. The design's current source draws an 8 px accent dot in the row's right-hand marks cluster — between the flag and the time — and gives the name and the subject of a read row exactly the weight and colour an unread one takes. So the row now draws the dot, keeps the words beside it for a reader who is not looking at either, and no longer softens a message it has already been read.

**The open row.** It took `accent-line`, which is the tint that bounds a soft surface, where the design's `rowStyleFor` insets `--accent-2` — this repository's `accent-strong`. It read visibly dimmer than the design at both themes, which is what the report's fifth finding is about. The selected row's `accent` edge is unchanged and already agreed.

**One count.** `FolderRow.tsx` drew `unreadEmailCount` on every row that had one, so a mailbox heading, the workspace over all of them, an archive, and a folder with no role each carried a number. The owner's rule is that a count belongs to the inbox alone and counts unread mail, so that is what it draws now, and nothing stands in its place on the rows that lost it.

## What was checked and left alone

**The palette agrees with the design, token for token.** Both blocks were read against `MailFathom Prototyp.dc.html`'s own `[data-theme]` declarations — 29 tokens in the light theme and 28 in the dark — and every value matches to the digit, the only differences being trailing zeros in the spelling. So the fifth finding is one wrong token choice rather than a drifted palette, and nothing in `styles.css` moved.

**The mailbox symbols already follow the role.** Every symbol the design's folder rows draw is the one the client's role table names — `inbox`, `send`, `draft`, `archive`, `delete`, `all_inbox` — so the map is unchanged. One row is unresolved rather than fixed: the design's global *Ważne* draws `star`, and the client's `Important` role draws `label_important`. Which of the client's roles that row is — `Important` or `Flagged` — is not something the artboard settles, so it is named here rather than guessed at.

## Two differences this change does not close

- **The row's marks are a superset of the design's.** The design draws flag, unread, count and time; the client also draws an answered mark and an attachment mark. Both carry information the design's row does not, so they are kept and named rather than dropped in a defect fix.
- **The thread count.** The design's pill needs a count of the messages sharing a thread, which `MailTimelineEntry` does not carry and a page cannot compute — #1761 adds the field and draws it.

## Verification

`scripts/verify-full.sh` passed over exactly this content, 299 checks, and the client suite with it. The two visual changes are not unit-testable under `frontend/tests/AGENTS.md`, which asserts no class name and settles what a screen looks like by looking at it, so they were held against the design as captures: `mail-list` and `mail-thread` at the desktop composition in the dark theme, from the fixture corpus. The unread dot lands where the design puts it, the open row's edge now reads as the design's bright accent rather than as a dim line, and the tree carries one count on each inbox and none elsewhere. The counts rule is covered by a unit test in `FolderTree.test.tsx`.
