### PR TITLE
[#1185] Show what MailFathom made of a message on its row, and let a view turn it off

### DIFF
--- a/frontend/src/Client.App/src/development/fixtureDeployment.test.ts
+++ b/frontend/src/Client.App/src/development/fixtureDeployment.test.ts
@@ -96,6 +96,21 @@ describe('fixtureAnswer', () => {
         expect(message['storedEmailId']).toBe('00000000-0000-4000-8000-0000000000c3');
     });
 
+    it('follows a mark’s evidence, answering one resolution per passage in the order they were asked about', () => {
+        const asked = JSON.stringify({
+            citations: [
+                { kind: 'fragment', email: 'message-1', fragment: 'fragment-1-1' },
+                { kind: 'fragment', email: 'message-1', fragment: 'fragment-1-2' },
+            ],
+        });
+
+        const resolved = stated(answered('/citations/resolution', {}, 1, 'POST', asked))['citations'];
+
+        expect(resolved).toHaveLength(2);
+        expect((resolved as Record<string, unknown>[])[0]?.['outcome']).toBe('Resolved');
+        expect((resolved as Record<string, unknown>[])[1]?.['outcome']).toBe('Unresolvable');
+    });
+
     it('challenges as MailFathom where nothing carried a credential, so a password may be typed', () => {
         const request: ClientRequest = { method: 'GET', path: `${deploymentAddress}/api/client/session`, headers: {} };
         const answer = fixtureAnswer(request, fixtureDeploymentDefaults, 1, fixtureDeploymentState());

--- a/frontend/src/Client.App/src/development/fixtureDeployment.ts
+++ b/frontend/src/Client.App/src/development/fixtureDeployment.ts
@@ -290,6 +290,10 @@ function answerFor(
         return answering(mail.timelinePage(asked.get('direction') === 'backward' ? cursor - mail.rowsPerPage : cursor));
     }
 
+    if (route === '/citations/resolution') {
+        return answering(mail.citationResolutions(fragmentsIn(request.body)));
+    }
+
     if (route === '/preferences') {
         if (request.method === 'POST') {
             state.preferences = recordIn(request.body) ?? state.preferences;
@@ -417,6 +421,21 @@ function messageAnswer(route: string, asked: URLSearchParams): ClientResponse | 
 }
 
 /** What a request body states, where it states an object at all. */
+// The passages a citation request named, in the order it named them, which is what the answer is paired against. A
+// body this cannot read answers no citations at all, which the client refuses as an answer it cannot pair — the same
+// thing a deployment answering nonsense would produce.
+function fragmentsIn(body: string | undefined): readonly string[] {
+    const citations = recordIn(body)?.['citations'];
+
+    if (!Array.isArray(citations)) {
+        return [];
+    }
+
+    return citations
+        .map((citation) => (citation as Record<string, unknown> | null)?.['fragment'])
+        .filter((fragment): fragment is string => typeof fragment === 'string');
+}
+
 function recordIn(body: string | undefined): Record<string, unknown> | null {
     if (body === undefined) {
         return null;

--- a/frontend/src/Client.App/src/development/fixtureDeployment.ts
+++ b/frontend/src/Client.App/src/development/fixtureDeployment.ts
@@ -420,7 +420,6 @@ function messageAnswer(route: string, asked: URLSearchParams): ClientResponse | 
     return answering({ ...message, storedEmailId });
 }
 
-/** What a request body states, where it states an object at all. */
 // The passages a citation request named, in the order it named them, which is what the answer is paired against. A
 // body this cannot read answers no citations at all, which the client refuses as an answer it cannot pair — the same
 // thing a deployment answering nonsense would produce.
@@ -436,6 +435,7 @@ function fragmentsIn(body: string | undefined): readonly string[] {
         .filter((fragment): fragment is string => typeof fragment === 'string');
 }
 
+/** What a request body states, where it states an object at all. */
 function recordIn(body: string | undefined): Record<string, unknown> | null {
     if (body === undefined) {
         return null;

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -489,6 +489,31 @@ export const en = {
     'list.senderUnknown': 'No sender',
     'list.threadMessages': '{count} messages in this conversation',
 
+    'list.readings': 'What MailFathom made of it',
+    'list.showReadings': 'Show a reading on each row',
+    'list.readingsExplained':
+        'One sentence per message, under the subject. It is kept for this folder, and turning it off changes nothing about the mail itself.',
+
+    'reading.sense': 'What this is about',
+    'reading.significance': 'Why this may matter',
+    'reading.commitment': 'What is committed to',
+    'reading.said': '{aspect}: {text}',
+    'reading.title': 'What MailFathom made of this message',
+    'reading.about':
+        'Each reading below was derived from the message and can be checked against the passages it rests on.',
+    'reading.check': 'Check what MailFathom made of it',
+    'reading.close': 'Close',
+    'reading.reason': 'Why: {reason}',
+    'reading.dueAt': 'Due {when}',
+    'reading.byRule': 'A rule of this deployment — {origin}',
+    'reading.byModel': 'A model — {origin}',
+    'reading.readingEvidence': 'Reading the passages this rests on…',
+    'reading.evidenceFailed': 'The passages this rests on could not be read: {reason}.',
+    'reading.noEvidence': 'This reading names no passage.',
+    'reading.passageGone': 'This passage is no longer where it was — the message has been read again since.',
+    'reading.passagePrivate': 'This passage cannot be read with this sign-in.',
+    'reading.passageNotFollowed': 'Only the first ten passages a message rests on are followed, and this is past them.',
+
     'search.label': 'Find a message',
     'search.placeholder': 'Words from the message you are looking for',
     'search.blank': 'Type something to look for.',

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -494,6 +494,32 @@ export const pl: Catalogue = {
     'list.senderUnknown': 'Brak nadawcy',
     'list.threadMessages': 'Wiadomości w tym wątku: {count}',
 
+    'list.readings': 'Co MailFathom z tego wyczytał',
+    'list.showReadings': 'Pokazuj odczyt przy każdym wierszu',
+    'list.readingsExplained':
+        'Jedno zdanie o wiadomości, pod tematem. Ustawienie dotyczy tego folderu, a wyłączenie go niczego nie zmienia w samej poczcie.',
+
+    'reading.sense': 'O co tu chodzi',
+    'reading.significance': 'Dlaczego to może być ważne',
+    'reading.commitment': 'Jakie jest zobowiązanie',
+    'reading.said': '{aspect}: {text}',
+    'reading.title': 'Co MailFathom wyczytał z tej wiadomości',
+    'reading.about':
+        'Każdy odczyt poniżej powstał z tej wiadomości i można go sprawdzić w fragmentach, na których się opiera.',
+    'reading.check': 'Sprawdź, co MailFathom z tego wyczytał',
+    'reading.close': 'Zamknij',
+    'reading.reason': 'Dlaczego: {reason}',
+    'reading.dueAt': 'Termin: {when}',
+    'reading.byRule': 'Reguła tego wdrożenia — {origin}',
+    'reading.byModel': 'Model — {origin}',
+    'reading.readingEvidence': 'Wczytuję fragmenty, na których się to opiera…',
+    'reading.evidenceFailed': 'Nie udało się wczytać fragmentów, na których się to opiera: {reason}.',
+    'reading.noEvidence': 'Ten odczyt nie wskazuje żadnego fragmentu.',
+    'reading.passageGone': 'Tego fragmentu już tam nie ma — wiadomość została w międzyczasie przeczytana na nowo.',
+    'reading.passagePrivate': 'Tego fragmentu nie da się odczytać przy tym logowaniu.',
+    'reading.passageNotFollowed':
+        'Sprawdzanych jest tylko pierwszych dziesięć fragmentów, na których opiera się wiadomość, a ten jest poza nimi.',
+
     'search.label': 'Znajdź wiadomość',
     'search.placeholder': 'Słowa z wiadomości, której szukasz',
     'search.blank': 'Wpisz, czego szukasz.',

--- a/frontend/src/Client.App/src/mailboxActs/useMailboxActs.test.ts
+++ b/frontend/src/Client.App/src/mailboxActs/useMailboxActs.test.ts
@@ -24,6 +24,7 @@ const email: MailTimelineEntry = {
     attachmentCount: 0,
     sizeOctets: 1_024,
     preview: 'The opening of the message.',
+    enrichment: null,
     threadMessageCount: null,
 };
 

--- a/frontend/src/Client.App/src/messageList/ListSettings.test.tsx
+++ b/frontend/src/Client.App/src/messageList/ListSettings.test.tsx
@@ -17,10 +17,17 @@ function renderSettings(
     listing: MailListing = openingListing,
     onRead: (listing: MailListing) => void = () => undefined,
     junkAskable = false,
+    readings: { shown?: boolean; onDrawReadings?: (shown: boolean) => void } = {},
 ): void {
     render(
         <LocalizationProvider>
-            <ListSettings listing={listing} junkAskable={junkAskable} onRead={onRead} />
+            <ListSettings
+                listing={listing}
+                junkAskable={junkAskable}
+                readingsShown={readings.shown ?? true}
+                onRead={onRead}
+                onDrawReadings={readings.onDrawReadings ?? (() => undefined)}
+            />
         </LocalizationProvider>,
     );
 }
@@ -58,7 +65,13 @@ describe('ListSettings', () => {
             render(
                 <LocalizationProvider>
                     <ListHeadRowContext value={row}>
-                        <ListSettings listing={openingListing} junkAskable={false} onRead={() => undefined} />
+                        <ListSettings
+                            listing={openingListing}
+                            junkAskable={false}
+                            readingsShown
+                            onRead={() => undefined}
+                            onDrawReadings={() => undefined}
+                        />
                     </ListHeadRowContext>
                 </LocalizationProvider>,
             );
@@ -76,6 +89,32 @@ describe('ListSettings', () => {
         } finally {
             row.remove();
         }
+    });
+
+    it('offers turning the readings off for this view, drawn as on where they are shown', () => {
+        renderSettings();
+        openFilters();
+
+        expect(screen.getByRole('switch', { name: 'Show a reading on each row', checked: true })).toBeTruthy();
+    });
+
+    it('says the readings are off for this view where somebody turned them off', () => {
+        renderSettings(openingListing, () => undefined, false, { shown: false });
+        openFilters();
+
+        expect(screen.getByRole('switch', { name: 'Show a reading on each row', checked: false })).toBeTruthy();
+    });
+
+    it('asks for the plain row rather than asking the deployment for the folder again', () => {
+        const drawn = vi.fn<(shown: boolean) => void>();
+        const read = vi.fn<(listing: MailListing) => void>();
+
+        renderSettings(openingListing, read, false, { onDrawReadings: drawn });
+        openFilters();
+        fireEvent.click(screen.getByRole('switch', { name: 'Show a reading on each row' }));
+
+        expect(drawn).toHaveBeenCalledWith(false);
+        expect(read).not.toHaveBeenCalled();
     });
 
     it('says nothing narrows the folder rather than drawing a count nobody has to act on', () => {

--- a/frontend/src/Client.App/src/messageList/ListSettings.tsx
+++ b/frontend/src/Client.App/src/messageList/ListSettings.tsx
@@ -8,6 +8,7 @@ import type { MailTimelineOrder } from '@mailfathom/client-backend';
 import { CheckControl } from '../controls/CheckControl';
 import { chip } from '../controls/chrome';
 import { Icon } from '../controls/Icon';
+import { Switch } from '../controls/Switch';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
 import { useListHeadRow } from '../mailSpace/listHeadRow';
@@ -65,11 +66,26 @@ const noRangeTyped: TypedRange = { receivedFrom: null, receivedTo: null };
 export function ListSettings({
     listing,
     junkAskable,
+    readingsShown,
     onRead,
+    onDrawReadings,
 }: {
     readonly listing: MailListing;
     readonly junkAskable: boolean;
+
+    /** Whether this folder's rows draw what MailFathom made of each message. */
+    readonly readingsShown: boolean;
+
     readonly onRead: (listing: MailListing) => void;
+
+    /**
+     * Turns the readings on or off for this folder, which reads no page and moves nobody's place in one.
+     *
+     * Its own call rather than a field of the listing above, because the listing is what a cursor was issued under:
+     * this changes neither the order nor a filter, so a reader who turns the sentences off keeps the row they were on
+     * instead of being returned to the top of the folder.
+     */
+    readonly onDrawReadings: (shown: boolean) => void;
 }) {
     const { translate } = useLocalization();
 
@@ -191,6 +207,22 @@ export function ListSettings({
                                 }}
                             />
                         ) : null}
+                    </div>
+
+                    {/* What the rows say about the messages, which is not one of the narrowings above and is drawn
+                        apart from them: a filter decides which mail is in the folder and this decides what each row
+                        says about the mail that is, so counting it among the narrowings in force would tell somebody
+                        their folder was being kept from them. A switch rather than a filter chip for the same reason,
+                        and it reads no page — the folder stays where it is and the rows stop saying it. */}
+                    <div className="flex flex-col gap-1.25 border-t border-line-soft pt-2">
+                        <p className={sectionLabel}>{translate('list.readings')}</p>
+
+                        <label className="flex cursor-pointer items-center gap-2 text-sm text-text-soft">
+                            <Switch on={readingsShown} onChange={onDrawReadings} />
+                            {translate('list.showReadings')}
+                        </label>
+
+                        <p className="text-sm text-faint text-pretty">{translate('list.readingsExplained')}</p>
                     </div>
 
                     {/* Radio buttons rather than pressable chips, for the reason `shell/Preferences.tsx` gives about the

--- a/frontend/src/Client.App/src/messageList/MessageList.test.tsx
+++ b/frontend/src/Client.App/src/messageList/MessageList.test.tsx
@@ -63,6 +63,32 @@ function message(at: number, carried: Record<string, unknown> = {}): Record<stri
     };
 }
 
+// What a derivation concluded about a message, as the deployment publishes it: two readings, so the row proves it
+// draws the most actionable one rather than the first one answered.
+const derived = {
+    derivedAt: '2026-08-31T09:41:00+00:00',
+    marks: [
+        {
+            aspect: 'Sense',
+            text: 'An invoice for August.',
+            reason: 'The message attaches a document the sender calls an invoice.',
+            dueAt: null,
+            source: 'DeterministicRule',
+            origin: 'rules/invoice',
+            evidence: [],
+        },
+        {
+            aspect: 'Commitment',
+            text: 'An answer is owed by Friday.',
+            reason: 'The sender asks for confirmation before the end of the week.',
+            dueAt: '2026-09-04T16:00:00+00:00',
+            source: 'Model',
+            origin: 'agents/reader',
+            evidence: ['fragment-1'],
+        },
+    ],
+};
+
 function pageOf(rows: readonly unknown[], cursors: Record<string, unknown> = {}): string {
     return JSON.stringify({
         emails: rows,
@@ -296,6 +322,7 @@ describe('MessageList', () => {
         rememberListing(session.baseAddress, everything, {
             order: 'newestFirst',
             filters: openingListing.filters,
+            readingsShown: true,
             cursor: 'where-they-were',
             readAs: 'forward',
             rowInPage: 3,
@@ -313,6 +340,7 @@ describe('MessageList', () => {
         rememberListing(session.baseAddress, everything, {
             order: 'newestFirst',
             filters: openingListing.filters,
+            readingsShown: true,
             cursor: 'where-they-were',
             readAs: 'forward',
             rowInPage: rowsPerPage - 1,
@@ -808,6 +836,65 @@ describe('MessageList', () => {
 
         await rows();
         expect(asked.requests.length).toBe(before + 1);
+    });
+
+    it('draws the most actionable reading on a row that carries one, without displacing the mail', async () => {
+        renderList(answering(pageOf([message(0, { enrichment: derived }), message(1)])));
+        await rows();
+
+        const enriched = screen.getByRole('option', { name: /An answer is owed by Friday\.$/ });
+
+        expect(enriched.textContent).toContain('An answer is owed by Friday.');
+        expect(enriched.textContent).toContain('Writer 0');
+        expect(enriched.textContent).toContain('Message 0');
+    });
+
+    it('draws an ordinary row for a message no derivation reached', async () => {
+        renderList(answering(pageOf([message(0, { enrichment: derived }), message(1)])));
+        await rows();
+
+        const plain = row(1);
+
+        expect(plain.textContent).toContain('Message 1');
+        expect(plain.textContent).not.toContain('An answer is owed by Friday.');
+        expect(within(plain).queryByRole('status')).toBeNull();
+    });
+
+    it('restores the plain row when the readings are turned off for the view', async () => {
+        renderList(answering(pageOf([message(0, { enrichment: derived })])));
+        await rows();
+
+        openFilters();
+        fireEvent.click(screen.getByRole('switch', { name: 'Show a reading on each row' }));
+
+        const plain = row(0);
+
+        expect(plain.textContent).not.toContain('An answer is owed by Friday.');
+        expect(plain.textContent).toContain('Writer 0');
+        expect(plain.textContent).toContain('Message 0');
+    });
+
+    it('keeps the switch with the view it was turned off in, so returning to the folder finds it off', async () => {
+        renderList(answering(pageOf([message(0, { enrichment: derived })])));
+        await rows();
+
+        openFilters();
+        fireEvent.click(screen.getByRole('switch', { name: 'Show a reading on each row' }));
+
+        expect(rememberedListing(session.baseAddress, everything).readingsShown).toBe(false);
+    });
+
+    it('offers checking a reading from the row that carries one, and from no other row', async () => {
+        renderList(answering(pageOf([message(0, { enrichment: derived }), message(1)])));
+        await rows();
+
+        fireEvent.contextMenu(screen.getByRole('option', { name: /An answer is owed by Friday\.$/ }));
+        expect(screen.getByRole('menuitem', { name: 'Check what MailFathom made of it' })).toBeTruthy();
+
+        fireEvent.keyDown(document, { key: 'Escape' });
+        fireEvent.contextMenu(row(1));
+
+        expect(screen.queryByRole('menuitem', { name: 'Check what MailFathom made of it' })).toBeNull();
     });
 
     it('reads nothing again for a change in another account than the one it is showing', async () => {

--- a/frontend/src/Client.App/src/messageList/MessageList.tsx
+++ b/frontend/src/Client.App/src/messageList/MessageList.tsx
@@ -18,6 +18,7 @@ import {
     type ClientSession,
     type MailAccount,
     type MailFathomTransport,
+    type MailTimelineEntry,
 } from '@mailfathom/client-backend';
 import type { MenuPoint } from '../contextMenu/menuPlacement';
 import { SecondaryButton } from '../controls/SecondaryButton';
@@ -27,8 +28,11 @@ import { useLocalization } from '../localization/useLocalization';
 import { ActQuestions } from '../mailboxActs/ActQuestions';
 import { useMailboxActs, type ActedMessage } from '../mailboxActs/useMailboxActs';
 import { useComposing } from '../composer/useComposing';
+import { MessageReading } from '../messageRows/MessageReading';
+import { leadingReading, readingsOf } from '../messageRows/messageReadings';
 import { MessageRow } from '../messageRows/MessageRow';
 import { MessageRowMenu, type ActAsked } from '../messageRows/MessageRowMenu';
+import { ReadingsAsked, type AskedReadings } from '../messageRows/ReadingsAsked';
 import { estimatedRowHeight, leadingRow, offsetOfRow, windowOf } from '../messageRows/rowWindow';
 import { needsAttention } from '../synchronization/synchronizationState';
 import { accountInScope, scopeReaches, type MailScope } from '../workspace/mailScope';
@@ -116,6 +120,11 @@ export function MessageList({
     const [opening, setOpening] = useState(() => rememberedListing(session.baseAddress, scope));
 
     const [listing, setListing] = useState<MailListing>(opening);
+
+    // Whether this folder's rows say what MailFathom made of each message. Beside the listing rather than inside it,
+    // because the listing is what a cursor was issued under and this changes neither the order nor a filter: turning
+    // the sentences off leaves the reader on the row they were on instead of at the top of the folder.
+    const [readingsShown, setReadingsShown] = useState(opening.readingsShown);
     const [held, setHeld] = useState<HeldTimeline>(nothingHeld);
     const [failure, setFailure] = useState<ClientFailure | null>(null);
 
@@ -132,6 +141,9 @@ export function MessageList({
     const [pressed, setPressed] = useState<{ readonly row: number; readonly at: MenuPoint } | null>(null);
     const [questioned, setQuestioned] = useState<readonly ActedMessage[]>([]);
 
+    // The readings being checked, which outlive the menu they were asked from for the reason a question does.
+    const [askedReadings, setAskedReadings] = useState<AskedReadings | null>(null);
+
     // Whether the reader has been put back where they were. State rather than a ref, because what depends on it is what
     // the list asks the deployment for, and that is worked out during render: a list restored into a page it opened
     // from a cursor spends the commit before the scroller is moved with its window at the leading end of that page,
@@ -142,6 +154,7 @@ export function MessageList({
     const scroller = useRef<HTMLDivElement>(null);
     const deleting = useRef<HTMLDialogElement>(null);
     const filing = useRef<HTMLDialogElement>(null);
+    const checking = useRef<HTMLDialogElement>(null);
     const elements = useRef(new Map<number, HTMLLIElement>());
     const dragging = useRef(false);
     const wantsFocus = useRef(false);
@@ -235,7 +248,7 @@ export function MessageList({
             const position = positionOfRow(held, leadingRow(scrollTop, rowHeight));
 
             if (position !== null) {
-                rememberListing(session.baseAddress, scope, { ...listing, ...position });
+                rememberListing(session.baseAddress, scope, { ...listing, readingsShown, ...position });
             }
         }
 
@@ -246,7 +259,7 @@ export function MessageList({
             window.clearTimeout(timer);
             window.removeEventListener('pagehide', keep);
         };
-    }, [held, scrollTop, rowHeight, listing, scope, session.baseAddress]);
+    }, [held, scrollTop, rowHeight, listing, readingsShown, scope, session.baseAddress]);
 
     // The two measurements the window is arithmetic over, taken after the browser has laid the list out rather than
     // written down as numbers here. One element each, on a commit that has already happened: the row height is a token
@@ -395,7 +408,7 @@ export function MessageList({
     function readWith(chosen: MailListing): void {
         // The cursor belongs to the order and the filters it was issued under, so changing either starts the list at
         // its leading end rather than continuing from a cursor the deployment would refuse.
-        const restarted = { ...chosen, cursor: null, readAs: 'forward' as const, rowInPage: 0 };
+        const restarted = { ...chosen, readingsShown, cursor: null, readAs: 'forward' as const, rowInPage: 0 };
 
         // Written down here rather than left to the effect below, because how a folder is read is a choice somebody
         // made rather than a position they drifted to: leaving the moment after making it keeps it.
@@ -412,6 +425,52 @@ export function MessageList({
         // the new one's last row under a screen of blank space, with no scroll left to fire the event that would
         // correct it.
         setScrollTop(0);
+    }
+
+    // Turning the readings on or off for this folder, which reads no page: the rows already held stop saying what
+    // MailFathom made of them, or start, and the reader stays on the row they were on. Written down on the press for
+    // the reason `readWith` writes there — this is a choice somebody made rather than a position they drifted to, and
+    // leaving the moment after making it keeps it.
+    function drawReadings(shown: boolean): void {
+        setReadingsShown(shown);
+
+        const position = positionOfRow(held, leadingRow(scrollTop, rowHeight));
+
+        rememberListing(session.baseAddress, scope, {
+            ...listing,
+            readingsShown: shown,
+            ...(position ?? { cursor: opening.cursor, readAs: opening.readAs, rowInPage: opening.rowInPage }),
+        });
+    }
+
+    // What the row says about the message, which is the leading reading of it and nothing where the folder is drawn
+    // plainly. `undefined` rather than an empty element for a row with nothing to say: the row keeps the space either
+    // way, and what changes is whether the line is announced at all.
+    function readingOn(email: MailTimelineEntry): ReactNode {
+        if (!readingsShown) {
+            return undefined;
+        }
+
+        const mark = leadingReading(email.enrichment);
+
+        return mark === null ? undefined : <MessageReading mark={mark} />;
+    }
+
+    // Opening what MailFathom made of one message, offered only where it made something of it. It is reached from the
+    // row's menu because the row is an `option` of a listbox and holds no focusable descendant of its own —
+    // `messageRows/ReadingsAsked.tsx` holds the whole of that reasoning.
+    function checkingReadings(email: MailTimelineEntry): (() => void) | undefined {
+        const marks = readingsOf(email.enrichment);
+
+        if (marks.length === 0) {
+            return undefined;
+        }
+
+        return () => {
+            setAskedReadings({ storedEmailId: email.id, subject: email.subject, marks });
+            closeMenu();
+            checking.current?.showModal();
+        };
     }
 
     function reveal(row: number): void {
@@ -660,7 +719,9 @@ export function MessageList({
             <ListSettings
                 listing={listing}
                 junkAskable={scope.kind !== 'folder' && scope.kind !== 'role'}
+                readingsShown={readingsShown}
                 onRead={readWith}
+                onDrawReadings={drawReadings}
             />
 
             {/* How many messages are picked out is said once, on the selection bar above this column, which is where
@@ -721,6 +782,7 @@ export function MessageList({
                                     open={workspace.selection === email.id}
                                     selected={workspace.selected.includes(email.id)}
                                     focusable={row === focusedRow}
+                                    note={readingOn(email)}
                                     onOpen={() => {
                                         open(row);
                                     }}
@@ -775,6 +837,7 @@ export function MessageList({
                         select(withToggled(workspace.selected, pressedRow.id));
                     }}
                     onAsk={ask}
+                    onCheckReadings={checkingReadings(pressedRow)}
                     onClose={closeMenu}
                 />
             )}
@@ -782,6 +845,10 @@ export function MessageList({
             {/* The two questions an act from that menu stands behind. Here rather than in the menu, because the menu is
                 gone the moment an item is chosen and the question is what is left standing. */}
             <ActQuestions messages={questioned} deleting={deleting} filing={filing} />
+
+            {/* Where a reading is checked, standing here for the same reason: the menu it is reached from is gone the
+                moment the item is chosen. */}
+            <ReadingsAsked asked={askedReadings} session={session} transport={transport} dialog={checking} />
         </div>
     );
 }

--- a/frontend/src/Client.App/src/messageList/heldTimeline.test.ts
+++ b/frontend/src/Client.App/src/messageList/heldTimeline.test.ts
@@ -44,6 +44,7 @@ function message(at: number): MailTimelineEntry {
         attachmentCount: 0,
         sizeOctets: 1_024,
         preview: null,
+        enrichment: null,
         threadMessageCount: null,
     };
 }

--- a/frontend/src/Client.App/src/messageList/rememberedListings.test.ts
+++ b/frontend/src/Client.App/src/messageList/rememberedListings.test.ts
@@ -20,10 +20,16 @@ const inbox: MailScope = { kind: 'folder', accountId: 'work', alias: 'INBOX' };
 const kept: RememberedListing = {
     order: 'oldestFirst',
     filters: { ...openingListing.filters, unread: true },
+    readingsShown: true,
     cursor: 'the-cursor-that-page-was-read-with',
     readAs: 'backward',
     rowInPage: 17,
 };
+
+// A copy of a record with one field left out, which is how a body written before a field existed is stated.
+function without(record: Record<string, unknown>, field: string): Record<string, unknown> {
+    return Object.fromEntries(Object.entries(record).filter(([named]) => named !== field));
+}
 
 function stored(value: unknown): void {
     window.sessionStorage.setItem(storageKey, JSON.stringify(value));
@@ -86,6 +92,7 @@ describe('rememberedListing', () => {
     it('opens a folder nobody has read at its leading end, newest first', () => {
         expect(rememberedListing(deployment, inbox)).toStrictEqual({
             ...openingListing,
+            readingsShown: true,
             cursor: null,
             readAs: 'forward',
             rowInPage: 0,
@@ -144,6 +151,7 @@ describe('rememberedListing', () => {
                 },
             },
         ],
+        ['a switch that is neither shown nor hidden', { ...kept, readingsShown: 'yes' }],
         ['a listing that is not a record', 'the inbox'],
     ])('opens at the leading end for a record carrying %s', (_, written) => {
         stored({ [keyFor(inbox)]: written });
@@ -160,6 +168,18 @@ describe('rememberedListing', () => {
         rememberListing(deployment, inbox, narrowed);
 
         expect(rememberedListing(deployment, inbox)).toStrictEqual(narrowed);
+    });
+
+    it('draws the readings for a folder kept before the switch existed', () => {
+        stored({ [keyFor(inbox)]: without({ ...kept }, 'readingsShown') });
+
+        expect(rememberedListing(deployment, inbox).readingsShown).toBe(true);
+    });
+
+    it('reads back a folder somebody turned the readings off in, so the switch outlives leaving it', () => {
+        rememberListing(deployment, inbox, { ...kept, readingsShown: false });
+
+        expect(rememberedListing(deployment, inbox)).toStrictEqual({ ...kept, readingsShown: false });
     });
 
     it('refuses a store holding more folders than it keeps rather than reading part of it', () => {

--- a/frontend/src/Client.App/src/messageList/rememberedListings.ts
+++ b/frontend/src/Client.App/src/messageList/rememberedListings.ts
@@ -42,6 +42,20 @@ const longestCursor = 4_096;
 
 /** Where a folder was left, and how it was being read at the time. */
 export interface RememberedListing extends MailListing {
+    /**
+     * Whether the rows of this folder draw what MailFathom made of each message.
+     *
+     * Here rather than on {@link MailListing}, and that separation is load-bearing: a listing is what a cursor was
+     * issued under, and the deployment refuses one presented under different filters or a different order. This
+     * changes neither, so folding it in would have meant every reader who turned the readings off lost their place in
+     * the folder to a question the deployment was never asked.
+     *
+     * Kept per folder because it is a way of reading one rather than a statement about the person: somebody scanning a
+     * busy folder for what is owed and somebody reading a newsletter folder are not disagreeing with themselves. It is
+     * on by default for the reason the derivation exists at all, and a folder nobody has turned it off in draws it.
+     */
+    readonly readingsShown: boolean;
+
     /** The cursor of the page the reader's leading row was in, or `null` where it was the leading page. */
     readonly cursor: string | null;
 
@@ -60,6 +74,7 @@ export interface RememberedListing extends MailListing {
  */
 export const neverOpenedListing: RememberedListing = {
     ...openingListing,
+    readingsShown: true,
     cursor: null,
     readAs: 'forward',
     rowInPage: 0,
@@ -168,7 +183,12 @@ function listingIn(value: unknown): RememberedListing | null {
     const readAs = record['readAs'];
     const rowInPage = record['rowInPage'];
 
-    if (!isOrder(order) || filters === null || !isDirection(readAs)) {
+    // Read as on where the record predates the field, which is a record this client wrote before the readings were
+    // drawn at all rather than one somebody edited: what it says about the folder is still true, and the default is
+    // what a folder nobody has answered for draws.
+    const readingsShown = record['readingsShown'] ?? true;
+
+    if (!isOrder(order) || filters === null || !isDirection(readAs) || typeof readingsShown !== 'boolean') {
         return null;
     }
 
@@ -182,7 +202,7 @@ function listingIn(value: unknown): RememberedListing | null {
 
     // A row past the page it names is a record this client never wrote: the page it would be read back into cannot
     // hold it, and scrolling to it would leave the reader below every row there is.
-    return rowInPage >= rowsPerPage ? null : { order, filters, cursor, readAs, rowInPage };
+    return rowInPage >= rowsPerPage ? null : { order, filters, readingsShown, cursor, readAs, rowInPage };
 }
 
 function filtersIn(value: unknown): MailListFilters | null {

--- a/frontend/src/Client.App/src/messageRows/MessageReading.test.tsx
+++ b/frontend/src/Client.App/src/messageRows/MessageReading.test.tsx
@@ -1,0 +1,64 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { MailEnrichmentAspect, MailEnrichmentMark } from '@mailfathom/client-backend';
+import { LocalizationProvider } from '../localization/Localization';
+import { MessageReading } from './MessageReading';
+
+function mark(aspect: MailEnrichmentAspect, text: string): MailEnrichmentMark {
+    return {
+        aspect,
+        text,
+        reason: 'Because the message says so.',
+        dueAt: null,
+        source: 'Model',
+        origin: 'agents/reader',
+        evidence: [],
+    };
+}
+
+function drawn(one: MailEnrichmentMark): HTMLElement {
+    const { container } = render(
+        <LocalizationProvider>
+            <MessageReading mark={one} />
+        </LocalizationProvider>,
+    );
+
+    return container;
+}
+
+describe('MessageReading', () => {
+    it('draws the reading itself', () => {
+        drawn(mark('Sense', 'An invoice for August.'));
+
+        expect(screen.getByText('An invoice for August.')).toBeTruthy();
+    });
+
+    it('announces the reading as what it is rather than as part of the mail', () => {
+        const container = drawn(mark('Commitment', 'An answer is owed by Friday.'));
+
+        expect(container.textContent).toContain('What is committed to: An answer is owed by Friday.');
+    });
+
+    it('says once what a screen reader meets, rather than the mark and the sentence twice', () => {
+        const container = drawn(mark('Significance', 'The auditor is waiting.'));
+
+        expect(container.querySelector('.sr-only')?.textContent).toBe('Why this may matter: The auditor is waiting.');
+        expect(container.querySelectorAll('[aria-hidden="true"]')).toHaveLength(2);
+    });
+
+    it('draws no control, because the row it sits on may hold none', () => {
+        const container = drawn(mark('Sense', 'An invoice for August.'));
+
+        expect(container.querySelectorAll('button, a, input, [tabindex]')).toHaveLength(0);
+    });
+
+    it('clips a reading too long for the line rather than letting it wrap the row taller', () => {
+        const container = drawn(mark('Sense', 'a'.repeat(240)));
+
+        expect(container.querySelector('.truncate')).toBeTruthy();
+    });
+});

--- a/frontend/src/Client.App/src/messageRows/MessageReading.tsx
+++ b/frontend/src/Client.App/src/messageRows/MessageReading.tsx
@@ -1,0 +1,55 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { MailEnrichmentMark } from '@mailfathom/client-backend';
+import { useLocalization } from '../localization/useLocalization';
+import { readingNames } from './messageReadings';
+
+// What MailFathom made of a message, on the row that stands for it. It is the design project's own line: a small mark
+// reading `AI` and then one sentence, clipped where it does not fit, in the line the row's height already reserves.
+//
+// **It never displaces the mail.** Who wrote, what about, and when are the two lines above it and are untouched by
+// this; a row with a reading is the same height as a row without one, and a folder of enriched mail shows exactly as
+// many messages per screen as a plain one. That is the density decision this component exists to keep: the alternative
+// was a second line that wraps, which would have cost a list a third of its rows to add a sentence.
+//
+// **It says what it is rather than only showing it.** A screen reader meets the aspect by name — a commitment, why the
+// message matters, or what it is about — because a sentence announced bare inside a row reads as part of the mail, and
+// the whole point of the mark beside it is that this one is not.
+//
+// **It is not a control.** The row is an `option` of a listbox, which holds no focusable descendant of its own, and
+// its height is what the window above it does arithmetic over — so a mark that expanded where it stands would break
+// both. Where the reading is checked is the row's own menu, which a pointer, a finger and a keyboard all already
+// reach; `ReadingsAsked.tsx` is what it opens.
+
+export function MessageReading({ mark }: { readonly mark: MailEnrichmentMark }) {
+    const { translate } = useLocalization();
+
+    return (
+        <span className="flex items-center gap-1.5">
+            {/* Hidden from the accessibility tree because the words beside it say the same thing at more length: two
+                statements about the same mark would be read out one after the other. */}
+            <span
+                aria-hidden="true"
+                className="shrink-0 rounded-xs border border-line-strong px-1.25 text-2xs leading-none text-muted"
+            >
+                {translate('ai.badge')}
+            </span>
+
+            {/* The whole sentence is announced once, aspect and all, and the line that shows it is hidden from the
+                accessibility tree — the alternative is two nodes read one after the other with the punctuation
+                between them written into the markup, which is a sentence assembled at the call site. */}
+            <span className="sr-only">
+                {translate('reading.said', {
+                    aspect: translate(readingNames[mark.aspect]),
+                    text: mark.text,
+                })}
+            </span>
+
+            <span aria-hidden="true" className="truncate">
+                {mark.text}
+            </span>
+        </span>
+    );
+}

--- a/frontend/src/Client.App/src/messageRows/MessageRow.test.tsx
+++ b/frontend/src/Client.App/src/messageRows/MessageRow.test.tsx
@@ -31,6 +31,7 @@ const email: MailTimelineEntry = {
     attachmentCount: 0,
     sizeOctets: 1_024,
     preview: 'The opening of the message.',
+    enrichment: null,
     threadMessageCount: null,
 };
 

--- a/frontend/src/Client.App/src/messageRows/MessageRowMenu.test.tsx
+++ b/frontend/src/Client.App/src/messageRows/MessageRowMenu.test.tsx
@@ -50,11 +50,13 @@ function menuUnder({
     composing = writing,
     onSelect = vi.fn(),
     onAsk = vi.fn(),
+    onCheckReadings,
 }: {
     acts?: MailboxActs;
     composing?: Composing;
     onSelect?: () => void;
     onAsk?: (act: 'delete' | 'move', messages: readonly ActedMessage[]) => void;
+    onCheckReadings?: () => void;
 } = {}): void {
     render(
         <LocalizationProvider>
@@ -66,6 +68,7 @@ function menuUnder({
                         at={{ x: 20, y: 30 }}
                         onSelect={onSelect}
                         onAsk={onAsk}
+                        onCheckReadings={onCheckReadings}
                         onClose={vi.fn()}
                     />
                 </MailboxActsContext>
@@ -149,6 +152,29 @@ describe('MessageRowMenu', () => {
         fireEvent.click(screen.getByRole('menuitem', { name: 'Move…' }));
 
         expect(asked).toHaveBeenCalledWith('move', messages);
+    });
+
+    it('draws no way to check a reading for a message that carries none', () => {
+        menuUnder();
+
+        expect(screen.queryByRole('menuitem', { name: 'Check what MailFathom made of it' })).toBeNull();
+    });
+
+    it('offers checking a reading at the foot, below the acts that change the mailbox', () => {
+        menuUnder({ onCheckReadings: vi.fn() });
+
+        expect(drawn().at(-1)).toBe('Check what MailFathom made of it');
+    });
+
+    it('opens the readings rather than acting on the message', () => {
+        const checked = vi.fn();
+        const performed = vi.fn();
+
+        menuUnder({ acts: actsWhere(() => null, performed), onCheckReadings: checked });
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Check what MailFathom made of it' }));
+
+        expect(checked).toHaveBeenCalledOnce();
+        expect(performed).not.toHaveBeenCalled();
     });
 
     it('starts a conversation about the message where one was asked for', () => {

--- a/frontend/src/Client.App/src/messageRows/MessageRowMenu.tsx
+++ b/frontend/src/Client.App/src/messageRows/MessageRowMenu.tsx
@@ -38,6 +38,7 @@ export function MessageRowMenu({
     at,
     onSelect,
     onAsk,
+    onCheckReadings,
     onClose,
 }: {
     readonly email: MailTimelineEntry;
@@ -53,6 +54,15 @@ export function MessageRowMenu({
     /** Raises the question an act stands behind, over the messages it is about. */
     readonly onAsk: (act: ActAsked, messages: readonly ActedMessage[]) => void;
 
+    /**
+     * Opens what MailFathom made of this message, with the evidence behind each reading.
+     *
+     * This menu is where checking a reading is reached from, and that is a platform constraint rather than a choice:
+     * the row is an `option` of a listbox and holds no focusable descendant, so the sentence on it cannot be a control
+     * of its own. Absent where the message carries no reading, and absent on a list that offers no menu at all.
+     */
+    readonly onCheckReadings?: (() => void) | undefined;
+
     readonly onClose: () => void;
 }) {
     const { translate } = useLocalization();
@@ -63,7 +73,7 @@ export function MessageRowMenu({
         <ContextMenu
             header={email.subject ?? translate('list.noSubject')}
             at={at}
-            items={rowItems({ email, messages, acts, composing, translate, onSelect, onAsk })}
+            items={rowItems({ email, messages, acts, composing, translate, onSelect, onAsk, onCheckReadings })}
             onClose={onClose}
         />
     );
@@ -78,6 +88,7 @@ function rowItems({
     translate,
     onSelect,
     onAsk,
+    onCheckReadings,
 }: {
     readonly email: MailTimelineEntry;
     readonly messages: readonly ActedMessage[];
@@ -86,6 +97,7 @@ function rowItems({
     readonly translate: Translate;
     readonly onSelect: () => void;
     readonly onAsk: (act: ActAsked, messages: readonly ActedMessage[]) => void;
+    readonly onCheckReadings: (() => void) | undefined;
 }): readonly ContextMenuItem[] {
     const answering: readonly ContextMenuItem[] = composing.offered
         ? [
@@ -121,5 +133,18 @@ function rowItems({
             },
         }));
 
-    return [{ icon: 'check_box', label: translate('mail.selectMessages'), choose: onSelect }, ...answering, ...mailbox];
+    // Where a reading is checked. It stands at the foot rather than among the acts, because it changes nothing about
+    // the mailbox: what it opens is an explanation of a sentence the row is drawing, and putting it beside archiving
+    // and deleting would read as a sixth thing that happens to the message.
+    const readings: readonly ContextMenuItem[] =
+        onCheckReadings === undefined
+            ? []
+            : [{ icon: 'auto_awesome', label: translate('reading.check'), choose: onCheckReadings }];
+
+    return [
+        { icon: 'check_box', label: translate('mail.selectMessages'), choose: onSelect },
+        ...answering,
+        ...mailbox,
+        ...readings,
+    ];
 }

--- a/frontend/src/Client.App/src/messageRows/ReadingsAsked.test.tsx
+++ b/frontend/src/Client.App/src/messageRows/ReadingsAsked.test.tsx
@@ -1,0 +1,259 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { useRef } from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type {
+    ClientRequest,
+    ClientResponse,
+    ClientSession,
+    MailEnrichmentMark,
+    MailFathomTransport,
+} from '@mailfathom/client-backend';
+import { LocalizationProvider } from '../localization/Localization';
+import { ReadingsAsked, type AskedReadings } from './ReadingsAsked';
+
+// What the harness's own control says, held as a value rather than written into the markup: a literal there is a
+// user-visible string, and the rule that refuses one does not know this button belongs to a test.
+const opening = 'Check';
+
+const session: ClientSession = {
+    baseAddress: 'https://mail.example.invalid',
+    authorization: 'Basic dGVzdA==',
+};
+
+const commitment: MailEnrichmentMark = {
+    aspect: 'Commitment',
+    text: 'An answer is owed by Friday.',
+    reason: 'The sender asks for confirmation before the end of the week.',
+    dueAt: '2026-09-04T16:00:00+00:00',
+    source: 'Model',
+    origin: 'agents/reader',
+    evidence: ['fragment-1', 'fragment-2'],
+};
+
+const sense: MailEnrichmentMark = {
+    aspect: 'Sense',
+    text: 'An invoice for August.',
+    reason: 'The message attaches a document the sender calls an invoice.',
+    dueAt: null,
+    source: 'DeterministicRule',
+    origin: 'rules/invoice',
+    evidence: [],
+};
+
+function asking(marks: readonly MailEnrichmentMark[]): AskedReadings {
+    return { storedEmailId: 'message-1', subject: 'Contract annex — signatures', marks };
+}
+
+function resolving(citations: readonly unknown[]): ClientResponse {
+    return { status: 200, body: JSON.stringify({ citations }), headers: {} };
+}
+
+function Checking({ asked, transport }: { readonly asked: AskedReadings; readonly transport: MailFathomTransport }) {
+    const dialog = useRef<HTMLDialogElement>(null);
+
+    return (
+        <>
+            <button
+                type="button"
+                onClick={() => {
+                    dialog.current?.showModal();
+                }}
+            >
+                {opening}
+            </button>
+
+            <ReadingsAsked asked={asked} session={session} transport={transport} dialog={dialog} />
+        </>
+    );
+}
+
+function check(asked: AskedReadings, transport: MailFathomTransport): void {
+    render(
+        <LocalizationProvider>
+            <Checking asked={asked} transport={transport} />
+        </LocalizationProvider>,
+    );
+
+    act(() => {
+        fireEvent.click(screen.getByRole('button', { name: opening }));
+    });
+}
+
+function answering(...responses: readonly (ClientResponse | null)[]): MailFathomTransport {
+    return recording(...responses).transport;
+}
+
+function recording(...responses: readonly (ClientResponse | null)[]): {
+    transport: MailFathomTransport;
+    requests: ClientRequest[];
+} {
+    const requests: ClientRequest[] = [];
+
+    return {
+        requests,
+        transport: (request) => {
+            requests.push(request);
+
+            const response = responses[requests.length - 1];
+
+            // A transport answers or rejects, exactly as the real one does: nothing reached is a rejected promise
+            // rather than an absent answer, which is what `send` reads as a deployment that could not be reached.
+            return response === undefined || response === null
+                ? Promise.reject(new Error('the name does not resolve'))
+                : Promise.resolve(response);
+        },
+    };
+}
+
+describe('ReadingsAsked', () => {
+    it('draws every reading of the message, in the order it was handed them', async () => {
+        check(
+            asking([commitment, sense]),
+            answering(resolving([{ outcome: 'Unresolvable' }, { outcome: 'Unresolvable' }])),
+        );
+
+        expect(screen.getAllByRole('heading', { level: 3 }).map((one) => one.textContent)).toStrictEqual([
+            'What is committed to',
+            'What this is about',
+        ]);
+        expect(await screen.findByText('An answer is owed by Friday.')).toBeTruthy();
+        expect(screen.getByText('An invoice for August.')).toBeTruthy();
+    });
+
+    it('names what a reading is about the message rather than of it', () => {
+        check(asking([sense]), answering());
+
+        expect(screen.getByRole('dialog', { name: 'What MailFathom made of this message' })).toBeTruthy();
+        expect(screen.getByText('Contract annex — signatures')).toBeTruthy();
+    });
+
+    it('says a model produced a reading in words rather than only in a colour', () => {
+        check(
+            asking([commitment, sense]),
+            answering(resolving([{ outcome: 'Unresolvable' }, { outcome: 'Unresolvable' }])),
+        );
+
+        expect(screen.getByText('A model — agents/reader')).toBeTruthy();
+        expect(screen.getByText('A rule of this deployment — rules/invoice')).toBeTruthy();
+    });
+
+    it('says why the producer says it, so the reading can be disagreed with', () => {
+        check(asking([sense]), answering());
+
+        expect(screen.getByText('Why: The message attaches a document the sender calls an invoice.')).toBeTruthy();
+    });
+
+    it('says when a commitment falls due', () => {
+        check(asking([commitment]), answering(resolving([{ outcome: 'Unresolvable' }, { outcome: 'Unresolvable' }])));
+
+        expect(screen.getByText(/^Due /)).toBeTruthy();
+    });
+
+    it('says a reading names no passage rather than drawing an empty list under it', () => {
+        check(asking([sense]), answering());
+
+        expect(screen.getByText('This reading names no passage.')).toBeTruthy();
+    });
+
+    it('asks nothing of the deployment where no reading rests on a passage', () => {
+        const { transport, requests } = recording();
+
+        check(asking([sense]), transport);
+
+        expect(requests).toHaveLength(0);
+    });
+
+    it('follows the whole message’s evidence in one request', async () => {
+        const { transport, requests } = recording(
+            resolving([
+                { outcome: 'Resolved', fragment: { fragmentId: 'fragment-1', ordinal: 0, text: 'Please confirm.' } },
+                { outcome: 'Resolved', fragment: { fragmentId: 'fragment-2', ordinal: 4, text: 'Before Friday.' } },
+            ]),
+        );
+
+        check(asking([commitment, sense]), transport);
+
+        expect(await screen.findByText('Please confirm.')).toBeTruthy();
+        expect(screen.getByText('Before Friday.')).toBeTruthy();
+        expect(requests).toHaveLength(1);
+        expect(JSON.parse(requests[0]?.body ?? '')).toStrictEqual({
+            citations: [
+                { kind: 'fragment', email: 'message-1', fragment: 'fragment-1' },
+                { kind: 'fragment', email: 'message-1', fragment: 'fragment-2' },
+            ],
+        });
+    });
+
+    it('says it is reading the passages while the request is in flight', () => {
+        check(asking([commitment]), answering(resolving([])));
+
+        expect(screen.getByRole('status').textContent).toBe('Reading the passages this rests on…');
+    });
+
+    it('keeps a passage that has moved apart from one this sign-in may not read', async () => {
+        check(asking([commitment]), answering(resolving([{ outcome: 'Unresolvable' }, { outcome: 'PrivateSource' }])));
+
+        expect(
+            await screen.findByText('This passage is no longer where it was — the message has been read again since.'),
+        ).toBeTruthy();
+        expect(screen.getByText('This passage cannot be read with this sign-in.')).toBeTruthy();
+    });
+
+    it('says a passage past what one request follows was not followed, rather than that it has moved', async () => {
+        const crowded: MailEnrichmentMark[] = ['Commitment', 'Significance', 'Sense'].map((aspect, at) => ({
+            ...commitment,
+            aspect: aspect as MailEnrichmentMark['aspect'],
+            evidence: Array.from({ length: 4 }, (_unused, which) => `fragment-${String(at)}-${String(which)}`),
+        }));
+
+        const followed = Array.from({ length: 10 }, (_unused, at) => ({
+            outcome: 'Resolved',
+            fragment: {
+                fragmentId: `fragment-${String(Math.floor(at / 4))}-${String(at % 4)}`,
+                ordinal: at,
+                text: 'Words.',
+            },
+        }));
+
+        check(asking(crowded), answering(resolving(followed)));
+
+        expect(await screen.findAllByText('Words.')).toHaveLength(10);
+        expect(
+            screen.getAllByText('Only the first ten passages a message rests on are followed, and this is past them.'),
+        ).toHaveLength(2);
+    });
+
+    it('offers to read the passages again where the deployment could not be reached', async () => {
+        const { transport, requests } = recording(
+            null,
+            resolving([
+                { outcome: 'Resolved', fragment: { fragmentId: 'fragment-1', ordinal: 0, text: 'Please confirm.' } },
+                { outcome: 'Resolved', fragment: { fragmentId: 'fragment-2', ordinal: 4, text: 'Before Friday.' } },
+            ]),
+        );
+
+        check(asking([commitment]), transport);
+
+        const again = await screen.findByRole('button', { name: 'Try again' });
+
+        expect(screen.getByRole('alert').textContent).toContain('The passages this rests on could not be read');
+
+        act(() => {
+            fireEvent.click(again);
+        });
+
+        expect(await screen.findByText('Please confirm.')).toBeTruthy();
+        expect(requests).toHaveLength(2);
+    });
+
+    it('closes on the control it draws for that, because no state is reachable that cannot be left', () => {
+        check(asking([sense]), answering());
+        fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+
+        expect(screen.queryByRole('dialog')).toBeNull();
+    });
+});

--- a/frontend/src/Client.App/src/messageRows/ReadingsAsked.tsx
+++ b/frontend/src/Client.App/src/messageRows/ReadingsAsked.tsx
@@ -1,0 +1,312 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { useEffect, useId, useState, type RefObject } from 'react';
+import {
+    mostCitedPassages,
+    readCitedPassages,
+    type CitedPassage,
+    type ClientFailure,
+    type ClientFailureReason,
+    type ClientSession,
+    type MailEnrichmentMark,
+    type MailFathomTransport,
+} from '@mailfathom/client-backend';
+import { Icon } from '../controls/Icon';
+import { SecondaryButton } from '../controls/SecondaryButton';
+import { SurfaceControl } from '../controls/SurfaceControl';
+import type { MessageKey } from '../localization/en';
+import { wordInstant } from '../localization/instants';
+import { useLocalization } from '../localization/useLocalization';
+import { readingNames, readingSources } from './messageReadings';
+
+// Where a reading is checked. Every mark a message carries, each with the sentence, why the producer says it, what
+// produced it, and the passages of the message it was drawn from — which is the whole of what makes a mark something
+// somebody can disagree with rather than something they have to take.
+//
+// **A modal rather than something that opens on the row.** Two things decide that and neither is taste: a row is an
+// `option` of a listbox, which holds no focusable descendant, and its height is what the window above it does
+// arithmetic over — so a reading that expanded where it stands would take the keyboard path off the list and put every
+// row below it somewhere other than where the list drew the space for it. What opens this is the row's own menu, which
+// a pointer, a finger and a keyboard already reach four ways. The design project draws neither this surface nor an
+// affordance that opens it, which is a gap in it rather than a shape settled here.
+//
+// **The evidence is fetched rather than carried.** A row publishes passage identifiers because a list page carrying
+// the passages themselves would be publishing a body it had no reason to, so the words arrive when somebody asks to
+// see them — one request for the whole message's evidence, made when this is opened.
+//
+// **Nothing here is written down anywhere.** The sentences, the reasons and the passages are mail, and they live for
+// as long as this dialog is open.
+
+/** What is being checked: one message's readings, and the message its evidence is followed against. */
+export interface AskedReadings {
+    readonly storedEmailId: string;
+    readonly subject: string | null;
+    readonly marks: readonly MailEnrichmentMark[];
+}
+
+const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
+    unauthenticated: 'failure.unauthenticated',
+    unauthorized: 'failure.unauthorized',
+    unavailable: 'failure.unavailable',
+    unreadable: 'failure.unreadable',
+    missing: 'failure.missing',
+};
+
+export function ReadingsAsked({
+    asked,
+    session,
+    transport,
+    dialog,
+}: {
+    /** The readings being checked, or `null` while nothing is. */
+    readonly asked: AskedReadings | null;
+
+    readonly session: ClientSession;
+    readonly transport: MailFathomTransport;
+
+    /** The dialog itself, opened by whichever surface asked, so that whether it is open is the element's own state. */
+    readonly dialog: RefObject<HTMLDialogElement | null>;
+}) {
+    const { translate } = useLocalization();
+    const names = useId();
+
+    return (
+        <dialog
+            ref={dialog}
+            aria-labelledby={names}
+            className="m-auto w-160 max-w-full rounded-2xl border border-line bg-panel p-0 text-text shadow-dialog backdrop:bg-scrim"
+        >
+            <div className="flex items-center gap-2.5 border-b border-line px-4 py-3">
+                <Icon name="auto_awesome" className="size-5 shrink-0 text-accent-strong" />
+
+                <h2 id={names} className="flex-1 truncate text-base font-semibold">
+                    {translate('reading.title')}
+                </h2>
+
+                <SurfaceControl
+                    label={translate('reading.close')}
+                    icon="close"
+                    onActivate={() => {
+                        dialog.current?.close();
+                    }}
+                />
+            </div>
+
+            {/* Keyed by the message, so asking about a second one starts its evidence read rather than reconciling an
+                answer with a question the reader has already moved on from. */}
+            {asked === null ? null : (
+                <AskedMessage key={asked.storedEmailId} asked={asked} session={session} transport={transport} />
+            )}
+        </dialog>
+    );
+}
+
+function AskedMessage({
+    asked,
+    session,
+    transport,
+}: {
+    readonly asked: AskedReadings;
+    readonly session: ClientSession;
+    readonly transport: MailFathomTransport;
+}) {
+    const { locale, translate } = useLocalization();
+    const evidence = useCitedEvidence(session, transport, asked);
+
+    return (
+        <div className="flex max-h-144 flex-col gap-3.5 overflow-y-auto px-4 py-3.5">
+            <p className="text-sm text-muted text-pretty">{translate('reading.about')}</p>
+
+            <p className="text-base font-semibold text-pretty">{asked.subject ?? translate('list.noSubject')}</p>
+
+            {asked.marks.map((mark) => {
+                const due = mark.dueAt === null ? null : wordInstant(mark.dueAt, locale, 'full');
+
+                return (
+                    <section key={mark.aspect} className="flex flex-col gap-1.5 rounded-xl border border-line p-3">
+                        <div className="flex flex-wrap items-center gap-1.5">
+                            <h3 className="text-2xs font-semibold tracking-widest text-muted uppercase">
+                                {translate(readingNames[mark.aspect])}
+                            </h3>
+
+                            {/* What produced the reading, drawn apart from the reading itself and drawn differently
+                                for each producer: a deterministic rule re-run over the same message says the same
+                                thing and a model promises no such thing, so somebody weighing a mark meets that before
+                                they read the sentence. The words carry the distinction as well as the tint, because
+                                one only a colour makes is one a reader who cannot see it does not get. */}
+                            <span
+                                className={`ms-auto rounded-full px-2 py-px text-2xs ${
+                                    mark.source === 'Model'
+                                        ? 'bg-accent-soft text-accent-deep'
+                                        : 'bg-healthy-soft text-healthy-text'
+                                }`}
+                            >
+                                {translate(readingSources[mark.source], { origin: mark.origin })}
+                            </span>
+                        </div>
+
+                        <p className="text-base text-pretty">{mark.text}</p>
+
+                        {due === null ? null : (
+                            <p className="flex items-center gap-1.5 text-sm text-muted">
+                                <Icon name="schedule" className="size-4 shrink-0" />
+
+                                {translate('reading.dueAt', { when: due })}
+                            </p>
+                        )}
+
+                        <p className="text-sm text-muted text-pretty">
+                            {translate('reading.reason', { reason: mark.reason })}
+                        </p>
+
+                        <MarkEvidence mark={mark} evidence={evidence} />
+                    </section>
+                );
+            })}
+        </div>
+    );
+}
+
+// What one mark rests on, which is the half of this surface somebody who doubts the sentence actually came for. The
+// passages are drawn in the order the producer named them, best first, and each says for itself whether the words
+// behind it could still be reached.
+function MarkEvidence({ mark, evidence }: { readonly mark: MailEnrichmentMark; readonly evidence: CitedEvidence }) {
+    const { translate } = useLocalization();
+
+    // A reading with no evidence is one the deployment refuses to store, so this states an absence rather than drawing
+    // an empty list under a sentence that is supposed to be checkable.
+    if (mark.evidence.length === 0) {
+        return <p className="text-sm text-faint">{translate('reading.noEvidence')}</p>;
+    }
+
+    if (evidence.reading) {
+        return (
+            <p className="text-sm text-muted" role="status">
+                {translate('reading.readingEvidence')}
+            </p>
+        );
+    }
+
+    if (evidence.failure !== null) {
+        return (
+            <div className="flex flex-wrap items-center gap-1.5">
+                <p className="text-sm text-warning" role="alert">
+                    {translate('reading.evidenceFailed', {
+                        reason: translate(failureLabels[evidence.failure.reason]),
+                    })}
+                </p>
+
+                {evidence.failure.reason === 'unavailable' ? (
+                    <SecondaryButton label={translate('connection.retry')} onActivate={evidence.readAgain} />
+                ) : null}
+            </div>
+        );
+    }
+
+    return (
+        <ul className="flex flex-col gap-1.5">
+            {mark.evidence.map((passage) => {
+                const cited = evidence.passages.get(passage);
+                const words = cited?.text ?? null;
+
+                return (
+                    <li
+                        key={passage}
+                        className="border-s-2 border-s-line-strong ps-2.5 text-sm text-text-soft text-pretty"
+                    >
+                        {words ?? <span className="text-faint">{translate(insteadOf(cited))}</span>}
+                    </li>
+                );
+            })}
+        </ul>
+    );
+}
+
+/**
+ * What is said where a passage produced no words, which is three different things and not one.
+ *
+ * A passage nothing answered for was never asked about: one request follows ten citations and a message may name
+ * twelve, so the last of them are past what this surface follows. Saying the message had moved under it would be
+ * telling somebody a fact about their mail that this client has no evidence for.
+ */
+function insteadOf(cited: CitedPassage | undefined): MessageKey {
+    if (cited === undefined) {
+        return 'reading.passageNotFollowed';
+    }
+
+    return cited.outcome === 'PrivateSource' ? 'reading.passagePrivate' : 'reading.passageGone';
+}
+
+interface CitedEvidence {
+    readonly reading: boolean;
+    readonly failure: ClientFailure | null;
+    readonly passages: ReadonlyMap<string, CitedPassage>;
+    readonly readAgain: () => void;
+}
+
+/** What one answer was to, so an answer that arrives for a question nobody is asking any more is not read as this one. */
+interface EvidenceAnswer {
+    readonly asking: string;
+    readonly attempt: number;
+    readonly failure: ClientFailure | null;
+    readonly passages: ReadonlyMap<string, CitedPassage>;
+}
+
+// One read for the whole message's evidence rather than one per mark: three readings resting on four passages each is
+// within the ten one request follows, so a message's readings are backed by a single request however many there are.
+//
+// Whether it is still reading is derived from whether the answer standing is the answer to the question being asked,
+// rather than kept as a second piece of state beside it: the two would have to be held in step, and the pair that
+// disagrees is a spinner over an answer that has already arrived.
+function useCitedEvidence(session: ClientSession, transport: MailFathomTransport, asked: AskedReadings): CitedEvidence {
+    const wanted = [...new Set(asked.marks.flatMap((mark) => mark.evidence))].slice(0, mostCitedPassages);
+
+    // The identities joined rather than the array itself, because a fresh array of the same passages on every render
+    // would start the read again on every render. They are identifiers rather than words, so this is a key rather
+    // than a copy of anything anybody wrote.
+    const asking = wanted.join('\n');
+
+    const [attempt, setAttempt] = useState(0);
+    const [answer, setAnswer] = useState<EvidenceAnswer | null>(null);
+
+    const standing = answer !== null && answer.asking === asking && answer.attempt === attempt ? answer : null;
+
+    useEffect(() => {
+        if (asking === '') {
+            return;
+        }
+
+        let listening = true;
+
+        void readCitedPassages(session, transport, asked.storedEmailId, asking.split('\n')).then((result) => {
+            if (!listening) {
+                return;
+            }
+
+            setAnswer({
+                asking,
+                attempt,
+                failure: result.outcome === 'failed' ? result.failure : null,
+                passages:
+                    result.outcome === 'read'
+                        ? new Map(result.value.map((cited) => [cited.passage, cited]))
+                        : new Map(),
+            });
+        });
+
+        return () => {
+            listening = false;
+        };
+    }, [session, transport, asked.storedEmailId, asking, attempt]);
+
+    return {
+        reading: asking !== '' && standing === null,
+        failure: standing?.failure ?? null,
+        passages: standing?.passages ?? new Map(),
+        readAgain: () => {
+            setAttempt(attempt + 1);
+        },
+    };
+}

--- a/frontend/src/Client.App/src/messageRows/messageReadings.test.ts
+++ b/frontend/src/Client.App/src/messageRows/messageReadings.test.ts
@@ -1,0 +1,72 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import type { MailEnrichmentAspect, MailEnrichmentMark } from '@mailfathom/client-backend';
+import { leadingReading, readingNames, readingsOf, readingSources } from './messageReadings';
+
+function mark(aspect: MailEnrichmentAspect): MailEnrichmentMark {
+    return {
+        aspect,
+        text: `A reading of ${aspect}.`,
+        reason: 'Because the message says so.',
+        dueAt: null,
+        source: 'DeterministicRule',
+        origin: 'rules/one',
+        evidence: [],
+    };
+}
+
+function derived(marks: readonly MailEnrichmentMark[]) {
+    return { derivedAt: '2026-08-31T09:41:00+00:00', marks };
+}
+
+describe('readingsOf', () => {
+    it('reads a message no derivation reached as carrying no reading', () => {
+        expect(readingsOf(null)).toStrictEqual([]);
+    });
+
+    it('reads a derivation that settled with nothing to say as carrying no reading', () => {
+        expect(readingsOf(derived([]))).toStrictEqual([]);
+    });
+
+    it('puts what is owed first, then why the message matters, then what it is about', () => {
+        const readings = readingsOf(derived([mark('Sense'), mark('Commitment'), mark('Significance')]));
+
+        expect(readings.map((one) => one.aspect)).toStrictEqual(['Commitment', 'Significance', 'Sense']);
+    });
+
+    it('leaves what the deployment answered untouched', () => {
+        const marks = [mark('Sense'), mark('Commitment')];
+
+        readingsOf(derived(marks));
+
+        expect(marks.map((one) => one.aspect)).toStrictEqual(['Sense', 'Commitment']);
+    });
+});
+
+describe('leadingReading', () => {
+    it('draws nothing for a message with no reading', () => {
+        expect(leadingReading(null)).toBeNull();
+        expect(leadingReading(derived([]))).toBeNull();
+    });
+
+    it('draws the most actionable reading rather than the first one answered', () => {
+        expect(leadingReading(derived([mark('Sense'), mark('Commitment')]))?.aspect).toBe('Commitment');
+    });
+
+    it('draws the only reading a message carries whichever it is', () => {
+        expect(leadingReading(derived([mark('Sense')]))?.aspect).toBe('Sense');
+    });
+});
+
+describe('what a reading and its producer are called', () => {
+    it('names every aspect the deployment publishes', () => {
+        expect(Object.keys(readingNames)).toStrictEqual(['Sense', 'Significance', 'Commitment']);
+    });
+
+    it('keeps a rule and a model apart rather than calling both of them AI', () => {
+        expect(readingSources.DeterministicRule).not.toBe(readingSources.Model);
+    });
+});

--- a/frontend/src/Client.App/src/messageRows/messageReadings.ts
+++ b/frontend/src/Client.App/src/messageRows/messageReadings.ts
@@ -1,0 +1,89 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type {
+    MailEnrichment,
+    MailEnrichmentAspect,
+    MailEnrichmentMark,
+    MailEnrichmentSource,
+} from '@mailfathom/client-backend';
+import type { MessageKey } from '../localization/en';
+
+// Which of a message's readings a row draws, and in what order every one of them is read when somebody opens them.
+//
+// It is arithmetic over what the deployment already decided rather than a judgement of its own, and it is a module
+// because both surfaces need the same answer: the row draws one reading and the panel behind it draws all of them, and
+// a second ordering written into either is how the sentence on the row would stop being the first one in the panel.
+//
+// **A row draws one reading and never three.** The row's height is the token's rather than its contents', which is
+// what the window above it is arithmetic over, so what the reserved line holds is one sentence — and choosing which
+// is a decision rather than a default: a folder is scanned for what is owed, so a commitment leads, then why the
+// message matters, then what it is about. That order is also why a message with all three is not a taller row.
+
+/**
+ * Every reading, most actionable first.
+ *
+ * A commitment is the one that carries a date and the one that costs somebody something if it is missed, so it leads;
+ * the significance says why the message matters at all; the sense says what it is, which is the reading a subject line
+ * already half-answers.
+ */
+export const readingOrder: readonly MailEnrichmentAspect[] = ['Commitment', 'Significance', 'Sense'];
+
+/**
+ * What each reading is called, which is what says a sentence on a row is a reading of the message rather than from it.
+ *
+ * Exhaustive by the deployment's own closed set rather than a lookup with a fallback: an aspect this client has no
+ * name for is a compiler error here, which is where it can still be answered, rather than an unlabelled sentence on
+ * somebody's list.
+ */
+export const readingNames: Readonly<Record<MailEnrichmentAspect, MessageKey>> = {
+    Sense: 'reading.sense',
+    Significance: 'reading.significance',
+    Commitment: 'reading.commitment',
+};
+
+/**
+ * What each producer is called, which is the distinction a reader weighs before they read the sentence.
+ *
+ * A deterministic rule re-run over the same message says the same thing and a model promises no such thing, so the two
+ * are named apart and drawn apart. Nothing here collapses them into "AI".
+ */
+export const readingSources: Readonly<Record<MailEnrichmentSource, MessageKey>> = {
+    DeterministicRule: 'reading.byRule',
+    Model: 'reading.byModel',
+};
+
+/**
+ * The readings of one message, most actionable first.
+ *
+ * @param enrichment What a derivation concluded, or `null` where none has reached the message.
+ * @returns The marks in reading order, which is empty for a message with nothing to say and for one never derived.
+ */
+export function readingsOf(enrichment: MailEnrichment | null): readonly MailEnrichmentMark[] {
+    if (enrichment === null) {
+        return [];
+    }
+
+    // Sorted from the aspect rather than filtered per aspect, because the deployment publishes at most one mark of
+    // each: a message carrying two of one aspect is refused at the boundary, so there is no choosing to do here.
+    return [...enrichment.marks].sort((first, second) => positionOf(first.aspect) - positionOf(second.aspect));
+}
+
+/**
+ * The reading a row draws, or `null` where the row draws none.
+ *
+ * @param enrichment What a derivation concluded, or `null` where none has reached the message.
+ * @returns The leading mark, or `null` for a message no reading was written for.
+ */
+export function leadingReading(enrichment: MailEnrichment | null): MailEnrichmentMark | null {
+    return readingsOf(enrichment)[0] ?? null;
+}
+
+function positionOf(aspect: MailEnrichmentAspect): number {
+    const at = readingOrder.indexOf(aspect);
+
+    // An aspect this order does not name sorts last rather than first: the closed set is the deployment's and a
+    // member added to it is one this client has not been told how to rank, which is not a reason to lead with it.
+    return at === -1 ? readingOrder.length : at;
+}

--- a/frontend/src/Client.App/src/search/citedFile.test.ts
+++ b/frontend/src/Client.App/src/search/citedFile.test.ts
@@ -45,6 +45,7 @@ function found(carried: Partial<MailSearchResult> = {}): MailSearchResult {
         attachmentCount: 2,
         sizeOctets: 4_096,
         preview: 'The renewal falls due.',
+        enrichment: null,
         threadMessageCount: null,
         snippets: [],
         matchedBy: 'LexicalRanking',

--- a/frontend/src/Client.App/src/thread/ThreadMessage.test.tsx
+++ b/frontend/src/Client.App/src/thread/ThreadMessage.test.tsx
@@ -95,6 +95,7 @@ function message(overrides: Partial<MailThreadMessage> = {}): MailThreadMessage 
             attachmentCount: 0,
             sizeOctets: 1_024,
             preview: 'The figures you asked for are attached.',
+            enrichment: null,
             threadMessageCount: null,
         },
         message: described,

--- a/frontend/src/Client.App/src/thread/threadOpening.test.ts
+++ b/frontend/src/Client.App/src/thread/threadOpening.test.ts
@@ -28,6 +28,7 @@ function message(id: string, position: number, unread = false): MailThreadMessag
             attachmentCount: 0,
             sizeOctets: 1_024,
             preview: 'What this one added.',
+            enrichment: null,
             threadMessageCount: null,
         },
         message: null,

--- a/frontend/src/Client.Backend/src/citedPassages.test.ts
+++ b/frontend/src/Client.Backend/src/citedPassages.test.ts
@@ -181,6 +181,28 @@ describe('readCitedPassages', () => {
         expect(answer).toStrictEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
     });
 
+    it('refuses words attached to an outcome that resolved to none, rather than drawing them', async () => {
+        const attached = {
+            outcome: 'PrivateSource',
+            fragment: { fragmentId: 'first', ordinal: 0, text: 'What this sign-in may not read.' },
+        };
+
+        const answer = await readCitedPassages(session, answering(resolving([attached])), storedEmailId, ['first']);
+
+        expect(answer).toStrictEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+
+    it('refuses a resolution that says it resolved and names no passage', async () => {
+        const answer = await readCitedPassages(
+            session,
+            answering(resolving([{ outcome: 'Resolved', fragment: null }])),
+            storedEmailId,
+            ['first'],
+        );
+
+        expect(answer).toStrictEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+
     it('refuses an outcome this client does not know, rather than drawing a conclusion from it', async () => {
         const answer = await readCitedPassages(
             session,

--- a/frontend/src/Client.Backend/src/citedPassages.test.ts
+++ b/frontend/src/Client.Backend/src/citedPassages.test.ts
@@ -1,0 +1,240 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import { mostCitedPassages, readCitedPassages } from './citedPassages';
+import type { ClientSession } from './session';
+import type { ClientRequest, ClientResponse, MailFathomTransport } from './transport';
+
+const session: ClientSession = {
+    baseAddress: 'https://mail.example.invalid',
+    authorization: 'Basic dGVzdA==',
+};
+
+const storedEmailId = '2f7d4f2a-6c1e-4e0a-9a2f-1b0c9d8e7f60';
+
+type Answer = Omit<ClientResponse, 'headers'>;
+
+function answering(response: Answer): MailFathomTransport {
+    return () => Promise.resolve({ ...response, headers: {} });
+}
+
+function recording(response: Answer): { transport: MailFathomTransport; requests: ClientRequest[] } {
+    const requests: ClientRequest[] = [];
+
+    return {
+        requests,
+        transport: (request) => {
+            requests.push(request);
+
+            return Promise.resolve({ ...response, headers: {} });
+        },
+    };
+}
+
+function resolving(citations: readonly unknown[]): Answer {
+    return { status: 200, body: JSON.stringify({ citations }) };
+}
+
+describe('readCitedPassages', () => {
+    it('asks the citation route for one fragment of this message per passage', async () => {
+        const { transport, requests } = recording(
+            resolving([
+                { outcome: 'Resolved', fragment: { fragmentId: 'first', ordinal: 0, text: 'The figures.' } },
+                { outcome: 'Resolved', fragment: { fragmentId: 'second', ordinal: 3, text: 'By Friday.' } },
+            ]),
+        );
+
+        await readCitedPassages(session, transport, storedEmailId, ['first', 'second']);
+
+        expect(requests[0]?.method).toBe('POST');
+        expect(requests[0]?.path).toBe('https://mail.example.invalid/api/client/citations/resolution');
+        expect(requests[0]?.headers['Authorization']).toBe('Basic dGVzdA==');
+        expect(requests[0]?.headers['Content-Type']).toBe('application/json');
+        expect(JSON.parse(requests[0]?.body ?? '')).toStrictEqual({
+            citations: [
+                { kind: 'fragment', email: storedEmailId, fragment: 'first' },
+                { kind: 'fragment', email: storedEmailId, fragment: 'second' },
+            ],
+        });
+    });
+
+    it('pairs each resolution with the passage that position asked about', async () => {
+        const answer = await readCitedPassages(
+            session,
+            answering(
+                resolving([
+                    { outcome: 'Resolved', fragment: { fragmentId: 'first', ordinal: 0, text: 'The figures.' } },
+                    { outcome: 'Resolved', fragment: { fragmentId: 'second', ordinal: 3, text: 'By Friday.' } },
+                ]),
+            ),
+            storedEmailId,
+            ['first', 'second'],
+        );
+
+        expect(answer).toStrictEqual({
+            outcome: 'read',
+            value: [
+                { passage: 'first', outcome: 'Resolved', ordinal: 0, text: 'The figures.' },
+                { passage: 'second', outcome: 'Resolved', ordinal: 3, text: 'By Friday.' },
+            ],
+        });
+    });
+
+    it('keeps a passage that has moved apart from a message this sign-in may not read', async () => {
+        const answer = await readCitedPassages(
+            session,
+            answering(resolving([{ outcome: 'Unresolvable' }, { outcome: 'PrivateSource', fragment: null }])),
+            storedEmailId,
+            ['first', 'second'],
+        );
+
+        expect(answer).toStrictEqual({
+            outcome: 'read',
+            value: [
+                { passage: 'first', outcome: 'Unresolvable', ordinal: null, text: null },
+                { passage: 'second', outcome: 'PrivateSource', ordinal: null, text: null },
+            ],
+        });
+    });
+
+    it('reads a passage the message holds as empty words rather than as nothing', async () => {
+        const answer = await readCitedPassages(
+            session,
+            answering(resolving([{ outcome: 'Resolved', fragment: { fragmentId: 'first', ordinal: 0, text: '' } }])),
+            storedEmailId,
+            ['first'],
+        );
+
+        expect(answer).toStrictEqual({
+            outcome: 'read',
+            value: [{ passage: 'first', outcome: 'Resolved', ordinal: 0, text: '' }],
+        });
+    });
+
+    it('sends nothing where there is no passage to follow', async () => {
+        const { transport, requests } = recording(resolving([]));
+
+        const answer = await readCitedPassages(session, transport, storedEmailId, []);
+
+        expect(answer).toStrictEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: null } });
+        expect(requests).toHaveLength(0);
+    });
+
+    it('sends nothing where more passages are named than the route follows at once', async () => {
+        const { transport, requests } = recording(resolving([]));
+        const passages = Array.from({ length: mostCitedPassages + 1 }, (_unused, at) => `fragment-${String(at)}`);
+
+        const answer = await readCitedPassages(session, transport, storedEmailId, passages);
+
+        expect(answer).toStrictEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: null } });
+        expect(requests).toHaveLength(0);
+    });
+
+    it('reports a deployment that did not answer as unreachable', async () => {
+        const answer = await readCitedPassages(
+            session,
+            () => Promise.reject(new Error('the name does not resolve')),
+            storedEmailId,
+            ['first'],
+        );
+
+        expect(answer).toStrictEqual({ outcome: 'failed', failure: { reason: 'unavailable', status: null } });
+    });
+
+    it('reads what a refused status stands for', async () => {
+        const answer = await readCitedPassages(session, answering({ status: 403, body: '' }), storedEmailId, ['first']);
+
+        expect(answer).toStrictEqual({ outcome: 'failed', failure: { reason: 'unauthorized', status: 403 } });
+    });
+
+    it('refuses a body that is not an answer at all', async () => {
+        const answer = await readCitedPassages(session, answering({ status: 200, body: 'not json' }), storedEmailId, [
+            'first',
+        ]);
+
+        expect(answer).toStrictEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+
+    it('refuses an answer holding a different number of resolutions than were asked for', async () => {
+        const answer = await readCitedPassages(
+            session,
+            answering(resolving([{ outcome: 'Unresolvable' }])),
+            storedEmailId,
+            ['first', 'second'],
+        );
+
+        expect(answer).toStrictEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+
+    it('refuses an answer that names a passage other than the one that position asked about', async () => {
+        const answer = await readCitedPassages(
+            session,
+            answering(
+                resolving([{ outcome: 'Resolved', fragment: { fragmentId: 'second', ordinal: 0, text: 'Words.' } }]),
+            ),
+            storedEmailId,
+            ['first'],
+        );
+
+        expect(answer).toStrictEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+
+    it('refuses an outcome this client does not know, rather than drawing a conclusion from it', async () => {
+        const answer = await readCitedPassages(
+            session,
+            answering(resolving([{ outcome: 'Redacted' }])),
+            storedEmailId,
+            ['first'],
+        );
+
+        expect(answer).toStrictEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+
+    it('refuses a resolved passage that does not say where in the message it sits', async () => {
+        const answers = [
+            { outcome: 'Resolved', fragment: { fragmentId: 'first', ordinal: -1, text: 'Words.' } },
+            { outcome: 'Resolved', fragment: { fragmentId: 'first', ordinal: 0.5, text: 'Words.' } },
+            { outcome: 'Resolved', fragment: { fragmentId: 'first', text: 'Words.' } },
+        ];
+
+        for (const one of answers) {
+            const answer = await readCitedPassages(session, answering(resolving([one])), storedEmailId, ['first']);
+
+            expect(answer).toStrictEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+        }
+    });
+
+    it('refuses a passage larger than one chunk of a message', async () => {
+        const answer = await readCitedPassages(
+            session,
+            answering(
+                resolving([
+                    { outcome: 'Resolved', fragment: { fragmentId: 'first', ordinal: 0, text: 'a'.repeat(8_193) } },
+                ]),
+            ),
+            storedEmailId,
+            ['first'],
+        );
+
+        expect(answer).toStrictEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+
+    it('refuses an answer whose resolutions are not records', async () => {
+        const answer = await readCitedPassages(session, answering(resolving(['Resolved'])), storedEmailId, ['first']);
+
+        expect(answer).toStrictEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+
+    it('refuses an answer that holds no citations at all', async () => {
+        const answer = await readCitedPassages(
+            session,
+            answering({ status: 200, body: JSON.stringify({ citations: 'none' }) }),
+            storedEmailId,
+            ['first'],
+        );
+
+        expect(answer).toStrictEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+});

--- a/frontend/src/Client.Backend/src/citedPassages.ts
+++ b/frontend/src/Client.Backend/src/citedPassages.ts
@@ -1,0 +1,198 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { failed, failureReasonForStatus, read, type ClientResult } from './failure';
+import { asRecord } from './json';
+import { headersFor, routeFor, type ClientSession } from './session';
+import { spanned } from './telemetry';
+import { send, type MailFathomTransport } from './transport';
+
+// Following a mark's evidence back to the words it rests on. The deployment publishes evidence as passage identifiers
+// rather than as text — a list page carrying the passages themselves would be publishing a body it had no reason to —
+// so a screen that wants to show somebody what a reading was drawn from asks for it, which is this.
+//
+// It asks the citation route, and only for the one kind a mark's evidence names: a passage of a message. The route
+// follows two other kinds as well, and neither is composed here, because an operation this package publishes with no
+// caller is a wire contract nobody is holding to. The route's own request document is flat across all three kinds, so
+// the second caller adds its members rather than a second module.
+//
+// **The three outcomes are three states and none of them is a failure.** A passage resolves to its words; a passage
+// the message has been re-cut since resolves to nothing while the message stays; and a message the caller may not read
+// resolves to nothing at all. A reader owes the difference between "this reading rests on a passage that has since
+// moved" and "this reading has nothing behind it", and folding the three into an absence would take it away.
+
+/** The route a citation is followed at, relative to the client prefix. */
+export const citedPassagesRoute = '/citations/resolution';
+
+/** What became of one citation, as the deployment names it. */
+export type CitedPassageOutcome = 'Resolved' | 'Unresolvable' | 'PrivateSource';
+
+const outcomes: readonly CitedPassageOutcome[] = ['Resolved', 'Unresolvable', 'PrivateSource'];
+
+/**
+ * How many citations one request follows, which is the deployment's own bound rather than a preference.
+ *
+ * A request naming more is refused with a `400`, so the client holds the same number and asks within it. A mark rests
+ * on at most four passages and a message carries at most three marks, so one message's whole evidence is within it and
+ * no screen here has to page.
+ */
+export const mostCitedPassages = 10;
+
+// A resolved passage is one chunk of a message's text, which chunking already cut to a fixed length, and ten of them
+// with their offsets and identities is what an answer holds. Well above that and far below the transport's backstop.
+const longestCitationAnswer = 128 * 1024;
+
+const longestIdentity = 256;
+const longestPassage = 8_192;
+
+/** One passage a mark's evidence names, and what following it produced. */
+export interface CitedPassage {
+    /** The passage the citation named, which is what pairs a resolution with the evidence entry that asked for it. */
+    readonly passage: string;
+
+    readonly outcome: CitedPassageOutcome;
+
+    /**
+     * Where in the message's text the passage sits, counted from the start of it.
+     *
+     * `null` for either outcome that resolved to no passage, so a screen never draws a position for words it does not
+     * have.
+     */
+    readonly ordinal: number | null;
+
+    /** The words the passage holds, or `null` where the citation resolved to no passage. */
+    readonly text: string | null;
+}
+
+/**
+ * Follows the passages one message's evidence names, answering an expected failure as a value rather than by throwing.
+ *
+ * @param session The address to reach and the finished header value to present.
+ * @param transport How the request goes out.
+ * @param storedEmailId The message every passage belongs to, which every citation names.
+ * @param passages The passages to follow, at most {@link mostCitedPassages} of them.
+ * @returns One resolution per passage in the order they were named, or why none arrived.
+ */
+export function readCitedPassages(
+    session: ClientSession,
+    transport: MailFathomTransport,
+    storedEmailId: string,
+    passages: readonly string[],
+): Promise<ClientResult<readonly CitedPassage[]>> {
+    return spanned(`POST ${citedPassagesRoute}`, async () => {
+        if (passages.length === 0 || passages.length > mostCitedPassages) {
+            // Refused here rather than sent, because a request the route answers `400` to is one this client composed
+            // wrongly: the reader would meet it as a deployment that would not answer, which is not what happened.
+            return failed('unreadable', null);
+        }
+
+        const response = await send(transport, {
+            method: 'POST',
+            path: routeFor(session, citedPassagesRoute),
+            headers: { ...headersFor(session), 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                citations: passages.map((passage) => ({ kind: 'fragment', email: storedEmailId, fragment: passage })),
+            }),
+            longestAnswer: longestCitationAnswer,
+        });
+
+        if (response === null) {
+            return failed('unavailable', null);
+        }
+
+        if (response.status !== 200) {
+            return failed(failureReasonForStatus(response.status), response.status);
+        }
+
+        const resolved = parseResolutions(response.body, passages);
+
+        return resolved === null ? failed('unreadable', response.status) : read(resolved);
+    });
+}
+
+// The answer is held against what was asked for as well as against its own shape: the route answers one resolution per
+// citation in the order the request named them, so a count that disagrees is an answer this client cannot pair with
+// the evidence it asked about and refuses rather than draws against the wrong mark.
+function parseResolutions(body: string, asked: readonly string[]): readonly CitedPassage[] | null {
+    let parsed: unknown;
+
+    try {
+        parsed = JSON.parse(body);
+    } catch {
+        return null;
+    }
+
+    const record = asRecord(parsed);
+    if (record === null) {
+        return null;
+    }
+
+    const citations = record['citations'];
+    if (!Array.isArray(citations) || citations.length !== asked.length) {
+        return null;
+    }
+
+    const resolved: CitedPassage[] = [];
+    for (const [at, citation] of citations.entries()) {
+        const passage = asked[at];
+        if (passage === undefined) {
+            return null;
+        }
+
+        const one = parseResolution(citation, passage);
+        if (one === null) {
+            return null;
+        }
+
+        resolved.push(one);
+    }
+
+    return resolved;
+}
+
+function parseResolution(value: unknown, passage: string): CitedPassage | null {
+    const record = asRecord(value);
+    if (record === null) {
+        return null;
+    }
+
+    const outcome = record['outcome'];
+    if (typeof outcome !== 'string' || !outcomes.includes(outcome as CitedPassageOutcome)) {
+        return null;
+    }
+
+    const fragment = record['fragment'] ?? null;
+    if (fragment === null) {
+        return { passage, outcome: outcome as CitedPassageOutcome, ordinal: null, text: null };
+    }
+
+    const cited = asRecord(fragment);
+    if (cited === null) {
+        return null;
+    }
+
+    const fragmentId = cited['fragmentId'];
+    const ordinal = cited['ordinal'];
+    const text = cited['text'];
+
+    if (typeof fragmentId !== 'string' || fragmentId.length === 0 || fragmentId.length > longestIdentity) {
+        return null;
+    }
+
+    // The route answers in the order it was asked, so a resolution naming a passage other than the one this position
+    // asked about is an answer that would put one mark's words under another's.
+    if (fragmentId !== passage) {
+        return null;
+    }
+
+    if (typeof ordinal !== 'number' || !Number.isSafeInteger(ordinal) || ordinal < 0) {
+        return null;
+    }
+
+    if (typeof text !== 'string' || text.length > longestPassage) {
+        return null;
+    }
+
+    return { passage, outcome: outcome as CitedPassageOutcome, ordinal, text };
+}

--- a/frontend/src/Client.Backend/src/citedPassages.ts
+++ b/frontend/src/Client.Backend/src/citedPassages.ts
@@ -33,9 +33,11 @@ const outcomes: readonly CitedPassageOutcome[] = ['Resolved', 'Unresolvable', 'P
 /**
  * How many citations one request follows, which is the deployment's own bound rather than a preference.
  *
- * A request naming more is refused with a `400`, so the client holds the same number and asks within it. A mark rests
- * on at most four passages and a message carries at most three marks, so one message's whole evidence is within it and
- * no screen here has to page.
+ * A request naming more is refused with a `400`, so the client holds the same number and asks within it. It is below
+ * what one message can name rather than above it: a message carries at most three marks and a mark rests on at most
+ * four passages, so twelve distinct passages are reachable and the first ten of them — after the marks' own repeats
+ * are folded together — are what a caller may follow. A caller that means to draw the rest says so in its own words
+ * rather than asking twice; `Client.App/src/messageRows/ReadingsAsked.tsx` is the one that does.
  */
 export const mostCitedPassages = 10;
 
@@ -163,6 +165,16 @@ function parseResolution(value: unknown, passage: string): CitedPassage | null {
     }
 
     const fragment = record['fragment'] ?? null;
+    const resolved = outcome === 'Resolved';
+
+    // The outcome and the passage beside it are one answer rather than two, so an answer whose halves disagree is
+    // refused rather than reconciled. It is the privacy half that makes this a refusal rather than a tidiness: a
+    // deployment answering `PrivateSource` and attaching the words anyway would have those words drawn, because what
+    // a screen shows is the passage it was handed and the outcome is what it says where there is none.
+    if (resolved === (fragment === null)) {
+        return null;
+    }
+
     if (fragment === null) {
         return { passage, outcome: outcome as CitedPassageOutcome, ordinal: null, text: null };
     }

--- a/frontend/src/Client.Backend/src/index.ts
+++ b/frontend/src/Client.Backend/src/index.ts
@@ -19,7 +19,20 @@ export {
     type DeploymentSession,
     type MailFathomPermission,
 } from './deploymentSession';
+export {
+    citedPassagesRoute,
+    mostCitedPassages,
+    readCitedPassages,
+    type CitedPassage,
+    type CitedPassageOutcome,
+} from './citedPassages';
 export { failureReasonForStatus, type ClientFailure, type ClientFailureReason, type ClientResult } from './failure';
+export {
+    type MailEnrichment,
+    type MailEnrichmentAspect,
+    type MailEnrichmentMark,
+    type MailEnrichmentSource,
+} from './mailEnrichment';
 export {
     mailBodyRoute,
     readMailBody,

--- a/frontend/src/Client.Backend/src/mailEnrichment.test.ts
+++ b/frontend/src/Client.Backend/src/mailEnrichment.test.ts
@@ -1,0 +1,164 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import { parseEnrichment } from './mailEnrichment';
+
+const mark = {
+    aspect: 'Sense',
+    text: 'An invoice for August.',
+    reason: 'The message attaches a document the sender calls an invoice.',
+    dueAt: null,
+    source: 'DeterministicRule',
+    origin: 'rules/invoice',
+    evidence: ['fragment-1', 'fragment-2'],
+};
+
+// A copy of a record with one field left out, which is how a body written before a field existed is stated.
+function without(record: Record<string, unknown>, field: string): Record<string, unknown> {
+    return Object.fromEntries(Object.entries(record).filter(([named]) => named !== field));
+}
+
+function derivation(marks: readonly unknown[]): unknown {
+    return { derivedAt: '2026-08-31T09:41:00+00:00', marks };
+}
+
+describe('parseEnrichment', () => {
+    it('reads a message no derivation has reached as carrying none', () => {
+        expect(parseEnrichment(null)).toEqual({ enrichment: null });
+        expect(parseEnrichment(undefined)).toEqual({ enrichment: null });
+    });
+
+    it('keeps a derivation that settled with nothing to say apart from one that never ran', () => {
+        expect(parseEnrichment(derivation([]))).toEqual({
+            enrichment: { derivedAt: '2026-08-31T09:41:00+00:00', marks: [] },
+        });
+    });
+
+    it('reads every field of a mark, in the order the deployment named them', () => {
+        const commitment = {
+            ...mark,
+            aspect: 'Commitment',
+            text: 'An answer is owed by Friday.',
+            dueAt: '2026-09-04T16:00:00+00:00',
+            source: 'Model',
+            origin: 'agents/reader',
+            evidence: ['fragment-3'],
+        };
+
+        expect(parseEnrichment(derivation([mark, commitment]))).toEqual({
+            enrichment: {
+                derivedAt: '2026-08-31T09:41:00+00:00',
+                marks: [
+                    {
+                        aspect: 'Sense',
+                        text: 'An invoice for August.',
+                        reason: 'The message attaches a document the sender calls an invoice.',
+                        dueAt: null,
+                        source: 'DeterministicRule',
+                        origin: 'rules/invoice',
+                        evidence: ['fragment-1', 'fragment-2'],
+                    },
+                    {
+                        aspect: 'Commitment',
+                        text: 'An answer is owed by Friday.',
+                        reason: 'The message attaches a document the sender calls an invoice.',
+                        dueAt: '2026-09-04T16:00:00+00:00',
+                        source: 'Model',
+                        origin: 'agents/reader',
+                        evidence: ['fragment-3'],
+                    },
+                ],
+            },
+        });
+    });
+
+    it('reads a mark that named no passage as resting on none', () => {
+        const parsed = parseEnrichment(derivation([{ ...mark, evidence: [] }]));
+
+        expect(parsed?.enrichment?.marks[0]?.evidence).toEqual([]);
+    });
+
+    it('reads an omitted due date as none', () => {
+        const parsed = parseEnrichment(derivation([without(mark, 'dueAt')]));
+
+        expect(parsed?.enrichment?.marks[0]?.dueAt).toBeNull();
+    });
+
+    it('refuses a field that is not a derivation at all', () => {
+        expect(parseEnrichment('derived')).toBeNull();
+        expect(parseEnrichment([])).toBeNull();
+    });
+
+    it('refuses a derivation that does not say when it ran', () => {
+        expect(parseEnrichment({ marks: [] })).toBeNull();
+        expect(parseEnrichment({ derivedAt: '', marks: [] })).toBeNull();
+        expect(parseEnrichment({ derivedAt: 17, marks: [] })).toBeNull();
+    });
+
+    it('refuses a derivation whose marks are not a list', () => {
+        expect(parseEnrichment({ derivedAt: '2026-08-31T09:41:00+00:00' })).toBeNull();
+        expect(parseEnrichment({ derivedAt: '2026-08-31T09:41:00+00:00', marks: {} })).toBeNull();
+    });
+
+    it('refuses more marks than a message may carry', () => {
+        const aspects = ['Sense', 'Significance', 'Commitment', 'Sense'];
+
+        expect(parseEnrichment(derivation(aspects.map((aspect) => ({ ...mark, aspect }))))).toBeNull();
+    });
+
+    it('refuses a message answering twice for one aspect', () => {
+        expect(parseEnrichment(derivation([mark, { ...mark, text: 'A second reading.' }]))).toBeNull();
+    });
+
+    it('refuses a reading of something other than the three aspects', () => {
+        expect(parseEnrichment(derivation([{ ...mark, aspect: 'Tone' }]))).toBeNull();
+    });
+
+    it('refuses a mark produced by something other than a rule or a model', () => {
+        expect(parseEnrichment(derivation([{ ...mark, source: 'Guess' }]))).toBeNull();
+    });
+
+    it('refuses a reading with no sentence in it', () => {
+        expect(parseEnrichment(derivation([{ ...mark, text: '' }]))).toBeNull();
+        expect(parseEnrichment(derivation([{ ...mark, reason: '' }]))).toBeNull();
+    });
+
+    it('refuses a sentence longer than the deployment stores', () => {
+        expect(parseEnrichment(derivation([{ ...mark, text: 'a'.repeat(241) }]))).toBeNull();
+        expect(parseEnrichment(derivation([{ ...mark, reason: 'a'.repeat(241) }]))).toBeNull();
+    });
+
+    it('refuses a mark that does not say what produced it', () => {
+        expect(parseEnrichment(derivation([{ ...mark, origin: '' }]))).toBeNull();
+        expect(parseEnrichment(derivation([{ ...mark, origin: 'a'.repeat(129) }]))).toBeNull();
+    });
+
+    it('refuses a due date on a reading that is not a commitment', () => {
+        expect(parseEnrichment(derivation([{ ...mark, dueAt: '2026-09-04T16:00:00+00:00' }]))).toBeNull();
+    });
+
+    it('refuses a due date that is not an instant', () => {
+        expect(parseEnrichment(derivation([{ ...mark, aspect: 'Commitment', dueAt: 17 }]))).toBeNull();
+        expect(parseEnrichment(derivation([{ ...mark, aspect: 'Commitment', dueAt: '' }]))).toBeNull();
+    });
+
+    it('refuses a mark that does not say what it rests on', () => {
+        expect(parseEnrichment(derivation([without(mark, 'evidence')]))).toBeNull();
+    });
+
+    it('refuses more passages than a mark may rest on', () => {
+        expect(parseEnrichment(derivation([{ ...mark, evidence: ['a', 'b', 'c', 'd', 'e'] }]))).toBeNull();
+    });
+
+    it('refuses a passage identity that names nothing', () => {
+        expect(parseEnrichment(derivation([{ ...mark, evidence: [''] }]))).toBeNull();
+        expect(parseEnrichment(derivation([{ ...mark, evidence: [17] }]))).toBeNull();
+        expect(parseEnrichment(derivation([{ ...mark, evidence: ['a'.repeat(257)] }]))).toBeNull();
+    });
+
+    it('refuses a mark that is not a record', () => {
+        expect(parseEnrichment(derivation(['Sense']))).toBeNull();
+    });
+});

--- a/frontend/src/Client.Backend/src/mailEnrichment.ts
+++ b/frontend/src/Client.Backend/src/mailEnrichment.ts
@@ -1,0 +1,204 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { asRecord } from './json';
+
+// What a derivation concluded about one message, which the deployment writes down once when the message arrives and
+// then publishes on every row that draws that message. It is its own module rather than three more fields inside
+// `mailTimeline.ts` because two things reach for it: the row parser every mail surface shares, and the reader that
+// follows a mark's evidence back to the passages it rests on.
+//
+// **The two empty answers are different answers.** A message no derivation has reached carries `null`; one a
+// derivation settled with nothing to say carries an object whose `marks` is empty. Nothing here collapses them,
+// because a deployment with enrichment switched off is the first of the two and a message there is nothing to say
+// about is the second, and a screen that drew them alike would still have been told which it was.
+
+/** Which of the three readings a mark carries, named as the deployment publishes it. */
+export type MailEnrichmentAspect = 'Sense' | 'Significance' | 'Commitment';
+
+/** What produced a mark, which is the distinction somebody weighing it asks about before they read it. */
+export type MailEnrichmentSource = 'DeterministicRule' | 'Model';
+
+const aspects: readonly MailEnrichmentAspect[] = ['Sense', 'Significance', 'Commitment'];
+
+const sources: readonly MailEnrichmentSource[] = ['DeterministicRule', 'Model'];
+
+// What one mark may carry before the row it is on is refused. Each is the deployment's own bound rather than a guess:
+// the sentence and the reason are cut to 240 characters where they are stored, a message carries at most one mark of
+// each aspect, and a mark rests on at most four passages. A row past any of them is an answer this surface does not
+// produce, and drawing it would be drawing something other than a derivation.
+const longestMarkText = 240;
+const longestOrigin = 128;
+const mostMarks = 3;
+const mostEvidence = 4;
+const longestPassageIdentity = 256;
+
+/** One reading of a message, with what backs it and what produced it. */
+export interface MailEnrichmentMark {
+    readonly aspect: MailEnrichmentAspect;
+
+    /** The reading itself, as one sentence, which is what a row draws. */
+    readonly text: string;
+
+    /** Why the producer says it, which is what somebody checks the reading against. */
+    readonly reason: string;
+
+    /** When the commitment falls due, or `null` on every other aspect and on a commitment that named no date. */
+    readonly dueAt: string | null;
+
+    readonly source: MailEnrichmentSource;
+
+    /** What within that source produced it: a rule identity, or the name the agent was composed under. */
+    readonly origin: string;
+
+    /**
+     * The passages the reading rests on, in the order the producer named them.
+     *
+     * Identifiers rather than text, because the deployment publishes them that way: a list page carrying the passages
+     * themselves would be publishing a body it had no reason to. Following one is a request of its own — see
+     * {@link readCitedPassages}.
+     */
+    readonly evidence: readonly string[];
+}
+
+/** What a derivation concluded about one message. */
+export interface MailEnrichment {
+    /** When the derivation ran. */
+    readonly derivedAt: string;
+
+    /** What it concluded, which is empty where it settled with nothing to say. */
+    readonly marks: readonly MailEnrichmentMark[];
+}
+
+/**
+ * What reading a row's derivation produced: the value, which may legitimately be `null`.
+ *
+ * A wrapper rather than a bare `MailEnrichment | null`, because `null` is one of the two states this field publishes
+ * and is therefore not available to mean *refused*. Every other parser in this package can say "no" with `null`; this
+ * one cannot, and returning the same shape from both answers would hand a screen a row whose derivation was silently
+ * dropped rather than refusing the page.
+ */
+export interface ParsedEnrichment {
+    readonly enrichment: MailEnrichment | null;
+}
+
+/**
+ * Reads what a row says about its message's derivation.
+ *
+ * @param value The field as the deployment sent it, which every row carries and no row omits.
+ * @returns The derivation or its absence, or `null` where the field is neither.
+ */
+export function parseEnrichment(value: unknown): ParsedEnrichment | null {
+    if (value === undefined || value === null) {
+        return { enrichment: null };
+    }
+
+    const record = asRecord(value);
+    if (record === null) {
+        return null;
+    }
+
+    const derivedAt = record['derivedAt'];
+    const marks = record['marks'];
+
+    if (typeof derivedAt !== 'string' || derivedAt.length === 0 || derivedAt.length > longestMarkText) {
+        return null;
+    }
+
+    if (!Array.isArray(marks) || marks.length > mostMarks) {
+        return null;
+    }
+
+    const read: MailEnrichmentMark[] = [];
+    for (const mark of marks) {
+        const parsed = parseMark(mark);
+        if (parsed === null) {
+            return null;
+        }
+
+        read.push(parsed);
+    }
+
+    // A message carries at most one mark of each aspect, which is what lets a row draw a reading without choosing
+    // between two answers to one question. A page answering twice for one aspect is refused rather than reconciled.
+    if (new Set(read.map((mark) => mark.aspect)).size !== read.length) {
+        return null;
+    }
+
+    return { enrichment: { derivedAt, marks: read } };
+}
+
+function parseMark(value: unknown): MailEnrichmentMark | null {
+    const record = asRecord(value);
+    if (record === null) {
+        return null;
+    }
+
+    const aspect = record['aspect'];
+    const text = record['text'];
+    const reason = record['reason'];
+    const dueAt = record['dueAt'] ?? null;
+    const source = record['source'];
+    const origin = record['origin'];
+
+    if (!isAspect(aspect) || !isSource(source)) {
+        return null;
+    }
+
+    if (!isSentence(text) || !isSentence(reason)) {
+        return null;
+    }
+
+    if (typeof origin !== 'string' || origin.length === 0 || origin.length > longestOrigin) {
+        return null;
+    }
+
+    if (dueAt !== null && (typeof dueAt !== 'string' || dueAt.length === 0 || dueAt.length > longestMarkText)) {
+        return null;
+    }
+
+    // A date on any aspect but a commitment is an answer the deployment refuses to store, so a row carrying one is not
+    // a row this client draws: the mark would say something about a due date on a reading that has none.
+    if (dueAt !== null && aspect !== 'Commitment') {
+        return null;
+    }
+
+    const evidence = parseEvidence(record['evidence']);
+    if (evidence === null) {
+        return null;
+    }
+
+    return { aspect, text, reason, dueAt, source, origin, evidence };
+}
+
+function parseEvidence(value: unknown): readonly string[] | null {
+    if (!Array.isArray(value) || value.length > mostEvidence) {
+        return null;
+    }
+
+    const passages: string[] = [];
+    for (const passage of value) {
+        if (typeof passage !== 'string' || passage.length === 0 || passage.length > longestPassageIdentity) {
+            return null;
+        }
+
+        passages.push(passage);
+    }
+
+    return passages;
+}
+
+function isAspect(value: unknown): value is MailEnrichmentAspect {
+    return typeof value === 'string' && aspects.includes(value as MailEnrichmentAspect);
+}
+
+function isSource(value: unknown): value is MailEnrichmentSource {
+    return typeof value === 'string' && sources.includes(value as MailEnrichmentSource);
+}
+
+// A reading with nothing in it is refused rather than drawn as an empty line: the deployment stores no such mark, and
+// a row drawing one would reserve the space for a sentence and then say nothing in it.
+function isSentence(value: unknown): value is string {
+    return typeof value === 'string' && value.length > 0 && value.length <= longestMarkText;
+}

--- a/frontend/src/Client.Backend/src/mailThread.test.ts
+++ b/frontend/src/Client.Backend/src/mailThread.test.ts
@@ -164,7 +164,9 @@ describe('readMailThread', () => {
             outcome: 'read',
             value: {
                 threadId,
-                messages: [{ position: 0, answeredId: null, email, message: null, body: null }],
+                messages: [
+                    { position: 0, answeredId: null, email: { ...email, enrichment: null }, message: null, body: null },
+                ],
                 participants: [participant],
                 messageCount: 1,
                 moreMessagesNotAssembled: false,
@@ -197,6 +199,7 @@ describe('readMailThread', () => {
 
         expect(answered.outcome === 'read' && answered.value.messages[1]).toStrictEqual({
             ...answer,
+            email: { ...answer.email, enrichment: null },
             message: null,
             body: null,
         });

--- a/frontend/src/Client.Backend/src/mailTimeline.test.ts
+++ b/frontend/src/Client.Backend/src/mailTimeline.test.ts
@@ -162,7 +162,12 @@ describe('readMailTimeline', () => {
 
         expect(result).toStrictEqual({
             outcome: 'read',
-            value: { emails: [message], nextCursor: 'after', previousCursor: 'before', pageSize: 50 },
+            value: {
+                emails: [{ ...message, enrichment: null }],
+                nextCursor: 'after',
+                previousCursor: 'before',
+                pageSize: 50,
+            },
         });
     });
 
@@ -237,10 +242,43 @@ describe('readMailTimeline', () => {
         ['a negative size', bodyOf([{ ...message, sizeOctets: -1 }])],
         ['a conversation holding no message at all', bodyOf([{ ...message, threadMessageCount: 0 }])],
         ['a conversation size that is not whole', bodyOf([{ ...message, threadMessageCount: 2.5 }])],
+        ['a derivation that is not a record', bodyOf([{ ...message, enrichment: 'derived' }])],
+        ['a derivation that does not say when it ran', bodyOf([{ ...message, enrichment: { marks: [] } }])],
     ])('refuses %s rather than reading a page with a hole in it', async (_, body) => {
         const result = await readMailTimeline(session, answering({ status: 200, body }), leadingPage);
 
         expect(result).toStrictEqual({ outcome: 'failed', failure: { reason: 'unreadable', status: 200 } });
+    });
+
+    it('reads what a derivation concluded about a message onto the row that stands for it', async () => {
+        const enrichment = {
+            derivedAt: '2026-08-31T09:41:00+00:00',
+            marks: [
+                {
+                    aspect: 'Commitment',
+                    text: 'An answer is owed by Friday.',
+                    reason: 'The sender asks for confirmation before the end of the week.',
+                    dueAt: '2026-09-04T16:00:00+00:00',
+                    source: 'Model',
+                    origin: 'agents/reader',
+                    evidence: ['fragment-1'],
+                },
+            ],
+        };
+
+        const transport = answering({ status: 200, body: bodyOf([{ ...message, enrichment }]) });
+
+        const result = await readMailTimeline(session, transport, leadingPage);
+
+        expect(result.outcome === 'read' && result.value.emails[0]?.enrichment).toStrictEqual(enrichment);
+    });
+
+    it('reads a message no derivation has reached as carrying none', async () => {
+        const transport = answering({ status: 200, body: bodyOf([{ ...message, enrichment: null }]) });
+
+        const result = await readMailTimeline(session, transport, leadingPage);
+
+        expect(result.outcome === 'read' && result.value.emails[0]?.enrichment).toBeNull();
     });
 
     it('refuses a row carrying more recipients than a message has', async () => {

--- a/frontend/src/Client.Backend/src/mailTimeline.ts
+++ b/frontend/src/Client.Backend/src/mailTimeline.ts
@@ -4,6 +4,7 @@
 
 import { failed, failureReasonForStatus, read, type ClientResult } from './failure';
 import { asRecord } from './json';
+import { parseEnrichment, type MailEnrichment } from './mailEnrichment';
 import { headersFor, routeFor, type ClientSession } from './session';
 import { spanned } from './telemetry';
 import { send, type MailFathomTransport } from './transport';
@@ -96,6 +97,21 @@ export interface MailTimelineEntry {
 
     /** The opening of the message's own text, or `null` for a message this deployment has stored but not extracted. */
     readonly preview: string | null;
+
+    /**
+     * What a derivation concluded about the message, or `null` where none has reached it.
+     *
+     * The two empty answers are different answers and neither is a failure: `null` is a message no derivation has
+     * reached, which is every message on a deployment that has not switched enrichment on, and an object whose `marks`
+     * is empty is one a derivation settled with nothing to say. A screen may draw them alike, and it was still told
+     * which it was.
+     *
+     * Every surface drawing this row carries it, because the deployment publishes it on every row of every response —
+     * a conversation answering `null` for a message the list beside it shows a reading for would be stating that no
+     * derivation has reached it, which is the one thing this field is for. The search route is the exception the wire
+     * makes rather than one this parser does: it answers no derivation at all, so its rows read `null` here.
+     */
+    readonly enrichment: MailEnrichment | null;
 
     /**
      * How many messages the correspondence this row stands for holds, or `null` where the row's surface states none.
@@ -342,6 +358,11 @@ export function parseTimelineEntry(value: unknown): MailTimelineEntry | null {
         return null;
     }
 
+    const derived = parseEnrichment(record['enrichment']);
+    if (derived === null) {
+        return null;
+    }
+
     const threadMessageCount = record['threadMessageCount'] ?? null;
 
     // A conversation holds at least the message the row is about, so a count of zero is an answer no deployment
@@ -368,6 +389,7 @@ export function parseTimelineEntry(value: unknown): MailTimelineEntry | null {
         attachmentCount,
         sizeOctets,
         preview,
+        enrichment: derived.enrichment,
         threadMessageCount,
     };
 }

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -133,6 +133,15 @@ async function servedByADeployment(page: Page): Promise<void> {
         return answering(route, mail.timelinePage(from));
     });
 
+    // Following a mark's evidence: the passages are in the request body rather than in the query, so the corpus is
+    // asked for a resolution per passage the client named and in the order it named them.
+    await page.route('**/api/client/citations/resolution', (route) => {
+        const asked: unknown = JSON.parse(route.request().postData() ?? '{}');
+        const citations = (asked as { citations?: { fragment?: string }[] }).citations ?? [];
+
+        return answering(route, mail.citationResolutions(citations.map((citation) => citation.fragment ?? '')));
+    });
+
     // The other route whose answer depends on what the client asked for: the reader's ask for the sender's pictures is
     // in the query too, so answering it here is what lets this suite watch a request leave for the sender's host — and
     // watch it not leave before the ask.
@@ -1257,6 +1266,25 @@ test('draws every row of the list at one height, which is what the window is ari
     // measures rows, which this list deliberately does not carry.
     expect(new Set(heights).size).toBe(1);
     expect(heights[0]).toBeGreaterThan(0);
+});
+
+test('opens what MailFathom made of a message from its own row, with the passages it rests on', async ({ page }) => {
+    await openSignedIn(page, '/#/mail');
+
+    const list = page.getByRole('listbox', { name: 'Messages' });
+    const enriched = list.getByRole('option').nth(1);
+
+    await expect(enriched).toContainText('An answer is owed before the end of the week.');
+
+    // The row's own menu, which is where checking a reading is reached from: a row is an `option` of a listbox and
+    // holds no focusable descendant, so the sentence on it cannot be a control of its own.
+    await enriched.click({ button: 'right' });
+    await page.getByRole('menuitem', { name: 'Check what MailFathom made of it' }).click();
+
+    const checking = page.getByRole('dialog', { name: 'What MailFathom made of this message' });
+
+    await expect(checking.getByText('A model — agents/reader')).toBeVisible();
+    await expect(checking.getByText('Please confirm the bays you want before the end of the week.')).toBeVisible();
 });
 
 test('draws the mail screens at the phone composition, with its own row height and nothing over the question', async ({

--- a/frontend/tests/fixtures/mail.ts
+++ b/frontend/tests/fixtures/mail.ts
@@ -27,6 +27,48 @@ export const rowsPerPage = 100;
 /** The conversation every corpus message that belongs to one belongs to. */
 export const conversationId = '00000000-0000-4000-8000-0000000000c0';
 
+/**
+ * What a derivation concluded about the rows that carry one.
+ *
+ * Not every row, and that is deliberate — a corpus whose every message carried a reading could not show the state a
+ * message no derivation reached is drawn in, which is an ordinary row rather than a gap. The first row carries none so
+ * that a check reaching a row by what it is about still matches on the mail alone.
+ *
+ * @param at Which row of the folder, which decides whether it carries one at all and what it says.
+ */
+function derivedReading(at: number) {
+    if (at % 4 !== 1) {
+        return null;
+    }
+
+    const owed = at % 8 === 1;
+
+    return {
+        derivedAt: '2026-08-31T09:42:00+00:00',
+        marks: [
+            owed
+                ? {
+                      aspect: 'Commitment',
+                      text: 'An answer is owed before the end of the week.',
+                      reason: 'The message asks for confirmation and names a day.',
+                      dueAt: '2026-09-04T16:00:00+00:00',
+                      source: 'Model',
+                      origin: 'agents/reader',
+                      evidence: [`fragment-${String(at)}-1`],
+                  }
+                : {
+                      aspect: 'Sense',
+                      text: 'A delivery note for an order already placed.',
+                      reason: 'The sender names an order number the message is about.',
+                      dueAt: null,
+                      source: 'DeterministicRule',
+                      origin: 'rules/delivery-note',
+                      evidence: [`fragment-${String(at)}-1`, `fragment-${String(at)}-2`],
+                  },
+        ],
+    };
+}
+
 function timelineRow(at: number) {
     return {
         id: `message-${String(at)}`,
@@ -46,6 +88,7 @@ function timelineRow(at: number) {
         attachmentCount: at % 5 === 0 ? 1 : 0,
         sizeOctets: 4_096,
         preview: `The opening of message ${String(at)}.`,
+        enrichment: derivedReading(at),
         threadMessageCount: null,
     };
 }
@@ -93,6 +136,31 @@ export function timelinePage(from: number) {
         nextCursor: start + rows >= mailboxSize ? null : String(start + rows),
         previousCursor: start === 0 ? null : String(start),
         pageSize: rowsPerPage,
+    };
+}
+
+/**
+ * What following a mark's evidence answers with, one resolution per citation and in the order they were asked about.
+ *
+ * The last of several is left unresolvable deliberately: a corpus that resolved every passage could not show the state
+ * a reading whose message has been re-cut since is drawn in, which is a sentence saying so rather than a blank.
+ *
+ * @param fragments The passages the request named, which the answer is paired against by position.
+ */
+export function citationResolutions(fragments: readonly string[]) {
+    return {
+        citations: fragments.map((fragment, at) =>
+            at > 0 && at === fragments.length - 1
+                ? { outcome: 'Unresolvable', fragment: null }
+                : {
+                      outcome: 'Resolved',
+                      fragment: {
+                          fragmentId: fragment,
+                          ordinal: at,
+                          text: 'Please confirm the bays you want before the end of the week.',
+                      },
+                  },
+        ),
     };
 }
 

--- a/frontend/tests/fixtures/mail.ts
+++ b/frontend/tests/fixtures/mail.ts
@@ -34,7 +34,8 @@ export const conversationId = '00000000-0000-4000-8000-0000000000c0';
  * message no derivation reached is drawn in, which is an ordinary row rather than a gap. The first row carries none so
  * that a check reaching a row by what it is about still matches on the mail alone.
  *
- * @param at Which row of the folder, which decides whether it carries one at all and what it says.
+ * @param at Which position in the answer, which decides whether it carries one at all and what it says. A folder page
+ * counts rows and a conversation counts messages, and the derivation is the same shape on both.
  */
 function derivedReading(at: number) {
     if (at % 4 !== 1) {
@@ -334,6 +335,11 @@ const conversationRows = [
  * The screen shows the latest message and folds every earlier one behind a control naming how many there are, so a
  * conversation of two would draw the collapsed history and prove nothing about it. Five is the shortest one where the
  * fold is worth reading: four messages behind the control, in both folders the exchange ran through.
+ *
+ * Each message carries what a derivation concluded about it, because the thread route publishes a message in the same
+ * shape a list row is published in — the field and all — and a corpus that left it off would be stating this route
+ * answering like the search route, which is the one route that genuinely publishes no derivation. Only one of the five
+ * carries a reading, for the reason {@link derivedReading} gives about a folder page.
  */
 export const conversation = {
     threadId: conversationId,
@@ -358,6 +364,7 @@ export const conversation = {
             attachmentCount: 0,
             sizeOctets: 3_120,
             preview: row.preview,
+            enrichment: derivedReading(position),
             threadMessageCount: conversationRows.length,
         },
     })),

--- a/frontend/tests/fixtures/mail.ts
+++ b/frontend/tests/fixtures/mail.ts
@@ -88,9 +88,19 @@ function timelineRow(at: number) {
         attachmentCount: at % 5 === 0 ? 1 : 0,
         sizeOctets: 4_096,
         preview: `The opening of message ${String(at)}.`,
-        enrichment: derivedReading(at),
         threadMessageCount: null,
     };
+}
+
+/**
+ * One row of a folder, which is a row plus what a derivation concluded about the message.
+ *
+ * Apart from {@link timelineRow} because the search route publishes no derivation at all — not the field answering
+ * nothing, the field absent — and a search result is that same row with two fields added. A corpus that carried one
+ * into a search answer would be stating the service answering with something it never answers.
+ */
+function folderRow(at: number) {
+    return { ...timelineRow(at), enrichment: derivedReading(at) };
 }
 
 /**
@@ -106,7 +116,7 @@ const conversationRowPosition = 3;
 // as a constant because what it is built from is declared further down this file.
 function conversationTimelineRow() {
     return {
-        ...timelineRow(conversationRowPosition),
+        ...folderRow(conversationRowPosition),
         id: rackingQuote.id,
         threadId: conversationId,
         threadMessageCount: conversationRows.length,
@@ -131,7 +141,7 @@ export function timelinePage(from: number) {
 
     return {
         emails: Array.from({ length: rows }, (_, at) =>
-            start + at === conversationRowPosition ? conversationTimelineRow() : timelineRow(start + at),
+            start + at === conversationRowPosition ? conversationTimelineRow() : folderRow(start + at),
         ),
         nextCursor: start + rows >= mailboxSize ? null : String(start + rows),
         previousCursor: start === 0 ? null : String(start),
@@ -194,6 +204,9 @@ const rackingQuote = {
  *
  * The file the first of them cites is the one the newsletter message in `messages.ts` actually carries, at the position
  * that message publishes it at, because a citation nothing behind it answers for is a coordinate a reader cannot follow.
+ *
+ * No row here carries a derivation, and that is the route rather than a gap in the corpus: the search endpoint
+ * publishes no such field at all, which is why these are built from `timelineRow` rather than from `folderRow`.
  */
 export const searchResults = {
     results: [

--- a/scripts/test-agent-workflow.sh
+++ b/scripts/test-agent-workflow.sh
@@ -9234,6 +9234,8 @@ mail.ts rackingQuote GET /api/client/emails
 mail.ts searchResults GET /api/client/emails/search
 mail.ts noSearchResults GET /api/client/emails/search
 mail.ts conversationRows - -
+mail.ts derivedReading GET /api/client/emails
+mail.ts citationResolutions POST /api/client/citations/resolution
 mail.ts conversation GET /api/client/threads/{threadId}
 messages.ts run GET /api/client/messages/{storedEmailId}/body
 messages.ts newsletterBlocks GET /api/client/messages/{storedEmailId}/body

--- a/scripts/test-agent-workflow.sh
+++ b/scripts/test-agent-workflow.sh
@@ -9235,6 +9235,7 @@ mail.ts searchResults GET /api/client/emails/search
 mail.ts noSearchResults GET /api/client/emails/search
 mail.ts conversationRows - -
 mail.ts derivedReading GET /api/client/emails
+mail.ts folderRow GET /api/client/emails
 mail.ts citationResolutions POST /api/client/citations/resolution
 mail.ts conversation GET /api/client/threads/{threadId}
 messages.ts run GET /api/client/messages/{storedEmailId}/body


### PR DESCRIPTION
Closes #1185

An enriched row now says what MailFathom made of the message without displacing who wrote, what
about, or when, and a reader can turn that off for the view they are in.

## The wire

`Client.Backend/src/mailEnrichment.ts` reads the derivation every list row carries and keeps the two
empty answers apart: a message no derivation reached carries `null`, and one a derivation settled with
nothing to say carries an object whose `marks` is empty. Nothing collapses them, because a deployment
with enrichment switched off is the first and a message there is nothing to say about is the second.
It refuses a row that answers twice for one aspect, dates a reading that is not a commitment, writes
an empty sentence, or names more marks or passages than the deployment stores.

It is read by `parseTimelineEntry`, which is the one shared row parser, so the timeline, a search
result and a message in a conversation gain the field in one place rather than three.

`Client.Backend/src/citedPassages.ts` follows a mark's evidence back to the words. A list page
publishes passage identifiers rather than passages — a page carrying the passages themselves would be
publishing a body it had no reason to — so the words are asked for when somebody wants to see them,
one request for the whole message's evidence. The three outcomes are three states and none of them is
a failure: a passage resolves to its words, a passage the message has been re-cut since resolves to
nothing while the message stays, and a message this sign-in may not read resolves to nothing at all.
An answer whose citation count differs from the request, or whose resolution names a passage other
than the one that position asked about, is refused rather than drawn under the wrong mark.

## The row

One clipped line, in the space the row already reserved. That is the density decision and it is
answered by changing nothing: the row's height is a token rather than its contents', so a folder of
enriched mail shows exactly as many messages per screen as a plain one, and `rowWindow.ts` stays
arithmetic over one number. The browser suite asserts every row in the list is one height, over a
corpus in which some rows carry a reading and some do not.

A screen reader meets the aspect by name and then the sentence, because a sentence announced bare
inside a row reads as part of the mail. The line is inert: an `option` of a listbox may hold no
focusable descendant.

## Checking a reading

The row's own menu opens a dialog holding every mark of the message — the sentence, why the producer
says it, what produced it, and the passages it rests on. A model verdict and a deterministic rule are
drawn apart and named in words rather than collapsed into "AI", so somebody weighing a mark meets that
before they read it. Evidence has its own loading, failed-with-retry, no-evidence, moved-passage,
private-source and past-the-tenth states.

## The switch

Per view and per folder, in the list's own settings panel, kept on `RememberedListing` rather than on
`MailListing`. That separation is load-bearing: a listing is what a cursor was issued under and the
deployment refuses one presented under different filters or a different order, so folding the switch
in would have moved every reader who turned the sentences off back to the top of the folder. It reads
no page, it persists in the existing bounded `sessionStorage` record, and turning it off restores the
plain row exactly. A record written before the field existed reads as on.

## Two corrections the design owes, and one deviation

Neither is invented into the client silently, and both are for the owner to make in the design project
rather than for this pull request to settle.

1. The prototype gates the row's reading on an `aiHints` component property that no control anywhere
   reaches, so the design settles neither where a per-view switch lives nor what it is called. This
   change puts it in the list settings panel beside the order and the filters, drawn apart from the
   narrowings because a filter decides which mail is in the folder and this decides what each row says
   about the mail that is.
2. Nothing in the design expands a reading into its evidence. The only evidence vocabulary in the
   project belongs to the Discover answer, so the dialog this change adds has no drawn counterpart.

The deviation that follows from the platform rather than from taste: *expands in place* cannot be an
expansion of the row. A `role="option"` may hold no focusable descendant, and the row's height is what
the window is arithmetic over — a row that grew would take the keyboard path off the list and put
every row below it somewhere other than where the list drew the space for it. The expansion is
therefore a modal reached from the row's menu, which a pointer, a finger, the ContextMenu key and
Shift+F10 all already reach.

## Verification

- `scripts/verify-full.sh` — passed.
- Client unit suite: 3335 tests across 195 files, including new suites for the two wire modules, the
  reading order, the row's line, the dialog, and the switch's persistence.
- Browser suite: 53 specs, including a new one that opens a reading from a row's menu and reads the
  passages it rests on, and the existing one asserting every row in the list is one height.
- The `mail-list` screen was captured against the design project at `desktop` and `telefon` and read
  region by region. The reported share measures the two corpora rather than the two designs — the
  artboard renders a Polish thread and the client the English fixture corpus — so the row was read as
  images instead: the bordered `AI` mark, the muted one-line sentence, its position under the subject
  and its clipping match, and the plain row keeps the reserved line.

Out of scope, as the issue states: producing the enrichment, and filtering by it.

Issue: https://github.com/Krzysztof318/MailFathom/issues/1185
