### PR TITLE
[#1757] Fall back where the folder or the message somebody left the client on has gone

### DIFF
--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -1287,9 +1287,9 @@ Both carry `mailfathom.client.request`, which is the method and the **route temp
 `GET /folders`, `GET /messages/{storedEmailId}/body` — never a composed path, so a message identifier is not a
 dimension value. The span takes the same string as its name. Beside it sits `mailfathom.client.outcome`, whose values
 are the client's own contract rather than words invented here — `read` and `failed` — and, on a failure,
-`mailfathom.client.failure`, carrying which of `unauthenticated`, `unauthorized`, `unavailable`, or `unreadable` the
-client mapped the answer to. A failed request's span status is an error carrying no message: what failed is already the
-dimension beside it.
+`mailfathom.client.failure`, carrying which of `unauthenticated`, `unauthorized`, `unavailable`, `unreadable`, or
+`missing` the client mapped the answer to. A failed request's span status is an error carrying no message: what failed
+is already the dimension beside it.
 
 **Every request the client makes is one of them, including the four it does not put on the wire itself.** A file a
 message carries, and the picture the signed-in person is drawn by, arrive as octets rather than as a document, so those
@@ -1301,8 +1301,12 @@ other request's and the request carries the trace context exactly as one this cl
 **The outcome says whether an answer arrived, not whether the answer was yes.** A route that deliberately refuses — a
 name this deployment will not record, a person it holds no portrait for — has answered something a screen acts on, so
 it is `read`; so is a download the person waiting on it stopped, that being their own act rather than the deployment
-failing to answer. What `failed` names is the four an operator can act on, and a file larger than the message described
-is `unreadable` among them, the body having been refused rather than absent.
+failing to answer. What `failed` names is the five an operator can act on, and a file larger than the message described
+is `unreadable` among them, the body having been refused rather than absent. `missing` is the one of the five that is
+not a fault to chase: only `GET /messages/{storedEmailId}` produces it, and it says the deployment answered that it no
+longer holds that message — a reader who had it open is told it is gone rather than offered a retry. A rate of it that
+tracks how much mail is being deleted is the deployment working, and it is worth separating from `unavailable` on a
+dashboard for exactly that reason.
 
 **Moving between screens is the client's alone to report.** Every screen after the first is rendered rather than
 fetched, so the wait a person actually has is invisible from the deployment.

--- a/frontend/src/AGENTS.md
+++ b/frontend/src/AGENTS.md
@@ -279,8 +279,11 @@ not a preference about polish.
   A screen that looks finished while a read is in flight is a screen a person acts on twice.
 - **Every failure says what failed and offers the way out.** Each failure reason is its own sentence and its own next
   step: signing in again, saying the grant is missing, retrying, reporting a defect, and — for something the deployment
-  no longer holds — letting go of it and landing on the empty state, which is the one whose way out is that no way out
-  is needed. "Something went wrong" is none of them, and neither is a status code on a screen.
+  no longer holds — letting go of it. The surface that lets go is the one _holding_ it, which is the reading pane: what
+  was open is dropped from the workspace, and the empty state is what is left. A surface merely drawn _about_ that
+  message says so and keeps the control it was opened with, because closing itself would put somebody back on a screen
+  still drawing the message with nothing having said why the surface went. "Something went wrong" is none of them, and
+  neither is a status code on a screen.
 - **No state is reachable that a person cannot leave.** Every dialog closes, every flow can be abandoned, and every
   error state offers something other than reloading the page.
 - **Every screen has its five states, and each is designed rather than defaulted**: loading, empty, partial (some of it

--- a/frontend/src/AGENTS.md
+++ b/frontend/src/AGENTS.md
@@ -61,9 +61,13 @@ Four things may never cross, in either direction:
 
 - One exported function per thing the client asks for, named for what it asks — `readMailAccounts`, not `getAccounts`
   and not `accountsApi.fetch`. It takes the session and the transport and answers a `ClientResult`.
-- **An expected failure is a value, never an exception.** The four `ClientFailureReason` values exist because a screen
-  does something different with each, so a new operation reuses them rather than inventing a fifth for the same four
-  outcomes; a genuinely new outcome is a new member argued in the change that adds it.
+- **An expected failure is a value, never an exception.** The `ClientFailureReason` values exist because a screen does
+  something different with each, so a new operation reuses them rather than inventing another for outcomes they already
+  cover; a genuinely new outcome is a new member argued in the change that adds it. `missing` is the worked example of
+  that bar being met — a message the deployment no longer holds is let go of where every other failure is retried or
+  reported — and it is also the example of where such a reading belongs: `failureReasonForStatus` maps a `404` to
+  `unavailable`, because most routes here name no one thing, and the one route that names a single message reads that
+  status differently at its own call site.
 - **The credential is a finished header value and nothing composes it here.** Nothing logs it, puts it in a URL, stores
   it where another origin can read it, or passes it to anything but a request on the client surface.
 - Bound what a screen asks for. A route that can answer with a mailbox-sized collection is called with the window the
@@ -273,9 +277,10 @@ not a preference about polish.
 
 - **Every surface that waits says it is waiting**, from the moment the wait starts, in the place the answer will appear.
   A screen that looks finished while a read is in flight is a screen a person acts on twice.
-- **Every failure says what failed and offers the way out.** The four failure reasons are four different sentences and
-  four different next steps: signing in again, saying the grant is missing, retrying, and reporting a defect. "Something
-  went wrong" is none of them, and neither is a status code on a screen.
+- **Every failure says what failed and offers the way out.** Each failure reason is its own sentence and its own next
+  step: signing in again, saying the grant is missing, retrying, reporting a defect, and — for something the deployment
+  no longer holds — letting go of it and landing on the empty state, which is the one whose way out is that no way out
+  is needed. "Something went wrong" is none of them, and neither is a status code on a screen.
 - **No state is reachable that a person cannot leave.** Every dialog closes, every flow can be abandoned, and every
   error state offers something other than reloading the page.
 - **Every screen has its five states, and each is designed rather than defaulted**: loading, empty, partial (some of it

--- a/frontend/src/Client.App/src/App.session.test.tsx
+++ b/frontend/src/Client.App/src/App.session.test.tsx
@@ -5,6 +5,7 @@
 import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import type { DeploymentTransport } from './deployment/sendToDeployment';
+import { emptyWorkspace, type Workspace } from './workspace/useWorkspace';
 import { mostReconnectionAttempts } from './shell/useConnection';
 import {
     asked,
@@ -193,6 +194,33 @@ describe('App session', () => {
         await screen.findByText(/This machine is offline\./);
 
         expect(within(screen.getByRole('navigation', { name: 'Spaces' })).queryAllByRole('link')).toEqual([]);
+    });
+
+    // What somebody was reading and where they were reading it goes with the credential, and the store is where that
+    // has to be true rather than only the screen: the next start reads the store, so a folder or a message left in it
+    // would be the last person's place handed to whoever signs in next on this machine.
+    it('keeps neither the folder nor the message somebody was on once they have signed out', async () => {
+        renderApp(servedFrom, null, deploymentAnswering(), storeKeeping());
+        signIn();
+        await framed();
+
+        window.sessionStorage.setItem(
+            'mailfathom.workspace',
+            JSON.stringify({
+                ...emptyWorkspace,
+                scope: { kind: 'folder', accountId: 'work', alias: 'INBOX' },
+                selection: 'AAMkAD-42',
+            }),
+        );
+
+        await signOut();
+
+        await waitFor(() => {
+            const kept = JSON.parse(window.sessionStorage.getItem('mailfathom.workspace') ?? 'null') as Workspace;
+
+            expect(kept.scope).toEqual({ kind: 'everything' });
+            expect(kept.selection).toBeNull();
+        });
     });
 
     it('reports the deployment it is reading from beside the client it is running, on the settings screen', async () => {

--- a/frontend/src/Client.App/src/composer/Composer.test.tsx
+++ b/frontend/src/Client.App/src/composer/Composer.test.tsx
@@ -930,6 +930,17 @@ describe('Composer, an answer', () => {
         });
     });
 
+    // The reading pane lets go of a message the deployment no longer holds, because the pane is what holds what is
+    // open. The composer is drawn *about* that message rather than holding it, so it says the message is gone and
+    // waits: closing itself would take away the only thing that said so, and it is a surface somebody opened.
+    it('says the message it was answering is gone, and stays open on it', async () => {
+        const { closed } = drawComposer(replying, { message: { status: 404, body: '' } });
+
+        expect(await screen.findByText(/nothing here to answer/u)).toBeDefined();
+        expect(closed).not.toHaveBeenCalled();
+        expect(screen.getByRole('button', { name: 'Close the message' })).toBeDefined();
+    });
+
     it('reads nothing where this tab was already writing that answer', () => {
         rememberComposition({
             answering: { storedEmailId: messageId, answers: 'everyone' },

--- a/frontend/src/Client.App/src/composer/Composer.tsx
+++ b/frontend/src/Client.App/src/composer/Composer.tsx
@@ -45,8 +45,12 @@ import { WrittenMessage } from './WrittenMessage';
 /** What the composer is doing before there is anything to write in, which is a state of its own rather than a blank. */
 type Reading = { readonly kind: 'reading' } | { readonly kind: 'unread'; readonly reason: ClientFailureReason };
 
-// What each of the four failures means for somebody trying to write mail, said as what they do next. The reading
-// failure and the deployment's own are worded the same way because they are the same four answers.
+// What each of the five failures means for somebody trying to write mail, said as what they do next. The reading
+// failure and the deployment's own are worded from one table because four of the five are the same answer to either.
+// `missing` reaches only the read: the message route is the one that reads a `404` as something the deployment no
+// longer holds, so the sentence is about the message being answered rather than about a draft. The composer says it
+// and stays open: a surface somebody opened is left by the control they opened it with, and closing itself under them
+// would report a message that is gone by taking away the one place that said so.
 const failureSaid: Readonly<Record<ClientFailureReason, MessageKey>> = {
     unauthenticated: 'compose.failedUnauthenticated',
     unauthorized: 'compose.failedUnauthorized',

--- a/frontend/src/Client.App/src/composer/Composer.tsx
+++ b/frontend/src/Client.App/src/composer/Composer.tsx
@@ -52,6 +52,7 @@ const failureSaid: Readonly<Record<ClientFailureReason, MessageKey>> = {
     unauthorized: 'compose.failedUnauthorized',
     unavailable: 'compose.failedUnavailable',
     unreadable: 'compose.failedUnreadable',
+    missing: 'compose.failedMissing',
 };
 
 // What each rule that refuses a send is called, and what would change it. Exhaustive by its own type, so a refusal the

--- a/frontend/src/Client.App/src/composer/useDraftAtDeployment.ts
+++ b/frontend/src/Client.App/src/composer/useDraftAtDeployment.ts
@@ -196,7 +196,7 @@ export function useDraftAtDeployment(session: ClientSession, transport: MailFath
         return written.draftId;
     }
 
-    // Every act ends by saying what happened, and a failure says which of the four it was rather than that something
+    // Every act ends by saying what happened, and a failure says which of the five it was rather than that something
     // went wrong. Stated once here because five acts would otherwise each carry their own copy of the same three lines.
     function settled<TValue>(answer: ClientResult<TValue>, whenRead: (value: TValue) => DraftStanding): DraftStanding {
         return hold(

--- a/frontend/src/Client.App/src/folders/FolderTree.test.tsx
+++ b/frontend/src/Client.App/src/folders/FolderTree.test.tsx
@@ -3,7 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import type { ReactElement } from 'react';
-import { act, fireEvent, render, screen, type RenderResult } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, type RenderResult } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ClientSession, ClientSignal, MailFathomTransport } from '@mailfathom/client-backend';
 import { LocalizationProvider } from '../localization/Localization';
@@ -15,7 +15,7 @@ import {
     type SignalledChanges,
 } from '../signals/signalledChanges';
 import { WorkspaceProvider } from '../workspace/Workspace';
-import { useWorkspace, type Workspace } from '../workspace/useWorkspace';
+import { emptyWorkspace, useWorkspace, type Workspace } from '../workspace/useWorkspace';
 import { FolderTree } from './FolderTree';
 
 const session: ClientSession = { baseAddress: 'https://mail.example.invalid', authorization: 'Basic dGVzdA==' };
@@ -351,6 +351,37 @@ describe('FolderTree', () => {
         fireEvent.click(row(/^Inbox12 unread/));
 
         expect(carried().scope).toEqual({ kind: 'folder', accountId: 'work', alias: 'INBOX' });
+    });
+
+    // What is scoped to outlives the answer it was chosen from, so the answer is also what says whether it is still
+    // there. Seeded through the store rather than clicked, because a folder a reader could click is by definition one
+    // the tree is still drawing.
+    it.each<{ gone: string; gap: Workspace['scope'] }>([
+        { gone: 'a folder', gap: { kind: 'folder', accountId: 'work', alias: 'ARCHIVE-2019' } },
+        { gone: 'a mailbox', gap: { kind: 'account', accountId: 'retired' } },
+        { gone: 'the last folder playing a role', gap: { kind: 'role', role: 'Junk' } },
+    ])('opens on every mailbox where what was scoped to is $gone the deployment no longer offers', async ({ gap }) => {
+        window.sessionStorage.setItem('mailfathom.workspace', JSON.stringify({ ...emptyWorkspace, scope: gap }));
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+
+        // Awaited rather than asserted outright: the tree is drawn from the answer and the scope is corrected against
+        // that same answer, so the correction lands on the render after the one that first drew a row.
+        await waitFor(() => {
+            expect(carried().scope).toEqual({ kind: 'everything' });
+        });
+    });
+
+    it('leaves a scope the deployment still offers exactly where it was', async () => {
+        const kept: Workspace['scope'] = { kind: 'folder', accountId: 'work', alias: 'ARCHIVE' };
+
+        window.sessionStorage.setItem('mailfathom.workspace', JSON.stringify({ ...emptyWorkspace, scope: kept }));
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+
+        expect(carried().scope).toEqual(kept);
     });
 
     it('says which folder is behind and which one nothing could reach, rather than showing either as waiting', async () => {

--- a/frontend/src/Client.App/src/folders/FolderTree.tsx
+++ b/frontend/src/Client.App/src/folders/FolderTree.tsx
@@ -16,7 +16,7 @@ import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
 import { useReadMarking } from '../readMarking/useReadMarking';
 import { useSignalledChanges } from '../signals/signalledChanges';
-import { scopeKey } from '../workspace/mailScope';
+import { everything, scopeKey, scopeStillOffered } from '../workspace/mailScope';
 import { useWorkspace } from '../workspace/useWorkspace';
 import { FolderRow } from './FolderRow';
 import { folderTreeOf, visibleRows, type VisibleRow } from './folderTreeRows';
@@ -44,6 +44,7 @@ const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
     unauthorized: 'failure.unauthorized',
     unavailable: 'failure.unavailable',
     unreadable: 'failure.unreadable',
+    missing: 'failure.missing',
 };
 
 /** What one attempt answered, tagged with the attempt, so whether a read is in flight is worked out rather than kept. */
@@ -108,6 +109,24 @@ export function FolderTree({
             listening = false;
         };
     }, [session, transport, attempt, refreshed, online]);
+
+    // A scope outlives the tree it was chosen from, so the answer that arrives is also what says whether it still
+    // names anything: the session's store carries a folder across a reload, and a folder deleted on the mail server in
+    // between would otherwise leave the list asking for a mailbox nobody can reach and the tree highlighting no row.
+    // Falling back to the widest scope is what the client opens with, so a folder that has gone reads as never having
+    // been chosen rather than as an error somebody has to press through.
+    //
+    // An effect rather than a derivation, which § *State* would otherwise prefer: the scope is one value the whole
+    // client reads and this tree is one of its readers, so deriving a second scope here would be the two-values-that
+    // -must-agree defect rather than a cure for it. It is also not the reconciling effect that rule refuses — nothing
+    // is being kept in step, and this runs once per answer that disagrees rather than on every render.
+    useEffect(() => {
+        if (answered?.result.outcome !== 'read' || scopeStillOffered(workspace.scope, answered.result.value)) {
+            return;
+        }
+
+        revise({ scope: everything });
+    }, [answered, workspace.scope, revise]);
 
     // Three of the five kinds move this tree, because all three move a count it draws: mail arriving in a folder, a
     // message changing folder or read state, and the mapping itself moving. It re-reads under whatever is drawn rather

--- a/frontend/src/Client.App/src/folders/FolderTree.tsx
+++ b/frontend/src/Client.App/src/folders/FolderTree.tsx
@@ -166,8 +166,8 @@ export function FolderTree({
                     {translate('folders.failed', { reason: translate(failureLabels[reason]) })}
                 </p>
 
-                {/* Reading again is the way out of exactly one of the four failures, for the reason
-                    `shell/ConnectionSummary.tsx` gives: the other three repeat identically on a second attempt. */}
+                {/* Reading again is the way out of exactly one of the five failures, for the reason
+                    `shell/ConnectionSummary.tsx` gives: the other four repeat identically on a second attempt. */}
                 {reason === 'unavailable' ? (
                     <SecondaryButton
                         label={translate('connection.retry')}

--- a/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.test.tsx
+++ b/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.test.tsx
@@ -291,6 +291,23 @@ describe('FullHtmlSurface', () => {
         expect(screen.getByRole('button', { name: 'Try again' })).toBeDefined();
     });
 
+    // A message the deployment no longer holds reaches this surface too, and it is not the reading pane's case. The
+    // pane holds what is open, so it lets go and lands on the empty state; this surface is drawn *about* that message,
+    // and closing itself would put somebody back on a pane still drawing it with nothing having said why the surface
+    // went. So it says the message is gone, offers no retry that could not answer, and waits for the control it was
+    // opened with.
+    it('says the message is no longer there, offering no retry and closing nothing by itself', async () => {
+        const closed = vi.fn();
+        const gone: MailFathomTransport = () => Promise.resolve({ status: 404, body: '', headers: {} });
+
+        await drawing(gone, { onClose: closed });
+
+        expect(await screen.findByText(/could not be read: no longer there/u)).toBeDefined();
+        expect(screen.queryByRole('button', { name: 'Try again' })).toBeNull();
+        expect(closed).not.toHaveBeenCalled();
+        expect(screen.getByRole('button', { name: 'Close this view' })).toBeDefined();
+    });
+
     it('reads both the head and the markup again when the reader tries again', async () => {
         let refusals = 2;
 

--- a/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.tsx
+++ b/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.tsx
@@ -301,8 +301,8 @@ function Markup({
                     {translate('fullHtml.failed', { reason: translate(failureLabels[failure.reason]) })}
                 </p>
 
-                {/* Reading again is the way out of exactly one of the four failures, for the reason
-                    `shell/ConnectionSummary.tsx` gives: the other three repeat identically on a second attempt. It
+                {/* Reading again is the way out of exactly one of the five failures, for the reason
+                    `shell/ConnectionSummary.tsx` gives: the other four repeat identically on a second attempt. It
                     re-runs both reads, because both are keyed on the one attempt. */}
                 {failure.reason === 'unavailable' ? (
                     <SecondaryButton label={translate('connection.retry')} onActivate={onRetry} />

--- a/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.tsx
+++ b/frontend/src/Client.App/src/fullHtml/FullHtmlSurface.tsx
@@ -47,6 +47,7 @@ const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
     unauthorized: 'failure.unauthorized',
     unavailable: 'failure.unavailable',
     unreadable: 'failure.unreadable',
+    missing: 'failure.missing',
 };
 
 // What a reader is told about each bound that could have cut this representation short, and nothing where none did.

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -412,6 +412,8 @@ export const en = {
     'compose.failedUnavailable': 'Your deployment did not answer. What you wrote is kept here; try again.',
     'compose.failedUnreadable':
         'Your deployment answered, but this client could not act on the answer. That is a defect worth reporting.',
+    'compose.failedMissing':
+        'Your deployment no longer holds what this was about. What you wrote is still here, and it can be filed as something new.',
 
     'tabs.strip': 'Open tabs',
     'tabs.close': 'Close {title}',
@@ -579,6 +581,7 @@ export const en = {
     'failure.unauthorized': 'unauthorized',
     'failure.unavailable': 'unavailable',
     'failure.unreadable': 'unreadable',
+    'failure.missing': 'no longer there',
 
     'body.reading': 'Reading the message…',
     'body.failed': 'The message could not be read: {reason}.',

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -413,7 +413,7 @@ export const en = {
     'compose.failedUnreadable':
         'Your deployment answered, but this client could not act on the answer. That is a defect worth reporting.',
     'compose.failedMissing':
-        'Your deployment no longer holds what this was about. What you wrote is still here, and it can be filed as something new.',
+        'Your deployment no longer holds the message this was answering, so there is nothing here to answer.',
 
     'tabs.strip': 'Open tabs',
     'tabs.close': 'Close {title}',

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -418,7 +418,7 @@ export const pl: Catalogue = {
     'compose.failedUnreadable':
         'Twoje wdrożenie odpowiedziało, ale klient nie potrafił nic z tą odpowiedzią zrobić. To usterka warta zgłoszenia.',
     'compose.failedMissing':
-        'Twoje wdrożenie nie ma już tego, czego to dotyczyło. To, co zostało napisane, nadal tu jest i można je zapisać jako coś nowego.',
+        'Twoje wdrożenie nie ma już wiadomości, na którą to miała być odpowiedź, więc nie ma tu na co odpowiadać.',
 
     'tabs.strip': 'Co jest otwarte',
     'tabs.close': 'Zamknij: {title}',

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -417,6 +417,8 @@ export const pl: Catalogue = {
         'Twoje wdrożenie nie odpowiedziało. To, co zostało napisane, zostaje tutaj; spróbuj ponownie.',
     'compose.failedUnreadable':
         'Twoje wdrożenie odpowiedziało, ale klient nie potrafił nic z tą odpowiedzią zrobić. To usterka warta zgłoszenia.',
+    'compose.failedMissing':
+        'Twoje wdrożenie nie ma już tego, czego to dotyczyło. To, co zostało napisane, nadal tu jest i można je zapisać jako coś nowego.',
 
     'tabs.strip': 'Co jest otwarte',
     'tabs.close': 'Zamknij: {title}',
@@ -583,6 +585,7 @@ export const pl: Catalogue = {
     'failure.unauthorized': 'brak uprawnień',
     'failure.unavailable': 'usługa niedostępna',
     'failure.unreadable': 'odpowiedź nie do odczytania',
+    'failure.missing': 'już nie istnieje',
 
     'body.reading': 'Odczytywanie wiadomości…',
     'body.failed': 'Nie udało się odczytać wiadomości: {reason}.',

--- a/frontend/src/Client.App/src/mailboxActs/MailboxActs.tsx
+++ b/frontend/src/Client.App/src/mailboxActs/MailboxActs.tsx
@@ -56,6 +56,7 @@ const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
     unauthorized: 'failure.unauthorized',
     unavailable: 'failure.unavailable',
     unreadable: 'failure.unreadable',
+    missing: 'failure.missing',
 };
 
 // How many messages are counted in each of the forms a language has for the noun. Selected rather than spelled, for

--- a/frontend/src/Client.App/src/messageBody/Message.tsx
+++ b/frontend/src/Client.App/src/messageBody/Message.tsx
@@ -120,8 +120,8 @@ export function Message({ body, storedEmailId, quotedHistoryOnRequest = false, o
                     {translate('body.failed', { reason: translate(failureLabels[failure.reason]) })}
                 </p>
 
-                {/* Reading again is the way out of exactly one of the four failures, for the reason
-                    `shell/ConnectionSummary.tsx` gives: the other three repeat identically on a second attempt. */}
+                {/* Reading again is the way out of exactly one of the five failures, for the reason
+                    `shell/ConnectionSummary.tsx` gives: the other four repeat identically on a second attempt. */}
                 {failure.reason === 'unavailable' ? (
                     <SecondaryButton label={translate('connection.retry')} onActivate={body.readAgain} />
                 ) : null}

--- a/frontend/src/Client.App/src/messageBody/Message.tsx
+++ b/frontend/src/Client.App/src/messageBody/Message.tsx
@@ -42,6 +42,7 @@ const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
     unauthorized: 'failure.unauthorized',
     unavailable: 'failure.unavailable',
     unreadable: 'failure.unreadable',
+    missing: 'failure.missing',
 };
 
 interface MessageToDraw {

--- a/frontend/src/Client.App/src/messageList/MessageList.tsx
+++ b/frontend/src/Client.App/src/messageList/MessageList.tsx
@@ -632,8 +632,8 @@ export function MessageList({
                     {translate('list.failed', { reason: translate(failureLabels[failure.reason]) })}
                 </p>
 
-                {/* Reading again is the way out of exactly one of the four failures, for the reason
-                    `shell/ConnectionSummary.tsx` gives: the other three repeat identically on a second attempt. */}
+                {/* Reading again is the way out of exactly one of the five failures, for the reason
+                    `shell/ConnectionSummary.tsx` gives: the other four repeat identically on a second attempt. */}
                 {failure.reason === 'unavailable' ? (
                     <SecondaryButton label={translate('connection.retry')} onActivate={tryAgain} />
                 ) : null}

--- a/frontend/src/Client.App/src/messageList/MessageList.tsx
+++ b/frontend/src/Client.App/src/messageList/MessageList.tsx
@@ -74,6 +74,7 @@ const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
     unauthorized: 'failure.unauthorized',
     unavailable: 'failure.unavailable',
     unreadable: 'failure.unreadable',
+    missing: 'failure.missing',
 };
 
 // How long after scrolling stops before where the reader is is written down. Long enough that a flick through a folder

--- a/frontend/src/Client.App/src/notifications/NotificationCentre.tsx
+++ b/frontend/src/Client.App/src/notifications/NotificationCentre.tsx
@@ -38,6 +38,7 @@ const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
     unauthorized: 'failure.unauthorized',
     unavailable: 'failure.unavailable',
     unreadable: 'failure.unreadable',
+    missing: 'failure.missing',
 };
 
 // How many are picked out, in the forms a language has for the noun — the same sentence the mail list's own bar says,

--- a/frontend/src/Client.App/src/pendingChanges/changeWording.ts
+++ b/frontend/src/Client.App/src/pendingChanges/changeWording.ts
@@ -71,4 +71,5 @@ export const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = 
     unauthorized: 'failure.unauthorized',
     unavailable: 'failure.unavailable',
     unreadable: 'failure.unreadable',
+    missing: 'failure.missing',
 };

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
@@ -3,7 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type {
     ClientRequest,
     ClientResponse,
@@ -23,7 +23,7 @@ import {
 } from '../readMarking/useReadMarking';
 import { IntentField } from '../shell/IntentField';
 import { LinkOpenerContext } from '../shellOperations/linkOpener';
-import { useWorkspace, type Workspace } from '../workspace/useWorkspace';
+import { emptyWorkspace, useWorkspace, type Workspace } from '../workspace/useWorkspace';
 import { WorkspaceProvider } from '../workspace/Workspace';
 import {
     SignalledChangesContext,
@@ -110,6 +110,47 @@ const answersNothing: MailFathomTransport = (request) => {
     return new Promise<ClientResponse>(() => undefined);
 };
 
+// What the pane wrote back, read the way the frame above it reads it: out of the workspace rather than out of the
+// component. An `output` reports itself as a status region, so it is picked out by carrying a workspace.
+function SelectionProbe() {
+    const { workspace } = useWorkspace();
+
+    return <output>{JSON.stringify(workspace)}</output>;
+}
+
+function selected(): string | null {
+    const probe = screen.getAllByRole('status').find((element) => element.textContent.startsWith('{'));
+
+    return (JSON.parse(probe?.textContent ?? '') as Workspace).selection;
+}
+
+// The pane opened on the message the workspace says is open, which is the arrangement a reload produces and the only
+// one in which letting go of what is open means anything.
+function drawingWithSelection(transport: MailFathomTransport): void {
+    window.sessionStorage.setItem('mailfathom.workspace', JSON.stringify({ ...emptyWorkspace, selection: messageId }));
+
+    render(
+        <LocalizationProvider>
+            <WorkspaceProvider>
+                <LinkOpenerContext value={() => Promise.resolve()}>
+                    <AttachmentExchangeContext value={deliversNothing}>
+                        <OpenAttachmentContext value={() => undefined}>
+                            <ReadingPane
+                                session={session}
+                                transport={transport}
+                                storedEmailId={messageId}
+                                online
+                                onShowFullHtml={() => undefined}
+                            />
+                        </OpenAttachmentContext>
+                    </AttachmentExchangeContext>
+                </LinkOpenerContext>
+                <SelectionProbe />
+            </WorkspaceProvider>
+        </LocalizationProvider>,
+    );
+}
+
 function drawing(
     transport: MailFathomTransport,
     storedEmailId: string | null = messageId,
@@ -179,6 +220,12 @@ function recordingMarkings(): { marking: ReadMarking; opened: MessageOpened[] } 
         },
     };
 }
+
+// The session's store outlives a test rather than a file, so a workspace one test opened the pane on would be the one
+// the next test opened with.
+afterEach(() => {
+    window.sessionStorage.clear();
+});
 
 describe('ReadingPane', () => {
     it('says nothing is open rather than drawing an empty message', () => {
@@ -316,6 +363,28 @@ describe('ReadingPane', () => {
         expect(await screen.findByText('This message could not be opened: unauthorized.')).toBeDefined();
         expect(screen.queryByRole('button', { name: 'Try again' })).toBeNull();
     });
+
+    // What is open outlives the message across a reload, so a reader returning to a message their deployment no longer
+    // holds is owed the empty state rather than a failure with nothing behind it. Asserted on the workspace because
+    // that is where the fact lives: the pane above this one draws nothing open once the selection has gone.
+    it('lets go of a message the deployment no longer holds, so what is open is nothing rather than a failure', async () => {
+        drawingWithSelection(deploymentDescribing(description(), 404));
+
+        await waitFor(() => {
+            expect(selected()).toBeNull();
+        });
+    });
+
+    it.each([401, 403, 500, 503])(
+        'keeps what is open where a status of %i says nothing about the message being there',
+        async (status) => {
+            drawingWithSelection(deploymentDescribing(description(), status));
+
+            await screen.findByRole('alert');
+
+            expect(selected()).toBe(messageId);
+        },
+    );
 
     it('names no file where the message carries none', async () => {
         drawing(deploymentDescribing());
@@ -577,21 +646,33 @@ describe('ReadingPane against a deployment that says what changed', () => {
 // Following a search result's citation, which is one act across two components: the row records which file of which
 // message it cited, and this pane is the only place that learns how large that file declares itself to be — the bound
 // the download is read under, and the reason the citation is a coordinate rather than an opened file.
+const followTheCitation = 'Follow the citation, as a search result would write it.';
+
 describe('ReadingPane following a cited file', () => {
     // The citation is written the way a search row writes it — through the workspace, before the pane has read the
     // message — rather than by seeding a store, which `rememberWorkspace` deliberately never keeps it in.
     function citing(cited: Workspace['citedAttachment']): { opened: OpenedAttachment[]; cite: () => void } {
         const opened: OpenedAttachment[] = [];
-        let cite = (): void => undefined;
 
+        // A control the test presses rather than a function captured out of the render: writing to a variable declared
+        // outside a component is a side effect during render whatever the variable is for, and a render React repeats
+        // is a render that would do it twice.
         function Citing() {
             const { workspace, revise } = useWorkspace();
 
-            cite = () => {
-                revise({ citedAttachment: cited });
-            };
-
-            return <output>{JSON.stringify(workspace.citedAttachment)}</output>;
+            return (
+                <>
+                    <button
+                        type="button"
+                        onClick={() => {
+                            revise({ citedAttachment: cited });
+                        }}
+                    >
+                        {followTheCitation}
+                    </button>
+                    <output>{JSON.stringify(workspace.citedAttachment)}</output>
+                </>
+            );
         }
 
         render(
@@ -624,7 +705,7 @@ describe('ReadingPane following a cited file', () => {
         return {
             opened,
             cite: () => {
-                cite();
+                fireEvent.click(screen.getByRole('button', { name: followTheCitation }));
             },
         };
     }

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
@@ -58,6 +58,7 @@ const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
     unauthorized: 'failure.unauthorized',
     unavailable: 'failure.unavailable',
     unreadable: 'failure.unreadable',
+    missing: 'failure.missing',
 };
 
 // The most of a selected passage the workspace carries. A question is asked about a fragment somebody pointed at, so a
@@ -218,12 +219,27 @@ function OpenMessage({
             }
 
             setAnswer({ read, result: answered });
+
+            // A message the deployment no longer holds is let go of rather than drawn as a failure to press through.
+            // What is open outlives the message across a reload, so somebody returning to a client whose message has
+            // since been deleted or moved lands on the empty state they would have had if nothing had been open — and
+            // somebody whose open message is deleted elsewhere while they read it lands there too, which is the same
+            // fact arriving a moment later.
+            //
+            // It is only ever `missing` that does this, and that is the whole reason the reason exists: every other
+            // failure may answer differently on the next attempt, and closing what a reader had open because their
+            // deployment blinked would lose their place for a fault that is about to pass. The read that answered is
+            // the message that is open — a message changed under this component ends this attempt above rather than
+            // reaching here — so nothing has to be compared against what is selected now.
+            if (answered.outcome === 'failed' && answered.failure.reason === 'missing') {
+                revise({ selection: null });
+            }
         });
 
         return () => {
             listening = false;
         };
-    }, [session, transport, read, online]);
+    }, [session, transport, read, online, revise]);
 
     // A search result cited a file rather than the message, and a description of the message is what turns that
     // coordinate into something openable: the citation carries a position, and only the description says how large the

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
@@ -381,8 +381,8 @@ function OpenMessage({
                     {translate('message.failed', { reason: translate(failureLabels[held.result.failure.reason]) })}
                 </p>
 
-                {/* Reading again is the way out of exactly one of the four failures, for the reason
-                    `shell/ConnectionSummary.tsx` gives: the other three repeat identically on a second attempt. */}
+                {/* Reading again is the way out of exactly one of the five failures, for the reason
+                    `shell/ConnectionSummary.tsx` gives: the other four repeat identically on a second attempt. */}
                 {held.result.failure.reason === 'unavailable' ? (
                     <SecondaryButton
                         label={translate('connection.retry')}

--- a/frontend/src/Client.App/src/search/SearchResults.tsx
+++ b/frontend/src/Client.App/src/search/SearchResults.tsx
@@ -43,6 +43,7 @@ const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
     unauthorized: 'failure.unauthorized',
     unavailable: 'failure.unavailable',
     unreadable: 'failure.unreadable',
+    missing: 'failure.missing',
 };
 
 // Why a page ranked by words alone was ranked that way, which is the difference between a deployment that embeds

--- a/frontend/src/Client.App/src/search/SearchResults.tsx
+++ b/frontend/src/Client.App/src/search/SearchResults.tsx
@@ -289,8 +289,8 @@ export function SearchResults({
                     {translate('search.failed', { reason: translate(failureLabels[failure.reason]) })}
                 </p>
 
-                {/* Searching again is the way out of exactly one of the four failures, for the reason
-                    `shell/ConnectionSummary.tsx` gives: the other three repeat identically on a second attempt. */}
+                {/* Searching again is the way out of exactly one of the five failures, for the reason
+                    `shell/ConnectionSummary.tsx` gives: the other four repeat identically on a second attempt. */}
                 {failure.reason === 'unavailable' ? (
                     <SecondaryButton label={translate('connection.retry')} onActivate={tryAgain} />
                 ) : null}

--- a/frontend/src/Client.App/src/shell/ConnectionSummary.tsx
+++ b/frontend/src/Client.App/src/shell/ConnectionSummary.tsx
@@ -139,11 +139,12 @@ function Freshness({ connection }: { readonly connection: Connection }) {
             <Line tone="attention">
                 {translate('accounts.failed', { reason: translate(failureLabels[accounts.failure.reason]) })}
 
-                {/* Reading again is the way out of exactly one of the four failures. A refused credential, a missing
-                    grant, and an answer this client cannot parse each repeat identically on a second attempt, so
-                    offering the button there hands somebody an action that cannot work and says nothing about why.
-                    Their next steps — signing in again, saying the grant is missing, reporting a defect — are actions
-                    this frame has nowhere to send anybody to yet, and each arrives with the screen that can. */}
+                {/* Reading again is the way out of exactly one of the five failures. A refused credential, a missing
+                    grant, an answer this client cannot parse, and something the deployment no longer holds each repeat
+                    identically on a second attempt, so offering the button there hands somebody an action that cannot
+                    work and says nothing about why. Their next steps — signing in again, saying the grant is missing,
+                    reporting a defect, letting go of what is gone — are actions this frame has nowhere to send anybody
+                    to yet, and each arrives with the screen that can. */}
                 {accounts.failure.reason === 'unavailable' && (
                     <SecondaryButton label={translate('connection.retry')} onActivate={reread} />
                 )}

--- a/frontend/src/Client.App/src/shell/ConnectionSummary.tsx
+++ b/frontend/src/Client.App/src/shell/ConnectionSummary.tsx
@@ -27,6 +27,7 @@ const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
     unauthorized: 'failure.unauthorized',
     unavailable: 'failure.unavailable',
     unreadable: 'failure.unreadable',
+    missing: 'failure.missing',
 };
 
 type Tone = 'healthy' | 'attention' | 'quiet';

--- a/frontend/src/Client.App/src/signIn/SignIn.tsx
+++ b/frontend/src/Client.App/src/signIn/SignIn.tsx
@@ -88,6 +88,12 @@ const refusals: Readonly<Record<SignInScreenRefusal, Refusal>> = {
     unauthorized: { message: 'signIn.grantMissing', controls: [] },
     unavailable: { message: 'connect.unavailable', controls: [] },
     unreadable: { message: 'connect.unreadable', controls: [] },
+
+    // `missing` is named for the same reason the two above it are and is reached from here even less: it is produced
+    // by the one route that names a single message, which nothing on this screen calls. It reads as a deployment that
+    // did not answer, because at this point that is what a reader would have to act on — an address to check and a
+    // deployment to start — and nothing here has named a thing that could have gone.
+    missing: { message: 'connect.unavailable', controls: [] },
 };
 
 // What "nothing answered" reads as where there is no address on the screen. `connect.unavailable` asks somebody to

--- a/frontend/src/Client.App/src/thread/Thread.tsx
+++ b/frontend/src/Client.App/src/thread/Thread.tsx
@@ -268,8 +268,8 @@ export function Thread({
                     {translate('thread.failed', { reason: translate(failureLabels[failure.reason]) })}
                 </p>
 
-                {/* Reading again is the way out of exactly one of the four failures, for the reason
-                    `shell/ConnectionSummary.tsx` gives: the other three repeat identically on a second attempt. */}
+                {/* Reading again is the way out of exactly one of the five failures, for the reason
+                    `shell/ConnectionSummary.tsx` gives: the other four repeat identically on a second attempt. */}
                 {failure.reason === 'unavailable' ? (
                     <SecondaryButton
                         label={translate('connection.retry')}

--- a/frontend/src/Client.App/src/thread/Thread.tsx
+++ b/frontend/src/Client.App/src/thread/Thread.tsx
@@ -53,6 +53,7 @@ const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
     unauthorized: 'failure.unauthorized',
     unavailable: 'failure.unavailable',
     unreadable: 'failure.unreadable',
+    missing: 'failure.missing',
 };
 
 export function Thread({

--- a/frontend/src/Client.App/src/workspace/Workspace.test.tsx
+++ b/frontend/src/Client.App/src/workspace/Workspace.test.tsx
@@ -83,6 +83,7 @@ describe('WorkspaceProvider', () => {
         const change: Partial<Workspace> = {
             scope: { kind: 'folder', accountId: 'work', alias: 'INBOX' },
             collapsed: ['account:personal'],
+            selection: 'AAMkAD-42',
         };
         const { rerender } = renderProbe(change);
 

--- a/frontend/src/Client.App/src/workspace/mailScope.test.ts
+++ b/frontend/src/Client.App/src/workspace/mailScope.test.ts
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { describe, expect, it } from 'vitest';
+import type { MailFolderDirectory } from '@mailfathom/client-backend';
 import {
     accountInScope,
     everything,
@@ -12,10 +13,38 @@ import {
     scopeKey,
     scopeOfAccount,
     scopeReaches,
+    scopeStillOffered,
     type MailScope,
 } from './mailScope';
 
 const workInbox: MailScope = { kind: 'folder', accountId: 'work', alias: 'INBOX' };
+
+const offered: MailFolderDirectory = {
+    synchronizationEnabled: true,
+    accounts: [
+        {
+            account: {
+                id: 'work',
+                displayName: 'Work',
+                synchronizationState: 'Synchronized',
+                lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
+                behind: false,
+            },
+            folders: [
+                {
+                    alias: 'INBOX',
+                    role: 'Inbox',
+                    path: ['INBOX'],
+                    storedEmailCount: 4213,
+                    unreadEmailCount: 12,
+                    synchronizationState: 'Synchronized',
+                    lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
+                    behind: false,
+                },
+            ],
+        },
+    ],
+};
 
 describe('scopeKey', () => {
     it.each<{ scope: MailScope; key: string }>([
@@ -109,5 +138,26 @@ describe('scopeReaches', () => {
 
     it('reaches a folder scope with a change named against the account alone', () => {
         expect(scopeReaches(workInbox, 'work', null)).toBe(true);
+    });
+});
+
+describe('scopeStillOffered', () => {
+    it.each<{ scope: MailScope; still: boolean }>([
+        { scope: everything, still: true },
+        { scope: { kind: 'role', role: 'Inbox' }, still: true },
+        { scope: { kind: 'role', role: 'Junk' }, still: false },
+        { scope: { kind: 'account', accountId: 'work' }, still: true },
+        { scope: { kind: 'account', accountId: 'personal' }, still: false },
+        { scope: workInbox, still: true },
+        { scope: { kind: 'folder', accountId: 'work', alias: 'ARCHIVE-2024' }, still: false },
+        { scope: { kind: 'folder', accountId: 'personal', alias: 'INBOX' }, still: false },
+    ])('answers $still for a scope the deployment does or does not still offer', ({ scope, still }) => {
+        expect(scopeStillOffered(scope, offered)).toBe(still);
+    });
+
+    // Somebody holding no mailbox at all is told so by the tree drawing the sentence for it, and taking the widest
+    // scope away from them would answer that with something nobody can act on instead.
+    it('offers everything even where the deployment answered with no account at all', () => {
+        expect(scopeStillOffered(everything, { synchronizationEnabled: true, accounts: [] })).toBe(true);
     });
 });

--- a/frontend/src/Client.App/src/workspace/mailScope.ts
+++ b/frontend/src/Client.App/src/workspace/mailScope.ts
@@ -2,7 +2,7 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import type { MailFolderRole } from '@mailfathom/client-backend';
+import type { MailFolderDirectory, MailFolderRole } from '@mailfathom/client-backend';
 import type { MessageKey } from '../localization/en';
 
 // What the client is looking at, which the list, the search, and the next question are all asked against. It is one
@@ -169,4 +169,33 @@ export function scopeReaches(scope: MailScope, account: string, folder: string |
 /** The scope naming one whole account, or everything where no account was named. */
 export function scopeOfAccount(accountId: string | null): MailScope {
     return accountId === null ? everything : { kind: 'account', accountId };
+}
+
+/**
+ * Whether the deployment still offers what a scope names.
+ *
+ * A scope outlives the answer it was chosen from — the session's store carries it across a reload — so a folder
+ * somebody deleted from their mail server, an account whose declaration was removed, or the last folder playing a role
+ * each leave a scope naming something nobody can reach. Asked of the directory rather than of the tree drawn from it,
+ * because what makes a scope reachable is the mapping the deployment answered with and not how a column happens to be
+ * folded.
+ *
+ * `everything` is always offered, including where there is no account at all: it is the widest scope rather than a
+ * place, and a client with no mailbox is told so by the tree rather than by having its scope taken away.
+ */
+export function scopeStillOffered(scope: MailScope, directory: MailFolderDirectory): boolean {
+    switch (scope.kind) {
+        case 'everything':
+            return true;
+        case 'role':
+            return directory.accounts.some((entry) => entry.folders.some((folder) => folder.role === scope.role));
+        case 'account':
+            return directory.accounts.some((entry) => entry.account.id === scope.accountId);
+        case 'folder':
+            return directory.accounts.some(
+                (entry) =>
+                    entry.account.id === scope.accountId &&
+                    entry.folders.some((folder) => folder.alias === scope.alias),
+            );
+    }
 }

--- a/frontend/src/Client.Backend/src/failure.test.ts
+++ b/frontend/src/Client.Backend/src/failure.test.ts
@@ -6,9 +6,13 @@ import { describe, expect, it } from 'vitest';
 import { failed, failureReasonForStatus, read } from './failure';
 
 describe('failureReasonForStatus', () => {
-    // The four reasons exist because a screen acts differently on each, so the mapping is asserted status by status
-    // rather than as "not read": a refused credential that arrived as `unavailable` would be retried forever instead
-    // of sending the person back to sign in.
+    // The reasons exist because a screen acts differently on each, so the mapping is asserted status by status rather
+    // than as "not read": a refused credential that arrived as `unavailable` would be retried forever instead of
+    // sending the person back to sign in.
+    //
+    // `404` is `unavailable` here deliberately, and `mailMessage.test.ts` is where the other reading of it is asserted:
+    // most routes on this surface name no one thing, so a deployment that never served the client surface answers a
+    // probe with the same status a deleted message answers a read with.
     it.each([
         [401, 'unauthenticated'],
         [403, 'unauthorized'],

--- a/frontend/src/Client.Backend/src/failure.ts
+++ b/frontend/src/Client.Backend/src/failure.ts
@@ -5,10 +5,17 @@
 /**
  * Why a read did not answer.
  *
- * The four are separated because a screen does something different with each: a refused credential is signed in again,
- * a missing grant is not, an unreachable deployment is retried, and a body this package could not read is a defect.
+ * The five are separated because a screen does something different with each: a refused credential is signed in again,
+ * a missing grant is not, an unreachable deployment is retried, a body this package could not read is a defect, and
+ * something the deployment no longer holds is let go of.
+ *
+ * `missing` is the member added last and it is the one that earns its place by what a screen must *not* do: a message
+ * somebody had open which has since been deleted or moved answers exactly as a deployment that is down does, so a
+ * client that cannot tell them apart either offers to retry something that will never answer, or drops what a reader
+ * had open every time the deployment blinks. Both are wrong, and neither is fixable on the screen — only the status
+ * knows, and a status is this package's to read.
  */
-export type ClientFailureReason = 'unauthenticated' | 'unauthorized' | 'unavailable' | 'unreadable';
+export type ClientFailureReason = 'unauthenticated' | 'unauthorized' | 'unavailable' | 'unreadable' | 'missing';
 
 /** A read that did not answer, and enough to say so on a screen without showing what the service returned. */
 export interface ClientFailure {
@@ -29,7 +36,14 @@ export function failed<TValue>(reason: ClientFailureReason, status: number | nul
     return { outcome: 'failed', failure: { reason, status } };
 }
 
-/** The failure an HTTP status stands for, for a status this package did not expect to succeed. */
+/**
+ * The failure an HTTP status stands for, for a status this package did not expect to succeed.
+ *
+ * A `404` is `unavailable` here rather than `missing`, because most routes on this surface name no one thing: a
+ * deployment that never served the client surface at all answers a session probe with the same status a deleted
+ * message answers a read with, and the two are not the same sentence. A route that does name one thing says so at its
+ * own call site, which is where the knowledge that a status means *gone* actually lives.
+ */
 export function failureReasonForStatus(status: number): ClientFailureReason {
     switch (status) {
         case 401:

--- a/frontend/src/Client.Backend/src/mailMessage.test.ts
+++ b/frontend/src/Client.Backend/src/mailMessage.test.ts
@@ -169,6 +169,20 @@ describe('readMailMessage', () => {
         },
     );
 
+    // The one status on this route that says something a screen can act on rather than retry. It is separated because
+    // a client that could not tell it from a deployment that is down would either offer a retry that cannot answer, or
+    // close what a reader had open every time their deployment blinked.
+    it.each<{ status: number; reason: string }>([
+        { status: 404, reason: 'missing' },
+        { status: 401, reason: 'unauthenticated' },
+        { status: 403, reason: 'unauthorized' },
+        { status: 503, reason: 'unavailable' },
+    ])('reports a status of $status as $reason', async ({ status, reason }) => {
+        const result = await readMailMessage(session, answering({ status, body: '' }), messageId);
+
+        expect(result).toEqual({ outcome: 'failed', failure: { reason, status } });
+    });
+
     it('reports a deployment that answered nothing at all as unavailable', async () => {
         const result = await readMailMessage(
             session,

--- a/frontend/src/Client.Backend/src/mailMessage.ts
+++ b/frontend/src/Client.Backend/src/mailMessage.ts
@@ -154,7 +154,13 @@ export function readMailMessage(
         }
 
         if (response.status !== 200) {
-            return failed(failureReasonForStatus(response.status), response.status);
+            // The one route where a `404` is its own answer rather than one more way of not reaching the deployment:
+            // it names a single message, so the deployment saying it does not hold that message is the deployment
+            // answering. A reader whose open message was deleted or moved elsewhere is told it is gone and let go of
+            // it, rather than being offered a retry that cannot succeed.
+            const reason = response.status === 404 ? 'missing' : failureReasonForStatus(response.status);
+
+            return failed(reason, response.status);
         }
 
         const message = parseMessage(response.body);

--- a/frontend/src/Client.Backend/src/ownDisplayName.ts
+++ b/frontend/src/Client.Backend/src/ownDisplayName.ts
@@ -106,7 +106,7 @@ export function changeOwnDisplayName(
         // `reported` rather than `spanned` because this answers an outcome of its own, and a refused name is recorded
         // as a read: the deployment answered, and what a person does about it is to type another name. Recording it as
         // a failure would put a typing mistake in the dimension an operator reads for a deployment that is not
-        // answering, and none of the four reasons is true of it either.
+        // answering, and none of the five reasons is true of it either.
         (change) => (change.outcome === 'failed' ? change.failure.reason : null),
     );
 }

--- a/frontend/src/Client.Backend/src/telemetry.ts
+++ b/frontend/src/Client.Backend/src/telemetry.ts
@@ -79,7 +79,7 @@ export function spanned<TValue>(
  * @param request The route template this asks for, method first, which is the dimension every record here is grouped
  * by. It is a template rather than the composed path: a message identifier in a span name is one name per message.
  * @param ask The operation, which answers a value rather than throwing for anything it expected.
- * @param failureOf Which of the four failure reasons the answer amounts to, or `null` where the client got an answer it
+ * @param failureOf Which of the five failure reasons the answer amounts to, or `null` where the client got an answer it
  * acts on. It is the operation's reading rather than a status, and the distinction it draws is whether an answer
  * arrived rather than whether the answer was yes: a name this deployment will not record, a person with no portrait
  * stored, and a download somebody stopped are each answered and acted on, so each is a `read`.


### PR DESCRIPTION
## What this changes

The workspace already carries the folder in scope and the message being read across a reload, in the session's store — which is where [ADR 0028](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0028-no-mail-on-the-device-and-an-honest-client-with-no-route-to-its-deployment.md) permits an identifier naming a place to live. What it did not have is either fallback the issue asks for, and both are what this change adds.

**A folder that has gone falls back to the widest scope.** A scope outlives the answer it was chosen from, so the folder answer is now also what says whether it still names anything. `scopeStillOffered` asks the directory rather than the tree drawn from it — a scope naming a folder, a mailbox, or the last folder playing a role that the deployment no longer offers is answered with `everything`, so a folder deleted on the mail server between two starts reads as never having been chosen rather than leaving the list asking for a mailbox nobody can reach and the tree highlighting no row.

**A message that has gone falls back to nothing open.** That needed the client to be able to tell it apart from a deployment that is down, which it could not: both arrived as `unavailable`, so a reader whose open message had been deleted was offered a *Try again* that could never answer. `ClientFailureReason` gains `missing`, produced by the one route that names a single message, and the reading pane lets go of what is open when it arrives. Every other failure keeps what a reader had open, because a deployment that blinked is about to stop blinking — closing on any failure would lose somebody's place for a fault that is about to pass.

**Letting go is the obligation of the surface holding what is gone, and that is the reading pane.** Two other surfaces read the same route — the markup surface and the composer answering a message — and neither holds the selection; each is drawn *about* a message rather than owning what is open. So each says the message is gone and keeps the control it was opened with, and a test on each pins that it does not close itself: closing would put somebody back on a pane still drawing the message with nothing having said why the surface went, and in the composer's case would take away the only thing that said so. `frontend/src/AGENTS.md` § *UX* says which surface owes which.

`frontend/src/AGENTS.md` § *Reaching `/api/client`* already set the bar a fifth member has to meet — a genuinely new outcome, argued in the change that adds it — and this is that argument: the screen does something no other reason does. The thirteen exhaustive lookups and both catalogues gain the member, which is the cost the closed set exists to impose.

## Where the state lives, and why it did not move

The issue's third acceptance bullet asks for both values in the device store. **That is exactly what ADR 0028 forbids** — "in the device's store … nothing about mail is written, in any form … and not an identifier naming any of them" — and a folder alias and a message id are both identifiers naming mail. The owner settled it: the values stay in the session's store, which ADR 0028 does permit and where `rememberedWorkspace.ts` already keeps them. So the surviving scope of the issue is the two fallbacks and their tests, and nothing here writes to a store that outlives the process.

What that leaves undelivered is the issue's own user story about *reopening the client*: a closed tab still starts from the default scope with nothing selected, because the session's store dies with the tab. Reading it that way was the owner's call rather than an omission.

## Documentation

`frontend/src/AGENTS.md` said "four" in two places and now says what the closed set actually holds, and where a status is read as *gone* — `failureReasonForStatus` maps a `404` to `unavailable`, because most routes here name no one thing, and a deployment that never served the client surface answers a session probe with the same status a deleted message answers a read with. The one route that names a single message reads it differently at its own call site.

`docs/operations/telemetry.md` enumerated the four values `mailfathom.client.failure` carries and now names five, with what separates `missing` from a fault an operator would chase: only `GET /messages/{storedEmailId}` produces it, and a rate of it that tracks how much mail is being deleted is the deployment working.

Every comment stating the old count is corrected too — the seven retry comments, the one in `shell/ConnectionSummary.tsx` they point at, and the four in prose in `Composer`, `useDraftAtDeployment`, `telemetry` and `ownDisplayName`.

## Incidental

`ReadingPane.test.tsx` had a component reassigning a variable declared outside it, which `react-hooks/globals` refuses. The rule surfaced it once this change touched the file; it is now the control-and-press idiom the rest of the suite uses for the same job.

## Not in scope

In tab mode, a tab whose message has gone stays on the strip after the pane lets go of it — pressing it re-reads, gets the same answer, and lands on nothing open again. That is unchanged by this change rather than introduced by it: the tab set is state of its own, and closing a tab from the reading pane needs a callback threaded through the frame. Worth its own issue if it is worth fixing.

## Verification

- `scripts/verify-full.sh` — passed, 299 contract checks and the whole client suite, run again after the rebase onto current `main`.
- `scripts/review-obligations.sh` — every row answered; the files it names without a test are single added lookup keys, which are not behaviour a test can reach.
- `$check-docs-licenses` — Docs `pass`, Changelog `n/a`, Licenses `n/a` (no pin moved, no new file, so no header owed).

Closes #1757
