### PR TITLE
[#1542] Draw the standing AI filters in the folder tree, over what enrichment already derived

### DIFF
--- a/backend/src/Application/Emails/BrowseTimeline/BrowseTimelineRequest.cs
+++ b/backend/src/Application/Emails/BrowseTimeline/BrowseTimelineRequest.cs
@@ -2,6 +2,7 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Emails.Enrichment;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
@@ -42,6 +43,21 @@ public sealed record BrowseTimelineRequest
 
     /// <summary>Gets whether attachments are required, or <see langword="null" /> for either.</summary>
     public bool? HasAttachments { get; init; }
+
+    /// <summary>Gets the reading a derivation must have made about the message, or <see langword="null" /> for any.</summary>
+    /// <remarks>
+    /// This and the two bounds below are the standing views of a mailbox the folder tree offers, and they read what an
+    /// enrichment pass already stored rather than deriving anything: a list narrowed by one is the mail somebody has
+    /// already said this about. A deployment running no enrichment therefore answers with no mail rather than with a
+    /// refusal, which is the honest answer to a question about marks nothing made.
+    /// </remarks>
+    public EmailEnrichmentAspect? CarriesMarkOfAspect { get; init; }
+
+    /// <summary>Gets the inclusive start of the range a commitment falls due in, or <see langword="null" /> for no start.</summary>
+    public DateTimeOffset? MarkDueOnOrAfter { get; init; }
+
+    /// <summary>Gets the exclusive end of that range, or <see langword="null" /> for no end.</summary>
+    public DateTimeOffset? MarkDueBefore { get; init; }
 
     /// <summary>Gets the inclusive start of the received range, or <see langword="null" /> for no start.</summary>
     public DateTimeOffset? ReceivedOnOrAfter { get; init; }

--- a/backend/src/Application/Emails/BrowseTimeline/MailTimelineBrowser.cs
+++ b/backend/src/Application/Emails/BrowseTimeline/MailTimelineBrowser.cs
@@ -416,5 +416,6 @@ public sealed class MailTimelineBrowser
         request.IsRemotelyFlagged,
         keyword: null,
         request.HasAttachments,
-        request.Order);
+        request.Order,
+        EmailMarkSelection.Create(request.CarriesMarkOfAspect, request.MarkDueOnOrAfter, request.MarkDueBefore));
 }

--- a/backend/src/Application/Emails/Mailboxes/EmailMarkSelection.cs
+++ b/backend/src/Application/Emails/Mailboxes/EmailMarkSelection.cs
@@ -1,0 +1,109 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Globalization;
+using MailFathom.Application.Emails.Enrichment;
+
+namespace MailFathom.Application.Emails.Mailboxes;
+
+/// <summary>Selects mail by a reading a derivation already made about it, rather than by anything the message itself carries.</summary>
+/// <remarks>
+/// <para>
+/// It reads what an enrichment pass stored and derives nothing: a caller asks for mail carrying a mark of one aspect,
+/// or a mark whose commitment falls due inside a range, and the answer is whichever mail already has one. A deployment
+/// that never enriched anything therefore answers with no mail rather than with a refusal, which is the honest reading
+/// of "the mail somebody has said this about".
+/// </para>
+/// <para>
+/// Every criterion stated here is met by <b>one</b> mark. A message carrying an undated commitment and a separate
+/// commitment due tomorrow matches a range naming tomorrow because of the second mark; a message whose only commitment
+/// is undated matches nothing. Spreading the criteria across two marks would answer "carries a commitment, and
+/// separately has something due this week", which is a different question that no reader could tell from this one by
+/// looking at the result.
+/// </para>
+/// <para>
+/// The due bounds select dated commitments alone. A commitment that named no date compares to neither bound, exactly as
+/// an undated email compares to neither bound of a received range, and for the same reason: it is not known to fall
+/// inside the span the caller asked about.
+/// </para>
+/// </remarks>
+public sealed record EmailMarkSelection
+{
+    /// <summary>Marks a criterion nobody named in <see cref="CanonicalText" />, where no value written beside it can be it.</summary>
+    /// <remarks>An aspect is one of three words and an instant is digits, so neither produces this text and no caller can reach it.</remarks>
+    private const string CanonicalAbsentValue = "-";
+
+    private EmailMarkSelection(EmailEnrichmentAspect? aspect, DateTimeOffset? dueOnOrAfter, DateTimeOffset? dueBefore)
+    {
+        this.Aspect = aspect;
+        this.DueOnOrAfter = dueOnOrAfter;
+        this.DueBefore = dueBefore;
+        this.CanonicalText = ComputeCanonicalText(aspect, dueOnOrAfter, dueBefore);
+    }
+
+    /// <summary>Gets the reading the mark must be, or <see langword="null" /> when any reading matches.</summary>
+    public EmailEnrichmentAspect? Aspect { get; }
+
+    /// <summary>Gets the inclusive start of the range the commitment falls due in, in UTC, or <see langword="null" /> for no start.</summary>
+    public DateTimeOffset? DueOnOrAfter { get; }
+
+    /// <summary>Gets the exclusive end of that range, in UTC, or <see langword="null" /> for no end.</summary>
+    /// <remarks>The end is exclusive so consecutive weeks tile a calendar without both claiming the instant they meet.</remarks>
+    public DateTimeOffset? DueBefore { get; }
+
+    /// <summary>Gets the injective text of every criterion, which the selection wrapping this one writes into its own.</summary>
+    public string CanonicalText { get; }
+
+    /// <summary>Validates and normalizes what a request asked of the readings a message carries.</summary>
+    /// <param name="aspect">The reading the mark must be, or <see langword="null" /> for any reading.</param>
+    /// <param name="dueOnOrAfter">The inclusive start of the range the commitment falls due in, or <see langword="null" /> for no start.</param>
+    /// <param name="dueBefore">The exclusive end of that range, or <see langword="null" /> for no end.</param>
+    /// <returns>The validated selection, or <see langword="null" /> where the request narrowed by no reading at all.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="aspect" /> is not a defined member.</exception>
+    /// <exception cref="MailboxQueryFilterInvalidException">Thrown when the due range can select nothing.</exception>
+    /// <remarks>
+    /// A request naming none of the three is answered with <see langword="null" /> rather than with a selection that
+    /// admits everything, so nothing narrows a list by a criterion that says nothing — and the canonical text of a list
+    /// nobody narrowed this way stays what it was before this filter existed only where the wrapping selection says so.
+    /// </remarks>
+    public static EmailMarkSelection? Create(
+        EmailEnrichmentAspect? aspect,
+        DateTimeOffset? dueOnOrAfter,
+        DateTimeOffset? dueBefore)
+    {
+        if (aspect is { } named && !Enum.IsDefined(named))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(aspect),
+                aspect,
+                "A mark is one of the readings a derivation makes, and no other value names one.");
+        }
+
+        if (aspect is null && dueOnOrAfter is null && dueBefore is null)
+        {
+            return null;
+        }
+
+        if (dueOnOrAfter is { } start && dueBefore is { } end && start >= end)
+        {
+            throw MailboxQueryFilterInvalidException.EmptyRange("commitment due range");
+        }
+
+        // Held as instants rather than at the offsets a caller wrote, for the reason the received range is: Npgsql binds
+        // a timestamptz parameter at offset zero alone, and two callers naming one instant are one query.
+        return new EmailMarkSelection(aspect, dueOnOrAfter?.ToUniversalTime(), dueBefore?.ToUniversalTime());
+    }
+
+    private static string ComputeCanonicalText(
+        EmailEnrichmentAspect? aspect,
+        DateTimeOffset? dueOnOrAfter,
+        DateTimeOffset? dueBefore) => string.Concat(
+        MailboxEmailSelection.LengthPrefixed(aspect is { } named ? named.ToString() : CanonicalAbsentValue),
+        MailboxEmailSelection.LengthPrefixed(CanonicalInstant(dueOnOrAfter)),
+        MailboxEmailSelection.LengthPrefixed(CanonicalInstant(dueBefore)));
+
+    private static string CanonicalInstant(DateTimeOffset? instant) => instant is { } value
+        ? value.UtcTicks.ToString(CultureInfo.InvariantCulture)
+        : CanonicalAbsentValue;
+}

--- a/backend/src/Application/Emails/Mailboxes/EmailTimelineFilter.cs
+++ b/backend/src/Application/Emails/Mailboxes/EmailTimelineFilter.cs
@@ -66,10 +66,11 @@ public sealed record EmailTimelineFilter
     /// <param name="keyword">The keyword an email must carry, in any case, or <see langword="null" /> for any.</param>
     /// <param name="hasAttachments">Whether attachments are required, or <see langword="null" /> for either.</param>
     /// <param name="direction">The end of the timeline to read from.</param>
+    /// <param name="mark">The reading a derivation must have made about the email, or <see langword="null" /> when no reading is required.</param>
     /// <returns>The validated filter.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="scope" /> is <see langword="null" />.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="direction" /> is not a defined member.</exception>
-    /// <exception cref="MailboxQueryFilterInvalidException">Thrown when an address is unusable or over-long, the subject fragment is too long, the keyword is not one this system stores, or the received range can select nothing.</exception>
+    /// <exception cref="MailboxQueryFilterInvalidException">Thrown when an address is unusable or over-long, the subject fragment is too long, the keyword is not one this system stores, or a range can select nothing.</exception>
     public static EmailTimelineFilter Create(
         MailboxScope scope,
         string? senderAddress,
@@ -81,7 +82,8 @@ public sealed record EmailTimelineFilter
         bool? isRemotelyFlagged,
         string? keyword,
         bool? hasAttachments,
-        EmailTimelineDirection direction) => ReadIn(
+        EmailTimelineDirection direction,
+        EmailMarkSelection? mark = null) => ReadIn(
         MailboxEmailSelection.Create(
             scope,
             senderAddress,
@@ -92,7 +94,8 @@ public sealed record EmailTimelineFilter
             isRemotelySeen,
             isRemotelyFlagged,
             keyword,
-            hasAttachments),
+            hasAttachments,
+            mark),
         direction);
 
     /// <summary>Reads an already validated selection from one end of the timeline.</summary>

--- a/backend/src/Application/Emails/Mailboxes/MailboxEmailSelection.cs
+++ b/backend/src/Application/Emails/Mailboxes/MailboxEmailSelection.cs
@@ -63,9 +63,11 @@ public sealed record MailboxEmailSelection
         bool? isRemotelySeen,
         bool? isRemotelyFlagged,
         string? keyword,
-        bool? hasAttachments)
+        bool? hasAttachments,
+        EmailMarkSelection? mark)
     {
         this.Scope = scope;
+        this.Mark = mark;
         this.SenderNormalizedAddress = senderNormalizedAddress;
         this.RecipientNormalizedAddress = recipientNormalizedAddress;
         this.SubjectFragment = subjectFragment;
@@ -141,6 +143,14 @@ public sealed record MailboxEmailSelection
     /// </remarks>
     public bool? HasAttachments { get; }
 
+    /// <summary>Gets the reading a derivation must have made about an email, or <see langword="null" /> when no reading is required.</summary>
+    /// <remarks>
+    /// It narrows by what an enrichment pass already stored rather than by anything the message carries, which is why it
+    /// is a criterion of its own rather than another flag: an email a derivation has never reached matches none of it,
+    /// and so does every email on a deployment that runs no enrichment.
+    /// </remarks>
+    public EmailMarkSelection? Mark { get; }
+
     /// <summary>Gets the injective text of every field, which whatever wraps this selection identifies it by.</summary>
     /// <remarks>
     /// Every field is written, absent ones included, so a filter added to this type in future changes the text of
@@ -160,9 +170,15 @@ public sealed record MailboxEmailSelection
     /// <param name="isRemotelyFlagged">The remote <c>\Flagged</c> state to require, or <see langword="null" /> for either.</param>
     /// <param name="keyword">The keyword an email must carry, in any case, or <see langword="null" /> for any.</param>
     /// <param name="hasAttachments">Whether attachments are required, or <see langword="null" /> for either.</param>
+    /// <param name="mark">The reading a derivation must have made about the email, or <see langword="null" /> when no reading is required.</param>
     /// <returns>The validated selection.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="scope" /> is <see langword="null" />.</exception>
     /// <exception cref="MailboxQueryFilterInvalidException">Thrown when an address is unusable or over-long, the subject fragment is too long, the keyword is not one this system stores, or the received range can select nothing.</exception>
+    /// <remarks>
+    /// The reading is optional in the signature because only a screen drawing MailFathom's own marks ever asks for one,
+    /// and every other read model narrows by none: an omitted argument here says the same thing a <see langword="null" />
+    /// says for each of the filters above it.
+    /// </remarks>
     public static MailboxEmailSelection Create(
         MailboxScope scope,
         string? senderAddress,
@@ -173,7 +189,8 @@ public sealed record MailboxEmailSelection
         bool? isRemotelySeen,
         bool? isRemotelyFlagged,
         string? keyword,
-        bool? hasAttachments)
+        bool? hasAttachments,
+        EmailMarkSelection? mark = null)
     {
         ArgumentNullException.ThrowIfNull(scope);
 
@@ -196,7 +213,8 @@ public sealed record MailboxEmailSelection
             isRemotelySeen,
             isRemotelyFlagged,
             ComparableKeyword(keyword),
-            hasAttachments);
+            hasAttachments,
+            mark);
     }
 
     /// <summary>Writes one value with its own length in front of it, so nothing a caller supplies can imitate a separator.</summary>
@@ -281,7 +299,7 @@ public sealed record MailboxEmailSelection
 
     private string ComputeCanonicalText() => string.Join(
         CanonicalFieldSeparator,
-        LengthPrefixed("f2"),
+        LengthPrefixed("f3"),
         CanonicalList(this.Scope.AccountIds.Select(static accountId => accountId.Value)),
 
         // Both halves of a folder are written, because the pair is what the query narrows by: one role selects a
@@ -312,7 +330,13 @@ public sealed record MailboxEmailSelection
         // Already the comparison form, so nothing is folded again here: two requests that wrote one keyword in
         // different cases are one walk, and they reached this text as one value rather than as two.
         CanonicalOptionalText(this.Keyword),
-        LengthPrefixed(CanonicalFlag(this.HasAttachments)));
+        LengthPrefixed(CanonicalFlag(this.HasAttachments)),
+
+        // The reading a derivation made, written as the criterion it is rather than folded away when nobody named one.
+        // It removes rows from the middle of an ordering exactly as the flags above it do, and it is why this text opens
+        // f3 rather than f2 — a cursor issued before it existed names a row in a result set this reading no longer
+        // produces.
+        LengthPrefixed(this.Mark?.CanonicalText ?? CanonicalAbsentValue));
 
     /// <summary>Writes an optional free-text filter, marking whether one was named ahead of what it said.</summary>
     /// <remarks>

--- a/backend/src/Application/Preferences/ClientPreferences.cs
+++ b/backend/src/Application/Preferences/ClientPreferences.cs
@@ -11,11 +11,12 @@ namespace MailFathom.Application.Preferences;
 /// <param name="MarkReadOnOpen">Whether opening a message in the client marks it read on the user's own mail server.</param>
 /// <param name="ExpandWholeThread">Whether opening a conversation draws every message in it rather than the one it was opened at.</param>
 /// <param name="EmbeddedHtmlMessages">Whether an open message draws the sender's own markup inline rather than the reduced text.</param>
+/// <param name="AiFiltersShown">Whether the folder tree carries the standing views of what a derivation read in the mail.</param>
 /// <remarks>
 /// <para>
-/// A closed set of six rather than a settings service. Each of them says how somebody wants to work rather than what
+/// A closed set of seven rather than a settings service. Each of them says how somebody wants to work rather than what
 /// the screen in front of them is like, which is why they belong to the person and not to the browser profile or the
-/// desktop install they happened to set them in — and why a seventh is added when there is a seventh to add.
+/// desktop install they happened to set them in — and why an eighth is added when there is an eighth to add.
 /// </para>
 /// <para>
 /// Marking read is here rather than on the mail account for the reason
@@ -40,7 +41,8 @@ public sealed record ClientPreferences(
     bool OpenMailInTabs,
     bool MarkReadOnOpen,
     bool ExpandWholeThread,
-    bool EmbeddedHtmlMessages)
+    bool EmbeddedHtmlMessages,
+    bool AiFiltersShown)
 {
     /// <summary>Gets what a person who has set nothing is answered with.</summary>
     /// <remarks>
@@ -52,6 +54,9 @@ public sealed record ClientPreferences(
     /// A conversation opens at the message it was opened at, because that is the message somebody came for and the
     /// history behind it is one control away. A message is read as the reduced text, because that is what this client
     /// has always drawn and the sender's own markup is a surface somebody asks for rather than one they are handed.
+    /// The standing views are drawn, because they are a section of the tree somebody turns off rather than one they
+    /// go looking for, and a deployment deriving nothing answers each of them as a list with nothing in it.
     /// </remarks>
-    public static ClientPreferences Unset { get; } = new(true, ClientThemeChoice.System, false, true, false, false);
+    public static ClientPreferences Unset { get; } =
+        new(true, ClientThemeChoice.System, false, true, false, false, true);
 }

--- a/backend/src/Host/Api/ClientMailTimelineEndpoint.cs
+++ b/backend/src/Host/Api/ClientMailTimelineEndpoint.cs
@@ -60,14 +60,18 @@ internal static class ClientMailTimelineEndpoint
     /// <summary>The <c>direction</c> value that reads the page before the cursor.</summary>
     internal const string BackwardDirection = "backward";
 
+    // The three readings a request may narrow by, spelled as this surface already publishes them on a row's own
+    // `enrichment.marks`. A caller therefore hands back the value it read rather than translating between two
+    // spellings of one closed set, which is what a second spelling on the same route would have made it do.
+
     /// <summary>The <c>carriesMark</c> value naming the reading that says what a message is about.</summary>
-    internal const string SenseMark = "sense";
+    internal const string SenseMark = "Sense";
 
     /// <summary>The <c>carriesMark</c> value naming the reading that says why a message may matter.</summary>
-    internal const string SignificanceMark = "significance";
+    internal const string SignificanceMark = "Significance";
 
     /// <summary>The <c>carriesMark</c> value naming the reading that carries a commitment, which is the one that may carry a date.</summary>
-    internal const string CommitmentMark = "commitment";
+    internal const string CommitmentMark = "Commitment";
 
     /// <summary>Maps the route into the client group, so it inherits the group's requirement, its policy, and its limits.</summary>
     /// <param name="api">The client route group.</param>

--- a/backend/src/Host/Api/ClientMailTimelineEndpoint.cs
+++ b/backend/src/Host/Api/ClientMailTimelineEndpoint.cs
@@ -60,6 +60,15 @@ internal static class ClientMailTimelineEndpoint
     /// <summary>The <c>direction</c> value that reads the page before the cursor.</summary>
     internal const string BackwardDirection = "backward";
 
+    /// <summary>The <c>carriesMark</c> value naming the reading that says what a message is about.</summary>
+    internal const string SenseMark = "sense";
+
+    /// <summary>The <c>carriesMark</c> value naming the reading that says why a message may matter.</summary>
+    internal const string SignificanceMark = "significance";
+
+    /// <summary>The <c>carriesMark</c> value naming the reading that carries a commitment, which is the one that may carry a date.</summary>
+    internal const string CommitmentMark = "commitment";
+
     /// <summary>Maps the route into the client group, so it inherits the group's requirement, its policy, and its limits.</summary>
     /// <param name="api">The client route group.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="api" /> is <see langword="null" />.</exception>
@@ -85,6 +94,9 @@ internal static class ClientMailTimelineEndpoint
     /// <param name="direction">Whether the page lies <c>forward</c> of the cursor or <c>backward</c> of it.</param>
     /// <param name="pageSize">How many rows the page may hold, or <see langword="null" /> for the default.</param>
     /// <param name="cursor">The cursor a previous page returned, or <see langword="null" /> for the leading end of the list.</param>
+    /// <param name="carriesMark">The reading a derivation must have made about the message, or <see langword="null" /> for any.</param>
+    /// <param name="markDueOnOrAfter">The inclusive start of the range a commitment falls due in, or <see langword="null" /> for no start.</param>
+    /// <param name="markDueBefore">The exclusive end of that range, or <see langword="null" /> for no end.</param>
     /// <param name="timeline">Reads the page, for a caller the read's own grant admits.</param>
     /// <param name="cancellationToken">Cancels the read when the client disconnects.</param>
     /// <returns><c>200</c> with the page, <c>400</c> naming what was wrong with the request, or <c>403</c> for a caller whose grant does not carry <c>mailfathom.mail.read</c>.</returns>
@@ -107,6 +119,9 @@ internal static class ClientMailTimelineEndpoint
         [FromQuery] string? direction,
         [FromQuery] int? pageSize,
         [FromQuery] string? cursor,
+        [FromQuery] string? carriesMark,
+        [FromQuery] DateTimeOffset? markDueOnOrAfter,
+        [FromQuery] DateTimeOffset? markDueBefore,
         [FromServices] MailTimelineBrowser timeline,
         CancellationToken cancellationToken)
     {
@@ -132,6 +147,11 @@ internal static class ClientMailTimelineEndpoint
             return Refuse("The account or the folder names a value this deployment does not issue.");
         }
 
+        if (!TryReadMarkAspect(Named(carriesMark), out var carriedAspect))
+        {
+            return Refuse($"A mark names one of '{SenseMark}', '{SignificanceMark}', and '{CommitmentMark}'.");
+        }
+
         var request = new BrowseTimelineRequest
         {
             Accounts = accounts,
@@ -146,6 +166,9 @@ internal static class ClientMailTimelineEndpoint
             PageDirection = pageDirection,
             PageSize = pageSize,
             Cursor = cursor,
+            CarriesMarkOfAspect = carriedAspect,
+            MarkDueOnOrAfter = markDueOnOrAfter,
+            MarkDueBefore = markDueBefore,
         };
 
         try
@@ -210,6 +233,30 @@ internal static class ClientMailTimelineEndpoint
         _ when NamesTheSame(direction, BackwardDirection) => TimelinePageDirection.Backward,
         _ => null,
     };
+
+    /// <summary>Reads the reading a derivation must have made, reporting whether the request named one this surface publishes.</summary>
+    /// <param name="carriesMark">The mark named, or <see langword="null" /> where the request narrowed by none.</param>
+    /// <param name="aspect">The reading named, or <see langword="null" /> where the request narrowed by none.</param>
+    /// <returns>Whether the request is one this route can answer.</returns>
+    /// <remarks>
+    /// Two answers rather than one, because absence and a name nobody publishes are different requests: a list narrowed
+    /// by no mark is the ordinary list, and a list narrowed by a word this deployment never issued is a screen asking
+    /// for something it will not get — answering the second with the first would draw the whole mailbox under a filter
+    /// somebody believes is in force. A closed mapping rather than parsing the enum, for the reason the order is one.
+    /// </remarks>
+    private static bool TryReadMarkAspect(string? carriesMark, out EmailEnrichmentAspect? aspect)
+    {
+        aspect = carriesMark switch
+        {
+            null => null,
+            _ when NamesTheSame(carriesMark, SenseMark) => EmailEnrichmentAspect.Sense,
+            _ when NamesTheSame(carriesMark, SignificanceMark) => EmailEnrichmentAspect.Significance,
+            _ when NamesTheSame(carriesMark, CommitmentMark) => EmailEnrichmentAspect.Commitment,
+            _ => null,
+        };
+
+        return carriesMark is null || aspect is not null;
+    }
 
     /// <summary>Reports whether a caller wrote one of this surface's published names.</summary>
     private static bool NamesTheSame(string written, string published) =>

--- a/backend/src/Host/Api/ClientPreferencesEndpoint.cs
+++ b/backend/src/Host/Api/ClientPreferencesEndpoint.cs
@@ -130,11 +130,12 @@ internal static class ClientPreferencesEndpoint
 /// <param name="MarkReadOnOpen">Whether opening a message marks it read on their mail server, or nothing for the unset answer.</param>
 /// <param name="ExpandWholeThread">Whether a conversation opens with every message drawn, or nothing for the unset answer.</param>
 /// <param name="EmbeddedHtmlMessages">Whether an open message draws the sender's own markup inline, or nothing for the unset answer.</param>
+/// <param name="AiFiltersShown">Whether the folder tree carries the standing views of what a derivation read, or nothing for the unset answer.</param>
 /// <remarks>
 /// <para>
 /// Bound strictly: a key nothing here binds fails the bind rather than being stored, which is what keeps the document
-/// closed — it holds six preferences because six is what a client can state, not because a writer happened to send
-/// six. Every one of them is optional, and an omitted one is committed as its unset answer rather than left at
+/// closed — it holds seven preferences because seven is what a client can state, not because a writer happened to send
+/// seven. Every one of them is optional, and an omitted one is committed as its unset answer rather than left at
 /// whatever the row held.
 /// </para>
 /// <para>
@@ -151,7 +152,8 @@ internal sealed record ClientPreferencesRequest(
     bool? OpenMailInTabs = null,
     bool? MarkReadOnOpen = null,
     bool? ExpandWholeThread = null,
-    bool? EmbeddedHtmlMessages = null)
+    bool? EmbeddedHtmlMessages = null,
+    bool? AiFiltersShown = null)
 {
     /// <summary>Reads the request as the whole set the write commits.</summary>
     /// <returns>The preferences, with every one the body omitted answered as unset, or <see langword="null" /> when the body names a theme this build does not publish.</returns>
@@ -170,7 +172,8 @@ internal sealed record ClientPreferencesRequest(
             this.OpenMailInTabs ?? ClientPreferences.Unset.OpenMailInTabs,
             this.MarkReadOnOpen ?? ClientPreferences.Unset.MarkReadOnOpen,
             this.ExpandWholeThread ?? ClientPreferences.Unset.ExpandWholeThread,
-            this.EmbeddedHtmlMessages ?? ClientPreferences.Unset.EmbeddedHtmlMessages);
+            this.EmbeddedHtmlMessages ?? ClientPreferences.Unset.EmbeddedHtmlMessages,
+            this.AiFiltersShown ?? ClientPreferences.Unset.AiFiltersShown);
     }
 }
 
@@ -181,6 +184,7 @@ internal sealed record ClientPreferencesRequest(
 /// <param name="MarkReadOnOpen">Whether opening a message marks it read on the user's own mail server.</param>
 /// <param name="ExpandWholeThread">Whether a conversation opens with every message drawn rather than at the one it was opened at.</param>
 /// <param name="EmbeddedHtmlMessages">Whether an open message draws the sender's own markup inline rather than the reduced text.</param>
+/// <param name="AiFiltersShown">Whether the folder tree carries the standing views of what a derivation read in the mail.</param>
 /// <remarks>
 /// Every preference is answered, whether or not the person ever set it, so a client renders one screen rather than one
 /// per combination of what happens to be stored. What it does not report is when anything was set or from where: this
@@ -193,7 +197,8 @@ internal sealed record ClientPreferencesResponse(
     bool OpenMailInTabs,
     bool MarkReadOnOpen,
     bool ExpandWholeThread,
-    bool EmbeddedHtmlMessages)
+    bool EmbeddedHtmlMessages,
+    bool AiFiltersShown)
 {
     /// <summary>Describes one person's preferences on the wire.</summary>
     /// <param name="preferences">What they set.</param>
@@ -209,6 +214,7 @@ internal sealed record ClientPreferencesResponse(
             preferences.OpenMailInTabs,
             preferences.MarkReadOnOpen,
             preferences.ExpandWholeThread,
-            preferences.EmbeddedHtmlMessages);
+            preferences.EmbeddedHtmlMessages,
+            preferences.AiFiltersShown);
     }
 }

--- a/backend/src/Infrastructure/Persistence/Emails/StoredEmailSelectionPredicate.cs
+++ b/backend/src/Infrastructure/Persistence/Emails/StoredEmailSelectionPredicate.cs
@@ -85,7 +85,7 @@ internal static class StoredEmailSelectionPredicate
                 && EF.Functions.ILike(email.Subject, pattern, PatternEscapeCharacter));
         }
 
-        return MatchingReceivedRange(MatchingFlags(emails, selection), selection);
+        return MatchingMark(MatchingReceivedRange(MatchingFlags(emails, selection), selection), selection);
     }
 
     /// <summary>Narrows the stored emails to the mail a scope admits, whatever the caller then asked for.</summary>
@@ -246,6 +246,45 @@ internal static class StoredEmailSelectionPredicate
         }
 
         return emails;
+    }
+
+    /// <summary>Narrows the emails to the ones a derivation has already said something about.</summary>
+    /// <remarks>
+    /// <para>
+    /// One <c>EXISTS</c> over the marks rather than a clause per criterion, because the criteria describe a single
+    /// reading: <see cref="EmailMarkSelection" /> states that a message carrying an undated commitment and one due
+    /// tomorrow matches a range naming tomorrow, while a message whose only commitment is undated matches nothing.
+    /// Separate clauses would answer a different question that no reader could tell apart by looking at the result.
+    /// </para>
+    /// <para>
+    /// The subquery is anchored on the email, which is the column the marks are indexed by together with their aspect,
+    /// so a list already walking the emails in keyset order tests a handful of rows per candidate rather than scanning
+    /// the marks. An email no derivation has reached carries no derivation row at all and matches nothing, which is
+    /// also every email on a deployment that runs no enrichment.
+    /// </para>
+    /// <para>
+    /// Each bound is compared only where the caller named one, and an absent one is a parameter the predicate still
+    /// carries rather than a clause it drops — the three criteria have to be judged against one mark, so they cannot be
+    /// composed as separate queries the way the filters above are.
+    /// </para>
+    /// </remarks>
+    private static IQueryable<StoredEmailEntity> MatchingMark(
+        IQueryable<StoredEmailEntity> emails,
+        MailboxEmailSelection selection)
+    {
+        if (selection.Mark is not { } mark)
+        {
+            return emails;
+        }
+
+        var aspect = mark.Aspect;
+        var dueOnOrAfter = mark.DueOnOrAfter;
+        var dueBefore = mark.DueBefore;
+
+        return emails.Where(email => email.Enrichment != null && email.Enrichment.Marks.Any(stored =>
+            (aspect == null || stored.Aspect == aspect)
+            && (dueOnOrAfter == null || (stored.DueAt != null && stored.DueAt >= dueOnOrAfter))
+            && (dueBefore == null || (stored.DueAt != null && stored.DueAt < dueBefore))));
     }
 
     /// <summary>Builds the <c>ILIKE</c> pattern that matches a fragment anywhere in a subject.</summary>

--- a/backend/src/Infrastructure/Persistence/Preferences/ClientPreferencesDocument.cs
+++ b/backend/src/Infrastructure/Persistence/Preferences/ClientPreferencesDocument.cs
@@ -15,6 +15,7 @@ namespace MailFathom.Infrastructure.Persistence.Preferences;
 /// <param name="MarkReadOnOpen">What they said about opening a message marking it read, or nothing where they never said.</param>
 /// <param name="ExpandWholeThread">What they said about a conversation opening expanded, or nothing where they never said.</param>
 /// <param name="EmbeddedHtmlMessages">What they said about a message drawing the sender's own markup, or nothing where they never said.</param>
+/// <param name="AiFiltersShown">What they said about the tree carrying the standing views, or nothing where they never said.</param>
 /// <remarks>
 /// <para>
 /// Sparse, and every member is therefore optional: a key the document does not carry reads as that preference's own
@@ -39,7 +40,8 @@ internal sealed record ClientPreferencesDocument(
     bool? OpenMailInTabs,
     bool? MarkReadOnOpen,
     bool? ExpandWholeThread,
-    bool? EmbeddedHtmlMessages)
+    bool? EmbeddedHtmlMessages,
+    bool? AiFiltersShown)
 {
     /// <summary>How the column is written and read, which is fixed here rather than inherited from a host's own options.</summary>
     /// <remarks>
@@ -68,7 +70,8 @@ internal sealed record ClientPreferencesDocument(
             preferences.OpenMailInTabs,
             preferences.MarkReadOnOpen,
             preferences.ExpandWholeThread,
-            preferences.EmbeddedHtmlMessages);
+            preferences.EmbeddedHtmlMessages,
+            preferences.AiFiltersShown);
 
         return JsonSerializer.Serialize(document, StoredFormat);
     }
@@ -91,6 +94,7 @@ internal sealed record ClientPreferencesDocument(
             document.OpenMailInTabs ?? ClientPreferences.Unset.OpenMailInTabs,
             document.MarkReadOnOpen ?? ClientPreferences.Unset.MarkReadOnOpen,
             document.ExpandWholeThread ?? ClientPreferences.Unset.ExpandWholeThread,
-            document.EmbeddedHtmlMessages ?? ClientPreferences.Unset.EmbeddedHtmlMessages);
+            document.EmbeddedHtmlMessages ?? ClientPreferences.Unset.EmbeddedHtmlMessages,
+            document.AiFiltersShown ?? ClientPreferences.Unset.AiFiltersShown);
     }
 }

--- a/backend/tests/Application.UnitTests/Emails/Mailboxes/EmailMarkSelectionTests.cs
+++ b/backend/tests/Application.UnitTests/Emails/Mailboxes/EmailMarkSelectionTests.cs
@@ -1,0 +1,106 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Enrichment;
+using MailFathom.Application.Emails.Mailboxes;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Emails.Mailboxes;
+
+/// <summary>Covers what a list narrowed by a reading a derivation already made validates and normalizes.</summary>
+public sealed class EmailMarkSelectionTests
+{
+    private static readonly DateTimeOffset MondayMorning = new(2026, 7, 6, 6, 0, 0, TimeSpan.Zero);
+
+    /// <summary>A request that narrowed by no reading narrows by nothing, rather than by a criterion admitting everything.</summary>
+    [Fact]
+    public void Create_NothingNamed_NarrowsByNoReading()
+    {
+        // Act
+        var selection = EmailMarkSelection.Create(aspect: null, dueOnOrAfter: null, dueBefore: null);
+
+        // Assert
+        Assert.Null(selection);
+    }
+
+    [Theory]
+    [InlineData(EmailEnrichmentAspect.Sense)]
+    [InlineData(EmailEnrichmentAspect.Significance)]
+    [InlineData(EmailEnrichmentAspect.Commitment)]
+    public void Create_OneReading_KeepsTheReadingTheListIsNarrowedTo(EmailEnrichmentAspect aspect)
+    {
+        // Act
+        var selection = EmailMarkSelection.Create(aspect, dueOnOrAfter: null, dueBefore: null);
+
+        // Assert
+        Assert.Equal(aspect, selection?.Aspect);
+    }
+
+    /// <summary>A due range whose end falls on or before its start selects nothing, and is refused rather than answered with an empty page.</summary>
+    [Fact]
+    public void Create_DueRangeThatSelectsNothing_IsRejected()
+    {
+        // Act
+        var failure = Assert.Throws<MailboxQueryFilterInvalidException>(() => EmailMarkSelection.Create(
+            EmailEnrichmentAspect.Commitment,
+            MondayMorning.AddDays(7),
+            MondayMorning));
+
+        // Assert
+        Assert.Equal("commitment due range", failure.FilterName);
+    }
+
+    /// <summary>A caller naming a value no derivation produces is refused, rather than narrowing to mail nothing can carry.</summary>
+    [Fact]
+    public void Create_ReadingThatNamesNoAspect_IsRejected()
+    {
+        // Act
+        var failure = Assert.Throws<ArgumentOutOfRangeException>(() => EmailMarkSelection.Create(
+            (EmailEnrichmentAspect)7,
+            dueOnOrAfter: null,
+            dueBefore: null));
+
+        // Assert
+        Assert.Equal("aspect", failure.ParamName);
+    }
+
+    /// <summary>Two requests naming one instant are one walk, whichever offset each of them wrote it at.</summary>
+    [Fact]
+    public void CanonicalText_DueBoundsAtDifferentOffsets_NameTheSameWalk()
+    {
+        // Act
+        var inUtc = EmailMarkSelection.Create(
+            EmailEnrichmentAspect.Commitment,
+            MondayMorning,
+            MondayMorning.AddDays(7));
+
+        var written = EmailMarkSelection.Create(
+            EmailEnrichmentAspect.Commitment,
+            MondayMorning.ToOffset(TimeSpan.FromHours(2)),
+            MondayMorning.AddDays(7).ToOffset(TimeSpan.FromHours(-5)));
+
+        // Assert
+        Assert.Equal(inUtc?.CanonicalText, written?.CanonicalText);
+    }
+
+    /// <summary>The bounds and the reading are each written, so no two of the standing views share a cursor.</summary>
+    [Fact]
+    public void CanonicalText_SelectionsDifferingInOneCriterion_AreNotOneWalk()
+    {
+        // Act
+        var commitments = EmailMarkSelection.Create(EmailEnrichmentAspect.Commitment, null, null);
+        var significance = EmailMarkSelection.Create(EmailEnrichmentAspect.Significance, null, null);
+        var dueThisWeek = EmailMarkSelection.Create(
+            EmailEnrichmentAspect.Commitment,
+            MondayMorning,
+            MondayMorning.AddDays(7));
+
+        // Assert
+        Assert.Equal(
+            3,
+            new[] { commitments?.CanonicalText, significance?.CanonicalText, dueThisWeek?.CanonicalText }
+                .Distinct()
+                .Count());
+    }
+}

--- a/backend/tests/Application.UnitTests/Emails/Mailboxes/MailboxEmailSelectionTests.cs
+++ b/backend/tests/Application.UnitTests/Emails/Mailboxes/MailboxEmailSelectionTests.cs
@@ -377,7 +377,6 @@ public sealed class MailboxEmailSelectionTests
         Assert.Equal(3, new[] { whole, conversation, selection }.Distinct(StringComparer.Ordinal).Count());
     }
 
-    /// <summary>Builds the resolver a mailbox read gets its scope from, since the scope's own narrowing is not public.</summary>
     /// <summary>A list narrowed by a derived reading is a different walk, so a cursor cannot cross between the two.</summary>
     [Fact]
     public void CanonicalText_SelectionsDifferingOnlyInTheMarkTheyRequire_AreNotOneWalk()
@@ -396,6 +395,7 @@ public sealed class MailboxEmailSelectionTests
         Assert.Equal(3, new[] { everything, commitments, dueThisWeek }.Distinct().Count());
     }
 
+    /// <summary>Builds the resolver a mailbox read gets its scope from, since the scope's own narrowing is not public.</summary>
     private static MailboxScopeResolver ResolverWithJunkFolder(IJunkMailFolderCatalog? junkFolders = null)
     {
         var catalog = Substitute.For<ICallerMailAccountCatalog>();

--- a/backend/tests/Application.UnitTests/Emails/Mailboxes/MailboxEmailSelectionTests.cs
+++ b/backend/tests/Application.UnitTests/Emails/Mailboxes/MailboxEmailSelectionTests.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Accounts;
+using MailFathom.Application.Emails.Enrichment;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Folders;
 using MailFathom.Domain.Accounts;
@@ -377,6 +378,24 @@ public sealed class MailboxEmailSelectionTests
     }
 
     /// <summary>Builds the resolver a mailbox read gets its scope from, since the scope's own narrowing is not public.</summary>
+    /// <summary>A list narrowed by a derived reading is a different walk, so a cursor cannot cross between the two.</summary>
+    [Fact]
+    public void CanonicalText_SelectionsDifferingOnlyInTheMarkTheyRequire_AreNotOneWalk()
+    {
+        // Act
+        var everything = SelectionWith().CanonicalText;
+        var commitments = SelectionWith(
+            mark: EmailMarkSelection.Create(EmailEnrichmentAspect.Commitment, null, null)).CanonicalText;
+        var dueThisWeek = SelectionWith(
+            mark: EmailMarkSelection.Create(
+                EmailEnrichmentAspect.Commitment,
+                FirstJuly,
+                FirstJuly.AddDays(7))).CanonicalText;
+
+        // Assert
+        Assert.Equal(3, new[] { everything, commitments, dueThisWeek }.Distinct().Count());
+    }
+
     private static MailboxScopeResolver ResolverWithJunkFolder(IJunkMailFolderCatalog? junkFolders = null)
     {
         var catalog = Substitute.For<ICallerMailAccountCatalog>();
@@ -407,7 +426,8 @@ public sealed class MailboxEmailSelectionTests
         bool? isRemotelySeen = null,
         bool? isRemotelyFlagged = null,
         string? keyword = null,
-        bool? hasAttachments = null) => MailboxEmailSelection.Create(
+        bool? hasAttachments = null,
+        EmailMarkSelection? mark = null) => MailboxEmailSelection.Create(
         scope ?? MailboxScope.NothingReadable,
         senderAddress,
         recipientAddress,
@@ -417,5 +437,6 @@ public sealed class MailboxEmailSelectionTests
         isRemotelySeen,
         isRemotelyFlagged,
         keyword,
-        hasAttachments);
+        hasAttachments,
+        mark);
 }

--- a/backend/tests/Application.UnitTests/Preferences/OwnClientPreferencesTests.cs
+++ b/backend/tests/Application.UnitTests/Preferences/OwnClientPreferencesTests.cs
@@ -19,7 +19,7 @@ namespace MailFathom.Application.UnitTests.Preferences;
 /// </summary>
 public sealed class OwnClientPreferencesTests
 {
-    private static readonly ClientPreferences Chosen = new(false, ClientThemeChoice.Dark, true, false, true, true);
+    private static readonly ClientPreferences Chosen = new(false, ClientThemeChoice.Dark, true, false, true, true, false);
 
     [Fact]
     public async Task ReadAsync_APersonWhoHasSetSomething_AnswersWhatTheySet()

--- a/backend/tests/Host.UnitTests/Api/ClientMailTimelineEndpointTests.cs
+++ b/backend/tests/Host.UnitTests/Api/ClientMailTimelineEndpointTests.cs
@@ -203,6 +203,93 @@ public sealed class ClientMailTimelineEndpointTests
             Arg.Any<CancellationToken>());
     }
 
+    /// <summary>A reading no derivation produces would otherwise narrow to nothing while reading as a list that is simply empty.</summary>
+    [Theory]
+    [InlineData("decision")]
+    [InlineData("commitment,significance")]
+    [InlineData("2")]
+    public async Task ReadTimelineAsync_AMarkThisSurfaceDoesNotPublish_IsRefused(string carriesMark)
+    {
+        // Act
+        var result = await this.ReadAsync(carriesMark: carriesMark);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, Assert.IsType<ProblemHttpResult>(result.Result).StatusCode);
+    }
+
+    /// <summary>A standing entry in the folder tree is these criteria and nothing else, so each published name reaches the query as the reading it names.</summary>
+    [Theory]
+    [InlineData(ClientMailTimelineEndpoint.SenseMark, EmailEnrichmentAspect.Sense)]
+    [InlineData(ClientMailTimelineEndpoint.SignificanceMark, EmailEnrichmentAspect.Significance)]
+    [InlineData(ClientMailTimelineEndpoint.CommitmentMark, EmailEnrichmentAspect.Commitment)]
+    public async Task ReadTimelineAsync_APublishedMark_NarrowsTheListToMailCarryingThatReading(
+        string carriesMark,
+        EmailEnrichmentAspect aspect)
+    {
+        // Act
+        var result = await this.ReadAsync(carriesMark: carriesMark);
+
+        // Assert
+        Assert.IsType<Ok<ClientMailTimelineResponse>>(result.Result);
+        await this.timeline.Received(1).ReadPageAsync(
+            Arg.Is<EmailTimelineFilter>(filter =>
+                filter != null && filter.Selection.Mark != null && filter.Selection.Mark.Aspect == aspect),
+            Arg.Any<EmailTimelinePosition?>(),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>The deadlines a week holds are the same criteria with a range on them rather than a query of their own.</summary>
+    [Fact]
+    public async Task ReadTimelineAsync_ACommitmentDueRange_NarrowsTheListToThatRange()
+    {
+        // Act
+        await this.ReadAsync(
+            carriesMark: ClientMailTimelineEndpoint.CommitmentMark,
+            markDueOnOrAfter: FirstJuly,
+            markDueBefore: FirstJuly.AddDays(7));
+
+        // Assert
+        await this.timeline.Received(1).ReadPageAsync(
+            Arg.Is<EmailTimelineFilter>(filter =>
+                filter != null
+                && filter.Selection.Mark != null
+                && filter.Selection.Mark.DueOnOrAfter == FirstJuly
+                && filter.Selection.Mark.DueBefore == FirstJuly.AddDays(7)),
+            Arg.Any<EmailTimelinePosition?>(),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>A request naming no reading narrows by none, so the list a screen opens on is unchanged by this filter existing.</summary>
+    [Fact]
+    public async Task ReadTimelineAsync_NoMarkNamed_NarrowsByNoReading()
+    {
+        // Act
+        await this.ReadAsync();
+
+        // Assert
+        await this.timeline.Received(1).ReadPageAsync(
+            Arg.Is<EmailTimelineFilter>(filter => filter != null && filter.Selection.Mark == null),
+            Arg.Any<EmailTimelinePosition?>(),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>A due range that selects nothing is a mistake in the request rather than a week with no deadlines in it.</summary>
+    [Fact]
+    public async Task ReadTimelineAsync_ADueRangeThatSelectsNothing_IsRefused()
+    {
+        // Act
+        var result = await this.ReadAsync(
+            carriesMark: ClientMailTimelineEndpoint.CommitmentMark,
+            markDueOnOrAfter: FirstJuly.AddDays(7),
+            markDueBefore: FirstJuly);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, Assert.IsType<ProblemHttpResult>(result.Result).StatusCode);
+    }
+
     /// <summary>Every fact a list row draws reaches the wire from one request, which is what the route exists for.</summary>
     [Fact]
     public void For_ARowOfTheList_CarriesEveryFactAListDraws()
@@ -379,7 +466,10 @@ public sealed class ClientMailTimelineEndpointTests
         string? order = null,
         string? direction = null,
         int? pageSize = null,
-        string? cursor = null)
+        string? cursor = null,
+        string? carriesMark = null,
+        DateTimeOffset? markDueOnOrAfter = null,
+        DateTimeOffset? markDueBefore = null)
     {
         this.timeline
             .ReadPageAsync(
@@ -403,6 +493,9 @@ public sealed class ClientMailTimelineEndpointTests
             direction,
             pageSize,
             cursor,
+            carriesMark,
+            markDueOnOrAfter,
+            markDueBefore,
             this.Browser(),
             TestContext.Current.CancellationToken);
     }

--- a/backend/tests/Host.UnitTests/Api/ClientPreferencesEndpointTests.cs
+++ b/backend/tests/Host.UnitTests/Api/ClientPreferencesEndpointTests.cs
@@ -23,7 +23,7 @@ namespace MailFathom.Host.UnitTests.Api;
 /// </summary>
 public sealed class ClientPreferencesEndpointTests
 {
-    private static readonly ClientPreferences Chosen = new(false, ClientThemeChoice.Dark, true, false, true, true);
+    private static readonly ClientPreferences Chosen = new(false, ClientThemeChoice.Dark, true, false, true, true, false);
 
     [Fact]
     public async Task ReadAsync_APersonWhoHasSetSomething_HandsThemWhatTheySet()
@@ -46,6 +46,7 @@ public sealed class ClientPreferencesEndpointTests
         Assert.False(preferences.MarkReadOnOpen);
         Assert.True(preferences.ExpandWholeThread);
         Assert.True(preferences.EmbeddedHtmlMessages);
+        Assert.False(preferences.AiFiltersShown);
     }
 
     /// <summary>A first run is a screen rather than an error, so every preference is answered whether or not it was ever set.</summary>
@@ -70,6 +71,7 @@ public sealed class ClientPreferencesEndpointTests
         Assert.True(preferences.MarkReadOnOpen);
         Assert.False(preferences.ExpandWholeThread);
         Assert.False(preferences.EmbeddedHtmlMessages);
+        Assert.True(preferences.AiFiltersShown);
     }
 
     /// <summary>The row is one only this deployment writes, so a reader learns what to do about it and nothing about what it held.</summary>
@@ -104,7 +106,7 @@ public sealed class ClientPreferencesEndpointTests
         // Act
         var result = await ClientPreferencesEndpoint.SaveAsync(
             SignedIn(store),
-            new ClientPreferencesRequest(false, "dark", true, false, true, true),
+            new ClientPreferencesRequest(false, "dark", true, false, true, true, false),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -132,7 +134,7 @@ public sealed class ClientPreferencesEndpointTests
         // Assert
         await store.Received(1).SaveAsync(
             SyntheticMailUser.Deployment,
-            new ClientPreferences(true, ClientThemeChoice.Light, false, true, false, false),
+            new ClientPreferences(true, ClientThemeChoice.Light, false, true, false, false, true),
             Arg.Any<CancellationToken>());
     }
 
@@ -198,7 +200,7 @@ public sealed class ClientPreferencesEndpointTests
     {
         // Act
         var request = JsonSerializer.Deserialize<ClientPreferencesRequest>(
-            """{"telemetryEnabled":false,"theme":"dark","openMailInTabs":true,"markReadOnOpen":false,"expandWholeThread":true,"embeddedHtmlMessages":true}""",
+            """{"telemetryEnabled":false,"theme":"dark","openMailInTabs":true,"markReadOnOpen":false,"expandWholeThread":true,"embeddedHtmlMessages":true,"aiFiltersShown":false}""",
             WebFormat);
 
         // Assert
@@ -229,6 +231,19 @@ public sealed class ClientPreferencesEndpointTests
 
         // Assert
         Assert.False(request!.Stated()!.EmbeddedHtmlMessages);
+    }
+
+    /// <summary>The seventh preference binds like the six beside it, and a body written before it existed draws the standing views rather than hiding them.</summary>
+    [Fact]
+    public void Deserialize_ABodyOmittingTheStandingViews_StatesThemAsDrawn()
+    {
+        // Act
+        var request = JsonSerializer.Deserialize<ClientPreferencesRequest>(
+            """{"telemetryEnabled":false,"theme":"dark","openMailInTabs":true,"markReadOnOpen":false,"expandWholeThread":true,"embeddedHtmlMessages":true}""",
+            WebFormat);
+
+        // Assert
+        Assert.True(request!.Stated()!.AiFiltersShown);
     }
 
     /// <summary>The document is closed, so a body stating the message view under a name this build does not publish is refused rather than stored.</summary>

--- a/backend/tests/Infrastructure.UnitTests/Persistence/Emails/StoredEmailSelectionPredicateCommandTests.cs
+++ b/backend/tests/Infrastructure.UnitTests/Persistence/Emails/StoredEmailSelectionPredicateCommandTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Emails.Enrichment;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
@@ -21,6 +22,8 @@ namespace MailFathom.Infrastructure.UnitTests.Persistence.Emails;
 /// </summary>
 public sealed class StoredEmailSelectionPredicateCommandTests
 {
+    private static readonly DateTimeOffset FirstJuly = new(2026, 7, 1, 8, 0, 0, TimeSpan.Zero);
+
     private static MailboxScope WholeMailbox { get; } = MailboxScope.Create(
         SyntheticMailUser.Deployment,
         [MailAccountId.Create("primary")],
@@ -123,6 +126,66 @@ public sealed class StoredEmailSelectionPredicateCommandTests
         Assert.DoesNotContain($"\"{nameof(StoredEmailEntity.Id)}\" = ANY", narrowing, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// A standing entry in the folder tree is a list of mail a derivation left a reading on, and reading that in the
+    /// process would mean fetching every message the scope admits to drop most of them. The correlated existence
+    /// narrowing is what serves it from the mark table's own <c>(StoredEmailId, Aspect)</c> index instead.
+    /// </summary>
+    [Fact]
+    public void Matching_MarkFilter_AsksTheMarkTableWhetherOneSuchReadingExists()
+    {
+        // Act
+        var narrowing = NarrowingOf(SelectionWith(
+            mark: EmailMarkSelection.Create(EmailEnrichmentAspect.Commitment, null, null)));
+
+        // Assert
+        Assert.Contains("EXISTS (", narrowing, StringComparison.Ordinal);
+        Assert.Contains(nameof(EmailEnrichmentMarkEntity.Aspect), narrowing, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Every criterion has to be met by one mark rather than by the message as a whole: a message carrying an undated
+    /// commitment and an unrelated dated one is not a message due this week. Two narrowings applied to the same
+    /// existence test is what says so, and separate ones would answer the wrong question off the same rows.
+    /// </summary>
+    [Fact]
+    public void Matching_MarkFilterWithADueRange_AsksOneExistenceTestForEveryCriterion()
+    {
+        // Act
+        var narrowing = NarrowingOf(SelectionWith(
+            mark: EmailMarkSelection.Create(EmailEnrichmentAspect.Commitment, FirstJuly, FirstJuly.AddDays(7))));
+
+        // Assert
+        Assert.Equal(1, Occurrences(narrowing, "EXISTS ("));
+        Assert.Contains($"\"{nameof(EmailEnrichmentMarkEntity.DueAt)}\" >= ", narrowing, StringComparison.Ordinal);
+        Assert.Contains($"\"{nameof(EmailEnrichmentMarkEntity.DueAt)}\" < ", narrowing, StringComparison.Ordinal);
+    }
+
+    /// <summary>A list nobody narrowed by a reading reads no derivation at all, which is what keeps the mark table out of an ordinary listing.</summary>
+    [Fact]
+    public void Matching_NoMarkNamed_LeavesTheMarkTableOutOfTheCommand()
+    {
+        // Act
+        var narrowing = NarrowingOf(SelectionWith());
+
+        // Assert
+        Assert.DoesNotContain("EXISTS (", narrowing, StringComparison.Ordinal);
+    }
+
+    private static int Occurrences(string command, string fragment)
+    {
+        var found = 0;
+        var index = command.IndexOf(fragment, StringComparison.Ordinal);
+
+        while (index >= 0)
+        {
+            found++;
+            index = command.IndexOf(fragment, index + fragment.Length, StringComparison.Ordinal);
+        }
+
+        return found;
+    }
+
     /// <summary>Generates what a scope alone narrows by, without opening a connection.</summary>
     private static string ScopeNarrowingOf(MailboxScope scope)
     {
@@ -167,7 +230,8 @@ public sealed class StoredEmailSelectionPredicateCommandTests
 
     private static MailboxEmailSelection SelectionWith(
         bool? isRemotelyFlagged = null,
-        string? keyword = null) => MailboxEmailSelection.Create(
+        string? keyword = null,
+        EmailMarkSelection? mark = null) => MailboxEmailSelection.Create(
         MailboxScope.NothingReadable,
         senderAddress: null,
         recipientAddress: null,
@@ -177,5 +241,6 @@ public sealed class StoredEmailSelectionPredicateCommandTests
         isRemotelySeen: null,
         isRemotelyFlagged,
         keyword,
-        hasAttachments: null);
+        hasAttachments: null,
+        mark);
 }

--- a/backend/tests/Infrastructure.UnitTests/Persistence/Preferences/ClientPreferencesDocumentTests.cs
+++ b/backend/tests/Infrastructure.UnitTests/Persistence/Preferences/ClientPreferencesDocumentTests.cs
@@ -22,11 +22,11 @@ public sealed class ClientPreferencesDocumentTests
     {
         // Act
         var document = ClientPreferencesDocument.Render(
-            new ClientPreferences(false, ClientThemeChoice.Dark, true, false, true, true));
+            new ClientPreferences(false, ClientThemeChoice.Dark, true, false, true, true, false));
 
         // Assert
         Assert.Equal(
-            """{"telemetryEnabled":false,"theme":"dark","openMailInTabs":true,"markReadOnOpen":false,"expandWholeThread":true,"embeddedHtmlMessages":true}""",
+            """{"telemetryEnabled":false,"theme":"dark","openMailInTabs":true,"markReadOnOpen":false,"expandWholeThread":true,"embeddedHtmlMessages":true,"aiFiltersShown":false}""",
             document);
     }
 
@@ -39,7 +39,7 @@ public sealed class ClientPreferencesDocumentTests
 
         // Assert
         Assert.Equal(
-            """{"telemetryEnabled":true,"theme":"system","openMailInTabs":false,"markReadOnOpen":true,"expandWholeThread":false,"embeddedHtmlMessages":false}""",
+            """{"telemetryEnabled":true,"theme":"system","openMailInTabs":false,"markReadOnOpen":true,"expandWholeThread":false,"embeddedHtmlMessages":false,"aiFiltersShown":true}""",
             document);
     }
 
@@ -47,7 +47,7 @@ public sealed class ClientPreferencesDocumentTests
     public void Parse_ADocumentThisBuildWrote_ReadsBackWhatWasWritten()
     {
         // Arrange
-        var chosen = new ClientPreferences(false, ClientThemeChoice.Light, true, false, true, true);
+        var chosen = new ClientPreferences(false, ClientThemeChoice.Light, true, false, true, true, false);
 
         // Act
         var read = ClientPreferencesDocument.Parse(ClientPreferencesDocument.Render(chosen));
@@ -74,7 +74,7 @@ public sealed class ClientPreferencesDocumentTests
         var read = ClientPreferencesDocument.Parse("""{"theme":"dark"}""");
 
         // Assert
-        Assert.Equal(new ClientPreferences(true, ClientThemeChoice.Dark, false, true, false, false), read);
+        Assert.Equal(new ClientPreferences(true, ClientThemeChoice.Dark, false, true, false, false, true), read);
     }
 
     /// <summary>The reduced text is what the client drew before the message view was a preference, so a row written then reads as that rather than as the sender's own markup.</summary>
@@ -87,6 +87,21 @@ public sealed class ClientPreferencesDocumentTests
 
         // Assert
         Assert.False(read.EmbeddedHtmlMessages);
+    }
+
+    /// <summary>
+    /// The standing views are a section of the tree somebody turns off rather than one they go looking for, so a row
+    /// written before the section existed draws them rather than leaving the tree short of what the design shows.
+    /// </summary>
+    [Fact]
+    public void Parse_ARowWrittenBeforeTheStandingViewsExisted_DrawsThem()
+    {
+        // Act
+        var read = ClientPreferencesDocument.Parse(
+            """{"telemetryEnabled":false,"theme":"dark","openMailInTabs":true,"markReadOnOpen":true,"expandWholeThread":true,"embeddedHtmlMessages":true}""");
+
+        // Assert
+        Assert.True(read.AiFiltersShown);
     }
 
     /// <summary>Opening a conversation at the message it was opened at is what the client did before the preference existed, so a row written then reads as that rather than as expanding.</summary>

--- a/backend/tests/PublicSurfaces.UnitTests/http-api-contract.json
+++ b/backend/tests/PublicSurfaces.UnitTests/http-api-contract.json
@@ -2705,6 +2705,12 @@
       "ClientPreferencesRequest": {
         "additionalProperties": false,
         "properties": {
+          "aiFiltersShown": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
           "embeddedHtmlMessages": {
             "type": [
               "null",
@@ -2746,6 +2752,9 @@
       },
       "ClientPreferencesResponse": {
         "properties": {
+          "aiFiltersShown": {
+            "type": "boolean"
+          },
           "embeddedHtmlMessages": {
             "type": "boolean"
           },
@@ -2771,7 +2780,8 @@
           "openMailInTabs",
           "markReadOnOpen",
           "expandWholeThread",
-          "embeddedHtmlMessages"
+          "embeddedHtmlMessages",
+          "aiFiltersShown"
         ],
         "type": "object"
       },

--- a/backend/tests/PublicSurfaces.UnitTests/http-api-contract.json
+++ b/backend/tests/PublicSurfaces.UnitTests/http-api-contract.json
@@ -11424,6 +11424,29 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "carriesMark",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "markDueOnOrAfter",
+            "schema": {
+              "format": "date-time",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "markDueBefore",
+            "schema": {
+              "format": "date-time",
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/docs/features/mailbox-queries.md
+++ b/docs/features/mailbox-queries.md
@@ -46,6 +46,7 @@ divergence neither copy would look wrong for on its own.
 | `IsRemotelyFlagged` | The remote `\Flagged` state to require | either state |
 | `Keyword` | One keyword the email must carry, compared without regard to case | any keyword |
 | `HasAttachments` | Whether attachments are required | either |
+| `Mark` | The reading an enrichment must have left, and the range a commitment falls due in | any reading, and mail with none |
 | `IncludeJunkMail` | Whether the account's junk folder takes part | it does not |
 | `Direction` | Which end of the timeline to read from | `NewestFirst` |
 | `PageSize` | How many emails the page returns | the default of 25 |
@@ -100,6 +101,15 @@ and its result would read as an answer about the mailbox.
   bound, so naming either one excludes undated mail. Each bound names an instant, so it may be written at any UTC offset
   and the offset chosen changes neither what is selected nor which walk a cursor belongs to: `2026-07-01T10:00:00+02:00`
   and `2026-07-01T08:00:00Z` are one range asked for twice.
+- **A mark selection** narrows by what an enrichment already recorded and derives nothing: it names one
+  `EmailEnrichmentAspect` and, for a commitment, the range that commitment falls due in. Naming none of the three is
+  naming no such filter, and an aspect no build publishes is refused with `ArgumentOutOfRangeException` at the boundary
+  that read it rather than carried in as a value nothing can match. A due range whose end is not after its start is
+  refused with `51002 MailboxQueryFilterInvalid`, for the reason the received range is. Every criterion is met by **one
+  mark** rather than by the message as a whole, so a message whose `Sense` mark is old and whose `Commitment` falls due
+  tomorrow answers a commitment narrowed to tomorrow and does not answer a sense narrowed to it — the predicate is one
+  correlated existence test over the mark table, served by that table's own `(StoredEmailId, Aspect)` index. A
+  deployment that has derived nothing selects nothing, which is a narrowed list rather than a failure.
 - **The scope** accepts at most 64 accounts and 64 folders, counting what a request names rather than what is left
   after deduplication — that is what lets the limit be enforced while the caller's list is read instead of after it has
   been materialized. Both lists are then deduplicated and ordered, so two spellings of one scope are one query with one
@@ -601,7 +611,7 @@ mirrored or not and withheld or not, is [the administrative status route](../ope
   participant a header names, and `EmailThreadCursor`, whose boundary is a message rather than a position. It owns none
   of the threading: membership, the bound and the order come from `MailFathom.Application.Emails.Threads`, which the MCP
   content read publishes a conversation through as well.
-- `MailFathom.Application.Emails.Mailboxes` — `MailboxEmailSelection` and the timeline filter that wraps it, the cursor,
+- `MailFathom.Application.Emails.Mailboxes` — `MailboxEmailSelection`, `EmailMarkSelection` beside it, the timeline filter that wraps them, the cursor,
   the page size, and the query failures shared with the other read models. `MailboxScopeResolver` is here too: it
   resolves the accounts a read runs against and refuses one this deployment does not serve, and it is a collaborator
   rather than a step inside the use case because the refusal is an access decision every read model has to make

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -1,6 +1,6 @@
 # The client endpoint
 
-<!-- describes: backend/src/AppHost/Program.cs, backend/src/AppHost/OrchestrationContract.cs, backend/src/Host/Configuration/Endpoints/ClientEndpointOptions.cs, backend/src/Host/Configuration/Endpoints/ClientApplicationOptions.cs, backend/src/Host/Configuration/Endpoints/TransportHttpsEndpointOptions.cs, backend/src/Host/Api/ClientApiEndpoints.cs, backend/src/Host/Api/ClientSessionTokenEndpoints.cs, backend/src/Host/Security/Sessions/**, backend/src/Host/Api/ClientMailAccountsEndpoint.cs, backend/src/Host/Api/ClientMailFoldersEndpoint.cs, backend/src/Host/Api/ClientMailTimelineEndpoint.cs, backend/src/Host/Api/ClientMailThreadEndpoint.cs, backend/src/Host/Api/ClientMailThreadStateEndpoint.cs, backend/src/Host/Api/ClientMailMessageEndpoint.cs, backend/src/Host/Api/ClientMailBodyEndpoint.cs, backend/src/Host/Api/ClientMailAttachmentEndpoint.cs, backend/src/Host/Api/ClientMailSearchPhraseEndpoint.cs, backend/src/Host/Api/AttachmentContentResponse.cs, backend/src/Host/Api/ProtectedResourceMetadataEndpoint.cs, backend/src/Host/Security/Endpoints/ClientTransportSecurityExtensions.cs, backend/src/Infrastructure/Security/Transport/BrowserOriginPolicy.cs, backend/src/Host/Hosting/ClientApplicationFiles.cs, backend/src/Host/Hosting/Startup/ClientResponseCompression.cs, backend/src/Host/Hosting/Warnings/ClientTransportSecurityWarning.cs, backend/src/Host/Hosting/Warnings/PasswordClearTextTransportWarning.cs, backend/src/Host/Api/ClientUserRecordEndpoint.cs, backend/src/Host/Api/ClientPortraitEndpoint.cs, backend/src/Host/Api/ClientDisplayNameEndpoint.cs, backend/src/Host/Configuration/UserSettings/Administration/OwnDisplayName.cs, backend/src/Host/Api/ClientMailMutationsEndpoint.cs, backend/src/Host/Api/ClientDraftEndpoints.cs, backend/src/Host/Api/ClientDraftResponses.cs, backend/src/Host/Api/ClientOutboxEndpoints.cs, backend/src/Host/Api/ClientNotificationEndpoints.cs, backend/src/Host/Api/ClientTelemetryEndpoint.cs, backend/src/Host/Api/ClientCitationEndpoint.cs, backend/src/Host/Api/ClientDiscoveryRunEndpoints.cs, backend/src/Host/Observability/ClientTelemetry/** -->
+<!-- describes: backend/src/AppHost/Program.cs, backend/src/AppHost/OrchestrationContract.cs, backend/src/Host/Configuration/Endpoints/ClientEndpointOptions.cs, backend/src/Host/Configuration/Endpoints/ClientApplicationOptions.cs, backend/src/Host/Configuration/Endpoints/TransportHttpsEndpointOptions.cs, backend/src/Host/Api/ClientApiEndpoints.cs, backend/src/Host/Api/ClientSessionTokenEndpoints.cs, backend/src/Host/Security/Sessions/**, backend/src/Host/Api/ClientMailAccountsEndpoint.cs, backend/src/Host/Api/ClientMailFoldersEndpoint.cs, backend/src/Host/Api/ClientMailTimelineEndpoint.cs, backend/src/Host/Api/ClientMailThreadEndpoint.cs, backend/src/Host/Api/ClientMailThreadStateEndpoint.cs, backend/src/Host/Api/ClientMailMessageEndpoint.cs, backend/src/Host/Api/ClientMailBodyEndpoint.cs, backend/src/Host/Api/ClientMailAttachmentEndpoint.cs, backend/src/Host/Api/ClientMailSearchPhraseEndpoint.cs, backend/src/Host/Api/AttachmentContentResponse.cs, backend/src/Host/Api/ProtectedResourceMetadataEndpoint.cs, backend/src/Host/Security/Endpoints/ClientTransportSecurityExtensions.cs, backend/src/Infrastructure/Security/Transport/BrowserOriginPolicy.cs, backend/src/Host/Hosting/ClientApplicationFiles.cs, backend/src/Host/Hosting/Startup/ClientResponseCompression.cs, backend/src/Host/Hosting/Warnings/ClientTransportSecurityWarning.cs, backend/src/Host/Hosting/Warnings/PasswordClearTextTransportWarning.cs, backend/src/Host/Api/ClientUserRecordEndpoint.cs, backend/src/Host/Api/ClientPortraitEndpoint.cs, backend/src/Host/Api/ClientDisplayNameEndpoint.cs, backend/src/Host/Api/ClientPreferencesEndpoint.cs, backend/src/Host/Configuration/UserSettings/Administration/OwnDisplayName.cs, backend/src/Host/Api/ClientMailMutationsEndpoint.cs, backend/src/Host/Api/ClientDraftEndpoints.cs, backend/src/Host/Api/ClientDraftResponses.cs, backend/src/Host/Api/ClientOutboxEndpoints.cs, backend/src/Host/Api/ClientNotificationEndpoints.cs, backend/src/Host/Api/ClientTelemetryEndpoint.cs, backend/src/Host/Api/ClientCitationEndpoint.cs, backend/src/Host/Api/ClientDiscoveryRunEndpoints.cs, backend/src/Host/Observability/ClientTelemetry/** -->
 
 Where the MailFathom client reaches the service, what a deployment has to enable before it answers, and what a person's
 mail client presents to get in.
@@ -541,11 +541,24 @@ leading end and answering with the leading page would read as having scrolled to
 | `hasAttachments` | `true`, `false` | both |
 | `receivedOnOrAfter` | A timestamp, inclusive | no start |
 | `receivedBefore` | A timestamp, exclusive | no end |
+| `carriesMark` | `Sense`, `Significance`, `Commitment` | any reading, and mail with none |
+| `markDueOnOrAfter` | A timestamp, inclusive | no start |
+| `markDueBefore` | A timestamp, exclusive | no end |
 | `sort` | `receivedAt` | `receivedAt` |
 | `order` | `newestFirst`, `oldestFirst` | `newestFirst` |
 | `direction` | `forward`, `backward` | `forward` |
 | `pageSize` | 1 to 100 | 25 |
 | `cursor` | A cursor a previous page returned | the leading end of the list |
+
+**The three `mark` parameters narrow by what an enrichment already derived, and derive nothing.** `carriesMark` keeps
+the mail one of this deployment's own readings was recorded on, spelled exactly as `enrichment.marks[].aspect` publishes
+it on a row of this same route, so a client hands back the value it read rather than translating between two spellings
+of one closed set. `markDueOnOrAfter` and `markDueBefore` bound the instant a mark falls due at, which only a
+`Commitment` carries, and every criterion is met by one mark rather than by the message as a whole — a message whose
+`Sense` mark is old and whose `Commitment` is due tomorrow answers `carriesMark=Commitment&markDueBefore=…` and not
+`carriesMark=Sense&markDueBefore=…`. A deployment that has read nothing answers each of them with an empty page: that
+is a list narrowed to no mail rather than a failure, and nothing here asks for a reading to be produced. A range whose
+end falls on or before its start is refused with `400` like every other, rather than answered empty.
 
 **A value this deployment cannot honour is refused with `400`, never ignored.** `sort=subject` is the case worth
 naming: the list is ordered by the column the timeline indexes are ordered by, and a screen that asked for something
@@ -1663,21 +1676,23 @@ and somebody who set the client up the way they work should not have to set it u
   "openMailInTabs": false,
   "markReadOnOpen": true,
   "expandWholeThread": false,
-  "embeddedHtmlMessages": false
+  "embeddedHtmlMessages": false,
+  "aiFiltersShown": true
 }
 ```
 
-**It holds six preferences and nothing else.** Whether this deployment may be told what the person's client is doing;
+**It holds seven preferences and nothing else.** Whether this deployment may be told what the person's client is doing;
 what the client is painted in, which is `system`, `light`, or `dark`; whether opening a message opens a tab rather
 than replacing what is on the screen; whether opening a message marks it read on the person's own mail server; whether
-opening a conversation draws every message in it rather than the one it was opened at; and whether an open message
-draws the sender's own markup rather than the reduced text. Each of them says how
+opening a conversation draws every message in it rather than the one it was opened at; whether an open message
+draws the sender's own markup rather than the reduced text; and whether the client offers the standing views of the
+mailbox beneath its folder tree. Each of them says how
 somebody wants to work, which is why it belongs to the person. The language does not, and stays on the device: it is
 resolved for somebody who has not signed in and may never get a session. Neither does the width a person drags the
 message list to, which describes the screen in front of them.
 
 **Unset reads as telemetry on, the theme following the machine, tabs off, marking read on, a conversation opening at
-the message it was opened at, and a message read as the reduced text.** A person who has set nothing is answered a
+the message it was opened at, a message read as the reduced text, and the standing views drawn.** A person who has set nothing is answered a
 document rather than a refusal, so a first run draws a screen. The theme is still resolved on the device
 before sign-in — the client cannot wait on the network to paint itself, and there is no session to read this over above
 the sign-in screen — and what this answers replaces that device value once a session exists.
@@ -1706,6 +1721,14 @@ asks for rather than only what is drawn: a client in the reduced view never asks
 representation, so turning this on is what puts `fullHtml=true` on
 [the body route](#the-message-body-route). A message whose markup this deployment holds none of, or served cut short, falls
 back to the reduced tree with the reason named rather than to an empty frame.
+
+**`aiFiltersShown` decides whether the client draws the standing views beneath the folder tree.** With it unset or on,
+the tree carries a section offering three of them — the mail a significance was recorded on, the mail a commitment was,
+and the commitments falling due this week. Each is a shortcut to the `carriesMark`, `markDueOnOrAfter` and
+`markDueBefore` parameters above and to nothing else, so what a view puts in force stands in the list's own filter
+control where any other narrowing does, and can be taken off or changed there one criterion at a time. With it off the
+section is gone rather than empty, and nothing else changes: the criteria are still reachable from that control, and no
+list this deployment answers is narrowed differently.
 
 **A write states the whole document.** It is a closed set rather than a patch: a key nothing binds is refused rather
 than stored, a theme this deployment does not publish is refused naming the three that are, and a preference the body

--- a/frontend/src/Client.App/src/App.harness.tsx
+++ b/frontend/src/Client.App/src/App.harness.tsx
@@ -206,7 +206,7 @@ export function deploymentAnswering(
 }
 
 /** The whole preferences document, because the route answers all of it whether or not anything was ever set. */
-export function preferencesAnswering(telemetryEnabled: boolean): Answer {
+export function preferencesAnswering(telemetryEnabled: boolean, aiFiltersShown = true): Answer {
     return {
         status: 200,
         body: JSON.stringify({
@@ -215,6 +215,7 @@ export function preferencesAnswering(telemetryEnabled: boolean): Answer {
             openMailInTabs: false,
             markReadOnOpen: true,
             expandWholeThread: false,
+            aiFiltersShown,
             embeddedHtmlMessages: false,
         }),
     };
@@ -381,6 +382,7 @@ export function deploymentWorkingInTabs(): DeploymentTransport {
                     openMailInTabs: true,
                     markReadOnOpen: true,
                     expandWholeThread: false,
+                    aiFiltersShown: true,
                     embeddedHtmlMessages: false,
                 }),
             }),

--- a/frontend/src/Client.App/src/App.test.tsx
+++ b/frontend/src/Client.App/src/App.test.tsx
@@ -21,6 +21,7 @@ import {
     goTo,
     heldSession,
     openingAt,
+    preferencesAnswering,
     renderApp,
     resetsBetweenTests,
     routesAsked,
@@ -113,6 +114,28 @@ describe('App', () => {
 
         expect(await screen.findByRole('tab', { name: 'Quarterly invoice' })).toBeDefined();
         expect(await screen.findByText('A drawn message.')).toBeDefined();
+    });
+
+    // The section is the reader's to remove, and what removes it is a preference the deployment holds — so this is the
+    // one assertion that the answer reaches the tree rather than stopping at the hook that read it.
+    it('draws the standing views under the tree for a person who has not taken them out of it', async () => {
+        renderApp(servedFrom, heldSession, deploymentAnswering(undefined, accepted, preferencesAnswering(true)));
+        await framed();
+
+        await goTo('Mail');
+
+        expect(await screen.findByRole('region', { name: 'AI filters' })).toBeDefined();
+    });
+
+    it('draws no standing views at all for a person who took the section out of the tree', async () => {
+        renderApp(servedFrom, heldSession, deploymentAnswering(undefined, accepted, preferencesAnswering(true, false)));
+        await framed();
+
+        await goTo('Mail');
+
+        await screen.findByText('Folders');
+
+        expect(screen.queryByRole('region', { name: 'AI filters' })).toBeNull();
     });
 
     it('says nothing is open to a person working in tabs who has opened none', async () => {

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -50,6 +50,7 @@ import { NotificationCentre } from './notifications/NotificationCentre';
 import { usePanelSwipe } from './notifications/usePanelSwipe';
 import { useNotificationCentre } from './notifications/useNotificationCentre';
 import { PendingChangesProvider } from './pendingChanges/PendingChanges';
+import { AiFiltersShownContext } from './preferences/aiFilters';
 import { EmbeddedHtmlMessagesContext } from './preferences/messageView';
 import { useClientPreferences } from './preferences/useClientPreferences';
 import { useOwnProfile } from './profile/useOwnProfile';
@@ -644,113 +645,110 @@ export function App({
                 how every message anywhere below is drawn, and the two components that read it — the body and the
                 control on the message head — sit several levels under the reading pane and under the conversation
                 alike. */}
-                        <EmbeddedHtmlMessagesContext value={preferences.embeddedHtmlMessages}>
-                            {/* Above the frame for the reason the marking is, and above the acts because the acts read it: what the
+                        <AiFiltersShownContext value={preferences.aiFiltersShown}>
+                            {/* Above the frame for the same reason again: whether the tree carries the standing views is
+                                read by a section three components under the mail space, behind a space and a column
+                                that have nothing to do with the setting. */}
+                            <EmbeddedHtmlMessagesContext value={preferences.embeddedHtmlMessages}>
+                                {/* Above the frame for the reason the marking is, and above the acts because the acts read it: what the
             list has drawn is where a message belongs, and every act on one has to name that. It holds nothing that is
             drawn, so nothing below re-renders because of it. */}
-                            <ListedMailProvider>
-                                {/* Above the frame as well, because four surfaces reach the same five acts — the toolbar over what is
+                                <ListedMailProvider>
+                                    {/* Above the frame as well, because four surfaces reach the same five acts — the toolbar over what is
             open, the bar over a selection, the row that draws one as pending, and the message somebody swiped — and a
             second implementation of *archive* is how two of them come to file mail differently. */}
-                                <MailboxActsProvider
-                                    session={readsMail ? session : null}
-                                    transport={readMail}
-                                    online={connection.online}
-                                    flags={writesFlags}
-                                    moves={filesMail}
-                                >
-                                    {/* Above the frame rather than inside the mail space, because what is being written outlives moving
+                                    <MailboxActsProvider
+                                        session={readsMail ? session : null}
+                                        transport={readMail}
+                                        online={connection.online}
+                                        flags={writesFlags}
+                                        moves={filesMail}
+                                    >
+                                        {/* Above the frame rather than inside the mail space, because what is being written outlives moving
             between the spaces, and because the three controls that ask for it are each several components below here.
             Writing is offered where the credential may file a draft; one that may not is told so by the strip above
             rather than by a screen that refuses every act. */}
-                                    <ComposingContext value={composing}>
-                                        {/* Above the frame as well, and for a stronger reason than the composer's: what it draws covers
+                                        <ComposingContext value={composing}>
+                                            {/* Above the frame as well, and for a stronger reason than the composer's: what it draws covers
                 everything below it, and the operations that ask for it — a mailbox migration, a bulk change, an
                 export — each begin somewhere different and none of them is the parent of what has to be covered. The
                 surface itself is the platform's own modal dialog, so where it sits in the document decides nothing
                 about where it is drawn; it stands first here because it stands in front of everything. */}
-                                        <BlockingContext value={blocking}>
-                                            <BlockingOverlay operation={blockedOn} />
+                                            <BlockingContext value={blocking}>
+                                                <BlockingOverlay operation={blockedOn} />
 
-                                            {/* Beside them for the composer's own reason, one component further down: the row that opens a
+                                                {/* Beside them for the composer's own reason, one component further down: the row that opens a
                     file a message carries sits three components below the frame that owns what is open, and none of
                     the three between them has a reason to name a file it never opens. */}
-                                            <OpenAttachmentContext value={openTabs.openAttachment}>
-                                                <div className="flex h-dvh flex-col bg-rail pt-safe-top pr-safe-right pb-safe-bottom pl-safe-left workspace:flex-row">
-                                                    <div
-                                                        ref={workspaceRegion}
-                                                        tabIndex={-1}
-                                                        className="flex min-h-0 min-w-0 flex-1 flex-col bg-page"
-                                                    >
-                                                        {/* Inside the frame as well as on the sign-in screen, because a credential that could not be kept is
+                                                <OpenAttachmentContext value={openTabs.openAttachment}>
+                                                    <div className="flex h-dvh flex-col bg-rail pt-safe-top pr-safe-right pb-safe-bottom pl-safe-left workspace:flex-row">
+                                                        <div
+                                                            ref={workspaceRegion}
+                                                            tabIndex={-1}
+                                                            className="flex min-h-0 min-w-0 flex-1 flex-col bg-page"
+                                                        >
+                                                            {/* Inside the frame as well as on the sign-in screen, because a credential that could not be kept is
                     learned about at the moment somebody successfully signed in — which is the one of these sentences
                     whose reader is already past that screen. Beside it, and in the same strip, is what this credential
                     may not do: both are statements about the credential rather than about anything it read. */}
-                                                        {notices.length === 0 && withheld.length === 0 ? null : (
-                                                            <div className="flex flex-col gap-2 border-b border-line-soft bg-panel px-4 py-2 workspace:px-8">
-                                                                <CredentialNotices notices={notices} />
-                                                                <GrantNotice withheld={withheld} />
-                                                            </div>
-                                                        )}
+                                                            {notices.length === 0 && withheld.length === 0 ? null : (
+                                                                <div className="flex flex-col gap-2 border-b border-line-soft bg-panel px-4 py-2 workspace:px-8">
+                                                                    <CredentialNotices notices={notices} />
+                                                                    <GrantNotice withheld={withheld} />
+                                                                </div>
+                                                            )}
 
-                                                        {/* The region the space is drawn in is there before the deployment says which space that is, so
+                                                            {/* The region the space is drawn in is there before the deployment says which space that is, so
                     nothing on the screen moves under a reader when the answer arrives. Until it does, what stands in
                     the region is what the connection says — reaching, retrying, offline, or refused — because that is
                     the only thing on the screen there is to read, and the way out of a deployment that never answers
                     has to be somewhere. */}
-                                                        {space === null ? (
-                                                            <main className="flex-1 px-4 py-6 workspace:px-8">
-                                                                <ConnectionSummary connection={connection} />
-                                                            </main>
-                                                        ) : (
-                                                            <Space
-                                                                space={space}
-                                                                // Who is signed in, which is what was kept beside the session rather than anything read out of a credential.
-                                                                // A screen never sees the credential; what it is handed is the name the deployment knows the
-                                                                // person by, which is what a preference kept per person on this machine is written under.
-                                                                person={person}
-                                                                // Asking is what the field is for, so a credential that may not ask is not shown one. It is
-                                                                // absent rather than disabled: a control nobody can use says less about why than the sentence
-                                                                // above does. Where it stands is the space's decision, which is why it is handed in rather
-                                                                // than drawn here.
-                                                                intent={
-                                                                    // Not while a message is being written: what stands at the foot of that column then is
-                                                                    // the composer's own footer, and two rows of controls under one column is two answers
-                                                                    // to what the primary act is.
-                                                                    written === null &&
-                                                                    deploymentSession !== null &&
-                                                                    offers(deploymentSession, 'askMail') ? (
-                                                                        <IntentField accounts={mailAccounts} />
-                                                                    ) : null
-                                                                }
-                                                                status={<ConnectionSummary connection={connection} />}
-                                                                folders={
-                                                                    session === null || !readsMail ? null : (
-                                                                        <FolderTree
-                                                                            session={session}
-                                                                            transport={readMail}
-                                                                            online={connection.online}
-                                                                        />
-                                                                    )
-                                                                }
-                                                                list={
-                                                                    session === null || !readsMail ? null : (
-                                                                        // Both keyed by the scope, so pointing at another mailbox starts a list and a search
-                                                                        // rather than resetting either: every value below belongs to one mailbox read one way,
-                                                                        // and a search carries the mailbox it was made in as a filter it would go on showing.
-                                                                        // Searching stands above the list rather than beside it because it is where somebody
-                                                                        // reaches for it — looking at a folder, with the message not in front of them — and
-                                                                        // what it finds is drawn in the same column with the same row.
-                                                                        <MailSearch
-                                                                            key={scopeKey(workspace.scope)}
-                                                                            session={session}
-                                                                            transport={readMail}
-                                                                            scope={workspace.scope}
-                                                                            accounts={mailAccounts}
-                                                                            online={connection.online}
-                                                                            onOpen={openTabs.openMail}
-                                                                        >
-                                                                            <MessageList
+                                                            {space === null ? (
+                                                                <main className="flex-1 px-4 py-6 workspace:px-8">
+                                                                    <ConnectionSummary connection={connection} />
+                                                                </main>
+                                                            ) : (
+                                                                <Space
+                                                                    space={space}
+                                                                    // Who is signed in, which is what was kept beside the session rather than anything read out of a credential.
+                                                                    // A screen never sees the credential; what it is handed is the name the deployment knows the
+                                                                    // person by, which is what a preference kept per person on this machine is written under.
+                                                                    person={person}
+                                                                    // Asking is what the field is for, so a credential that may not ask is not shown one. It is
+                                                                    // absent rather than disabled: a control nobody can use says less about why than the sentence
+                                                                    // above does. Where it stands is the space's decision, which is why it is handed in rather
+                                                                    // than drawn here.
+                                                                    intent={
+                                                                        // Not while a message is being written: what stands at the foot of that column then is
+                                                                        // the composer's own footer, and two rows of controls under one column is two answers
+                                                                        // to what the primary act is.
+                                                                        written === null &&
+                                                                        deploymentSession !== null &&
+                                                                        offers(deploymentSession, 'askMail') ? (
+                                                                            <IntentField accounts={mailAccounts} />
+                                                                        ) : null
+                                                                    }
+                                                                    status={
+                                                                        <ConnectionSummary connection={connection} />
+                                                                    }
+                                                                    folders={
+                                                                        session === null || !readsMail ? null : (
+                                                                            <FolderTree
+                                                                                session={session}
+                                                                                transport={readMail}
+                                                                                online={connection.online}
+                                                                            />
+                                                                        )
+                                                                    }
+                                                                    list={
+                                                                        session === null || !readsMail ? null : (
+                                                                            // Both keyed by the scope, so pointing at another mailbox starts a list and a search
+                                                                            // rather than resetting either: every value below belongs to one mailbox read one way,
+                                                                            // and a search carries the mailbox it was made in as a filter it would go on showing.
+                                                                            // Searching stands above the list rather than beside it because it is where somebody
+                                                                            // reaches for it — looking at a folder, with the message not in front of them — and
+                                                                            // what it finds is drawn in the same column with the same row.
+                                                                            <MailSearch
                                                                                 key={scopeKey(workspace.scope)}
                                                                                 session={session}
                                                                                 transport={readMail}
@@ -758,105 +756,119 @@ export function App({
                                                                                 accounts={mailAccounts}
                                                                                 online={connection.online}
                                                                                 onOpen={openTabs.openMail}
-                                                                            />
-                                                                        </MailSearch>
-                                                                    )
-                                                                }
-                                                                tabs={
-                                                                    /* A map of what is open, so it is drawn only where there is something to map: an empty
+                                                                            >
+                                                                                <MessageList
+                                                                                    key={scopeKey(workspace.scope)}
+                                                                                    session={session}
+                                                                                    transport={readMail}
+                                                                                    scope={workspace.scope}
+                                                                                    accounts={mailAccounts}
+                                                                                    online={connection.online}
+                                                                                    onOpen={openTabs.openMail}
+                                                                                />
+                                                                            </MailSearch>
+                                                                        )
+                                                                    }
+                                                                    tabs={
+                                                                        /* A map of what is open, so it is drawn only where there is something to map: an empty
                                    strip over an empty pane would say the same thing twice. */
-                                                                    inTabs && openTabs.tabs.length > 0 ? (
-                                                                        <TabStrip
-                                                                            tabs={openTabs.tabs}
-                                                                            active={openTabs.active}
-                                                                            onActivate={openTabs.activate}
-                                                                            onClose={openTabs.close}
-                                                                            onCloseEverything={openTabs.closeEverything}
-                                                                        />
-                                                                    ) : null
-                                                                }
-                                                                mail={
-                                                                    // A message being written stands where one being read stands, which is the design
-                                                                    // project's composition rather than a window over it — and what is open is still open
-                                                                    // underneath, so closing the composer is a return rather than a second thing to find.
-                                                                    // Keyed by what is being written, so asking for an answer while a message of its own is
-                                                                    // open starts that answer rather than pouring it into the fields already on the screen.
-                                                                    written === null || session === null ? (
-                                                                        whatIsOpen()
-                                                                    ) : (
-                                                                        <Composer
-                                                                            key={openingKey(written)}
-                                                                            session={session}
-                                                                            transport={readMail}
-                                                                            accounts={mailAccounts}
-                                                                            opening={written}
-                                                                            online={connection.online}
-                                                                            onClosed={composing.close}
-                                                                        />
-                                                                    )
-                                                                }
-                                                            />
-                                                        )}
-                                                    </div>
+                                                                        inTabs && openTabs.tabs.length > 0 ? (
+                                                                            <TabStrip
+                                                                                tabs={openTabs.tabs}
+                                                                                active={openTabs.active}
+                                                                                onActivate={openTabs.activate}
+                                                                                onClose={openTabs.close}
+                                                                                onCloseEverything={
+                                                                                    openTabs.closeEverything
+                                                                                }
+                                                                            />
+                                                                        ) : null
+                                                                    }
+                                                                    mail={
+                                                                        // A message being written stands where one being read stands, which is the design
+                                                                        // project's composition rather than a window over it — and what is open is still open
+                                                                        // underneath, so closing the composer is a return rather than a second thing to find.
+                                                                        // Keyed by what is being written, so asking for an answer while a message of its own is
+                                                                        // open starts that answer rather than pouring it into the fields already on the screen.
+                                                                        written === null || session === null ? (
+                                                                            whatIsOpen()
+                                                                        ) : (
+                                                                            <Composer
+                                                                                key={openingKey(written)}
+                                                                                session={session}
+                                                                                transport={readMail}
+                                                                                accounts={mailAccounts}
+                                                                                opening={written}
+                                                                                online={connection.online}
+                                                                                onClosed={composing.close}
+                                                                            />
+                                                                        )
+                                                                    }
+                                                                />
+                                                            )}
+                                                        </div>
 
-                                                    {/* Navigation is last in the document because the keyboard follows the document rather than the layout,
+                                                        {/* Navigation is last in the document because the keyboard follows the document rather than the layout,
                 and the narrow composition puts it at the bottom of the screen: written the other way round, a reader
                 tabbing into a narrow window would reach the bottom bar before the header above it. The wide
                 composition then carries the one mismatch CSS cannot remove — a rail drawn on the left out of a node
                 that comes last — because no single document order matches both shapes, and content before navigation
                 is the direction a skip link exists to manufacture rather than the one it works around. */}
-                                                    <SpaceNavigation
-                                                        offered={offeredSpaces}
-                                                        current={space}
-                                                        onPointerDown={swipe.onNavigationPointerDown}
-                                                        onClickCapture={swipe.onNavigationClickCapture}
-                                                        notifications={
-                                                            // Offered on the grant the routes are admitted under, and absent
-                                                            // rather than inert without it: a bell that could never answer is
-                                                            // a control saying less about why than not drawing it does.
-                                                            readsMail ? (
-                                                                <NotificationBell
-                                                                    unreadCount={notifications.unreadCount}
-                                                                    shown={notifications.shown}
-                                                                    onPress={
-                                                                        notifications.shown
-                                                                            ? notifications.hide
-                                                                            : notifications.show
+                                                        <SpaceNavigation
+                                                            offered={offeredSpaces}
+                                                            current={space}
+                                                            onPointerDown={swipe.onNavigationPointerDown}
+                                                            onClickCapture={swipe.onNavigationClickCapture}
+                                                            notifications={
+                                                                // Offered on the grant the routes are admitted under, and absent
+                                                                // rather than inert without it: a bell that could never answer is
+                                                                // a control saying less about why than not drawing it does.
+                                                                readsMail ? (
+                                                                    <NotificationBell
+                                                                        unreadCount={notifications.unreadCount}
+                                                                        shown={notifications.shown}
+                                                                        onPress={
+                                                                            notifications.shown
+                                                                                ? notifications.hide
+                                                                                : notifications.show
+                                                                        }
+                                                                    />
+                                                                ) : null
+                                                            }
+                                                            account={
+                                                                <AccountMenu
+                                                                    accounts={mailAccounts}
+                                                                    deploymentVersion={
+                                                                        deploymentSession?.version ?? null
                                                                     }
+                                                                    telemetryForwarding={telemetryForwardedBy(
+                                                                        deploymentSession,
+                                                                        baseAddress,
+                                                                    )}
+                                                                    preferences={preferences}
+                                                                    profile={profile}
+                                                                    onSignOut={signOut}
                                                                 />
-                                                            ) : null
-                                                        }
-                                                        account={
-                                                            <AccountMenu
-                                                                accounts={mailAccounts}
-                                                                deploymentVersion={deploymentSession?.version ?? null}
-                                                                telemetryForwarding={telemetryForwardedBy(
-                                                                    deploymentSession,
-                                                                    baseAddress,
-                                                                )}
-                                                                preferences={preferences}
-                                                                profile={profile}
-                                                                onSignOut={signOut}
-                                                            />
-                                                        }
-                                                    />
+                                                            }
+                                                        />
 
-                                                    {/* Outside the frame's own columns because it stands over all of them,
+                                                        {/* Outside the frame's own columns because it stands over all of them,
                                                 and inside the frame because it goes with the credential: it is the
                                                 platform's own modal dialog, so where it sits in the document decides
                                                 nothing about where it is drawn. It is mounted whether or not it is
                                                 open, which is what lets it travel on and off the screen rather than
                                                 appearing and disappearing. */}
-                                                    {readsMail ? (
-                                                        <NotificationCentre centre={notifications} swipe={swipe} />
-                                                    ) : null}
-                                                </div>
-                                            </OpenAttachmentContext>
-                                        </BlockingContext>
-                                    </ComposingContext>
-                                </MailboxActsProvider>
-                            </ListedMailProvider>
-                        </EmbeddedHtmlMessagesContext>
+                                                        {readsMail ? (
+                                                            <NotificationCentre centre={notifications} swipe={swipe} />
+                                                        ) : null}
+                                                    </div>
+                                                </OpenAttachmentContext>
+                                            </BlockingContext>
+                                        </ComposingContext>
+                                    </MailboxActsProvider>
+                                </ListedMailProvider>
+                            </EmbeddedHtmlMessagesContext>
+                        </AiFiltersShownContext>
                     </ReadMarkingProvider>
                 </PendingChangesProvider>
             </SignalledChangesContext>

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -197,6 +197,10 @@ export const en = {
         'When the window is not in front of you, this machine says how much arrived and of what kind — never who wrote or what about.',
     'settings.systemNotificationsRefused':
         'This browser has been told to block notifications from here. Allow them in its own site settings, and this switch will work again.',
+    'settings.mailbox': 'Mailbox',
+    'settings.aiFilters': 'Show the AI filters in the folder tree',
+    'settings.aiFiltersExplanation':
+        'Three standing views of the mailbox, over what MailFathom already read. Turning them off takes the section out of the tree and changes nothing about the mail.',
     'settings.privacy': 'Privacy',
     'settings.telemetryWithheld': 'Do not send telemetry',
     'settings.telemetryExplanation': 'Error diagnostics and usage statistics stay on this device.',
@@ -240,6 +244,7 @@ export const en = {
     'aiFilters.needsDecision': 'Needs a decision',
     'aiFilters.commitments': 'Commitments',
     'aiFilters.deadlinesThisWeek': 'Deadlines this week',
+    'aiFilters.entryTitle': 'AI filter: {view}',
 
     'mail.toolbar': 'Mail actions',
     'mail.compose': 'New message',
@@ -465,6 +470,8 @@ export const en = {
     'list.partiallyFailed': 'Part of this folder could not be read: {reason}.',
     'list.emptyFolder': 'There is no mail in this folder.',
     'list.nothingMatches': 'No message in this folder matches what the list is narrowed to.',
+    'list.nothingRead':
+        'No message in this folder carries the reading the list is narrowed to. Either none of them does, or MailFathom has not read this folder yet.',
     'list.notSynchronizedYet':
         'Nothing has been taken into this deployment from this mailbox yet, so there is nothing to show. The folder is not empty — it has not been read.',
     'list.emptyWhileFailing':
@@ -504,6 +511,11 @@ export const en = {
     'list.showReadings': 'Show a reading on each row',
     'list.readingsExplained':
         'One sentence per message, under the subject. It is kept for this folder, and turning it off changes nothing about the mail itself.',
+
+    'list.readingNarrowing': 'What MailFathom read',
+    'list.dueThisWeek': 'Due this week',
+    'list.readingNarrowingExplained':
+        'Keeps the mail MailFathom already read this way. It reads nothing now, so a folder it has not reached shows none of its mail here.',
 
     'reading.sense': 'What this is about',
     'reading.significance': 'Why this may matter',

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -199,6 +199,10 @@ export const pl: Catalogue = {
         'Gdy okno nie jest przed Tobą, to urządzenie mówi, ile rzeczy przyszło i jakiego rodzaju — nigdy od kogo ani w jakiej sprawie.',
     'settings.systemNotificationsRefused':
         'Ta przeglądarka ma zablokowane powiadomienia z tej strony. Zezwól na nie w jej własnych ustawieniach witryny, a przełącznik znów zadziała.',
+    'settings.mailbox': 'Skrzynka',
+    'settings.aiFilters': 'Pokazuj filtry AI w drzewie katalogów',
+    'settings.aiFiltersExplanation':
+        'Trzy stałe widoki skrzynki, oparte na tym, co MailFathom już wyczytał. Wyłączenie usuwa sekcję z drzewa i niczego nie zmienia w samej poczcie.',
     'settings.privacy': 'Prywatność',
     'settings.telemetryWithheld': 'Nie wysyłaj danych telemetrycznych',
     'settings.telemetryExplanation': 'Diagnostyka błędów i statystyki użycia zostają na tym urządzeniu.',
@@ -242,6 +246,7 @@ export const pl: Catalogue = {
     'aiFilters.needsDecision': 'Wymaga decyzji',
     'aiFilters.commitments': 'Zobowiązania',
     'aiFilters.deadlinesThisWeek': 'Terminy w tym tygodniu',
+    'aiFilters.entryTitle': 'Filtr AI: {view}',
 
     'mail.toolbar': 'Działania na poczcie',
     'mail.compose': 'Nowa wiadomość',
@@ -470,6 +475,8 @@ export const pl: Catalogue = {
     'list.partiallyFailed': 'Części tego folderu nie udało się odczytać: {reason}.',
     'list.emptyFolder': 'W tym folderze nie ma poczty.',
     'list.nothingMatches': 'Żadna wiadomość w tym folderze nie pasuje do zawężenia listy.',
+    'list.nothingRead':
+        'Żadna wiadomość w tym folderze nie ma odczytu, po którym zawężasz listę. Albo naprawdę żadna go nie ma, albo MailFathom jeszcze nie przeczytał tego folderu.',
     'list.notSynchronizedYet':
         'Do tego wdrożenia nie pobrano jeszcze niczego z tej skrzynki, więc nie ma czego pokazać. Folder nie jest pusty — nie został odczytany.',
     'list.emptyWhileFailing':
@@ -509,6 +516,11 @@ export const pl: Catalogue = {
     'list.showReadings': 'Pokazuj odczyt przy każdym wierszu',
     'list.readingsExplained':
         'Jedno zdanie o wiadomości, pod tematem. Ustawienie dotyczy tego folderu, a wyłączenie go niczego nie zmienia w samej poczcie.',
+
+    'list.readingNarrowing': 'Co wyczytał MailFathom',
+    'list.dueThisWeek': 'Termin w tym tygodniu',
+    'list.readingNarrowingExplained':
+        'Zostawia pocztę, którą MailFathom już tak odczytał. Teraz niczego nie czyta, więc folder, do którego jeszcze nie dotarł, nie pokaże tu żadnej wiadomości.',
 
     'reading.sense': 'O co tu chodzi',
     'reading.significance': 'Dlaczego to może być ważne',

--- a/frontend/src/Client.App/src/mailSpace/AiFilters.test.tsx
+++ b/frontend/src/Client.App/src/mailSpace/AiFilters.test.tsx
@@ -1,0 +1,68 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { LocalizationProvider } from '../localization/Localization';
+import type { StandingView } from '../messageList/listing';
+import { ListedMailContext, nothingListed } from '../messageList/useListedMail';
+import { AiFiltersShownContext } from '../preferences/aiFilters';
+import { AiFilters } from './AiFilters';
+
+function drawing(shown = true, stand: (view: StandingView) => void = () => undefined, folded = false): void {
+    render(
+        <LocalizationProvider>
+            <AiFiltersShownContext value={shown}>
+                <ListedMailContext value={{ ...nothingListed, stand }}>
+                    <AiFilters folded={folded} />
+                </ListedMailContext>
+            </AiFiltersShownContext>
+        </LocalizationProvider>,
+    );
+}
+
+describe('AiFilters', () => {
+    it('draws the section the design names, under the tree', () => {
+        drawing();
+
+        expect(screen.getByRole('region', { name: 'AI filters' })).toBeTruthy();
+    });
+
+    it.each([
+        ['Needs a decision', 'needsDecision'],
+        ['Commitments', 'commitments'],
+        ['Deadlines this week', 'deadlinesThisWeek'],
+    ] as const)('puts %s in force on the list in front of the reader', (named, view) => {
+        const stand = vi.fn<(view: StandingView) => void>();
+
+        drawing(true, stand);
+        fireEvent.click(screen.getByRole('button', { name: named }));
+
+        expect(stand).toHaveBeenCalledWith(view);
+    });
+
+    // Turned off is the section gone rather than a heading with nothing under it: a heading over three missing entries
+    // would say the views had failed, which is a different thing from a reader having asked not to be offered them.
+    it('draws nothing at all where the reader has turned the section off', () => {
+        drawing(false);
+
+        expect(screen.queryByRole('region', { name: 'AI filters' })).toBeNull();
+        expect(screen.queryByRole('button')).toBeNull();
+    });
+
+    it('says what pressing an entry will do, the design drawing no lit state to say it afterwards', () => {
+        drawing();
+
+        expect(screen.getByRole('button', { name: 'Commitments' }).getAttribute('title')).toBe(
+            'AI filter: Commitments',
+        );
+    });
+
+    it('keeps every entry named in the folded rail, where the names are not drawn', () => {
+        drawing(true, () => undefined, true);
+
+        expect(screen.getByRole('button', { name: 'Deadlines this week' })).toBeTruthy();
+        expect(screen.queryByText('AI filters')).toBeNull();
+    });
+});

--- a/frontend/src/Client.App/src/mailSpace/AiFilters.tsx
+++ b/frontend/src/Client.App/src/mailSpace/AiFilters.tsx
@@ -2,23 +2,43 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+import { Icon } from '../controls/Icon';
 import type { IconName } from '../controls/icons';
-import { PlannedControl } from '../controls/PlannedControl';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
+import { standingViews, type StandingView } from '../messageList/listing';
+import { useListedMail } from '../messageList/useListedMail';
+import { useAiFiltersShown } from '../preferences/aiFilters';
 
-// The section the design project draws under the mailbox tree: three views of the mailbox that MailFathom's own
-// reading of the mail would produce. That reading is stage 3's, so what stands here is the room for it, drawn as the
-// placeholders every unbuilt control in this client is drawn as.
+// The section the design project draws under the mailbox tree: three standing views of the mailbox, over what
+// MailFathom's own reading of the mail already produced.
+//
+// Each entry is a shortcut to filter criteria and nothing else. Pressing one narrows the list in front of the reader
+// by what a derivation recorded, exactly as the filter panel does, and the criteria then stand in that panel where
+// every other narrowing stands — removable one at a time and changeable there. There is no second way of asking the
+// deployment for mail behind these, and nothing here derives anything: what a view can find is what MailFathom already
+// read, so a deployment that has read nothing answers each of them with a folder narrowed to no mail.
+//
+// The design draws no reaction and no lit state on these entries — only the folder rows above them carry one — so
+// nothing here draws a view as being in force. What says so is the filter panel's own count and the criteria in it,
+// which is where the design does draw what a list is narrowed by.
 
-const filters: readonly { readonly icon: IconName; readonly label: MessageKey }[] = [
-    { icon: 'pending_actions', label: 'aiFilters.needsDecision' },
-    { icon: 'handshake', label: 'aiFilters.commitments' },
-    { icon: 'schedule', label: 'aiFilters.deadlinesThisWeek' },
-];
+const views: Readonly<Record<StandingView, { readonly icon: IconName; readonly label: MessageKey }>> = {
+    needsDecision: { icon: 'pending_actions', label: 'aiFilters.needsDecision' },
+    commitments: { icon: 'handshake', label: 'aiFilters.commitments' },
+    deadlinesThisWeek: { icon: 'schedule', label: 'aiFilters.deadlinesThisWeek' },
+};
 
 export function AiFilters({ folded }: { readonly folded: boolean }) {
     const { translate } = useLocalization();
+    const listed = useListedMail();
+    const shown = useAiFiltersShown();
+
+    // Turned off is the section gone rather than a heading with nothing under it: what it says when it is off is
+    // nothing at all, and a heading over three missing entries would say the views had failed.
+    if (!shown) {
+        return null;
+    }
 
     return (
         <section
@@ -31,14 +51,26 @@ export function AiFilters({ folded }: { readonly folded: boolean }) {
                 <p className="px-2.75 text-xs tracking-widest text-muted uppercase">{translate('aiFilters.heading')}</p>
             )}
 
-            {filters.map((filter) => (
-                <PlannedControl
-                    key={filter.icon}
-                    label={translate(filter.label)}
-                    icon={filter.icon}
-                    shape={folded ? 'symbol' : 'labelled'}
-                    className={folded ? 'self-center' : 'justify-start'}
-                />
+            {standingViews.map((view) => (
+                <button
+                    key={view}
+                    type="button"
+                    title={translate('aiFilters.entryTitle', { view: translate(views[view].label) })}
+                    className={`flex cursor-pointer items-center rounded-md text-sm text-text-soft transition hover:bg-hover ${
+                        folded ? 'justify-center self-center px-1.75 py-1.5' : 'gap-2.5 px-2.75 py-1.25'
+                    }`}
+                    onClick={() => {
+                        listed.stand(view);
+                    }}
+                >
+                    <Icon name={views[view].icon} className={folded ? 'size-5.75 text-muted' : 'size-4.5 text-muted'} />
+
+                    {folded ? (
+                        <span className="sr-only">{translate(views[view].label)}</span>
+                    ) : (
+                        <span className="min-w-0 flex-1 truncate text-start">{translate(views[view].label)}</span>
+                    )}
+                </button>
             ))}
         </section>
     );

--- a/frontend/src/Client.App/src/mailSpace/MailSpace.test.tsx
+++ b/frontend/src/Client.App/src/mailSpace/MailSpace.test.tsx
@@ -3,7 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { useEffect } from 'react';
-import { act, fireEvent, render, renderHook, screen } from '@testing-library/react';
+import { act, fireEvent, render, renderHook, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ComposingContext, type Composing } from '../composer/useComposing';
 import { LocalizationProvider } from '../localization/Localization';
@@ -342,9 +342,11 @@ describe('MailSpace, wide', () => {
 
         const filters = screen.getByRole('region', { name: 'AI filters' });
 
-        expect(filters.querySelectorAll('button[aria-disabled="true"]').length).toBe(3);
-        expect(filters.textContent).toBe('');
-        expect(screen.getByRole('button', { name: 'Needs a decision — not built yet' })).toBeDefined();
+        // What the fold drops is the heading over the three entries. Each entry keeps its name, because a rail drawn
+        // as three unnamed symbols is three controls nobody reading with anything but their eyes can tell apart.
+        expect(within(filters).getAllByRole('button')).toHaveLength(3);
+        expect(within(filters).getByRole('button', { name: 'Needs a decision' })).toBeDefined();
+        expect(filters.querySelector('p')).toBeNull();
     });
 
     it('draws every action of the toolbar, each saying in its own name why it cannot act here', () => {
@@ -383,12 +385,16 @@ describe('MailSpace, wide', () => {
         );
     });
 
-    it('offers the three AI filters as what the product will have rather than as working controls', () => {
+    it('offers the three standing views the design draws, in the order it draws them', () => {
         renderSpace(desktop);
 
         const filters = screen.getByRole('region', { name: 'AI filters' });
 
-        expect(filters.querySelectorAll('button[aria-disabled="true"]').length).toBe(3);
+        expect(
+            within(filters)
+                .getAllByRole('button')
+                .map((entry) => entry.textContent),
+        ).toStrictEqual(['Needs a decision', 'Commitments', 'Deadlines this week']);
     });
 });
 

--- a/frontend/src/Client.App/src/messageList/ListSettings.test.tsx
+++ b/frontend/src/Client.App/src/messageList/ListSettings.test.tsx
@@ -243,6 +243,106 @@ describe('ListSettings', () => {
         expect(screen.queryByLabelText('Include junk')).toBeNull();
     });
 
+    it.each([
+        ['What this is about', 'Sense'],
+        ['Why this may matter', 'Significance'],
+        ['What is committed to', 'Commitment'],
+    ])('narrows the list to the %s a derivation recorded', (named, aspect) => {
+        const read = vi.fn<(listing: MailListing) => void>();
+
+        renderSettings(openingListing, read);
+        openFilters();
+        fireEvent.click(screen.getByRole('button', { name: named }));
+
+        expect(read.mock.calls[0]?.[0].filters.markAspect).toBe(aspect);
+    });
+
+    it('draws the reading in force as chosen, which is what a standing view pressed in the tree looks like here', () => {
+        const filters = { ...openingListing.filters, markAspect: 'Significance' as const };
+
+        renderSettings({ ...openingListing, filters });
+        openFilters();
+
+        expect(screen.getByRole('button', { name: 'Why this may matter' }).getAttribute('aria-pressed')).toBe('true');
+        expect(screen.getByRole('button', { name: 'What is committed to' }).getAttribute('aria-pressed')).toBe('false');
+    });
+
+    it('takes the reading off again when the one in force is pressed, so a view can be removed one criterion at a time', () => {
+        const read = vi.fn<(listing: MailListing) => void>();
+        const filters = { ...openingListing.filters, markAspect: 'Commitment' as const };
+
+        renderSettings({ ...openingListing, filters }, read);
+        openFilters();
+        fireEvent.click(screen.getByRole('button', { name: 'What is committed to' }));
+
+        expect(read.mock.calls[0]?.[0].filters.markAspect).toBeNull();
+    });
+
+    it('bounds the commitments to the reader’s own week, reckoned from the start of their day', () => {
+        const read = vi.fn<(listing: MailListing) => void>();
+
+        renderSettings(openingListing, read);
+        openFilters();
+        fireEvent.click(screen.getByRole('button', { name: 'Due this week' }));
+
+        expect(read.mock.calls[0]?.[0].filters.markDueFrom).toBe('2026-09-03T00:00');
+        expect(read.mock.calls[0]?.[0].filters.markDueTo).toBe('2026-09-10T00:00');
+    });
+
+    it('takes the due window off again, leaving the reading it was set beside in force', () => {
+        const read = vi.fn<(listing: MailListing) => void>();
+        const filters = {
+            ...openingListing.filters,
+            markAspect: 'Commitment' as const,
+            markDueFrom: '2026-09-03T00:00',
+            markDueTo: '2026-09-10T00:00',
+        };
+
+        renderSettings({ ...openingListing, filters }, read);
+        openFilters();
+        fireEvent.click(screen.getByRole('button', { name: 'Due this week' }));
+
+        const narrowed = read.mock.calls[0]?.[0];
+
+        expect(narrowed?.filters.markDueFrom).toBeNull();
+        expect(narrowed?.filters.markDueTo).toBeNull();
+        expect(narrowed?.filters.markAspect).toBe('Commitment');
+    });
+
+    it('counts what a standing view put in force among the narrowings, so the control says the list is narrowed', () => {
+        const filters = {
+            ...openingListing.filters,
+            markAspect: 'Commitment' as const,
+            markDueFrom: '2026-09-03T00:00',
+            markDueTo: '2026-09-10T00:00',
+        };
+
+        renderSettings({ ...openingListing, filters });
+        openFilters();
+
+        expect(screen.getByText('Active filters: 1')).toBeTruthy();
+    });
+
+    it('clears what a standing view put in force with every other narrowing', () => {
+        const read = vi.fn<(listing: MailListing) => void>();
+        const filters = {
+            ...openingListing.filters,
+            markAspect: 'Commitment' as const,
+            markDueFrom: '2026-09-03T00:00',
+            markDueTo: '2026-09-10T00:00',
+        };
+
+        renderSettings({ ...openingListing, filters }, read);
+        openFilters();
+        fireEvent.click(screen.getByText('Clear filters'));
+
+        const cleared = read.mock.calls[0]?.[0];
+
+        expect(cleared?.filters.markAspect).toBeNull();
+        expect(cleared?.filters.markDueFrom).toBeNull();
+        expect(cleared?.filters.markDueTo).toBeNull();
+    });
+
     it('leaves what the reader chose about junk alone when the narrowings are cleared', () => {
         const read = vi.fn<(listing: MailListing) => void>();
         const filters = { ...openingListing.filters, unread: true, includeJunk: true };

--- a/frontend/src/Client.App/src/messageList/ListSettings.tsx
+++ b/frontend/src/Client.App/src/messageList/ListSettings.tsx
@@ -4,7 +4,7 @@
 
 import { useId, useState } from 'react';
 import { createPortal } from 'react-dom';
-import type { MailTimelineOrder } from '@mailfathom/client-backend';
+import type { MailEnrichmentAspect, MailTimelineOrder } from '@mailfathom/client-backend';
 import { CheckControl } from '../controls/CheckControl';
 import { chip } from '../controls/chrome';
 import { Icon } from '../controls/Icon';
@@ -15,6 +15,7 @@ import { useListHeadRow } from '../mailSpace/listHeadRow';
 import {
     dateRanges,
     narrowedToRange,
+    narrowedToThisWeek,
     narrowingsInForce,
     openingListing,
     selectableRange,
@@ -50,6 +51,17 @@ const rangeNames: Readonly<Record<MailListDateRange, MessageKey>> = {
 };
 
 const orders: readonly MailTimelineOrder[] = ['newestFirst', 'oldestFirst'];
+
+// What each of the three readings a derivation records is called where a reader picks one. The set is closed and this
+// table is exhaustive by its own type, so a reading added to the wire arrives here as a compiler error rather than as
+// a chip with no name.
+const readingNames: Readonly<Record<MailEnrichmentAspect, MessageKey>> = {
+    Sense: 'reading.sense',
+    Significance: 'reading.significance',
+    Commitment: 'reading.commitment',
+};
+
+const readings: readonly MailEnrichmentAspect[] = ['Sense', 'Significance', 'Commitment'];
 
 // The pill every choice in the panel is drawn as, and the tint it takes while it is the one in force. Stated once
 // because the toggles, the orders, and the offered spans are the same control drawn three times, and a chip that is on
@@ -310,6 +322,50 @@ export function ListSettings({
                                 {translate('list.rangeSelectsNothing')}
                             </p>
                         )}
+                    </div>
+
+                    {/* What a derivation read, which is what a standing view in the tree puts in force. It is drawn
+                        here rather than only in the tree because that is what makes a view a shortcut to criteria:
+                        somebody who pressed one can see exactly what it set, take one criterion off, and change
+                        another, in the same place every other narrowing is. Pressable rather than radio buttons, for
+                        the reason the offered spans are — each reading can be taken off again by pressing it. */}
+                    <div className="flex flex-col gap-1.25">
+                        <p className={sectionLabel}>{translate('list.readingNarrowing')}</p>
+
+                        <div className="flex flex-wrap gap-1.5">
+                            {readings.map((offered) => (
+                                <button
+                                    key={offered}
+                                    type="button"
+                                    aria-pressed={filters.markAspect === offered}
+                                    className={`${choice} ${filters.markAspect === offered ? chosen : ''}`}
+                                    onClick={() => {
+                                        narrow({ markAspect: filters.markAspect === offered ? null : offered });
+                                    }}
+                                >
+                                    {translate(readingNames[offered])}
+                                </button>
+                            ))}
+
+                            <button
+                                type="button"
+                                aria-pressed={filters.markDueFrom !== null}
+                                className={`${choice} ${filters.markDueFrom === null ? '' : chosen}`}
+                                onClick={() => {
+                                    onRead({
+                                        ...listing,
+                                        filters:
+                                            filters.markDueFrom === null
+                                                ? narrowedToThisWeek(filters, new Date())
+                                                : { ...filters, markDueFrom: null, markDueTo: null },
+                                    });
+                                }}
+                            >
+                                {translate('list.dueThisWeek')}
+                            </button>
+                        </div>
+
+                        <p className="text-sm text-faint text-pretty">{translate('list.readingNarrowingExplained')}</p>
                     </div>
 
                     <div className="flex items-center gap-2.5 border-t border-line-soft pt-2">

--- a/frontend/src/Client.App/src/messageList/ListedMail.test.tsx
+++ b/frontend/src/Client.App/src/messageList/ListedMail.test.tsx
@@ -51,7 +51,7 @@ describe('ListedMailProvider', () => {
         const listed = held();
         const everything = vi.fn();
 
-        listed.listing({ selectAll: everything, takeFocus: () => undefined });
+        listed.listing({ selectAll: everything, takeFocus: () => undefined, stand: () => undefined });
         listed.selectAll();
 
         listed.listing(null);
@@ -60,11 +60,24 @@ describe('ListedMailProvider', () => {
         expect(everything).toHaveBeenCalledOnce();
     });
 
+    it('puts a standing view in force through the list that registered it, and nowhere once it has left', () => {
+        const listed = held();
+        const stood = vi.fn();
+
+        listed.listing({ selectAll: () => undefined, takeFocus: () => undefined, stand: stood });
+        listed.stand('commitments');
+
+        listed.listing(null);
+        listed.stand('commitments');
+
+        expect(stood).toHaveBeenCalledExactlyOnceWith('commitments');
+    });
+
     it('hands focus to the list that registered it, and to nothing at all once no list is on the screen', () => {
         const listed = held();
         const focused = vi.fn();
 
-        listed.listing({ selectAll: () => undefined, takeFocus: focused });
+        listed.listing({ selectAll: () => undefined, takeFocus: focused, stand: () => undefined });
         listed.takeFocus();
 
         listed.listing(null);

--- a/frontend/src/Client.App/src/messageList/ListedMail.tsx
+++ b/frontend/src/Client.App/src/messageList/ListedMail.tsx
@@ -42,6 +42,9 @@ export function ListedMailProvider({ children }: { readonly children: ReactNode 
         takeFocus: () => {
             mailbox.current?.takeFocus();
         },
+        stand: (view) => {
+            mailbox.current?.stand(view);
+        },
         listing: (list) => {
             mailbox.current = list;
         },

--- a/frontend/src/Client.App/src/messageList/MessageList.test.tsx
+++ b/frontend/src/Client.App/src/messageList/MessageList.test.tsx
@@ -3,7 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import type { ReactElement } from 'react';
-import { act, fireEvent, render, screen, within, type RenderResult } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within, type RenderResult } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type {
     ClientRequest,
@@ -434,6 +434,20 @@ describe('MessageList', () => {
         ).toBeDefined();
     });
 
+    it('says a folder narrowed by a reading may simply not have been read, rather than saying nothing matched', async () => {
+        renderList(answering(pageOf([])));
+
+        await screen.findByText('There is no mail in this folder.');
+        openFilters();
+        fireEvent.click(screen.getByRole('button', { name: 'Why this may matter' }));
+
+        expect(
+            await screen.findByText(
+                'No message in this folder carries the reading the list is narrowed to. Either none of them does, or MailFathom has not read this folder yet.',
+            ),
+        ).toBeDefined();
+    });
+
     it('says the machine is offline rather than reporting a deployment that did not answer', () => {
         renderList(answering(wholeFolder), { online: false });
 
@@ -640,6 +654,30 @@ describe('MessageList', () => {
         drawn.unmount();
 
         expect(asked.at(-1)).toBeNull();
+    });
+
+    // The tree draws the standing views and the list is what holds a folder's filters, so pressing one there is an ask
+    // rather than a second way of reading mail: what arrives here is the same narrowing the panel writes.
+    it('reads the folder again narrowed to what a standing view stands on when the tree asks for one', async () => {
+        const asked: (ListedMailbox | null)[] = [];
+        const listed = {
+            ...nothingListed,
+            listing: (list: ListedMailbox | null) => {
+                asked.push(list);
+            },
+        };
+        const { transport, requests } = recording(wholeFolder);
+
+        render(<ListedMailContext value={listed}>{listUnder(transport)}</ListedMailContext>);
+
+        await rows();
+        act(() => {
+            asked.at(-1)?.stand('needsDecision');
+        });
+
+        await waitFor(() => {
+            expect(requests.at(-1)?.path).toContain('carriesMark=Significance');
+        });
     });
 
     // The bar above the list hands focus back before it clears the selection and disappears, and the row the keyboard

--- a/frontend/src/Client.App/src/messageList/MessageList.tsx
+++ b/frontend/src/Client.App/src/messageList/MessageList.tsx
@@ -54,7 +54,7 @@ import {
     type TimelineRead,
 } from './heldTimeline';
 import { ListSettings } from './ListSettings';
-import { narrowed, queryFor, type MailListing } from './listing';
+import { narrowed, narrowedByReading, narrowedToView, queryFor, type MailListing } from './listing';
 import { extendedTo, inReadingOrder, withToggled } from './messageSelection';
 import { rememberedListing, rememberListing } from './rememberedListings';
 import { actedMessages, useListedMail } from './useListedMail';
@@ -377,6 +377,13 @@ export function MessageList({
                 } else {
                     row.focus();
                 }
+            },
+
+            // A standing view in the tree is a shortcut to filters on the folder in front of the reader, so it lands
+            // here as any other filter change does — the same restart, the same remembered listing, and the criteria
+            // then drawn in the panel where every other narrowing is.
+            stand: (view) => {
+                readWith({ ...listing, filters: narrowedToView(listing.filters, view, new Date()) });
             },
         });
 
@@ -858,11 +865,16 @@ function identityOf(email: { readonly id: string }): string {
 }
 
 /**
- * Why a folder is showing nothing, which is four different sentences rather than one.
+ * Why a folder is showing nothing, which is five different sentences rather than one.
  *
  * A folder nothing has been taken into yet is the one a reader would otherwise read as empty and act on — so it is told
  * apart from a folder that genuinely holds nothing, from one whose account stopped synchronizing, and from a list the
  * reader has narrowed to nothing themselves.
+ *
+ * A list narrowed by what a derivation read is the fifth, and it is its own sentence because the reader cannot tell
+ * the two apart from the mail: nothing here derives anything, so an empty answer is either mail carrying no such
+ * reading or a deployment that has derived nothing over this folder at all — and a client that said only "nothing
+ * matches" would leave somebody correcting a filter that was never the reason.
  */
 function emptyReason(accounts: readonly MailAccount[], scope: MailScope, listing: MailListing): MessageKey {
     const named = accountInScope(scope);
@@ -874,6 +886,10 @@ function emptyReason(accounts: readonly MailAccount[], scope: MailScope, listing
 
     if (inScope.some((account) => needsAttention(account.synchronizationState))) {
         return 'list.emptyWhileFailing';
+    }
+
+    if (narrowedByReading(listing.filters)) {
+        return 'list.nothingRead';
     }
 
     return narrowed(listing.filters) ? 'list.nothingMatches' : 'list.emptyFolder';

--- a/frontend/src/Client.App/src/messageList/listing.test.ts
+++ b/frontend/src/Client.App/src/messageList/listing.test.ts
@@ -6,12 +6,16 @@ import { describe, expect, it } from 'vitest';
 import { everything, type MailScope } from '../workspace/mailScope';
 import {
     narrowed,
+    narrowedByReading,
     narrowedToRange,
+    narrowedToThisWeek,
+    narrowedToView,
     narrowingsInForce,
     openingListing,
     queryFor,
     rowsPerPage,
     selectableRange,
+    standingViews,
     type MailListing,
 } from './listing';
 
@@ -106,6 +110,33 @@ describe('queryFor', () => {
 
         expect(queryFor(everything, { ...openingListing, filters }, null, 'forward').receivedOnOrAfter).toBeNull();
     });
+
+    it('asks for the reading a derivation must have left, which is the whole of what a standing view is', () => {
+        const filters = { ...openingListing.filters, markAspect: 'Significance' as const };
+
+        expect(queryFor(everything, { ...openingListing, filters }, null, 'forward').carriesMark).toBe('Significance');
+    });
+
+    it('asks for the due window as the two instants the reader’s own wall clock names', () => {
+        const filters = {
+            ...openingListing.filters,
+            markAspect: 'Commitment' as const,
+            markDueFrom: '2026-09-03T00:00',
+            markDueTo: '2026-09-10T00:00',
+        };
+        const query = queryFor(everything, { ...openingListing, filters }, null, 'forward');
+
+        expect(query.markDueOnOrAfter).toBe(new Date(2026, 8, 3).toISOString());
+        expect(query.markDueBefore).toBe(new Date(2026, 8, 10).toISOString());
+    });
+
+    it('asks for no reading where nothing a derivation left is what the list is narrowed by', () => {
+        const query = queryFor(everything, openingListing, null, 'forward');
+
+        expect(query.carriesMark).toBeNull();
+        expect(query.markDueOnOrAfter).toBeNull();
+        expect(query.markDueBefore).toBeNull();
+    });
 });
 
 describe('narrowed', () => {
@@ -130,6 +161,33 @@ describe('narrowed', () => {
             expect(narrowed({ ...openingListing.filters, ...range })).toBe(true);
         },
     );
+
+    it.each([{ markAspect: 'Sense' as const }, { markDueFrom: '2026-09-03T00:00' }, { markDueTo: '2026-09-10T00:00' }])(
+        'reports a list narrowed by what a derivation read: %o',
+        (criterion) => {
+            expect(narrowed({ ...openingListing.filters, ...criterion })).toBe(true);
+        },
+    );
+});
+
+describe('narrowedByReading', () => {
+    it('reports a list nobody has narrowed by anything a derivation left', () => {
+        expect(narrowedByReading(openingListing.filters)).toBe(false);
+    });
+
+    it('does not read a received range as one, so an empty folder is not blamed on a derivation', () => {
+        const filters = { ...openingListing.filters, receivedFrom: '2026-08-01T00:00' };
+
+        expect(narrowedByReading(filters)).toBe(false);
+    });
+
+    it.each([
+        { markAspect: 'Commitment' as const },
+        { markDueFrom: '2026-09-03T00:00' },
+        { markDueTo: '2026-09-10T00:00' },
+    ])('reports %o', (criterion) => {
+        expect(narrowedByReading({ ...openingListing.filters, ...criterion })).toBe(true);
+    });
 });
 
 describe('narrowingsInForce', () => {
@@ -143,6 +201,17 @@ describe('narrowingsInForce', () => {
 
     it('counts a range as one however many of its two ends are set', () => {
         const filters = { ...openingListing.filters, receivedFrom: '2026-08-01T00:00', receivedTo: '2026-09-01T00:00' };
+
+        expect(narrowingsInForce({ ...openingListing, filters })).toBe(1);
+    });
+
+    it('counts what a derivation read as one however many of its three criteria are in force', () => {
+        const filters = {
+            ...openingListing.filters,
+            markAspect: 'Commitment' as const,
+            markDueFrom: '2026-09-03T00:00',
+            markDueTo: '2026-09-10T00:00',
+        };
 
         expect(narrowingsInForce({ ...openingListing, filters })).toBe(1);
     });
@@ -168,10 +237,13 @@ describe('narrowingsInForce', () => {
                 dateRange: 'today',
                 receivedFrom: '2026-09-03T00:00',
                 receivedTo: null,
+                markAspect: 'Commitment',
+                markDueFrom: '2026-09-03T00:00',
+                markDueTo: '2026-09-10T00:00',
             },
         };
 
-        expect(narrowingsInForce(listing)).toBe(5);
+        expect(narrowingsInForce(listing)).toBe(6);
     });
 });
 
@@ -230,5 +302,77 @@ describe('selectableRange', () => {
         [null, null, true],
     ])('reads %s to %s as a range that can select something: %s', (from, to, selects) => {
         expect(selectableRange(from, to)).toBe(selects);
+    });
+});
+
+describe('narrowedToView', () => {
+    // A Thursday mid-afternoon, so that a window reckoned from the instant rather than from the start of the reader's
+    // day would be visibly wrong rather than off by an hour.
+    const pickedAt = new Date(2026, 8, 3, 15, 42);
+
+    it.each([
+        ['needsDecision', 'Significance'],
+        ['commitments', 'Commitment'],
+        ['deadlinesThisWeek', 'Commitment'],
+    ] as const)('stands %s on the %s a derivation recorded', (view, aspect) => {
+        expect(narrowedToView(openingListing.filters, view, pickedAt).markAspect).toBe(aspect);
+    });
+
+    it('bounds the deadlines to the reader’s own week, opening today and closing on the eighth day', () => {
+        const inForce = narrowedToView(openingListing.filters, 'deadlinesThisWeek', pickedAt);
+
+        expect(inForce.markDueFrom).toBe('2026-09-03T00:00');
+        expect(inForce.markDueTo).toBe('2026-09-10T00:00');
+    });
+
+    it.each(['needsDecision', 'commitments'] as const)('bounds %s by no due window at all', (view) => {
+        const inForce = narrowedToView(openingListing.filters, view, pickedAt);
+
+        expect(inForce.markDueFrom).toBeNull();
+        expect(inForce.markDueTo).toBeNull();
+    });
+
+    it('replaces the window a previous view put in force, so two views are never half in force at once', () => {
+        const week = narrowedToView(openingListing.filters, 'deadlinesThisWeek', pickedAt);
+        const inForce = narrowedToView(week, 'needsDecision', pickedAt);
+
+        expect(inForce.markAspect).toBe('Significance');
+        expect(inForce.markDueFrom).toBeNull();
+        expect(inForce.markDueTo).toBeNull();
+    });
+
+    it('leaves every narrowing the reader had already chosen where it was', () => {
+        const filters = { ...openingListing.filters, unread: true, receivedFrom: '2026-08-01T00:00' };
+        const inForce = narrowedToView(filters, 'commitments', pickedAt);
+
+        expect(inForce.unread).toBe(true);
+        expect(inForce.receivedFrom).toBe('2026-08-01T00:00');
+    });
+
+    it('writes what it puts in force into the filters the panel draws, so each criterion can be taken off there', () => {
+        for (const view of standingViews) {
+            expect(narrowedByReading(narrowedToView(openingListing.filters, view, pickedAt))).toBe(true);
+        }
+    });
+});
+
+describe('narrowedToThisWeek', () => {
+    it('opens the window at the start of the reader’s day rather than at the instant they pressed', () => {
+        const inForce = narrowedToThisWeek(openingListing.filters, new Date(2026, 8, 3, 23, 59));
+
+        expect(inForce.markDueFrom).toBe('2026-09-03T00:00');
+    });
+
+    it('runs the window across a month’s end in the reader’s own calendar', () => {
+        const inForce = narrowedToThisWeek(openingListing.filters, new Date(2026, 8, 28, 9, 0));
+
+        expect(inForce.markDueFrom).toBe('2026-09-28T00:00');
+        expect(inForce.markDueTo).toBe('2026-10-05T00:00');
+    });
+
+    it('leaves the reading the list is narrowed by where it was, being a window rather than a view', () => {
+        const filters = { ...openingListing.filters, markAspect: 'Sense' as const };
+
+        expect(narrowedToThisWeek(filters, new Date(2026, 8, 3)).markAspect).toBe('Sense');
     });
 });

--- a/frontend/src/Client.App/src/messageList/listing.ts
+++ b/frontend/src/Client.App/src/messageList/listing.ts
@@ -4,6 +4,7 @@
 
 import {
     longestTimelinePage,
+    type MailEnrichmentAspect,
     type MailTimelineOrder,
     type MailTimelinePageDirection,
     type MailTimelineQuery,
@@ -47,6 +48,26 @@ export interface MailListFilters {
 
     /** The end of the received range as a local `YYYY-MM-DDTHH:mm`, exclusive, or `null` for no end. */
     readonly receivedTo: string | null;
+
+    /**
+     * The reading a derivation must have left on the message, or `null` to keep mail whatever it read.
+     *
+     * It narrows by what MailFathom already derived and derives nothing itself: a deployment that has read nothing
+     * answers this as a list with no mail in it, which is a folder narrowed to nothing rather than a failure.
+     */
+    readonly markAspect: MailEnrichmentAspect | null;
+
+    /**
+     * The start of the range a commitment falls due in, as a local `YYYY-MM-DDTHH:mm`, inclusive, or `null`.
+     *
+     * Resolved to a wall-clock minute the moment the window is picked rather than each time the list is read, for the
+     * reason {@link MailListFilters.dateRange} gives: a window reckoned afresh would silently become a different
+     * filter at midnight, and the cursor the reader is holding is issued under the filters.
+     */
+    readonly markDueFrom: string | null;
+
+    /** The end of that range as a local `YYYY-MM-DDTHH:mm`, exclusive, or `null` for no end. */
+    readonly markDueTo: string | null;
 }
 
 /** How one folder is being read. */
@@ -66,6 +87,9 @@ export const openingListing: MailListing = {
         dateRange: null,
         receivedFrom: null,
         receivedTo: null,
+        markAspect: null,
+        markDueFrom: null,
+        markDueTo: null,
     },
 };
 
@@ -106,6 +130,9 @@ export function queryFor(
         hasAttachments: listing.filters.hasAttachments,
         receivedOnOrAfter: instantAt(listing.filters.receivedFrom),
         receivedBefore: instantAt(listing.filters.receivedTo),
+        carriesMark: listing.filters.markAspect,
+        markDueOnOrAfter: instantAt(listing.filters.markDueFrom),
+        markDueBefore: instantAt(listing.filters.markDueTo),
         order: listing.order,
         direction,
         pageSize: rowsPerPage,
@@ -120,8 +147,14 @@ export function narrowed(filters: MailListFilters): boolean {
         filters.flagged !== null ||
         filters.hasAttachments !== null ||
         filters.receivedFrom !== null ||
-        filters.receivedTo !== null
+        filters.receivedTo !== null ||
+        narrowedByReading(filters)
     );
+}
+
+/** Whether the list is narrowed by what a derivation read, which is what a standing view in the tree puts in force. */
+export function narrowedByReading(filters: MailListFilters): boolean {
+    return filters.markAspect !== null || filters.markDueFrom !== null || filters.markDueTo !== null;
 }
 
 /**
@@ -131,7 +164,9 @@ export function narrowed(filters: MailListFilters): boolean {
  * than two about a pair of fields. Reading the mail the folder holds in another order is counted with them: it is not a
  * narrowing, but it is a reason the message somebody expected at the top is not there, which is the same surprise the
  * count exists to answer. Including junk is deliberately not counted — it widens the list, so it can never be why a
- * folder looks emptier than the reader expects.
+ * folder looks emptier than the reader expects. What a derivation read counts once however many of its three criteria
+ * are in force, on the same reading as the received range: a standing view in the tree is one decision somebody took,
+ * and reporting it as two would say the folder was being kept from them twice over.
  *
  * @param listing How the reader has asked the folder to be read.
  * @returns The count of narrowings and orderings the reader has chosen.
@@ -143,6 +178,7 @@ export function narrowingsInForce(listing: MailListing): number {
         listing.filters.hasAttachments !== null,
         listing.filters.receivedFrom !== null || listing.filters.receivedTo !== null,
         listing.order !== openingListing.order,
+        narrowedByReading(listing.filters),
     ];
 
     return chosen.filter(Boolean).length;
@@ -166,6 +202,63 @@ export function narrowedToRange(filters: MailListFilters, range: MailListDateRan
     }
 
     return { ...filters, dateRange: range, receivedFrom: localMinute(startOf(range, now)), receivedTo: null };
+}
+
+/** The standing views of the mailbox the folder tree offers, each of them a set of criteria and nothing else. */
+export type StandingView = 'needsDecision' | 'commitments' | 'deadlinesThisWeek';
+
+/** Every standing view, in the order the design project draws them under the tree. */
+export const standingViews: readonly StandingView[] = ['needsDecision', 'commitments', 'deadlinesThisWeek'];
+
+/**
+ * The filters a folder is read with once one of the standing views is asked for.
+ *
+ * A view is a shortcut to criteria rather than a second way of asking for mail: what it puts in force is written into
+ * the same filters the panel draws, so the reader can see each of them, take one off, and change another. Everything
+ * the reader had already narrowed by stays — a view says what MailFathom read, and says nothing about whether they
+ * were also reading only unread mail.
+ *
+ * `needsDecision` stands on the significance a derivation recorded, which is the reading that says why a message may
+ * matter at all. There is no *decision* among the three readings MailFathom stores, so a view that claimed to be one
+ * would be naming something nothing produces.
+ *
+ * @param filters What the list is narrowed to now.
+ * @param view The view the reader asked for.
+ * @param now The instant they asked for it at.
+ * @returns The filters with that view's criteria in force.
+ */
+export function narrowedToView(filters: MailListFilters, view: StandingView, now: Date): MailListFilters {
+    const cleared: MailListFilters = { ...filters, markDueFrom: null, markDueTo: null };
+
+    switch (view) {
+        case 'needsDecision':
+            return { ...cleared, markAspect: 'Significance' };
+        case 'commitments':
+            return { ...cleared, markAspect: 'Commitment' };
+        case 'deadlinesThisWeek':
+            return narrowedToThisWeek({ ...cleared, markAspect: 'Commitment' }, now);
+    }
+}
+
+/**
+ * The filters a folder is read with once the commitments falling due this week are asked for.
+ *
+ * The window is the reader's own week rather than a rolling seven days: it opens at the start of today and closes at
+ * the start of the eighth day, so a commitment due later today is in it and one due at midnight next Monday is not.
+ * Resolved here, at the moment somebody picked it, for the reason {@link narrowedToRange} resolves a span there.
+ *
+ * @param filters What the list is narrowed to now.
+ * @param now The instant the reader asked for it at.
+ * @returns The filters with that window in force.
+ */
+export function narrowedToThisWeek(filters: MailListFilters, now: Date): MailListFilters {
+    const opens = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+    return {
+        ...filters,
+        markDueFrom: localMinute(opens),
+        markDueTo: localMinute(new Date(opens.getFullYear(), opens.getMonth(), opens.getDate() + 7)),
+    };
 }
 
 /**

--- a/frontend/src/Client.App/src/messageList/rememberedListings.test.ts
+++ b/frontend/src/Client.App/src/messageList/rememberedListings.test.ts
@@ -168,6 +168,14 @@ describe('rememberedListing', () => {
                 },
             },
         ],
+        [
+            'a due window carrying one bound, which the control that writes it puts in force as a pair',
+            { ...kept, filters: { ...kept.filters, markAspect: 'Commitment', markDueFrom: '2026-09-03T00:00' } },
+        ],
+        [
+            'a due window carrying only its end, for the same reason',
+            { ...kept, filters: { ...kept.filters, markAspect: 'Commitment', markDueTo: '2026-09-10T00:00' } },
+        ],
         ['a switch that is neither shown nor hidden', { ...kept, readingsShown: 'yes' }],
         ['a listing that is not a record', 'the inbox'],
     ])('opens at the leading end for a record carrying %s', (_, written) => {

--- a/frontend/src/Client.App/src/messageList/rememberedListings.test.ts
+++ b/frontend/src/Client.App/src/messageList/rememberedListings.test.ts
@@ -151,6 +151,23 @@ describe('rememberedListing', () => {
                 },
             },
         ],
+        ['a reading this surface does not publish', { ...kept, filters: { ...kept.filters, markAspect: 'Mood' } }],
+        [
+            'a due bound the window control never wrote',
+            { ...kept, filters: { ...kept.filters, markAspect: 'Commitment', markDueFrom: 'next Monday' } },
+        ],
+        [
+            'a due window whose end precedes its start, which the deployment refuses rather than answers',
+            {
+                ...kept,
+                filters: {
+                    ...kept.filters,
+                    markAspect: 'Commitment',
+                    markDueFrom: '2026-09-10T00:00',
+                    markDueTo: '2026-09-03T00:00',
+                },
+            },
+        ],
         ['a switch that is neither shown nor hidden', { ...kept, readingsShown: 'yes' }],
         ['a listing that is not a record', 'the inbox'],
     ])('opens at the leading end for a record carrying %s', (_, written) => {
@@ -168,6 +185,28 @@ describe('rememberedListing', () => {
         rememberListing(deployment, inbox, narrowed);
 
         expect(rememberedListing(deployment, inbox)).toStrictEqual(narrowed);
+    });
+
+    it('reads back the standing view a folder was left narrowed to, so returning to it finds the criteria', () => {
+        const standing = {
+            ...kept,
+            filters: {
+                ...kept.filters,
+                markAspect: 'Commitment' as const,
+                markDueFrom: '2026-09-03T00:00',
+                markDueTo: '2026-09-10T00:00',
+            },
+        };
+
+        rememberListing(deployment, inbox, standing);
+
+        expect(rememberedListing(deployment, inbox)).toStrictEqual(standing);
+    });
+
+    it('narrows by no reading for a folder kept before the tree offered the standing views', () => {
+        stored({ [keyFor(inbox)]: { ...kept, filters: without({ ...kept.filters }, 'markAspect') } });
+
+        expect(rememberedListing(deployment, inbox).filters.markAspect).toBeNull();
     });
 
     it('draws the readings for a folder kept before the switch existed', () => {

--- a/frontend/src/Client.App/src/messageList/rememberedListings.ts
+++ b/frontend/src/Client.App/src/messageList/rememberedListings.ts
@@ -243,6 +243,14 @@ function filtersIn(value: unknown): MailListFilters | null {
         return null;
     }
 
+    // The due window is written and cleared as a pair — the one control that sets it puts both bounds in force or
+    // takes both off, and a standing view clears both — so a record carrying one of them is a record this client
+    // never wrote. Refused rather than read: an open-ended commitment filter nobody chose would narrow the folder
+    // while the panel drew the window as off, which is the case this file exists to keep out.
+    if ((markDueFrom === null) !== (markDueTo === null)) {
+        return null;
+    }
+
     // A span resolves to a start and no end the moment it is picked, so a record pairing one with a missing start or
     // with an end is a record this client never wrote. Both are refused rather than read: the panel draws neither
     // field while a span is lit, so a bound arriving that way would narrow the folder where nothing shows it.

--- a/frontend/src/Client.App/src/messageList/rememberedListings.ts
+++ b/frontend/src/Client.App/src/messageList/rememberedListings.ts
@@ -2,7 +2,7 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import type { MailTimelineOrder, MailTimelinePageDirection } from '@mailfathom/client-backend';
+import type { MailEnrichmentAspect, MailTimelineOrder, MailTimelinePageDirection } from '@mailfathom/client-backend';
 import { scopeKey, type MailScope } from '../workspace/mailScope';
 import {
     dateRanges,
@@ -219,11 +219,27 @@ function filtersIn(value: unknown): MailListFilters | null {
     const receivedFrom = record['receivedFrom'] ?? null;
     const receivedTo = record['receivedTo'] ?? null;
 
+    // Read as narrowing by no reading where the record predates the standing views, which is a record this client
+    // wrote before the tree offered them rather than one somebody edited.
+    const markAspect = record['markAspect'] ?? null;
+    const markDueFrom = record['markDueFrom'] ?? null;
+    const markDueTo = record['markDueTo'] ?? null;
+
     if (!isWanted(unread) || !isWanted(flagged) || !isWanted(hasAttachments) || typeof includeJunk !== 'boolean') {
         return null;
     }
 
     if (!isRange(dateRange) || !isMinute(receivedFrom) || !isMinute(receivedTo)) {
+        return null;
+    }
+
+    if (!isAspect(markAspect) || !isMinute(markDueFrom) || !isMinute(markDueTo)) {
+        return null;
+    }
+
+    // The same test the due window is composed under, for the reason the received pair is held to the control's:
+    // a window selecting nothing is one the deployment refuses, and reading one back would put the folder on it.
+    if (!selectableRange(markDueFrom, markDueTo)) {
         return null;
     }
 
@@ -241,11 +257,28 @@ function filtersIn(value: unknown): MailListFilters | null {
         return null;
     }
 
-    return { unread, flagged, hasAttachments, includeJunk, dateRange, receivedFrom, receivedTo };
+    return {
+        unread,
+        flagged,
+        hasAttachments,
+        includeJunk,
+        dateRange,
+        receivedFrom,
+        receivedTo,
+        markAspect,
+        markDueFrom,
+        markDueTo,
+    };
 }
 
 function isWanted(value: unknown): value is boolean | null {
     return value === null || typeof value === 'boolean';
+}
+
+// The three readings a derivation records, which is the closed set the deployment answers a row with and the only
+// values it narrows a list by. Anything else is a record this client never wrote.
+function isAspect(value: unknown): value is MailEnrichmentAspect | null {
+    return value === null || value === 'Sense' || value === 'Significance' || value === 'Commitment';
 }
 
 function isRange(value: unknown): value is MailListDateRange | null {

--- a/frontend/src/Client.App/src/messageList/useListedMail.ts
+++ b/frontend/src/Client.App/src/messageList/useListedMail.ts
@@ -4,9 +4,11 @@
 
 import { createContext, useContext } from 'react';
 import type { ActedMessage } from '../mailboxActs/useMailboxActs';
+import type { StandingView } from './listing';
 
 // The message list as the surfaces outside it reach it, which is two questions and nothing else: where a message the
-// list has drawn belongs, and *select everything*.
+// list has drawn belongs, and *select everything*. Two more are here for the reason the second one is, and the two
+// paragraphs below say what that reason is: taking focus back, and standing on one of the tree's views.
 //
 // It exists because the workspace keeps a selection as identities alone — which is what lets a selection outlive the
 // pages the list has scrolled away from — while an act on one has to name the account it is in and the folder it is
@@ -19,6 +21,10 @@ import type { ActedMessage } from '../mailboxActs/useMailboxActs';
 // **Selecting everything is the list's own act**, not a rewrite of the selection from outside: what *everything* means
 // is the rows the list is holding, which is a window over a folder rather than the folder. So the bar draws the
 // control and the list performs it, and a screen with no list on it performs nothing.
+//
+// **Standing on one of the folder tree's views is the same shape.** A view is a set of filter criteria on the folder
+// in front of the reader, and a folder's filters belong to the list rather than to the tree — so the tree asks and the
+// list narrows itself, exactly as its own filter panel does, and a tree drawn beside no list narrows nothing.
 //
 // The context and its hook sit apart from the provider that fills them for the reason `workspace/useWorkspace.ts`
 // gives: a module Vite hot-reloads may export components alone.
@@ -46,12 +52,21 @@ export interface ListedMail {
 
     /** Says which list is on the screen, and `null` as it leaves. */
     readonly listing: (list: ListedMailbox | null) => void;
+
+    /** Puts one of the tree's standing views in force on the list, and does nothing where no list is on the screen. */
+    readonly stand: (view: StandingView) => void;
 }
 
 /** What a list on the screen answers for, filled by the list itself and by nothing above it. */
 export interface ListedMailbox {
     readonly selectAll: () => void;
     readonly takeFocus: () => void;
+
+    /**
+     * Puts one of the tree's standing views in force, which is the list's own act for the reason selecting everything
+     * is: what a view sets is filters on the folder in front of the reader, and the folder's filters are the list's.
+     */
+    readonly stand: (view: StandingView) => void;
 }
 
 /** What a tree with no provider above it reads, which is a client where nothing outside a list can reach into one. */
@@ -61,6 +76,7 @@ export const nothingListed: ListedMail = {
     selectAll: () => undefined,
     takeFocus: () => undefined,
     listing: () => undefined,
+    stand: () => undefined,
 };
 
 export const ListedMailContext = createContext<ListedMail>(nothingListed);

--- a/frontend/src/Client.App/src/preferences/aiFilters.ts
+++ b/frontend/src/Client.App/src/preferences/aiFilters.ts
@@ -1,0 +1,28 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { createContext, useContext } from 'react';
+
+// Whether the folder tree carries the standing views of what MailFathom read, reached by the section that draws them.
+//
+// A context rather than a prop, on the exception `preferences/messageView.ts` takes and for the same reason: the
+// section sits three components below the frame that holds the preference, behind a space, a mail screen and a column
+// that each have nothing to do with it.
+//
+// It carries the answer alone rather than the whole preferences object, because that is what the section needs: the
+// control that moves it belongs to the settings screen, and a tree that could reach the setter from here would be one
+// where the section turned itself off.
+
+/**
+ * Whether the tree draws the standing views, which a tree with no provider above it reads as `true`.
+ *
+ * Drawn is the default for the reason the deployment's own unset answer is: the section is part of the tree the design
+ * project draws, so it is something somebody turns off rather than something they go looking for.
+ */
+export const AiFiltersShownContext = createContext(true);
+
+/** Whether the folder tree draws the standing views of what a derivation read in the mail. */
+export function useAiFiltersShown(): boolean {
+    return useContext(AiFiltersShownContext);
+}

--- a/frontend/src/Client.App/src/preferences/useClientPreferences.test.tsx
+++ b/frontend/src/Client.App/src/preferences/useClientPreferences.test.tsx
@@ -21,7 +21,7 @@ const anna = 'anna';
 const bartek = 'bartek';
 
 // The whole document, because the route answers with nothing less and the package refuses an answer missing a field.
-// The three preferences no control in this hook's own tests moves are defaulted rather than named at each call, so
+// The four preferences no control in this hook's own tests moves are defaulted rather than named at each call, so
 // only the tests that are about one of them say anything about it.
 function stored(preferences: {
     telemetryEnabled: boolean;
@@ -29,11 +29,13 @@ function stored(preferences: {
     openMailInTabs: boolean;
     markReadOnOpen?: boolean;
     expandWholeThread?: boolean;
+    aiFiltersShown?: boolean;
     embeddedHtmlMessages?: boolean;
 }): string {
     return JSON.stringify({
         markReadOnOpen: true,
         expandWholeThread: false,
+        aiFiltersShown: true,
         embeddedHtmlMessages: false,
         ...preferences,
     });
@@ -185,6 +187,54 @@ describe('useClientPreferences', () => {
             openMailInTabs: true,
             markReadOnOpen: true,
             expandWholeThread: false,
+            aiFiltersShown: true,
+            embeddedHtmlMessages: false,
+        });
+    });
+
+    it('answers the standing views as drawn before anything has been read, the tree offering them by default', () => {
+        const { transport } = recording(stored({ telemetryEnabled: true, theme: 'dark', openMailInTabs: true }));
+        const { result } = reading(transport);
+
+        expect(result.current.preferences.aiFiltersShown).toBe(true);
+    });
+
+    it('answers the standing views as gone once the person has taken them out of the tree', async () => {
+        const { transport } = recording(
+            stored({ telemetryEnabled: true, theme: 'system', openMailInTabs: false, aiFiltersShown: false }),
+        );
+        const { result } = reading(transport);
+
+        await waitFor(() => {
+            expect(result.current.preferences.aiFiltersShown).toBe(false);
+        });
+    });
+
+    it('states the whole document when the standing views are the decision that changed', async () => {
+        const { transport, requests } = recording(
+            stored({ telemetryEnabled: false, theme: 'light', openMailInTabs: false }),
+        );
+        const { result } = reading(transport);
+
+        await waitFor(() => {
+            expect(result.current.theme.choice).toBe('light');
+        });
+
+        act(() => {
+            result.current.preferences.chooseAiFilters(false);
+        });
+
+        await waitFor(() => {
+            expect(requests).toHaveLength(2);
+        });
+
+        expect(JSON.parse(requests[1]?.body ?? '')).toStrictEqual({
+            telemetryEnabled: false,
+            theme: 'light',
+            openMailInTabs: false,
+            markReadOnOpen: true,
+            expandWholeThread: false,
+            aiFiltersShown: false,
             embeddedHtmlMessages: false,
         });
     });
@@ -213,6 +263,7 @@ describe('useClientPreferences', () => {
                 openMailInTabs: false,
                 markReadOnOpen: true,
                 expandWholeThread: false,
+                aiFiltersShown: true,
                 embeddedHtmlMessages: false,
             });
         });
@@ -268,6 +319,7 @@ describe('useClientPreferences', () => {
             openMailInTabs: true,
             markReadOnOpen: true,
             expandWholeThread: false,
+            aiFiltersShown: true,
             embeddedHtmlMessages: false,
         });
     });
@@ -335,6 +387,7 @@ describe('useClientPreferences', () => {
             openMailInTabs: true,
             markReadOnOpen: true,
             expandWholeThread: false,
+            aiFiltersShown: true,
             embeddedHtmlMessages: false,
         });
     });
@@ -367,6 +420,7 @@ describe('useClientPreferences', () => {
             openMailInTabs: false,
             markReadOnOpen: true,
             expandWholeThread: false,
+            aiFiltersShown: true,
             embeddedHtmlMessages: false,
         });
         expect(window.localStorage.getItem(telemetryKey(anna))).toBe('false');

--- a/frontend/src/Client.App/src/preferences/useClientPreferences.ts
+++ b/frontend/src/Client.App/src/preferences/useClientPreferences.ts
@@ -66,6 +66,14 @@ export interface ClientPreferencesInForce {
      */
     readonly embeddedHtmlMessages: boolean;
 
+    /**
+     * Whether the folder tree carries the standing views of what a derivation read in the mail.
+     *
+     * Unset reads as on, which is the tree the design project draws: the section is one somebody turns off rather than
+     * one they go looking for, and a deployment deriving nothing answers each view as a folder narrowed to no mail.
+     */
+    readonly aiFiltersShown: boolean;
+
     /** Whether the deployment refused the last change, which is the one thing about this a screen has to say out loud. */
     readonly notStated: boolean;
 
@@ -74,6 +82,7 @@ export interface ClientPreferencesInForce {
     readonly chooseTelemetry: (telemetryEnabled: boolean) => void;
     readonly chooseThreadExpansion: (expandWholeThread: boolean) => void;
     readonly chooseMessageView: (embeddedHtmlMessages: boolean) => void;
+    readonly chooseAiFilters: (aiFiltersShown: boolean) => void;
 }
 
 // What is held, and whose it is. The session is carried beside the document rather than trusted to have stayed the
@@ -223,6 +232,7 @@ export function useClientPreferences(
         telemetryEnabled: inForce.session === null ? rememberedTelemetry(person) : inForce.preferences.telemetryEnabled,
         expandWholeThread: inForce.preferences.expandWholeThread,
         embeddedHtmlMessages: inForce.preferences.embeddedHtmlMessages,
+        aiFiltersShown: inForce.preferences.aiFiltersShown,
         notStated: inForce.notStated,
         chooseTheme: (choice) => {
             setThemeChoice(choice);
@@ -239,6 +249,9 @@ export function useClientPreferences(
         },
         chooseMessageView: (embeddedHtmlMessages) => {
             state({ ...composedFrom(), embeddedHtmlMessages });
+        },
+        chooseAiFilters: (aiFiltersShown) => {
+            state({ ...composedFrom(), aiFiltersShown });
         },
     };
 }

--- a/frontend/src/Client.App/src/preferences/useClientPreferences.ts
+++ b/frontend/src/Client.App/src/preferences/useClientPreferences.ts
@@ -111,7 +111,7 @@ const heldForNobody: HeldPreferences = {
  * offline or the grant does not let it read, and somebody is still signed in through all of that. It decides one thing
  * only — whose remembered telemetry answer the device is asked for — and getting it wrong is what would hand the next
  * person the last person's answer.
- * @returns The settings in force, and the five ways of changing one.
+ * @returns The settings in force, and the six ways of changing one.
  */
 export function useClientPreferences(
     session: ClientSession | null,

--- a/frontend/src/Client.App/src/settings/MessageView.test.tsx
+++ b/frontend/src/Client.App/src/settings/MessageView.test.tsx
@@ -23,12 +23,14 @@ function inForce(
         openMailInTabs: false,
         markReadOnOpen: true,
         expandWholeThread: false,
+        aiFiltersShown: true,
         embeddedHtmlMessages,
         chooseTheme: () => undefined,
         chooseTelemetry: () => undefined,
         chooseTabMode: () => undefined,
         chooseThreadExpansion: () => undefined,
         chooseMessageView,
+        chooseAiFilters: () => undefined,
     };
 }
 

--- a/frontend/src/Client.App/src/settings/Settings.test.tsx
+++ b/frontend/src/Client.App/src/settings/Settings.test.tsx
@@ -23,6 +23,7 @@ const settings: ClientPreferencesInForce = {
     markReadOnOpen: true,
     telemetryEnabled: true,
     expandWholeThread: false,
+    aiFiltersShown: true,
     embeddedHtmlMessages: false,
     notStated: false,
     chooseTheme: () => undefined,
@@ -30,6 +31,7 @@ const settings: ClientPreferencesInForce = {
     chooseTelemetry: () => undefined,
     chooseThreadExpansion: () => undefined,
     chooseMessageView: () => undefined,
+    chooseAiFilters: () => undefined,
 };
 
 const named: OwnProfileInForce = {
@@ -447,6 +449,30 @@ describe('Settings', () => {
         openApplication();
 
         expect(screen.getByRole('switch', { name: /Expand the whole thread/u })).toHaveProperty('checked', true);
+    });
+
+    it('draws the AI filters in the tree as shown, which is what a person who has stated nothing gets', () => {
+        renderSettings();
+        openApplication();
+
+        expect(screen.getByRole('switch', { name: /Show the AI filters/u })).toHaveProperty('checked', true);
+    });
+
+    it('hands the AI-filters switch to what holds the preference', () => {
+        const chooseAiFilters = vi.fn();
+        renderSettings({ preferences: { ...settings, chooseAiFilters } });
+        openApplication();
+
+        fireEvent.click(screen.getByRole('switch', { name: /Show the AI filters/u }));
+
+        expect(chooseAiFilters).toHaveBeenCalledWith(false);
+    });
+
+    it('draws the AI-filters switch as off where the person took the section out of the tree', () => {
+        renderSettings({ preferences: { ...settings, aiFiltersShown: false } });
+        openApplication();
+
+        expect(screen.getByRole('switch', { name: /Show the AI filters/u })).toHaveProperty('checked', false);
     });
 
     it('offers no system-notification switch where the head offered no such operation', () => {

--- a/frontend/src/Client.App/src/settings/Settings.tsx
+++ b/frontend/src/Client.App/src/settings/Settings.tsx
@@ -59,7 +59,7 @@ export function Settings({
     /** Who the client is drawing, and the three ways this surface changes it. */
     readonly profile: OwnProfileInForce;
 
-    /** The settings that follow the person, of which this surface edits three. */
+    /** The settings that follow the person, of which this surface edits four. */
     readonly preferences: ClientPreferencesInForce;
 
     /** What this deployment has said about forwarding this client's telemetry, including that it has said nothing. */

--- a/frontend/src/Client.App/src/settings/Settings.tsx
+++ b/frontend/src/Client.App/src/settings/Settings.tsx
@@ -284,6 +284,11 @@ function Application({
             <ThreadExpansion preferences={preferences} />
             <MessageViewWarning preferences={preferences} />
 
+            <Divider />
+
+            <SectionName>{translate('settings.mailbox')}</SectionName>
+            <AiFiltersSection preferences={preferences} />
+
             <SystemNotifications />
 
             <Divider />
@@ -398,6 +403,24 @@ function ThreadExpansion({ preferences }: { readonly preferences: ClientPreferen
             </span>
 
             <Switch on={preferences.expandWholeThread} onChange={preferences.chooseThreadExpansion} />
+        </label>
+    );
+}
+
+// Whether the folder tree carries the standing views of what MailFathom read. Turning it off removes the section
+// rather than emptying it, which is what the switch says: the views are three sets of filter criteria, and a tree
+// carrying a heading over nothing would read as three views that had failed rather than as a section nobody wanted.
+function AiFiltersSection({ preferences }: { readonly preferences: ClientPreferencesInForce }) {
+    const { translate } = useLocalization();
+
+    return (
+        <label className="flex cursor-pointer items-start gap-2.75 rounded-xl border border-line bg-sunken px-2.5 py-2.25 transition hover:bg-hover">
+            <span className="flex min-w-0 flex-1 flex-col gap-0.75">
+                {translate('settings.aiFilters')}
+                <span className="text-xs text-muted">{translate('settings.aiFiltersExplanation')}</span>
+            </span>
+
+            <Switch on={preferences.aiFiltersShown} onChange={preferences.chooseAiFilters} />
         </label>
     );
 }

--- a/frontend/src/Client.App/src/shell/AccountMenu.test.tsx
+++ b/frontend/src/Client.App/src/shell/AccountMenu.test.tsx
@@ -31,6 +31,7 @@ const settings: ClientPreferencesInForce = {
     markReadOnOpen: true,
     telemetryEnabled: true,
     expandWholeThread: false,
+    aiFiltersShown: true,
     embeddedHtmlMessages: false,
     notStated: false,
     chooseTheme: () => undefined,
@@ -38,6 +39,7 @@ const settings: ClientPreferencesInForce = {
     chooseTelemetry: () => undefined,
     chooseThreadExpansion: () => undefined,
     chooseMessageView: () => undefined,
+    chooseAiFilters: () => undefined,
 };
 
 const nobody: OwnProfileInForce = {

--- a/frontend/src/Client.Backend/src/clientPreferences.test.ts
+++ b/frontend/src/Client.Backend/src/clientPreferences.test.ts
@@ -19,6 +19,7 @@ const stored = {
     markReadOnOpen: false,
     expandWholeThread: true,
     embeddedHtmlMessages: true,
+    aiFiltersShown: false,
 } as const;
 const storedBody = JSON.stringify(stored);
 
@@ -55,7 +56,7 @@ describe('readClientPreferences', () => {
         expect(requests[0]?.headers['Authorization']).toBe('Basic dGVzdA==');
     });
 
-    it('reads the six preferences the deployment answered', async () => {
+    it('reads the seven preferences the deployment answered', async () => {
         const answer = await readClientPreferences(session, answering({ status: 200, body: storedBody }));
 
         expect(answer).toStrictEqual({ outcome: 'read', value: stored });
@@ -114,6 +115,17 @@ describe('readClientPreferences', () => {
                 openMailInTabs: false,
                 markReadOnOpen: true,
                 expandWholeThread: false,
+            }),
+        ],
+        [
+            'an answer from a deployment older than the standing views in the tree',
+            JSON.stringify({
+                telemetryEnabled: true,
+                theme: 'dark',
+                openMailInTabs: false,
+                markReadOnOpen: true,
+                expandWholeThread: false,
+                embeddedHtmlMessages: false,
             }),
         ],
     ])('refuses %s as unreadable rather than reading a document with a hole in it', async (_, body) => {

--- a/frontend/src/Client.Backend/src/clientPreferences.ts
+++ b/frontend/src/Client.Backend/src/clientPreferences.ts
@@ -36,6 +36,9 @@ export interface ClientPreferences {
 
     /** Whether an open message draws the sender's own markup inline rather than the reduced text this client reduces to. */
     readonly embeddedHtmlMessages: boolean;
+
+    /** Whether the folder tree carries the standing views of what a derivation read in the mail. */
+    readonly aiFiltersShown: boolean;
 }
 
 /**
@@ -51,12 +54,13 @@ export const unsetClientPreferences: ClientPreferences = {
     markReadOnOpen: true,
     expandWholeThread: false,
     embeddedHtmlMessages: false,
+    aiFiltersShown: true,
 };
 
 /**
  * The most of one preferences answer this package reads before refusing it.
  *
- * The document is six scalars, so this is far above anything the deployment will legitimately send and far below
+ * The document is seven scalars, so this is far above anything the deployment will legitimately send and far below
  * anything worth buffering. It is the same order the write route bounds its request body at, for the same reason:
  * what the bound guards against is an answer that was never a preferences document.
  */
@@ -142,13 +146,15 @@ function parsePreferences(body: string): ClientPreferences | null {
     const markReadOnOpen = record['markReadOnOpen'];
     const expandWholeThread = record['expandWholeThread'];
     const embeddedHtmlMessages = record['embeddedHtmlMessages'];
+    const aiFiltersShown = record['aiFiltersShown'];
 
     if (
         typeof telemetryEnabled !== 'boolean' ||
         typeof openMailInTabs !== 'boolean' ||
         typeof markReadOnOpen !== 'boolean' ||
         typeof expandWholeThread !== 'boolean' ||
-        typeof embeddedHtmlMessages !== 'boolean'
+        typeof embeddedHtmlMessages !== 'boolean' ||
+        typeof aiFiltersShown !== 'boolean'
     ) {
         return null;
     }
@@ -157,7 +163,15 @@ function parsePreferences(body: string): ClientPreferences | null {
         return null;
     }
 
-    return { telemetryEnabled, theme, openMailInTabs, markReadOnOpen, expandWholeThread, embeddedHtmlMessages };
+    return {
+        telemetryEnabled,
+        theme,
+        openMailInTabs,
+        markReadOnOpen,
+        expandWholeThread,
+        embeddedHtmlMessages,
+        aiFiltersShown,
+    };
 }
 
 function isThemePreference(value: unknown): value is ClientThemePreference {

--- a/frontend/src/Client.Backend/src/mailTimeline.test.ts
+++ b/frontend/src/Client.Backend/src/mailTimeline.test.ts
@@ -21,6 +21,9 @@ const leadingPage: MailTimelineQuery = {
     hasAttachments: null,
     receivedOnOrAfter: null,
     receivedBefore: null,
+    carriesMark: null,
+    markDueOnOrAfter: null,
+    markDueBefore: null,
     order: 'newestFirst',
     direction: 'forward',
     pageSize: 50,
@@ -124,6 +127,31 @@ describe('timelineQueryString', () => {
 
         expect(asked).toContain('receivedOnOrAfter=');
         expect(asked).not.toContain('receivedBefore');
+    });
+
+    it('carries the reading a derivation must have left, spelled as this surface publishes it on a row', () => {
+        expect(timelineQueryString({ ...leadingPage, carriesMark: 'Significance' })).toContain(
+            'carriesMark=Significance',
+        );
+    });
+
+    it('carries the range a commitment falls due in as the two instants that bound it', () => {
+        const asked = timelineQueryString({
+            ...leadingPage,
+            carriesMark: 'Commitment',
+            markDueOnOrAfter: '2026-09-03T00:00:00.000Z',
+            markDueBefore: '2026-09-10T00:00:00.000Z',
+        });
+
+        expect(asked).toContain('markDueOnOrAfter=2026-09-03T00%3A00%3A00.000Z');
+        expect(asked).toContain('markDueBefore=2026-09-10T00%3A00%3A00.000Z');
+    });
+
+    it('leaves out what a derivation read where the list is not narrowed by it', () => {
+        const asked = timelineQueryString(leadingPage);
+
+        expect(asked).not.toContain('carriesMark');
+        expect(asked).not.toContain('markDue');
     });
 
     it('escapes the cursor a previous page answered with', () => {

--- a/frontend/src/Client.Backend/src/mailTimeline.ts
+++ b/frontend/src/Client.Backend/src/mailTimeline.ts
@@ -4,7 +4,7 @@
 
 import { failed, failureReasonForStatus, read, type ClientResult } from './failure';
 import { asRecord } from './json';
-import { parseEnrichment, type MailEnrichment } from './mailEnrichment';
+import { parseEnrichment, type MailEnrichment, type MailEnrichmentAspect } from './mailEnrichment';
 import { headersFor, routeFor, type ClientSession } from './session';
 import { spanned } from './telemetry';
 import { send, type MailFathomTransport } from './transport';
@@ -57,6 +57,25 @@ export interface MailTimelineQuery {
 
     /** The exclusive end of the received range as an instant, or `null` for no end. */
     readonly receivedBefore: string | null;
+
+    /**
+     * The reading a derivation must have left on the message, or `null` to narrow by none.
+     *
+     * The same value a row publishes in {@link MailTimelineEntry.enrichment}, so what narrows the list is what the
+     * list was drawing rather than a second spelling of the same closed set.
+     */
+    readonly carriesMark: MailEnrichmentAspect | null;
+
+    /**
+     * The inclusive start of the range the commitment falls due in, as an instant, or `null` for no start.
+     *
+     * A bound selects dated commitments alone, whichever reading is named beside it: a mark carrying no date meets
+     * neither bound, so a range asked for on its own is a list of what MailFathom read a date out of.
+     */
+    readonly markDueOnOrAfter: string | null;
+
+    /** The exclusive end of that range as an instant, or `null` for no end. */
+    readonly markDueBefore: string | null;
 
     readonly order: MailTimelineOrder;
     readonly direction: MailTimelinePageDirection;
@@ -214,6 +233,9 @@ export function timelineQueryString(query: MailTimelineQuery): string {
         ['folder', query.folder],
         ['receivedOnOrAfter', query.receivedOnOrAfter],
         ['receivedBefore', query.receivedBefore],
+        ['carriesMark', query.carriesMark],
+        ['markDueOnOrAfter', query.markDueOnOrAfter],
+        ['markDueBefore', query.markDueBefore],
     ] as const) {
         if (named !== null) {
             asked.push(`${name}=${encodeURIComponent(named)}`);

--- a/frontend/src/Client.Backend/src/telemetry.test.ts
+++ b/frontend/src/Client.Backend/src/telemetry.test.ts
@@ -407,6 +407,9 @@ describe('what the whole of this package records', () => {
             direction: 'forward',
             receivedOnOrAfter: null,
             receivedBefore: null,
+            carriesMark: null,
+            markDueOnOrAfter: null,
+            markDueBefore: null,
         });
         await readMailSearch(session, refusing, {
             ...window,

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -704,6 +704,7 @@ test('states the whole preferences document to the deployment when one of them i
         markReadOnOpen: true,
         expandWholeThread: false,
         embeddedHtmlMessages: false,
+        aiFiltersShown: true,
     });
 });
 

--- a/frontend/tests/fixtures/deployment.ts
+++ b/frontend/tests/fixtures/deployment.ts
@@ -63,6 +63,7 @@ export const clientPreferences = {
     markReadOnOpen: true,
     expandWholeThread: false,
     embeddedHtmlMessages: false,
+    aiFiltersShown: true,
 };
 
 /** The mailbox everything else in the corpus belongs to, up to date and with nothing to say about itself. */


### PR DESCRIPTION
Closes #1542

The design project draws a `FILTRY AI` section under the mailbox tree with three standing entries. This builds them, and it builds the criteria they stand on — the client half needed a way to ask for mail an enrichment left a mark on, and `/api/client/emails` had none, so both stacks move in one pull request.

## What a standing view is

**A shortcut to filter criteria and nothing else.** Pressing an entry writes `markAspect`, and for the week's deadlines a due window, into the same `MailListFilters` the list's own filter panel draws. The criteria then stand in that panel where every other narrowing stands: each is drawn, each is removable by pressing the lit chip again, and the due window is changeable there. There is no second query path behind the entries, and the tree asks the list rather than reading mail itself — `ListedMail.stand` is the same shape as `selectAll` and `takeFocus`, for the reason those two are there: a folder's filters belong to the list, so the list narrows itself and a tree drawn beside no list narrows nothing.

**Nothing here derives anything.** A view finds what MailFathom already read, so a deployment that has enriched nothing answers each of them with a folder narrowed to no mail rather than with a failure. The empty state says which of the two it is — `list.nothingRead` rather than `list.nothingMatches` — because a reader cannot tell them apart from the mail, and "nothing matched" would leave somebody correcting a filter that was never the reason.

`Wymaga decyzji` stands on the **significance** a derivation recorded. There is no *decision* among the three readings MailFathom stores, so a view claiming to be one would name something nothing produces; this was the owner's decision taken when the task opened.

**The section can be turned off**, and off is the section gone rather than a heading over three missing entries: a heading over nothing would read as three views that had failed. `aiFiltersShown` joins the preferences document as its seventh member and reaches the tree through `AiFiltersShownContext`, on the exception `preferences/messageView.ts` already takes.

**Nothing about the mailbox reaches a log or telemetry.** The client composes a query string and the service reads it; neither writes what was asked for, which message answered, or how many did.

## The service half

`EmailMarkSelection` carries the narrowing — the aspect a mark names, and the range a commitment falls due in. Every criterion is met by **one mark** rather than by the message as a whole, so it reaches PostgreSQL as one correlated existence test over `email_enrichment_marks`, served by that table's own `(StoredEmailId, Aspect)` index. No migration comes with it.

The canonical text a keyset cursor's fingerprint is taken from opens `f3` rather than `f2`, so a cursor issued before this cannot resume a walk it would change.

The three published mark names are `Sense`, `Significance` and `Commitment` — spelled exactly as `enrichment.marks[].aspect` already publishes them on a row of the same route, so a client hands back the value it read rather than translating between two spellings of one closed set.

## Breaking changes

Two, both on the HTTP API, and neither needs an operator to act:

- **`GET /api/client/emails` gains `carriesMark`, `markDueOnOrAfter` and `markDueBefore`.** All three are optional; a request naming none reads exactly as it did. A cursor issued before this merged is refused with `52001 MailboxQueryCursorMalformed` because the fingerprint format moved to `f3` — a client that presents one is answered a refusal and reads the leading page, which is what it already does for a cursor from any older build.
- **The preferences document and both preference routes gain `aiFiltersShown`.** A stored document written before it existed reads as drawn, and a write omitting it stores the drawn answer, so nothing is lost and no operator acts.

## Verification

- `scripts/verify-full.sh` over both stacks.
- Held against the design as images: `mail-list` and `settings-application`, both sides captured at the design project's own four compositions and compared by `scripts/compare-captures.sh`. The folder tree's new section matches the artboard region for region — heading, the three icons, the three labels, the order and the type. The whole-frame difference the report counts for `mail-list` is the two corpora, which is what that pairing has always measured.

## Two things for the owner rather than for review

- **The design project draws no `Mailbox` section on the settings screen**, and the acceptance requires the section be turnable off, so the switch is built where the thread-expansion row's shape already is. The design correction is named in the session report; per the project's own rule it is the owner's to make in the editor rather than an issue to open here.
- **`main` was already red on `pnpm typecheck`** before this branch existed: `thread/ThreadState.test.tsx` and `thread/threadStateSources.test.ts` are missing `enrichment` on a `MailTimelineEntry`, which is merge skew between the change that made the field required and the change that added those fixtures. Two lines here set it to `null` so the gate can go green. The defect is not this change's.

https://github.com/Krzysztof318/MailFathom/issues/1542
