### PR TITLE
[#1773] Generate the markup real mail actually carries in AI mode

### DIFF
--- a/backend/tests/SyntheticMail.UnitTests/Commands/CorpusListingTests.cs
+++ b/backend/tests/SyntheticMail.UnitTests/Commands/CorpusListingTests.cs
@@ -120,19 +120,25 @@ public sealed class CorpusListingTests
     }
 
     [Fact]
-    public void Describe_AMessageGeneratedByAProvider_NamesTheLanguageAndTheTopicItWasGeneratedUnder()
+    public void Describe_AMessageGeneratedByAProvider_NamesTheLanguageTheTopicAndTheMarkupItWasGeneratedUnder()
     {
         // Arrange
         var email = Build(inReplyTo: null, carbonCopies: 0, attachment: null) with
         {
-            AiOrigin = new SyntheticEmailAiOrigin("pl", SyntheticMailTopic.TechnicalSupport),
+            AiOrigin = new SyntheticEmailAiOrigin(
+                "pl",
+                SyntheticMailTopic.TechnicalSupport,
+                SyntheticMarkupDialect.WordOutlook),
         };
 
         // Act
         var line = CorpusListing.Describe(email);
 
         // Assert
-        Assert.Contains("| sensitive=none | language=pl topic=technical-support |", line, StringComparison.Ordinal);
+        Assert.Contains(
+            "| sensitive=none | language=pl topic=technical-support markup=word-outlook |",
+            line,
+            StringComparison.Ordinal);
     }
 
     [Fact]

--- a/backend/tests/SyntheticMail.UnitTests/Generation/AiContent/OpenAiEmailContentSourceTests.cs
+++ b/backend/tests/SyntheticMail.UnitTests/Generation/AiContent/OpenAiEmailContentSourceTests.cs
@@ -36,7 +36,15 @@ public sealed class OpenAiEmailContentSourceTests
         int expected)
     {
         // Arrange
-        var request = new AiEmailContentRequest("en", SyntheticMailTopic.Business, "Ada Kowalska", null, null, fileName, drawn);
+        var request = new AiEmailContentRequest(
+            "en",
+            SyntheticMailTopic.Business,
+            SyntheticMarkupDialect.GmailComposer,
+            "Ada Kowalska",
+            null,
+            null,
+            fileName,
+            drawn);
 
         // Act
         var bound = OpenAiEmailContentSource.AttachmentBoundOf(request);
@@ -149,6 +157,48 @@ public sealed class OpenAiEmailContentSourceTests
         // Assert
         // The endpoint is one a developer named and what it answers is delivered to a real mailbox, so the run stops
         // rather than reducing the answer into something nobody asked for.
+        Assert.Contains("will not deliver", failure.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    // Word's own HTML: a proprietary namespace, a conditional block, an mso- property, and the paragraph filler.
+    [InlineData("<html xmlns:o=\"urn:schemas-microsoft-com:office:office\"><body><!--[if gte mso 9]><xml></xml><![endif]--><p class=\"MsoNormal\" style=\"mso-pagination:widow-orphan\">Hello.<o:p></o:p></p></body></html>")]
+    // A campaign's nested layout tables, with the deprecated attributes and the font element that come with them.
+    [InlineData("<table border=\"0\" cellpadding=\"0\" bgcolor=\"#eeeeee\"><tr><td align=\"center\"><font face=\"Arial\" size=\"2\">Hello.</font></td></tr></table>")]
+    // Markup that is not well-formed at all: unclosed blocks, a stray end tag, unquoted attributes, and a bare entity.
+    [InlineData("<div><p>Hello.<p>More.<table border=1 width=600><tr><td>One<td>Two</div></span>Rest &amp and &nbsp then.")]
+    public void ParseContent_AnAnswerWrittenAsARealClientsMarkup_IsDeliveredRatherThanRefused(string markup)
+    {
+        // Arrange
+        // Escaped for the same reason the refused constructs above are: the quotation marks these dialects carry in
+        // their attributes would otherwise end the JSON string and make the answer malformed, which is a different
+        // refusal from the one under test.
+        var escaped = markup.Replace("\"", "\\\"", StringComparison.Ordinal);
+        var answer = $$"""{ "subject": "Figures", "body": "Hello.", "html": "{{escaped}}" }""";
+
+        // Act
+        var content = OpenAiEmailContentSource.ParseContent(answer);
+
+        // Assert
+        // The refusal answers what executes, never what is merely deprecated, proprietary, or broken — and the last of
+        // those is the whole point of asking for it, because a corpus of well-formed markup proves nothing about a
+        // reader that has to survive what real senders emit.
+        Assert.Equal(markup, content.Html);
+    }
+
+    [Fact]
+    public void ParseContent_AnExecutableConstructInsideOtherwiseRealisticMarkup_IsStillRefused()
+    {
+        // Arrange
+        const string answer =
+            """{ "subject": "Figures", "body": "Hello.", "html": "<body><p class=\"MsoNormal\">Hello.<o:p></o:p><iframe src=\"x\"></iframe></p></body>" }""";
+
+        // Act
+        var failure = Assert.Throws<SyntheticMailFailure>(() => OpenAiEmailContentSource.ParseContent(answer));
+
+        // Assert
+        // Asking for a dialect's own quirks is not a licence for the constructs the refusal exists for: what reaches a
+        // mailbox is decided by the scan rather than by which markup the request asked for.
         Assert.Contains("will not deliver", failure.Message, StringComparison.Ordinal);
     }
 

--- a/backend/tests/SyntheticMail.UnitTests/Generation/SyntheticEmailGeneratorAiModeTests.cs
+++ b/backend/tests/SyntheticMail.UnitTests/Generation/SyntheticEmailGeneratorAiModeTests.cs
@@ -78,7 +78,50 @@ public sealed class SyntheticEmailGeneratorAiModeTests
             CancellationToken.None);
 
         // Assert
-        Assert.All(corpus, email => Assert.Equal(new SyntheticEmailAiOrigin("pl", SyntheticMailTopic.Travel), email.AiOrigin));
+        Assert.All(
+            corpus,
+            email =>
+            {
+                Assert.NotNull(email.AiOrigin);
+                Assert.Equal("pl", email.AiOrigin.Language);
+                Assert.Equal(SyntheticMailTopic.Travel, email.AiOrigin.Topic);
+                Assert.Contains(email.AiOrigin.MarkupDialect, SyntheticMarkupDialect.All);
+            });
+    }
+
+    [Fact]
+    public async Task GenerateAsync_EveryMarkupDialect_IsReachedWhenTheBatchIsLargeEnough()
+    {
+        // Arrange, Act
+        var source = await Generate(["en"], [SyntheticMailTopic.Business], count: 120);
+
+        // Assert
+        // No invocation names a dialect, so a corpus large enough has to meet all of them: a run that could only
+        // reach some would leave whichever it missed untested by every corpus anybody generated.
+        var asked = source.Requests.Select(request => request.MarkupDialect).Distinct().ToArray();
+
+        Assert.Equal(SyntheticMarkupDialect.All.Count, asked.Length);
+    }
+
+    [Fact]
+    public async Task GenerateAsync_TheMarkupAskedFor_IsTheOneTheMessageReports()
+    {
+        // Arrange
+        var source = new ScriptedAiEmailContentSource(Answer);
+
+        // Act
+        var corpus = await SyntheticEmailGenerator.GenerateAsync(
+            Plan(["en"], [SyntheticMailTopic.Business], count: 40),
+            source,
+            1,
+            CancellationToken.None);
+
+        // Assert
+        // The listing is what a message that reads badly is reproduced from, so the dialect it prints has to be the
+        // one the source was actually asked for rather than a second draw beside it.
+        Assert.Equal(
+            source.Requests.Select(request => request.MarkupDialect),
+            corpus.Select(message => message.AiOrigin!.MarkupDialect));
     }
 
     [Fact]
@@ -444,5 +487,5 @@ public sealed class SyntheticEmailGeneratorAiModeTests
         $"<p>{HtmlEncoder.Create(new TextEncoderSettings(UnicodeRanges.All)).Encode(sentence)}</p>";
 
     private static string RequestFingerprint(AiEmailContentRequest request) =>
-        $"{request.LanguageCode}|{request.Topic}|{request.AuthorName}|{request.ParentSubject ?? "-"}";
+        $"{request.LanguageCode}|{request.Topic}|{request.MarkupDialect}|{request.AuthorName}|{request.ParentSubject ?? "-"}";
 }

--- a/backend/tests/SyntheticMail.UnitTests/Generation/SyntheticMarkupDialectTests.cs
+++ b/backend/tests/SyntheticMail.UnitTests/Generation/SyntheticMarkupDialectTests.cs
@@ -1,0 +1,100 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.SyntheticMail.Generation;
+
+using Xunit;
+
+namespace MailFathom.SyntheticMail.UnitTests.Generation;
+
+/// <summary>The markup set a message's HTML alternative is drawn from, and what each member promises the prompt.</summary>
+public sealed class SyntheticMarkupDialectTests
+{
+    [Fact]
+    public void All_EveryMemberHasADistinctName()
+    {
+        // Arrange, Act
+        var names = SyntheticMarkupDialect.All.Select(dialect => dialect.ToString()).ToArray();
+
+        // Assert
+        Assert.Equal(names.Length, names.Distinct().Count());
+        Assert.All(names, name => Assert.False(string.IsNullOrWhiteSpace(name)));
+    }
+
+    [Fact]
+    public void All_EveryMemberCarriesADescriptionNamingConstructsRatherThanAClient()
+    {
+        // Arrange, Act
+        var descriptions = SyntheticMarkupDialect.All.Select(dialect => dialect.PromptDescription).ToArray();
+
+        // Assert
+        // A description that named the client and left the markup to the model would be answered with the well-formed
+        // document a model writes by default, which is the corpus this set exists to replace.
+        Assert.All(descriptions, description => Assert.False(string.IsNullOrWhiteSpace(description)));
+        Assert.All(descriptions, description => Assert.Contains("<", description, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void All_OneMemberAsksForMarkupThatIsNotWellFormed()
+    {
+        // Arrange, Act
+        var malformed = SyntheticMarkupDialect.LegacyMalformed.PromptDescription;
+
+        // Assert
+        // The one member whose defects are the point: every reader here recovers from broken markup rather than
+        // refusing it, and a corpus that never carried any could not show which of those recoveries is wrong.
+        Assert.Contains(SyntheticMarkupDialect.LegacyMalformed, SyntheticMarkupDialect.All);
+        Assert.Contains("unclosed", malformed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void All_NoMemberAsksForAConstructTheAnswerWouldBeRefusedFor()
+    {
+        // Arrange
+        string[] refused = ["<script", "<iframe", "<object", "<embed", "javascript:"];
+
+        // Act
+        var descriptions = SyntheticMarkupDialect.All.Select(dialect => dialect.PromptDescription);
+
+        // Assert
+        // A dialect asking for something the answer check refuses would fail every run it was drawn for, which reads
+        // as a model that cannot write the answer rather than as a prompt that contradicted itself.
+        Assert.All(
+            descriptions,
+            description => Assert.All(
+                refused,
+                construct => Assert.DoesNotContain(construct, description, StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [Fact]
+    public void TheDefault_IsNotADialectAndSaysSo()
+    {
+        // Arrange
+        SyntheticMarkupDialect dialect = default;
+
+        // Act, Assert
+        Assert.DoesNotContain(dialect, SyntheticMarkupDialect.All);
+        Assert.Equal("(unspecified)", dialect.ToString());
+        Assert.Throws<InvalidOperationException>(() => _ = dialect.PromptDescription);
+    }
+
+    [Fact]
+    public void ToString_ADeclaredDialect_IsTheNameTheListingPrints()
+    {
+        // Arrange, Act
+        var line = string.Join(", ", SyntheticMarkupDialect.All.Select(dialect => dialect.ToString()));
+
+        // Assert
+        Assert.Equal("word-outlook, campaign-template, gmail-composer, apple-mail, legacy-malformed", line);
+    }
+
+    [Fact]
+    public void Equality_ADialectIsItsOwnValue()
+    {
+        // Arrange, Act, Assert
+        Assert.Equal(SyntheticMarkupDialect.AppleMail, SyntheticMarkupDialect.AppleMail);
+        Assert.NotEqual(SyntheticMarkupDialect.AppleMail, SyntheticMarkupDialect.GmailComposer);
+        Assert.NotEqual(SyntheticMarkupDialect.AppleMail, default);
+    }
+}

--- a/backend/tools/SyntheticMail/Commands/CorpusListing.cs
+++ b/backend/tools/SyntheticMail/Commands/CorpusListing.cs
@@ -42,9 +42,13 @@ internal static class CorpusListing
             : "none";
 
         // What an AI-generated message was written in and about, which the seed decided like every other axis and is
-        // the one a dry run of it has to say without a reader recognising a language in the subject.
+        // the one a dry run of it has to say without a reader recognising a language in the subject. The markup is
+        // there for the stronger version of the same reason: nothing in a listing shows which client's HTML a message
+        // was written as, and that is exactly what a message the readers handle badly has to be reproduced by.
         var aiContent = email.AiOrigin is { } origin
-            ? string.Create(CultureInfo.InvariantCulture, $" | language={origin.Language} topic={origin.Topic}")
+            ? string.Create(
+                CultureInfo.InvariantCulture,
+                $" | language={origin.Language} topic={origin.Topic} markup={origin.MarkupDialect}")
             : string.Empty;
 
         return string.Create(

--- a/backend/tools/SyntheticMail/Generation/AiContent/AiEmailContent.cs
+++ b/backend/tools/SyntheticMail/Generation/AiContent/AiEmailContent.cs
@@ -14,8 +14,10 @@ namespace MailFathom.SyntheticMail.Generation.AiContent;
 /// The two body forms are answered together rather than one being derived from the other, and that is the whole point
 /// of this mode. The deterministic generator's HTML is one <c>&lt;p&gt;</c> per paragraph around its own text, so a
 /// corpus built from it exercises MIME extraction and the client's document model against markup this repository
-/// wrote. Real mail is headings, lists, tables, links, emphasis, and a signature block, and asking for that shape is
-/// how the readers meet markup nobody here chose.
+/// wrote. Real mail is what a sending client emitted — Word's own HTML, a campaign of nested layout tables, a web
+/// composer's <c>&lt;div&gt;</c> soup, or markup that is not well-formed at all — and
+/// <see cref="SyntheticMarkupDialect" /> is what the request names so the answer is one of those rather than the
+/// well-formed document a model writes when nobody says otherwise.
 /// </para>
 /// <para>
 /// Model-produced markup is untrusted by construction, which is what

--- a/backend/tools/SyntheticMail/Generation/AiContent/AiEmailContentRequest.cs
+++ b/backend/tools/SyntheticMail/Generation/AiContent/AiEmailContentRequest.cs
@@ -7,6 +7,7 @@ namespace MailFathom.SyntheticMail.Generation.AiContent;
 /// <summary>One message's content, in the terms the generation is asked for.</summary>
 /// <param name="LanguageCode">The code of the language the message is written in, as the invocation named it.</param>
 /// <param name="Topic">The subject matter the message is written about.</param>
+/// <param name="MarkupDialect">The client whose markup the message's HTML form is written as.</param>
 /// <param name="AuthorName">The display name the message is written as, drawn from the corpus's participant pool.</param>
 /// <param name="ParentSubject">The subject of the message this one answers, or <see langword="null" /> when it opens a thread.</param>
 /// <param name="ParentOpening">The opening of the message this one answers, bounded in length, or <see langword="null" /> when it opens a thread.</param>
@@ -15,7 +16,8 @@ namespace MailFathom.SyntheticMail.Generation.AiContent;
 /// <remarks>
 /// <para>
 /// What the deterministic generator decides arrives here, and only that: the envelope — who writes, to which thread,
-/// in which language, about what — is seed-derived and reproducible, while the words are the source's to invent.
+/// in which language, about what, and in whose markup — is seed-derived and reproducible, while the words are the
+/// source's to invent.
 /// The author is named because a message that signs itself with a name different from the one the <c>From</c> header
 /// carries is one a reader files as a defect rather than as mail.
 /// </para>
@@ -25,6 +27,12 @@ namespace MailFathom.SyntheticMail.Generation.AiContent;
 /// earlier request or by the vocabulary in this repository, so nothing here has ever been near a real mailbox. What it
 /// buys is a reply that answers something — a request carrying a subject alone produces a second message about the
 /// same topic, which reads as a thread only in the headers.
+/// </para>
+/// <para>
+/// The dialect is on the envelope's side of that line for the reason everything else here is: which client a message
+/// looks like it came from is what a corpus varies deliberately, and a source left to choose would write the markup
+/// it writes best. It reaches the prompt as the list of constructs the dialect names rather than as its name, because
+/// a name is a thing to recognise and the list is a thing to write.
 /// </para>
 /// <para>
 /// The last two move together and are the file the message carries. A corpus exists to be searched, and an attachment
@@ -38,6 +46,7 @@ namespace MailFathom.SyntheticMail.Generation.AiContent;
 internal sealed record AiEmailContentRequest(
     string LanguageCode,
     SyntheticMailTopic Topic,
+    SyntheticMarkupDialect MarkupDialect,
     string AuthorName,
     string? ParentSubject,
     string? ParentOpening,

--- a/backend/tools/SyntheticMail/Generation/AiContent/OpenAiEmailContentSource.cs
+++ b/backend/tools/SyntheticMail/Generation/AiContent/OpenAiEmailContentSource.cs
@@ -42,7 +42,10 @@ internal sealed partial class OpenAiEmailContentSource : IAiEmailContentSource
     /// content again as the markup real mail carries, and a message in a language whose words cost more tokens than
     /// English pays that twice as well. Measured against real answers, a rich HTML message runs to about two thousand
     /// output tokens, so the earlier bound cut one in the middle — and a cut answer arrives as an incomplete JSON
-    /// object, which reads as a model that cannot write the answer rather than as a ceiling that stopped it.
+    /// object, which reads as a model that cannot write the answer rather than as a ceiling that stopped it. A
+    /// message written as a real client's markup costs more again, a dialect that wraps every run of words in a span
+    /// most of all, which is why every description in <see cref="SyntheticMarkupDialect" /> asks for a compact
+    /// document rather than a full client export.
     /// </remarks>
     private const int MaximumOutputTokens = 6000;
 
@@ -362,6 +365,7 @@ internal sealed partial class OpenAiEmailContentSource : IAiEmailContentSource
         {
             $"Language: {request.LanguageCode}",
             $"Topic: {request.Topic.PromptDescription}",
+            $"Markup: {request.MarkupDialect.PromptDescription}",
             $"Write as {request.AuthorName}.",
         };
 
@@ -403,7 +407,7 @@ internal sealed partial class OpenAiEmailContentSource : IAiEmailContentSource
 
         "body": the message as plain text, with paragraphs separated by blank lines, opening with a natural greeting and closing with a short signature.
 
-        "html": the same message as an HTML document, carrying the structure real business mail carries rather than one paragraph per line. Use a mixture appropriate to what the message says, drawn from headings, paragraphs, ordered and unordered lists, a table with a header row where the message reports figures or items, links, bold and italic emphasis, blockquotes for anything being quoted back, a horizontal rule, and a signature block. Inline style attributes are welcome and so are simple font, colour, and spacing choices. Say the same things the plain-text body says, in the same order and in the same language. Never include a script, an iframe, an object, an embed, a javascript: URL, an inline event-handler attribute such as onclick or onerror, a remote image, or a tracking pixel.
+        "html": the same message as an HTML document, written as the markup the request's "Markup" line describes. That line names the constructs a real mail client of one kind emits, and several of them are deprecated, proprietary, redundant, or not well-formed. Write them as described rather than tidying them into clean semantic markup: a well-formed document is the one thing this answer must not be, because the corpus exists to be read by software that has to survive what real senders emit. Keep it compact — a few of each named construct is what makes the document that dialect, and a full client export would be cut off by the answer's own length. Say the same things the plain-text body says, in the same order and in the same language. Never include a script, an iframe, an object, an embed, a javascript: URL, an inline event-handler attribute such as onclick or onerror, a remote image, or a tracking pixel; nothing the "Markup" line asks for overrides this sentence.
 
         "attachment": present only when the request names an enclosed file, holding that file's contents as text. Write it in the format the file's extension names — a .csv as a header row and data rows, a .txt as the notes or the log the name describes — and make it say what the message says it encloses, with the same invented names, figures, and dates. Nothing else goes in this key: no explanation, no code fence, no repeat of the body.
 

--- a/backend/tools/SyntheticMail/Generation/SyntheticEmailAiOrigin.cs
+++ b/backend/tools/SyntheticMail/Generation/SyntheticEmailAiOrigin.cs
@@ -4,13 +4,19 @@
 
 namespace MailFathom.SyntheticMail.Generation;
 
-/// <summary>What an AI-generated message was generated under: its language and its topic.</summary>
+/// <summary>What an AI-generated message was generated under: its language, its topic, and the markup it is written in.</summary>
 /// <param name="Language">The code of the language the message's content was asked for, as the invocation named it.</param>
 /// <param name="Topic">The subject matter the message's content was asked for.</param>
+/// <param name="MarkupDialect">The client's markup the message's HTML alternative was asked to be written as.</param>
 /// <remarks>
 /// Carried beside the message for the reason the body's decoy is: the run has to be able to say what a message
 /// carries without a reader having to recognise it — a listing that printed a Polish subject and its language only
-/// as the language happened to be readable would be telling half of what the seed decided. A message the seeded
-/// vocabulary writes carries none.
+/// as the language happened to be readable would be telling half of what the seed decided. The dialect is there for
+/// the same reason and needs it more: a message that reads badly is reproduced from the seed, and which markup it was
+/// written in is what says whether the reader or the corpus is at fault. A message the seeded vocabulary writes
+/// carries none.
 /// </remarks>
-internal sealed record SyntheticEmailAiOrigin(string Language, SyntheticMailTopic Topic);
+internal sealed record SyntheticEmailAiOrigin(
+    string Language,
+    SyntheticMailTopic Topic,
+    SyntheticMarkupDialect MarkupDialect);

--- a/backend/tools/SyntheticMail/Generation/SyntheticEmailGenerator.cs
+++ b/backend/tools/SyntheticMail/Generation/SyntheticEmailGenerator.cs
@@ -516,7 +516,7 @@ internal sealed class SyntheticEmailGenerator
         MessageEnvelope? parent)
     {
         var sentAt = this.BuildSentAt(index, parent?.SentAt);
-        var origin = new SyntheticEmailAiOrigin(this.DrawLanguage(), this.DrawTopic());
+        var origin = new SyntheticEmailAiOrigin(this.DrawLanguage(), this.DrawTopic(), this.DrawMarkupDialect());
         var messageId = this.BuildMessageId(index, author);
         var bodyShape = (SyntheticBodyShape)this.source.Next(3);
         var decoy = this.PlantDecoy();
@@ -585,6 +585,7 @@ internal sealed class SyntheticEmailGenerator
                     new AiEmailContentRequest(
                         envelope.Origin.Language,
                         envelope.Origin.Topic,
+                        envelope.Origin.MarkupDialect,
                         envelope.Author.DisplayName,
                         parent?.Subject,
                         OpeningOf(parent),
@@ -624,6 +625,14 @@ internal sealed class SyntheticEmailGenerator
     private string DrawLanguage() => this.plan.Languages[this.source.Next(this.plan.Languages.Count)];
 
     private SyntheticMailTopic DrawTopic() => this.plan.Topics[this.source.Next(this.plan.Topics.Count)];
+
+    /// <summary>Draws the client whose markup one message's HTML alternative is written as.</summary>
+    /// <remarks>
+    /// Drawn from the whole set rather than from the plan, because no invocation names a dialect: what a corpus is
+    /// for is meeting all of them, and a run that could ask for one would be a run that could avoid the rest.
+    /// </remarks>
+    private SyntheticMarkupDialect DrawMarkupDialect() =>
+        SyntheticMarkupDialect.All[this.source.Next(SyntheticMarkupDialect.All.Count)];
 
     private List<SyntheticParticipant> BuildCarbonCopies(SyntheticParticipant author)
     {

--- a/backend/tools/SyntheticMail/Generation/SyntheticMarkupDialect.cs
+++ b/backend/tools/SyntheticMail/Generation/SyntheticMarkupDialect.cs
@@ -1,0 +1,104 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.SyntheticMail.Generation;
+
+/// <summary>Names the markup a client in the wild would have produced for an AI-generated message.</summary>
+/// <remarks>
+/// <para>
+/// A closed enumeration on exactly the terms <see cref="SyntheticMailTopic" /> is one: what a dialect is, is the
+/// list of constructs the generation prompt hands to the model, so the name and that list are one value rather than
+/// a name here and a lookup table somewhere else.
+/// </para>
+/// <para>
+/// The set exists because a corpus of well-formed markup proves only that the readers cope with markup somebody
+/// asked for politely. A message body reaching this repository is read three times over — the tokenizer that derives
+/// searchable text, the sanitizer, and the document model the reading pane draws — and each of those meets whatever
+/// the sending client emitted. The five members below are what actually arrives: Word's HTML, a campaign built out
+/// of nested layout tables, the two web and desktop composers whose quoting conventions every reply carries, and a
+/// sender whose markup is not well-formed at all.
+/// </para>
+/// <para>
+/// Each description asks for a compact document rather than a full client export. What exercises a reader is meeting
+/// the construct at all, and a hundred lines of <c>mso-</c> declarations would buy nothing but the output ceiling
+/// one generation is bounded by.
+/// </para>
+/// <para>
+/// Nothing parses one of these from a command line — the value is drawn from the seed and never named by an
+/// invocation — so there is no <c>TryParse</c> beside the members, no name to parse against, and nothing that
+/// serializes one. What a listing prints is <see cref="ToString" />. Being a struct, <see langword="default" /> is
+/// reachable and is not a dialect; the generator draws only from <see cref="All" />, so the throw below answers a
+/// value nothing here produces rather than one a caller has to guard against.
+/// </para>
+/// </remarks>
+internal readonly record struct SyntheticMarkupDialect
+{
+    private readonly string? name;
+    private readonly string? promptDescription;
+
+    private SyntheticMarkupDialect(string name, string promptDescription)
+    {
+        this.name = name;
+        this.promptDescription = promptDescription;
+    }
+
+    /// <summary>Gets the markup desktop Outlook produces, which the Word engine writes and most business mail carries.</summary>
+    public static SyntheticMarkupDialect WordOutlook { get; } = new(
+        "word-outlook",
+        """
+        the HTML desktop Outlook produces, which the Microsoft Word engine writes. Open the document with an <html> element declaring the xmlns:v, xmlns:o and xmlns:w namespaces; put a <!--[if !mso]><!--> block and a <!--[if gte mso 9]><xml><o:OfficeDocumentSettings/></xml><![endif]--> block in the head beside a <style> block declaring a handful of mso- properties such as mso-style-type, mso-pagination, mso-fareast-font-family and mso-line-height-rule; give every paragraph class="MsoNormal" and end it with <o:p>&nbsp;</o:p>; wrap every run of words in a <span style="font-size:11.0pt;font-family:&quot;Calibri&quot;,sans-serif;color:#1F497D">; use a nested table with valign, cellpadding="0" and cellspacing="0" for anything laid out; separate paragraphs with a <p class="MsoNormal"><o:p>&nbsp;</o:p></p> rather than with spacing; and put the quoted history behind a <div style="border:none;border-top:solid #E1E1E1 1.0pt;padding:3.0pt 0cm 0cm 0cm"> holding <b>From:</b>, <b>Sent:</b>, <b>To:</b> and <b>Subject:</b> lines
+        """);
+
+    /// <summary>Gets the markup a marketing campaign carries when a template engine built it out of nested tables.</summary>
+    public static SyntheticMarkupDialect CampaignTemplate { get; } = new(
+        "campaign-template",
+        """
+        the HTML a marketing campaign carries when a sending platform built it from a template. Lay the whole message out in three or four levels of nested <table> with border="0", cellpadding="0", cellspacing="0", role="presentation", width and bgcolor attributes and align="center"; open the body with a preheader <div style="display:none;max-height:0;overflow:hidden;mso-hide:all"> repeating the subject; use spacer rows whose only cell holds a single &nbsp; with an explicit height and a line-height of its own; write colours and sizes as <font face="Arial" size="2" color="#333333"> elements as well as inline styles; put the call to action in a table cell styled as a button rather than in a link; and close with an unsubscribe footer of tiny text and a <td align="center" style="font-size:11px;color:#999999;">
+        """);
+
+    /// <summary>Gets the markup the Gmail web composer produces, whose quoting convention every reply through it carries.</summary>
+    public static SyntheticMarkupDialect GmailComposer { get; } = new(
+        "gmail-composer",
+        """
+        the HTML the Gmail web composer produces. Wrap the whole body in <div dir="ltr"> and nest further <div> elements freely rather than using paragraphs, with <br> where a blank line belongs and <div><br></div> for an empty one; write emphasis as <b>, <i> and <span style="color:rgb(51,51,51);font-family:arial,sans-serif;font-size:small">; and where the message answers another one, append the quoted history as <div class="gmail_quote"> holding <div dir="ltr" class="gmail_attr">On Mon, 14 Apr 2025 at 09:12, Name &lt;name@example.com&gt; wrote:<br></div><blockquote class="gmail_quote" style="margin:0px 0px 0px 0.8ex;border-left:1px solid rgb(204,204,204);padding-left:1ex"> around the quoted body, which itself carries a nested quote one level deeper
+        """);
+
+    /// <summary>Gets the markup Apple Mail produces, with its own quoting and forwarding blocks.</summary>
+    public static SyntheticMarkupDialect AppleMail { get; } = new(
+        "apple-mail",
+        """
+        the HTML Apple Mail produces. Declare the document with <meta http-equiv="Content-Type" content="text/html; charset=utf-8"> and give the body style="word-wrap:break-word;-webkit-nbsp-mode:space;-webkit-line-break:after-white-space;"; write the message as <div> elements holding <br> rather than as paragraphs, and use <div class="AppleOriginalContents"> and <span style="font-family:-apple-system,Helvetica;font-size:14px;"> around runs of text; quote with <blockquote type="cite" style="margin:0 0 0 40px;border:none;padding:0px;"> nested two levels deep; and where the message forwards another one, open it with <div>Begin forwarded message:</div><br><div style="margin-top:0px;"><b>From:</b><span style="font-family:-apple-system;"> Name &lt;name@example.com&gt;</span><br></div> and the same shape again for Subject, Date and To
+        """);
+
+    /// <summary>Gets markup that is not well-formed, which is what a hand-rolled or legacy sender emits.</summary>
+    /// <remarks>
+    /// The one member whose description asks for defects rather than for a client's habits, and the reason the set
+    /// exists at all: every reader here recovers from malformed markup rather than refusing it, and a corpus that
+    /// never carried any could not show which of those recoveries is wrong.
+    /// </remarks>
+    public static SyntheticMarkupDialect LegacyMalformed { get; } = new(
+        "legacy-malformed",
+        """
+        HTML that is not well-formed, of the kind a hand-rolled sender or an old system emits. There is no head and no <html> element; open straight into the content. Leave <p>, <li> and <td> elements unclosed; write at least one stray </div> or </span> that closes nothing; open <b>, <font> or <span> inside one block and close it inside the next; write some attributes without quotes, as in <table border=1 cellpadding=3 width=600>, and give one element the same attribute twice; separate paragraphs with runs of <br> and pad alignment with runs of &nbsp;; write at least one entity without its semicolon, such as &amp or &nbsp followed by a letter; use uppercase tag names such as <TABLE>, <TR> and <FONT> beside the lowercase ones; and end a table whose rows disagree on how many cells they hold, with one <tr> missing its closing tag
+        """);
+
+    /// <summary>Gets every dialect a message may be drawn in.</summary>
+    /// <remarks>Declared last so the members it lists are already initialized when this initializer runs.</remarks>
+    public static IReadOnlyList<SyntheticMarkupDialect> All { get; } =
+    [
+        WordOutlook,
+        CampaignTemplate,
+        GmailComposer,
+        AppleMail,
+        LegacyMalformed,
+    ];
+
+    /// <summary>Gets the constructs the generation prompt hands to the model.</summary>
+    /// <exception cref="InvalidOperationException">Thrown when the value is the struct default rather than a dialect.</exception>
+    public string PromptDescription => this.promptDescription
+        ?? throw new InvalidOperationException("The value is the default of the struct and does not name a markup dialect.");
+
+    /// <inheritdoc />
+    public override string ToString() => this.name ?? "(unspecified)";
+}

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -841,8 +841,8 @@ terms the sending account's are.
 **What the seed still decides, and what it no longer does.** The envelope is still the seed's: author, participants,
 threading, dates, attachments, and the fabricated sensitive material are drawn exactly as in the default mode, and
 the seed is reported and repeated the same way. Each message's language and topic are drawn from the seed too, so a
-batch of one hundred with `--language en,pl` has a reproducible *assignment* of English and Polish. What the seed no
-longer decides is the words: two dry runs of one seed in AI mode agree on everything the listing's columns carry and
+batch of one hundred with `--language en,pl` has a reproducible *assignment* of English and Polish, and the markup
+dialect each message's HTML alternative is written as is drawn there too. What the seed no longer decides is the words: two dry runs of one seed in AI mode agree on everything the listing's columns carry and
 differ in the subjects and bodies, so the `diff` below compares envelopes, not content. A reply keeps the subject of
 the thread it answers rather than one the model invents, because the threading is what a corpus exists to exercise.
 The MIME shape a message takes is still drawn from the seed; the charset is not, because a body written in the
@@ -851,12 +851,32 @@ any of them.
 
 **The message is answered twice, and the second form is the point.** The default mode's HTML alternative is one
 `<p>` per paragraph wrapped around its own text, so MIME extraction and the client's document model are exercised
-against markup this repository wrote. In this mode the model answers the message as text *and* as an HTML document
-carrying the structure real business mail carries — headings, lists, a table where the message reports figures,
-links, emphasis, blockquotes, a horizontal rule, a signature block, and inline styles — and the two say the same
-things in the same order. Which of them a message emits is still the seed's draw between plain text, HTML, and
-`multipart/alternative`, so the axis is unchanged and only what fills it is new. The fabricated sensitive material is
-planted in both, because which alternative a reader extracts from is the extractor's choice rather than the corpus's.
+against markup this repository wrote. In this mode the model answers the message as text *and* as an HTML document,
+and the two say the same things in the same order. Which of them a message emits is still the seed's draw between
+plain text, HTML, and `multipart/alternative`, so the axis is unchanged and only what fills it is new. The fabricated
+sensitive material is planted in both, because which alternative a reader extracts from is the extractor's choice
+rather than the corpus's.
+
+**That document is written as a real client's markup, drawn from the seed like everything else.** Asking for
+well-formed semantic markup produced a corpus that proved the readers cope with markup somebody asked for politely,
+which is not what a mailbox receives. So every generated message is drawn one of five dialects, and the prompt hands
+the model the constructs that dialect actually carries rather than its name:
+
+| Dialect | What the message is written as |
+|---|---|
+| `word-outlook` | The HTML desktop Outlook produces through the Word engine: `xmlns:o` and `xmlns:w` namespaces, `<!--[if gte mso 9]>` conditional blocks, a `<style>` block of `mso-` properties, `class="MsoNormal"` on every paragraph with an `<o:p>` filler, a `<span>` carrying the font on every run of text, nested layout tables, and a quoted history behind a bordered `<div>` of `<b>From:</b>` lines |
+| `campaign-template` | A campaign a sending platform built from a template: three or four levels of nested `<table>` with `cellpadding`, `cellspacing`, `bgcolor` and `align`, a hidden preheader `<div>`, spacer rows, `<font>` elements beside inline styles, a table cell styled as a button, and a small-print unsubscribe footer |
+| `gmail-composer` | What the Gmail web composer emits: `<div dir="ltr">` soup with `<br>` where a blank line belongs, and quoted history as `<div class="gmail_quote">` around a `<blockquote>` carrying Gmail's own border and padding, nested a second level deep |
+| `apple-mail` | What Apple Mail emits: `-webkit-` properties on the body, `<div>` elements holding `<br>`, `<blockquote type="cite">` nested two levels, and a *Begin forwarded message:* block of `<b>From:</b>` lines |
+| `legacy-malformed` | Markup that is not well-formed at all: unclosed `<p>`, `<li>` and `<td>`, stray end tags, unquoted and duplicated attributes, emphasis opened in one block and closed in the next, runs of `<br>` and `&nbsp;`, entities without their semicolon, uppercase tag names beside lowercase ones, and a table whose rows disagree on how many cells they hold |
+
+The last of those is the reason the set exists. A message body is read three times over here — the tokenizer that
+derives its searchable text, the sanitizer, and the document model the reading pane draws — and each of them
+*recovers* from broken markup rather than refusing it, so a corpus that never carried any could not show which
+recovery is wrong. The listing names the dialect beside the language and the topic, as `markup=legacy-malformed`,
+because a message the readers handle badly is reproduced from the seed and which markup it was written in is what
+says where the fault is. No invocation names a dialect: a run that could ask for one would be a run that could avoid
+the other four.
 
 **A text attachment is written by the same call as the message.** The seed still decides whether a message carries an
 attachment, what it is called, and how large it may be; where the drawn file is a text one, the model writes its
@@ -878,7 +898,9 @@ event-handler attribute such as `onerror` stops the run with a line naming what 
 was not the JSON object it was asked for does. The handler is read as a pattern rather than as another spelling in
 that list, because an attribute name is what carries it and a list would refuse the few somebody thought of. Refused
 rather than reduced: stripping one would deliver a message nobody asked for and hide that the endpoint answered with
-something it was told not to. Everything an answer survives with is markup a reader has to handle anyway.
+something it was told not to. Everything an answer survives with is markup a reader has to handle anyway, which is
+the line the dialects above sit on the right side of whatever they ask for: a deprecated attribute, a proprietary
+element, and a `<td>` nobody closed are all things a mailbox receives, and none of them executes.
 
 **What leaves the machine.** In this mode a run sends the generation prompt to the endpoint and reads the message
 content back. The prompt names the language, the topic, who writes the message, and — for a reply — the subject of


### PR DESCRIPTION
## What this changes

`--ai` asked the model for a well-formed HTML document — semantic headings, tidy lists, a `<table>` with a header row, a signature block — so the corpus proved that the readers cope with markup somebody asked for politely. That is not what a mailbox receives, and the owner reports the readers handling this corpus well and real mail badly.

Every AI-generated message now draws a **markup dialect** from the seed, beside the language and topic it already drew, and the prompt hands the model the constructs that dialect actually emits rather than its name:

| Dialect | What the message is written as |
|---|---|
| `word-outlook` | `xmlns:o`/`xmlns:w` namespaces, `<!--[if gte mso 9]>` conditional blocks, a `<style>` block of `mso-` properties, `class="MsoNormal"` with `<o:p>` fillers, a font-bearing `<span>` on every run of text, nested layout tables, a bordered `<div>` of `<b>From:</b>` lines |
| `campaign-template` | Three or four levels of nested `<table>` with `cellpadding`, `cellspacing`, `bgcolor` and `align`, a hidden preheader, spacer rows, `<font>` elements, a cell styled as a button, a small-print unsubscribe footer |
| `gmail-composer` | `<div dir="ltr">` soup with `<br>`, and quoted history as `<div class="gmail_quote">` around Gmail's own `<blockquote>`, nested a second level deep |
| `apple-mail` | `-webkit-` body properties, `<div>` elements holding `<br>`, `<blockquote type="cite">` nested two levels, a *Begin forwarded message:* block |
| `legacy-malformed` | Unclosed `<p>`, `<li>` and `<td>`, stray end tags, unquoted and duplicated attributes, emphasis crossing a block boundary, runs of `<br>` and `&nbsp;`, entities without their semicolon, uppercase tag names, a table whose rows disagree on how many cells they hold |

The last one is the reason the set exists. A body is read three times here — `HtmlBodyTextReader`, `EmailHtmlSanitizer`, and `MailBodyProjection` with the reducers behind it — and each *recovers* from broken markup rather than refusing it, so a corpus that never carried any could not show which recovery is wrong.

The dry-run listing names the dialect as `markup=legacy-malformed` beside `language=` and `topic=`, so a message the readers handle badly is reproducible from the seed and the dialect says where to look.

## What is unchanged

- The refusal. `<script>`, `<iframe>`, `<object>`, `<embed>`, a `javascript:` URL, and an inline event-handler attribute still stop the run rather than being reduced, and the prompt states that nothing the markup line asks for overrides it. No dialect asks for a remote image or a tracking pixel. A new test asserts an executable construct is still refused when it sits inside otherwise realistic markup.
- The envelope. Author, threading, dates, attachments, MIME shape, and the planted decoy are drawn from the seed exactly as before; the dialect joins them on that side of the line, and no invocation can name one — a run that could ask for one dialect is a run that could avoid the other four.
- The plain-text alternative still says what the HTML says, in the same order and language.
- The default mode, which keeps its one `<p>` per paragraph.

## Contract impact

None. No configuration key, MCP tool, database column, or deployment contract moves. `SyntheticMail` is a development tool and the change is internal to it.

The corpus a given seed produces does change, because a new draw joins the sequence. Seeds stay reproducible within a version, which is what they promise.

## Verification

- `scripts/verify-full.sh` — passed.
- `scripts/review-obligations.sh` — every page describing a changed path is in this change.
- `$check-docs-licenses` — Docs pass (`docs/operations/local-development.md`), Changelog n/a, Licenses n/a: no package, tool, service, image, or model added or moved.

Closes #1773
