### PR TITLE
[#1175] Give the client one intent field whose scope is visible before the question is asked

### DIFF
--- a/frontend/src/Client.App/src/App.deployment.test.tsx
+++ b/frontend/src/Client.App/src/App.deployment.test.tsx
@@ -286,7 +286,7 @@ describe('App deployment', () => {
         await framed();
 
         expect(screen.getByRole('searchbox', { name: 'Ask your mail' })).toHaveProperty('value', '');
-        expect(screen.getByRole('combobox', { name: 'Mailbox in scope' })).toHaveProperty('value', '');
+        expect(screen.getByRole('combobox', { name: 'What the question is asked about' })).toHaveProperty('value', '');
     });
 
     it('signs in against the next deployment of its own, and never reads the one before it again', async () => {

--- a/frontend/src/Client.App/src/App.signIn.test.tsx
+++ b/frontend/src/Client.App/src/App.signIn.test.tsx
@@ -250,7 +250,9 @@ describe('App sign-in', () => {
         fireEvent.change(screen.getByRole('searchbox', { name: 'Ask your mail' }), {
             target: { value: 'the renewal Nordwind sent' },
         });
-        fireEvent.change(screen.getByRole('combobox', { name: 'Mailbox in scope' }), { target: { value: 'work' } });
+        fireEvent.change(screen.getByRole('combobox', { name: 'What the question is asked about' }), {
+            target: { value: 'account:work' },
+        });
 
         await signOut();
         signIn();
@@ -259,7 +261,7 @@ describe('App sign-in', () => {
         // The next person to sign in on this machine reads their own empty screen rather than the last one's question
         // and the mailbox it was scoped to.
         expect(screen.getByRole('searchbox', { name: 'Ask your mail' })).toHaveProperty('value', '');
-        expect(screen.getByRole('combobox', { name: 'Mailbox in scope' })).toHaveProperty('value', '');
+        expect(screen.getByRole('combobox', { name: 'What the question is asked about' })).toHaveProperty('value', '');
     });
 
     it('says the password was not kept when the store would not write it, without refusing the sign-in', async () => {

--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -350,7 +350,9 @@ describe('App', () => {
         fireEvent.change(screen.getByRole('searchbox', { name: 'Ask your mail' }), {
             target: { value: 'the renewal Nordwind sent' },
         });
-        fireEvent.change(screen.getByRole('combobox', { name: 'Mailbox in scope' }), { target: { value: 'work' } });
+        fireEvent.change(screen.getByRole('combobox', { name: 'What the question is asked about' }), {
+            target: { value: 'account:work' },
+        });
 
         await goTo('Mail');
 
@@ -358,7 +360,10 @@ describe('App', () => {
             'value',
             'the renewal Nordwind sent',
         );
-        expect(screen.getByRole('combobox', { name: 'Mailbox in scope' })).toHaveProperty('value', 'work');
+        expect(screen.getByRole('combobox', { name: 'What the question is asked about' })).toHaveProperty(
+            'value',
+            'account:work',
+        );
     });
 
     it('offers every mailbox the user holds as a scope, beside all of them at once', async () => {
@@ -366,7 +371,7 @@ describe('App', () => {
 
         renderApp(servedFrom, heldSession, deploymentAnswering(twoMailboxes));
 
-        const scope = await screen.findByRole('combobox', { name: 'Mailbox in scope' });
+        const scope = await screen.findByRole('combobox', { name: 'What the question is asked about' });
         await waitFor(() => {
             expect([...scope.querySelectorAll('option')].map((option) => option.textContent)).toEqual([
                 'All mailboxes',

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -55,9 +55,19 @@ export const en = {
     'intent.label': 'Ask your mail',
     'intent.placeholder': 'What do you want to ask your mail?',
     'intent.ask': 'Ask',
+    'intent.askedBefore': 'Asked before',
+    'intent.forgetAsked': 'Forget these',
 
-    'scope.mailbox': 'Mailbox in scope',
+    'scope.inScope': 'What the question is asked about',
+    'scope.asking': 'Asking about {scope}',
     'scope.allMailboxes': 'All mailboxes',
+    'scope.everyMailbox': '{folder}, every mailbox',
+    'scope.folderIn': '{folder} in {mailbox}',
+    'scope.thread': 'This correspondence',
+    'scope.selection.one': '{count} selected message',
+    'scope.selection.few': '{count} selected messages',
+    'scope.selection.many': '{count} selected messages',
+    'scope.selection.other': '{count} selected messages',
 
     'signIn.claim': 'Your mail stays on your own server.',
     'signIn.claimExplanation':

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -56,6 +56,7 @@ export const en = {
     'intent.placeholder': 'What do you want to ask your mail?',
     'intent.ask': 'Ask',
     'intent.askedBefore': 'Asked before',
+    'intent.askedUnder': '{question}, asking about {scope}',
     'intent.forgetAsked': 'Forget these',
 
     'scope.inScope': 'What the question is asked about',

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -55,6 +55,7 @@ export const pl: Catalogue = {
     'intent.placeholder': 'O co chcesz zapytać swoją pocztę?',
     'intent.ask': 'Zapytaj',
     'intent.askedBefore': 'Wcześniejsze pytania',
+    'intent.askedUnder': '{question}, pytanie dotyczy: {scope}',
     'intent.forgetAsked': 'Wyczyść listę',
 
     'scope.inScope': 'Czego dotyczy pytanie',

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -54,9 +54,19 @@ export const pl: Catalogue = {
     'intent.label': 'Zapytaj swoją pocztę',
     'intent.placeholder': 'O co chcesz zapytać swoją pocztę?',
     'intent.ask': 'Zapytaj',
+    'intent.askedBefore': 'Wcześniejsze pytania',
+    'intent.forgetAsked': 'Wyczyść listę',
 
-    'scope.mailbox': 'Skrzynka w zakresie',
+    'scope.inScope': 'Czego dotyczy pytanie',
+    'scope.asking': 'Pytanie dotyczy: {scope}',
     'scope.allMailboxes': 'Wszystkie skrzynki',
+    'scope.everyMailbox': '{folder} we wszystkich skrzynkach',
+    'scope.folderIn': '{folder} w skrzynce {mailbox}',
+    'scope.thread': 'Ta korespondencja',
+    'scope.selection.one': '{count} zaznaczona wiadomość',
+    'scope.selection.few': '{count} zaznaczone wiadomości',
+    'scope.selection.many': '{count} zaznaczonych wiadomości',
+    'scope.selection.other': '{count} zaznaczonych wiadomości',
 
     'signIn.claim': 'Twoja poczta zostaje na Twoim serwerze.',
     'signIn.claimExplanation':

--- a/frontend/src/Client.App/src/shell/IntentField.test.tsx
+++ b/frontend/src/Client.App/src/shell/IntentField.test.tsx
@@ -8,7 +8,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import type { MailAccount } from '@mailfathom/client-backend';
 import { LocalizationProvider } from '../localization/Localization';
 import { WorkspaceProvider } from '../workspace/Workspace';
-import { useWorkspace } from '../workspace/useWorkspace';
+import { useWorkspace, type Workspace } from '../workspace/useWorkspace';
 import { IntentField } from './IntentField';
 
 const workAccount: MailAccount = {
@@ -18,6 +18,8 @@ const workAccount: MailAccount = {
     lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
     behind: false,
 };
+
+const homeAccount: MailAccount = { ...workAccount, id: 'home', displayName: 'Home' };
 
 function renderField(accounts: readonly MailAccount[] = [workAccount]): void {
     render(
@@ -63,33 +65,73 @@ describe('IntentField', () => {
     it('says every mailbox is in scope until one is chosen', () => {
         renderField();
 
-        expect(screen.getByRole('combobox', { name: 'Mailbox in scope' })).toHaveProperty('value', '');
+        expect(screen.getByRole('combobox', { name: 'What the question is asked about' })).toHaveProperty('value', '');
         expect(screen.getByRole('option', { name: 'All mailboxes' })).toBeDefined();
+    });
+
+    // The field is the front door, so it is reachable without tabbing out of whatever is being read. The shortcut is
+    // announced on the field itself, and a promise a screen reader passes on that nothing listens for is worse than
+    // promising none — so both halves are asserted together.
+    it('takes focus from anywhere on the shortcut it announces', () => {
+        renderField();
+
+        const field = screen.getByRole('searchbox', { name: 'Ask your mail' });
+
+        expect(field.getAttribute('aria-keyshortcuts')).toBe('Control+K Meta+K');
+
+        fireEvent.keyDown(document, { key: 'k', ctrlKey: true });
+
+        expect(field).toBe(document.activeElement);
     });
 });
 
-// A fragment reaches the workspace from a gesture over a message, which is the reading pane's own act rather than
-// anything this field can do — so what stands in for that here is the same write made on mount, and everything
-// asserted below is the field's own behaviour once the value is there.
-function Selecting({ words }: { readonly words: string }) {
+// The workspace reaches this field from gestures made elsewhere — a row ticked in the list, a correspondence opened, a
+// passage selected in a message — so what stands in for those here is the same write made on mount. What is asserted
+// below is the field's own behaviour once the value is there.
+function Standing({ as }: { readonly as: Partial<Workspace> }) {
     const { revise } = useWorkspace();
 
     useEffect(() => {
-        revise({ fragment: words });
-    }, [revise, words]);
+        revise(as);
+    }, [revise, as]);
 
     return null;
 }
 
-function fieldBesideASelection(words: string): void {
+// What the workspace holds while the field is being driven, which is how *without changing what the mail space
+// displays* is proven at all: the scope the list is read under is a value rather than something on this screen.
+function Reporting({ onWorkspace }: { readonly onWorkspace: (workspace: Workspace) => void }) {
+    const { workspace } = useWorkspace();
+
+    onWorkspace(workspace);
+
+    return null;
+}
+
+function fieldStanding(as: Partial<Workspace>, accounts: readonly MailAccount[] = [workAccount]): () => Workspace {
+    let last: Workspace | null = null;
+
     render(
         <LocalizationProvider>
             <WorkspaceProvider>
-                <Selecting words={words} />
-                <IntentField accounts={[workAccount]} />
+                <Standing as={as} />
+                <IntentField accounts={accounts} />
+                <Reporting
+                    onWorkspace={(workspace) => {
+                        last = workspace;
+                    }}
+                />
             </WorkspaceProvider>
         </LocalizationProvider>,
     );
+
+    return () => {
+        if (last === null) {
+            throw new Error('The workspace was never reported.');
+        }
+
+        return last;
+    };
 }
 
 describe('IntentField scope', () => {
@@ -100,7 +142,7 @@ describe('IntentField scope', () => {
     });
 
     it('quotes the words a question would be asked about, rather than saying a fragment exists', () => {
-        fieldBesideASelection('the part of the message somebody pointed at');
+        fieldStanding({ fragment: 'the part of the message somebody pointed at' });
 
         expect(
             screen.getByText(
@@ -110,7 +152,7 @@ describe('IntentField scope', () => {
     });
 
     it('gives the whole message back as the scope when that is asked for', () => {
-        fieldBesideASelection('the part of the message somebody pointed at');
+        fieldStanding({ fragment: 'the part of the message somebody pointed at' });
 
         fireEvent.click(screen.getByRole('button', { name: 'Ask about the whole message instead' }));
 
@@ -120,10 +162,126 @@ describe('IntentField scope', () => {
     // Widening the scope takes the control that did it off the screen, so where focus lands is the behaviour:
     // left to the browser it falls to the document, which is where reading from a keyboard silently stops.
     it('puts focus on the question when the control that widened the scope goes', () => {
-        fieldBesideASelection('the part of the message somebody pointed at');
+        fieldStanding({ fragment: 'the part of the message somebody pointed at' });
 
         fireEvent.click(screen.getByRole('button', { name: 'Ask about the whole message instead' }));
 
         expect(screen.getByRole('searchbox', { name: 'Ask your mail' })).toBe(document.activeElement);
+    });
+
+    it('names the correspondence being read as what the question is about', () => {
+        fieldStanding({ conversation: { threadId: 'thread-1', openAt: null } });
+
+        expect(screen.getByRole('combobox', { name: 'What the question is asked about' })).toHaveProperty('value', '');
+        expect(screen.getByRole('option', { name: 'This correspondence' })).toBeDefined();
+    });
+
+    it('counts the messages picked out, which are narrower than the correspondence holding them', () => {
+        fieldStanding({ conversation: { threadId: 'thread-1', openAt: null }, selected: ['one', 'two', 'three'] });
+
+        expect(screen.getByRole('option', { name: '3 selected messages' })).toBeDefined();
+        expect(screen.queryByRole('option', { name: 'This correspondence' })).toBeNull();
+    });
+
+    it('names the folder and the mailbox it is in', () => {
+        fieldStanding({ scope: { kind: 'folder', accountId: 'work', alias: 'Invoices' } });
+
+        expect(screen.getByRole('option', { name: 'Invoices in Work' })).toBeDefined();
+    });
+
+    // The whole point of the field owning a scope of its own: widening a question must not move the list out from
+    // under somebody who was reading a folder, nor drop the rows they had picked out.
+    it('changes nothing the mail space displays when the scope is chosen in the field', () => {
+        const reported = fieldStanding({
+            scope: { kind: 'folder', accountId: 'work', alias: 'Invoices' },
+            selected: ['one'],
+        });
+
+        fireEvent.change(screen.getByRole('combobox', { name: 'What the question is asked about' }), {
+            target: { value: 'everything' },
+        });
+
+        expect(reported().scope).toEqual({ kind: 'folder', accountId: 'work', alias: 'Invoices' });
+        expect(reported().selected).toEqual(['one']);
+        expect(reported().askScope).toEqual({ kind: 'everything' });
+    });
+
+    it('follows the mail space again when what it is showing is chosen back', () => {
+        const reported = fieldStanding({}, [workAccount, homeAccount]);
+
+        fireEvent.change(screen.getByRole('combobox', { name: 'What the question is asked about' }), {
+            target: { value: 'account:home' },
+        });
+        fireEvent.change(screen.getByRole('combobox', { name: 'What the question is asked about' }), {
+            target: { value: '' },
+        });
+
+        expect(reported().askScope).toBeNull();
+    });
+});
+
+describe('IntentField history', () => {
+    it('offers nothing back before anything has been asked', () => {
+        renderField();
+
+        expect(screen.queryByRole('list', { name: 'Asked before' })).toBeNull();
+    });
+
+    it('keeps what was asked beside the scope it was asked under', () => {
+        const reported = fieldStanding({ conversation: { threadId: 'thread-1', openAt: null } });
+
+        fireEvent.change(screen.getByRole('searchbox', { name: 'Ask your mail' }), {
+            target: { value: 'what did they promise' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+
+        expect(reported().askedBefore).toEqual([
+            { question: 'what did they promise', scope: { kind: 'thread', threadId: 'thread-1' } },
+        ]);
+    });
+
+    it('records nothing for a submission with no question in it', () => {
+        const reported = fieldStanding({});
+
+        fireEvent.submit(screen.getByRole('search'));
+
+        expect(reported().askedBefore).toEqual([]);
+    });
+
+    // Widening is what somebody does after an answer that was too narrow, so asking a past question again asks it
+    // under the scope in force now rather than the one it carries — otherwise widening would mean retyping.
+    it('asks a past question again under the scope in force now', () => {
+        const reported = fieldStanding(
+            {
+                askedBefore: [{ question: 'what did they promise', scope: { kind: 'thread', threadId: 'thread-1' } }],
+            },
+            [workAccount, homeAccount],
+        );
+
+        fireEvent.change(screen.getByRole('combobox', { name: 'What the question is asked about' }), {
+            target: { value: 'account:home' },
+        });
+        fireEvent.click(screen.getByRole('button', { name: /what did they promise/ }));
+
+        expect(reported().askedBefore).toEqual([
+            {
+                question: 'what did they promise',
+                scope: { kind: 'mail', scope: { kind: 'account', accountId: 'home' } },
+            },
+        ]);
+        expect(window.location.hash).toBe('#/discover');
+    });
+
+    it('lets go of what was asked when that is asked for', () => {
+        const reported = fieldStanding({
+            askedBefore: [
+                { question: 'what did they promise', scope: { kind: 'mail', scope: { kind: 'everything' } } },
+            ],
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Forget these' }));
+
+        expect(reported().askedBefore).toEqual([]);
+        expect(screen.queryByRole('list', { name: 'Asked before' })).toBeNull();
     });
 });

--- a/frontend/src/Client.App/src/shell/IntentField.test.tsx
+++ b/frontend/src/Client.App/src/shell/IntentField.test.tsx
@@ -206,6 +206,18 @@ describe('IntentField scope', () => {
         expect(reported().askScope).toEqual({ kind: 'everything' });
     });
 
+    // The list the control renders drops the mailbox the mail space is already showing, so that it is not offered
+    // twice. A reader who names a mailbox here and then walks the folder tree to it is the case where those two meet,
+    // and the control has to keep saying what the question is about rather than falling blank between them.
+    it('keeps saying what is in scope when the mail space arrives at the mailbox the field was pointed at', () => {
+        fieldStanding(
+            { askScope: { kind: 'account', accountId: 'home' }, scope: { kind: 'account', accountId: 'home' } },
+            [workAccount, homeAccount],
+        );
+
+        expect(screen.getByRole('option', { name: 'Home', selected: true })).toBeDefined();
+    });
+
     it('follows the mail space again when what it is showing is chosen back', () => {
         const reported = fieldStanding({}, [workAccount, homeAccount]);
 
@@ -228,30 +240,30 @@ describe('IntentField history', () => {
     });
 
     it('keeps what was asked beside the scope it was asked under', () => {
-        const reported = fieldStanding({ conversation: { threadId: 'thread-1', openAt: null } });
+        fieldStanding({ conversation: { threadId: 'thread-1', openAt: null } });
 
         fireEvent.change(screen.getByRole('searchbox', { name: 'Ask your mail' }), {
             target: { value: 'what did they promise' },
         });
         fireEvent.submit(screen.getByRole('search'));
 
-        expect(reported().askedBefore).toEqual([
-            { question: 'what did they promise', scope: { kind: 'thread', threadId: 'thread-1' } },
-        ]);
+        expect(
+            screen.getByRole('button', { name: 'what did they promise, asking about This correspondence' }),
+        ).toBeDefined();
     });
 
     it('records nothing for a submission with no question in it', () => {
-        const reported = fieldStanding({});
+        fieldStanding({});
 
         fireEvent.submit(screen.getByRole('search'));
 
-        expect(reported().askedBefore).toEqual([]);
+        expect(screen.queryByRole('list', { name: 'Asked before' })).toBeNull();
     });
 
     // Widening is what somebody does after an answer that was too narrow, so asking a past question again asks it
     // under the scope in force now rather than the one it carries — otherwise widening would mean retyping.
     it('asks a past question again under the scope in force now', () => {
-        const reported = fieldStanding(
+        fieldStanding(
             {
                 askedBefore: [{ question: 'what did they promise', scope: { kind: 'thread', threadId: 'thread-1' } }],
             },
@@ -263,17 +275,12 @@ describe('IntentField history', () => {
         });
         fireEvent.click(screen.getByRole('button', { name: /what did they promise/ }));
 
-        expect(reported().askedBefore).toEqual([
-            {
-                question: 'what did they promise',
-                scope: { kind: 'mail', scope: { kind: 'account', accountId: 'home' } },
-            },
-        ]);
+        expect(screen.getByRole('button', { name: 'what did they promise, asking about Home' })).toBeDefined();
         expect(window.location.hash).toBe('#/discover');
     });
 
     it('lets go of what was asked when that is asked for', () => {
-        const reported = fieldStanding({
+        fieldStanding({
             askedBefore: [
                 { question: 'what did they promise', scope: { kind: 'mail', scope: { kind: 'everything' } } },
             ],
@@ -281,7 +288,21 @@ describe('IntentField history', () => {
 
         fireEvent.click(screen.getByRole('button', { name: 'Forget these' }));
 
-        expect(reported().askedBefore).toEqual([]);
         expect(screen.queryByRole('list', { name: 'Asked before' })).toBeNull();
+    });
+
+    // Forgetting the list takes away the control that was pressed, so focus is placed rather than left on an element
+    // that is no longer in the document — which is where keyboard and screen-reader use stops without anything saying
+    // so, and is the same reason the fragment chip's own close button places it.
+    it('puts the keyboard back on the question when the list it was pressed in goes', () => {
+        fieldStanding({
+            askedBefore: [
+                { question: 'what did they promise', scope: { kind: 'mail', scope: { kind: 'everything' } } },
+            ],
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Forget these' }));
+
+        expect(screen.getByRole('searchbox', { name: 'Ask your mail' })).toBe(document.activeElement);
     });
 });

--- a/frontend/src/Client.App/src/shell/IntentField.tsx
+++ b/frontend/src/Client.App/src/shell/IntentField.tsx
@@ -46,6 +46,15 @@ export function IntentField({ accounts }: { readonly accounts: readonly MailAcco
     const inForce = askScopeInForce(workspace, accounts);
     const offered = scopesOffered(onScreen, accounts, translate, locale);
 
+    // Read out of the list the control renders rather than out of the workspace, because the list is the shorter of
+    // the two: a mailbox somebody named in the field stops being offered separately the moment the mail space moves to
+    // it, and a value naming an option that is no longer there leaves the control drawing nothing selected while the
+    // question is still scoped to it. The first option is what answers then, and it is the same scope under another
+    // name — following the screen, where the screen now shows what was named.
+    const named = workspace.askScope;
+    const chosen =
+        named === null ? undefined : offered.find((one) => one.scope !== null && sameScope(one.scope, named));
+
     // The front door is reachable without hunting for it, which is what "from anywhere in the application" costs: a
     // reader inside a list of messages would otherwise tab back out of it to reach the field. An imperative browser
     // API being subscribed to is what an effect is for, and the shortcut is announced on the field itself rather than
@@ -102,7 +111,7 @@ export function IntentField({ accounts }: { readonly accounts: readonly MailAcco
                     ref={question}
                     type="search"
                     aria-label={translate('intent.label')}
-                    aria-keyshortcuts="Control+K Meta+K"
+                    aria-keyshortcuts={askShortcut}
                     placeholder={translate('intent.placeholder')}
                     value={workspace.question}
                     onChange={(event) => {
@@ -129,7 +138,7 @@ export function IntentField({ accounts }: { readonly accounts: readonly MailAcco
             <div className="flex flex-wrap items-center gap-2">
                 <select
                     aria-label={translate('scope.inScope')}
-                    value={workspace.askScope === null ? '' : scopeKey(workspace.askScope)}
+                    value={chosen?.value ?? ''}
                     onChange={(event) => {
                         revise({ askScope: offered.find((one) => one.value === event.target.value)?.scope ?? null });
                     }}
@@ -180,8 +189,12 @@ export function IntentField({ accounts }: { readonly accounts: readonly MailAcco
                     asked={workspace.askedBefore}
                     accounts={accounts}
                     onAskAgain={ask}
+                    // Forgetting the list takes the list off the screen, and the control that was pressed with it, so
+                    // focus is placed rather than left to fall to the document — the same reason the fragment chip's
+                    // own close button places it, and the same place: the question, which is what the field is for.
                     onForget={() => {
                         revise({ askedBefore: [] });
+                        question.current?.focus();
                     }}
                 />
             )}
@@ -191,8 +204,10 @@ export function IntentField({ accounts }: { readonly accounts: readonly MailAcco
 
 // The key the shortcut is pressed with, beside the modifier the platform reads it under. Stated once because the
 // handler tests it and `aria-keyshortcuts` announces it, and a screen reader promising a shortcut nothing listens for
-// is worse than promising none.
+// is worse than promising none — which is why the announcement below is built from the key rather than spelled beside
+// it, where the two could drift apart without either half looking wrong.
 const askShortcutKey = 'k';
+const askShortcut = `Control+${askShortcutKey.toUpperCase()} Meta+${askShortcutKey.toUpperCase()}`;
 
 // How many messages are picked out, in the forms a language has for the noun — selected rather than spelled, for the
 // reason `mailSpace/SelectionBar.tsx` gives: Polish needs three forms and English hides that it needs two.
@@ -302,8 +317,15 @@ function AskedBefore({
             <ul aria-label={translate('intent.askedBefore')} className="flex flex-wrap items-center gap-2">
                 {asked.map((before) => (
                     <li key={before.question} className="min-w-0 max-w-full">
+                        {/* The name is a sentence rather than the two pieces the chip draws: the question and its
+                            scope sit in adjacent elements with no whitespace between them, so what a screen reader
+                            would otherwise read out is the two run together into one word at the join. */}
                         <button
                             type="button"
+                            aria-label={translate('intent.askedUnder', {
+                                question: before.question,
+                                scope: scopeName(before.scope, accounts, translate, locale),
+                            })}
                             title={before.question}
                             className={`flex min-w-0 max-w-full items-center gap-1.5 px-2.75 py-1.25 text-sm ${chip}`}
                             onClick={() => {

--- a/frontend/src/Client.App/src/shell/IntentField.tsx
+++ b/frontend/src/Client.App/src/shell/IntentField.tsx
@@ -2,38 +2,92 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import type { MailAccount } from '@mailfathom/client-backend';
 import { chip } from '../controls/chrome';
 import { Icon } from '../controls/Icon';
-import { useLocalization } from '../localization/useLocalization';
+import { SecondaryButton } from '../controls/SecondaryButton';
+import type { MessageKey } from '../localization/en';
+import type { Locale } from '../localization/locale';
+import { useLocalization, type Translate } from '../localization/useLocalization';
 import { goToSpace } from '../routing/useSpace';
-import { accountInScope, scopeOfAccount } from '../workspace/mailScope';
+import { askScopeInForce, askScopeOnScreen, withAsked, type AskedQuestion, type AskScope } from '../workspace/askScope';
+import {
+    everything,
+    folderRoleLabels,
+    sameScope,
+    scopeKey,
+    scopeOfAccount,
+    type MailScope,
+} from '../workspace/mailScope';
 import { useWorkspace } from '../workspace/useWorkspace';
 
 // What the product puts in front of the person in every space: the question they are composing, drawn as the design
-// project draws the composer — a field with the product's mark on it, and the scope the question would be asked under
-// as chips beneath it. It asks nothing here: running a question is Discover's work, so submitting goes to the space
-// that will answer and carries the question there in the workspace rather than starting anything.
+// project draws the bar under a correspondence — a field with the product's mark on it, and the scope the question
+// would be asked under beneath it. It asks nothing here: running a question is Discover's work, so submitting goes to
+// the space that will answer and carries the question and its scope there in the workspace rather than starting
+// anything.
 //
-// It reads and writes the one scope the folder tree writes, rather than holding a mailbox of its own: the two controls
-// are two ways to say one thing, and this one is present in every space where the tree is Mail's. Choosing a mailbox
-// here scopes to the whole of it, which is what somebody who has not opened a folder means by naming one.
+// One field takes every kind of ask — a question, an instruction to search, a request to compare, a request to draft —
+// because a mode selector is an admission that the field does not understand what was typed. What it does insist on is
+// the scope: every question is asked *against* something, and what is in scope is what is read and sent, so it is
+// named before the question is submitted rather than discovered in the answer.
+//
+// It no longer writes the scope the mail space is read under, which it used to: choosing a mailbox to ask about is not
+// choosing a folder to read, and somebody widening a question after too narrow an answer would otherwise lose the
+// folder they were in and the messages they had picked out.
 
 export function IntentField({ accounts }: { readonly accounts: readonly MailAccount[] }) {
-    const { translate } = useLocalization();
+    const { locale, translate } = useLocalization();
     const { workspace, revise } = useWorkspace();
     const question = useRef<HTMLInputElement>(null);
+
+    const onScreen = askScopeOnScreen(workspace);
+    const inForce = askScopeInForce(workspace, accounts);
+    const offered = scopesOffered(onScreen, accounts, translate, locale);
+
+    // The front door is reachable without hunting for it, which is what "from anywhere in the application" costs: a
+    // reader inside a list of messages would otherwise tab back out of it to reach the field. An imperative browser
+    // API being subscribed to is what an effect is for, and the shortcut is announced on the field itself rather than
+    // written anywhere on the screen.
+    useEffect(() => {
+        function pressed(event: KeyboardEvent): void {
+            if (event.key.toLowerCase() === askShortcutKey && (event.ctrlKey || event.metaKey) && !event.altKey) {
+                event.preventDefault();
+                question.current?.focus();
+                question.current?.select();
+            }
+        }
+
+        document.addEventListener('keydown', pressed);
+
+        return () => {
+            document.removeEventListener('keydown', pressed);
+        };
+    }, []);
+
+    // Submitting records what was asked and what it was asked about, in that one act: the pair is what a run is
+    // started from, and a question kept apart from its scope is a run that reads something the person never saw.
+    function ask(asked: string): void {
+        const words = asked.trim();
+
+        if (words.length > 0) {
+            revise({ question: asked, askedBefore: withAsked(workspace.askedBefore, words, inForce) });
+        }
+
+        goToSpace('discover');
+    }
 
     return (
         <form
             // The one landmark the platform has no element for, and the one this frame genuinely is: a region a reader
             // moves to in order to ask something, rather than a form that submits a record.
             role="search"
+            aria-label={translate('intent.label')}
             className="flex shrink-0 flex-col gap-2.25 border-t border-line bg-panel px-4 py-3.5 workspace:px-5.5"
             onSubmit={(event) => {
                 event.preventDefault();
-                goToSpace('discover');
+                ask(workspace.question);
             }}
         >
             <div className="flex items-center gap-3 rounded-xl border-2 border-accent px-3.25 py-2">
@@ -48,6 +102,7 @@ export function IntentField({ accounts }: { readonly accounts: readonly MailAcco
                     ref={question}
                     type="search"
                     aria-label={translate('intent.label')}
+                    aria-keyshortcuts="Control+K Meta+K"
                     placeholder={translate('intent.placeholder')}
                     value={workspace.question}
                     onChange={(event) => {
@@ -64,19 +119,25 @@ export function IntentField({ accounts }: { readonly accounts: readonly MailAcco
                 </button>
             </div>
 
+            {/* Said as well as drawn: the scope changes because somebody opened a correspondence or ticked a row, which
+                is a change a reader who cannot see the chip would otherwise not be told about at all — and this is the
+                one place where not being told is a disclosure rather than a missed detail. */}
+            <p className="sr-only" role="status">
+                {translate('scope.asking', { scope: scopeName(inForce, accounts, translate, locale) })}
+            </p>
+
             <div className="flex flex-wrap items-center gap-2">
                 <select
-                    aria-label={translate('scope.mailbox')}
-                    value={accountInScope(workspace.scope) ?? ''}
+                    aria-label={translate('scope.inScope')}
+                    value={workspace.askScope === null ? '' : scopeKey(workspace.askScope)}
                     onChange={(event) => {
-                        revise({ scope: scopeOfAccount(event.target.value === '' ? null : event.target.value) });
+                        revise({ askScope: offered.find((one) => one.value === event.target.value)?.scope ?? null });
                     }}
                     className={`px-2.75 py-1.25 text-sm ${chip}`}
                 >
-                    <option value="">{translate('scope.allMailboxes')}</option>
-                    {accounts.map((account) => (
-                        <option key={account.id} value={account.id}>
-                            {account.displayName}
+                    {offered.map((one) => (
+                        <option key={one.value} value={one.value}>
+                            {one.label}
                         </option>
                     ))}
                 </select>
@@ -113,6 +174,154 @@ export function IntentField({ accounts }: { readonly accounts: readonly MailAcco
                     </span>
                 )}
             </div>
+
+            {workspace.askedBefore.length === 0 ? null : (
+                <AskedBefore
+                    asked={workspace.askedBefore}
+                    accounts={accounts}
+                    onAskAgain={ask}
+                    onForget={() => {
+                        revise({ askedBefore: [] });
+                    }}
+                />
+            )}
         </form>
+    );
+}
+
+// The key the shortcut is pressed with, beside the modifier the platform reads it under. Stated once because the
+// handler tests it and `aria-keyshortcuts` announces it, and a screen reader promising a shortcut nothing listens for
+// is worse than promising none.
+const askShortcutKey = 'k';
+
+// How many messages are picked out, in the forms a language has for the noun — selected rather than spelled, for the
+// reason `mailSpace/SelectionBar.tsx` gives: Polish needs three forms and English hides that it needs two.
+const selectionCounted: Readonly<Record<Intl.LDMLPluralRule, MessageKey>> = {
+    zero: 'scope.selection.other',
+    one: 'scope.selection.one',
+    two: 'scope.selection.other',
+    few: 'scope.selection.few',
+    many: 'scope.selection.many',
+    other: 'scope.selection.other',
+};
+
+/** One thing the field offers to ask about: what to show for it, and the mailbox to pin, or `null` to follow the screen. */
+interface OfferedScope {
+    readonly value: string;
+    readonly label: string;
+    readonly scope: MailScope | null;
+}
+
+/**
+ * What the field offers to ask about.
+ *
+ * What the mail space is showing comes first, and choosing it is choosing to keep following the screen — so opening a
+ * correspondence or ticking a row moves the scope without anybody touching the control. Everything after it is a
+ * mailbox to hold the question to whatever the screen does next, which is what widening after too narrow an answer
+ * actually is. The screen's own scope is not offered twice.
+ */
+function scopesOffered(
+    onScreen: AskScope,
+    accounts: readonly MailAccount[],
+    translate: Translate,
+    locale: Locale,
+): readonly OfferedScope[] {
+    const mailboxes = [everything, ...accounts.map((account) => scopeOfAccount(account.id))].filter(
+        (scope) => onScreen.kind !== 'mail' || !sameScope(onScreen.scope, scope),
+    );
+
+    return [
+        { value: '', label: scopeName(onScreen, accounts, translate, locale), scope: null },
+        ...mailboxes.map((scope) => ({
+            value: scopeKey(scope),
+            label: mailScopeName(scope, accounts, translate),
+            scope,
+        })),
+    ];
+}
+
+// What a scope is called on the screen, which is the whole of what the field promises: the words beside the question
+// are what the question will be asked about.
+function scopeName(scope: AskScope, accounts: readonly MailAccount[], translate: Translate, locale: Locale): string {
+    switch (scope.kind) {
+        case 'thread':
+            return translate('scope.thread');
+        case 'selection':
+            return translate(selectionCounted[new Intl.PluralRules(locale).select(scope.messages.length)], {
+                count: new Intl.NumberFormat(locale).format(scope.messages.length),
+            });
+        case 'mail':
+            return mailScopeName(scope.scope, accounts, translate);
+    }
+}
+
+function mailScopeName(scope: MailScope, accounts: readonly MailAccount[], translate: Translate): string {
+    switch (scope.kind) {
+        case 'everything':
+            return translate('scope.allMailboxes');
+        case 'role':
+            return translate('scope.everyMailbox', { folder: translate(folderRoleLabels[scope.role]) });
+        case 'account':
+            return mailboxName(scope.accountId, accounts);
+        case 'folder':
+            return translate('scope.folderIn', {
+                folder: scope.alias,
+                mailbox: mailboxName(scope.accountId, accounts),
+            });
+    }
+}
+
+// A mailbox is called what the person calls it, and what the deployment assigned it where the declaration has gone
+// since the scope was chosen — which beats naming nothing at all on a line whose whole job is to say what is in scope.
+function mailboxName(accountId: string, accounts: readonly MailAccount[]): string {
+    return accounts.find((account) => account.id === accountId)?.displayName ?? accountId;
+}
+
+// What was asked before, offered back so that asking again under a wider scope is one press rather than retyping the
+// sentence — which is the commonest thing somebody does after an answer that was too narrow. Each carries the scope it
+// was asked under, and pressing it asks under the scope in force now rather than that one, because widening is the
+// point. Forgetting them is offered beside them: what somebody asked their own mail is theirs, and a list of it they
+// cannot clear is one they did not choose to keep.
+function AskedBefore({
+    asked,
+    accounts,
+    onAskAgain,
+    onForget,
+}: {
+    readonly asked: readonly AskedQuestion[];
+    readonly accounts: readonly MailAccount[];
+    readonly onAskAgain: (question: string) => void;
+    readonly onForget: () => void;
+}) {
+    const { locale, translate } = useLocalization();
+
+    return (
+        <div className="flex flex-col gap-1">
+            <p className="text-sm text-muted">{translate('intent.askedBefore')}</p>
+
+            <ul aria-label={translate('intent.askedBefore')} className="flex flex-wrap items-center gap-2">
+                {asked.map((before) => (
+                    <li key={before.question} className="min-w-0 max-w-full">
+                        <button
+                            type="button"
+                            title={before.question}
+                            className={`flex min-w-0 max-w-full items-center gap-1.5 px-2.75 py-1.25 text-sm ${chip}`}
+                            onClick={() => {
+                                onAskAgain(before.question);
+                            }}
+                        >
+                            <span className="truncate">{before.question}</span>
+                            <span className="shrink-0 text-faint">
+                                {scopeName(before.scope, accounts, translate, locale)}
+                            </span>
+                        </button>
+                    </li>
+                ))}
+
+                <li>
+                    <SecondaryButton label={translate('intent.forgetAsked')} onActivate={onForget} />
+                </li>
+            </ul>
+        </div>
     );
 }

--- a/frontend/src/Client.App/src/workspace/askScope.test.ts
+++ b/frontend/src/Client.App/src/workspace/askScope.test.ts
@@ -1,0 +1,126 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import type { MailAccount } from '@mailfathom/client-backend';
+import { askScopeInForce, askScopeKey, askScopeOnScreen, mostAskedQuestions, withAsked } from './askScope';
+import { emptyWorkspace, type Workspace } from './useWorkspace';
+
+const workAccount: MailAccount = {
+    id: 'work',
+    displayName: 'Work',
+    synchronizationState: 'Synchronized',
+    lastSynchronizedAt: '2026-08-31T09:41:00+00:00',
+    behind: false,
+};
+
+function looking(at: Partial<Workspace>): Workspace {
+    return { ...emptyWorkspace, ...at };
+}
+
+describe('askScopeOnScreen', () => {
+    it('is the mailbox being read where nothing narrower is open', () => {
+        expect(askScopeOnScreen(looking({ scope: { kind: 'account', accountId: 'work' } }))).toEqual({
+            kind: 'mail',
+            scope: { kind: 'account', accountId: 'work' },
+        });
+    });
+
+    it('is the correspondence being read rather than the folder it was reached from', () => {
+        expect(
+            askScopeOnScreen(
+                looking({
+                    scope: { kind: 'folder', accountId: 'work', alias: 'Invoices' },
+                    conversation: { threadId: 'thread-1', openAt: null },
+                }),
+            ),
+        ).toEqual({ kind: 'thread', threadId: 'thread-1' });
+    });
+
+    it('is the messages picked out, which are narrower than the correspondence holding them', () => {
+        expect(
+            askScopeOnScreen(
+                looking({ conversation: { threadId: 'thread-1', openAt: null }, selected: ['one', 'two'] }),
+            ),
+        ).toEqual({ kind: 'selection', messages: ['one', 'two'] });
+    });
+});
+
+describe('askScopeInForce', () => {
+    it('is what somebody named in the field rather than what the screen is showing', () => {
+        expect(
+            askScopeInForce(
+                looking({
+                    conversation: { threadId: 'thread-1', openAt: null },
+                    askScope: { kind: 'everything' },
+                }),
+                [workAccount],
+            ),
+        ).toEqual({ kind: 'mail', scope: { kind: 'everything' } });
+    });
+
+    // A scope outlives the answer it was chosen from, so a mailbox whose declaration has gone since would otherwise be
+    // a question asked about nothing at all, named on the line whose whole job is to say what is in scope.
+    it('falls back to the screen where the mailbox named is no longer declared', () => {
+        expect(askScopeInForce(looking({ askScope: { kind: 'account', accountId: 'gone' } }), [workAccount])).toEqual({
+            kind: 'mail',
+            scope: { kind: 'everything' },
+        });
+    });
+});
+
+describe('askScopeKey', () => {
+    it('tells the three shapes apart', () => {
+        const keys = [
+            askScopeKey({ kind: 'mail', scope: { kind: 'account', accountId: 'work' } }),
+            askScopeKey({ kind: 'thread', threadId: 'work' }),
+            askScopeKey({ kind: 'selection', messages: ['work'] }),
+        ];
+
+        expect(new Set(keys).size).toBe(keys.length);
+    });
+});
+
+describe('withAsked', () => {
+    it('puts the newest question at the front', () => {
+        const asked = withAsked(
+            [{ question: 'first', scope: { kind: 'mail', scope: { kind: 'everything' } } }],
+            'second',
+            { kind: 'thread', threadId: 'thread-1' },
+        );
+
+        expect(asked.map((one) => one.question)).toEqual(['second', 'first']);
+    });
+
+    // Asking the same question under a wider scope is the commonest thing somebody does after too narrow an answer,
+    // so the sentence moves rather than repeating: two rows reading the same words is a list nobody can pick from.
+    it('moves a question asked again rather than writing it twice', () => {
+        const asked = withAsked(
+            [
+                { question: 'what did they promise', scope: { kind: 'thread', threadId: 'thread-1' } },
+                { question: 'who signed it', scope: { kind: 'mail', scope: { kind: 'everything' } } },
+            ],
+            'what did they promise',
+            { kind: 'mail', scope: { kind: 'everything' } },
+        );
+
+        expect(asked).toEqual([
+            { question: 'what did they promise', scope: { kind: 'mail', scope: { kind: 'everything' } } },
+            { question: 'who signed it', scope: { kind: 'mail', scope: { kind: 'everything' } } },
+        ]);
+    });
+
+    it('drops the oldest once the list is as long as one tab keeps', () => {
+        const asked = Array.from({ length: mostAskedQuestions }, (_, at) => ({
+            question: `question ${String(at)}`,
+            scope: { kind: 'mail', scope: { kind: 'everything' } } as const,
+        }));
+
+        const kept = withAsked(asked, 'the newest one', { kind: 'mail', scope: { kind: 'everything' } });
+
+        expect(kept).toHaveLength(mostAskedQuestions);
+        expect(kept[0]?.question).toBe('the newest one');
+        expect(kept.some((one) => one.question === `question ${String(mostAskedQuestions - 1)}`)).toBe(false);
+    });
+});

--- a/frontend/src/Client.App/src/workspace/askScope.test.ts
+++ b/frontend/src/Client.App/src/workspace/askScope.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest';
 import type { MailAccount } from '@mailfathom/client-backend';
-import { askScopeInForce, askScopeKey, askScopeOnScreen, mostAskedQuestions, withAsked } from './askScope';
+import { askScopeInForce, askScopeOnScreen, mostAskedQuestions, withAsked } from './askScope';
 import { emptyWorkspace, type Workspace } from './useWorkspace';
 
 const workAccount: MailAccount = {
@@ -67,18 +67,6 @@ describe('askScopeInForce', () => {
             kind: 'mail',
             scope: { kind: 'everything' },
         });
-    });
-});
-
-describe('askScopeKey', () => {
-    it('tells the three shapes apart', () => {
-        const keys = [
-            askScopeKey({ kind: 'mail', scope: { kind: 'account', accountId: 'work' } }),
-            askScopeKey({ kind: 'thread', threadId: 'work' }),
-            askScopeKey({ kind: 'selection', messages: ['work'] }),
-        ];
-
-        expect(new Set(keys).size).toBe(keys.length);
     });
 });
 

--- a/frontend/src/Client.App/src/workspace/askScope.ts
+++ b/frontend/src/Client.App/src/workspace/askScope.ts
@@ -64,8 +64,9 @@ export function askScopeOnScreen(workspace: Workspace): AskScope {
  * The scope the next question would actually be asked under.
  *
  * What the person named in the field wins over what is on the screen. A mailbox they named that the deployment no
- * longer declares is not one — a chosen scope outlives the answer it was chosen from, exactly as the mail space's own
- * does — so it falls back to the screen rather than asking about a mailbox nobody has.
+ * longer declares is not one — a chosen scope outlives the answer it was chosen from — so it falls back to the screen
+ * rather than asking about a mailbox nobody has. What that check has to cover is decided by what may reach this value
+ * at all, which `stillOffered` below states.
  */
 export function askScopeInForce(workspace: Workspace, accounts: readonly MailAccount[]): AskScope {
     return workspace.askScope !== null && stillOffered(workspace.askScope, accounts)
@@ -109,9 +110,11 @@ export function withAsked(
     );
 }
 
-// A mailbox somebody pointed the field at is offered while the deployment still declares the account it names. Every
-// other mail scope either spans accounts or names none, and the folder scopes the field itself never sets are left to
-// the mail space, which already drops one the deployment stopped offering.
+// A mailbox somebody pointed the field at is offered while the deployment still declares the account it names. The
+// account is the only kind that has to be asked about: the field offers every mailbox at once or one of them and
+// nothing else, and `rememberedWorkspace.ts` refuses anything else on the way back in, so a folder or a role never
+// reaches this value to go stale in it. Checking the account against the accounts is therefore the whole of it rather
+// than a narrower reading of `mailScope.ts`'s own check, which needs the folder directory this field is never handed.
 function stillOffered(scope: MailScope, accounts: readonly MailAccount[]): boolean {
     return scope.kind !== 'account' || accounts.some((account) => account.id === scope.accountId);
 }

--- a/frontend/src/Client.App/src/workspace/askScope.ts
+++ b/frontend/src/Client.App/src/workspace/askScope.ts
@@ -3,7 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import type { MailAccount } from '@mailfathom/client-backend';
-import { scopeKey, type MailScope } from './mailScope';
+import type { MailScope } from './mailScope';
 import type { Workspace } from './useWorkspace';
 
 // What a question is asked about, which is not the same thing as what the mail space is showing. Somebody reading one
@@ -72,23 +72,6 @@ export function askScopeInForce(workspace: Workspace, accounts: readonly MailAcc
     return workspace.askScope !== null && stillOffered(workspace.askScope, accounts)
         ? { kind: 'mail', scope: workspace.askScope }
         : askScopeOnScreen(workspace);
-}
-
-/**
- * The scope's identity as one string.
- *
- * It is what a past question is compared by, so nothing has to write a comparison per shape and a fourth shape cannot
- * be forgotten by one of them.
- */
-export function askScopeKey(scope: AskScope): string {
-    switch (scope.kind) {
-        case 'mail':
-            return `mail:${scopeKey(scope.scope)}`;
-        case 'thread':
-            return `thread:${scope.threadId}`;
-        case 'selection':
-            return `selection:${scope.messages.join(',')}`;
-    }
 }
 
 /**

--- a/frontend/src/Client.App/src/workspace/askScope.ts
+++ b/frontend/src/Client.App/src/workspace/askScope.ts
@@ -1,0 +1,117 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { MailAccount } from '@mailfathom/client-backend';
+import { scopeKey, type MailScope } from './mailScope';
+import type { Workspace } from './useWorkspace';
+
+// What a question is asked about, which is not the same thing as what the mail space is showing. Somebody reading one
+// correspondence out of a folder means that correspondence when they ask, and somebody who has ticked four rows means
+// those four — so the scope is named beside the field before the question is sent rather than discovered in the answer.
+//
+// It is one value derived from two, rather than a second scope kept beside the mail space's own: what is on the screen
+// answers unless the person named something else in the field, and naming something else there changes what the next
+// question reads without moving the list out from under them. Two scopes free to disagree would be a field that says
+// one thing and asks another, which here is a disclosure rather than a display defect — what is in scope is what is
+// read and sent.
+
+/** What a question is asked about. */
+export type AskScope =
+    /** A mailbox, a folder, or every mailbox at once — the same scope the mail space is read under. */
+    | { readonly kind: 'mail'; readonly scope: MailScope }
+
+    /** The correspondence being read, whatever folder it was reached from. */
+    | { readonly kind: 'thread'; readonly threadId: string }
+
+    /** The messages picked out of the list, in the order the list draws them. */
+    | { readonly kind: 'selection'; readonly messages: readonly string[] };
+
+/** A question that was asked, and the scope it was asked under. */
+export interface AskedQuestion {
+    readonly question: string;
+    readonly scope: AskScope;
+}
+
+/**
+ * How many questions are offered back before the oldest is dropped.
+ *
+ * Read where a store is read back and written by the field that keeps them, so the bound one tab writes under and the
+ * bound a stored list is held to are one number rather than two that drift.
+ */
+export const mostAskedQuestions = 8;
+
+/**
+ * What the mail space is pointing at, narrowest first.
+ *
+ * A selection is narrower than the correspondence it was made in, and that is narrower than the mailbox it was reached
+ * from. Nothing here is a guess about what somebody meant: it is what the screen is showing, and the field draws it
+ * so that choosing differently is one control away rather than something to discover afterwards.
+ */
+export function askScopeOnScreen(workspace: Workspace): AskScope {
+    if (workspace.selected.length > 0) {
+        return { kind: 'selection', messages: workspace.selected };
+    }
+
+    if (workspace.conversation !== null) {
+        return { kind: 'thread', threadId: workspace.conversation.threadId };
+    }
+
+    return { kind: 'mail', scope: workspace.scope };
+}
+
+/**
+ * The scope the next question would actually be asked under.
+ *
+ * What the person named in the field wins over what is on the screen. A mailbox they named that the deployment no
+ * longer declares is not one — a chosen scope outlives the answer it was chosen from, exactly as the mail space's own
+ * does — so it falls back to the screen rather than asking about a mailbox nobody has.
+ */
+export function askScopeInForce(workspace: Workspace, accounts: readonly MailAccount[]): AskScope {
+    return workspace.askScope !== null && stillOffered(workspace.askScope, accounts)
+        ? { kind: 'mail', scope: workspace.askScope }
+        : askScopeOnScreen(workspace);
+}
+
+/**
+ * The scope's identity as one string.
+ *
+ * It is what a past question is compared by, so nothing has to write a comparison per shape and a fourth shape cannot
+ * be forgotten by one of them.
+ */
+export function askScopeKey(scope: AskScope): string {
+    switch (scope.kind) {
+        case 'mail':
+            return `mail:${scopeKey(scope.scope)}`;
+        case 'thread':
+            return `thread:${scope.threadId}`;
+        case 'selection':
+            return `selection:${scope.messages.join(',')}`;
+    }
+}
+
+/**
+ * The questions asked before with this one at the front, held to what one tab may accumulate.
+ *
+ * A question asked again moves rather than repeating, which is what keeps the list short without anything having to
+ * look for a duplicate before writing one — `search/MailSearch.tsx` keeps what was searched for the same way. It moves
+ * on the words alone, because asking the same question under a wider scope is the commonest thing somebody does after
+ * an answer that was too narrow, and two rows reading the same sentence is a list nobody can pick from.
+ */
+export function withAsked(
+    asked: readonly AskedQuestion[],
+    question: string,
+    scope: AskScope,
+): readonly AskedQuestion[] {
+    return [{ question, scope }, ...asked.filter((before) => before.question !== question)].slice(
+        0,
+        mostAskedQuestions,
+    );
+}
+
+// A mailbox somebody pointed the field at is offered while the deployment still declares the account it names. Every
+// other mail scope either spans accounts or names none, and the folder scopes the field itself never sets are left to
+// the mail space, which already drops one the deployment stopped offering.
+function stillOffered(scope: MailScope, accounts: readonly MailAccount[]): boolean {
+    return scope.kind !== 'account' || accounts.some((account) => account.id === scope.accountId);
+}

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
@@ -280,6 +280,17 @@ describe('rememberedWorkspace', () => {
             value: JSON.stringify({ ...emptyWorkspace, askScope: { kind: 'somewhere' } }),
         },
         {
+            shape: 'a scope the field was pointed at naming a folder, which the field cannot offer',
+            value: JSON.stringify({
+                ...emptyWorkspace,
+                askScope: { kind: 'folder', accountId: 'work', alias: 'Invoices' },
+            }),
+        },
+        {
+            shape: 'a scope the field was pointed at naming a folder role, which the field cannot offer',
+            value: JSON.stringify({ ...emptyWorkspace, askScope: { kind: 'role', role: 'Inbox' } }),
+        },
+        {
             shape: 'questions asked before kept as something other than a list of them',
             value: JSON.stringify({ ...emptyWorkspace, askedBefore: 'what did they promise' }),
         },

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
@@ -21,6 +21,8 @@ const kept: Workspace = {
     fragment: null,
     selected: ['AAMkAD-42', 'AAMkAD-43'],
     question: 'what did Nordwind send',
+    askScope: { kind: 'account', accountId: 'work' },
+    askedBefore: [{ question: 'what did they promise', scope: { kind: 'thread', threadId: 'thread-1' } }],
     recentSearches: ['quarterly figures'],
 };
 
@@ -177,6 +179,28 @@ describe('rememberedWorkspace', () => {
         expect(rememberedWorkspace()).toEqual(emptyWorkspace);
     });
 
+    // The same pair again for what the intent field holds, which is a workspace kept before the field had a scope of
+    // its own: it is one this client wrote, so it opens on what was kept, asking about whatever is on the screen and
+    // with nothing offered back.
+    it('reads a workspace kept before the field held a scope and a history as one holding neither', () => {
+        const { askScope, askedBefore, ...before } = kept;
+
+        stored(before);
+
+        expect(rememberedWorkspace()).toEqual({ ...kept, askScope: null, askedBefore: [] });
+        expect(askScope).not.toBeNull();
+        expect(askedBefore).toHaveLength(1);
+    });
+
+    it('opens on the mailbox the field was pointed at and the questions asked under it', () => {
+        stored(kept);
+
+        expect(rememberedWorkspace().askScope).toEqual({ kind: 'account', accountId: 'work' });
+        expect(rememberedWorkspace().askedBefore).toEqual([
+            { question: 'what did they promise', scope: { kind: 'thread', threadId: 'thread-1' } },
+        ]);
+    });
+
     it.each([
         { kind: 'everything' },
         { kind: 'role', role: 'Sent' },
@@ -250,6 +274,42 @@ describe('rememberedWorkspace', () => {
         {
             shape: 'a picked-out identifier longer than any the client wrote there',
             value: JSON.stringify({ ...emptyWorkspace, selected: ['a'.repeat(257)] }),
+        },
+        {
+            shape: 'a scope the field was pointed at that is not one',
+            value: JSON.stringify({ ...emptyWorkspace, askScope: { kind: 'somewhere' } }),
+        },
+        {
+            shape: 'questions asked before kept as something other than a list of them',
+            value: JSON.stringify({ ...emptyWorkspace, askedBefore: 'what did they promise' }),
+        },
+        {
+            shape: 'a question asked before that is not text',
+            value: JSON.stringify({
+                ...emptyWorkspace,
+                askedBefore: [{ question: 42, scope: { kind: 'thread', threadId: 'thread-1' } }],
+            }),
+        },
+        {
+            shape: 'a question asked before about nothing at all',
+            value: JSON.stringify({ ...emptyWorkspace, askedBefore: [{ question: 'what did they promise' }] }),
+        },
+        {
+            shape: 'a question asked before about a selection holding no message',
+            value: JSON.stringify({
+                ...emptyWorkspace,
+                askedBefore: [{ question: 'what did they promise', scope: { kind: 'selection', messages: [] } }],
+            }),
+        },
+        {
+            shape: 'more questions asked before than one tab keeps',
+            value: JSON.stringify({
+                ...emptyWorkspace,
+                askedBefore: Array.from({ length: 9 }, () => ({
+                    question: 'what did they promise',
+                    scope: { kind: 'mail', scope: { kind: 'everything' } },
+                })),
+            }),
         },
         {
             shape: 'searches kept as something other than a list of them',

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.ts
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { longestSearchText } from '@mailfathom/client-backend';
+import { mostAskedQuestions, type AskedQuestion, type AskScope } from './askScope';
 import { everything, isMailFolderRole, type MailScope } from './mailScope';
 import type { OpenConversation } from './openConversation';
 import { emptyWorkspace, type Workspace } from './useWorkspace';
@@ -104,6 +105,9 @@ function workspaceIn(value: unknown): Workspace | null {
 
     const record = value as Record<string, unknown>;
     const scope = scopeIn(record['scope']);
+    const chosen = record['askScope'] ?? null;
+    const askScope = chosen === null ? null : scopeIn(chosen);
+    const askedBefore = askedBeforeIn(record['askedBefore'] ?? []);
     const collapsed = collapsedIn(record['collapsed']);
     const mailboxesFolded = record['mailboxesFolded'] ?? false;
     const panelsHidden = record['panelsHidden'] ?? false;
@@ -115,6 +119,8 @@ function workspaceIn(value: unknown): Workspace | null {
 
     if (
         scope === null ||
+        (chosen !== null && askScope === null) ||
+        askedBefore === null ||
         collapsed === null ||
         selected === null ||
         recentSearches === null ||
@@ -151,8 +157,70 @@ function workspaceIn(value: unknown): Workspace | null {
         fragment: null,
         selected,
         question,
+        askScope,
+        askedBefore,
         recentSearches,
     };
+}
+
+// The questions asked before, each held to the same bound the question being typed is held to: what a store carries
+// for them is read back into state and written out again on every revision, and neither the sentence nor the list is
+// something this client would have written past those numbers.
+function askedBeforeIn(value: unknown): readonly AskedQuestion[] | null {
+    if (!Array.isArray(value) || value.length > mostAskedQuestions) {
+        return null;
+    }
+
+    const asked: AskedQuestion[] = [];
+    for (const entry of value) {
+        if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+            return null;
+        }
+
+        const question = (entry as Record<string, unknown>)['question'];
+        const scope = askScopeIn((entry as Record<string, unknown>)['scope']);
+
+        if (
+            typeof question !== 'string' ||
+            question.length === 0 ||
+            question.length > longestQuestion ||
+            scope === null
+        ) {
+            return null;
+        }
+
+        asked.push({ question, scope });
+    }
+
+    return asked;
+}
+
+// Read through the same three checks the workspace's own values are read through, because that is exactly what the
+// three shapes hold: a mail scope, a correspondence the deployment named, and a list of messages it named.
+function askScopeIn(value: unknown): AskScope | null {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        return null;
+    }
+
+    const record = value as Record<string, unknown>;
+    const threadId = record['threadId'];
+
+    switch (record['kind']) {
+        case 'mail': {
+            const scope = scopeIn(record['scope']);
+
+            return scope === null ? null : { kind: 'mail', scope };
+        }
+        case 'thread':
+            return isIdentifier(threadId) ? { kind: 'thread', threadId } : null;
+        case 'selection': {
+            const messages = selectedIn(record['messages']);
+
+            return messages === null || messages.length === 0 ? null : { kind: 'selection', messages };
+        }
+        default:
+            return null;
+    }
 }
 
 // The searches read back, each held to what this surface ranks against at all: text longer than that is not a search

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.ts
@@ -106,7 +106,7 @@ function workspaceIn(value: unknown): Workspace | null {
     const record = value as Record<string, unknown>;
     const scope = scopeIn(record['scope']);
     const chosen = record['askScope'] ?? null;
-    const askScope = chosen === null ? null : scopeIn(chosen);
+    const askScope = chosen === null ? null : namedScopeIn(chosen);
     const askedBefore = askedBeforeIn(record['askedBefore'] ?? []);
     const collapsed = collapsedIn(record['collapsed']);
     const mailboxesFolded = record['mailboxesFolded'] ?? false;
@@ -193,6 +193,17 @@ function askedBeforeIn(value: unknown): readonly AskedQuestion[] | null {
     }
 
     return asked;
+}
+
+// The mailbox somebody pointed the field at, held to the two shapes the field can actually offer: every mailbox at
+// once, or one of them. A folder or a role read back here would be a scope no control in the client can produce and
+// nothing anywhere drops when the deployment stops declaring it — the mail space watches its own scope and not this
+// one — so it would ask about a folder nobody has until the tab was closed. Refusing it at the boundary is what makes
+// `askScope.ts` right to re-check the account alone.
+function namedScopeIn(value: unknown): MailScope | null {
+    const scope = scopeIn(value);
+
+    return scope === null || scope.kind === 'everything' || scope.kind === 'account' ? scope : null;
 }
 
 // Read through the same three checks the workspace's own values are read through, because that is exactly what the

--- a/frontend/src/Client.App/src/workspace/useWorkspace.ts
+++ b/frontend/src/Client.App/src/workspace/useWorkspace.ts
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { createContext, useContext } from 'react';
+import type { AskedQuestion } from './askScope';
 import { everything, type MailScope } from './mailScope';
 import type { CitedAttachment, OpenedAttachment } from './openAttachment';
 import type { OpenConversation } from './openConversation';
@@ -115,6 +116,30 @@ export interface Workspace {
     readonly question: string;
 
     /**
+     * The mailbox the intent field was pointed at, or `null` where the field asks about what the mail space is showing.
+     *
+     * Beside the scope the list is read under rather than instead of it, because the two answer different questions:
+     * one says what is drawn, and the other what the next question is about. Widening a question after an answer that
+     * was too narrow is exactly the second changing while the first does not, so a person who asks again about every
+     * mailbox keeps the folder they were reading and the messages they had picked out.
+     *
+     * Only what the field itself offers ever reaches it — every mailbox at once, or one of them — and
+     * `workspace/askScope.ts` is where it is read against what is on the screen.
+     */
+    readonly askScope: MailScope | null;
+
+    /**
+     * What was asked before, newest first, each with the scope it was asked under.
+     *
+     * Here rather than in the space that answers, for the reason the searches are: the field is drawn in every space
+     * and an answer is drawn in one, so a list the answer held would be empty everywhere a question is composed. It is
+     * a list of questions rather than a conversation — what somebody does with one is ask it again, usually wider —
+     * and it goes with the credential like everything else the workspace holds, because what a person asked their own
+     * mail is theirs.
+     */
+    readonly askedBefore: readonly AskedQuestion[];
+
+    /**
      * What was searched for before, newest first, so a search is one press rather than something to retype.
      *
      * Here rather than inside the search screen because it has to outlive one: the column the search stands in is
@@ -145,6 +170,8 @@ export const emptyWorkspace: Workspace = {
     fragment: null,
     selected: [],
     question: '',
+    askScope: null,
+    askedBefore: [],
     recentSearches: [],
 };
 

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -489,18 +489,18 @@ test('moves back and forward through its own spaces without leaving the applicat
     await expect(page.getByRole('main', { name: 'Mail' })).toBeVisible();
 });
 
-test('carries the question and the mailbox in scope from one space to the next', async ({ page }) => {
+test('carries the question and the scope it is asked under from one space to the next', async ({ page }) => {
     await openSignedIn(page);
 
     const question = page.getByRole('searchbox', { name: 'Ask your mail' });
     await question.fill('the renewal Nordwind sent');
-    await page.getByRole('combobox', { name: 'Mailbox in scope' }).selectOption({ label: 'Work' });
+    await page.getByRole('combobox', { name: 'What the question is asked about' }).selectOption({ label: 'Work' });
 
     await page.getByRole('link', { name: 'Cases' }).click();
     await expect(page.getByRole('heading', { name: 'Cases', level: 1 })).toBeVisible();
 
     await expect(question).toHaveValue('the renewal Nordwind sent');
-    await expect(page.getByRole('combobox', { name: 'Mailbox in scope' })).toHaveValue('work');
+    await expect(page.getByRole('combobox', { name: 'What the question is asked about' })).toHaveValue('account:work');
 });
 
 test('puts the navigation beside the workspace in a wide window and under it in a narrow one', async ({ page }) => {
@@ -624,7 +624,7 @@ test('stays usable at the narrowest width a supported head presents', async ({ p
     // design project shows. Nothing is dropped by width, and the window it is measured in is the width alone.
     await expect(page.getByRole('heading', { name: 'Discover', level: 1 })).toBeVisible();
     await expect(page.getByRole('searchbox', { name: 'Ask your mail' })).toBeVisible();
-    await expect(page.getByRole('combobox', { name: 'Mailbox in scope' })).toBeVisible();
+    await expect(page.getByRole('combobox', { name: 'What the question is asked about' })).toBeVisible();
 
     // Three of the seven stand in the bar itself and the other four behind its overflow, which is what makes five
     // places enough for seven destinations. Reached rather than dropped is the whole of the claim, so both halves are


### PR DESCRIPTION
The intent field asked and read under one value, so pointing it at a mailbox moved the list the
reader was standing in. It now carries a scope of its own.

## What the field does now

**The scope in force is derived rather than kept.** `workspace/askScope.ts` reads what the mail
space is showing, narrowest first — the messages picked out, else the correspondence being read,
else the mailbox — and the field names that beside the question at all times. Nothing is stored for
it, so opening a correspondence or ticking a row moves the scope with no value to keep in step.

**What is stored is the override.** `workspace.askScope` holds a mailbox somebody named in the
field, and `null` means the field follows the screen. Choosing one changes what the next question
reads and nothing else: the folder stays open, the picked-out rows stay picked out, and the list
does not re-read. A named mailbox the deployment has since stopped declaring falls back to the
screen rather than asking about a mailbox nobody has.

**Submitting records the question beside the scope it was asked under.** `workspace.askedBefore`
holds those pairs, newest first, bounded at eight and read back through the same checks the rest of
the workspace is. They are offered back under the field, each showing the scope it carried, and
pressing one asks it again **under the scope in force now** rather than the one it carries — which
is what widening after too narrow an answer means, and is why re-asking is one press instead of
retyping a sentence. `Forget these` clears the list. It is the session's store, so it dies with the
tab and reaches no log and no telemetry.

**The field is reachable from anywhere** with `Ctrl`/`Cmd`+`K`, which it announces on itself with
`aria-keyshortcuts` — a shortcut a screen reader passes on that nothing listens for would be worse
than promising none, so the test asserts both halves together. A visually hidden `role="status"`
line says the scope in force, so a reader who cannot see the chip is told when opening a
correspondence changes what their next question is about. That is the one place where not being
told is a disclosure rather than a missed detail.

## Held against the design

The design project's bar under a correspondence was captured with `capture-design.sh` and the client
with `capture-client.sh`, at `desktop`, and the two were compared with `compare-captures.sh`. The
whole-frame share is 45.9%, which measures the two corpora rather than the two designs — the
artboard renders a Polish contract thread and the client renders the fixture corpus — so the bar
region was read as images instead. The field, its accent border, the badge, and the submit button
line up. Three differences stand, and none of them is this issue's to close:

- The scope names the mailbox where the reading pane holds a **single message** rather than a
  correspondence, while the design draws `Zakres: ten wątek`. Carrying what is open into the field
  as scope is #1183, which this issue's own Dependencies section hands it to; the shape it fills is
  already here.
- The design draws a second chip, `+ zaznaczony fragment`, unconditionally. The client draws the
  fragment chip only where a fragment exists, because a chip naming a passage nobody selected would
  say something untrue about what the question reads.
- The design's submit reads `Przygotuj szkic` and the client's reads `Zapytaj`, and the design's
  right-aligned note about a draft staying local is absent. Both belong to the drafting half of the
  bar rather than to the asking half this issue builds.

## Scope of the change

`Case` is not among the scopes the field can name, because no Cases space exists to produce one; the
member joins when that space is built. The run itself is not started here — Discover answers, under
#1170 — so submitting carries the question and its scope into the workspace and goes to that space,
which is what it did before.

Closes #1175

- Issue: https://github.com/Krzysztof318/MailFathom/issues/1175

