### PR TITLE
[#1759] Open a correspondence in one request and read it expanded

### DIFF
--- a/backend/src/Host/Api/ClientMailThreadEndpoint.cs
+++ b/backend/src/Host/Api/ClientMailThreadEndpoint.cs
@@ -89,11 +89,14 @@ internal static class ClientMailThreadEndpoint
 
         var drawing = content is true;
 
-        if (drawing && pageSize > GetEmailContentRequest.MaximumEmails)
+        // The whole range rather than the ceiling alone, so that a page of zero is refused in the words of the read it
+        // was asked for: the general bound below would otherwise answer a drawn conversation with the 1-to-100 range,
+        // which is not the range that request had.
+        if (drawing && pageSize is { } asked && asked is < 1 or > GetEmailContentRequest.MaximumEmails)
         {
             return Refuse(
-                $"A conversation read with its messages carries at most {GetEmailContentRequest.MaximumEmails} of them, "
-                + "so ask for a smaller page and read on with the cursor.");
+                $"A conversation read with its messages holds between 1 and {GetEmailContentRequest.MaximumEmails} of them, "
+                + "so ask for a page within that and read on with the cursor.");
         }
 
         var request = new BrowseThreadRequest

--- a/backend/src/Host/Api/ClientMailThreadEndpoint.cs
+++ b/backend/src/Host/Api/ClientMailThreadEndpoint.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Emails.BrowseThread;
+using MailFathom.Application.Emails.GetEmailContent;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Domain.Access;
 using MailFathom.Domain.Emails;
@@ -23,8 +24,16 @@ namespace MailFathom.Host.Api;
 /// <para>
 /// The document is one request. Its messages arrive in the conversation's own order, each drawn exactly as a list row
 /// is drawn and carrying the opening of what that message added with the quoted history trimmed off, and the
-/// participants arrive beside them so a header costs no walk over the messages. What it never carries is a body: the
-/// whole of a message, quoted history included, is a request of its own naming the identity a row already carries.
+/// participants arrive beside them so a header costs no walk over the messages.
+/// </para>
+/// <para>
+/// A caller that draws the messages rather than a list of them asks for them with <c>content=true</c>, and each message
+/// then arrives with what the message route and the body route answer for it — the headers it displays, the verdict on
+/// who sent it, the files it carries, and the body as words and as the reduced document tree. That is what makes
+/// reading a correspondence one request rather than one request per message somebody reveals. It costs what reading
+/// that many messages costs, so it is bounded by the same ceiling any content read is held to
+/// (<see cref="GetEmailContentRequest.MaximumEmails" />): a page asking for more messages than that with their content
+/// is refused rather than served half-drawn, and a longer conversation is read on with the cursor.
 /// </para>
 /// <para>
 /// It speaks to no mail server, so a request from a browser cannot wait on IMAP and cannot set the remote <c>\Seen</c>
@@ -51,7 +60,9 @@ internal static class ClientMailThreadEndpoint
     /// <param name="threadId">The conversation to read, as a message row published it.</param>
     /// <param name="pageSize">How many messages the page may hold, or <see langword="null" /> for the default.</param>
     /// <param name="cursor">The cursor a previous page returned, or <see langword="null" /> for the start of the conversation.</param>
+    /// <param name="content">Whether each message arrives with what it says, which is what a caller drawing the conversation asks for.</param>
     /// <param name="thread">Reads the conversation, for a caller the read's own grant admits.</param>
+    /// <param name="messages">Reads the messages themselves, where the caller asked for them.</param>
     /// <param name="cancellationToken">Cancels the read when the client disconnects.</param>
     /// <returns><c>200</c> with the page, <c>400</c> naming what was wrong with the request, <c>404</c> where this user has no such conversation, or <c>403</c> for a caller whose grant does not carry <c>mailfathom.mail.read</c>.</returns>
     /// <remarks>
@@ -63,20 +74,32 @@ internal static class ClientMailThreadEndpoint
         [FromRoute] Guid threadId,
         [FromQuery] int? pageSize,
         [FromQuery] string? cursor,
+        [FromQuery] bool? content,
         [FromServices] MailThreadBrowser thread,
+        [FromServices] EmailContentReader messages,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(thread);
+        ArgumentNullException.ThrowIfNull(messages);
 
         if (threadId == Guid.Empty)
         {
             return TypedResults.NotFound();
         }
 
+        var drawing = content is true;
+
+        if (drawing && pageSize > GetEmailContentRequest.MaximumEmails)
+        {
+            return Refuse(
+                $"A conversation read with its messages carries at most {GetEmailContentRequest.MaximumEmails} of them, "
+                + "so ask for a smaller page and read on with the cursor.");
+        }
+
         var request = new BrowseThreadRequest
         {
             ThreadId = EmailThreadId.Create(threadId),
-            PageSize = pageSize,
+            PageSize = drawing ? pageSize ?? GetEmailContentRequest.MaximumEmails : pageSize,
             Cursor = cursor,
         };
 
@@ -84,9 +107,14 @@ internal static class ClientMailThreadEndpoint
         {
             var page = await thread.BrowsePageAsync(request, cancellationToken);
 
-            return page is null
-                ? TypedResults.NotFound()
-                : TypedResults.Ok(ClientMailThreadResponse.For(page));
+            if (page is null)
+            {
+                return TypedResults.NotFound();
+            }
+
+            var drawn = drawing ? await ReadMessagesAsync(page, messages, cancellationToken) : [];
+
+            return TypedResults.Ok(ClientMailThreadResponse.For(page, drawn));
         }
         catch (MailboxQueryCursorMalformedException)
         {
@@ -105,6 +133,41 @@ internal static class ClientMailThreadEndpoint
             return Refuse($"A page holds between 1 and {MailboxQueryPageSize.MaximumValue} messages.");
         }
     }
+
+    /// <summary>Reads the page's messages themselves, so the conversation is drawn from one request rather than from one per message.</summary>
+    /// <param name="page">The page the conversation answered with.</param>
+    /// <param name="messages">Reads the messages from the local copy, under the caller's own grant.</param>
+    /// <param name="cancellationToken">Cancels the read when the client disconnects.</param>
+    /// <returns>What was read, in the order the page named its messages, with a message whose local copy is damaged absent.</returns>
+    private static async Task<IReadOnlyList<ReadEmailContent>> ReadMessagesAsync(
+        BrowsedThread page,
+        EmailContentReader messages,
+        CancellationToken cancellationToken)
+    {
+        if (page.Messages.Count == 0)
+        {
+            return [];
+        }
+
+        var read = await messages.ReadContentAsync(
+            ContentRequestFor([.. page.Messages.Select(message => message.Email.StoredEmailId)]),
+            cancellationToken);
+
+        return [.. read.Emails.Select(outcome => outcome.Content).OfType<ReadEmailContent>()];
+    }
+
+    /// <summary>Composes the read a drawn conversation makes, which asks for exactly what the two message routes ask for between them.</summary>
+    /// <param name="storedEmailIds">The page's messages, in the conversation's own order.</param>
+    /// <returns>The request the use case is asked with.</returns>
+    /// <remarks>
+    /// Named rather than inlined for the reason the body route's is: what it declines is the point. It asks for the
+    /// reduced tree, because that is what a message is drawn from, and for neither the sender's own markup nor a minted
+    /// download link — the first is the surface a reader opens per message, and the second is a bearer credential this
+    /// response would otherwise hand out once per message in a conversation. The reader's ask for remote pictures is
+    /// per message as well, so a conversation is drawn with none of them resolved.
+    /// </remarks>
+    internal static GetEmailContentRequest ContentRequestFor(IReadOnlyList<StoredEmailId> storedEmailIds) =>
+        GetEmailContentRequest.Create(storedEmailIds) with { IncludeMailDocument = true };
 
     /// <summary>States what a caller has to change, without echoing what they sent.</summary>
     private static ProblemHttpResult Refuse(string stated) =>
@@ -137,15 +200,22 @@ internal sealed record ClientMailThreadResponse(
 {
     /// <summary>Describes one page of one conversation for the wire.</summary>
     /// <param name="thread">The page the use case read.</param>
+    /// <param name="drawn">The messages themselves, where the caller asked for them, and empty where it did not.</param>
     /// <returns>The response body.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="thread" /> is <see langword="null" />.</exception>
-    internal static ClientMailThreadResponse For(BrowsedThread thread)
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="thread" /> or <paramref name="drawn" /> is <see langword="null" />.</exception>
+    internal static ClientMailThreadResponse For(BrowsedThread thread, IReadOnlyList<ReadEmailContent> drawn)
     {
         ArgumentNullException.ThrowIfNull(thread);
+        ArgumentNullException.ThrowIfNull(drawn);
+
+        var byIdentity = drawn.ToDictionary(message => message.StoredEmailId);
 
         return new ClientMailThreadResponse(
             thread.ThreadId.Value,
-            [.. thread.Messages.Select(message => ClientMailThreadEmailResponse.For(message, thread.MessageCount))],
+            [.. thread.Messages.Select(message => ClientMailThreadEmailResponse.For(
+                message,
+                thread.MessageCount,
+                byIdentity.GetValueOrDefault(message.Email.StoredEmailId)))],
             [.. thread.Participants.Select(ClientMailThreadParticipantResponse.For)],
             thread.MessageCount,
             thread.MoreMessagesNotAssembled,
@@ -159,12 +229,20 @@ internal sealed record ClientMailThreadResponse(
 /// <param name="Position">The zero-based place the message holds in the conversation's order.</param>
 /// <param name="AnsweredId">The message this one answers among the ones shown, or <see langword="null" /> where it is a root of what is shown.</param>
 /// <param name="Email">The message itself, in the same shape a list row carries.</param>
+/// <param name="Message">What a reading pane draws around the message, or <see langword="null" /> where the caller asked for a list of messages rather than for the messages.</param>
+/// <param name="Body">What the message says, or <see langword="null" /> for the same reason.</param>
 /// <remarks>
 /// <para>
 /// <c>email</c> is the mail list route's own row, field for field, so a client parses one message across this surface
 /// and the two routes cannot come to disagree about one message. Its <c>preview</c> is what this message added, with
 /// the quoted history and the signature block trimmed off, and its <c>id</c> is what the whole message — quoted history,
-/// body and attachments — is reached by. Nothing is repeated here under a second name.
+/// body and attachments — is reached by.
+/// </para>
+/// <para>
+/// <c>message</c> and <c>body</c> are the message route's and the body route's own answers, field for field, for the
+/// same reason: a conversation drawn from a shape of its own would be a second contract for one message, and the two
+/// would come to disagree. What they repeat of the row is what those two routes already publish beside it — a client
+/// draws the head from one and the row's preview from the other, and neither is derived here.
 /// </para>
 /// <para>
 /// <c>answeredId</c> names a message the caller can see. One whose parent sits in a folder an operator withheld is
@@ -174,13 +252,17 @@ internal sealed record ClientMailThreadResponse(
 internal sealed record ClientMailThreadEmailResponse(
     int Position,
     Guid? AnsweredId,
-    ClientMailTimelineEntryResponse Email)
+    ClientMailTimelineEntryResponse Email,
+    ClientMailMessageResponse? Message,
+    ClientMailBodyResponse? Body)
 {
     /// <summary>Describes one message of a conversation for the wire.</summary>
     /// <param name="message">The message the use case read.</param>
     /// <param name="threadMessageCount">How many messages the conversation holds of those this caller may see.</param>
+    /// <param name="drawn">The message itself, where the caller asked for it and its local copy could be read.</param>
     /// <returns>The response body.</returns>
     /// <remarks>
+    /// <para>
     /// The conversation's own count is what the row's <c>threadMessageCount</c> carries here, because that is what the
     /// field means and every message of one conversation is in the same conversation. A client drawing a message of a
     /// thread from this row therefore reads the same number the header above it reads — which is the assembled count
@@ -188,15 +270,26 @@ internal sealed record ClientMailThreadEmailResponse(
     /// <see cref="Application.Emails.Threads.IEmailThreadReader.MaximumAssembledEmails" /> reads here as the bound with
     /// <c>moreMessagesNotAssembled</c> beside it and reads on a list row as its real length. Agreeing with the list
     /// instead would mean counting the conversation a second time to publish a number this route already states.
+    /// </para>
+    /// <para>
+    /// A message the read could not open is published as the row alone rather than withheld from the conversation:
+    /// what a reader is owed is the correspondence with a gap in it they can still open on its own, and a client
+    /// reading a message this answer did not carry falls back to the two routes that serve one.
+    /// </para>
     /// </remarks>
-    internal static ClientMailThreadEmailResponse For(BrowsedThreadEmail message, int threadMessageCount) => new(
+    internal static ClientMailThreadEmailResponse For(
+        BrowsedThreadEmail message,
+        int threadMessageCount,
+        ReadEmailContent? drawn) => new(
         message.Position,
         message.AnsweredStoredEmailId?.Value,
         ClientMailTimelineEntryResponse.For(
             message.Email,
             message.Contribution,
             message.Enrichment,
-            threadMessageCount));
+            threadMessageCount),
+        drawn is null ? null : ClientMailMessageResponse.For(drawn),
+        drawn is null ? null : ClientMailBodyResponse.For(drawn, remoteImagesRequested: false));
 }
 
 /// <summary>Somebody who has written in the conversation, and how much of it is theirs.</summary>

--- a/backend/tests/Host.UnitTests/Api/ClientMailThreadEndpointTests.cs
+++ b/backend/tests/Host.UnitTests/Api/ClientMailThreadEndpointTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Security.Cryptography;
 using MailFathom.Application.Accounts;
 using MailFathom.Application.EmailContent;
 using MailFathom.Application.EmailContent.Attachments;
@@ -199,6 +200,57 @@ public sealed class ClientMailThreadEndpointTests
 
         // Assert
         Assert.IsType<Ok<ClientMailThreadResponse>>(result.Result);
+    }
+
+    /// <summary>A page of zero is refused in the words of the read it was asked for, rather than in the general range.</summary>
+    /// <remarks>
+    /// The general bound would refuse this too, and would name one to a hundred while the request that was made holds
+    /// one to ten. A caller acting on that refusal would ask again for a page this route refuses a second time.
+    /// </remarks>
+    [Fact]
+    public async Task ReadThreadAsync_ADrawnPageOfNoMessages_IsRefusedInTheRangeADrawnReadHolds()
+    {
+        // Arrange
+        this.Holding(2);
+
+        // Act
+        var result = await this.ReadAsync(pageSize: 0, content: true);
+
+        // Assert
+        var refusal = Assert.IsType<ProblemHttpResult>(result.Result);
+
+        Assert.Equal(StatusCodes.Status400BadRequest, refusal.StatusCode);
+        Assert.Contains(
+            $"between 1 and {GetEmailContentRequest.MaximumEmails}",
+            refusal.ProblemDetails.Detail,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>The whole of a drawn read, from the parameter through the content read and back onto the page it belongs to.</summary>
+    /// <remarks>
+    /// Every other test of the drawing branch stops at a refusal or asserts the response factories directly, so this is
+    /// the one that proves the route reaches the content read at all and pairs what it answered with the right row.
+    /// </remarks>
+    [Fact]
+    public async Task ReadThreadAsync_WithTheMessagesAsked_CarriesEachRowsOwnMessageAndWords()
+    {
+        // Arrange
+        var summaries = this.Holding(2);
+
+        // Act
+        var result = await this.ReadDrawingAsync(summaries);
+
+        // Assert
+        var page = Assert.IsType<Ok<ClientMailThreadResponse>>(result.Result).Value;
+
+        Assert.NotNull(page);
+        Assert.All(page.Messages, message =>
+        {
+            Assert.NotNull(message.Message);
+            Assert.NotNull(message.Body);
+            Assert.Equal(message.Email.Id, message.Message.StoredEmailId);
+            Assert.Equal(message.Email.Id, message.Body.StoredEmailId);
+        });
     }
 
     /// <summary>A conversation read as a list of messages carries neither the message nor its words, so nothing is paid for what nobody asked for.</summary>
@@ -486,11 +538,89 @@ public sealed class ClientMailThreadEndpointTests
             ReadingNothing(),
             TestContext.Current.CancellationToken);
 
-    /// <summary>A content read standing in for the one behind the route, which the tests here never let answer.</summary>
+    /// <summary>Reads the conversation with its messages drawn, over a content read that answers for the summaries given.</summary>
+    private Task<Results<Ok<ClientMailThreadResponse>, NotFound, ProblemHttpResult>> ReadDrawingAsync(
+        EmailSummary[] summaries) =>
+        ClientMailThreadEndpoint.ReadThreadAsync(
+            Conversation.Value,
+            null,
+            null,
+            content: true,
+            this.Browser(),
+            this.ReadingDrawnMessages(summaries),
+            TestContext.Current.CancellationToken);
+
+    /// <summary>A content read that answers, so the route's own composition is exercised rather than only its refusals.</summary>
     /// <remarks>
-    /// Every test that reaches it is a refusal taken before the read runs, and what a drawn conversation composes to is
-    /// asserted against the two response factories instead — where the message is a value rather than a store, a
-    /// renderer and a scope resolution stood up to produce one.
+    /// The folder every summary sits in is mapped here, which is what makes the mail readable at all: a read scoped
+    /// over an unmapped alias answers with nothing, and a test arranged that way would pass while proving the opposite
+    /// of what it claims.
+    /// </remarks>
+    private EmailContentReader ReadingDrawnMessages(EmailSummary[] summaries)
+    {
+        var catalog = Substitute.For<ICallerMailAccountCatalog>();
+        catalog.OwnedAccounts.Returns([SyntheticServedAccount.Of(MailAccountId.Create("work"))]);
+
+        var readTelemetry = Substitute.For<IMailboxReadTelemetry>();
+        readTelemetry.BeginRead(Arg.Any<MailboxReadOperation>(), Arg.Any<CancellationToken>())
+            .Returns(Substitute.For<IMailboxReadScope>());
+
+        foreach (var summary in summaries)
+        {
+            this.summaryReader.FindAsync(summary.StoredEmailId, Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult<EmailSummary?>(summary));
+        }
+
+        var rawMime = "From: sender@example.test\r\n\r\nBody"u8.ToArray();
+        var stored = new StoredEmailContent(rawMime, rawMime.Length, SHA256.HashData(rawMime));
+
+        var contentStore = Substitute.For<IEmailContentStore>();
+        contentStore.FindStoredContentAsync(Arg.Any<StoredEmailId>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<StoredEmailContent?>(stored));
+
+        var renderer = Substitute.For<IEmailContentRenderer>();
+        renderer.RenderAsync(
+                Arg.Any<StoredEmailContent>(),
+                Arg.Any<EmailContentRenderingBounds>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(EmailContentRenderingResult.Rendered(new EmailContentRendering(
+                new EmailContentHeaders("a subject", SentAt: null, ReceivedAt: null, [], EmailThreadReferences.None),
+                new EmailBodyRepresentation("Body", 4, EmailBodyTruncation.None),
+                SanitizedHtmlBody: null,
+                new EmailBodyForms(PlainText: true, Html: false),
+                BodyIsEncrypted: false,
+                EmailAttachmentSummary.Create(
+                    [],
+                    inlineResourceCount: 0,
+                    isEncrypted: false,
+                    carriesUnverifiedSignature: false,
+                    containsUnexpandedTnefPart: false),
+                []))));
+
+        return new EmailContentReader(
+            this.summaryReader,
+            this.threadReader,
+            contentStore,
+            renderer,
+            Substitute.For<IEmailContentRepairRequestStore>(),
+            new MailboxScopeResolver(
+                catalog,
+                StubMailFolderParticipation.Mapping(
+                    new MailFolderIdentity(MailAccountId.Create("work"), MailFolderAlias.Create("INBOX"))),
+                StubJunkMailFolderCatalog.None,
+                StubMailFolderMappings.ResolvingNothing),
+            Substitute.For<IAttachmentDownloadLinkIssuer>(),
+            SensitiveContentEgressGuards.Inactive(),
+            new EmailContentReadOptions(),
+            readTelemetry,
+            AccessAuthorizations.ForCallerGranted(MailFathomPermission.MailRead));
+    }
+
+    /// <summary>A content read standing in for the one behind the route, which the test reaching it never lets answer.</summary>
+    /// <remarks>
+    /// Every test given this one is a refusal taken before the read runs, so a read that answered would prove nothing
+    /// they claim. <see cref="ReadingDrawnMessages" /> is the one that answers, and it is what the drawn read itself is
+    /// asserted through.
     /// </remarks>
     private static EmailContentReader ReadingNothing()
     {

--- a/backend/tests/Host.UnitTests/Api/ClientMailThreadEndpointTests.cs
+++ b/backend/tests/Host.UnitTests/Api/ClientMailThreadEndpointTests.cs
@@ -3,8 +3,14 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Accounts;
+using MailFathom.Application.EmailContent;
+using MailFathom.Application.EmailContent.Attachments;
+using MailFathom.Application.EmailContent.Rendering;
+using MailFathom.Application.EmailContent.Repair;
+using MailFathom.Application.EmailContent.Storage;
 using MailFathom.Application.Emails.BrowseThread;
 using MailFathom.Application.Emails.Enrichment;
+using MailFathom.Application.Emails.GetEmailContent;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Emails.Threads;
@@ -12,6 +18,7 @@ using MailFathom.Application.Observability;
 using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
+using MailFathom.Domain.Emails.Authentication;
 using MailFathom.Domain.Emails.Authorship;
 using MailFathom.Domain.Folders;
 using MailFathom.Host.Api;
@@ -39,6 +46,8 @@ public sealed class ClientMailThreadEndpointTests
 
     private static readonly EmailThreadId OtherConversation =
         EmailThreadId.Create(new Guid("22222222-2222-2222-2222-222222222222"));
+
+    private static readonly Guid Message = new("33333333-3333-3333-3333-333333333333");
 
     private readonly IEmailThreadReader threadReader = Substitute.For<IEmailThreadReader>();
 
@@ -160,6 +169,126 @@ public sealed class ClientMailThreadEndpointTests
         Assert.Equal(StatusCodes.Status400BadRequest, Assert.IsType<ProblemHttpResult>(result.Result).StatusCode);
     }
 
+    /// <summary>A page asking for more messages than a content read composes is refused, rather than served half-drawn.</summary>
+    /// <remarks>
+    /// The ceiling is the content read's own rather than one invented here, so a conversation drawn out costs exactly
+    /// what reading that many messages costs. A longer correspondence is read on with the cursor.
+    /// </remarks>
+    [Fact]
+    public async Task ReadThreadAsync_APageLargerThanAContentReadComposes_IsRefused()
+    {
+        // Arrange
+        this.Holding(2);
+
+        // Act
+        var result = await this.ReadAsync(pageSize: GetEmailContentRequest.MaximumEmails + 1, content: true);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, Assert.IsType<ProblemHttpResult>(result.Result).StatusCode);
+    }
+
+    /// <summary>That same page is served where the caller asked for a list of the messages rather than for the messages.</summary>
+    [Fact]
+    public async Task ReadThreadAsync_APageLargerThanAContentReadComposes_IsServedWhereTheMessagesAreNotDrawn()
+    {
+        // Arrange
+        this.Holding(2);
+
+        // Act
+        var result = await this.ReadAsync(pageSize: GetEmailContentRequest.MaximumEmails + 1);
+
+        // Assert
+        Assert.IsType<Ok<ClientMailThreadResponse>>(result.Result);
+    }
+
+    /// <summary>A conversation read as a list of messages carries neither the message nor its words, so nothing is paid for what nobody asked for.</summary>
+    [Fact]
+    public async Task ReadThreadAsync_WithoutTheMessagesAsked_CarriesNeitherTheMessageNorItsWords()
+    {
+        // Arrange
+        this.Holding(2);
+
+        // Act
+        var result = await this.ReadAsync();
+
+        // Assert
+        var page = Assert.IsType<Ok<ClientMailThreadResponse>>(result.Result).Value;
+
+        Assert.NotNull(page);
+        Assert.All(page.Messages, message =>
+        {
+            Assert.Null(message.Message);
+            Assert.Null(message.Body);
+        });
+    }
+
+    /// <summary>A drawn conversation carries each message as the two message routes answer for it, which is what makes it one request.</summary>
+    [Fact]
+    public void For_AMessageTheReadOpened_CarriesWhatAReadingPaneDrawsAndWhatTheMessageSays()
+    {
+        // Arrange
+        var email = SyntheticListedEmail(Message);
+        var message = new BrowsedThreadEmail(email, Position: 0, AnsweredStoredEmailId: null, "what I added", Enrichment: null);
+
+        // Act
+        var response = ClientMailThreadEmailResponse.For(message, threadMessageCount: 1, drawn: DrawnMessage());
+
+        // Assert
+        Assert.NotNull(response.Message);
+        Assert.NotNull(response.Body);
+        Assert.Equal(Message, response.Message.StoredEmailId);
+        Assert.Equal("Quarterly invoice", response.Message.Headers.Subject);
+        Assert.Equal("Just words.", response.Body.PlainText?.Text);
+        Assert.Equal(Message, response.Email.Id);
+    }
+
+    /// <summary>A message the read could not open is published as its row alone, so the correspondence is drawn with a gap rather than short.</summary>
+    [Fact]
+    public void For_AConversationOneOfWhoseMessagesCouldNotBeOpened_CarriesThatMessageAsItsRowAlone()
+    {
+        // Arrange
+        var opened = SyntheticListedEmail(Message);
+        var thread = new BrowsedThread(
+            Conversation,
+            [
+                new BrowsedThreadEmail(opened, Position: 0, AnsweredStoredEmailId: null, Contribution: null, Enrichment: null),
+                new BrowsedThreadEmail(SyntheticListedEmail(), Position: 1, AnsweredStoredEmailId: null, Contribution: null, Enrichment: null),
+            ],
+            [],
+            MessageCount: 2,
+            MoreMessagesNotAssembled: false,
+            MoreParticipantsNotNamed: false,
+            NextCursor: null,
+            PageSize: 10);
+
+        // Act
+        var response = ClientMailThreadResponse.For(thread, [DrawnMessage()]);
+
+        // Assert
+        Assert.NotNull(response.Messages[0].Message);
+        Assert.NotNull(response.Messages[0].Body);
+        Assert.Null(response.Messages[1].Message);
+        Assert.Null(response.Messages[1].Body);
+    }
+
+    /// <summary>The read a drawn conversation makes asks for the reduced tree and declines both of the per-message asks.</summary>
+    /// <remarks>
+    /// The sender's own markup is a surface a reader opens one message at a time, and a download link is a bearer
+    /// credential this answer would otherwise mint once per message of a conversation.
+    /// </remarks>
+    [Fact]
+    public void ContentRequestFor_TheMessagesOfAConversation_AsksForTheDocumentAndForNeitherMarkupNorALink()
+    {
+        // Act
+        var request = ClientMailThreadEndpoint.ContentRequestFor([StoredEmailId.Create(Message)]);
+
+        // Assert
+        Assert.True(request.IncludeMailDocument);
+        Assert.False(request.IncludeSelfContainedHtml);
+        Assert.False(request.IncludeAttachmentDownloadLinks);
+        Assert.False(request.RetainRemoteImageReferences);
+    }
+
     /// <summary>The header describes the whole conversation, so a client draws it from the first page and keeps it.</summary>
     [Fact]
     public void For_AConversationCutAtBothItsBounds_CarriesWhatWasCutAndTheCursorThatContinuesIt()
@@ -177,7 +306,7 @@ public sealed class ClientMailThreadEndpointTests
             PageSize: 25);
 
         // Act
-        var response = ClientMailThreadResponse.For(thread);
+        var response = ClientMailThreadResponse.For(thread, []);
 
         // Assert
         Assert.Equal(500, response.MessageCount);
@@ -202,7 +331,7 @@ public sealed class ClientMailThreadEndpointTests
         var message = new BrowsedThreadEmail(SyntheticListedEmail(), Position: 2, answered, "what I added", Enrichment: null);
 
         // Act
-        var response = ClientMailThreadEmailResponse.For(message, threadMessageCount: 4);
+        var response = ClientMailThreadEmailResponse.For(message, threadMessageCount: 4, drawn: null);
 
         // Assert
         Assert.Equal(2, response.Position);
@@ -225,12 +354,59 @@ public sealed class ClientMailThreadEndpointTests
             Enrichment: null);
 
         // Act
-        var response = ClientMailThreadEmailResponse.For(message, threadMessageCount: 1);
+        var response = ClientMailThreadEmailResponse.For(message, threadMessageCount: 1, drawn: null);
 
         // Assert
         Assert.Null(response.AnsweredId);
         Assert.Null(response.Email.Preview);
     }
+
+    /// <summary>One message as a content read opened it, which is what a drawn conversation carries beside each row.</summary>
+    private static ReadEmailContent DrawnMessage() => new()
+    {
+        StoredEmailId = StoredEmailId.Create(Message),
+        AccountId = MailAccountId.Create("work"),
+        FolderAlias = MailFolderAlias.Create("INBOX"),
+        SizeOctets = 2048,
+        Headers = new EmailContentHeaders(
+            "Quarterly invoice",
+            SentAt: FirstJuly,
+            ReceivedAt: FirstJuly,
+            [Participant(EmailAddressRole.From, "Billing", "sender@example.test")],
+            EmailThreadReferences.Create("abc@example.test", inReplyTo: null, references: null)),
+        Body = EmailContentBody.Readable(
+            new EmailBodyRepresentation("Just words.", 11, EmailBodyTruncation.None),
+            sanitizedHtml: null,
+            document: null,
+            selfContainedHtml: null,
+            new EmailBodyForms(PlainText: true, Html: false)),
+        AttachmentSummary = new StoredEmailAttachmentSummary(
+            AttachmentCount: 0,
+            TotalSizeOctets: 0,
+            InlineResourceCount: 0,
+            IsEncrypted: false,
+            CarriesUnverifiedSignature: false,
+            ContainsUnexpandedTnefPart: false),
+        Attachments = [],
+        RemoteFlags = RemoteEmailFlagSnapshot.NeverObserved,
+        SenderVerification = new SenderVerification
+        {
+            AuthorAuthentication = AuthorAuthenticationOutcome.Authenticated,
+            DeploymentTrust = SenderTrustLevel.Trusted,
+        },
+        SenderAuthenticationEvidence = SenderAuthenticationEvidence.None,
+        MachineAuthorship = MachineAuthorshipAssessment.NotAssessed,
+        Thread = new ReadEmailThread
+        {
+            ThreadId = Conversation,
+            EmailCount = 2,
+            MoreEmailsNotNamed = false,
+            OtherEmails = [],
+        },
+    };
+
+    private static EmailParticipant Participant(EmailAddressRole role, string? displayName, string address) =>
+        new(role, EmailAddress.TryCreate(displayName, address, out var parsed) ? parsed : default);
 
     private static EmailSummary SyntheticListedEmail(Guid? storedEmailId = null) => new()
     {
@@ -299,13 +475,49 @@ public sealed class ClientMailThreadEndpointTests
     private Task<Results<Ok<ClientMailThreadResponse>, NotFound, ProblemHttpResult>> ReadAsync(
         Guid? threadId = null,
         int? pageSize = null,
-        string? cursor = null) =>
+        string? cursor = null,
+        bool? content = null) =>
         ClientMailThreadEndpoint.ReadThreadAsync(
             threadId ?? Conversation.Value,
             pageSize,
             cursor,
+            content,
             this.Browser(),
+            ReadingNothing(),
             TestContext.Current.CancellationToken);
+
+    /// <summary>A content read standing in for the one behind the route, which the tests here never let answer.</summary>
+    /// <remarks>
+    /// Every test that reaches it is a refusal taken before the read runs, and what a drawn conversation composes to is
+    /// asserted against the two response factories instead — where the message is a value rather than a store, a
+    /// renderer and a scope resolution stood up to produce one.
+    /// </remarks>
+    private static EmailContentReader ReadingNothing()
+    {
+        var catalog = Substitute.For<ICallerMailAccountCatalog>();
+        catalog.OwnedAccounts.Returns([SyntheticServedAccount.Of(MailAccountId.Create("work"))]);
+
+        var readTelemetry = Substitute.For<IMailboxReadTelemetry>();
+        readTelemetry.BeginRead(Arg.Any<MailboxReadOperation>(), Arg.Any<CancellationToken>())
+            .Returns(Substitute.For<IMailboxReadScope>());
+
+        return new EmailContentReader(
+            Substitute.For<IStoredEmailSummaryReader>(),
+            Substitute.For<IEmailThreadReader>(),
+            Substitute.For<IEmailContentStore>(),
+            Substitute.For<IEmailContentRenderer>(),
+            Substitute.For<IEmailContentRepairRequestStore>(),
+            new MailboxScopeResolver(
+                catalog,
+                StubMailFolderParticipation.Nothing,
+                StubJunkMailFolderCatalog.None,
+                StubMailFolderMappings.ResolvingNothing),
+            Substitute.For<IAttachmentDownloadLinkIssuer>(),
+            SensitiveContentEgressGuards.Inactive(),
+            new EmailContentReadOptions(),
+            readTelemetry,
+            AccessAuthorizations.ForCallerGranted(MailFathomPermission.MailRead));
+    }
 
     /// <summary>Builds the use case behind the route over the real scope resolution, with storage and the instruments stood in for.</summary>
     private MailThreadBrowser Browser()

--- a/backend/tests/PublicSurfaces.UnitTests/http-api-contract.json
+++ b/backend/tests/PublicSurfaces.UnitTests/http-api-contract.json
@@ -2036,8 +2036,28 @@
               "string"
             ]
           },
+          "body": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ClientMailBodyResponse"
+              }
+            ]
+          },
           "email": {
             "$ref": "#/components/schemas/ClientMailTimelineEntryResponse"
+          },
+          "message": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ClientMailMessageResponse"
+              }
+            ]
           },
           "position": {
             "format": "int32",
@@ -2051,7 +2071,9 @@
         "required": [
           "position",
           "answeredId",
-          "email"
+          "email",
+          "message",
+          "body"
         ],
         "type": "object"
       },
@@ -12490,6 +12512,13 @@
             "name": "cursor",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "content",
+            "schema": {
+              "type": "boolean"
             }
           }
         ],

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -826,8 +826,24 @@ this conversation's own `messageCount`, because that is what the field means and
 conversation — so a row drawn from a thread reads the same number as the header above it. That is the *assembled* count
 rather than the counted one, so a conversation past the 500 this route assembles reads `500` here beside
 `moreMessagesNotAssembled` and reads its real length on a
-[mail list row](#the-mail-list-route). There is no body here
-either: the whole of a message is a request of its own, named by the `id` that row already carries.
+[mail list row](#the-mail-list-route).
+
+**`content=true` adds the messages themselves, which is how a client draws a correspondence in one request.** Without
+it every entry carries `email` alone and the whole of a message is a request of its own, named by the `id` that row
+already carries — which is what a client listing a thread wants. With it each entry gains two more fields, `message` and
+`body`, and they are [the message route's](#the-message-route) and [the message body route's](#the-message-body-route) own answers,
+field for field: a client that draws a conversation as a document of open messages parses one message shape across all
+three routes, and reading the earlier messages of an exchange costs nothing further on the wire.
+
+Two things are decided by that being a content read rather than a listing. **The page is bounded at 10**, which is the
+ceiling any content read is held to: `pageSize` above it with `content=true` is refused with `400` rather than served
+half-drawn, `pageSize` is 10 by default here rather than 25, and a longer conversation is read on with `nextCursor`
+exactly as it is without content. And **the three per-message asks are not made**: the sender's own markup is absent
+(`selfContainedHtml` is `null`), no attachment download link is minted, and no remote image reference is resolved —
+each of those is a decision a reader makes about one message, and a conversation that took all three would mint a
+bearer credential per message and disclose the reader to every sender's host at once. A message whose local copy this
+deployment could not open carries `message` and `body` as `null` rather than being left out of the conversation, so a
+client draws the correspondence with a gap in it that can still be opened on its own.
 
 **`position` and `answeredId` are where the message sits.** `position` is its zero-based place in the conversation's
 own order and continues across pages, so a client that has paged twice still knows what it is holding. `answeredId`
@@ -864,8 +880,9 @@ defect in the client.
 | Parameter | Accepts | Default |
 | --- | --- | --- |
 | `threadId` | The conversation's identifier, as a message row published it | required, in the path |
-| `pageSize` | 1 to 100 | 25 |
+| `pageSize` | 1 to 100, or 1 to 10 with `content=true` | 25, or 10 with `content=true` |
 | `cursor` | A cursor a previous page returned | the beginning of the conversation |
+| `content` | `true` to carry each message and its body beside the row | `false` |
 
 **A conversation this user does not hold is answered `404`**, and so is one no deployment ever held: nothing in the
 answer, its timing, or its failure separates somebody else's exchange from one that never existed. Text that is not a

--- a/frontend/src/Client.App/src/App.harness.tsx
+++ b/frontend/src/Client.App/src/App.harness.tsx
@@ -393,6 +393,11 @@ export function deploymentWorkingInTabs(): DeploymentTransport {
 // conversation, and closing the conversation returns to the message the workspace still holds.
 const conversationThreadId = '9b2a1c74-4a4e-4c93-9a2e-3f6f0a1b2c3d';
 
+/** One answer's body as the value it serializes to, so a conversation can carry what a route serves on its own. */
+function parsed(answer: Answer): Readonly<Record<string, unknown>> {
+    return JSON.parse(answer.body) as Readonly<Record<string, unknown>>;
+}
+
 function threaded(answer: Answer): Answer {
     return { ...answer, body: answer.body.replace('"threadId":null', `"threadId":"${conversationThreadId}"`) };
 }
@@ -424,6 +429,11 @@ const drawnConversation: Answer = {
                     sizeOctets: 4_096,
                     preview: 'The invoice for August.',
                 },
+
+                // The conversation route carries every message's own description and words, which is what makes
+                // opening a correspondence one request rather than one per message drawn.
+                message: parsed(threaded(describedMessage)),
+                body: parsed(drawnMessage),
             },
         ],
         participants: [{ address: 'billing@example.invalid', displayName: 'Billing', messageCount: 1 }],
@@ -431,7 +441,7 @@ const drawnConversation: Answer = {
         moreMessagesNotAssembled: false,
         moreParticipantsNotNamed: false,
         nextCursor: null,
-        pageSize: 100,
+        pageSize: 10,
     }),
 };
 

--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -167,7 +167,7 @@ describe('App', () => {
         ).toBe(String(startingListWidth));
     });
 
-    it('opens the conversation a message belongs to, and returns to that message when it is closed', async () => {
+    it('opens the conversation a message belongs to from the row itself, and returns to that message when it is closed', async () => {
         renderApp(servedFrom, heldSession, deploymentDrawingAConversation());
         await framed();
 
@@ -175,8 +175,6 @@ describe('App', () => {
 
         const list = await screen.findByRole('listbox', { name: 'Messages' });
         fireEvent.pointerDown(within(list).getByRole('option', { name: /Quarterly invoice/ }));
-
-        fireEvent.click(await screen.findByRole('button', { name: 'Show the whole conversation' }));
 
         const conversation = await screen.findByRole('region', { name: 'Conversation' });
         expect(within(conversation).getByText('Messages in this conversation: 1')).toBeDefined();
@@ -190,6 +188,26 @@ describe('App', () => {
         await waitFor(() => {
             expect(document.activeElement).toBe(screen.getByRole('article', { name: /Quarterly invoice/ }));
         });
+    });
+
+    // What #1759 is about: a correspondence costs one read of the deployment however many messages are drawn out of
+    // it. The route carries every message's description and words, so nothing under the conversation asks for either.
+    it('reads a whole conversation in one request, and asks for no message of it on its own', async () => {
+        renderApp(servedFrom, heldSession, deploymentDrawingAConversation());
+        await framed();
+
+        await goTo('Mail');
+
+        const list = await screen.findByRole('listbox', { name: 'Messages' });
+        fireEvent.pointerDown(within(list).getByRole('option', { name: /Quarterly invoice/ }));
+
+        await screen.findByText('A drawn message.');
+
+        const conversations = routesAsked().filter((path) => path.includes('/threads/'));
+
+        expect(conversations).toHaveLength(1);
+        expect(conversations[0]).toContain('content=true');
+        expect(routesAsked().some((path) => path.includes('/messages/'))).toBe(false);
     });
 
     // The message this one opens belongs to no conversation, which is deliberate: what is being proven is the shape the

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -1016,6 +1016,7 @@ function OpenMail({
                     conversation={conversation}
                     online={online}
                     expandWholeThread={expandWholeThread}
+                    onShowFullHtml={onShowFullHtml}
                 />
             )}
 

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -651,7 +651,6 @@ export const en = {
         'Pictures are being loaded from the sender for this message, so their servers can tell it was opened. Nothing about that is kept: leaving this message and coming back asks again.',
 
     'thread.label': 'Conversation',
-    'thread.open': 'Show the whole conversation',
     'thread.close': 'Back to the message',
     'thread.reading': 'Reading this conversation…',
     'thread.readingMore': 'Reading more of this conversation…',
@@ -670,8 +669,14 @@ export const en = {
     'thread.storedIn': 'In {account}, {folder}',
     'thread.openOnItsOwn': 'Open this message on its own',
     'thread.messageBy': 'Message from {sender}',
-    'thread.showEarlier': 'Show earlier messages ({count})',
+    'thread.showEarlier.one': 'Show {count} earlier message',
+    'thread.showEarlier.few': 'Show {count} earlier messages',
+    'thread.showEarlier.many': 'Show {count} earlier messages',
+    'thread.showEarlier.other': 'Show {count} earlier messages',
     'thread.hideEarlier': 'Hide earlier messages',
+    'thread.showAll': 'Show all the messages',
+    'thread.hideOthers': 'Hide the other messages',
+    'thread.messageNotRead': 'The message from {sender} could not be read here. Open it on its own to read it.',
     'thread.openedFromList': 'Opened from the list',
     'thread.landedFromResult': 'Brought here from a search result',
 

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -657,7 +657,6 @@ export const pl: Catalogue = {
         'Obrazy tej wiadomości są pobierane od nadawcy, więc jego serwery mogą rozpoznać, że ją otwarto. Nic z tego nie jest zapamiętywane: po wyjściu z wiadomości i powrocie pytamy ponownie.',
 
     'thread.label': 'Rozmowa',
-    'thread.open': 'Pokaż całą rozmowę',
     'thread.close': 'Wróć do wiadomości',
     'thread.reading': 'Trwa wczytywanie tej rozmowy…',
     'thread.readingMore': 'Trwa wczytywanie dalszej części tej rozmowy…',
@@ -675,8 +674,14 @@ export const pl: Catalogue = {
     'thread.storedIn': 'W koncie {account}, folder {folder}',
     'thread.openOnItsOwn': 'Otwórz tę wiadomość osobno',
     'thread.messageBy': 'Wiadomość od: {sender}',
-    'thread.showEarlier': 'Pokaż wcześniejsze wiadomości ({count})',
+    'thread.showEarlier.one': 'Pokaż {count} wcześniejszą wiadomość',
+    'thread.showEarlier.few': 'Pokaż {count} wcześniejsze wiadomości',
+    'thread.showEarlier.many': 'Pokaż {count} wcześniejszych wiadomości',
+    'thread.showEarlier.other': 'Pokaż {count} wcześniejszych wiadomości',
     'thread.hideEarlier': 'Ukryj wcześniejsze wiadomości',
+    'thread.showAll': 'Pokaż wszystkie wiadomości',
+    'thread.hideOthers': 'Ukryj pozostałe wiadomości',
+    'thread.messageNotRead': 'Nie udało się tutaj odczytać wiadomości od: {sender}. Otwórz ją osobno, aby przeczytać.',
     'thread.openedFromList': 'Otwarta z listy',
     'thread.landedFromResult': 'Otwarta z wyniku wyszukiwania',
 

--- a/frontend/src/Client.App/src/mailSpace/useOpenTabs.test.tsx
+++ b/frontend/src/Client.App/src/mailSpace/useOpenTabs.test.tsx
@@ -14,6 +14,7 @@ import { useOpenTabs } from './useOpenTabs';
 const openTheQuarterly = 'Open the quarterly figures.';
 const openTheInvoice = 'Open the invoice.';
 const openTheQuarterlyAgain = 'Open the quarterly figures a second time.';
+const openTheCorrespondence = 'Open a message the deployment threaded.';
 const readDownTheConversation = 'Read down the conversation, as the pane would.';
 const openTheChart = 'Open the chart the quarterly figures carry.';
 const closeTheChart = 'Close the file being read.';
@@ -67,6 +68,15 @@ function Tabs({ inTabs }: { readonly inTabs: boolean }) {
                 }}
             >
                 {openTheQuarterlyAgain}
+            </button>
+
+            <button
+                type="button"
+                onClick={() => {
+                    tabs.openMail('message-3', 'A correspondence', 'thread-3');
+                }}
+            >
+                {openTheCorrespondence}
             </button>
 
             <button
@@ -431,5 +441,37 @@ describe('useOpenTabs, opening a file a message carries', () => {
         press(openTheInvoice);
 
         expect(fileBeingRead()).toBe('File: nothing');
+    });
+});
+
+describe('useOpenTabs opening a threaded message', () => {
+    // #1759: opening a message from the list opens the correspondence it belongs to, at that message — so the reading
+    // column draws the conversation and one request carries every message in it.
+    it('opens the conversation a threaded message belongs to, at that message', () => {
+        render(
+            <WorkspaceProvider>
+                <Tabs inTabs={false} />
+            </WorkspaceProvider>,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: openTheCorrespondence }));
+
+        expect(screen.getByText('In front of it: thread-3')).toBeDefined();
+
+        // The message itself stays what the workspace holds, which is what closing the conversation returns to.
+        expect(screen.getByText('Reading: message-3')).toBeDefined();
+    });
+
+    it('opens a message the deployment threaded with nothing on its own', () => {
+        render(
+            <WorkspaceProvider>
+                <Tabs inTabs={false} />
+            </WorkspaceProvider>,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: openTheQuarterly }));
+
+        expect(screen.getByText('In front of it: nothing')).toBeDefined();
+        expect(screen.getByText('Reading: message-1')).toBeDefined();
     });
 });

--- a/frontend/src/Client.App/src/mailSpace/useOpenTabs.ts
+++ b/frontend/src/Client.App/src/mailSpace/useOpenTabs.ts
@@ -42,8 +42,14 @@ export interface OpenTabsInForce {
      */
     readonly emptiedByClosing: boolean;
 
-    /** Opens a message — in a tab of its own where the person works in tabs, and in the pane where they do not. */
-    readonly openMail: (storedEmailId: string, subject: string | null) => void;
+    /**
+     * Opens a message — in a tab of its own where the person works in tabs, and in the pane where they do not.
+     *
+     * A message the deployment threaded opens as the correspondence it belongs to, at that message: the reading
+     * column draws the conversation and one request carries every message in it. `threadId` absent, or `null`, is a
+     * message that belongs to no correspondence, and that one is drawn on its own.
+     */
+    readonly openMail: (storedEmailId: string, subject: string | null, threadId?: string | null) => void;
 
     /**
      * Opens the surface that draws one message's own markup, the reader having been asked first.
@@ -147,10 +153,10 @@ export function useOpenTabs(inTabs: boolean): OpenTabsInForce {
         active: held.active,
         emptiedByClosing,
 
-        openMail: (storedEmailId, subject) => {
+        openMail: (storedEmailId, subject, threadId = null) => {
             const tab = tabFor('thread', storedEmailId, subject, {
                 selection: storedEmailId,
-                conversation: null,
+                conversation: threadId === null ? null : { threadId, openAt: storedEmailId },
                 fullHtml: null,
                 attachment: null,
             });

--- a/frontend/src/Client.App/src/messageBody/useMessageBody.ts
+++ b/frontend/src/Client.App/src/messageBody/useMessageBody.ts
@@ -80,6 +80,20 @@ function opening(storedEmailId: string, markup: boolean): Read {
 }
 
 /**
+ * The body a caller already holds, dressed as the answer to the read that would otherwise have fetched it.
+ *
+ * A conversation arrives with every message's body in it, so a surface drawing one of those messages has the answer
+ * before this hook is called and a read of its own would be the request that answer exists to spare. It stands as the
+ * opening read's answer and no more than that: it carries no markup and no remote picture, so a reader who asks for
+ * either is read for exactly as they would have been.
+ */
+function carriedAs(storedEmailId: string, carried: MailBody | null): Answered | null {
+    return carried === null
+        ? null
+        : { read: opening(storedEmailId, false), result: { outcome: 'read', value: carried } };
+}
+
+/**
  * The answer a read may still be drawn under, which is not every answer this hook happens to be holding.
  *
  * It has to be this message's, and it has to have asked for no more than the current read does: a caller that leaves a
@@ -119,12 +133,14 @@ function covers(had: Read | undefined, wants: Read): boolean {
  * message was opened rather than at the moment something else has answered.
  *
  * @param wanted Whether a read may be made at all: this message is the one being shown, and the deployment is reachable.
+ * @param carried The body the caller already holds, which a conversation hands every message of it, or `null`.
  */
 export function useMessageBody(
     session: ClientSession,
     transport: MailFathomTransport,
     storedEmailId: string,
     wanted: boolean,
+    carried: MailBody | null = null,
 ): MessageBodyRead {
     const embeddedHtml = useEmbeddedHtmlMessages();
     const [read, setRead] = useState<Read>(() => opening(storedEmailId, embeddedHtml));
@@ -132,7 +148,7 @@ export function useMessageBody(
     // The answer carries the read it came from, so whether one is still in flight is computed rather than kept beside
     // it: two pieces of state that must agree is one piece of state and a function, and the answer to a previous read
     // is never drawn under the current one.
-    const [answer, setAnswer] = useState<Answered | null>(null);
+    const [answer, setAnswer] = useState<Answered | null>(() => carriedAs(storedEmailId, carried));
 
     // The ask belongs to the one message it was made for, so a message changing under this hook is not state to carry
     // over — the next message would otherwise be read with `remoteImages=true` although nobody asked for its pictures,
@@ -140,6 +156,10 @@ export function useMessageBody(
     // rather than in an effect, which is why this is an assignment and not a second read.
     if (read.storedEmailId !== storedEmailId) {
         setRead(opening(storedEmailId, embeddedHtml));
+
+        // The body handed in belongs to the message handed in with it, so the next message arrives with its own or
+        // with none — never with the previous message's answer still standing as what may be drawn.
+        setAnswer(carriedAs(storedEmailId, carried));
     } else if (read.markup !== embeddedHtml) {
         // The view changed under a message already on the screen. That is a changed ask rather than a changed message,
         // so the pictures and the attempt stay where they are — and the read below is skipped entirely where what is

--- a/frontend/src/Client.App/src/messageList/MessageList.tsx
+++ b/frontend/src/Client.App/src/messageList/MessageList.tsx
@@ -102,7 +102,7 @@ export function MessageList({
      * its own beside what is already open — belongs to the frame, and a list that decided it would be the second
      * implementation of a decision the frame already holds.
      */
-    readonly onOpen: (storedEmailId: string, subject: string | null) => void;
+    readonly onOpen: (storedEmailId: string, subject: string | null, threadId: string | null) => void;
 }) {
     const { translate } = useLocalization();
     const { workspace, revise } = useWorkspace();
@@ -456,7 +456,7 @@ export function MessageList({
         const email = rowAt(held, row);
 
         if (email !== null) {
-            onOpen(email.id, email.subject);
+            onOpen(email.id, email.subject, email.threadId);
         }
     }
 
@@ -500,7 +500,7 @@ export function MessageList({
         // as open, and a selection is the modifier's, the drag's, the menu's, or the keyboard's to make.
         dragging.current = true;
         setAnchor(email.id);
-        onOpen(email.id, email.subject);
+        onOpen(email.id, email.subject, email.threadId);
     }
 
     // Closing the menu puts focus back on the row it was opened from, because that is where the reader was: a menu

--- a/frontend/src/Client.App/src/readingPane/OpenedMessage.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/OpenedMessage.test.tsx
@@ -1,0 +1,152 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ClientSession, MailBody, MailMessage } from '@mailfathom/client-backend';
+import { LocalizationProvider } from '../localization/Localization';
+import { EmbeddedHtmlMessagesContext } from '../preferences/messageView';
+import { ReadMarkingContext, nothingMarkedRead, type ReadMarking } from '../readMarking/useReadMarking';
+import { LinkOpenerContext } from '../shellOperations/linkOpener';
+import { WorkspaceProvider } from '../workspace/Workspace';
+import type { MessageBodyRead } from '../messageBody/useMessageBody';
+import { OpenedMessage } from './OpenedMessage';
+
+// The drawing one message takes wherever it is drawn. What is asserted here is that it is one drawing rather than two:
+// the surface reading a message on its own and the conversation reading it inside a correspondence hand this the same
+// two values and get the same thing back, so a difference between the two screens cannot be introduced in one of them.
+
+const session: ClientSession = {
+    baseAddress: 'https://mail.example.invalid',
+    authorization: 'Basic dGVzdA==',
+};
+
+const storedEmailId = '00000000-0000-4000-8000-000000000000';
+
+const described: MailMessage = {
+    storedEmailId,
+    account: 'work',
+    folder: 'INBOX',
+    threadId: null,
+    sizeOctets: 40_960,
+    headers: {
+        subject: 'Quarterly invoice',
+        sentAt: '2026-08-31T09:41:00+00:00',
+        receivedAt: '2026-08-31T09:41:10+00:00',
+        participants: [{ role: 'From', address: 'billing@example.invalid', displayName: 'Billing' }],
+        messageId: 'abc@example.invalid',
+        inReplyTo: null,
+        references: [],
+    },
+    body: { availability: 'Readable', plainText: true, html: true },
+    sender: { authorAuthentication: 'Authenticated', deploymentTrust: 'Unknown', authenticatedDomain: null },
+    attachments: [],
+    carried: null,
+    unread: true,
+    flagged: false,
+    answered: false,
+};
+
+const said: MailBody = {
+    storedEmailId,
+    availability: 'Readable',
+    plainText: { text: 'The invoice is attached.', originalCharacterCount: 24, truncation: 'None' },
+    document: null,
+    selfContainedHtml: null,
+    remoteImagesRequested: false,
+};
+
+/** A read that has already answered, which is the state both surfaces hand this component in the ordinary case. */
+const read: MessageBodyRead = {
+    drawn: { outcome: 'read', value: said },
+    reading: false,
+    askingForPictures: false,
+    askedForPictures: false,
+    embeddedHtml: false,
+    readAgain: () => undefined,
+    showRemotePictures: () => undefined,
+    showWithoutRemotePictures: () => undefined,
+};
+
+function drawing(
+    message: MailMessage = described,
+    body: MessageBodyRead = read,
+    marking: ReadMarking = nothingMarkedRead,
+    embeddedHtml = false,
+    onShowFullHtml: () => void = () => undefined,
+): void {
+    render(
+        <LocalizationProvider>
+            <WorkspaceProvider>
+                <LinkOpenerContext value={() => Promise.resolve()}>
+                    <EmbeddedHtmlMessagesContext value={embeddedHtml}>
+                        <ReadMarkingContext value={marking}>
+                            <OpenedMessage
+                                session={session}
+                                message={message}
+                                body={body}
+                                onShowFullHtml={onShowFullHtml}
+                            />
+                        </ReadMarkingContext>
+                    </EmbeddedHtmlMessagesContext>
+                </LinkOpenerContext>
+            </WorkspaceProvider>
+        </LocalizationProvider>,
+    );
+}
+
+describe('OpenedMessage', () => {
+    it('draws who wrote the message and what it says', () => {
+        drawing();
+
+        expect(screen.getByText('Billing')).toBeDefined();
+        expect(screen.getByText('The invoice is attached.')).toBeDefined();
+    });
+
+    it('names an author the message wrote nobody for, rather than drawing an empty line', () => {
+        drawing({ ...described, headers: { ...described.headers, participants: [] } });
+
+        expect(screen.getByText('This message names nobody as its author.')).toBeDefined();
+    });
+
+    // ADR 0026: the body being drawn is what opening a message means, and it is one rule wherever a message is drawn.
+    it('marks the message read, and says where in the mailbox it stands', () => {
+        const opened: { storedEmailId: string; account: string; folder: string; unread: boolean }[] = [];
+
+        drawing(described, read, {
+            marked: new Map(),
+            markRead: (message) => {
+                opened.push(message);
+            },
+        });
+
+        expect(opened).toStrictEqual([{ storedEmailId, account: 'work', folder: 'INBOX', unread: true }]);
+    });
+
+    it('offers the sender own markup, which is the ask a reader makes about one message', () => {
+        const onShowFullHtml = vi.fn();
+
+        drawing(described, read, nothingMarkedRead, false, onShowFullHtml);
+        fireEvent.click(screen.getByRole('button', { name: 'Show the full HTML version' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Show the HTML' }));
+
+        expect(onShowFullHtml).toHaveBeenCalled();
+    });
+
+    // With the embedded view chosen the markup is already under this line, so a control offering to open it would open
+    // a second copy of what is being read.
+    it('offers no way to the markup where the reader is already reading it', () => {
+        drawing(described, read, nothingMarkedRead, true);
+
+        expect(screen.queryByRole('button', { name: 'Show the full HTML version' })).toBeNull();
+    });
+
+    // The screen's own head is the caller's: a conversation says its subject once above every message in it, and a
+    // message read on its own says it above that one.
+    it('draws no subject of its own, that being the surface head each caller draws', () => {
+        drawing();
+
+        expect(screen.queryByRole('heading', { name: 'Quarterly invoice' })).toBeNull();
+    });
+});

--- a/frontend/src/Client.App/src/readingPane/OpenedMessage.tsx
+++ b/frontend/src/Client.App/src/readingPane/OpenedMessage.tsx
@@ -1,0 +1,189 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { useRef } from 'react';
+import type { ClientSession, MailCarried, MailMessage } from '@mailfathom/client-backend';
+import { Icon } from '../controls/Icon';
+import { ReceivedAt } from '../controls/ReceivedAt';
+import { SenderAvatar } from '../controls/SenderAvatar';
+import { ShowFullHtml } from '../fullHtml/ShowFullHtml';
+import type { MessageKey } from '../localization/en';
+import { sizeOf } from '../localization/octets';
+import { useLocalization } from '../localization/useLocalization';
+import { Message } from '../messageBody/Message';
+import type { MessageBodyRead } from '../messageBody/useMessageBody';
+import { useEmbeddedHtmlMessages } from '../preferences/messageView';
+import { useReadMarking } from '../readMarking/useReadMarking';
+import { useWorkspace } from '../workspace/useWorkspace';
+import { Attachments } from './Attachments';
+import { SenderVerdict } from './SenderVerdict';
+
+// One message drawn out in full, which is the same drawing wherever a message is drawn: the verdict on who sent it, who
+// wrote it and what the copy holds on one line, the words themselves, and the files the message carries.
+//
+// It is one component rather than two because a message read on its own and a message read inside the correspondence it
+// belongs to are the same message. The design project draws them identically, and a second implementation of this is
+// how the two would come to differ by a line height nobody meant to change — which is exactly what the conversation
+// screen had before it drew the message this way.
+//
+// What is *not* here is the screen's own head. A subject, the acts over what is being read, and the way back to the
+// list belong to the surface rather than to a message: a conversation says its subject once above every message in it,
+// and a message read on its own says it above that one. Each caller therefore draws its own head and this draws what
+// stands under it.
+//
+// Reading the body is the caller's, for the reason `messageBody/useMessageBody.ts` gives — the read starts where the
+// surface mounts rather than where the body is drawn — and a conversation hands the answer it already holds instead of
+// starting one at all.
+
+// The most of a selected passage the workspace carries. A question is asked about a fragment somebody pointed at, so a
+// select-all is a gesture rather than a scope, and a whole message in the workspace would travel into every later screen
+// that reads it.
+const longestFragment = 2000;
+
+export function OpenedMessage({
+    session,
+    message,
+    body,
+    onShowFullHtml,
+}: {
+    readonly session: ClientSession;
+
+    /** The message as the deployment described it, which is what everything but the words is drawn from. */
+    readonly message: MailMessage;
+
+    /** The words, as the surface drawing this message is reading them. */
+    readonly body: MessageBodyRead;
+
+    /** Opens the surface drawing this message's own markup, which the line above the words offers. */
+    readonly onShowFullHtml: () => void;
+}) {
+    const { locale, translate } = useLocalization();
+    const embeddedHtml = useEmbeddedHtmlMessages();
+    const { revise } = useWorkspace();
+    const { markRead } = useReadMarking();
+    const words = useRef<HTMLDivElement>(null);
+
+    const storedEmailId = message.storedEmailId;
+    const author = message.headers.participants.find((participant) => participant.role === 'From') ?? null;
+    const numbers = new Intl.NumberFormat(locale);
+
+    // What a person selected becomes the scope the intent field asks its next question under. It is read from the
+    // gesture that produced it rather than from an effect watching the document, and it is bounded, trimmed, and
+    // confined to this message's own words: a selection that started outside the body is not part of the message.
+    function capture(): void {
+        const selected = window.getSelection();
+        const region = words.current;
+
+        if (selected === null || region === null) {
+            return;
+        }
+
+        if (!region.contains(selected.anchorNode) || !region.contains(selected.focusNode)) {
+            return;
+        }
+
+        const fragment = selected.toString().trim().slice(0, longestFragment);
+
+        revise({ fragment: fragment === '' ? null : fragment });
+    }
+
+    return (
+        <>
+            <SenderVerdict verdict={message.sender} />
+
+            {/* The message as the design project draws one: flat on the column, at the measure a conversation's
+                messages take, with who wrote it and what the copy holds on its first line — how many attachments, the
+                sender's own markup where there is one, and when this deployment recorded it — and what it says under
+                that. */}
+            <div className="mx-auto flex w-full max-w-conversation flex-col gap-3">
+                <div className="flex items-center gap-2.75">
+                    <SenderAvatar
+                        displayName={author?.displayName ?? null}
+                        address={author?.address ?? null}
+                        place="card"
+                    />
+
+                    <span className="min-w-0 truncate text-md font-semibold text-text">
+                        {author === null ? translate('message.noAuthor') : (author.displayName ?? author.address)}
+                    </span>
+
+                    <span className="flex-1" />
+
+                    {message.attachments.length === 0 ? null : (
+                        <span className="flex shrink-0 items-center gap-0.75 text-xs text-faint">
+                            <Icon name="attach_file" className="size-3.5" />
+                            {numbers.format(message.attachments.length)}
+                        </span>
+                    )}
+
+                    {/* Drawn in the reduced view and in no other. With the embedded HTML view chosen the markup is
+                        already on the screen under this line, so a control offering to open it would open a second
+                        copy of what is being read — which is why it goes rather than being disabled. */}
+                    {embeddedHtml ? null : <ShowFullHtml onShow={onShowFullHtml} />}
+
+                    <ReceivedAt at={message.headers.receivedAt} />
+                </div>
+
+                {/* The gestures a selection ends on rather than a document-wide subscription: a selection made with the
+                    pointer settles on the release and one made with the keyboard on the key coming back up, and both of
+                    them are events this region already receives. */}
+                {/* The ceiling a message's words are read under, which binds the content alone: the verdict about who
+                    sent it, the files it carries, and the line above have no measure to keep. It is ranged left, so a
+                    window wider than the ceiling leaves its margin on the empty side rather than pushing the words away
+                    from the list they were opened from. */}
+                <div ref={words} onKeyUp={capture} onMouseUp={capture} className="max-w-reading">
+                    {/* The body being drawn is what opening this message means, so it is what marks it read — one rule
+                        wherever a message is drawn, because a message read inside its conversation was read. */}
+                    <Message
+                        body={body}
+                        storedEmailId={storedEmailId}
+                        onBodyDrawn={() => {
+                            markRead({
+                                storedEmailId,
+                                account: message.account,
+                                folder: message.folder,
+                                unread: message.unread,
+                            });
+                        }}
+                    />
+                </div>
+
+                {message.attachments.length === 0 ? null : (
+                    <Attachments session={session} storedEmailId={storedEmailId} attachments={message.attachments} />
+                )}
+            </div>
+
+            {message.carried === null ? null : <Carried carried={message.carried} />}
+        </>
+    );
+}
+
+// What a message carries besides its files, where any of it is true. Each of the three is a fact about the message
+// rather than about a part, which is why they are said here and not on a row: a signature and an unopened `winmail.dat`
+// are not files a reader can open, and drawing them as ones would offer a download that answers with nothing.
+function Carried({ carried }: { readonly carried: MailCarried }) {
+    const { locale, translate } = useLocalization();
+
+    const notes: readonly MessageKey[] = [
+        ...(carried.encrypted ? (['carried.encrypted'] as const) : []),
+        ...(carried.unverifiedSignature ? (['carried.unverifiedSignature'] as const) : []),
+        ...(carried.unexpandedTnefPart ? (['carried.unexpandedTnefPart'] as const) : []),
+    ];
+
+    if (notes.length === 0 && carried.attachmentCount === 0) {
+        return null;
+    }
+
+    return (
+        <aside className="flex flex-col gap-1 text-sm text-muted">
+            {carried.attachmentCount === 0 ? null : (
+                <p>{translate('carried.total', { size: sizeOf(carried.totalSizeOctets, locale) })}</p>
+            )}
+
+            {notes.map((note) => (
+                <p key={note}>{translate(note)}</p>
+            ))}
+        </aside>
+    );
+}

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
@@ -845,22 +845,6 @@ describe('ReadingPane selection', () => {
         ).toBeNull();
     });
 
-    it('offers the way into the conversation where the service threaded the message', async () => {
-        asked.length = 0;
-        drawing(deploymentDescribing(description({ threadId: '9b2a1c74-4a4e-4c93-9a2e-3f6f0a1b2c3d' })));
-
-        expect(await screen.findByRole('button', { name: 'Show the whole conversation' })).toBeDefined();
-    });
-
-    it('offers no conversation for a message the service threaded with nothing', async () => {
-        asked.length = 0;
-        drawing(deploymentDescribing());
-
-        await screen.findByRole('heading', { name: 'Quarterly invoice' });
-
-        expect(screen.queryByRole('button', { name: 'Show the whole conversation' })).toBeNull();
-    });
-
     // Opening a message is its words having reached the pane, and where it stands travels with it, because the folder
     // whose count has to answer for the marking is the folder the deployment counted the message in.
     it('says which message was opened, and where in the mailbox it stands', async () => {

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
@@ -8,32 +8,23 @@ import {
     type ClientFailureReason,
     type ClientResult,
     type ClientSession,
-    type MailCarried,
     type MailFathomTransport,
     type MailMessage,
 } from '@mailfathom/client-backend';
-import { Icon } from '../controls/Icon';
 import { SecondaryButton } from '../controls/SecondaryButton';
-import { ReceivedAt } from '../controls/ReceivedAt';
-import { SenderAvatar } from '../controls/SenderAvatar';
-import { ShowFullHtml } from '../fullHtml/ShowFullHtml';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
-import { useEmbeddedHtmlMessages } from '../preferences/messageView';
-import { useReadMarking } from '../readMarking/useReadMarking';
 import { useSignalledChanges } from '../signals/signalledChanges';
 import { useOpenAttachment } from '../workspace/openAttachment';
 import { useWorkspace } from '../workspace/useWorkspace';
-import { Message, WordsWaiting } from '../messageBody/Message';
+import { WordsWaiting } from '../messageBody/Message';
 import { Skeleton } from '../controls/Skeleton';
 import { useMessageBody } from '../messageBody/useMessageBody';
 import { BackToList } from '../mailSpace/BackToList';
 import { NothingOpen } from '../mailSpace/NothingOpen';
 import { useTwoPanes } from '../shell/useWideWorkspace';
-import { Attachments } from './Attachments';
 import { MessageHeaders } from './MessageHeaders';
-import { sizeOf } from '../localization/octets';
-import { SenderVerdict } from './SenderVerdict';
+import { OpenedMessage } from './OpenedMessage';
 
 // Reading one message, which is the act everything else in this client exists to support and where the most is on screen
 // at once. What this component owns is the composition and the honesty of it: the headers, what the deployment
@@ -60,11 +51,6 @@ const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
     unreadable: 'failure.unreadable',
     missing: 'failure.missing',
 };
-
-// The most of a selected passage the workspace carries. A question is asked about a fragment somebody pointed at, so a
-// select-all is a gesture rather than a scope, and a whole message in the workspace would travel into every later screen
-// that reads it.
-const longestFragment = 2000;
 
 /** What is being read: which message, which attempt at it, and whether the attempt may show. A change to any reads again. */
 interface Read {
@@ -154,12 +140,10 @@ function OpenMessage({
     readonly onShowFullHtml: (storedEmailId: string, subject: string | null) => void;
     readonly arriving: boolean;
 }) {
-    const { locale, translate } = useLocalization();
+    const { translate } = useLocalization();
     const twoPanes = useTwoPanes();
-    const embeddedHtml = useEmbeddedHtmlMessages();
     const { workspace, revise } = useWorkspace();
     const openAttachment = useOpenAttachment();
-    const { markRead } = useReadMarking();
     const signalledChanges = useSignalledChanges();
     const [read, setRead] = useState<Read>({ storedEmailId, attempt: 0, quietly: false });
     const [answer, setAnswer] = useState<Answered | null>(null);
@@ -175,7 +159,6 @@ function OpenMessage({
     const openCitedFile = useRef(openAttachment);
 
     const opened = useRef<HTMLElement>(null);
-    const body = useRef<HTMLDivElement>(null);
     // The message focus was last placed on, which starts as the one this pane mounted with so that landing on a message
     // does not steal focus. A reader arriving back from the conversation that stood in front of it is not landing, so
     // that mount starts having focused nothing and the effect below places it once the message is drawable.
@@ -293,26 +276,6 @@ function OpenMessage({
         revise({ fragment: null });
     }, [storedEmailId, revise]);
 
-    // What a person selected becomes the scope the intent field asks its next question under. It is read from the
-    // gesture that produced it rather than from an effect watching the document, and it is bounded, trimmed, and
-    // confined to this message's own words: a selection that started outside the body is not part of the message.
-    function capture(): void {
-        const selected = window.getSelection();
-        const region = body.current;
-
-        if (selected === null || region === null) {
-            return;
-        }
-
-        if (!region.contains(selected.anchorNode) || !region.contains(selected.focusNode)) {
-            return;
-        }
-
-        const fragment = selected.toString().trim().slice(0, longestFragment);
-
-        revise({ fragment: fragment === '' ? null : fragment });
-    }
-
     // The answer to the attempt in flight, or — while a quiet attempt is in flight — the one already on the screen,
     // which is what keeps a signalled re-read from blanking a message its reader is part-way through.
     const held =
@@ -396,9 +359,6 @@ function OpenMessage({
     }
 
     const message = held.result.value;
-    const threadId = message.threadId;
-    const author = message.headers.participants.find((participant) => participant.role === 'From') ?? null;
-    const numbers = new Intl.NumberFormat(locale);
 
     // Named by its own subject, which is what a reader arriving in the region needs to hear and what tells one message's
     // region from the body's inside it. The heading below says the same words on the screen; this is what the region
@@ -413,104 +373,14 @@ function OpenMessage({
             <MessageHeaders headers={message.headers} message={message} />
 
             <div className="flex flex-col gap-3 px-5.5 py-4.5">
-                <SenderVerdict verdict={message.sender} />
-
-                {/* The way into the conversation this message belongs to, offered where the service threaded it and
-                    absent where it did not: a control that opened a conversation of one message would be a control
-                    that answers nothing. It carries this message, so the conversation opens at what is being read
-                    rather than at its beginning, and closing it returns here — the selection this pane draws from is
-                    what it was opened from. Drawn as the pill the design project stands between a message and the
-                    conversation behind it. */}
-                {threadId === null ? null : (
-                    <div className="flex justify-center">
-                        <button
-                            type="button"
-                            className="rounded-full border border-line bg-sunken px-3.5 py-1.75 text-base text-text-soft transition hover:bg-hover"
-                            onClick={() => {
-                                revise({ conversation: { threadId, openAt: storedEmailId } });
-                            }}
-                        >
-                            {translate('thread.open')}
-                        </button>
-                    </div>
-                )}
-
-                {/* The message as the design project draws one in the reading column: flat on the column, at the
-                    measure a conversation's messages take, with who wrote it and what the copy holds on its first
-                    line — how many attachments, the sender's own markup where there is one, and when this deployment
-                    recorded it — and what it says under that. */}
-                <div className="mx-auto flex w-full max-w-conversation flex-col gap-3">
-                    <div className="flex items-center gap-2.75">
-                        <SenderAvatar
-                            displayName={author?.displayName ?? null}
-                            address={author?.address ?? null}
-                            place="card"
-                        />
-
-                        <span className="min-w-0 truncate text-md font-semibold text-text">
-                            {author === null ? translate('message.noAuthor') : (author.displayName ?? author.address)}
-                        </span>
-
-                        <span className="flex-1" />
-
-                        {message.attachments.length === 0 ? null : (
-                            <span className="flex shrink-0 items-center gap-0.75 text-xs text-faint">
-                                <Icon name="attach_file" className="size-3.5" />
-                                {numbers.format(message.attachments.length)}
-                            </span>
-                        )}
-
-                        {/* Drawn in the reduced view and in no other. With the embedded HTML view chosen the markup
-                            is already on the screen under this line, so a control offering to open it would open a
-                            second copy of what is being read — which is why it goes rather than being disabled. */}
-                        {embeddedHtml ? null : (
-                            <ShowFullHtml
-                                onShow={() => {
-                                    onShowFullHtml(storedEmailId, message.headers.subject);
-                                }}
-                            />
-                        )}
-
-                        <ReceivedAt at={message.headers.receivedAt} />
-                    </div>
-
-                    {/* The gestures a selection ends on rather than a document-wide subscription: a selection made
-                        with the pointer settles on the release and one made with the keyboard on the key coming back
-                        up, and both of them are events this region already receives. */}
-                    {/* The ceiling this pane reads a message's words under, which binds the content alone: the head
-                        above it, the verdict about who sent it, the files it carries, and the actions have no measure
-                        to keep and take the pane's own width. It is ranged left, so a window wider than the ceiling
-                        leaves its margin on the empty side of the pane rather than pushing the words away from the
-                        list they were opened from. A conversation answers the same question differently, which is why
-                        the measure is stated by each surface rather than inside the message. */}
-                    <div ref={body} onKeyUp={capture} onMouseUp={capture} className="max-w-reading">
-                        {/* The body being drawn is what opening this message means, so it is what marks it read. The
-                            description above already says which account and folder the message is counted in, which is
-                            what a folder's unread count is corrected by. */}
-                        <Message
-                            body={bodyRead}
-                            storedEmailId={storedEmailId}
-                            onBodyDrawn={() => {
-                                markRead({
-                                    storedEmailId: message.storedEmailId,
-                                    account: message.account,
-                                    folder: message.folder,
-                                    unread: message.unread,
-                                });
-                            }}
-                        />
-                    </div>
-
-                    {message.attachments.length === 0 ? null : (
-                        <Attachments
-                            session={session}
-                            storedEmailId={storedEmailId}
-                            attachments={message.attachments}
-                        />
-                    )}
-                </div>
-
-                {message.carried === null ? null : <Carried carried={message.carried} />}
+                <OpenedMessage
+                    session={session}
+                    message={message}
+                    body={bodyRead}
+                    onShowFullHtml={() => {
+                        onShowFullHtml(storedEmailId, message.headers.subject);
+                    }}
+                />
             </div>
         </article>
     );
@@ -540,34 +410,5 @@ function MessageWaiting({ oneColumn }: { readonly oneColumn: boolean }) {
 
             <WordsWaiting />
         </div>
-    );
-}
-
-// What a message carries besides its files, where any of it is true. Each of the three is a fact about the message
-// rather than about a part, which is why they are said here and not on a row: a signature and an unopened `winmail.dat`
-// are not files a reader can open, and drawing them as ones would offer a download that answers with nothing.
-function Carried({ carried }: { readonly carried: MailCarried }) {
-    const { locale, translate } = useLocalization();
-
-    const notes: readonly MessageKey[] = [
-        ...(carried.encrypted ? (['carried.encrypted'] as const) : []),
-        ...(carried.unverifiedSignature ? (['carried.unverifiedSignature'] as const) : []),
-        ...(carried.unexpandedTnefPart ? (['carried.unexpandedTnefPart'] as const) : []),
-    ];
-
-    if (notes.length === 0 && carried.attachmentCount === 0) {
-        return null;
-    }
-
-    return (
-        <aside className="flex flex-col gap-1 text-sm text-muted">
-            {carried.attachmentCount === 0 ? null : (
-                <p>{translate('carried.total', { size: sizeOf(carried.totalSizeOctets, locale) })}</p>
-            )}
-
-            {notes.map((note) => (
-                <p key={note}>{translate(note)}</p>
-            ))}
-        </aside>
     );
 }

--- a/frontend/src/Client.App/src/thread/Thread.test.tsx
+++ b/frontend/src/Client.App/src/thread/Thread.test.tsx
@@ -84,14 +84,68 @@ function row(id: string, overrides: Readonly<Record<string, unknown>> = {}): Rea
     };
 }
 
+/** One message as the conversation route describes it, which is what everything but the words is drawn from. */
+function describing(id: string, unread: boolean): Readonly<Record<string, unknown>> {
+    return {
+        storedEmailId: id,
+        account: 'work',
+        folder: 'INBOX',
+        threadId,
+        sizeOctets: 1_024,
+        headers: {
+            subject: 'The quarterly figures',
+            sentAt: '2026-08-31T09:40:00+00:00',
+            receivedAt: '2026-08-31T09:41:00+00:00',
+            participants: [{ role: 'From', address: 'auditor@example.invalid', displayName: 'The auditor' }],
+            messageId: `${id}@example.invalid`,
+            inReplyTo: null,
+            references: [],
+        },
+        body: { availability: 'Readable', plainText: true, html: false },
+        sender: { authorAuthentication: 'Authenticated', deploymentTrust: 'Unknown', authenticatedDomain: null },
+        attachments: [],
+        carried: null,
+        unread,
+        flagged: false,
+        answered: false,
+    };
+}
+
+/** The same message's words, carried by the same answer, which is what makes the conversation one request. */
+function saying(id: string): Readonly<Record<string, unknown>> {
+    return {
+        storedEmailId: id,
+        availability: 'Readable',
+        plainText: {
+            text: `The whole of what ${id} says.`,
+            originalCharacterCount: 32,
+            truncation: 'None',
+        },
+        document: null,
+        selfContainedHtml: null,
+        remoteImagesRequested: false,
+    };
+}
+
 function pageOf(
     ids: readonly string[],
     overrides: Readonly<Record<string, unknown>> = {},
     rows: Readonly<Record<string, Readonly<Record<string, unknown>>>> = {},
+    unopened: readonly string[] = [],
 ): string {
     return JSON.stringify({
         threadId,
-        messages: ids.map((id, at) => ({ position: at, answeredId: null, email: row(id, rows[id] ?? {}) })),
+        messages: ids.map((id, at) => ({
+            position: at,
+            answeredId: null,
+            email: row(id, rows[id] ?? {}),
+
+            // A message named in `unopened` is one whose local copy the deployment could not open, and it arrives
+            // carrying neither field — which is the gap a conversation is still drawn with.
+            ...(unopened.includes(id)
+                ? {}
+                : { message: describing(id, rows[id]?.['unread'] === true), body: saying(id) }),
+        })),
         participants: [
             { address: 'auditor@example.invalid', displayName: 'The auditor', messageCount: 2 },
             { address: 'user@example.invalid', displayName: null, messageCount: 1 },
@@ -100,7 +154,7 @@ function pageOf(
         moreMessagesNotAssembled: false,
         moreParticipantsNotNamed: false,
         nextCursor: null,
-        pageSize: 100,
+        pageSize: 10,
         ...overrides,
     });
 }
@@ -108,21 +162,9 @@ function pageOf(
 /** What the deployment says about a message nobody has read yet. */
 const unread = { unread: true };
 
-/** One message's whole text, named after the message so a test can tell which of them was read. */
+/** One message's whole text served on its own, which is a route nothing under a conversation reaches any more. */
 function bodyAsWords(path: string): string {
-    const storedEmailId = path.split('/messages/')[1]?.split('/')[0] ?? '';
-
-    return JSON.stringify({
-        storedEmailId,
-        availability: 'Readable',
-        plainText: {
-            text: `The whole of what ${storedEmailId} says.`,
-            originalCharacterCount: 32,
-            truncation: 'None',
-        },
-        document: null,
-        remoteImagesRequested: false,
-    });
+    return JSON.stringify(saying(path.split('/messages/')[1]?.split('/')[0] ?? ''));
 }
 
 /** A deployment answering the conversation with what a test named, and every message body the same way. */
@@ -186,6 +228,7 @@ function inTheFrame(
                             conversation={conversation}
                             online={online}
                             expandWholeThread={expandWholeThread}
+                            onShowFullHtml={() => undefined}
                         />
                     </ReadMarkingContext>
                 </LinkOpenerContext>
@@ -224,17 +267,6 @@ function bodiesAsked(): string[] {
     return asked.filter((request) => request.path.includes('/body')).map((request) => request.path);
 }
 
-// The head of the first earlier message drawn collapsed, which is the control that opens it.
-function firstCollapsedHead(): HTMLElement {
-    const [head] = screen.getAllByRole('button', { expanded: false });
-
-    if (head === undefined) {
-        throw new Error('No message of the conversation is drawn collapsed.');
-    }
-
-    return head;
-}
-
 describe('Thread', () => {
     // Issue 1758's panel control, from the conversation's side. jsdom answers every media query `false`, so the
     // composition here is the single-pane one — where the design keeps the head whatever the control says, because it
@@ -258,22 +290,18 @@ describe('Thread', () => {
 
         expect(await screen.findByText('The whole of what three says.')).toBeDefined();
         expect(screen.getAllByRole('listitem')).toHaveLength(1);
-        expect(screen.getByRole('button', { name: 'Show earlier messages (2)' })).toBeDefined();
+        expect(screen.getByRole('button', { name: 'Show 2 earlier messages' })).toBeDefined();
     });
 
     it('shows the whole history in one press, and hides it again in the next', async () => {
         drawing(deploymentAnswering(pageOf(['one', 'two', 'three'])));
 
-        fireEvent.click(await screen.findByRole('button', { name: 'Show earlier messages (2)' }));
+        fireEvent.click(await screen.findByRole('button', { name: 'Show 2 earlier messages' }));
 
-        // Every earlier message arrives as its head alone, so nothing already drawn moves while a body arrives.
+        // Every message revealed is drawn out, which is what the conversation carried the words for.
         expect(screen.getAllByRole('listitem')).toHaveLength(3);
-        expect(screen.getAllByRole('button', { expanded: false })).toHaveLength(2);
-        expect(screen.queryByText('The whole of what one says.')).toBeNull();
-
-        fireEvent.click(firstCollapsedHead());
-
-        expect(await screen.findByText('The whole of what one says.')).toBeDefined();
+        expect(screen.getByText('The whole of what one says.')).toBeDefined();
+        expect(screen.getByText('The whole of what two says.')).toBeDefined();
 
         fireEvent.click(screen.getByRole('button', { name: 'Hide earlier messages' }));
 
@@ -281,6 +309,34 @@ describe('Thread', () => {
         expect(screen.queryByText('The whole of what one says.')).toBeNull();
     });
 
+    // #1759: no message of a conversation carries a control that would fold it away. The one control on the screen is
+    // the correspondence's own, which is what makes `aria-expanded` unambiguous here.
+    it('draws every revealed message in full, with no control on any of them', async () => {
+        drawing(deploymentAnswering(pageOf(['one', 'two', 'three'])));
+
+        fireEvent.click(await screen.findByRole('button', { name: 'Show 2 earlier messages' }));
+
+        expect(screen.getAllByRole('button', { expanded: true })).toHaveLength(1);
+        expect(screen.queryAllByRole('button', { expanded: false })).toHaveLength(0);
+    });
+
+    // The whole correspondence stands in the pane it was already open in: nothing is asked for over the wire, and
+    // nothing about where the client is has moved.
+    it('reveals the history without asking the deployment for anything', async () => {
+        drawing(deploymentAnswering(pageOf(['one', 'two', 'three'])));
+
+        const control = await screen.findByRole('button', { name: 'Show 2 earlier messages' });
+        const asksOnOpening = asked.length;
+
+        fireEvent.click(control);
+
+        expect(screen.getByText('The whole of what one says.')).toBeDefined();
+        expect(asked).toHaveLength(asksOnOpening);
+        expect(window.location.hash).toBe('');
+    });
+
+    // Both values of the setting, which #1759 asks for by name: off, the conversation opens at the message it was
+    // reached by and the rest wait behind the design's own control; on, the whole correspondence is drawn at once.
     it('opens with every message drawn where the reader asked conversations to open expanded', async () => {
         drawing(
             deploymentAnswering(pageOf(['one', 'two', 'three'])),
@@ -346,15 +402,18 @@ describe('Thread', () => {
         ).toBeDefined();
     });
 
-    it('reads no body for a message the history hides', async () => {
+    // #1759: the correspondence is one read of the deployment. Every message's words came with it, so no message of it
+    // is asked for on its own however many of them are drawn.
+    it('reads the whole conversation in one request and no message body at all', async () => {
         drawing(deploymentAnswering(pageOf(['one', 'two', 'three'])));
-        await screen.findByText('The whole of what three says.');
 
-        // The latest of them is drawn, so exactly one body is read out of three messages rather than all three.
-        await waitFor(() => {
-            expect(bodiesAsked()).toHaveLength(1);
-        });
-        expect(bodiesAsked()[0]).toContain('/messages/three/body');
+        await screen.findByText('The whole of what three says.');
+        fireEvent.click(screen.getByRole('button', { name: 'Show 2 earlier messages' }));
+        await screen.findByText('The whole of what one says.');
+
+        expect(bodiesAsked()).toHaveLength(0);
+        expect(asked).toHaveLength(1);
+        expect(asked[0]?.path).toContain('content=true');
     });
 
     // ADR 0026 marks read every body the conversation drew, which is one rule rather than two — and the conversation
@@ -376,7 +435,7 @@ describe('Thread', () => {
         });
     });
 
-    it('marks read each earlier message the reader opens, and none they only showed the head of', async () => {
+    it('marks read every message revealing the history drew, each of them having been read', async () => {
         const { marking, opened } = recordingMarkings();
 
         drawing(
@@ -386,14 +445,7 @@ describe('Thread', () => {
             marking,
         );
 
-        fireEvent.click(await screen.findByRole('button', { name: 'Show earlier messages (1)' }));
-
-        await waitFor(() => {
-            expect(opened.map((message) => message.storedEmailId)).toStrictEqual(['two']);
-        });
-
-        fireEvent.click(screen.getByRole('button', { expanded: false }));
-        await screen.findByText('The whole of what one says.');
+        fireEvent.click(await screen.findByRole('button', { name: 'Show 1 earlier message' }));
 
         await waitFor(() => {
             expect(opened.map((message) => message.storedEmailId).toSorted()).toStrictEqual(['one', 'two']);
@@ -412,23 +464,17 @@ describe('Thread', () => {
         });
     });
 
-    it('reads a message the reader opens, and not before: showing the history reads nothing', async () => {
-        drawing(deploymentAnswering(pageOf(['one', 'two'])));
-        const control = await screen.findByRole('button', { name: 'Show earlier messages (1)' });
+    // A message whose local copy the deployment could not open arrives without one, and is the one case a conversation
+    // still says something rather than drawing words.
+    it('says a message the conversation could not carry rather than drawing it empty', async () => {
+        drawing(deploymentAnswering(pageOf(['one', 'two'], {}, {}, ['one'])));
 
-        expect(bodiesAsked().some((path) => path.includes('/messages/one/'))).toBe(false);
+        fireEvent.click(await screen.findByRole('button', { name: 'Show 1 earlier message' }));
 
-        fireEvent.click(control);
-
-        expect(screen.getByRole('button', { expanded: false })).toBeDefined();
-        expect(bodiesAsked().some((path) => path.includes('/messages/one/'))).toBe(false);
-
-        fireEvent.click(screen.getByRole('button', { expanded: false }));
-
-        await waitFor(() => {
-            expect(bodiesAsked().some((path) => path.includes('/messages/one/'))).toBe(true);
-        });
-        expect(await screen.findByText('The whole of what one says.')).toBeDefined();
+        expect(
+            screen.getByText('The message from The auditor could not be read here. Open it on its own to read it.'),
+        ).toBeDefined();
+        expect(bodiesAsked()).toHaveLength(0);
     });
 
     it('opens a conversation nobody named a message in at its last word', async () => {
@@ -438,11 +484,14 @@ describe('Thread', () => {
         expect(screen.queryByText('The whole of what one says.')).toBeNull();
     });
 
-    it('shows the history and puts the reader at the message it was opened at', async () => {
+    // A conversation opened in the middle of its history hides messages on both sides of the one it was opened at, so
+    // what the control offers is the whole correspondence rather than the earlier part of it.
+    it('puts the reader at the message it was opened at, with the rest of the correspondence behind the control', async () => {
         drawing(deploymentAnswering(pageOf(['one', 'two', 'three'])), { threadId, openAt: 'two' });
 
         expect(await screen.findByText('The whole of what two says.')).toBeDefined();
-        expect(screen.getAllByRole('listitem')).toHaveLength(3);
+        expect(screen.getAllByRole('listitem')).toHaveLength(1);
+        expect(screen.getByRole('button', { name: 'Show all the messages' })).toBeDefined();
 
         await waitFor(() => {
             expect(document.activeElement?.getAttribute('aria-label')).toBe('Message from The auditor');
@@ -458,7 +507,7 @@ describe('Thread', () => {
         await waitFor(() => {
             expect(document.activeElement?.textContent).toContain('The whole of what three says.');
         });
-        expect(screen.getByRole('button', { name: 'Show earlier messages (2)' })).toBeDefined();
+        expect(screen.getByRole('button', { name: 'Show 2 earlier messages' })).toBeDefined();
     });
 
     it('puts the reader at the latest message, where the message it was opened at is not in the conversation', async () => {
@@ -487,7 +536,7 @@ describe('Thread', () => {
 
         expect(await screen.findByText('The whole of what three says.')).toBeDefined();
 
-        fireEvent.click(screen.getByRole('button', { name: 'Show earlier messages (2)' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Show 2 earlier messages' }));
 
         expect(screen.queryByText('Opened from the list')).toBeNull();
     });
@@ -498,10 +547,9 @@ describe('Thread', () => {
         expect(await screen.findByText('The whole of what three says.')).toBeDefined();
         expect(screen.queryByText('Opened from the list')).toBeNull();
 
-        fireEvent.click(screen.getByRole('button', { name: 'Show earlier messages (2)' }));
-        fireEvent.click(firstCollapsedHead());
+        fireEvent.click(screen.getByRole('button', { name: 'Show 2 earlier messages' }));
 
-        expect(await screen.findByText('The whole of what one says.')).toBeDefined();
+        expect(screen.getByText('The whole of what one says.')).toBeDefined();
         expect(screen.queryByText('Opened from the list')).toBeNull();
     });
 
@@ -534,7 +582,7 @@ describe('Thread', () => {
         });
 
         const arrivedAt = document.activeElement;
-        const control = screen.getByRole('button', { name: 'Show earlier messages (2)' });
+        const control = screen.getByRole('button', { name: 'Show 2 earlier messages' });
 
         control.focus();
         fireEvent.click(control);
@@ -544,7 +592,7 @@ describe('Thread', () => {
         expect(document.activeElement).not.toBe(arrivedAt);
     });
 
-    it('reads on until the message it was opened at is in hand, keeping the history above it', async () => {
+    it('reads on until the message it was opened at is in hand, and stands the reader on it', async () => {
         drawing(
             deploymentAnswering(
                 pageOf(['one', 'two'], { nextCursor: 'onwards', messageCount: 4 }),
@@ -554,8 +602,11 @@ describe('Thread', () => {
         );
 
         expect(await screen.findByText('The whole of what three says.')).toBeDefined();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Show all the messages' }));
+
         expect(screen.getAllByRole('listitem')).toHaveLength(4);
-        expect(screen.getByRole('button', { name: 'Hide earlier messages' })).toBeDefined();
+        expect(screen.getByRole('button', { name: 'Hide the other messages' })).toBeDefined();
     });
 
     it('keeps the message the reader is standing on when a further page arrives, rather than unmounting it under their focus', async () => {

--- a/frontend/src/Client.App/src/thread/Thread.tsx
+++ b/frontend/src/Client.App/src/thread/Thread.tsx
@@ -27,12 +27,17 @@ import { ThreadMessage } from './ThreadMessage';
 // is the presentation, and the presentation is the whole difficulty — a long conversation drawn naively is the same
 // paragraph eight times.
 //
-// Three things answer that. The conversation shows its latest message and hides everything before it behind one
+// Three things answer that. The conversation shows the message it was opened at and hides everything else behind one
 // control naming how many there are, so opening a long conversation is reading the message somebody came for rather
-// than first collapsing eight of them — and a message the control does not show is a body nobody asks the deployment
-// for, so a conversation of thirty messages costs one read rather than thirty. What each message says is trimmed of
+// than first scrolling past eight of them — and pressing that control draws every one of them out in full, because a
+// conversation is a document rather than a list of things to open one at a time. What each message says is trimmed of
 // the history it quoted by the deployment rather than here. And the history that is quoted inside a message is folded
 // away behind a disclosure, because the message it quotes is a message of its own a few lines up.
+//
+// **The whole correspondence arrives in one request**, messages and bodies together, so revealing the history costs
+// nothing on the wire and the setting that opens a conversation expanded costs nothing either. That is what bounds the
+// page: a read carrying the messages themselves is held to the deployment's own content-read ceiling, and a
+// correspondence longer than one page is read on with the control below it.
 //
 // It stands in front of the message it was opened from rather than replacing it: the workspace still holds that
 // message, so closing the conversation returns to it and the place it returns to is still there.
@@ -48,6 +53,32 @@ import { ThreadMessage } from './ThreadMessage';
 // how long something is said for, and the theme decides how movement happens rather than how long a screen speaks.
 const landingHeldFor = 2_200;
 
+// What the one control over the correspondence says, which is a question about two things rather than one: whether the
+// rest of it is standing, and whether the message it was opened at is the newest. A conversation opened in the middle
+// of its history hides messages on both sides of that one, so what it offers is the whole correspondence rather than
+// the earlier part of it — the design project words all four, and each is a different sentence rather than a wording of
+// one.
+//
+// Three of the four are one sentence each. The fourth counts, so it is a form per plural category rather than a number
+// appended to a sentence: Polish words one earlier message, two, and five differently, and the design project writes
+// all three out.
+const earlierHidden: Readonly<Record<Intl.LDMLPluralRule, MessageKey>> = {
+    zero: 'thread.showEarlier.other',
+    one: 'thread.showEarlier.one',
+    two: 'thread.showEarlier.other',
+    few: 'thread.showEarlier.few',
+    many: 'thread.showEarlier.many',
+    other: 'thread.showEarlier.other',
+};
+
+function revealLabel(historyShown: boolean, openedIsLatest: boolean, hidden: number, locale: string): MessageKey {
+    if (historyShown) {
+        return openedIsLatest ? 'thread.hideEarlier' : 'thread.hideOthers';
+    }
+
+    return openedIsLatest ? earlierHidden[new Intl.PluralRules(locale).select(hidden)] : 'thread.showAll';
+}
+
 const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
     unauthenticated: 'failure.unauthenticated',
     unauthorized: 'failure.unauthorized',
@@ -62,6 +93,7 @@ export function Thread({
     conversation,
     online,
     expandWholeThread,
+    onShowFullHtml,
 }: {
     readonly session: ClientSession;
     readonly transport: MailFathomTransport;
@@ -70,6 +102,9 @@ export function Thread({
 
     /** Whether the reader asked for conversations to open with every message drawn rather than at the one they came for. */
     readonly expandWholeThread: boolean;
+
+    /** Opens the surface drawing one message's own markup, which each message of the conversation offers. */
+    readonly onShowFullHtml: (storedEmailId: string, subject: string | null) => void;
 }) {
     const { locale, translate } = useLocalization();
     const { workspace, revise } = useWorkspace();
@@ -89,18 +124,11 @@ export function Thread({
     // does: nothing in a conversation brings one back, and a conversation reached a second time is a second mount.
     const [settled, setSettled] = useState(false);
 
-    // Whether the messages before the latest are drawn. It opens on what the reader asked conversations to open on,
-    // and is then decided by where they arrived — a message the history holds cannot be arrived at while the history
-    // is hidden — and theirs from then on. The preference is read once, on mounting, because it says how a conversation
-    // *opens*: a switch moved while one is on the screen changes the next conversation rather than this one, which is
-    // also why the control below still hides a history the preference showed.
+    // Whether the rest of the correspondence is drawn beside the message it was opened at. It opens on what the reader
+    // asked conversations to open on and is theirs from then on. The preference is read once, on mounting, because it
+    // says how a conversation *opens*: a switch moved while one is on the screen changes the next conversation rather
+    // than this one, which is also why the control below still hides a correspondence the preference showed.
     const [historyShown, setHistoryShown] = useState(expandWholeThread);
-
-    // Which messages a reader has pressed open or closed, against what each opens as on its own: the latest message
-    // and the one the conversation arrived at open, and every earlier one collapsed to its head — or every one open,
-    // where the reader asked conversations to open expanded. Held as the presses rather than as the states, so a page
-    // arriving with a newer latest message collapses nothing the reader opened and opens nothing they closed.
-    const [pressed, setPressed] = useState<readonly string[]>([]);
 
     const regions = useRef(new Map<string, HTMLElement>());
 
@@ -122,21 +150,15 @@ export function Thread({
     }
 
     const held = messagesOf(pages);
-    const drawn = historyShown ? held : held.slice(-1);
     const mark = arrivalMark(conversation, arrival, settled);
     const latest = pages.at(-1) ?? null;
 
-    function opensOnItsOwn(storedEmailId: string): boolean {
-        return expandWholeThread || storedEmailId === held.at(-1)?.email.id || storedEmailId === arrival?.storedEmailId;
-    }
-
-    function toggle(storedEmailId: string): void {
-        setPressed((current) =>
-            current.includes(storedEmailId)
-                ? current.filter((one) => one !== storedEmailId)
-                : [...current, storedEmailId],
-        );
-    }
+    // What stands on the screen: the whole correspondence, or the one message it was opened at. The design draws the
+    // second as the message somebody came for and nothing else — which is not the same as the latest message, because a
+    // conversation opened at a message in the middle of its history was opened at that one.
+    const opened = held.find((message) => message.email.id === arrival?.storedEmailId) ?? held.at(-1) ?? null;
+    const drawn = historyShown || opened === null ? held : [opened];
+    const openedIsLatest = opened !== null && opened.email.id === held.at(-1)?.email.id;
 
     // A conversation opened at a message is read forward until that message is in hand, because the route pages from
     // the beginning and the surrounding history is what somebody arriving from a search result came for. The count the
@@ -165,10 +187,6 @@ export function Thread({
 
         if (arriveAt !== null) {
             setArrival(arriveAt);
-
-            if (arriveAt.amongOthers) {
-                setHistoryShown(true);
-            }
         }
     }
 
@@ -181,7 +199,7 @@ export function Thread({
 
         let listening = true;
 
-        void readMailThread(session, transport, conversation.threadId, wantedCursor).then((result) => {
+        void readMailThread(session, transport, conversation.threadId, wantedCursor, true).then((result) => {
             if (!listening) {
                 return;
             }
@@ -378,7 +396,12 @@ export function Thread({
                         otherwise eight decisions about. It names how many are behind it, so pressing it is a choice
                         rather than a guess, and it stands above them because that is where the design project draws
                         it — between the head of the conversation and the messages themselves. A conversation of one
-                        message has no history to offer, and no control. */}
+                        message has no history to offer, and no control.
+
+                        It says four things rather than two, as the design does, because what it hides is *the rest of
+                        the correspondence* rather than what came before: a conversation opened at a message in the
+                        middle of its history has messages on both sides of it, and a control offering to show the
+                        earlier ones there would be offering something other than what it does. */}
                     {held.length < 2 ? null : (
                         <div className="flex items-center gap-2.5">
                             <span className="h-px flex-1 bg-line" />
@@ -391,11 +414,9 @@ export function Thread({
                                     setHistoryShown(!historyShown);
                                 }}
                             >
-                                {historyShown
-                                    ? translate('thread.hideEarlier')
-                                    : translate('thread.showEarlier', {
-                                          count: new Intl.NumberFormat(locale).format(held.length - 1),
-                                      })}
+                                {translate(revealLabel(historyShown, openedIsLatest, held.length - 1, locale), {
+                                    count: new Intl.NumberFormat(locale).format(held.length - 1),
+                                })}
                             </button>
 
                             <span className="h-px flex-1 bg-line" />
@@ -410,12 +431,12 @@ export function Thread({
                                 transport={transport}
                                 message={message}
                                 mark={message.email.id === arrival?.storedEmailId ? mark : null}
-                                collapsed={opensOnItsOwn(message.email.id) === pressed.includes(message.email.id)}
-                                onToggle={() => {
-                                    toggle(message.email.id);
-                                }}
+                                online={online}
                                 onOpenOnItsOwn={() => {
                                     openOnItsOwn(message.email.id);
+                                }}
+                                onShowFullHtml={() => {
+                                    onShowFullHtml(message.email.id, message.email.subject);
                                 }}
                                 onRegion={(element) => {
                                     if (element === null) {

--- a/frontend/src/Client.App/src/thread/ThreadMessage.test.tsx
+++ b/frontend/src/Client.App/src/thread/ThreadMessage.test.tsx
@@ -8,12 +8,15 @@ import type {
     ClientRequest,
     ClientResponse,
     ClientSession,
+    MailBody,
     MailFathomTransport,
+    MailMessage,
     MailThreadMessage,
 } from '@mailfathom/client-backend';
 import { LocalizationProvider } from '../localization/Localization';
 import { ReadMarkingContext, nothingMarkedRead, type ReadMarking } from '../readMarking/useReadMarking';
 import { LinkOpenerContext } from '../shellOperations/linkOpener';
+import { WorkspaceProvider } from '../workspace/Workspace';
 import { ThreadMessage } from './ThreadMessage';
 import type { ArrivalMark } from './threadOpening';
 
@@ -35,7 +38,42 @@ const answersNothing: MailFathomTransport = (request) => {
     return new Promise<ClientResponse>(() => undefined);
 };
 
-function message(overrides: Partial<MailThreadMessage['email']> = {}): MailThreadMessage {
+/** The message as the conversation route described it, which is what everything but the words is drawn from. */
+const described: MailMessage = {
+    storedEmailId: 'a-message',
+    account: 'work',
+    folder: 'Sent',
+    threadId: 'a-conversation',
+    sizeOctets: 1_024,
+    headers: {
+        subject: 'The quarterly figures',
+        sentAt: '2026-08-31T09:40:00+00:00',
+        receivedAt: '2026-08-31T09:41:00+00:00',
+        participants: [{ role: 'From', address: 'auditor@example.invalid', displayName: 'The auditor' }],
+        messageId: 'abc@example.invalid',
+        inReplyTo: null,
+        references: [],
+    },
+    body: { availability: 'Readable', plainText: true, html: true },
+    sender: { authorAuthentication: 'Authenticated', deploymentTrust: 'Unknown', authenticatedDomain: null },
+    attachments: [],
+    carried: null,
+    unread: false,
+    flagged: false,
+    answered: false,
+};
+
+/** The words the same answer carried, which is what makes drawing this message cost nothing on the wire. */
+const said: MailBody = {
+    storedEmailId: 'a-message',
+    availability: 'Readable',
+    plainText: { text: 'The figures you asked for are attached.', originalCharacterCount: 38, truncation: 'None' },
+    document: null,
+    selfContainedHtml: null,
+    remoteImagesRequested: false,
+};
+
+function message(overrides: Partial<MailThreadMessage> = {}): MailThreadMessage {
     return {
         position: 1,
         answeredId: 'the-one-before',
@@ -58,17 +96,23 @@ function message(overrides: Partial<MailThreadMessage['email']> = {}): MailThrea
             sizeOctets: 1_024,
             preview: 'The figures you asked for are attached.',
             threadMessageCount: null,
-            ...overrides,
         },
+        message: described,
+        body: said,
+        ...overrides,
     };
+}
+
+/** The same message with nothing the deployment could open, which is the gap a correspondence is still drawn with. */
+function unopened(): MailThreadMessage {
+    return message({ message: null, body: null });
 }
 
 function drawing(
     held: MailThreadMessage = message(),
     handlers: {
-        readonly collapsed?: boolean;
-        readonly onToggle?: () => void;
         readonly onOpenOnItsOwn?: () => void;
+        readonly onShowFullHtml?: () => void;
         readonly onRegion?: (element: HTMLElement | null) => void;
     } = {},
     marking: ReadMarking = nothingMarkedRead,
@@ -76,93 +120,88 @@ function drawing(
 ): void {
     render(
         <LocalizationProvider>
-            <LinkOpenerContext value={() => Promise.resolve()}>
-                <ReadMarkingContext value={marking}>
-                    <ul>
-                        <ThreadMessage
-                            session={session}
-                            transport={answersNothing}
-                            message={held}
-                            mark={mark}
-                            collapsed={handlers.collapsed ?? false}
-                            onToggle={handlers.onToggle ?? (() => undefined)}
-                            onOpenOnItsOwn={handlers.onOpenOnItsOwn ?? (() => undefined)}
-                            onRegion={handlers.onRegion ?? (() => undefined)}
-                        />
-                    </ul>
-                </ReadMarkingContext>
-            </LinkOpenerContext>
+            <WorkspaceProvider>
+                <LinkOpenerContext value={() => Promise.resolve()}>
+                    <ReadMarkingContext value={marking}>
+                        <ul>
+                            <ThreadMessage
+                                session={session}
+                                transport={answersNothing}
+                                message={held}
+                                mark={mark}
+                                online
+                                onOpenOnItsOwn={handlers.onOpenOnItsOwn ?? (() => undefined)}
+                                onShowFullHtml={handlers.onShowFullHtml ?? (() => undefined)}
+                                onRegion={handlers.onRegion ?? (() => undefined)}
+                            />
+                        </ul>
+                    </ReadMarkingContext>
+                </LinkOpenerContext>
+            </WorkspaceProvider>
         </LocalizationProvider>,
     );
 }
 
-/** What a client that has marked exactly this message read carries, which is what the head reads its state through. */
-function marked(storedEmailId: string): ReadMarking {
+/** A marking that records what was opened, so what a drawn message reports is asserted rather than a call count. */
+function recordingMarkings(): { readonly marking: ReadMarking; readonly opened: string[] } {
+    const opened: string[] = [];
+
     return {
-        marked: new Map([[storedEmailId, { account: 'work', folder: 'Sent' }]]),
-        markRead: () => undefined,
+        marking: {
+            marked: new Map(),
+            markRead: (message) => {
+                opened.push(message.storedEmailId);
+            },
+        },
+        opened,
     };
 }
 
 describe('ThreadMessage', () => {
-    it('draws a message as who wrote it, reads what it says, and names where in the mailbox it stands', () => {
+    it('draws the message out in full, as the surface reading one on its own draws it', () => {
         drawing();
 
         expect(screen.getByText('The auditor')).toBeDefined();
+        expect(screen.getByText('The figures you asked for are attached.')).toBeDefined();
         expect(screen.getByText('In work, Sent')).toBeDefined();
-        expect(asked.some((request) => request.path.includes('/messages/a-message/body'))).toBe(true);
     });
 
-    it('draws no contribution line, which the body below it would be saying twice on one screen', () => {
+    // The conversation is one document and every message in it is written out, so there is no control here that would
+    // fold one away: what a reader decides is how much of the correspondence stands in front of them, and that is the
+    // conversation's own decision rather than each message's.
+    it('offers nothing that would collapse the message it draws', () => {
         drawing();
 
-        expect(screen.queryByText('The figures you asked for are attached.')).toBeNull();
+        expect(screen.queryByRole('button', { expanded: true })).toBeNull();
+        expect(screen.queryByRole('button', { expanded: false })).toBeNull();
     });
 
-    it('carries no card while open, which the design project draws on a collapsed message alone', () => {
+    // The words arrived with the conversation, which is the whole of what makes revealing the earlier messages free.
+    it('reads nothing from the deployment for a message the conversation carried', () => {
         drawing();
-
-        const region = screen.getByRole('article');
-
-        expect(region.className).not.toContain('border');
-        expect(region.className).not.toContain('bg-sunken');
-    });
-
-    it('draws a collapsed message as its head on a card, with nothing read and nothing said under it', () => {
-        drawing(message(), { collapsed: true });
-
-        const region = screen.getByRole('article');
-
-        expect(region.className).toContain('border');
-        expect(screen.getByRole('button', { expanded: false })).toBeDefined();
-        expect(screen.queryByText('In work, Sent')).toBeNull();
-        expect(screen.queryByRole('button', { name: 'Open this message on its own' })).toBeNull();
-    });
-
-    // The words are what the read costs, and a conversation of thirty messages draws thirty heads: so a collapsed
-    // message reaches the deployment for nothing at all, and pressing it is what asks. The record is what proves it —
-    // a message drawing no words could be one whose read is merely still in flight.
-    it('reads nothing from the deployment while it is collapsed', () => {
-        drawing(message(), { collapsed: true });
 
         expect(asked).toEqual([]);
     });
 
-    it('reads the body from the deployment once it is open', () => {
-        drawing(message());
+    // A message whose local copy the deployment could not open arrives without one. The reader is owed the gap rather
+    // than a message drawn empty, and the way to it is the control that opens the message on its own.
+    it('says a message the conversation could not carry, rather than drawing it empty', () => {
+        drawing(unopened());
 
-        expect(asked.map((request) => request.path)).toEqual([
-            `${session.baseAddress}/api/client/messages/a-message/body`,
-        ]);
+        expect(
+            screen.getByText('The message from The auditor could not be read here. Open it on its own to read it.'),
+        ).toBeDefined();
+        expect(screen.getByRole('button', { name: 'Open this message on its own' })).toBeDefined();
     });
 
-    it('opens and closes from its head, which is the control the design draws it as', () => {
-        const toggled = vi.fn();
+    it('names a message nobody wrote a sender for by something rather than by nothing', () => {
+        const held = unopened();
 
-        drawing(message(), { collapsed: true, onToggle: toggled });
-        fireEvent.click(screen.getByRole('button', { expanded: false }));
+        drawing({ ...held, email: { ...held.email, senderDisplayName: null, senderAddress: null } });
 
-        expect(toggled).toHaveBeenCalledTimes(1);
+        expect(
+            screen.getByText('The message from No sender could not be read here. Open it on its own to read it.'),
+        ).toBeDefined();
     });
 
     it('names the region it puts a reader in, so arriving at a message announces more than a tag', () => {
@@ -175,63 +214,24 @@ describe('ThreadMessage', () => {
         const onRegion = vi.fn();
         drawing(message(), { onRegion });
 
-        expect(onRegion).toHaveBeenCalledWith(screen.getByRole('article'));
+        expect(onRegion).toHaveBeenCalledWith(screen.getByRole('article', { name: 'Message from The auditor' }));
     });
 
-    it('names a message nobody wrote a sender for by something rather than by nothing', () => {
-        drawing(message({ senderDisplayName: null, senderAddress: null }));
+    // A message read inside its conversation was read, which is one rule wherever a message is drawn.
+    it('marks the message read, the words it drew being what opening it means', () => {
+        const { marking, opened } = recordingMarkings();
 
-        expect(screen.getByText('No sender')).toBeDefined();
+        drawing(message(), {}, marking);
+
+        expect(opened).toEqual(['a-message']);
     });
 
-    it('names a message whose sender wrote no display name by the address they wrote from', () => {
-        drawing(message({ senderDisplayName: null }));
+    it('marks nothing read for a message it drew no words for', () => {
+        const { marking, opened } = recordingMarkings();
 
-        expect(screen.getByText('auditor@example.invalid')).toBeDefined();
-    });
+        drawing(unopened(), {}, marking);
 
-    it('marks a message nobody has read', () => {
-        drawing(message({ unread: true }));
-
-        expect(screen.getByText('Unread')).toBeDefined();
-    });
-
-    // The list's row and this head are the same message in two places, so a reader who opened it here would otherwise
-    // find it still unread there.
-    it('draws a message this client has marked read as read, though the deployment still reports it unread', () => {
-        drawing(message({ unread: true }), {}, marked('a-message'));
-
-        expect(screen.queryByText('Unread')).toBeNull();
-    });
-
-    it('recognises a sender by their initials, which is what a conversation of several people is scanned down', () => {
-        drawing();
-
-        expect(screen.getByText('TA')).toBeDefined();
-    });
-
-    it('takes the one initial a sender who wrote a single-word name offers, rather than two', () => {
-        drawing(message({ senderDisplayName: 'Prince' }));
-
-        expect(screen.getByText('P')).toBeDefined();
-    });
-
-    it('takes the initials from the address where the sender wrote no name', () => {
-        drawing(message({ senderDisplayName: null }));
-
-        expect(screen.getByText('A')).toBeDefined();
-    });
-
-    it('invents no initials for a sender this deployment could not name', () => {
-        drawing(message({ senderDisplayName: null, senderAddress: null }));
-
-        expect(screen.queryByText('NS')).toBeNull();
-    });
-
-    it('says a message carries files, which is what a reader looks for on its head', () => {
-        drawing(message({ hasAttachments: true, attachmentCount: 2 }));
-
-        expect(screen.getByText('2 attached')).toBeDefined();
+        expect(opened).toEqual([]);
     });
 
     it('offers the way to the message on its own, where everything a conversation does not draw is', () => {
@@ -241,6 +241,16 @@ describe('ThreadMessage', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Open this message on its own' }));
 
         expect(onOpenOnItsOwn).toHaveBeenCalled();
+    });
+
+    it('offers the sender own markup, which is the one ask a drawn message still makes of its surface', () => {
+        const onShowFullHtml = vi.fn();
+        drawing(message(), { onShowFullHtml });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Show the full HTML version' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Show the HTML' }));
+
+        expect(onShowFullHtml).toHaveBeenCalled();
     });
 
     it('says in words that this is the message somebody opened, rather than only drawing a rule beside it', () => {

--- a/frontend/src/Client.App/src/thread/ThreadMessage.tsx
+++ b/frontend/src/Client.App/src/thread/ThreadMessage.tsx
@@ -4,36 +4,29 @@
 
 import type { ClientSession, MailFathomTransport, MailThreadMessage } from '@mailfathom/client-backend';
 import { Icon } from '../controls/Icon';
-import { MessageMarkers } from '../controls/MessageMarkers';
-import { Organisation } from '../controls/Organisation';
-import { ReceivedAt } from '../controls/ReceivedAt';
 import { SecondaryButton } from '../controls/SecondaryButton';
-import { SenderAvatar } from '../controls/SenderAvatar';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
-import { Message } from '../messageBody/Message';
 import { useMessageBody } from '../messageBody/useMessageBody';
-import { drawnUnread, useReadMarking } from '../readMarking/useReadMarking';
+import { OpenedMessage } from '../readingPane/OpenedMessage';
 import type { ArrivalMark } from './threadOpening';
 
-// One message of a conversation, as a head and what it says. It is its own component for the reason a list row is: it
-// is what carries the read and the way out to the message on its own.
+// One message of a conversation, drawn out in full — which is the whole of what this component decides, because what a
+// message looks like is `readingPane/OpenedMessage.tsx`'s and is the same drawing wherever a message is drawn.
 //
-// It is drawn in the two states the design project draws a message of a conversation in. Open, it is flat on the
-// column: the head, the words, and the way to the message on its own. Collapsed, it is the head alone on a bordered
-// card, which is what every earlier message is until somebody presses it — so showing the history of a conversation of
-// thirty messages puts thirty heads on the screen and reads no body, and nothing already drawn moves while a body
-// arrives under it. The head is the control that opens and closes the message, in both states, which is what the
-// design draws it as.
+// **Nothing here collapses.** The design project draws a conversation as one document with every message in it written
+// out, and it hands the mail screen `showExpandAll: false` — so there is no per-message control, and what a reader
+// decides is how much of the correspondence stands in front of them rather than which message of it is open. The
+// conversation's own head is where that decision is made, and this is what it reveals.
+//
+// The body comes with the conversation rather than from a read of its own: one request carries every message of the
+// correspondence, so revealing the history costs nothing on the wire. A message whose local copy the deployment could
+// not open arrives without one, and that is the one case this reads a body itself — a gap in the correspondence the
+// reader can still be shown rather than a message drawn empty.
 //
 // It is a region of its own so that arriving at a conversation can place the reader on the message they came for, for
 // the reason `readingPane/ReadingPane.tsx` names its opened message: focus has to land on something a screen reader
 // announces by more than its tag.
-//
-// What it is bounded to is the conversation's measure rather than the pane's, and it is centred in the pane: a message
-// drawn the whole width of a wide window is a line nobody reads comfortably, and a column of messages has nothing
-// beside it to range against. The measure binds the whole message — its head as much as its words — which is why it
-// sits here rather than inside the body.
 
 // What a mark says in the head of the message it is on. Two sentences rather than one worded for both, because the two
 // are not the same claim: one says a person opened this message, the other that the client brought them to it.
@@ -55,9 +48,9 @@ export function ThreadMessage({
     transport,
     message,
     mark,
-    collapsed,
-    onToggle,
+    online,
     onOpenOnItsOwn,
+    onShowFullHtml,
     onRegion,
 }: {
     readonly session: ClientSession;
@@ -67,28 +60,21 @@ export function ThreadMessage({
     /** What marks this message out as the one the conversation arrived at, or `null` where nothing does. */
     readonly mark: ArrivalMark | null;
 
-    /** Whether the head stands alone, with the words behind a press on it. */
-    readonly collapsed: boolean;
-
-    /** What the head does when pressed: opens a collapsed message, and collapses an open one. */
-    readonly onToggle: () => void;
+    /** Whether the deployment is reachable, which decides whether a message the conversation did not carry is read. */
+    readonly online: boolean;
 
     readonly onOpenOnItsOwn: () => void;
+    readonly onShowFullHtml: () => void;
     readonly onRegion: (element: HTMLElement | null) => void;
 }) {
     const { translate } = useLocalization();
-    const marking = useReadMarking();
     const email = message.email;
     const sender = email.senderDisplayName ?? email.senderAddress ?? translate('list.senderUnknown');
 
-    // A collapsed message wants no read, which is what keeps a conversation of thirty heads to one body: the head is
-    // drawn from what the conversation already answered with, and pressing it is what asks for the words.
-    const body = useMessageBody(session, transport, email.id, !collapsed);
-
-    // What the deployment last reported, less what this client has marked read since — the same reading the list's own
-    // row draws from, because the two are the same message in two places and a reader who opened it here would
-    // otherwise find it still unread there.
-    const unread = drawnUnread(marking, email.id, email.unread);
+    // The body the conversation already answered with, which is what makes revealing the history cost no request. The
+    // read behind it stays reachable for the asks that are the reader's own — the sender's pictures, the sender's own
+    // markup, and reading again after a failure — and it is wanted at all only where there is a message to draw it in.
+    const body = useMessageBody(session, transport, email.id, online && message.message !== null, message.body);
 
     return (
         <li>
@@ -96,73 +82,44 @@ export function ThreadMessage({
                 ref={onRegion}
                 tabIndex={-1}
                 aria-label={translate('thread.messageBy', { sender })}
-                className={`mx-auto flex w-full max-w-conversation flex-col gap-2.75 transition ${
-                    collapsed ? 'rounded-xl border border-line bg-sunken px-3 py-2' : ''
-                } ${mark === null ? '' : arrivalStyles[mark]}`}
+                className={`flex flex-col gap-2.75 transition ${mark === null ? '' : arrivalStyles[mark]}`}
             >
-                <button
-                    type="button"
-                    aria-expanded={!collapsed}
-                    className="flex w-full items-center gap-2.75 rounded-md text-start transition hover:bg-hover"
-                    onClick={onToggle}
-                >
-                    <SenderAvatar displayName={email.senderDisplayName} address={email.senderAddress} place="card" />
-
-                    {unread ? <span className="sr-only">{translate('list.unread')}</span> : null}
-
-                    {/* Who wrote is what a conversation is scanned by, so it keeps its width and everything beside it
-                        is what gives way. */}
-                    <span className={`shrink-0 text-md font-semibold ${unread ? 'text-text' : 'text-text-soft'}`}>
-                        {sender}
-                    </span>
-
-                    {/* What the mark says, so that the message the conversation arrived at is named rather than only
-                        tinted: a rule down an edge is invisible to somebody who is being read to, and the accent is
-                        invisible to somebody who cannot tell it from the text beside it. */}
-                    {mark === null ? null : (
-                        <span className="flex shrink-0 items-center gap-1 rounded-sm bg-accent-soft px-1.75 py-0.5 text-2xs tracking-wide whitespace-nowrap text-accent-deep">
+                {/* What the mark says, so that the message the conversation arrived at is named rather than only
+                    tinted: a rule down an edge is invisible to somebody who is being read to, and the accent is
+                    invisible to somebody who cannot tell it from the text beside it. */}
+                {mark === null ? null : (
+                    <p className="mx-auto flex w-full max-w-conversation items-center">
+                        <span className="flex items-center gap-1 rounded-sm bg-accent-soft px-1.75 py-0.5 text-2xs tracking-wide whitespace-nowrap text-accent-deep">
                             <Icon name="arrow_right" className="size-3" />
                             {translate(arrivalLabels[mark])}
                         </span>
-                    )}
-
-                    <Organisation address={email.senderAddress} />
-
-                    <MessageMarkers email={email} />
-
-                    <ReceivedAt at={email.receivedAt} />
-                </button>
-
-                {collapsed ? null : (
-                    <>
-                        <p className="text-sm text-muted">
-                            {translate('thread.storedIn', { account: email.account, folder: email.folder })}
-                        </p>
-
-                        {/* Every body the conversation drew is marked read, which is one rule rather than two: the
-                            reading pane and a message here put the same words in front of the same person, and what
-                            marks a message read is that its body was drawn wherever it was drawn. Nothing the screen
-                            decides for itself draws more than the latest message — the rest are collapsed until
-                            pressed, which is a gesture the reader makes knowing whose message it opens. */}
-                        <Message
-                            body={body}
-                            storedEmailId={email.id}
-                            quotedHistoryOnRequest
-                            onBodyDrawn={() => {
-                                marking.markRead({
-                                    storedEmailId: email.id,
-                                    account: email.account,
-                                    folder: email.folder,
-                                    unread: email.unread,
-                                });
-                            }}
-                        />
-
-                        <div>
-                            <SecondaryButton label={translate('thread.openOnItsOwn')} onActivate={onOpenOnItsOwn} />
-                        </div>
-                    </>
+                    </p>
                 )}
+
+                {message.message === null ? (
+                    // A message this deployment could not open is said rather than drawn as an empty card: what the
+                    // reader is owed is the correspondence with a gap they can still open on its own.
+                    <p className="mx-auto w-full max-w-conversation text-sm text-muted" role="status">
+                        {translate('thread.messageNotRead', { sender })}
+                    </p>
+                ) : (
+                    <OpenedMessage
+                        session={session}
+                        message={message.message}
+                        body={body}
+                        onShowFullHtml={onShowFullHtml}
+                    />
+                )}
+
+                <div className="mx-auto flex w-full max-w-conversation flex-col gap-2.75">
+                    <p className="text-sm text-muted">
+                        {translate('thread.storedIn', { account: email.account, folder: email.folder })}
+                    </p>
+
+                    <div>
+                        <SecondaryButton label={translate('thread.openOnItsOwn')} onActivate={onOpenOnItsOwn} />
+                    </div>
+                </div>
             </article>
         </li>
     );

--- a/frontend/src/Client.App/src/thread/threadOpening.test.ts
+++ b/frontend/src/Client.App/src/thread/threadOpening.test.ts
@@ -30,6 +30,8 @@ function message(id: string, position: number, unread = false): MailThreadMessag
             preview: 'What this one added.',
             threadMessageCount: null,
         },
+        message: null,
+        body: null,
     };
 }
 

--- a/frontend/src/Client.Backend/src/index.ts
+++ b/frontend/src/Client.Backend/src/index.ts
@@ -151,6 +151,7 @@ export {
     type MailSemanticSearch,
 } from './mailSearch';
 export {
+    longestDrawnThreadPage,
     longestThreadPage,
     mailThreadRoute,
     readMailThread,

--- a/frontend/src/Client.Backend/src/mailBody.ts
+++ b/frontend/src/Client.Backend/src/mailBody.ts
@@ -251,7 +251,7 @@ const blockRevisions: Readonly<Record<string, number>> = {
  * base64 and are therefore a third longer again, so a newsletter with two photographs in it would be cut off and
  * reported to the reader as a defect. This is that arithmetic plus room for the words around it.
  */
-const longestBodyAnswer = 8 * 1024 * 1024;
+export const longestBodyAnswer = 8 * 1024 * 1024;
 
 const bounds = {
     maximumDepth: 24,
@@ -360,7 +360,21 @@ interface RemainingBudget {
 }
 
 function parseBody(body: string, ask: MailBodyAsk): MailBody | null {
-    const record = asRecord(parsed(body));
+    return parseMailBody(parsed(body), ask);
+}
+
+/**
+ * Reads one body out of an answer that already carries it as a value, which is how a conversation carries its own.
+ *
+ * The conversation route answers with this route's body field for field rather than with a shape of its own, so the
+ * parse — and every bound it holds the document to — is this one rather than a second one written to the same contract.
+ *
+ * @param value The body as it arrived, in whatever shape it arrived in.
+ * @param ask What the read asked for, which decides which representations may be present.
+ * @returns The body, or `null` where what arrived is not one.
+ */
+export function parseMailBody(value: unknown, ask: MailBodyAsk): MailBody | null {
+    const record = asRecord(value);
     if (record === null) {
         return null;
     }

--- a/frontend/src/Client.Backend/src/mailMessage.ts
+++ b/frontend/src/Client.Backend/src/mailMessage.ts
@@ -114,7 +114,7 @@ export interface MailMessage {
 // A description composes to a stated size, so the backstop written for a stranger is far looser than this answer ever
 // needs. It is generous against the bounds below rather than tight against them: the point of failing here is to stop a
 // body being buffered whole, and the point of failing there is to refuse a description this client would not draw.
-const longestMessageAnswer = 4 * 1024 * 1024;
+export const longestMessageAnswer = 4 * 1024 * 1024;
 
 // What the service will compose at most, mirrored so a description larger than that is refused rather than drawn. The
 // part count is the ceiling `MaxMimePartCount` defaults to, rounded up, because every part of a message can be an
@@ -170,15 +170,25 @@ export function readMailMessage(
 }
 
 function parseMessage(body: string): MailMessage | null {
-    let parsed: unknown;
-
     try {
-        parsed = JSON.parse(body);
+        return parseMailMessage(JSON.parse(body));
     } catch {
         return null;
     }
+}
 
-    const record = asRecord(parsed);
+/**
+ * Reads one message out of an answer that already carries it as a value, which is how a conversation carries its own.
+ *
+ * The conversation route answers with this route's message field for field rather than with a shape of its own, so the
+ * parse is this one rather than a second one written to the same contract — two parsers of one message are how a client
+ * comes to draw the same message differently on two screens.
+ *
+ * @param value The message as it arrived, in whatever shape it arrived in.
+ * @returns The message, or `null` where what arrived is not one.
+ */
+export function parseMailMessage(value: unknown): MailMessage | null {
+    const record = asRecord(value);
     if (record === null) {
         return null;
     }

--- a/frontend/src/Client.Backend/src/mailThread.test.ts
+++ b/frontend/src/Client.Backend/src/mailThread.test.ts
@@ -14,6 +14,9 @@ const session: ClientSession = {
 
 const threadId = '9b2a1c74-4a4e-4c93-9a2e-3f6f0a1b2c3d';
 
+/** A message the conversation does not hold, for the answers that pair a row with somebody else's head or words. */
+const anotherMessage = '7c3e5a91-2d84-4b6f-8e15-40a9c7b2d6e3';
+
 const email = {
     id: '2f7d4f2a-6c1e-4e0a-9a2f-1b0c9d8e7f60',
     account: 'work',
@@ -352,6 +355,36 @@ describe('readMailThread drawing the messages', () => {
         [
             'words that are not words',
             drawnBodyOf({ messages: [{ position: 0, answeredId: null, email, message: described, body: {} }] }),
+        ],
+        // The row, the head and the words are three identities parsed apart, and a screen handed a mismatched trio
+        // would draw one message's row beside another message's words with nothing saying so.
+        [
+            'a description belonging to another message',
+            drawnBodyOf({
+                messages: [
+                    {
+                        position: 0,
+                        answeredId: null,
+                        email,
+                        message: { ...described, storedEmailId: anotherMessage },
+                        body: said,
+                    },
+                ],
+            }),
+        ],
+        [
+            'words belonging to another message',
+            drawnBodyOf({
+                messages: [
+                    {
+                        position: 0,
+                        answeredId: null,
+                        email,
+                        message: described,
+                        body: { ...said, storedEmailId: anotherMessage },
+                    },
+                ],
+            }),
         ],
     ])('refuses %s rather than drawing a conversation with a hole in it', async (_, body) => {
         const answered = await readMailThread(session, answering({ status: 200, body }), threadId, null, true);

--- a/frontend/src/Client.Backend/src/mailThread.test.ts
+++ b/frontend/src/Client.Backend/src/mailThread.test.ts
@@ -3,7 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { describe, expect, it } from 'vitest';
-import { mailThreadRoute, readMailThread, threadQueryString } from './mailThread';
+import { longestDrawnThreadPage, mailThreadRoute, readMailThread, threadQueryString } from './mailThread';
 import type { ClientSession } from './session';
 import type { ClientRequest, ClientResponse, MailFathomTransport } from './transport';
 
@@ -36,6 +36,57 @@ const email = {
 };
 
 const participant = { address: 'auditor@example.invalid', displayName: 'The auditor', messageCount: 2 };
+
+// What a conversation read with its messages carries beside each row: the message as the service describes it, and the
+// words it says. Both are the shapes the message and body routes answer with, which is why nothing here parses them a
+// second way.
+const described = {
+    storedEmailId: email.id,
+    account: 'work',
+    folder: 'INBOX',
+    threadId,
+    sizeOctets: 84_213,
+    headers: {
+        subject: 'The quarterly figures',
+        sentAt: '2026-08-31T09:40:00+00:00',
+        receivedAt: '2026-08-31T09:41:00+00:00',
+        participants: [{ role: 'From', address: 'auditor@example.invalid', displayName: 'The auditor' }],
+        messageId: 'abc@example.invalid',
+        inReplyTo: null,
+        references: [],
+    },
+    body: { availability: 'Readable', plainText: true, html: false },
+    sender: { authorAuthentication: 'Authenticated', deploymentTrust: 'Unknown', authenticatedDomain: null },
+    attachments: [],
+    carried: null,
+    unread: true,
+    flagged: false,
+    answered: false,
+};
+
+const said = {
+    storedEmailId: email.id,
+    availability: 'Readable',
+    plainText: { text: 'The figures you asked for are attached.', originalCharacterCount: 38, truncation: 'None' },
+    document: null,
+    selfContainedHtml: null,
+    remoteImagesRequested: false,
+};
+
+/** A page of the shape the drawn read answers with: at most ten messages, each carrying its description and words. */
+function drawnBodyOf(page: Readonly<Record<string, unknown>> = {}): string {
+    return JSON.stringify({
+        threadId,
+        messages: [{ position: 0, answeredId: null, email, message: described, body: said }],
+        participants: [participant],
+        messageCount: 1,
+        moreMessagesNotAssembled: false,
+        moreParticipantsNotNamed: false,
+        nextCursor: null,
+        pageSize: longestDrawnThreadPage,
+        ...page,
+    });
+}
 
 function bodyOf(page: Readonly<Record<string, unknown>> = {}): string {
     return JSON.stringify({
@@ -88,6 +139,18 @@ describe('threadQueryString', () => {
     it('escapes the cursor a previous page answered with', () => {
         expect(threadQueryString('a+b/c=')).toBe('?pageSize=100&cursor=a%2Bb%2Fc%3D');
     });
+
+    // A conversation drawn out asks for the messages themselves, and for the smaller page the service composes them
+    // at: the whole correspondence a screen shows arrives in that one answer rather than one read per message drawn.
+    it('asks for the messages themselves, at the page the service composes them at', () => {
+        expect(threadQueryString(null, true)).toBe(`?pageSize=${String(longestDrawnThreadPage)}&content=true`);
+    });
+
+    it('reads on from a cursor with the messages still drawn', () => {
+        expect(threadQueryString('onwards', true)).toBe(
+            `?pageSize=${String(longestDrawnThreadPage)}&cursor=onwards&content=true`,
+        );
+    });
 });
 
 describe('readMailThread', () => {
@@ -98,7 +161,7 @@ describe('readMailThread', () => {
             outcome: 'read',
             value: {
                 threadId,
-                messages: [{ position: 0, answeredId: null, email }],
+                messages: [{ position: 0, answeredId: null, email, message: null, body: null }],
                 participants: [participant],
                 messageCount: 1,
                 moreMessagesNotAssembled: false,
@@ -129,7 +192,11 @@ describe('readMailThread', () => {
             null,
         );
 
-        expect(answered.outcome === 'read' && answered.value.messages[1]).toStrictEqual(answer);
+        expect(answered.outcome === 'read' && answered.value.messages[1]).toStrictEqual({
+            ...answer,
+            message: null,
+            body: null,
+        });
     });
 
     it('reads a conversation that names an author for whom no message carried a display name', async () => {
@@ -226,6 +293,79 @@ describe('readMailThread', () => {
             answering({ status: 200, body: bodyOf({ messages }) }),
             threadId,
             null,
+        );
+
+        expect(answered).toStrictEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+});
+
+describe('readMailThread drawing the messages', () => {
+    it('reads every message of the conversation with its description and its words', async () => {
+        const answered = await readMailThread(
+            session,
+            answering({ status: 200, body: drawnBodyOf() }),
+            threadId,
+            null,
+            true,
+        );
+
+        expect(answered.outcome === 'read' && answered.value.messages[0]?.message).toStrictEqual(described);
+        expect(answered.outcome === 'read' && answered.value.messages[0]?.body).toStrictEqual(said);
+    });
+
+    it('asks the deployment for the conversation and its messages in one request', async () => {
+        const { transport, requests } = recording({ status: 200, body: drawnBodyOf() });
+
+        await readMailThread(session, transport, threadId, null, true);
+
+        expect(requests).toHaveLength(1);
+        expect(requests[0]?.path).toBe(
+            `https://mail.example.invalid/api/client/threads/${threadId}` +
+                `?pageSize=${String(longestDrawnThreadPage)}&content=true`,
+        );
+    });
+
+    // A message whose local copy the deployment could not open arrives without one. That is a gap in the
+    // correspondence for the screen to say, rather than a page to refuse.
+    it('reads a message the deployment could not open as one carrying neither description nor words', async () => {
+        const answered = await readMailThread(
+            session,
+            answering({
+                status: 200,
+                body: drawnBodyOf({ messages: [{ position: 0, answeredId: null, email }] }),
+            }),
+            threadId,
+            null,
+            true,
+        );
+
+        expect(answered.outcome === 'read' && answered.value.messages[0]?.message).toBeNull();
+        expect(answered.outcome === 'read' && answered.value.messages[0]?.body).toBeNull();
+    });
+
+    it.each([
+        ['a page larger than the one messages are composed at', drawnBodyOf({ pageSize: longestDrawnThreadPage + 1 })],
+        [
+            'a description that is not one',
+            drawnBodyOf({ messages: [{ position: 0, answeredId: null, email, message: {}, body: said }] }),
+        ],
+        [
+            'words that are not words',
+            drawnBodyOf({ messages: [{ position: 0, answeredId: null, email, message: described, body: {} }] }),
+        ],
+    ])('refuses %s rather than drawing a conversation with a hole in it', async (_, body) => {
+        const answered = await readMailThread(session, answering({ status: 200, body }), threadId, null, true);
+
+        expect(answered).toStrictEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+
+    it('refuses a conversation drawn at the page a read without its messages serves', async () => {
+        const answered = await readMailThread(
+            session,
+            answering({ status: 200, body: drawnBodyOf({ pageSize: 100 }) }),
+            threadId,
+            null,
+            true,
         );
 
         expect(answered).toStrictEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });

--- a/frontend/src/Client.Backend/src/mailThread.ts
+++ b/frontend/src/Client.Backend/src/mailThread.ts
@@ -299,7 +299,18 @@ function parseMessage(value: unknown): MailThreadMessage | null {
     const message = parseMailMessage(carried);
     const body = parseMailBody(said, { remoteImages: false, fullHtml: false });
 
-    return message === null || body === null ? null : { position, answeredId, email, message, body };
+    if (message === null || body === null) {
+        return null;
+    }
+
+    // Three identities are parsed apart here — the row's, the head's and the words' — and a conversation is the one
+    // place they could be paired wrongly and still look drawable. A screen given a mismatched trio would draw one
+    // message's row and its `open on its own` beside another message's words, so the answer is refused instead.
+    if (message.storedEmailId !== email.id || body.storedEmailId !== email.id) {
+        return null;
+    }
+
+    return { position, answeredId, email, message, body };
 }
 
 function parseParticipants(value: unknown): readonly MailThreadParticipant[] | null {

--- a/frontend/src/Client.Backend/src/mailThread.ts
+++ b/frontend/src/Client.Backend/src/mailThread.ts
@@ -4,6 +4,8 @@
 
 import { failed, failureReasonForStatus, read, type ClientResult } from './failure';
 import { asRecord } from './json';
+import { longestBodyAnswer, parseMailBody, type MailBody } from './mailBody';
+import { longestMessageAnswer, parseMailMessage, type MailMessage } from './mailMessage';
 import { parseTimelineEntry, type MailTimelineEntry } from './mailTimeline';
 import { headersFor, routeFor, type ClientSession } from './session';
 import { spanned } from './telemetry';
@@ -19,8 +21,13 @@ import { send, type MailFathomTransport } from './transport';
 // would be paging a conversation in order to draw its header.
 //
 // A message arrives as the mail list route's own row, field for field, and is parsed by that module's own parser rather
-// than by a second one here. What a row does not carry is the message: the whole of one, quoted history included, is a
-// request of its own naming the identity the row already carries.
+// than by a second one here.
+//
+// A caller that draws the correspondence rather than a list of it asks for the messages themselves, and each one then
+// arrives with what the message route and the body route answer for it — parsed by those two modules' own parsers, for
+// the reason the row is. That is what makes reading a correspondence one request rather than one request per message
+// somebody reveals, and it is why a read that carries them asks for a smaller page: it costs what reading that many
+// messages costs, and the deployment refuses a larger one.
 
 /** The route one page of one conversation is served at, relative to the client prefix. */
 export function mailThreadRoute(threadId: string): string {
@@ -42,6 +49,17 @@ export interface MailThreadMessage {
 
     /** The message itself, in the same shape a list row carries. Its `preview` is what this message added. */
     readonly email: MailTimelineEntry;
+
+    /**
+     * What a reading surface draws around the message, or `null` where the read asked for a list of messages.
+     *
+     * It is also `null` for a message this deployment could not open, which is a gap in the correspondence rather than
+     * a refusal of it: the row is still here, and a surface that wants the message reads it on its own.
+     */
+    readonly message: MailMessage | null;
+
+    /** What the message says, or `null` for the same two reasons. */
+    readonly body: MailBody | null;
 }
 
 /** Somebody who has written in the conversation, and how much of it is theirs. */
@@ -87,10 +105,26 @@ export interface MailThreadPage {
  */
 export const longestThreadPage = 100;
 
-// The most of one page this client reads. A page is at most a hundred rows of the shape the mail list answers with,
-// beside the conversation's authors — who are bounded by the messages one read assembles rather than by the page. That
-// puts a full answer well inside this, and this well inside the transport's own backstop.
+/**
+ * The largest page a read carrying the messages themselves is served, which is the deployment's own content-read
+ * ceiling rather than a preference.
+ *
+ * Reading a conversation with what its messages say costs what reading that many messages costs, so the service holds
+ * it to the bound every content read is held to and refuses a larger page with a `400`. A correspondence longer than
+ * this is read on with the cursor, exactly as a longer page of rows is.
+ */
+export const longestDrawnThreadPage = 10;
+
+// The most of one page of rows this client reads. A page is at most a hundred rows of the shape the mail list answers
+// with, beside the conversation's authors — who are bounded by the messages one read assembles rather than by the page.
+// That puts a full answer well inside this, and this well inside the transport's own backstop.
 const longestThreadAnswer = 512 * 1024;
+
+// The most of one page carrying the messages themselves, which is the page times what one message is already allowed
+// to be: this answer is the two per-message routes' answers put end to end, so a conversation of ten legitimate
+// messages has to fit inside it. It is composed from those two ceilings rather than written as a number, because a
+// number would go on standing after one of them moved and would then refuse a conversation the service composed.
+const longestDrawnThreadAnswer = longestDrawnThreadPage * (longestMessageAnswer + longestBodyAnswer);
 
 // What one answer may carry before the page is refused unread. Each is far above anything the service composes and
 // exists for the answer that is not a page at all — checked while the collections are walked rather than after.
@@ -109,6 +143,7 @@ const mostParticipants = 1_024;
  * @param transport How the request goes out.
  * @param threadId The conversation to read, as a message row published it.
  * @param cursor The cursor a previous page answered with, or `null` for the beginning of the conversation.
+ * @param drawing Whether each message arrives with what it says, which a surface drawing the correspondence asks for.
  * @returns The page, or why it never arrived.
  */
 export function readMailThread(
@@ -116,13 +151,14 @@ export function readMailThread(
     transport: MailFathomTransport,
     threadId: string,
     cursor: string | null,
+    drawing = false,
 ): Promise<ClientResult<MailThreadPage>> {
     return spanned('GET /threads/{threadId}', async () => {
         const response = await send(transport, {
             method: 'GET',
-            path: routeFor(session, mailThreadRoute(threadId)) + threadQueryString(cursor),
+            path: routeFor(session, mailThreadRoute(threadId)) + threadQueryString(cursor, drawing),
             headers: headersFor(session),
-            longestAnswer: longestThreadAnswer,
+            longestAnswer: drawing ? longestDrawnThreadAnswer : longestThreadAnswer,
         });
 
         if (response === null) {
@@ -133,18 +169,22 @@ export function readMailThread(
             return failed(failureReasonForStatus(response.status), response.status);
         }
 
-        const page = parsePage(response.body);
+        const page = parsePage(response.body, drawing);
 
         return page === null ? failed('unreadable', response.status) : read(page);
     });
 }
 
-/** The query string one page is asked with: the size every read here runs under, and where in the conversation it starts. */
-export function threadQueryString(cursor: string | null): string {
-    const asked = [`pageSize=${String(longestThreadPage)}`];
+/** The query string one page is asked with: the size the read runs under, where in the conversation it starts, and whether it carries the messages. */
+export function threadQueryString(cursor: string | null, drawing = false): string {
+    const asked = [`pageSize=${String(drawing ? longestDrawnThreadPage : longestThreadPage)}`];
 
     if (cursor !== null) {
         asked.push(`cursor=${encodeURIComponent(cursor)}`);
+    }
+
+    if (drawing) {
+        asked.push('content=true');
     }
 
     return `?${asked.join('&')}`;
@@ -153,7 +193,7 @@ export function threadQueryString(cursor: string | null): string {
 // The page is held against what was asked for as well as against its own shape: a deployment answering with more
 // messages than the request admits is one this client refuses to render rather than one it draws, which is the bound
 // the root instructions place at every remote boundary.
-function parsePage(body: string): MailThreadPage | null {
+function parsePage(body: string, drawing: boolean): MailThreadPage | null {
     let parsed: unknown;
 
     try {
@@ -186,7 +226,9 @@ function parsePage(body: string): MailThreadPage | null {
         return null;
     }
 
-    if (!isCount(pageSize) || pageSize < 1 || pageSize > longestThreadPage) {
+    const largestPage = drawing ? longestDrawnThreadPage : longestThreadPage;
+
+    if (!isCount(pageSize) || pageSize < 1 || pageSize > largestPage) {
         return null;
     }
 
@@ -245,7 +287,19 @@ function parseMessage(value: unknown): MailThreadMessage | null {
         return null;
     }
 
-    return { position, answeredId, email };
+    const carried = record['message'] ?? null;
+    const said = record['body'] ?? null;
+
+    // The two arrive together or not at all: a message drawn from a head with no words under it, or from words with no
+    // head above them, is half a message, and the read that would repair it is the one this answer exists to spare.
+    if (carried === null || said === null) {
+        return { position, answeredId, email, message: null, body: null };
+    }
+
+    const message = parseMailMessage(carried);
+    const body = parseMailBody(said, { remoteImages: false, fullHtml: false });
+
+    return message === null || body === null ? null : { position, answeredId, email, message, body };
 }
 
 function parseParticipants(value: unknown): readonly MailThreadParticipant[] | null {


### PR DESCRIPTION
Closes #1759

Opening a message from the list read the correspondence's rows in one call and then one further pair of calls for
every message the reader revealed, in a second surface. It now reads the whole correspondence once, draws every
message from what that call already carried, and reveals the earlier ones in the pane the reader is already in.

## The contract change

`GET /api/client/threads/{id}` gains a `content=true` query parameter, and the answer's per-message object gains two
fields, `message` and `body`, carrying exactly what `/api/client/messages/{id}` and `/api/client/messages/{id}/body`
answer with. Both are absent — `null` — for a message whose stored copy the deployment could not open, and both are
absent from every answer the parameter was not asked for, so a client that does not ask sees the route it saw before.

That read is bounded by the service's own content ceiling, `GetEmailContentRequest.MaximumEmails`, which is ten: a
`pageSize` above it is refused with `400` naming the bound, and the existing cursor is what reads on. The per-message
read asks for the mail document alone — no sender's markup, no attachment download links, no remote image
references — so what the conversation carries is the plain reading each message would have been drawn with.

**Operator action: none.** The parameter is optional and the two fields are additive, so a deployment upgrades with
nothing to change and an older client keeps working against a newer service. `docs/operations/client-endpoint.md`
carries the whole of it, and `http-api-contract.json` records it.

## What the client does with it

- A row click opens the correspondence rather than the single-message pane, at the message that was clicked.
- Revealing the earlier messages changes no address, opens no second surface, and issues no request: the words are
  already held. The one control the design draws is what decides how much of the correspondence stands in front of
  the reader, and *Rozwijaj cały wątek automatycznie* decides its state on opening — off by default, in the client
  preferences the other device-or-deployment settings live in.
- A revealed message is drawn in full, by the same component the reading pane draws one with. That component,
  `readingPane/OpenedMessage.tsx`, is new and is the whole of the shared drawing, so the two surfaces cannot drift
  apart. No message carries a collapse control of its own.
- The head names how many earlier messages there are, in the design's own four wordings — Polish plural agreement
  through `Intl.PluralRules`, and no count on *Pokaż wszystkie wiadomości*.
- The carried body is handed to `useMessageBody` as the opening read's answer rather than bypassing the hook, so
  every per-message ask a reader still makes — remote pictures, the sender's own markup, reading again — is reachable
  from a message the conversation drew.

## Verification

`scripts/verify-full.sh`, and `scripts/review-obligations.sh` worked through. The design was read from the mirrored
prototype source rather than from a preview, which is where the collapse semantics and the four pill wordings come
from. Screens were captured on both sides and compared: the structural shape matched, and the raw pixel share is not
a parity number — the two captures draw different corpora, a Polish contract thread against an English fixture
newsletter, so what it measures is the mail rather than the design.

Out of scope, as the issue says: what the reading pane draws for one message (#1754), and threading itself.

- Issue: https://github.com/Krzysztof318/MailFathom/issues/1759

- Pull request: https://github.com/Krzysztof318/MailFathom/pull/1769
