### PR TITLE
[#1761] Say how many messages a correspondence holds on the row that stands for it

### DIFF
--- a/backend/src/Application/Emails/BrowseTimeline/BrowsedEmail.cs
+++ b/backend/src/Application/Emails/BrowseTimeline/BrowsedEmail.cs
@@ -11,11 +11,18 @@ namespace MailFathom.Application.Emails.BrowseTimeline;
 /// <param name="Email">The email as every other read of this deployment describes it.</param>
 /// <param name="Preview">The opening of the message's own text, or <see langword="null" /> where nothing has extracted the message yet.</param>
 /// <param name="Enrichment">What a derivation concluded about the message, or <see langword="null" /> where none has reached it.</param>
+/// <param name="ThreadMessageCount">How many messages this caller may see in the message's conversation, or <see langword="null" /> where nothing has placed it in one.</param>
 /// <remarks>
 /// <para>
 /// The summary is composed rather than copied, so a list row and a tool listing cannot come to disagree about the same
-/// message, and a field added to one arrives on the other. What a row adds are the preview and the enrichment — three
-/// separate values because they come from three separate tables, and a message may have any of them without the others.
+/// message, and a field added to one arrives on the other. What a row adds are the preview, the enrichment and the
+/// conversation's size — separate values because they come from separate tables, and a message may have any of them
+/// without the others.
+/// </para>
+/// <para>
+/// The count is of the conversation rather than of the page, which is the whole reason it is read here instead of
+/// derived by whoever draws the list: a correspondence spans a page boundary as readily as it sits inside one, and
+/// counting within a page would say a different number depending on where the page happened to be cut.
 /// </para>
 /// <para>
 /// An absent enrichment is a message no derivation has reached, which a client draws as a row nothing has been said
@@ -23,4 +30,8 @@ namespace MailFathom.Application.Emails.BrowseTimeline;
 /// deliberately distinguishable: one of them will change on a later run and the other will not.
 /// </para>
 /// </remarks>
-public sealed record BrowsedEmail(EmailSummary Email, string? Preview, EmailEnrichment? Enrichment);
+public sealed record BrowsedEmail(
+    EmailSummary Email,
+    string? Preview,
+    EmailEnrichment? Enrichment,
+    int? ThreadMessageCount);

--- a/backend/src/Application/Emails/BrowseTimeline/MailTimelineBrowser.cs
+++ b/backend/src/Application/Emails/BrowseTimeline/MailTimelineBrowser.cs
@@ -365,8 +365,10 @@ public sealed class MailTimelineBrowser
     /// <remarks>
     /// Neither an account nor a folder narrows the count and the junk folder takes part, exactly as they do not narrow
     /// the conversation <see cref="BrowseThread.MailThreadBrowser" /> reads: a correspondence is threaded across every
-    /// folder it reached, so a count narrowed to the folder somebody is listing would answer one for every row in it
-    /// and the pill a row draws would disagree with the conversation behind it.
+    /// folder it reached, so a count narrowed to the folder somebody is listing would answer one for nearly every row
+    /// in it. What it does not share with that read is the assembly bound — this is a count rather than an assembly, so
+    /// a correspondence past <see cref="IEmailThreadReader.MaximumAssembledEmails" /> is reported here as the length it
+    /// is while the conversation itself is published as the bound with its own flag saying more was not assembled.
     /// </remarks>
     private async Task<IReadOnlyDictionary<EmailThreadId, int>> ThreadSizesAsync(
         IReadOnlyList<EmailSummary> page,

--- a/backend/src/Application/Emails/BrowseTimeline/MailTimelineBrowser.cs
+++ b/backend/src/Application/Emails/BrowseTimeline/MailTimelineBrowser.cs
@@ -7,6 +7,7 @@ using MailFathom.Application.Accounts;
 using MailFathom.Application.Emails.Enrichment;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Summaries;
+using MailFathom.Application.Emails.Threads;
 using MailFathom.Application.Observability;
 using MailFathom.Application.SensitiveContent.Detection;
 using MailFathom.Application.SensitiveContent.Egress;
@@ -49,6 +50,7 @@ public sealed class MailTimelineBrowser
     private readonly IStoredEmailTimelineReader timelineReader;
     private readonly IStoredEmailPreviewReader previewReader;
     private readonly IStoredEmailEnrichmentReader enrichmentReader;
+    private readonly IEmailThreadReader threadReader;
     private readonly MailboxScopeResolver scopeResolver;
     private readonly SensitiveContentEgressGuard egressGuard;
     private readonly IMailboxReadTelemetry readTelemetry;
@@ -58,6 +60,7 @@ public sealed class MailTimelineBrowser
     /// <param name="timelineReader">Reads bounded pages of stored email summaries.</param>
     /// <param name="previewReader">Reads the bounded opening of the text of the emails a page returned.</param>
     /// <param name="enrichmentReader">Reads what a derivation concluded about the emails a page returned.</param>
+    /// <param name="threadReader">Counts the conversations the emails a page returned belong to.</param>
     /// <param name="scopeResolver">Decides which accounts and folders the list runs against.</param>
     /// <param name="egressGuard">Scans what the page is about to publish, where this deployment scans anything.</param>
     /// <param name="readTelemetry">Publishes the read as the operation it is, beside the call it happened inside.</param>
@@ -67,6 +70,7 @@ public sealed class MailTimelineBrowser
         IStoredEmailTimelineReader timelineReader,
         IStoredEmailPreviewReader previewReader,
         IStoredEmailEnrichmentReader enrichmentReader,
+        IEmailThreadReader threadReader,
         MailboxScopeResolver scopeResolver,
         SensitiveContentEgressGuard egressGuard,
         IMailboxReadTelemetry readTelemetry,
@@ -75,6 +79,7 @@ public sealed class MailTimelineBrowser
         ArgumentNullException.ThrowIfNull(timelineReader);
         ArgumentNullException.ThrowIfNull(previewReader);
         ArgumentNullException.ThrowIfNull(enrichmentReader);
+        ArgumentNullException.ThrowIfNull(threadReader);
         ArgumentNullException.ThrowIfNull(scopeResolver);
         ArgumentNullException.ThrowIfNull(egressGuard);
         ArgumentNullException.ThrowIfNull(readTelemetry);
@@ -83,6 +88,7 @@ public sealed class MailTimelineBrowser
         this.timelineReader = timelineReader;
         this.previewReader = previewReader;
         this.enrichmentReader = enrichmentReader;
+        this.threadReader = threadReader;
         this.scopeResolver = scopeResolver;
         this.egressGuard = egressGuard;
         this.readTelemetry = readTelemetry;
@@ -147,11 +153,12 @@ public sealed class MailTimelineBrowser
 
         var previews = await this.previewReader.ReadPreviewsAsync(pageIdentities, cancellationToken);
         var enrichments = await this.enrichmentReader.ReadEnrichmentsAsync(pageIdentities, cancellationToken);
+        var threadSizes = await this.ThreadSizesAsync(page, cancellationToken);
 
         // Guarded after the boundaries are taken rather than before. A cursor names a received instant and a stored
         // identity, and redaction touches neither, so issuing one from the guarded page would be the same value
         // arrived at through more work.
-        var rows = await this.GuardedAsync(page, previews, enrichments, cancellationToken);
+        var rows = await this.GuardedAsync(page, previews, enrichments, threadSizes, cancellationToken);
 
         read.Completed(rows.Count);
 
@@ -295,6 +302,7 @@ public sealed class MailTimelineBrowser
         IReadOnlyList<EmailSummary> page,
         IReadOnlyDictionary<StoredEmailId, string> previews,
         IReadOnlyDictionary<StoredEmailId, EmailEnrichment> enrichments,
+        IReadOnlyDictionary<EmailThreadId, int> threadSizes,
         CancellationToken cancellationToken)
     {
         if (!this.egressGuard.IsActive)
@@ -304,7 +312,8 @@ public sealed class MailTimelineBrowser
                 .. page.Select(email => new BrowsedEmail(
                     email,
                     PreviewOf(email, previews),
-                    EnrichmentOf(email, enrichments))),
+                    EnrichmentOf(email, enrichments),
+                    ThreadSizeOf(email, threadSizes))),
             ];
         }
 
@@ -339,7 +348,8 @@ public sealed class MailTimelineBrowser
                     this.egressGuard,
                     SensitiveContentEgressPoint.ClientMailListing,
                     EnrichmentOf(email, enrichments),
-                    cancellationToken)));
+                    cancellationToken),
+                ThreadSizeOf(email, threadSizes)));
         }
 
         scan.Completed();
@@ -350,6 +360,38 @@ public sealed class MailTimelineBrowser
     /// <summary>Reads the preview of one row, which is absent for a message nothing has extracted yet.</summary>
     private static string? PreviewOf(EmailSummary email, IReadOnlyDictionary<StoredEmailId, string> previews) =>
         previews.TryGetValue(email.StoredEmailId, out var preview) ? EmailPreview.Bounded(preview) : null;
+
+    /// <summary>Counts every conversation the page's rows belong to, in one read for the whole page.</summary>
+    /// <remarks>
+    /// Neither an account nor a folder narrows the count and the junk folder takes part, exactly as they do not narrow
+    /// the conversation <see cref="BrowseThread.MailThreadBrowser" /> reads: a correspondence is threaded across every
+    /// folder it reached, so a count narrowed to the folder somebody is listing would answer one for every row in it
+    /// and the pill a row draws would disagree with the conversation behind it.
+    /// </remarks>
+    private async Task<IReadOnlyDictionary<EmailThreadId, int>> ThreadSizesAsync(
+        IReadOnlyList<EmailSummary> page,
+        CancellationToken cancellationToken)
+    {
+        var conversations = page
+            .Where(static email => email.ThreadId is not null)
+            .Select(static email => email.ThreadId!.Value)
+            .Distinct()
+            .ToArray();
+
+        if (conversations.Length is 0)
+        {
+            return new Dictionary<EmailThreadId, int>();
+        }
+
+        return await this.threadReader.ReadMessageCountsAsync(
+            conversations,
+            this.scopeResolver.ReadableScope([], [], JunkMailInclusion.Included),
+            cancellationToken);
+    }
+
+    /// <summary>Reads how large one row's conversation is, which is absent for a message threading has not placed.</summary>
+    private static int? ThreadSizeOf(EmailSummary email, IReadOnlyDictionary<EmailThreadId, int> threadSizes) =>
+        email.ThreadId is { } threadId && threadSizes.TryGetValue(threadId, out var counted) ? counted : null;
 
     /// <summary>Reads what was derived about one row, which is absent for a message no derivation has reached.</summary>
     private static EmailEnrichment? EnrichmentOf(

--- a/backend/src/Application/Emails/Threads/IEmailThreadReader.cs
+++ b/backend/src/Application/Emails/Threads/IEmailThreadReader.cs
@@ -58,4 +58,34 @@ public interface IEmailThreadReader
         EmailThreadId threadId,
         MailboxScope scope,
         CancellationToken cancellationToken);
+
+    /// <summary>Counts how many messages the caller may see in each of the named conversations.</summary>
+    /// <param name="threadIds">The conversations to count, as the rows of one page named them.</param>
+    /// <param name="scope">The accounts and folders configuration admits, which the query is narrowed by.</param>
+    /// <param name="cancellationToken">Propagates caller cancellation.</param>
+    /// <returns>
+    /// The number of messages in each conversation that holds any, keyed by identifier. A conversation the scope admits
+    /// nothing of is absent rather than present as zero.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="threadIds" /> or <paramref name="scope" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// <para>
+    /// One query for the whole page rather than one per row, which is the same arrangement the preview and the
+    /// enrichment of a page are read under: a list of fifty rows costs one count instead of fifty.
+    /// </para>
+    /// <para>
+    /// It counts by membership and applies no bound, unlike the assembly above. A count is what a row draws to say the
+    /// message stands for an exchange rather than a single message, so cutting it at
+    /// <see cref="MaximumAssembledEmails" /> would report a long conversation as shorter than it is — and counting is
+    /// what a database does without carrying any of the rows.
+    /// </para>
+    /// <para>
+    /// No merge is followed, because none has to be: a merge repoints every message of the folded conversation at the
+    /// survivor, and the identifiers handed here are the ones the counted rows carry.
+    /// </para>
+    /// </remarks>
+    Task<IReadOnlyDictionary<EmailThreadId, int>> ReadMessageCountsAsync(
+        IReadOnlyList<EmailThreadId> threadIds,
+        MailboxScope scope,
+        CancellationToken cancellationToken);
 }

--- a/backend/src/Host/Api/ClientMailThreadEndpoint.cs
+++ b/backend/src/Host/Api/ClientMailThreadEndpoint.cs
@@ -183,7 +183,11 @@ internal sealed record ClientMailThreadEmailResponse(
     /// <remarks>
     /// The conversation's own count is what the row's <c>threadMessageCount</c> carries here, because that is what the
     /// field means and every message of one conversation is in the same conversation. A client drawing a message of a
-    /// thread from this row therefore reads the same number the header above it reads.
+    /// thread from this row therefore reads the same number the header above it reads — which is the assembled count
+    /// rather than the counted one, so a correspondence past
+    /// <see cref="Application.Emails.Threads.IEmailThreadReader.MaximumAssembledEmails" /> reads here as the bound with
+    /// <c>moreMessagesNotAssembled</c> beside it and reads on a list row as its real length. Agreeing with the list
+    /// instead would mean counting the conversation a second time to publish a number this route already states.
     /// </remarks>
     internal static ClientMailThreadEmailResponse For(BrowsedThreadEmail message, int threadMessageCount) => new(
         message.Position,

--- a/backend/src/Host/Api/ClientMailThreadEndpoint.cs
+++ b/backend/src/Host/Api/ClientMailThreadEndpoint.cs
@@ -145,7 +145,7 @@ internal sealed record ClientMailThreadResponse(
 
         return new ClientMailThreadResponse(
             thread.ThreadId.Value,
-            [.. thread.Messages.Select(ClientMailThreadEmailResponse.For)],
+            [.. thread.Messages.Select(message => ClientMailThreadEmailResponse.For(message, thread.MessageCount))],
             [.. thread.Participants.Select(ClientMailThreadParticipantResponse.For)],
             thread.MessageCount,
             thread.MoreMessagesNotAssembled,
@@ -178,11 +178,21 @@ internal sealed record ClientMailThreadEmailResponse(
 {
     /// <summary>Describes one message of a conversation for the wire.</summary>
     /// <param name="message">The message the use case read.</param>
+    /// <param name="threadMessageCount">How many messages the conversation holds of those this caller may see.</param>
     /// <returns>The response body.</returns>
-    internal static ClientMailThreadEmailResponse For(BrowsedThreadEmail message) => new(
+    /// <remarks>
+    /// The conversation's own count is what the row's <c>threadMessageCount</c> carries here, because that is what the
+    /// field means and every message of one conversation is in the same conversation. A client drawing a message of a
+    /// thread from this row therefore reads the same number the header above it reads.
+    /// </remarks>
+    internal static ClientMailThreadEmailResponse For(BrowsedThreadEmail message, int threadMessageCount) => new(
         message.Position,
         message.AnsweredStoredEmailId?.Value,
-        ClientMailTimelineEntryResponse.For(message.Email, message.Contribution, message.Enrichment));
+        ClientMailTimelineEntryResponse.For(
+            message.Email,
+            message.Contribution,
+            message.Enrichment,
+            threadMessageCount));
 }
 
 /// <summary>Somebody who has written in the conversation, and how much of it is theirs.</summary>

--- a/backend/src/Host/Api/ClientMailTimelineEndpoint.cs
+++ b/backend/src/Host/Api/ClientMailTimelineEndpoint.cs
@@ -315,9 +315,18 @@ internal sealed record ClientMailTimelineResponse(
 /// </para>
 /// <para>
 /// <c>threadMessageCount</c> counts the whole correspondence rather than the rows one page holds, and is counted across
-/// every folder this user may read with the junk folder included — the same membership the thread route publishes, so a
-/// row and the conversation it opens cannot disagree about how long the exchange is. It is absent for a message
-/// threading has placed in no conversation, and <c>1</c> for one whose conversation holds only it.
+/// every folder this user may read with the junk folder included — the same membership the conversation route reads
+/// under. It is absent for a message threading has placed in no conversation, and <c>1</c> for one whose conversation
+/// holds only it.
+/// </para>
+/// <para>
+/// It is counted rather than assembled, so it is the one place on this surface a conversation's length is published
+/// without the assembly bound. The two agree up to
+/// <see cref="Application.Emails.Threads.IEmailThreadReader.MaximumAssembledEmails" /> and part above it: a
+/// correspondence longer than that is published here as the length it actually is, while the conversation route
+/// reports the bound and says so with <c>moreMessagesNotAssembled</c>. That is deliberate rather than a discrepancy to
+/// reconcile — what this field is drawn as says *this row stands for a long exchange*, which a number capped at the
+/// bound would stop saying.
 /// </para>
 /// </remarks>
 internal sealed record ClientMailTimelineEntryResponse(

--- a/backend/src/Host/Api/ClientMailTimelineEndpoint.cs
+++ b/backend/src/Host/Api/ClientMailTimelineEndpoint.cs
@@ -295,6 +295,7 @@ internal sealed record ClientMailTimelineResponse(
 /// <param name="SizeOctets">The size the mail server reported for the message.</param>
 /// <param name="Preview">The opening of the message's own text, bounded, or <see langword="null" /> where nothing has extracted the message yet.</param>
 /// <param name="Enrichment">What a derivation concluded about the message, or <see langword="null" /> where none has reached it.</param>
+/// <param name="ThreadMessageCount">How many messages this user may see in the row's conversation, or <see langword="null" /> where threading has placed the message in none.</param>
 /// <remarks>
 /// <para>
 /// The three flags are published as the states a row draws rather than as the snapshot they came from, because a screen
@@ -311,6 +312,12 @@ internal sealed record ClientMailTimelineResponse(
 /// has not turned enrichment on — and present with an empty <c>marks</c> array for one a derivation answered nothing
 /// about. The two are different states and a screen draws them differently: the first may change on a later run and
 /// the second will not.
+/// </para>
+/// <para>
+/// <c>threadMessageCount</c> counts the whole correspondence rather than the rows one page holds, and is counted across
+/// every folder this user may read with the junk folder included — the same membership the thread route publishes, so a
+/// row and the conversation it opens cannot disagree about how long the exchange is. It is absent for a message
+/// threading has placed in no conversation, and <c>1</c> for one whose conversation holds only it.
 /// </para>
 /// </remarks>
 internal sealed record ClientMailTimelineEntryResponse(
@@ -331,30 +338,33 @@ internal sealed record ClientMailTimelineEntryResponse(
     int AttachmentCount,
     long SizeOctets,
     string? Preview,
-    ClientMailEnrichmentResponse? Enrichment)
+    ClientMailEnrichmentResponse? Enrichment,
+    int? ThreadMessageCount)
 {
     /// <summary>Describes one row for the wire.</summary>
     /// <param name="row">The row the use case read.</param>
     /// <returns>The response body.</returns>
     internal static ClientMailTimelineEntryResponse For(BrowsedEmail row) =>
-        For(row.Email, row.Preview, row.Enrichment);
+        For(row.Email, row.Preview, row.Enrichment, row.ThreadMessageCount);
 
     /// <summary>Describes one message for the wire, wherever on this surface a message is drawn.</summary>
     /// <param name="email">The message the use case read.</param>
     /// <param name="preview">The opening of the message's own text, or <see langword="null" /> where nothing has extracted it.</param>
     /// <param name="enrichment">What a derivation concluded about the message, or <see langword="null" /> where none has reached it.</param>
+    /// <param name="threadMessageCount">How many messages the caller may see in the message's conversation, or <see langword="null" /> where it is in none.</param>
     /// <returns>The response body.</returns>
     /// <remarks>
-    /// The three rather than a reading's own row type, because a message is one shape on this surface: a list row and a
+    /// The four rather than a reading's own row type, because a message is one shape on this surface: a list row and a
     /// message inside a conversation are drawn from the same fields, and a second mapping is how the two would come to
-    /// publish one message two ways. The derivation is a parameter rather than a default for the same reason — a caller
-    /// that had one and did not pass it would publish <see langword="null" />, which this surface reads as no derivation
-    /// having reached the message rather than as this reading not having asked.
+    /// publish one message two ways. The derivation and the conversation's size are parameters rather than defaults for
+    /// the same reason — a caller that had one and did not pass it would publish <see langword="null" />, which this
+    /// surface reads as nothing having reached the message rather than as this reading not having asked.
     /// </remarks>
     internal static ClientMailTimelineEntryResponse For(
         EmailSummary email,
         string? preview,
-        EmailEnrichment? enrichment) => new(
+        EmailEnrichment? enrichment,
+        int? threadMessageCount) => new(
         email.StoredEmailId.Value,
         email.AccountId.Value,
         email.FolderAlias.Value,
@@ -372,5 +382,6 @@ internal sealed record ClientMailTimelineEntryResponse(
         email.Attachments.AttachmentCount,
         email.SizeOctets,
         preview,
-        ClientMailEnrichmentResponse.For(enrichment));
+        ClientMailEnrichmentResponse.For(enrichment),
+        threadMessageCount);
 }

--- a/backend/src/Infrastructure/Persistence/Emails/Threads/StoredEmailThreadReader.cs
+++ b/backend/src/Infrastructure/Persistence/Emails/Threads/StoredEmailThreadReader.cs
@@ -80,6 +80,59 @@ internal sealed class StoredEmailThreadReader(MailFathomDbContext dbContext) : I
         ];
     }
 
+    /// <inheritdoc />
+    public async Task<IReadOnlyDictionary<EmailThreadId, int>> ReadMessageCountsAsync(
+        IReadOnlyList<EmailThreadId> threadIds,
+        MailboxScope scope,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(threadIds);
+        ArgumentNullException.ThrowIfNull(scope);
+
+        if (threadIds.Count is 0)
+        {
+            return new Dictionary<EmailThreadId, int>();
+        }
+
+        var identities = threadIds.Select(static threadId => threadId.Value).Distinct().ToArray();
+
+        var rows = await Counted(dbContext.StoredEmails.AsNoTracking(), identities, scope)
+            .ToArrayAsync(cancellationToken);
+
+        return rows.ToDictionary(
+            static row => EmailThreadId.Create(row.EmailThreadId),
+            static row => row.MessageCount);
+    }
+
+    /// <summary>Counts the messages of the named conversations that the scope admits, grouped by conversation.</summary>
+    /// <param name="emails">The stored emails to count over, untracked because nothing here writes.</param>
+    /// <param name="threadIds">The conversations to count, already deduplicated.</param>
+    /// <param name="scope">The accounts and folders configuration admits.</param>
+    /// <returns>One row per conversation the scope admits any message of.</returns>
+    /// <remarks>
+    /// <para>
+    /// The scope narrows the query for the reason it narrows the assembly beside it: a message in a folder an operator
+    /// withheld is in no conversation this surface publishes, so counting it would report that folder's contents one
+    /// integer at a time.
+    /// </para>
+    /// <para>
+    /// It is a member of this class rather than an expression inside the asynchronous read above, and that is
+    /// load-bearing for the reason <see cref="Readable" /> is: the architecture rule holding every mail-returning read
+    /// to the shared narrowing reads the class, and a call made only inside an async method body belongs to the
+    /// compiler-generated state machine instead. It takes the query rather than reaching for the context so the command
+    /// it generates can be read without a database, which is the only place the grouping and the narrowing are visible.
+    /// </para>
+    /// </remarks>
+    internal static IQueryable<StoredEmailThreadSizeRow> Counted(
+        IQueryable<StoredEmailEntity> emails,
+        Guid[] threadIds,
+        MailboxScope scope) =>
+        StoredEmailSelectionPredicate.WithinScope(
+                emails.Where(email => email.EmailThreadId != null && threadIds.Contains(email.EmailThreadId.Value)),
+                scope)
+            .GroupBy(email => email.EmailThreadId!.Value)
+            .Select(conversation => new StoredEmailThreadSizeRow(conversation.Key, conversation.Count()));
+
     /// <summary>Narrows one conversation's messages to the mail the scope admits.</summary>
     /// <remarks>
     /// <para>

--- a/backend/src/Infrastructure/Persistence/Emails/Threads/StoredEmailThreadSizeRow.cs
+++ b/backend/src/Infrastructure/Persistence/Emails/Threads/StoredEmailThreadSizeRow.cs
@@ -1,0 +1,14 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Infrastructure.Persistence.Emails.Threads;
+
+/// <summary>One conversation's identity and how many of its messages the scope admits, as PostgreSQL answers them.</summary>
+/// <param name="EmailThreadId">The conversation the count belongs to, as the column holds it.</param>
+/// <param name="MessageCount">How many of its messages the narrowed query counted.</param>
+/// <remarks>
+/// The identity is the raw value rather than the domain type, because a projection EF Core translates is written from
+/// what the provider can group by and the mapping back happens outside the query.
+/// </remarks>
+internal sealed record StoredEmailThreadSizeRow(Guid EmailThreadId, int MessageCount);

--- a/backend/tests/Application.UnitTests/Emails/BrowseTimeline/MailTimelineBrowserTests.cs
+++ b/backend/tests/Application.UnitTests/Emails/BrowseTimeline/MailTimelineBrowserTests.cs
@@ -9,6 +9,7 @@ using MailFathom.Application.Emails.Chunking;
 using MailFathom.Application.Emails.Enrichment;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Summaries;
+using MailFathom.Application.Emails.Threads;
 using MailFathom.Application.Observability;
 using MailFathom.Application.SensitiveContent.Detection;
 using MailFathom.Application.SensitiveContent.Egress;
@@ -342,6 +343,91 @@ public sealed class MailTimelineBrowserTests
         Assert.Equal("the release is out", Assert.Single(page.Emails).Preview);
     }
 
+    /// <summary>
+    /// A correspondence longer than the page it is read in reports its own length on every row of it, which is the whole
+    /// reason the number is read here rather than counted from the rows a page happened to hold.
+    /// </summary>
+    [Fact]
+    public async Task BrowsePageAsync_AConversationRunningPastThePage_ReportsWhatTheConversationHolds()
+    {
+        // Arrange
+        var conversation = Guid.CreateVersion7();
+        var threadReader = Substitute.For<IEmailThreadReader>();
+        threadReader.ReadMessageCountsAsync(
+                Arg.Any<IReadOnlyList<EmailThreadId>>(),
+                Arg.Any<MailboxScope>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyDictionary<EmailThreadId, int>>(
+                new Dictionary<EmailThreadId, int> { [EmailThreadId.Create(conversation)] = 4 }));
+
+        var browser = BrowserOver(
+            new InMemoryStoredEmailTimeline().WithAll(
+            [
+                .. Enumerable.Range(0, 4).Select(day =>
+                    SyntheticEmailSummaries.Create(FirstJuly.AddDays(day), threadId: conversation)),
+            ]),
+            threadReader: threadReader);
+
+        // Act
+        var page = await browser.BrowsePageAsync(
+            new BrowseTimelineRequest { PageSize = 2 },
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal([4, 4], page.Emails.Select(row => row.ThreadMessageCount));
+    }
+
+    /// <summary>One conversation named once for the whole page, because a count per row is a request per row.</summary>
+    [Fact]
+    public async Task BrowsePageAsync_APageWhoseRowsShareOneConversation_CountsItOnceAndNotPerRow()
+    {
+        // Arrange
+        var conversation = Guid.CreateVersion7();
+        var threadReader = Substitute.For<IEmailThreadReader>();
+        threadReader.ReadMessageCountsAsync(
+                Arg.Any<IReadOnlyList<EmailThreadId>>(),
+                Arg.Any<MailboxScope>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyDictionary<EmailThreadId, int>>(
+                new Dictionary<EmailThreadId, int>()));
+
+        var browser = BrowserOver(
+            new InMemoryStoredEmailTimeline().WithAll(
+            [
+                .. Enumerable.Range(0, 3).Select(day =>
+                    SyntheticEmailSummaries.Create(FirstJuly.AddDays(day), threadId: conversation)),
+            ]),
+            threadReader: threadReader);
+
+        // Act
+        await browser.BrowsePageAsync(new BrowseTimelineRequest(), TestContext.Current.CancellationToken);
+
+        // Assert
+        await threadReader.Received(1).ReadMessageCountsAsync(
+            Arg.Is<IReadOnlyList<EmailThreadId>>(named => named!.Count == 1),
+            Arg.Any<MailboxScope>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>A message threading has placed in no conversation reports no count, so nothing draws a pill over it.</summary>
+    [Fact]
+    public async Task BrowsePageAsync_AMessageInNoConversation_CarriesNoCountAndIsNotCounted()
+    {
+        // Arrange
+        var threadReader = Substitute.For<IEmailThreadReader>();
+        var browser = BrowserOver(
+            new InMemoryStoredEmailTimeline().With(SyntheticEmailSummaries.Create(FirstJuly)),
+            threadReader: threadReader);
+
+        // Act
+        var page = await browser.BrowsePageAsync(new BrowseTimelineRequest(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Null(Assert.Single(page.Emails).ThreadMessageCount);
+
+        Assert.Empty(threadReader.ReceivedCalls());
+    }
+
     /// <summary>Mail this deployment has stored but not yet extracted has no preview, which is not the same as an empty one.</summary>
     [Fact]
     public async Task BrowsePageAsync_AMessageNothingHasExtracted_CarriesNoPreview()
@@ -578,6 +664,7 @@ public sealed class MailTimelineBrowserTests
         InMemoryStoredEmailTimeline timeline,
         IStoredEmailPreviewReader? previewReader = null,
         IStoredEmailEnrichmentReader? enrichmentReader = null,
+        IEmailThreadReader? threadReader = null,
         ICallerMailAccountCatalog? accountCatalog = null,
         SensitiveContentEgressGuard? egressGuard = null,
         IMailboxReadTelemetry? readTelemetry = null,
@@ -585,6 +672,7 @@ public sealed class MailTimelineBrowserTests
         timeline,
         previewReader ?? new InMemoryStoredEmailPreviews(),
         enrichmentReader ?? new InMemoryStoredEmailEnrichments(),
+        threadReader ?? new StubEmailThreadReader(),
         new MailboxScopeResolver(
             accountCatalog ?? CatalogServing(EveryAccountTheSyntheticTimelineUses),
             StubMailFolderParticipation.Nothing,

--- a/backend/tests/Application.UnitTests/TestDoubles/SyntheticEmailSummaries.cs
+++ b/backend/tests/Application.UnitTests/TestDoubles/SyntheticEmailSummaries.cs
@@ -40,6 +40,7 @@ internal static class SyntheticEmailSummaries
     /// <param name="senderVerification">What was established about the displayed author, or the stored default.</param>
     /// <param name="senderAuthenticationEvidence">What that conclusion was reached from, or the stored default.</param>
     /// <param name="machineAuthorship">How much the message's own text read as machine written, or the stored default.</param>
+    /// <param name="threadId">The conversation the message belongs to, or <see langword="null" /> where threading has placed it in none.</param>
     /// <returns>The summary.</returns>
     public static EmailSummary Create(
         DateTimeOffset? receivedAt = null,
@@ -55,11 +56,13 @@ internal static class SyntheticEmailSummaries
         int inlineResourceCount = 0,
         SenderVerification? senderVerification = null,
         SenderAuthenticationEvidence? senderAuthenticationEvidence = null,
-        MachineAuthorshipAssessment? machineAuthorship = null) => new()
+        MachineAuthorshipAssessment? machineAuthorship = null,
+        Guid? threadId = null) => new()
         {
             StoredEmailId = StoredEmailId.Create(storedEmailId ?? Guid.CreateVersion7()),
             Account = MailAccountIdentity.Create(SyntheticMailUser.Deployment, MailAccountId.Create(accountId)),
             FolderAlias = MailFolderAlias.Create(folderAlias),
+            ThreadId = threadId is { } conversation ? EmailThreadId.Create(conversation) : null,
             InternetMessageId = null,
             Subject = subject,
             SentAt = receivedAt,

--- a/backend/tests/Host.UnitTests/Api/ClientMailThreadEndpointTests.cs
+++ b/backend/tests/Host.UnitTests/Api/ClientMailThreadEndpointTests.cs
@@ -202,13 +202,14 @@ public sealed class ClientMailThreadEndpointTests
         var message = new BrowsedThreadEmail(SyntheticListedEmail(), Position: 2, answered, "what I added", Enrichment: null);
 
         // Act
-        var response = ClientMailThreadEmailResponse.For(message);
+        var response = ClientMailThreadEmailResponse.For(message, threadMessageCount: 4);
 
         // Assert
         Assert.Equal(2, response.Position);
         Assert.Equal(answered.Value, response.AnsweredId);
         Assert.Equal("what I added", response.Email.Preview);
         Assert.Equal(message.Email.StoredEmailId.Value, response.Email.Id);
+        Assert.Equal(4, response.Email.ThreadMessageCount);
     }
 
     /// <summary>A root of what the caller is shown names no ancestor, which is also the answer for a withheld parent.</summary>
@@ -224,7 +225,7 @@ public sealed class ClientMailThreadEndpointTests
             Enrichment: null);
 
         // Act
-        var response = ClientMailThreadEmailResponse.For(message);
+        var response = ClientMailThreadEmailResponse.For(message, threadMessageCount: 1);
 
         // Assert
         Assert.Null(response.AnsweredId);

--- a/backend/tests/Host.UnitTests/Api/ClientMailTimelineEndpointTests.cs
+++ b/backend/tests/Host.UnitTests/Api/ClientMailTimelineEndpointTests.cs
@@ -8,6 +8,7 @@ using MailFathom.Application.Emails.Chunking;
 using MailFathom.Application.Emails.Enrichment;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Summaries;
+using MailFathom.Application.Emails.Threads;
 using MailFathom.Application.Observability;
 using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
@@ -210,7 +211,7 @@ public sealed class ClientMailTimelineEndpointTests
         var row = new BrowsedEmail(
             SyntheticListedEmail(subject: "the release is out", attachmentCount: 2),
             "it went out this morning",
-            Enrichment: null);
+            Enrichment: null, ThreadMessageCount: null);
 
         // Act
         var response = ClientMailTimelineEntryResponse.For(row);
@@ -233,7 +234,11 @@ public sealed class ClientMailTimelineEndpointTests
     public void For_ARowTheServerReportedAsSeen_IsNotUnread()
     {
         // Arrange
-        var row = new BrowsedEmail(SyntheticListedEmail(isRemotelySeen: true), Preview: null, Enrichment: null);
+        var row = new BrowsedEmail(
+            SyntheticListedEmail(isRemotelySeen: true),
+            Preview: null,
+            Enrichment: null,
+            ThreadMessageCount: null);
 
         // Act
         var response = ClientMailTimelineEntryResponse.For(row);
@@ -264,7 +269,8 @@ public sealed class ClientMailTimelineEndpointTests
                         EmailEnrichmentProvenance.FromAgent("mailfathom-email-enrichment"),
                         dueAt),
                 ],
-                FirstJuly));
+                FirstJuly),
+            ThreadMessageCount: null);
 
         // Act
         var response = ClientMailTimelineEntryResponse.For(row);
@@ -295,8 +301,9 @@ public sealed class ClientMailTimelineEndpointTests
         var nothingToSay = new BrowsedEmail(
             SyntheticListedEmail(),
             Preview: null,
-            new EmailEnrichment(StoredEmailId.Create(Guid.CreateVersion7()), [], FirstJuly));
-        var neverDerived = new BrowsedEmail(SyntheticListedEmail(), Preview: null, Enrichment: null);
+            new EmailEnrichment(StoredEmailId.Create(Guid.CreateVersion7()), [], FirstJuly),
+            ThreadMessageCount: null);
+        var neverDerived = new BrowsedEmail(SyntheticListedEmail(), Preview: null, Enrichment: null, ThreadMessageCount: null);
 
         // Act
         var settled = ClientMailTimelineEntryResponse.For(nothingToSay);
@@ -314,7 +321,7 @@ public sealed class ClientMailTimelineEndpointTests
     {
         // Arrange
         var page = new BrowsedTimelinePage(
-            [new BrowsedEmail(SyntheticListedEmail(), Preview: null, Enrichment: null)],
+            [new BrowsedEmail(SyntheticListedEmail(), Preview: null, Enrichment: null, ThreadMessageCount: null)],
             NextCursor: "after",
             PreviousCursor: "before",
             PageSize: 25);
@@ -420,10 +427,19 @@ public sealed class ClientMailTimelineEndpointTests
             .Returns(Task.FromResult<IReadOnlyDictionary<StoredEmailId, EmailEnrichment>>(
                 new Dictionary<StoredEmailId, EmailEnrichment>()));
 
+        var conversations = Substitute.For<IEmailThreadReader>();
+        conversations.ReadMessageCountsAsync(
+                Arg.Any<IReadOnlyList<EmailThreadId>>(),
+                Arg.Any<MailboxScope>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyDictionary<EmailThreadId, int>>(
+                new Dictionary<EmailThreadId, int>()));
+
         return new MailTimelineBrowser(
             this.timeline,
             previews,
             enrichments,
+            conversations,
             new MailboxScopeResolver(
                 catalog,
                 StubMailFolderParticipation.Nothing,

--- a/backend/tests/Infrastructure.UnitTests/Persistence/Emails/Threads/StoredEmailThreadSizeCommandTests.cs
+++ b/backend/tests/Infrastructure.UnitTests/Persistence/Emails/Threads/StoredEmailThreadSizeCommandTests.cs
@@ -1,0 +1,90 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Mailboxes;
+using MailFathom.Domain.Accounts;
+using MailFathom.Infrastructure.Persistence;
+using MailFathom.Infrastructure.Persistence.Emails.Threads;
+using MailFathom.Infrastructure.Persistence.Entities;
+using MailFathom.TestSupport;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Persistence.Emails.Threads;
+
+/// <summary>
+/// Covers what a page's conversation sizes ask PostgreSQL for, which the C# they are written in does not show. A count
+/// taken in this process would answer the same integers while having carried every message of every conversation on the
+/// page across the boundary, and a count that dropped the shared narrowing would answer plausible integers that report
+/// the size of a folder an operator withheld. Neither failure has a result to read, so the command is what is read.
+/// </summary>
+public sealed class StoredEmailThreadSizeCommandTests
+{
+    private static MailboxScope WholeMailbox { get; } = MailboxScope.Create(
+        SyntheticMailUser.Deployment,
+        [MailAccountId.Create("primary")],
+        []);
+
+    /// <summary>
+    /// The database groups and counts, which is what makes a page of fifty rows one small answer rather than every
+    /// message of every conversation those rows belong to.
+    /// </summary>
+    [Fact]
+    public void Counted_APageOfConversations_AsksPostgreSqlToCountThemRatherThanReturningTheirMessages()
+    {
+        // Act
+        var command = CountCommand();
+
+        // Assert
+        Assert.Contains("count(", command, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("GROUP BY", command, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The count is narrowed by the same predicate every mail-returning read composes. Without it the number a row
+    /// draws would include mail this caller may not see, which is a withheld folder's size published one integer at a
+    /// time — and the architecture rule reads the class rather than the query, so nothing else catches its absence.
+    /// </summary>
+    [Fact]
+    public void Counted_APageOfConversations_NarrowsTheCommandByWhatTheScopeAdmits()
+    {
+        // Act
+        var narrowing = NarrowingIn(CountCommand());
+
+        // Assert
+        Assert.Contains(nameof(StoredEmailEntity.UserId), narrowing, StringComparison.Ordinal);
+        Assert.Contains(nameof(StoredEmailEntity.MailboxAccountId), narrowing, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The page is what bounds this read, so the conversations it named narrow the query rather than a walk of every
+    /// conversation the scope admits.
+    /// </summary>
+    [Fact]
+    public void Counted_APageOfConversations_NarrowsTheCommandToTheConversationsThePageNamed()
+    {
+        // Act
+        var narrowing = NarrowingIn(CountCommand());
+
+        // Assert
+        Assert.Contains($"\"{nameof(StoredEmailEntity.EmailThreadId)}\" = ANY", narrowing, StringComparison.Ordinal);
+    }
+
+    /// <summary>Generates the command, without opening a connection.</summary>
+    private static string CountCommand()
+    {
+        using var context = new MailFathomDbContextDesignTimeFactory().CreateDbContext([]);
+
+        return StoredEmailThreadReader
+            .Counted(
+                context.StoredEmails.AsNoTracking(),
+                [new Guid("11111111-1111-1111-1111-111111111111")],
+                WholeMailbox)
+            .ToQueryString();
+    }
+
+    /// <summary>The command from its first narrowing onward, so a column named in the projection is not read as one.</summary>
+    private static string NarrowingIn(string command) =>
+        command[command.IndexOf("WHERE", StringComparison.Ordinal)..];
+}

--- a/backend/tests/PublicSurfaces.UnitTests/http-api-contract.json
+++ b/backend/tests/PublicSurfaces.UnitTests/http-api-contract.json
@@ -2233,6 +2233,15 @@
               "string"
             ]
           },
+          "threadMessageCount": {
+            "format": "int32",
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ]
+          },
           "toAddresses": {
             "items": {
               "type": "string"
@@ -2261,7 +2270,8 @@
           "attachmentCount",
           "sizeOctets",
           "preview",
-          "enrichment"
+          "enrichment",
+          "threadMessageCount"
         ],
         "type": "object"
       },

--- a/backend/tests/shared/StubEmailThreadReader.cs
+++ b/backend/tests/shared/StubEmailThreadReader.cs
@@ -33,6 +33,9 @@ internal sealed class StubEmailThreadReader(
     /// <summary>Gets how many times a thread was read, which is what proves one read assembles a conversation once.</summary>
     public int ReadCount { get; private set; }
 
+    /// <summary>Gets how many times conversations were counted, which is what proves a page costs one count.</summary>
+    public int CountReadCount { get; private set; }
+
     /// <summary>Records one conversation as folded into another, the way a merge leaves the table.</summary>
     /// <param name="merged">The conversation that was folded away, whose identifier a tool may already have published.</param>
     /// <param name="survivor">The conversation it was folded into.</param>
@@ -76,6 +79,28 @@ internal sealed class StubEmailThreadReader(
                 .OrderBy(email => email.StoredEmailId.Value)
                 .Take(IEmailThreadReader.MaximumAssembledEmails + 1),
         ]);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// No merge is followed and no bound is applied, exactly as the real reader does neither: the counted rows carry the
+    /// surviving identifier already, and a count of a conversation cut at the assembly bound would be a smaller number
+    /// than the conversation holds.
+    /// </remarks>
+    public Task<IReadOnlyDictionary<EmailThreadId, int>> ReadMessageCountsAsync(
+        IReadOnlyList<EmailThreadId> threadIds,
+        MailboxScope scope,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(threadIds);
+
+        this.CountReadCount++;
+
+        return Task.FromResult<IReadOnlyDictionary<EmailThreadId, int>>(
+            emails
+                .Where(held => threadIds.Contains(held.ThreadId) && Admits(scope, held.Email))
+                .GroupBy(static held => held.ThreadId)
+                .ToDictionary(static counted => counted.Key, static counted => counted.Count()));
     }
 
     /// <summary>Follows the merges recorded here to the conversation that survived them.</summary>

--- a/docs/features/mailbox-queries.md
+++ b/docs/features/mailbox-queries.md
@@ -299,9 +299,16 @@ at all asks nothing.
 
 **It counts under the same scope the conversation route reads under**, which is neither the account nor the folder the
 listing was narrowed to, with the junk folder included. A count narrowed to the folder somebody is listing would answer
-one for nearly every row in it, and a row and the conversation it opens would then disagree about how long the exchange
-is. What the scope does narrow is unchanged: a folder [withheld from tools](#folders-withheld-from-tools) is counted
-nowhere, which is what keeps a withheld folder's size from being published one integer at a time.
+one for nearly every row in it, which is the opposite of what the number is drawn for. What the scope does narrow is
+unchanged: a folder [withheld from tools](#folders-withheld-from-tools) is counted nowhere, which is what keeps a
+withheld folder's size from being published one integer at a time.
+
+**What it does not share with that read is the assembly bound.** A conversation is assembled to at most
+`IEmailThreadReader.MaximumAssembledEmails` messages and says `MoreMessagesNotAssembled` when it ran further, so
+`BrowsedThread.MessageCount` never exceeds that; this is a count rather than an assembly and has no such ceiling. So the
+two part above the bound, deliberately: a row says how long the exchange actually is, and the conversation says how much
+of it was assembled and that there is more. Capping the count to make them agree would leave a long correspondence
+drawn as though it were exactly the bound, which is the one thing the number exists to tell a reader apart from.
 
 Being a number rather than text, it reaches no sensitive-content scanner; the egress points are for what a message
 says.

--- a/docs/features/mailbox-queries.md
+++ b/docs/features/mailbox-queries.md
@@ -283,6 +283,29 @@ caller who could raise it could lift what limits how much mail one page draws ou
 preview is scanned wherever a sensitive-content scanner is switched on, at the `client_mail_listing` egress point
 beside the subject and the sender's display name.
 
+### How long a row's correspondence is
+
+A row stands for a message, and a screen drawing a list has to say which of those rows stands for an exchange rather
+than for a single message. `BrowsedEmail` therefore carries how many messages the caller may see in the conversation
+the row's message belongs to, or nothing at all where threading has placed it in none.
+
+**The count is of the conversation rather than of the page**, and that is the whole reason it is read here instead of
+counted by whoever draws the list: a correspondence spans a page boundary as readily as it sits inside one, so counting
+the rows a page happened to hold would answer a different number depending on where the page was cut.
+
+**It is one query for the whole page**, keyed by the distinct conversations that page's rows named, exactly as the
+preview above and the enrichment beside it are read — never a query per row. A page whose rows are in no conversation
+at all asks nothing.
+
+**It counts under the same scope the conversation route reads under**, which is neither the account nor the folder the
+listing was narrowed to, with the junk folder included. A count narrowed to the folder somebody is listing would answer
+one for nearly every row in it, and a row and the conversation it opens would then disagree about how long the exchange
+is. What the scope does narrow is unchanged: a folder [withheld from tools](#folders-withheld-from-tools) is counted
+nowhere, which is what keeps a withheld folder's size from being published one integer at a time.
+
+Being a number rather than text, it reaches no sensitive-content scanner; the egress points are for what a message
+says.
+
 ### The sender verdict a summary carries
 
 The sender's address is what the message wrote about itself, so the summary carries beside it what somebody else
@@ -451,6 +474,13 @@ then produces the one order that conversation has — the reply relation first, 
 the same parent, the local identity settling the rest. Nothing here re-sorts it into a screen's own order, which is what
 keeps two surfaces of one deployment from showing one exchange two ways.
 
+The same port answers one question without assembling anything, and it is what
+[a list row's conversation size](#how-long-a-rows-correspondence-is) is read through: how many messages the caller may
+see in each of a page's conversations. It applies no bound, because a count is what says an exchange is long and cutting
+it at the assembly's 500 would report a long conversation as shorter than it is — and counting is what a database does
+without carrying any of the rows. It follows no merge either: a merge repoints every message of the folded conversation
+at the survivor, so the identifiers a page's rows carry are already the ones the counted rows hold.
+
 **What each message carries is the list row of the page above**, read for the page's messages alone through the
 identity lookup beside the timeline reader, with the same [preview](#the-preview-a-list-row-shows) beside it. That
 preview is what the message added — the trimmed reading, without the quoted history the eight replies above it would
@@ -554,7 +584,8 @@ mirrored or not and withheld or not, is [the administrative status route](../ope
 
 - `MailFathom.Application.Emails.ListEmails` — the use case, its request, and its result.
 - `MailFathom.Application.Emails.BrowseTimeline` — `MailTimelineBrowser`, the same walk read for a screen, with its
-  request, its page, the row that pairs a summary with a preview, and the page direction that says which way a page
+  request, its page, the row that pairs a summary with a preview, what a derivation concluded and how long the
+  conversation the row stands for is, and the page direction that says which way a page
   continues from its cursor. It is a use case of its own rather than a wider listing because both of those are things a
   tool has no use for, and it shares the scope, the filters, the order, the bound and the cursor codec with the listing
   rather than restating any of them.

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -452,7 +452,6 @@ continues the list at each end:
       "attachmentCount": 2,
       "sizeOctets": 48213,
       "preview": "The release went out this morning and the notes are attached.",
-      "threadMessageCount": 4,
       "enrichment": {
         "derivedAt": "2026-08-15T10:02:44+00:00",
         "marks": [
@@ -466,7 +465,8 @@ continues the list at each end:
             "evidence": [ "0198f4a1-2b6c-7a1d-9f3e-4c5d6e7f8a92" ]
           }
         ]
-      }
+      },
+      "threadMessageCount": 4
     }
   ],
   "nextCursor": "AbCd...",
@@ -490,10 +490,16 @@ change it.
 **`threadMessageCount` is how long the correspondence is**, counted over the whole conversation rather than over the
 page — a correspondence spans a page boundary as readily as it sits inside one, so a client counting the rows it holds
 would answer a different number depending on where the page was cut. It is counted across every folder the user may
-read with the junk folder included, which is the same membership `GET /api/client/threads/{threadId}` publishes, so a
-row and the conversation it opens cannot disagree about how long the exchange is. It is `null` for a message threading
-has placed in no conversation, and `1` for one whose conversation holds only it. The count comes out of the same read
-the page comes from rather than a request per row.
+read with the junk folder included, which is the same membership `GET /api/client/threads/{threadId}` reads under. It is
+`null` for a message threading has placed in no conversation, and `1` for one whose conversation holds only it. The
+count comes out of the same read the page comes from rather than a request per row.
+
+**It is the one place a conversation's length is published without the assembly bound.** The two routes agree up to the
+500 messages the conversation route assembles and part above it: a correspondence longer than that is reported here as
+the length it actually is, while `GET /api/client/threads/{threadId}` reports `messageCount` as 500 and says so with
+`moreMessagesNotAssembled`. That is deliberate. What a client draws this field as says *this row stands for a long
+exchange*, which a number capped at the bound would stop saying — and making the two agree would mean counting the
+conversation a second time to publish a number the conversation route already states.
 
 **`enrichment` is what a derivation concluded about the message**, and it is on every row of every response, whether or
 not the deployment turned [message enrichment](../features/message-enrichment.md) on. It carries at most
@@ -742,7 +748,22 @@ It answers with one conversation as a single document — the messages in it, wh
         "hasAttachments": true,
         "attachmentCount": 2,
         "sizeOctets": 48213,
-        "preview": "The release went out this morning and the notes are attached."
+        "preview": "The release went out this morning and the notes are attached.",
+        "enrichment": {
+          "derivedAt": "2026-08-15T10:02:44+00:00",
+          "marks": [
+            {
+              "aspect": "Sense",
+              "text": "The 0.8.0 release notes, with the changelog attached.",
+              "reason": "The opening paragraph announces the release and names the attachment.",
+              "dueAt": null,
+              "source": "Model",
+              "origin": "mailfathom-email-enrichment",
+              "evidence": [ "0198f4a1-2b6c-7a1d-9f3e-4c5d6e7f8a92" ]
+            }
+          ]
+        },
+        "threadMessageCount": 2
       }
     },
     {
@@ -765,7 +786,9 @@ It answers with one conversation as a single document — the messages in it, wh
         "hasAttachments": false,
         "attachmentCount": 0,
         "sizeOctets": 3120,
-        "preview": "Thanks — I will read the notes this afternoon."
+        "preview": "Thanks — I will read the notes this afternoon.",
+        "enrichment": null,
+        "threadMessageCount": 2
       }
     }
   ],
@@ -800,7 +823,10 @@ trimmed off — which is what keeps the eighth reply from redrawing the seven ab
 derivation reached shows its marks whichever screen draws it, and a conversation that answered `null` for a message the
 list shows marks for would be stating that no derivation has reached it. `threadMessageCount` on each of these rows is
 this conversation's own `messageCount`, because that is what the field means and every message here is in this
-conversation — so a row drawn from a thread reads the same number as the header above it. There is no body here
+conversation — so a row drawn from a thread reads the same number as the header above it. That is the *assembled* count
+rather than the counted one, so a conversation past the 500 this route assembles reads `500` here beside
+`moreMessagesNotAssembled` and reads its real length on a
+[mail list row](#the-mail-list-route). There is no body here
 either: the whole of a message is a request of its own, named by the `id` that row already carries.
 
 **`position` and `answeredId` are where the message sits.** `position` is its zero-based place in the conversation's

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -452,6 +452,7 @@ continues the list at each end:
       "attachmentCount": 2,
       "sizeOctets": 48213,
       "preview": "The release went out this morning and the notes are attached.",
+      "threadMessageCount": 4,
       "enrichment": {
         "derivedAt": "2026-08-15T10:02:44+00:00",
         "marks": [
@@ -485,6 +486,14 @@ text as extraction trimmed it, without quoted history or a signature block, whic
 being the message it was answering. It is `null` for mail this deployment has stored but not yet extracted, which is
 not the same as a message whose text is empty. The bound is fixed: no request may raise it and no deployment may
 change it.
+
+**`threadMessageCount` is how long the correspondence is**, counted over the whole conversation rather than over the
+page — a correspondence spans a page boundary as readily as it sits inside one, so a client counting the rows it holds
+would answer a different number depending on where the page was cut. It is counted across every folder the user may
+read with the junk folder included, which is the same membership `GET /api/client/threads/{threadId}` publishes, so a
+row and the conversation it opens cannot disagree about how long the exchange is. It is `null` for a message threading
+has placed in no conversation, and `1` for one whose conversation holds only it. The count comes out of the same read
+the page comes from rather than a request per row.
 
 **`enrichment` is what a derivation concluded about the message**, and it is on every row of every response, whether or
 not the deployment turned [message enrichment](../features/message-enrichment.md) on. It carries at most
@@ -615,7 +624,8 @@ ranks both ways wherever it can, and the answer says which happened.
 **A result is a list row with two fields added**, so one layout draws both and a result can be opened, filtered, and
 acted on without a second request. `snippets` are the extracts around what matched, each marking the matched words with
 `**` — text cut from untrusted mail rather than markup to render — and `preview` is the same bounded opening the list
-route publishes.
+route publishes. The one list field a result does not carry is `threadMessageCount`: a search ranks messages rather
+than correspondences, and counting the conversation behind every result would be a query this route does not owe.
 
 **`matchedBy` is why the row is there**: `LexicalRanking` for a message carrying the query's words, `SemanticRanking`
 for one matching by meaning, and `BothRankings` for one both rankings found. It is the field a screen needs most for
@@ -788,8 +798,10 @@ across this surface, and its `preview` is what that message added with the quote
 trimmed off — which is what keeps the eighth reply from redrawing the seven above it. Field for field includes
 `enrichment`, which carries here exactly what it carries on a list row and means exactly the same thing: a message a
 derivation reached shows its marks whichever screen draws it, and a conversation that answered `null` for a message the
-list shows marks for would be stating that no derivation has reached it. There is no body here either: the whole of a
-message is a request of its own, named by the `id` that row already carries.
+list shows marks for would be stating that no derivation has reached it. `threadMessageCount` on each of these rows is
+this conversation's own `messageCount`, because that is what the field means and every message here is in this
+conversation — so a row drawn from a thread reads the same number as the header above it. There is no body here
+either: the whole of a message is a request of its own, named by the `id` that row already carries.
 
 **`position` and `answeredId` are where the message sits.** `position` is its zero-based place in the conversation's
 own order and continues across pages, so a client that has paged twice still knows what it is holding. `answeredId`

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -487,6 +487,7 @@ export const en = {
     'list.attachments': '{count} attached',
     'list.noSubject': 'No subject',
     'list.senderUnknown': 'No sender',
+    'list.threadMessages': '{count} messages in this conversation',
 
     'search.label': 'Find a message',
     'search.placeholder': 'Words from the message you are looking for',

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -492,6 +492,7 @@ export const pl: Catalogue = {
     'list.attachments': 'Załączniki: {count}',
     'list.noSubject': 'Bez tematu',
     'list.senderUnknown': 'Brak nadawcy',
+    'list.threadMessages': 'Wiadomości w tym wątku: {count}',
 
     'search.label': 'Znajdź wiadomość',
     'search.placeholder': 'Słowa z wiadomości, której szukasz',

--- a/frontend/src/Client.App/src/mailboxActs/useMailboxActs.test.ts
+++ b/frontend/src/Client.App/src/mailboxActs/useMailboxActs.test.ts
@@ -24,6 +24,7 @@ const email: MailTimelineEntry = {
     attachmentCount: 0,
     sizeOctets: 1_024,
     preview: 'The opening of the message.',
+    threadMessageCount: null,
 };
 
 function asking(act: MailboxAct, storedEmailId = email.id): MailboxActs {

--- a/frontend/src/Client.App/src/messageList/heldTimeline.test.ts
+++ b/frontend/src/Client.App/src/messageList/heldTimeline.test.ts
@@ -44,6 +44,7 @@ function message(at: number): MailTimelineEntry {
         attachmentCount: 0,
         sizeOctets: 1_024,
         preview: null,
+        threadMessageCount: null,
     };
 }
 

--- a/frontend/src/Client.App/src/messageRows/MessageRow.test.tsx
+++ b/frontend/src/Client.App/src/messageRows/MessageRow.test.tsx
@@ -31,6 +31,7 @@ const email: MailTimelineEntry = {
     attachmentCount: 0,
     sizeOctets: 1_024,
     preview: 'The opening of the message.',
+    threadMessageCount: null,
 };
 
 function drawRow(
@@ -39,6 +40,7 @@ function drawRow(
     marking: ReadMarking = nothingMarkedRead,
     acts: MailboxActs = nothingActed,
     flagged = false,
+    threadMessageCount: number | null = null,
 ): HTMLElement {
     render(
         <LocalizationProvider>
@@ -46,7 +48,7 @@ function drawRow(
                 <MailboxActsContext value={acts}>
                     <ul>
                         <MessageRow
-                            email={{ ...email, unread, flagged }}
+                            email={{ ...email, unread, flagged, threadMessageCount }}
                             position={1}
                             open={false}
                             selected={false}
@@ -174,6 +176,22 @@ describe('MessageRow', () => {
         drawRow();
 
         expect(screen.queryByText('Unread')).toBeNull();
+    });
+
+    // How long the correspondence is, which the design draws as a number alone — so the words beside it are what a
+    // reader who is not looking at the row gets, and both are asserted together. A conversation of one is every
+    // message that was never answered, so drawing the pill over it would put a mark on nearly every row in a folder.
+    it('says how many messages the correspondence holds where it holds more than the one', () => {
+        drawRow(undefined, false, nothingMarkedRead, nothingActed, false, 6);
+
+        expect(screen.getByText('6')).toBeDefined();
+        expect(screen.getByText('6 messages in this conversation')).toBeDefined();
+    });
+
+    it('says nothing of the sort where the correspondence is the one message', () => {
+        drawRow(undefined, false, nothingMarkedRead, nothingActed, false, 1);
+
+        expect(screen.queryByText('1 messages in this conversation')).toBeNull();
     });
 
     // The row draws from the pending mutation rather than waiting for the account's own pass to observe the flag,

--- a/frontend/src/Client.App/src/messageRows/MessageRow.tsx
+++ b/frontend/src/Client.App/src/messageRows/MessageRow.tsx
@@ -277,6 +277,25 @@ export function MessageRow({
                         </span>
                     ) : null}
 
+                    {/* How long the correspondence is, drawn where it is longer than the one message. The design
+                        project puts it between the unread mark and the time and draws nothing at all for a message
+                        standing alone, so the pill says this row stands for an exchange rather than repeating what
+                        every row already is. The number is the deployment's count over the whole conversation — a
+                        client counting the rows it holds would answer differently depending on where the page was
+                        cut — and the words beside it are for a reader who is not looking at it, which the design has
+                        no way to draw. */}
+                    {email.threadMessageCount !== null && email.threadMessageCount > 1 ? (
+                        <span className="shrink-0 rounded-full border border-line-soft bg-rail px-1.5 py-px text-2xs text-text-soft">
+                            <span aria-hidden="true">{email.threadMessageCount}</span>
+
+                            <span className="sr-only">
+                                {translate('list.threadMessages', {
+                                    count: String(email.threadMessageCount),
+                                })}
+                            </span>
+                        </span>
+                    ) : null}
+
                     <ReceivedAt at={email.receivedAt} />
                 </div>
 

--- a/frontend/src/Client.App/src/search/citedFile.test.ts
+++ b/frontend/src/Client.App/src/search/citedFile.test.ts
@@ -45,6 +45,7 @@ function found(carried: Partial<MailSearchResult> = {}): MailSearchResult {
         attachmentCount: 2,
         sizeOctets: 4_096,
         preview: 'The renewal falls due.',
+        threadMessageCount: null,
         snippets: [],
         matchedBy: 'LexicalRanking',
         attachmentMatches: [],

--- a/frontend/src/Client.App/src/thread/ThreadMessage.test.tsx
+++ b/frontend/src/Client.App/src/thread/ThreadMessage.test.tsx
@@ -57,6 +57,7 @@ function message(overrides: Partial<MailThreadMessage['email']> = {}): MailThrea
             attachmentCount: 0,
             sizeOctets: 1_024,
             preview: 'The figures you asked for are attached.',
+            threadMessageCount: null,
             ...overrides,
         },
     };

--- a/frontend/src/Client.App/src/thread/threadOpening.test.ts
+++ b/frontend/src/Client.App/src/thread/threadOpening.test.ts
@@ -28,6 +28,7 @@ function message(id: string, position: number, unread = false): MailThreadMessag
             attachmentCount: 0,
             sizeOctets: 1_024,
             preview: 'What this one added.',
+            threadMessageCount: null,
         },
     };
 }

--- a/frontend/src/Client.Backend/src/mailThread.test.ts
+++ b/frontend/src/Client.Backend/src/mailThread.test.ts
@@ -32,6 +32,7 @@ const email = {
     attachmentCount: 0,
     sizeOctets: 84_213,
     preview: 'The figures you asked for are attached.',
+    threadMessageCount: 2,
 };
 
 const participant = { address: 'auditor@example.invalid', displayName: 'The auditor', messageCount: 2 };

--- a/frontend/src/Client.Backend/src/mailTimeline.test.ts
+++ b/frontend/src/Client.Backend/src/mailTimeline.test.ts
@@ -45,6 +45,7 @@ const message = {
     attachmentCount: 2,
     sizeOctets: 84_213,
     preview: 'The figures you asked for are attached.',
+    threadMessageCount: null,
 };
 
 function bodyOf(emails: readonly unknown[], cursors: Readonly<Record<string, unknown>> = {}): string {
@@ -234,6 +235,8 @@ describe('readMailTimeline', () => {
         ['a flagged state that is not a boolean', bodyOf([{ ...message, flagged: null }])],
         ['an attachment count that is not whole', bodyOf([{ ...message, attachmentCount: 1.5 }])],
         ['a negative size', bodyOf([{ ...message, sizeOctets: -1 }])],
+        ['a conversation holding no message at all', bodyOf([{ ...message, threadMessageCount: 0 }])],
+        ['a conversation size that is not whole', bodyOf([{ ...message, threadMessageCount: 2.5 }])],
     ])('refuses %s rather than reading a page with a hole in it', async (_, body) => {
         const result = await readMailTimeline(session, answering({ status: 200, body }), leadingPage);
 
@@ -258,5 +261,26 @@ describe('readMailTimeline', () => {
         const result = await readMailTimeline(session, transport, leadingPage);
 
         expect(result.outcome === 'read' && result.value.emails[0]?.threadId).toBeNull();
+    });
+
+    // How long the correspondence is is the deployment's count over the whole of it, so it is read as it arrived and
+    // never recomputed here — and a route that states none leaves the row saying nothing rather than saying one.
+    it('reads how many messages the row’s correspondence holds', async () => {
+        const transport = answering({ status: 200, body: bodyOf([{ ...message, threadMessageCount: 6 }]) });
+
+        const result = await readMailTimeline(session, transport, leadingPage);
+
+        expect(result.outcome === 'read' && result.value.emails[0]?.threadMessageCount).toBe(6);
+    });
+
+    it('reads a row whose route states no conversation size as one that says nothing about it', async () => {
+        const transport = answering({
+            status: 200,
+            body: bodyOf([{ ...message, threadMessageCount: undefined }]),
+        });
+
+        const result = await readMailTimeline(session, transport, leadingPage);
+
+        expect(result.outcome === 'read' && result.value.emails[0]?.threadMessageCount).toBeNull();
     });
 });

--- a/frontend/src/Client.Backend/src/mailTimeline.ts
+++ b/frontend/src/Client.Backend/src/mailTimeline.ts
@@ -96,6 +96,18 @@ export interface MailTimelineEntry {
 
     /** The opening of the message's own text, or `null` for a message this deployment has stored but not extracted. */
     readonly preview: string | null;
+
+    /**
+     * How many messages the correspondence this row stands for holds, or `null` where the row's surface states none.
+     *
+     * It is the deployment's count over the whole conversation rather than over the page, which is the only place it
+     * could come from: a correspondence spans a page boundary as readily as it sits inside one, and counting the rows
+     * one page happened to hold would answer a different number depending on where the page was cut.
+     *
+     * `null` has two readings and a screen draws them the same way, because neither is a conversation: threading has
+     * placed the message in none, or the route that answered does not count them — which the search results do not.
+     */
+    readonly threadMessageCount: number | null;
 }
 
 /** One page of the list, and the two cursors the pages either side of it are asked with. */
@@ -330,6 +342,14 @@ export function parseTimelineEntry(value: unknown): MailTimelineEntry | null {
         return null;
     }
 
+    const threadMessageCount = record['threadMessageCount'] ?? null;
+
+    // A conversation holds at least the message the row is about, so a count of zero is an answer no deployment
+    // produces and the row is refused rather than drawn from it.
+    if (threadMessageCount !== null && (!isCount(threadMessageCount) || threadMessageCount < 1)) {
+        return null;
+    }
+
     return {
         id,
         account,
@@ -348,6 +368,7 @@ export function parseTimelineEntry(value: unknown): MailTimelineEntry | null {
         attachmentCount,
         sizeOctets,
         preview,
+        threadMessageCount,
     };
 }
 

--- a/frontend/tests/fixtures/mail.ts
+++ b/frontend/tests/fixtures/mail.ts
@@ -46,6 +46,31 @@ function timelineRow(at: number) {
         attachmentCount: at % 5 === 0 ? 1 : 0,
         sizeOctets: 4_096,
         preview: `The opening of message ${String(at)}.`,
+        threadMessageCount: null,
+    };
+}
+
+/**
+ * Where in the folder the one row standing for a correspondence sits.
+ *
+ * A folder whose every row is a single message draws none of the count the design puts on a row that stands for an
+ * exchange, so a corpus without one cannot show that state at all. It is far enough down that the rows a check reaches
+ * by position are the plain ones they were, and near enough the top to be on the first screen of every composition.
+ */
+const conversationRowPosition = 3;
+
+// The row that opens the conversation below, drawn in the folder it arrived in. It is composed here rather than held
+// as a constant because what it is built from is declared further down this file.
+function conversationTimelineRow() {
+    return {
+        ...timelineRow(conversationRowPosition),
+        id: rackingQuote.id,
+        threadId: conversationId,
+        threadMessageCount: conversationRows.length,
+        subject: rackingQuote.subject,
+        senderAddress: 'sales@nordwind.example',
+        senderDisplayName: 'Nordwind',
+        preview: rackingQuote.preview,
     };
 }
 
@@ -62,7 +87,9 @@ export function timelinePage(from: number) {
     const rows = Math.max(Math.min(rowsPerPage, mailboxSize - start), 0);
 
     return {
-        emails: Array.from({ length: rows }, (_, at) => timelineRow(start + at)),
+        emails: Array.from({ length: rows }, (_, at) =>
+            start + at === conversationRowPosition ? conversationTimelineRow() : timelineRow(start + at),
+        ),
         nextCursor: start + rows >= mailboxSize ? null : String(start + rows),
         previousCursor: start === 0 ? null : String(start),
         pageSize: rowsPerPage,
@@ -250,6 +277,7 @@ export const conversation = {
             attachmentCount: 0,
             sizeOctets: 3_120,
             preview: row.preview,
+            threadMessageCount: conversationRows.length,
         },
     })),
     participants: [

--- a/scripts/test-agent-workflow.sh
+++ b/scripts/test-agent-workflow.sh
@@ -9228,6 +9228,7 @@ drafts.ts queuedSend POST /api/client/drafts/{draftId}/send
 drafts.ts refusedSend - -
 mail.ts timelineRow GET /api/client/emails
 mail.ts timelinePage GET /api/client/emails
+mail.ts conversationTimelineRow GET /api/client/emails
 mail.ts emptyFolderPage GET /api/client/emails
 mail.ts rackingQuote GET /api/client/emails
 mail.ts searchResults GET /api/client/emails/search


### PR DESCRIPTION
Closes #1761

A message list draws one row per message, and nothing on it said which of those rows stood for an exchange rather than
for a single message. This adds the count the design draws — a small pill carrying how many messages the correspondence
holds — and the service field behind it.

## Where the count comes from

`MailTimelineBrowser` reads it in the same page read that produces the rows, keyed by the distinct conversations that
page's rows named — one query for the whole page, exactly as the preview and the enrichment beside it are read, never a
query per row. A page whose rows are in no conversation asks nothing at all.

It is a count of the **conversation** rather than of the page, and that is the whole reason the service answers it: a
correspondence spans a page boundary as readily as it sits inside one, so a client counting the rows it happened to
receive would say a different number depending on where the page was cut.

It counts under the same scope `MailThreadBrowser` reads under — unnarrowed by the account or folder the listing was
narrowed to, with the junk folder included. A count narrowed to the folder somebody is listing would answer `1` for
nearly every row in it, which is the opposite of what the number is drawn for. What the scope still does narrow is
unchanged: a folder an operator withheld is counted nowhere.

What the two reads do **not** share is the assembly bound, and that is deliberate. A conversation is assembled to at
most `IEmailThreadReader.MaximumAssembledEmails` messages and says `moreMessagesNotAssembled` when it ran further, so
`GET /api/client/threads/{threadId}` never publishes a `messageCount` above 500; this is a count rather than an
assembly and has no such ceiling, so a correspondence longer than that is reported on a list row as the length it
actually is. Capping the count to make the two agree would draw a nine-hundred-message exchange as exactly `500`, which
is the one reading the pill exists to give — *this row stands for a long exchange*. The prose on both routes and in
`docs/features/mailbox-queries.md` states where they part.

The new query is a member of `StoredEmailThreadReader` and composes `StoredEmailSelectionPredicate.WithinScope` like
every other mail-returning read. `MailboxReadBoundaryTests` reads the *class* rather than the query, so it would have
stayed green had the narrowing been dropped — `StoredEmailThreadSizeCommandTests` therefore reads the generated SQL and
asserts that PostgreSQL does the grouping and the counting, that the `WHERE` carries the scope's own columns, and that
the query is narrowed to the conversations the page named.

No merge walk is needed: a merge repoints every message of the folded conversation at the survivor, so the identifiers a
page's rows already carry are the ones the counted rows hold.

## Where the pill is drawn

`MessageRow` draws it where the count is greater than one, between the unread mark and the received time, which is where
the design project puts it. A correspondence of one message draws nothing — every message nobody answered is a
conversation of one, so a pill over those would be a mark on nearly every row in a folder.

The design draws a bare number. The row adds an `sr-only` sentence beside it (`list.threadMessages`, in both
catalogues), because a number alone says nothing to a reader who is not looking at it; that is the accessibility
obligation outranking the design rather than a departure from it.

`parseTimelineEntry` refuses a row whose count is zero or not whole — a conversation holds at least the message the row
is about, so zero is an answer no deployment produces.

## Verified against the design

Both sides of the `mail-list` screen were captured at 1440×900 and read region by region. The marks cluster matches:
blue unread dot, then the pale rounded pill with the digit, then the time, at the same size, radius, fill and text
colour. The two remaining differences are the corpus rather than the client — the design's mock message arrived
yesterday and the fixture's is dated, and the artboard is in Polish.

The fixture corpus had no multi-message correspondence in the list at all, so no capture could have shown the pill. One
coherent conversation row was added at position 3, chosen because the browser specs reach rows by `nth(1)` and `first()`
and the `mail-thread` parity screen clicks row 0.

## Public surface

`http-api-contract.json` moves. **`threadMessageCount` is added to the client timeline entry**, which is the row shape
both `GET /api/client/mail` and `GET /api/client/threads/{threadId}` publish. It is an added optional integer field, so
a client that does not read it is unaffected and **no operator action is required**. `GET /api/client/search` continues
to answer without it: a search ranks messages rather than correspondences, and counting the conversation behind every
result would be a query that route does not owe.

## Tests

- `MailTimelineBrowserTests` — a conversation running past the page reports what the conversation holds, a page whose
  rows share one conversation counts it once rather than per row, and a message in no conversation carries no count and
  is not counted.
- `StoredEmailThreadSizeCommandTests` — the three claims about the generated command above.
- `MessageRow.test.tsx` — the pill's two cases, the visible number and the words together.
- `mailTimeline.test.ts` — the count is read as it arrived, an absent field reads as nothing, and zero or a fraction is
  refused.
- `ClientMailThreadEndpointTests` — a thread row carries that conversation's own `messageCount`.

## Documentation

`docs/operations/client-endpoint.md` states the field on all three routes, including which one deliberately omits it.
`docs/features/mailbox-queries.md` gains a section on what is counted, why not per page, the scope it counts under and
what that keeps from leaking, and a paragraph naming the thread port's second, unbounded operation.
