### PR TITLE
[#1780] Refresh the design mirror onto the project's English demo, and pin what it copies to a named list

### DIFF
--- a/.agents/skills/mf-sync-design/SKILL.md
+++ b/.agents/skills/mf-sync-design/SKILL.md
@@ -80,11 +80,15 @@ Four steps, and an unchanged project stops at the second having written nothing 
      bash scripts/design-mirror.sh decode "design/files/<path>"
      ```
 
-   The mirror copies every `.html` screen source and `support.js`, the generated runtime that boots them — without it an
-   artboard renders nothing at all, which is what `scripts/capture-design.sh` needs it for. The project's assets and its
-   thumbnail are not read: they are images rather than text, several megabytes of them would be committed and
-   re-committed at every refresh, and a screen is built from the source rather than from them. The manifest covers
-   **every** file, so one appearing or disappearing is still visible in the diff.
+   The mirror copies the files named in the list at the top of `scripts/design-mirror.sh` — the screen sources, and
+   `support.js`, the generated runtime that boots them, without which an artboard renders nothing at all, which is what
+   `scripts/capture-design.sh` needs it for. **Nothing else is read, and a file the project has gained is not added to
+   that list by a session.** `plan` reports it as having appeared and says so in as many words; whether a public
+   repository carries it is the owner's decision, and the answer arrives as an edit to that list rather than as a file
+   that turned up in a refresh. The project's assets and its thumbnail are the standing case for leaving one out: they
+   are images rather than text, several megabytes of them would be committed and re-committed at every refresh, and a
+   screen is built from the source rather than from them. The manifest covers **every** file, so one appearing or
+   disappearing is still visible in the diff.
 
 4. **Record.** `bash scripts/design-mirror.sh record "$WORK_DIR/listing.json"` writes the manifest and checks every
    mirrored file against the byte count the project states. A mismatch is a transcription that dropped or doubled a

--- a/design/README.md
+++ b/design/README.md
@@ -13,8 +13,8 @@ loop that judges a client screen runs in any clone.
 
 | Path | What it is |
 |---|---|
-| `files/` | The project's screen sources, byte for byte, and `support.js`, the generated runtime that boots them. An artboard is a component that runtime renders rather than a document a browser draws, so a mirror without it renders nothing |
-| `manifest.json` | Every file the project holds — path, size, and the server's own opaque `etag` — including the images that are deliberately not copied. It is what a refresh compares against, and what makes an asset appearing or disappearing visible |
+| `files/` | The screen sources named in `scripts/design-mirror.sh`, byte for byte, and `support.js`, the generated runtime that boots them. An artboard is a component that runtime renders rather than a document a browser draws, so a mirror without it renders nothing |
+| `manifest.json` | Every file the project holds — path, size, and the server's own opaque `etag` — including everything deliberately not copied. It is what a refresh compares against, and what makes a file appearing or disappearing visible |
 | `state-inventory.md` | Every screen, the states it has, what reveals each one, and the states no rendered preview reaches. **This is what a screen is built from**; the sources under `files/` are what it was extracted from |
 | `parity.json` | Which artboard each screen in `frontend/design-parity/screens.json` is drawn on, the properties it takes, and what is pressed to reach it. `scripts/capture-design.sh` reads it |
 
@@ -22,8 +22,11 @@ Both `state-inventory.md` and `parity.json` record the **stamp** — a digest of
 they were written. `bash scripts/design-mirror.sh stamp` prints the mirror's own, and a disagreement means one of them
 is describing an older design.
 
-The project's images are not copied. They are megabytes no screen is built from, and the manifest still records them, so
-one arriving or leaving is visible without any of them being committed.
+**What is copied is a named list rather than a pattern**, and that list lives in `scripts/design-mirror.sh`. This
+repository is public and the project is not, so which of its files reach a public tree is a decision somebody takes by
+editing that list — a file the project gains is reported by a refresh as having appeared and is then left alone. The
+images are the standing case: megabytes no screen is built from. The manifest still records every file, so one arriving
+or leaving is visible without any of them being committed.
 
 ## How it is kept current
 

--- a/design/files/MailFathom Mail Search.html
+++ b/design/files/MailFathom Mail Search.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
-<html lang="pl">
+<html lang="en">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>MailFathom — Wyszukiwanie poczty</title>
+<title>MailFathom — Mail search</title>
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
 <style>
-  /* Barwy MailFathom pochodzą z ikony produktu, a nie z palety przykładowej: te same wartości,
-     które niesie frontend/src/Client.App/src/styles.css. */
+  /* MailFathom colours come from the product icon, not a sample palette: the same values
+     that frontend/src/Client.App/src/styles.css carries. */
   :root {
     color-scheme: light;
     --fathom-950: #010d33; --fathom-800: #0028a0; --fathom-600: #0048e0;
@@ -69,8 +69,8 @@
   .line2 { display: flex; align-items: baseline; gap: 8px; font-size: 14px; }
   .subject { max-width: 50%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .preview { color: var(--faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  /* Trzecia linia. Wiersz jest jeden — folder i wyniki rysują ten sam — a wysokość rezerwuje ją zawsze,
-     więc wiersz, który ma coś do powiedzenia, jest tym samym wierszem, a nie wyższym. */
+  /* Third line. There is one row shape — folder and results draw the same one — and the height always
+     reserves it, so a row with something to say is the same row, not a taller one. */
   .why { height: 16px; overflow: hidden; font-size: 12px; color: var(--faint); }
   .why mark { background: none; color: var(--accent-strong); font-weight: 600; }
   .foot { padding: 8px 12px; font-size: 13px; color: var(--faint); }
@@ -88,125 +88,125 @@
 <div class="sheet">
 
   <header style="display:flex;flex-direction:column;gap:10px">
-    <h1>Wyszukiwanie poczty</h1>
+    <h1>Mail search</h1>
     <p class="lede">
-      Znajdowanie wiadomości stoi na górze poczty, którą ktoś właśnie ogląda, a nie na osobnym ekranie: jedna kolumna,
-      jeden kształt wiersza i nic, do czego trzeba przejść i wrócić. Wyszukiwanie obejmuje zakres, na który ktoś patrzy,
-      a ten zakres jest skopiowany na nie jako filtry — widoczne i możliwe do zdjęcia.
+      Finding a message sits on top of the mail someone is already looking at, not on a separate screen: one column,
+      one row shape, and nothing you have to navigate to and back from. The search covers the scope someone is looking at,
+      and that scope is copied onto it as filters — visible and removable.
     </p>
     <p class="note">
-      Pole przyjmuje dziś słowa i nic więcej. Kolumna poczty w prototypie obiecuje w tym miejscu także opis tego,
-      czego ktoś potrzebuje — to jest praca etapu 3, który pisze filtry ze zdania i ląduje na tym ekranie zamiast go
-      zastępować. Dopóki nie wyląduje, pole obiecuje to, co robi: pole proponujące opis nad serwerem, który umie
-      dopasować tylko słowa, zawodzi człowieka dokładnie w chwili, gdy mu zaufał. Prototyp trzeba w tym jednym miejscu
-      poprawić do <em>Słowa z wiadomości, której szukasz</em>.
+      Today the field takes words and nothing more. The mail column in the prototype also promises a description of
+      what someone needs here — that is stage 3 work, which writes filters from a sentence and lands on this screen
+      instead of replacing it. Until it lands, the field promises what it does: a field inviting a description on top of
+      a server that can only match words fails the person exactly when they trusted it. In this one place the prototype
+      needs to be corrected to <em>Words from the message you are looking for</em>.
     </p>
   </header>
 
   <div class="gallery">
 
     <section class="state">
-      <h2>Wyniki</h2>
+      <h2>Results</h2>
       <div class="column">
         <div class="head">
           <div class="row-actions">
-            <div class="pill" style="flex:1;color:var(--text)">faktura sierpień</div>
-            <button class="btn" type="button">Szukaj</button>
-            <button class="btn" type="button">Zakończ</button>
+            <div class="pill" style="flex:1;color:var(--text)">invoice august</div>
+            <button class="btn" type="button">Search</button>
+            <button class="btn" type="button">Done</button>
           </div>
           <ul class="chips">
-            <li class="chip">Skrzynka: Praca <button aria-label="Usuń filtr Skrzynka: Praca">✕</button></li>
-            <li class="chip">Folder: Odebrane <button aria-label="Usuń filtr Folder: Odebrane">✕</button></li>
-            <li class="chip">Tylko z załącznikami <button aria-label="Usuń filtr Tylko z załącznikami">✕</button></li>
+            <li class="chip">Mailbox: Work <button aria-label="Remove filter Mailbox: Work">✕</button></li>
+            <li class="chip">Folder: Inbox <button aria-label="Remove filter Folder: Inbox">✕</button></li>
+            <li class="chip">With attachments only <button aria-label="Remove filter With attachments only">✕</button></li>
           </ul>
-          <div class="fold">▸ Zawęź to wyszukiwanie</div>
+          <div class="fold">▸ Narrow this search</div>
         </div>
         <div class="rows">
           <div class="row open">
-            <div class="line1"><span class="who">Hanna Wiśniewska</span><span class="org">nordwind.example</span><span class="when">27 sie</span></div>
-            <div class="line2"><span class="subject">Faktura 2026/08/114</span><span class="preview">Przesyłam w załączeniu fakturę za…</span></div>
-            <div class="why">Dlaczego to pasuje: <mark>Faktura</mark> za <mark>sierpień</mark>, numer 114</div>
+            <div class="line1"><span class="who">Hanna Wiśniewska</span><span class="org">nordwind.example</span><span class="when">27 Aug</span></div>
+            <div class="line2"><span class="subject">Invoice 2026/08/114</span><span class="preview">Attached is the invoice for…</span></div>
+            <div class="why">Why this matches: <mark>invoice</mark> for <mark>August</mark>, number 114</div>
           </div>
           <div class="row">
-            <div class="line1"><span class="who">Biuro rachunkowe</span><span class="org">kontor.example</span><span class="when">21 sie</span></div>
-            <div class="line2"><span class="subject">Rozliczenie miesiąca</span><span class="preview">Komplet dokumentów do zamknięcia…</span></div>
-            <div class="why">Pasują te słowa i to, czego dotyczy ta wiadomość.</div>
+            <div class="line1"><span class="who">Accounting office</span><span class="org">kontor.example</span><span class="when">21 Aug</span></div>
+            <div class="line2"><span class="subject">Monthly settlement</span><span class="preview">Full set of documents for the close…</span></div>
+            <div class="why">Both the words and what this message is about match.</div>
           </div>
           <div class="row">
-            <div class="line1"><span class="who">Marek Zieliński</span><span class="org">nordwind.example</span><span class="when">14 sie</span></div>
-            <div class="line2"><span class="subject">Płatność przeszła</span><span class="preview">Potwierdzam, przelew wyszedł wczoraj.</span></div>
-            <div class="why">Znalezione po znaczeniu, a nie po tych słowach.</div>
+            <div class="line1"><span class="who">Marek Zieliński</span><span class="org">nordwind.example</span><span class="when">14 Aug</span></div>
+            <div class="line2"><span class="subject">Payment went through</span><span class="preview">Confirming, the transfer went out yesterday.</span></div>
+            <div class="why">Found by meaning, not by these words.</div>
           </div>
         </div>
-        <div class="foot">To wszystko, co znalazło to wyszukiwanie.</div>
+        <div class="foot">That is everything this search found.</div>
       </div>
       <p class="note">
-        Wiersz jest wierszem listy folderu, a nie drugim kształtem: trzecia linia, którą wysokość wiersza rezerwuje
-        zawsze, niesie tu powód dopasowania. Wyimek pokazuje dopasowane słowa, bo to człowiek może sprawdzić sam;
-        zdanie zastępuje go tylko tam, gdzie serwer nie wyciął żadnego.
+        The row is the folder list row, not a second shape: the third line, which the row height always reserves,
+        carries the reason for the match here. The excerpt shows the matched words, because a person can check those
+        themselves; a sentence replaces it only where the server extracted none.
       </p>
     </section>
 
     <section class="state">
-      <h2>Pusto</h2>
+      <h2>Empty</h2>
       <div class="column">
         <div class="head">
           <div class="row-actions">
-            <div class="pill" style="flex:1;color:var(--text)">umowa najmu</div>
-            <button class="btn" type="button">Szukaj</button>
-            <button class="btn" type="button">Zakończ</button>
+            <div class="pill" style="flex:1;color:var(--text)">lease agreement</div>
+            <button class="btn" type="button">Search</button>
+            <button class="btn" type="button">Done</button>
           </div>
           <ul class="chips">
-            <li class="chip">Folder: Odebrane <button aria-label="Usuń filtr Folder: Odebrane">✕</button></li>
-            <li class="chip">Przyszło 1 sierpnia 2026 lub później <button aria-label="Usuń filtr daty">✕</button></li>
+            <li class="chip">Folder: Inbox <button aria-label="Remove filter Folder: Inbox">✕</button></li>
+            <li class="chip">Arrived on or after 1 August 2026 <button aria-label="Remove date filter">✕</button></li>
           </ul>
         </div>
         <div class="empty">
-          <p>Żadna wiadomość nie pasuje do tego wyszukiwania.</p>
-          <button class="btn" type="button">Przeszukaj zamiast tego całą pocztę</button>
+          <p>No message matches this search.</p>
+          <button class="btn" type="button">Search all mail instead</button>
         </div>
       </div>
       <p class="note">
-        Pusto nigdy nie jest pustym panelem: obok stoi zakres, który to pusto wyprodukował, i jedno naciśnięcie, które
-        je poszerza. Wyszukiwanie zawężone czymś, czego nikt nie widzi, czyta się jak skrzynka, która zgubiła pocztę.
+        Empty is never an empty panel: next to it stands the scope that produced the emptiness, and one press that
+        widens it. A search narrowed by something nobody can see reads like a mailbox that lost the mail.
       </p>
     </section>
 
     <section class="state">
-      <h2>Czekanie, awaria, tylko słowa</h2>
+      <h2>Waiting, failure, words only</h2>
       <div class="column">
         <div class="head">
-          <div class="pill" style="color:var(--text)">faktura sierpień</div>
+          <div class="pill" style="color:var(--text)">invoice august</div>
         </div>
-        <div class="waiting">Przeszukiwanie twojej poczty…</div>
+        <div class="waiting">Searching your mail…</div>
         <div class="banner">
-          Ten serwer nie wyszukuje po znaczeniu, więc te wyniki zawierają wpisane przez ciebie słowa i nic, co
-          zostałoby znalezione wyłącznie po znaczeniu.
+          This server does not search by meaning, so these results contain the words you typed and nothing that
+          would have been found by meaning alone.
         </div>
         <div class="banner">
-          Nie udało się przeprowadzić tego wyszukiwania: nie można się w tej chwili połączyć z serwerem.
+          This search could not be run: the server cannot be reached right now.
         </div>
         <div class="recent">
-          <span class="note" style="width:100%">Wcześniej wyszukiwane</span>
-          <button class="btn" type="button">faktura sierpień</button>
-          <button class="btn" type="button">umowa najmu</button>
-          <button class="btn" type="button">od hanny</button>
-          <button class="btn" type="button">Zapomnij je</button>
+          <span class="note" style="width:100%">Recent searches</span>
+          <button class="btn" type="button">invoice august</button>
+          <button class="btn" type="button">lease agreement</button>
+          <button class="btn" type="button">from hanna</button>
+          <button class="btn" type="button">Forget them</button>
         </div>
       </div>
       <p class="note">
-        Serwer, który nie umie szukać po znaczeniu, mówi to osobno od tego, czego nie wolno pytającemu: pierwsze
-        jest brakiem serwera, drugie odmową wobec człowieka. Wcześniejsze wyszukiwania żyją wyłącznie w stanie
-        klienta i znikają razem z poświadczeniem — żadna wpisana fraza nie trafia do logu ani do telemetrii.
+        A server that cannot search by meaning says so separately from what the asker is not allowed to see: the first
+        is a shortcoming of the server, the second a refusal towards a person. Recent searches live only in client
+        state and disappear with the credential — no typed phrase reaches a log or telemetry.
       </p>
     </section>
 
   </div>
 
   <footer class="note">
-    Ten ekran jest zaimplementowany w <code>frontend/src/Client.App/src/search/</code>. Zawężenie po folderze oferuje
-    dziś role folderów, a nie całe drzewo kont — folder spoza ról trafia na wyszukiwanie przez to, na co ktoś patrzył,
-    i stoi na nim jako filtr do zdjęcia.
+    This screen is implemented in <code>frontend/src/Client.App/src/search/</code>. Narrowing by folder currently
+    offers folder roles rather than the whole account tree — a folder outside those roles reaches the search through
+    whatever someone was looking at, and stands on it as a removable filter.
   </footer>
 
 </div>

--- a/design/files/MailFathom Notification Gesture.dc.html
+++ b/design/files/MailFathom Notification Gesture.dc.html
@@ -12,11 +12,11 @@
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,300,0,0&display=block" rel="stylesheet" />
 <style>
   html, body { margin: 0; padding: 0; background: oklch(0.980 0.004 88); }
-  body:has([data-theme="ciemny"]) { background: oklch(0.183 0.016 262); }
+  body:has([data-theme="dark"]) { background: oklch(0.183 0.016 262); }
   a { color: var(--accent); }
   a:hover { color: var(--accent-2); }
-  [data-theme="jasny"] { color-scheme:light;--bg:oklch(0.980 0.004 88);--panel:#ffffff;--rail:oklch(0.951 0.006 88);--hover:oklch(0.906 0.010 88);--sub:oklch(0.969 0.005 88);--line:oklch(0.906 0.008 88);--line2:oklch(0.949 0.005 88);--border2:oklch(0.856 0.010 88);--text:oklch(0.240 0.014 262);--text2:oklch(0.420 0.012 240);--muted:oklch(0.565 0.010 200);--faint:oklch(0.690 0.009 160);--accent:oklch(0.555 0.185 262);--accent-2:oklch(0.465 0.175 262);--accent-d:oklch(0.385 0.150 262);--accent-soft:oklch(0.945 0.038 258);--accent-line:oklch(0.870 0.062 258);--onaccent:#ffffff;--ok:oklch(0.56 0.14 155);--ok-text:oklch(0.44 0.11 155);--ok-soft:oklch(0.945 0.038 155);--warn:oklch(0.62 0.155 62);--warn-soft:oklch(0.955 0.045 75);--warn-text:oklch(0.46 0.135 55);--err:oklch(0.545 0.195 25);--err-soft:oklch(0.958 0.028 25);--err-text:oklch(0.470 0.180 25);--hl:oklch(0.945 0.070 88);--hl-line:oklch(0.775 0.145 85);--inset:rgba(255,255,255,0.65);--sh-1:oklch(0.30 0.02 262 / 0.07);--sh-2:oklch(0.30 0.025 262 / 0.14);--sh-3:oklch(0.28 0.03 262 / 0.28);--scrim:oklch(0.26 0.03 262 / 0.36); }
-  [data-theme="ciemny"] { color-scheme:dark;--bg:oklch(0.183 0.016 262);--panel:oklch(0.246 0.016 262);--rail:oklch(0.212 0.017 262);--hover:oklch(0.325 0.021 262);--sub:oklch(0.277 0.016 262);--line:oklch(0.336 0.018 262);--line2:oklch(0.283 0.015 262);--border2:oklch(0.416 0.022 262);--text:oklch(0.945 0.007 262);--text2:oklch(0.835 0.011 262);--muted:oklch(0.705 0.013 262);--faint:oklch(0.585 0.015 262);--accent:oklch(0.615 0.175 262);--accent-2:oklch(0.735 0.150 262);--accent-d:oklch(0.865 0.085 262);--accent-soft:oklch(0.320 0.070 262);--accent-line:oklch(0.430 0.095 262);--onaccent:#ffffff;--ok:oklch(0.72 0.14 155);--ok-text:oklch(0.82 0.12 155);--ok-soft:oklch(0.30 0.045 155);--warn:oklch(0.74 0.13 55);--warn-soft:oklch(0.315 0.05 50);--warn-text:oklch(0.87 0.10 62);--err:oklch(0.660 0.190 25);--err-soft:oklch(0.325 0.078 22);--err-text:oklch(0.845 0.105 25);--hl:oklch(0.345 0.055 85);--hl-line:oklch(0.72 0.13 85);--inset:rgba(255,255,255,0.045);--sh-1:oklch(0.10 0.03 262 / 0.38);--sh-2:oklch(0.10 0.03 262 / 0.50);--sh-3:oklch(0.09 0.035 262 / 0.64);--scrim:oklch(0.12 0.045 262 / 0.66); }
+  [data-theme="light"] { color-scheme:light;--bg:oklch(0.980 0.004 88);--panel:#ffffff;--rail:oklch(0.951 0.006 88);--hover:oklch(0.906 0.010 88);--sub:oklch(0.969 0.005 88);--line:oklch(0.906 0.008 88);--line2:oklch(0.949 0.005 88);--border2:oklch(0.856 0.010 88);--text:oklch(0.240 0.014 262);--text2:oklch(0.420 0.012 240);--muted:oklch(0.565 0.010 200);--faint:oklch(0.690 0.009 160);--accent:oklch(0.555 0.185 262);--accent-2:oklch(0.465 0.175 262);--accent-d:oklch(0.385 0.150 262);--accent-soft:oklch(0.945 0.038 258);--accent-line:oklch(0.870 0.062 258);--onaccent:#ffffff;--ok:oklch(0.56 0.14 155);--ok-text:oklch(0.44 0.11 155);--ok-soft:oklch(0.945 0.038 155);--warn:oklch(0.62 0.155 62);--warn-soft:oklch(0.955 0.045 75);--warn-text:oklch(0.46 0.135 55);--err:oklch(0.545 0.195 25);--err-soft:oklch(0.958 0.028 25);--err-text:oklch(0.470 0.180 25);--hl:oklch(0.945 0.070 88);--hl-line:oklch(0.775 0.145 85);--inset:rgba(255,255,255,0.65);--sh-1:oklch(0.30 0.02 262 / 0.07);--sh-2:oklch(0.30 0.025 262 / 0.14);--sh-3:oklch(0.28 0.03 262 / 0.28);--scrim:oklch(0.26 0.03 262 / 0.36); }
+  [data-theme="dark"] { color-scheme:dark;--bg:oklch(0.183 0.016 262);--panel:oklch(0.246 0.016 262);--rail:oklch(0.212 0.017 262);--hover:oklch(0.325 0.021 262);--sub:oklch(0.277 0.016 262);--line:oklch(0.336 0.018 262);--line2:oklch(0.283 0.015 262);--border2:oklch(0.416 0.022 262);--text:oklch(0.945 0.007 262);--text2:oklch(0.835 0.011 262);--muted:oklch(0.705 0.013 262);--faint:oklch(0.585 0.015 262);--accent:oklch(0.615 0.175 262);--accent-2:oklch(0.735 0.150 262);--accent-d:oklch(0.865 0.085 262);--accent-soft:oklch(0.320 0.070 262);--accent-line:oklch(0.430 0.095 262);--onaccent:#ffffff;--ok:oklch(0.72 0.14 155);--ok-text:oklch(0.82 0.12 155);--ok-soft:oklch(0.30 0.045 155);--warn:oklch(0.74 0.13 55);--warn-soft:oklch(0.315 0.05 50);--warn-text:oklch(0.87 0.10 62);--err:oklch(0.660 0.190 25);--err-soft:oklch(0.325 0.078 22);--err-text:oklch(0.845 0.105 25);--hl:oklch(0.345 0.055 85);--hl-line:oklch(0.72 0.13 85);--inset:rgba(255,255,255,0.045);--sh-1:oklch(0.10 0.03 262 / 0.38);--sh-2:oklch(0.10 0.03 262 / 0.50);--sh-3:oklch(0.09 0.035 262 / 0.64);--scrim:oklch(0.12 0.045 262 / 0.66); }
 </style>
 </helmet>
 <div data-theme="{{ themeAttr }}" style="min-height:100vh;box-sizing:border-box;padding:26px;background:var(--bg);color:var(--text);font-family:'Instrument Sans',system-ui,sans-serif;display:flex;flex-direction:column;gap:22px">
@@ -24,8 +24,8 @@
   <div style="display:flex;align-items:flex-end;justify-content:space-between;gap:18px;flex-wrap:wrap">
     <div style="display:flex;flex-direction:column;gap:4px">
       <div style="font-size:11px;letter-spacing:0.10em;text-transform:uppercase;color:var(--muted)">MailFathom — system · #1507</div>
-      <div style="font-size:27px;font-weight:600;letter-spacing:-0.02em">Centrum powiadomień: gesty</div>
-      <div style="font-size:13.5px;color:var(--muted);max-width:74ch;text-wrap:pretty">Na telefonie panel powiadomień ma dwa gesty na całej powierzchni: ruch w górę rozpoczęty gdziekolwiek na belce nawigacji wyciąga go, ruch w dół rozpoczęty gdziekolwiek na otwartym panelu — na nagłówku, na filtrach, na wierszu, na pustym stanie — odsuwa go. Dotknięcie dzwonka zostaje bez zmian jako druga droga do tego samego panelu. Osobnego uchwytu „tylko górna belka” już nie ma.</div>
+      <div style="font-size:27px;font-weight:600;letter-spacing:-0.02em">Notification centre: gestures</div>
+      <div style="font-size:13.5px;color:var(--muted);max-width:74ch;text-wrap:pretty">On a phone the notification panel has two gestures across its whole surface: an upward move started anywhere on the nav bar pulls it out; a downward move started anywhere on the open panel — the header, the filters, a row, the empty state — pushes it away. Tapping the bell is unchanged as a second route to the same panel. There is no separate “top handle only” grip any more.</div>
     </div>
     <div onClick="{{ toggleTheme }}" style="display:flex;align-items:center;gap:8px;height:36px;padding:0 14px;border:1px solid var(--border2);border-radius:10px;font-size:13px;color:var(--text2)" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1">{{ themeIcon }}</span>{{ themeAttr }}</div>
   </div>
@@ -51,8 +51,8 @@
         <div style="position:absolute;left:50%;bottom:104px;margin-left:-9px;font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1;color:var(--accent)">keyboard_arrow_up</div>
       </div>
       <div style="display:flex;flex-direction:column;gap:3px">
-        <div style="font-size:14px;font-weight:600">1 · Belka w spoczynku</div>
-        <div style="font-size:12.5px;color:var(--muted);line-height:1.45;text-wrap:pretty">Palec dotknął belki, przebył 0 px. Do 12 px to nadal dotknięcie tego elementu belki — panel jeszcze nie istnieje.</div>
+        <div style="font-size:14px;font-weight:600">1 · Bar at rest</div>
+        <div style="font-size:12.5px;color:var(--muted);line-height:1.45;text-wrap:pretty">The finger touched the bar and travelled 0 px. Up to 12 px it is still a tap on that bar item — the panel does not exist yet.</div>
       </div>
     </div>
 
@@ -69,12 +69,12 @@
           <div style="flex:0 0 auto;display:flex;align-items:center;justify-content:center;padding:8px 0 2px"><span style="width:38px;height:4px;border-radius:2px;background:var(--border2)"></span></div>
           <div style="flex:0 0 auto;display:flex;align-items:center;gap:8px;padding:12px 12px 10px 14px;border-bottom:1px solid var(--line2)">
             <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1;color:var(--muted)">notifications</span>
-            <div style="flex:1;min-width:0;font-size:14px;font-weight:600">Powiadomienia</div>
-            <div style="height:20px;padding:0 7px;display:flex;align-items:center;border-radius:6px;background:var(--accent-soft);color:var(--accent-d);font-size:10.5px;font-weight:600">3 nowe</div>
+            <div style="flex:1;min-width:0;font-size:14px;font-weight:600">Notifications</div>
+            <div style="height:20px;padding:0 7px;display:flex;align-items:center;border-radius:6px;background:var(--accent-soft);color:var(--accent-d);font-size:10.5px;font-weight:600">3 new</div>
           </div>
           <div style="flex:0 0 auto;display:flex;align-items:center;gap:6px;padding:9px 12px;border-bottom:1px solid var(--line2);background:var(--sub)">
-            <div style="height:24px;padding:0 9px;display:flex;align-items:center;border-radius:7px;border:1px solid var(--accent);background:var(--accent-soft);color:var(--accent-d);font-size:10.5px;font-weight:600">Wszystkie</div>
-            <div style="height:24px;padding:0 9px;display:flex;align-items:center;border-radius:7px;border:1px solid var(--border2);background:var(--panel);color:var(--text2);font-size:10.5px">Nieprzeczytane · 3</div>
+            <div style="height:24px;padding:0 9px;display:flex;align-items:center;border-radius:7px;border:1px solid var(--accent);background:var(--accent-soft);color:var(--accent-d);font-size:10.5px;font-weight:600">All</div>
+            <div style="height:24px;padding:0 9px;display:flex;align-items:center;border-radius:7px;border:1px solid var(--border2);background:var(--panel);color:var(--text2);font-size:10.5px">Unread · 3</div>
           </div>
           <sc-for list="{{ rows }}" as="r" hint-placeholder-count="3">
             <div style="flex:0 0 auto;display:flex;gap:9px;padding:11px 12px;border-bottom:1px solid var(--line2)">
@@ -96,8 +96,8 @@
         <div style="position:absolute;left:50%;top:222px;margin-left:-9px;font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1;color:var(--accent)">keyboard_arrow_up</div>
       </div>
       <div style="display:flex;flex-direction:column;gap:3px">
-        <div style="font-size:14px;font-weight:600">2 · Gest w połowie drogi</div>
-        <div style="font-size:12.5px;color:var(--muted);line-height:1.45;text-wrap:pretty">Panel stoi dokładnie tam, gdzie palec: przebyte 0,54 wysokości panelu, krycie przesłony 0,54. Bez wygładzania i bez opóźnienia — puszczenie w tym miejscu otwiera panel, bo 0,54 &gt; 0,32.</div>
+        <div style="font-size:14px;font-weight:600">2 · Gesture halfway</div>
+        <div style="font-size:12.5px;color:var(--muted);line-height:1.45;text-wrap:pretty">The panel sits exactly where the finger is: 0.54 of the panel height travelled, scrim opacity 0.54. No smoothing and no delay — releasing here opens the panel, because 0.54 &gt; 0.32.</div>
       </div>
     </div>
 
@@ -108,14 +108,14 @@
           <div style="flex:0 0 auto;display:flex;align-items:center;justify-content:center;padding:8px 0 2px"><span style="width:38px;height:4px;border-radius:2px;background:var(--border2)"></span></div>
           <div style="flex:0 0 auto;display:flex;align-items:center;gap:8px;padding:12px 12px 10px 14px;border-bottom:1px solid var(--line2)">
             <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1;color:var(--muted)">notifications</span>
-            <div style="flex:1;min-width:0;font-size:14px;font-weight:600">Powiadomienia</div>
-            <div style="height:20px;padding:0 7px;display:flex;align-items:center;border-radius:6px;background:var(--accent-soft);color:var(--accent-d);font-size:10.5px;font-weight:600">3 nowe</div>
+            <div style="flex:1;min-width:0;font-size:14px;font-weight:600">Notifications</div>
+            <div style="height:20px;padding:0 7px;display:flex;align-items:center;border-radius:6px;background:var(--accent-soft);color:var(--accent-d);font-size:10.5px;font-weight:600">3 new</div>
             <div style="width:26px;height:26px;display:flex;align-items:center;justify-content:center;border-radius:8px;color:var(--muted);font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">close</div>
           </div>
           <div style="flex:0 0 auto;display:flex;align-items:center;gap:4px;padding:9px 10px;border-bottom:1px solid var(--line2);background:var(--sub)">
-            <div style="flex:0 0 auto;height:24px;padding:0 6px;display:flex;align-items:center;border-radius:7px;border:1px solid var(--accent);background:var(--accent-soft);color:var(--accent-d);font-size:10px;font-weight:600;white-space:nowrap">Wszystkie</div>
-            <div style="flex:0 0 auto;height:24px;padding:0 6px;display:flex;align-items:center;border-radius:7px;border:1px solid var(--border2);background:var(--panel);color:var(--text2);font-size:10px;white-space:nowrap">Nieprzeczytane</div>
-            <div style="margin-left:auto;font-size:10px;color:var(--accent-d);white-space:nowrap">Oznacz wszystkie</div>
+            <div style="flex:0 0 auto;height:24px;padding:0 6px;display:flex;align-items:center;border-radius:7px;border:1px solid var(--accent);background:var(--accent-soft);color:var(--accent-d);font-size:10px;font-weight:600;white-space:nowrap">All</div>
+            <div style="flex:0 0 auto;height:24px;padding:0 6px;display:flex;align-items:center;border-radius:7px;border:1px solid var(--border2);background:var(--panel);color:var(--text2);font-size:10px;white-space:nowrap">Unread</div>
+            <div style="margin-left:auto;font-size:10px;color:var(--accent-d);white-space:nowrap">Mark all read</div>
           </div>
           <sc-for list="{{ rowsFull }}" as="r" hint-placeholder-count="5">
             <div style="flex:0 0 auto;display:flex;gap:9px;padding:11px 12px;border-bottom:1px solid var(--line2)">
@@ -134,8 +134,8 @@
         </div>
       </div>
       <div style="display:flex;flex-direction:column;gap:3px">
-        <div style="font-size:14px;font-weight:600">3 · Panel otwarty</div>
-        <div style="font-size:12.5px;color:var(--muted);line-height:1.45;text-wrap:pretty">Gest dokonany: droga 1,0, przesłona pełna, belka zostaje widoczna pod panelem. Ten sam stan, do którego prowadzi dotknięcie dzwonka.</div>
+        <div style="font-size:14px;font-weight:600">3 · Panel open</div>
+        <div style="font-size:12.5px;color:var(--muted);line-height:1.45;text-wrap:pretty">Gesture committed: distance 1.0, scrim full, the bar stays visible under the panel. The same state a tap on the bell leads to.</div>
       </div>
     </div>
 
@@ -150,12 +150,12 @@
           <div style="flex:0 0 auto;display:flex;align-items:center;justify-content:center;padding:8px 0 2px"><span style="width:38px;height:4px;border-radius:2px;background:var(--border2)"></span></div>
           <div style="flex:0 0 auto;display:flex;align-items:center;gap:8px;padding:12px 12px 10px 14px;border-bottom:1px solid var(--line2)">
             <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1;color:var(--muted)">notifications</span>
-            <div style="flex:1;min-width:0;font-size:14px;font-weight:600">Powiadomienia</div>
-            <div style="height:20px;padding:0 7px;display:flex;align-items:center;border-radius:6px;background:var(--accent-soft);color:var(--accent-d);font-size:10.5px;font-weight:600">3 nowe</div>
+            <div style="flex:1;min-width:0;font-size:14px;font-weight:600">Notifications</div>
+            <div style="height:20px;padding:0 7px;display:flex;align-items:center;border-radius:6px;background:var(--accent-soft);color:var(--accent-d);font-size:10.5px;font-weight:600">3 new</div>
           </div>
           <div style="flex:0 0 auto;display:flex;align-items:center;gap:6px;padding:9px 12px;border-bottom:1px solid var(--line2);background:var(--sub)">
-            <div style="height:24px;padding:0 9px;display:flex;align-items:center;border-radius:7px;border:1px solid var(--accent);background:var(--accent-soft);color:var(--accent-d);font-size:10.5px;font-weight:600">Wszystkie</div>
-            <div style="height:24px;padding:0 9px;display:flex;align-items:center;border-radius:7px;border:1px solid var(--border2);background:var(--panel);color:var(--text2);font-size:10.5px">Nieprzeczytane · 3</div>
+            <div style="height:24px;padding:0 9px;display:flex;align-items:center;border-radius:7px;border:1px solid var(--accent);background:var(--accent-soft);color:var(--accent-d);font-size:10.5px;font-weight:600">All</div>
+            <div style="height:24px;padding:0 9px;display:flex;align-items:center;border-radius:7px;border:1px solid var(--border2);background:var(--panel);color:var(--text2);font-size:10.5px">Unread · 3</div>
           </div>
           <sc-for list="{{ rowsFull }}" as="r" hint-placeholder-count="4">
             <div style="flex:0 0 auto;display:flex;gap:9px;padding:11px 12px;border-bottom:1px solid var(--line2)">
@@ -174,18 +174,18 @@
         </div>
         <div style="position:absolute;left:20px;top:60px;width:34px;height:34px;border-radius:50%;border:2px dashed var(--accent);opacity:0.7"></div>
         <div style="position:absolute;left:58px;top:68px;font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1;color:var(--accent)">keyboard_arrow_up</div>
-        <div style="position:absolute;left:16px;right:16px;top:16px;display:flex;align-items:center;justify-content:center;height:26px;border-radius:8px;background:var(--panel);border:1px solid var(--accent-line);font-size:10.5px;color:var(--accent-d)">powrót 260 ms</div>
+        <div style="position:absolute;left:16px;right:16px;top:16px;display:flex;align-items:center;justify-content:center;height:26px;border-radius:8px;background:var(--panel);border:1px solid var(--accent-line);font-size:10.5px;color:var(--accent-d)">spring back 260 ms</div>
       </div>
       <div style="display:flex;flex-direction:column;gap:3px">
-        <div style="font-size:14px;font-weight:600">4 · Powrót sprężyną</div>
-        <div style="font-size:12.5px;color:var(--muted);line-height:1.45;text-wrap:pretty">Palec puszczony po 0,24 wysokości panelu z prędkością 0,2 px/ms — ani droga, ani prędkość nie sięga progu, więc panel wraca na miejsce w 260 ms krzywą cubic-bezier(.32,.72,0,1). Przesłona wraca tą samą krzywą.</div>
+        <div style="font-size:14px;font-weight:600">4 · Spring back</div>
+        <div style="font-size:12.5px;color:var(--muted);line-height:1.45;text-wrap:pretty">The finger was released after 0.24 of the panel height at 0.2 px/ms — neither distance nor velocity reaches the threshold, so the panel returns in 260 ms on a cubic-bezier(.32,.72,0,1) curve. The scrim returns on the same curve.</div>
       </div>
     </div>
 
   </div>
 
   <div style="display:flex;flex-direction:column;gap:12px">
-    <div style="font-size:16px;font-weight:600">Liczby, z których czyta implementacja</div>
+    <div style="font-size:16px;font-weight:600">The numbers the implementation reads</div>
     <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(268px,1fr));gap:12px">
       <sc-for list="{{ numbers }}" as="n" hint-placeholder-count="6">
         <div style="display:flex;flex-direction:column;gap:7px;background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:14px">
@@ -200,7 +200,7 @@
   </div>
 
   <div style="display:flex;flex-direction:column;gap:12px">
-    <div style="font-size:16px;font-weight:600">Kto komu oddaje gest</div>
+    <div style="font-size:16px;font-weight:600">Who hands the gesture to whom</div>
     <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:12px">
       <sc-for list="{{ handovers }}" as="h" hint-placeholder-count="3">
         <div style="display:flex;flex-direction:column;gap:8px;background:var(--sub);border:1px solid var(--line);border-radius:12px;padding:14px">
@@ -216,13 +216,13 @@
   </div>
 
   <div style="display:flex;flex-direction:column;gap:9px;background:var(--warn-soft);border:1px solid var(--hl-line);border-radius:12px;padding:14px 16px">
-    <div style="font-size:13.5px;font-weight:600;color:var(--warn-text)">Gdzie to działa</div>
-    <div style="font-size:12.5px;color:var(--text2);line-height:1.5;max-width:88ch;text-wrap:pretty">Tylko kompozycja telefonu i tylko przy wskaźniku zgrubnym (<span style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:11.5px">pointer: coarse</span>). Fold, tablet i biurko zostają dokładnie przy tym, co rysują dziś: panel wjeżdża z lewej obok szyny, zamyka go przesłona, krzyżyk albo Escape — żadnego gestu ciągnięcia, bo tam nie ma belki nawigacji na dole.</div>
+    <div style="font-size:13.5px;font-weight:600;color:var(--warn-text)">Where this applies</div>
+    <div style="font-size:12.5px;color:var(--text2);line-height:1.5;max-width:88ch;text-wrap:pretty">Phone layout only, and only with a coarse pointer (<span style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:11.5px">pointer: coarse</span>). Fold, tablet and desktop keep exactly what they draw today: the panel slides in from the left next to the rail and closes via the scrim, the close button or Escape — no drag gesture, because there is no bottom nav bar there.</div>
   </div>
 
 </div>
 </x-dc>
-<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1240,&quot;height&quot;:1180},&quot;theme&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;jasny&quot;,&quot;ciemny&quot;],&quot;default&quot;:&quot;jasny&quot;,&quot;tsType&quot;:&quot;\&quot;jasny\&quot; | \&quot;ciemny\&quot;&quot;}}">
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1240,&quot;height&quot;:1180},&quot;theme&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;light&quot;,&quot;dark&quot;],&quot;default&quot;:&quot;light&quot;,&quot;tsType&quot;:&quot;\&quot;light\&quot; | \&quot;dark\&quot;&quot;}}">
 class Component extends DCLogic {
   state = { theme: null };
 
@@ -236,38 +236,38 @@ class Component extends DCLogic {
   }));
 
   renderVals() {
-    const theme = this.state.theme ?? (this.props.theme ?? "jasny");
+    const theme = this.state.theme ?? (this.props.theme ?? "light");
     return {
       themeAttr: theme,
-      themeIcon: theme === "ciemny" ? "dark_mode" : "light_mode",
-      toggleTheme: () => this.setState({ theme: theme === "ciemny" ? "jasny" : "ciemny" }),
+      themeIcon: theme === "dark" ? "dark_mode" : "light_mode",
+      toggleTheme: () => this.setState({ theme: theme === "dark" ? "light" : "dark" }),
       barIcons: this.bar(1),
       barIconsOpen: this.bar(4),
       rows: [{ icon: "mail", iconWrapStyle: this.icon("accent") }, { icon: "event", iconWrapStyle: this.icon("ok") }, { icon: "task_alt", iconWrapStyle: this.icon() }],
       rowsFull: [{ icon: "mail", iconWrapStyle: this.icon("accent") }, { icon: "event", iconWrapStyle: this.icon("ok") }, { icon: "task_alt", iconWrapStyle: this.icon() }, { icon: "topic", iconWrapStyle: this.icon("accent") }, { icon: "group", iconWrapStyle: this.icon() }],
       numbers: [
-        { value: "1:1", name: "Podążanie za palcem", text: "Panel stoi tam, gdzie palec — bez wygładzania, bez bezwładności, bez opóźnienia. Punkt zerowy ustawia się w chwili przejęcia gestu, nie w chwili dotknięcia, więc panel nigdy nie przeskakuje o wielkość slopu." },
-        { value: "= droga", name: "Krycie przesłony", text: "Krycie przesłony to wprost przebyta droga podzielona przez wysokość panelu: 0 przy zamkniętym, 1 przy otwartym. Ta sama liczba w obie strony gestu." },
-        { value: "0,32", name: "Próg drogi", text: "Gest dokonuje się, gdy palec przebył więcej niż 0,32 wysokości panelu — liczone od miejsca przejęcia gestu, nie od krawędzi ekranu." },
-        { value: "0,5 px/ms", name: "Próg prędkości", text: "Krótki rzut powyżej 0,5 px/ms dokonuje gestu nawet poniżej progu drogi. Prędkość liczona z ostatniego odcinka ruchu; rzut w przeciwną stronę zawsze wygrywa z drogą." },
-        { value: "260 ms", name: "Powrót sprężyną", text: "Gdy nie sięgnięto ani drogi, ani prędkości, panel wraca na miejsce w 260 ms krzywą cubic-bezier(.32,.72,0,1). Ta jedna krzywa obsługuje oba kierunki powrotu." },
-        { value: "12 / 10 px", name: "Slop belki i wiersza", text: "12 px w górę zabiera dotknięcie belce nawigacji, 10 px w dół zabiera długie przytrzymanie wierszowi. Pierwszy próg jest większy, bo belka ma cel dotknięcia i pomyłka kosztuje przejście na inny ekran." },
+        { value: "1:1", name: "Follows the finger", text: "The panel sits where the finger is — no smoothing, no inertia, no delay. The zero point is set the moment the gesture is taken over, not on touch, so the panel never jumps by the slop distance." },
+        { value: "= distance", name: "Scrim opacity", text: "Scrim opacity is simply the distance travelled divided by panel height: 0 when closed, 1 when open. The same number in both directions of the gesture." },
+        { value: "0.32", name: "Distance threshold", text: "The gesture commits once the finger has travelled more than 0.32 of the panel height — measured from where the gesture was taken over, not from the screen edge." },
+        { value: "0.5 px/ms", name: "Velocity threshold", text: "A short flick above 0.5 px/ms commits the gesture even below the distance threshold. Velocity is measured over the last segment of movement; a flick in the opposite direction always beats distance." },
+        { value: "260 ms", name: "Spring back", text: "When neither distance nor velocity was met, the panel returns in 260 ms on a cubic-bezier(.32,.72,0,1) curve. That single curve serves both directions of return." },
+        { value: "12 / 10 px", name: "Bar and row slop", text: "12 px upward takes the tap away from the nav bar; 10 px downward takes the long press away from a row. The first threshold is larger because the bar has a tap target and a mistake costs a jump to another screen." },
       ],
       handovers: [
         {
-          icon: "swipe_down", name: "Przewinięta lista oddaje gest panelowi", iconWrapStyle: this.icon("accent"),
-          text: "Gdy lista powiadomień nie jest na swojej górze, ruch w dół przewija najpierw listę. Panel nie rusza się ani o piksel.",
-          rule: "Jedno pociągnięcie, bez podnoszenia palca: w chwili, gdy lista dojdzie do góry, ten sam ruch staje się oddaleniem panelu. Punkt zerowy ustawia się właśnie wtedy — pozostała droga liczy się od tego miejsca, więc panel nie skacze na spotkanie palca.",
+          icon: "swipe_down", name: "A scrolled list hands the gesture to the panel", iconWrapStyle: this.icon("accent"),
+          text: "When the notification list is not at its top, a downward move scrolls the list first. The panel does not move a single pixel.",
+          rule: "One drag, without lifting the finger: the moment the list reaches the top, the same move becomes a panel dismissal. The zero point is set right then — the remaining distance counts from there, so the panel does not jump to meet the finger.",
         },
         {
-          icon: "touch_app", name: "Wiersz: przeciągnięcie albo przytrzymanie", iconWrapStyle: this.icon("ok"),
-          text: "Ruch przekraczający 10 px kasuje 420 ms długiego przytrzymania — menu kontekstowe wiersza już się nie otworzy.",
-          rule: "W drugą stronę też szczelnie: gdy menu zdąży się otworzyć, ten sam palec nie zaczyna już oddalania panelu, a nowy gest oddalenia nie startuje przy otwartym menu. Nigdy oba, nigdy żadne.",
+          icon: "touch_app", name: "Row: drag or long press", iconWrapStyle: this.icon("ok"),
+          text: "Movement beyond 10 px cancels the 420 ms long press — the row context menu will not open.",
+          rule: "Tight the other way too: once the menu has opened, that same finger no longer starts a panel dismissal, and a new dismissal gesture does not start while the menu is open. Never both, never neither.",
         },
         {
-          icon: "swipe_up", name: "Belka nawigacji oddaje gest panelowi", iconWrapStyle: this.icon(),
-          text: "Do 12 px w górę gest należy do elementu belki, na którym się zaczął — puszczenie to zwykłe dotknięcie i przejście na tamten ekran.",
-          rule: "Po 12 px belka oddaje gest: dotknięcie przepada i nie odpali się przy puszczeniu, a panel wyjeżdża spod palca. Ruch w dół rozpoczęty na belce nie jest niczyim gestem — nic się nie dzieje.",
+          icon: "swipe_up", name: "The nav bar hands the gesture to the panel", iconWrapStyle: this.icon(),
+          text: "Up to 12 px upward the gesture belongs to the bar item it started on — releasing is an ordinary tap and navigates to that screen.",
+          rule: "After 12 px the bar hands over: the tap is cancelled and will not fire on release, and the panel comes out from under the finger. A downward move started on the bar belongs to nobody — nothing happens.",
         },
       ],
     };

--- a/design/files/MailFathom Prototype.dc.html
+++ b/design/files/MailFathom Prototype.dc.html
@@ -13,15 +13,15 @@
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
 <!--
   IKONY — Material Symbols (Rounded), Google.  LICENCJA: Apache License 2.0.
-  Font webowy (użyty tutaj): https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded
-  Przeglądarka / pobieranie SVG: https://fonts.google.com/icons
-  Repozytorium źródłowe (SVG + font): https://github.com/google/material-design-icons
+  Web font (used here): https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded
+  Browser / SVG download: https://fonts.google.com/icons
+  Source repository (SVG + font): https://github.com/google/material-design-icons
     - pojedyncze SVG: symbols/web/<nazwa>/materialsymbolsrounded/<nazwa>_<waga>grad0.svg
-    - pełny tekst licencji: https://github.com/google/material-design-icons/blob/master/LICENSE
-  Android natywnie: te same symbole dostępne w androidx.compose.material:material-icons-extended (Apache-2.0)
-    oraz jako font Material Symbols (com.google.android.material) — https://github.com/material-components/material-components-android (Apache-2.0)
+    - full licence text: https://github.com/google/material-design-icons/blob/master/LICENSE
+  Android natively: the same symbols are available in androidx.compose.material:material-icons-extended (Apache-2.0)
+    and as the Material Symbols font (com.google.android.material) — https://github.com/material-components/material-components-android (Apache-2.0)
   W kodzie ikona = nazwa ligatury z katalogu Google (np. "mail", "reply", "flag"), waga 300, styl Rounded, FILL 0.
-  Zamienniki na MIT, jeśli potrzebny inny styl kreski (1:1 z nazwami do przemapowania):
+  MIT alternatives if a different stroke style is needed (1:1 name remapping):
     Tabler Icons  — https://github.com/tabler/tabler-icons  (MIT)
     Feather Icons — https://github.com/feathericons/feather (MIT)
     Phosphor      — https://github.com/phosphor-icons/core  (MIT)
@@ -29,12 +29,12 @@
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,300,0,0&display=block" rel="stylesheet" />
 <style>
   html, body { margin: 0; padding: 0; background: oklch(0.980 0.004 88); min-height: 100%; }
-  html:has([data-theme="ciemny"]), body:has([data-theme="ciemny"]) { background: oklch(0.183 0.016 262); }
+  html:has([data-theme="dark"]), body:has([data-theme="dark"]) { background: oklch(0.183 0.016 262); }
   input::placeholder { color: var(--faint); }
   [data-rail]::-webkit-scrollbar { width: 0; height: 0; }
   [data-rail] { scrollbar-width: none; }
-  [data-theme="jasny"] { color-scheme:light;--bg:oklch(0.980 0.004 88);--panel:#ffffff;--rail:oklch(0.951 0.006 88);--hover:oklch(0.906 0.010 88);--sub:oklch(0.969 0.005 88);--line:oklch(0.906 0.008 88);--line2:oklch(0.949 0.005 88);--border2:oklch(0.856 0.010 88);--text:oklch(0.240 0.014 262);--text2:oklch(0.420 0.012 240);--muted:oklch(0.565 0.010 200);--faint:oklch(0.690 0.009 160);--accent:oklch(0.555 0.185 262);--accent-2:oklch(0.465 0.175 262);--accent-d:oklch(0.385 0.150 262);--accent-soft:oklch(0.945 0.038 258);--accent-line:oklch(0.870 0.062 258);--onaccent:#ffffff;--ok:oklch(0.56 0.14 155);--ok-text:oklch(0.44 0.11 155);--ok-soft:oklch(0.945 0.038 155);--warn:oklch(0.62 0.155 62);--warn-soft:oklch(0.955 0.045 75);--warn-text:oklch(0.46 0.135 55);--hl:oklch(0.945 0.070 88);--hl-line:oklch(0.775 0.145 85);--inset:rgba(255,255,255,0.65);--sh-1:oklch(0.30 0.02 262 / 0.07);--sh-2:oklch(0.30 0.025 262 / 0.14);--sh-3:oklch(0.28 0.03 262 / 0.28);--scrim:oklch(0.26 0.03 262 / 0.36);--err:oklch(0.545 0.195 25);--err-soft:oklch(0.958 0.028 25);--err-text:oklch(0.470 0.180 25); }
-  [data-theme="ciemny"] { color-scheme:dark;--bg:oklch(0.183 0.016 262);--panel:oklch(0.246 0.016 262);--rail:oklch(0.212 0.017 262);--hover:oklch(0.325 0.021 262);--sub:oklch(0.277 0.016 262);--line:oklch(0.336 0.018 262);--line2:oklch(0.283 0.015 262);--border2:oklch(0.416 0.022 262);--text:oklch(0.945 0.007 262);--text2:oklch(0.835 0.011 262);--muted:oklch(0.705 0.013 262);--faint:oklch(0.585 0.015 262);--accent:oklch(0.615 0.175 262);--accent-2:oklch(0.735 0.150 262);--accent-d:oklch(0.865 0.085 262);--accent-soft:oklch(0.320 0.070 262);--accent-line:oklch(0.430 0.095 262);--onaccent:#ffffff;--ok:oklch(0.72 0.14 155);--ok-text:oklch(0.82 0.12 155);--ok-soft:oklch(0.30 0.045 155);--warn:oklch(0.74 0.13 55);--warn-soft:oklch(0.315 0.05 50);--warn-text:oklch(0.87 0.10 62);--hl:oklch(0.345 0.055 85);--hl-line:oklch(0.72 0.13 85);--inset:rgba(255,255,255,0.045);--sh-1:oklch(0.10 0.03 262 / 0.38);--sh-2:oklch(0.10 0.03 262 / 0.50);--sh-3:oklch(0.09 0.035 262 / 0.64);--scrim:oklch(0.12 0.045 262 / 0.66);--err:oklch(0.660 0.190 25);--err-soft:oklch(0.325 0.078 22);--err-text:oklch(0.845 0.105 25); }
+  [data-theme="light"] { color-scheme:light;--bg:oklch(0.980 0.004 88);--panel:#ffffff;--rail:oklch(0.951 0.006 88);--hover:oklch(0.906 0.010 88);--sub:oklch(0.969 0.005 88);--line:oklch(0.906 0.008 88);--line2:oklch(0.949 0.005 88);--border2:oklch(0.856 0.010 88);--text:oklch(0.240 0.014 262);--text2:oklch(0.420 0.012 240);--muted:oklch(0.565 0.010 200);--faint:oklch(0.690 0.009 160);--accent:oklch(0.555 0.185 262);--accent-2:oklch(0.465 0.175 262);--accent-d:oklch(0.385 0.150 262);--accent-soft:oklch(0.945 0.038 258);--accent-line:oklch(0.870 0.062 258);--onaccent:#ffffff;--ok:oklch(0.56 0.14 155);--ok-text:oklch(0.44 0.11 155);--ok-soft:oklch(0.945 0.038 155);--warn:oklch(0.62 0.155 62);--warn-soft:oklch(0.955 0.045 75);--warn-text:oklch(0.46 0.135 55);--hl:oklch(0.945 0.070 88);--hl-line:oklch(0.775 0.145 85);--inset:rgba(255,255,255,0.65);--sh-1:oklch(0.30 0.02 262 / 0.07);--sh-2:oklch(0.30 0.025 262 / 0.14);--sh-3:oklch(0.28 0.03 262 / 0.28);--scrim:oklch(0.26 0.03 262 / 0.36);--err:oklch(0.545 0.195 25);--err-soft:oklch(0.958 0.028 25);--err-text:oklch(0.470 0.180 25); }
+  [data-theme="dark"] { color-scheme:dark;--bg:oklch(0.183 0.016 262);--panel:oklch(0.246 0.016 262);--rail:oklch(0.212 0.017 262);--hover:oklch(0.325 0.021 262);--sub:oklch(0.277 0.016 262);--line:oklch(0.336 0.018 262);--line2:oklch(0.283 0.015 262);--border2:oklch(0.416 0.022 262);--text:oklch(0.945 0.007 262);--text2:oklch(0.835 0.011 262);--muted:oklch(0.705 0.013 262);--faint:oklch(0.585 0.015 262);--accent:oklch(0.615 0.175 262);--accent-2:oklch(0.735 0.150 262);--accent-d:oklch(0.865 0.085 262);--accent-soft:oklch(0.320 0.070 262);--accent-line:oklch(0.430 0.095 262);--onaccent:#ffffff;--ok:oklch(0.72 0.14 155);--ok-text:oklch(0.82 0.12 155);--ok-soft:oklch(0.30 0.045 155);--warn:oklch(0.74 0.13 55);--warn-soft:oklch(0.315 0.05 50);--warn-text:oklch(0.87 0.10 62);--hl:oklch(0.345 0.055 85);--hl-line:oklch(0.72 0.13 85);--inset:rgba(255,255,255,0.045);--sh-1:oklch(0.10 0.03 262 / 0.38);--sh-2:oklch(0.10 0.03 262 / 0.50);--sh-3:oklch(0.09 0.035 262 / 0.64);--scrim:oklch(0.12 0.045 262 / 0.66);--err:oklch(0.660 0.190 25);--err-soft:oklch(0.325 0.078 22);--err-text:oklch(0.845 0.105 25); }
   a { color: var(--accent); }
   a:hover { color: var(--accent-2); }
   input { font-family: inherit; }
@@ -76,7 +76,7 @@
             <span style="{{ notifDotStyle }}">{{ notifCountLabel }}</span>
           </sc-if>
         </div>
-        <div style="{{ railLabelStyle }}">Alerty</div>
+        <div style="{{ railLabelStyle }}">Alerts</div>
       </div>
     </sc-if>
     <div onClick="{{ goTasks }}" style="{{ railTasksStyle }}" style-hover="background:var(--hover);cursor:pointer">
@@ -94,17 +94,17 @@
     <sc-if value="{{ isPhone }}" hint-placeholder-val="{{ false }}">
       <div onClick="{{ toggleMore }}" style="{{ railMoreStyle }}" style-hover="background:var(--hover);cursor:pointer">
         <div style="{{ railIconStyle }}">more_horiz</div>
-        <div style="{{ railLabelStyle }}">Więcej</div>
+        <div style="{{ railLabelStyle }}">More</div>
       </div>
     </sc-if>
     <sc-if value="{{ notMobile }}" hint-placeholder-val="{{ true }}">
       <div ref="{{ userMenuRef }}" style="margin-top:auto;padding-top:10px;flex:0 0 auto;position:relative;display:flex;flex-direction:column;align-items:center;gap:8px">
-        <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:10px;letter-spacing:0.08em;color:var(--faint);text-align:center;line-height:1.4">PROTO<br />TYP</div>
+        <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:10px;letter-spacing:0.08em;color:var(--faint);text-align:center;line-height:1.4">PROTO<br />TYPE</div>
         <sc-if value="{{ userMenuOpen }}" hint-placeholder-val="{{ false }}">
           <div style="position:fixed;bottom:18px;left:106px;width:216px;z-index:60;display:flex;flex-direction:column;background:var(--panel);border:1px solid var(--line);border-radius:12px;box-shadow:0 1px 0 var(--inset) inset,0 10px 24px var(--sh-2),0 2px 6px var(--sh-2);overflow:hidden">
             <div style="display:flex;flex-direction:column;gap:1px;padding:11px 13px 9px 13px;border-bottom:1px solid var(--line2)">
               <div style="font-size:13px;font-weight:600">{{ meName }}</div>
-              <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:9.5px;letter-spacing:0.09em;color:var(--faint);padding-top:6px">SKRZYNKI</div>
+              <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:9.5px;letter-spacing:0.09em;color:var(--faint);padding-top:6px">MAILBOXES</div>
               <sc-for list="{{ userMailboxes }}" as="mb" hint-placeholder-count="2">
                 <div onClick="{{ mb.pick }}" style="{{ mb.style }}" style-hover="cursor:pointer;background:var(--hover)">
                   <span style="flex:0 0 6px;width:6px;height:6px;border-radius:50%;background:{{ mb.dot }}"></span>
@@ -115,12 +115,12 @@
             </div>
             <div onClick="{{ toggleTabsMode }}" style="{{ tabsRowStyle }}" style-hover="cursor:pointer;background:var(--hover)">
               <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:19px;line-height:1;width:22px;text-align:center">tab</span>
-              <span style="flex:1;min-width:0;display:flex;flex-direction:column;gap:1px">Tryb zakładek<sc-if value="{{ tabsRowNote }}" hint-placeholder-val="{{ false }}"><span style="font-size:10.5px;color:var(--faint)">{{ tabsRowNote }}</span></sc-if></span>
+              <span style="flex:1;min-width:0;display:flex;flex-direction:column;gap:1px">Tab mode<sc-if value="{{ tabsRowNote }}" hint-placeholder-val="{{ false }}"><span style="font-size:10.5px;color:var(--faint)">{{ tabsRowNote }}</span></sc-if></span>
               <span style="{{ tabsSwitchStyle }}"><span style="{{ denseKnobStyle }}"></span></span>
             </div>
             <div style="display:flex;flex-direction:column;gap:7px;padding:10px 13px;border-bottom:1px solid var(--line2)">
               <div style="display:flex;align-items:center;gap:10px;font-size:13px">
-                <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:19px;line-height:1;width:22px;text-align:center">dark_mode</span>Motyw
+                <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:19px;line-height:1;width:22px;text-align:center">dark_mode</span>Theme
               </div>
               <div style="display:flex;gap:3px;background:var(--rail);border:1px solid var(--line);border-radius:9px;padding:2px">
                 <sc-for list="{{ themeSegs }}" as="ts" hint-placeholder-count="3">
@@ -129,14 +129,14 @@
               </div>
             </div>
             <div onClick="{{ openSettings }}" style="display:flex;align-items:center;gap:10px;padding:10px 13px;font-size:13px" style-hover="cursor:pointer;background:var(--hover)">
-              <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:19px;line-height:1;width:22px;text-align:center">settings</span>Ustawienia
+              <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:19px;line-height:1;width:22px;text-align:center">settings</span>Settings
             </div>
             <div style="display:flex;align-items:center;gap:10px;padding:10px 13px;font-size:13px;color:var(--muted);border-top:1px solid var(--line2)" style-hover="cursor:pointer;background:var(--hover)">
               <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:19px;line-height:1;width:22px;text-align:center">logout</span>Wyloguj
             </div>
           </div>
         </sc-if>
-        <div onClick="{{ toggleNotifCenter }}" title="Powiadomienia" style="{{ railBellStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)">
+        <div onClick="{{ toggleNotifCenter }}" title="Notifications" style="{{ railBellStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)">
           <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 400;font-size:25px;line-height:1">{{ railBellIcon }}</span>
           <sc-if value="{{ notifHasUnread }}" hint-placeholder-val="{{ true }}">
             <span style="{{ notifBadgeStyle }}">{{ notifCountLabel }}</span>
@@ -150,15 +150,15 @@
   <sc-if value="{{ isDiscover }}" hint-placeholder-val="{{ true }}">
     <div style="flex:1;display:flex;flex-direction:column;min-width:0;min-height:0">
       <div style="{{ headerStyle }}">
-        <div style="font-size:16px;font-weight:600">Odkrywaj</div>
+        <div style="font-size:16px;font-weight:600">Discover</div>
         <sc-if value="{{ notMobile }}" hint-placeholder-val="{{ true }}">
-          <div style="display:flex;align-items:center;gap:8px;font-size:13px;color:var(--muted)"><span style="width:7px;height:7px;border-radius:50%;background:var(--ok)"></span>Synchronizacja 2 min temu · 3 konta</div>
+          <div style="display:flex;align-items:center;gap:8px;font-size:13px;color:var(--muted)"><span style="width:7px;height:7px;border-radius:50%;background:var(--ok)"></span>Synced 2 min ago · 3 accounts</div>
         </sc-if>
         <div style="margin-left:auto;display:flex;gap:10px;align-items:center">
           <sc-if value="{{ hasRun }}" hint-placeholder-val="{{ false }}">
             <div style="display:flex;gap:9px;align-items:center">
-              <div onClick="{{ continueInAgent }}" style="display:flex;align-items:center;gap:8px;font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:7px 14px" style-hover="cursor:pointer;opacity:0.9"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">auto_awesome</span>Kontynuuj z agentem</div>
-              <div onClick="{{ reset }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:7px;padding:7px 14px" style-hover="background:var(--rail);cursor:pointer">Nowe pytanie</div>
+              <div onClick="{{ continueInAgent }}" style="display:flex;align-items:center;gap:8px;font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:7px 14px" style-hover="cursor:pointer;opacity:0.9"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">auto_awesome</span>Continue with the agent</div>
+              <div onClick="{{ reset }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:7px;padding:7px 14px" style-hover="background:var(--rail);cursor:pointer">New question</div>
             </div>
           </sc-if>
         </div>
@@ -167,11 +167,11 @@
       <div style="{{ searchWrapStyle }}">
         <div style="{{ searchBoxStyle }}">
           <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.06em;color:var(--onaccent);background:var(--accent);border-radius:5px;padding:4px 8px">AI</div>
-          <input value="{{ query }}" onChange="{{ onQuery }}" onKeyDown="{{ onKey }}" placeholder="O co chcesz zapytać swoją pocztę?" style="flex:1;min-width:0;border:none;outline:none;font-size:16px;color:var(--text);background:transparent" />
-          <div onClick="{{ submit }}" style="font-size:13px;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:8px 16px;white-space:nowrap" style-hover="opacity:0.88;cursor:pointer">Zapytaj ⏎</div>
+          <input value="{{ query }}" onChange="{{ onQuery }}" onKeyDown="{{ onKey }}" placeholder="What do you want to ask your mail?" style="flex:1;min-width:0;border:none;outline:none;font-size:16px;color:var(--text);background:transparent" />
+          <div onClick="{{ submit }}" style="font-size:13px;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:8px 16px;white-space:nowrap" style-hover="opacity:0.88;cursor:pointer">Ask ⏎</div>
         </div>
         <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
-          <div style="font-size:13px;background:var(--rail);border:1px solid var(--line);border-radius:16px;padding:5px 12px">Wszystkie skrzynki<span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:16px;line-height:1;vertical-align:-3px;margin-left:3px">expand_more</span></div>
+          <div style="font-size:13px;background:var(--rail);border:1px solid var(--line);border-radius:16px;padding:5px 12px">All mailboxes<span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:16px;line-height:1;vertical-align:-3px;margin-left:3px">expand_more</span></div>
           <div style="font-size:13px;background:var(--rail);border:1px solid var(--line);border-radius:16px;padding:5px 12px">2019–2026<span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:16px;line-height:1;vertical-align:-3px;margin-left:3px">expand_more</span></div>
           <sc-if value="{{ hasRun }}" hint-placeholder-val="{{ false }}">
             <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
@@ -186,12 +186,12 @@
         <div style="{{ idleStyle }}">
           <div style="{{ idleMainStyle }}">
             <div style="{{ briefingWrapStyle }}">
-              <div style="{{ idleTitleStyle }}">Dzień dobry, Karolino</div>
+              <div style="{{ idleTitleStyle }}">Good morning, Karolina</div>
               <div style="display:flex;flex-direction:column;gap:10px;background:var(--panel);border:1px solid var(--line);border-left:3px solid var(--accent);border-radius:11px;padding:15px 17px">
                 <div style="display:flex;align-items:center;gap:9px">
                   <span style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:10px;letter-spacing:0.06em;color:var(--onaccent);background:var(--accent);border-radius:4px;padding:3px 7px">AI</span>
-                  <span style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">ODPRAWA PORANNA</span>
-                  <span style="margin-left:auto;font-size:11px;color:var(--faint)">czwartek, 27 sierpnia</span>
+                  <span style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">MORNING BRIEFING</span>
+                  <span style="margin-left:auto;font-size:11px;color:var(--faint)">Thursday, 27 August</span>
                 </div>
                 <div style="font-size:16px;line-height:1.55;color:var(--text2);text-wrap:pretty">{{ briefingText }}</div>
                 <div style="{{ briefingStatsStyle }}">
@@ -205,7 +205,7 @@
               </div>
             </div>
             <div style="display:flex;flex-direction:column;gap:10px">
-              <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">DZIŚ WYMAGA CIEBIE</div>
+              <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">NEEDS YOU TODAY</div>
               <div style="{{ todoGridStyle }}">
                 <sc-for list="{{ todayItems }}" as="ti" hint-placeholder-count="3">
                   <div onClick="{{ ti.open }}" style="{{ ti.style }}" style-hover="cursor:pointer;background:var(--hover)">
@@ -221,7 +221,7 @@
             </div>
 
             <div style="display:flex;flex-direction:column;gap:10px">
-              <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">SPRÓBUJ</div>
+              <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">TRY THIS</div>
               <sc-for list="{{ suggestions }}" as="s" hint-placeholder-count="3">
                 <div onClick="{{ s.pick }}" style="{{ sugRowStyle }}" style-hover="border-color:var(--accent);cursor:pointer">
                   <div style="font-size:15px;text-wrap:pretty">{{ s.text }}</div>
@@ -241,19 +241,19 @@
               <div style="display:flex;align-items:center;gap:12px;background:var(--panel);border:1px solid var(--line);border-radius:9px;padding:14px 18px">
                 <div style="width:8px;height:8px;flex:0 0 8px;border-radius:50%;background:var(--accent);animation:mfpulse 1s ease-in-out infinite"></div>
                 <div style="font-size:14px;color:var(--text2);text-wrap:pretty">{{ progressText }}</div>
-                <div onClick="{{ reset }}" style="margin-left:auto;font-size:13px;color:var(--muted);border:1px solid var(--border2);border-radius:7px;padding:6px 12px;white-space:nowrap" style-hover="background:var(--rail);cursor:pointer">Anuluj run</div>
+                <div onClick="{{ reset }}" style="margin-left:auto;font-size:13px;color:var(--muted);border:1px solid var(--border2);border-radius:7px;padding:6px 12px;white-space:nowrap" style-hover="background:var(--rail);cursor:pointer">Cancel run</div>
               </div>
             </sc-if>
 
             <sc-if value="{{ answerReady }}" hint-placeholder-val="{{ false }}">
               <div style="display:flex;flex-direction:column;gap:9px;background:var(--panel);border:1px solid var(--line);border-left:3px solid var(--accent);border-radius:9px;padding:16px 18px">
                 <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
-                  <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">ODPOWIEDŹ</div>
+                  <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">ANSWER</div>
                   <div style="font-size:11px;background:var(--ok-soft);color:var(--ok-text);border-radius:11px;padding:3px 9px">{{ confidence }}</div>
                   <sc-if value="{{ gapNote }}" hint-placeholder-val="{{ false }}">
                     <div style="font-size:11px;background:var(--warn-soft);color:var(--warn);border-radius:11px;padding:3px 9px">{{ gapNote }}</div>
                   </sc-if>
-                  <div style="{{ answerHintStyle }}">kliknij cytowanie, aby zobaczyć dowód</div>
+                  <div style="{{ answerHintStyle }}">click a citation to see the evidence</div>
                 </div>
                 <div style="font-size:17px;line-height:1.5;text-wrap:pretty">
                   <sc-for list="{{ answerParts }}" as="p" hint-placeholder-count="2">
@@ -265,7 +265,7 @@
 
             <sc-if value="{{ timelineReady }}" hint-placeholder-val="{{ false }}">
               <div style="display:flex;flex-direction:column;gap:12px;background:var(--panel);border:1px solid var(--line);border-radius:9px;padding:16px 18px">
-                <div style="display:flex;align-items:center;gap:10px"><div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">OŚ CZASU</div><div style="margin-left:auto;font-size:12px;color:var(--muted)">4 zdarzenia · 2021–2026</div></div>
+                <div style="display:flex;align-items:center;gap:10px"><div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">TIMELINE</div><div style="margin-left:auto;font-size:12px;color:var(--muted)">4 events · 2021–2026</div></div>
                 <div style="{{ timelineRowStyle }}">
                   <sc-for list="{{ timeline }}" as="t" hint-placeholder-count="4">
                     <div onClick="{{ t.open }}" style="{{ tlItemStyle }}" style-hover="cursor:pointer;border-top-color:var(--accent)">
@@ -280,13 +280,13 @@
 
             <sc-if value="{{ tableReady }}" hint-placeholder-val="{{ false }}">
               <div style="display:flex;flex-direction:column;gap:10px;background:var(--panel);border:1px solid var(--line);border-radius:9px;padding:16px 18px">
-                <div style="display:flex;align-items:center;gap:10px"><div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">TABELA FAKTÓW</div><div style="{{ answerHintStyle }}">każda komórka ma źródło</div></div>
+                <div style="display:flex;align-items:center;gap:10px"><div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">FACT TABLE</div><div style="{{ answerHintStyle }}">every cell has a source</div></div>
                 <div style="overflow-x:auto">
                   <div style="{{ tableGridStyle }}">
-                    <div style="font-size:12px;color:var(--muted);border-bottom:1px solid var(--line);padding:0 10px 8px 0">Wersja</div>
-                    <div style="font-size:12px;color:var(--muted);border-bottom:1px solid var(--line);padding:0 10px 8px 0">Cena</div>
+                    <div style="font-size:12px;color:var(--muted);border-bottom:1px solid var(--line);padding:0 10px 8px 0">Version</div>
+                    <div style="font-size:12px;color:var(--muted);border-bottom:1px solid var(--line);padding:0 10px 8px 0">Price</div>
                     <div style="font-size:12px;color:var(--muted);border-bottom:1px solid var(--line);padding:0 10px 8px 0">SLA</div>
-                    <div style="font-size:12px;color:var(--muted);border-bottom:1px solid var(--line);padding:0 0 8px 0">Indeksacja</div>
+                    <div style="font-size:12px;color:var(--muted);border-bottom:1px solid var(--line);padding:0 0 8px 0">Indexation</div>
                     <sc-for list="{{ table }}" as="r" hint-placeholder-count="4">
                       <div style="{{ r.version.cellStyle }}"><span>{{ r.version.value }}</span><sc-if value="{{ r.version.hasCite }}" hint-placeholder-val="{{ false }}"><sup onClick="{{ r.version.open }}" style="font-size:11px;color:var(--accent-d);background:var(--accent-soft);border-radius:4px;padding:2px 6px" style-hover="background:var(--accent-2);color:var(--onaccent);cursor:pointer">{{ r.version.cite }}</sup></sc-if></div>
                       <div style="{{ r.price.cellStyle }}"><span>{{ r.price.value }}</span><sc-if value="{{ r.price.hasCite }}" hint-placeholder-val="{{ false }}"><sup onClick="{{ r.price.open }}" style="font-size:11px;color:var(--accent-d);background:var(--accent-soft);border-radius:4px;padding:2px 6px" style-hover="background:var(--accent-2);color:var(--onaccent);cursor:pointer">{{ r.price.cite }}</sup></sc-if></div>
@@ -300,7 +300,7 @@
 
             <sc-if value="{{ galleryReady }}" hint-placeholder-val="{{ false }}">
               <div style="display:flex;flex-direction:column;gap:12px;background:var(--panel);border:1px solid var(--line);border-radius:9px;padding:16px 18px">
-                <div style="display:flex;align-items:center;gap:10px"><div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">ZAŁĄCZNIKI</div><div style="{{ answerHintStyle }}">4 pliki · sortowane po wersji</div></div>
+                <div style="display:flex;align-items:center;gap:10px"><div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">ATTACHMENTS</div><div style="{{ answerHintStyle }}">4 files · sorted by version</div></div>
                 <div style="{{ galleryGridStyle }}">
                   <sc-for list="{{ gallery }}" as="g" hint-placeholder-count="4">
                     <div onClick="{{ g.open }}" style="display:flex;flex-direction:column;gap:7px;background:var(--sub);border:1px solid var(--line);border-radius:8px;padding:13px 14px" style-hover="border-color:var(--accent);cursor:pointer">
@@ -315,7 +315,7 @@
 
             <sc-if value="{{ peopleReady }}" hint-placeholder-val="{{ false }}">
               <div style="display:flex;flex-direction:column;gap:12px;background:var(--panel);border:1px solid var(--line);border-radius:9px;padding:16px 18px">
-                <div style="display:flex;align-items:center;gap:10px"><div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">OSOBY</div><div style="{{ answerHintStyle }}">3 osoby · rola w sprawie</div></div>
+                <div style="display:flex;align-items:center;gap:10px"><div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">PEOPLE</div><div style="{{ answerHintStyle }}">3 people · role in the case</div></div>
                 <sc-for list="{{ people }}" as="p" hint-placeholder-count="3">
                   <div onClick="{{ p.open }}" style="display:flex;align-items:center;gap:14px;border-bottom:1px solid var(--line2);padding:10px 0" style-hover="cursor:pointer">
                     <div style="width:32px;height:32px;flex:0 0 32px;border-radius:50%;background:var(--accent-soft);color:var(--accent-d);display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:600">{{ p.initials }}</div>
@@ -329,21 +329,21 @@
             <sc-if value="{{ actionReady }}" hint-placeholder-val="{{ false }}">
               <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;background:var(--accent-soft);border:1px solid var(--accent-line);border-radius:9px;padding:13px 16px">
                 <span style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:10px;letter-spacing:0.06em;color:var(--onaccent);background:var(--accent);border-radius:4px;padding:3px 7px">AI</span>
-                <span style="font-size:14px;color:var(--text2);text-wrap:pretty">Chcesz dopytać albo kazać coś z tym zrobić?</span>
-                <div onClick="{{ continueInAgent }}" style="margin-left:auto;font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:8px 15px;white-space:nowrap" style-hover="cursor:pointer;opacity:0.9">Przenieś do agenta</div>
+                <span style="font-size:14px;color:var(--text2);text-wrap:pretty">Want to dig deeper, or have something done with this?</span>
+                <div onClick="{{ continueInAgent }}" style="margin-left:auto;font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:8px 15px;white-space:nowrap" style-hover="cursor:pointer;opacity:0.9">Hand to the agent</div>
               </div>
               <div style="{{ actionRowStyle }}">
-                <div style="display:flex;flex-direction:column;gap:3px"><div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">SUGEROWANE DZIAŁANIE</div><div style="font-size:14px;text-wrap:pretty">{{ actionText }}</div></div>
+                <div style="display:flex;flex-direction:column;gap:3px"><div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">SUGGESTED ACTION</div><div style="font-size:14px;text-wrap:pretty">{{ actionText }}</div></div>
                 <div style="{{ actionBtnsStyle }}">
-                  <div style="font-size:13px;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:8px 15px" style-hover="opacity:0.88;cursor:pointer">Zapisz jako Sprawę</div>
-                  <div style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:7px;padding:8px 15px" style-hover="background:var(--rail);cursor:pointer">Odrzuć</div>
+                  <div style="font-size:13px;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:8px 15px" style-hover="opacity:0.88;cursor:pointer">Save as Case</div>
+                  <div style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:7px;padding:8px 15px" style-hover="background:var(--rail);cursor:pointer">Dismiss</div>
                 </div>
               </div>
             </sc-if>
 
             <sc-if value="{{ showTrace }}" hint-placeholder-val="{{ false }}">
               <div style="display:flex;flex-direction:column;gap:6px;background:var(--sub);border:1px solid var(--line);border-radius:9px;padding:14px 18px">
-                <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">ŚLAD DECYZJI</div>
+                <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">DECISION TRAIL</div>
                 <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:12px;color:var(--text2);line-height:1.6">{{ traceText }}</div>
               </div>
             </sc-if>
@@ -353,7 +353,7 @@
             <sc-if value="{{ inspectorClosed }}" hint-placeholder-val="{{ true }}">
               <div style="{{ evWrapStyle }}">
                 <div style="display:flex;flex-direction:column;gap:3px;padding:15px 18px;border-bottom:1px solid var(--line)">
-                  <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">DOWODY</div>
+                  <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">EVIDENCE</div>
                   <div style="font-size:15px;font-weight:600">{{ evidenceCount }}</div>
                 </div>
                 <div style="{{ evListStyle }}">
@@ -370,7 +370,7 @@
             <sc-if value="{{ inspectorOpen }}" hint-placeholder-val="{{ false }}">
               <div style="display:flex;flex-direction:column;min-height:0;flex:1;background:var(--sub)">
                 <div style="display:flex;align-items:center;gap:10px;padding:13px 18px;border-bottom:1px solid var(--line);background:var(--panel)">
-                  <div onClick="{{ closeInspector }}" style="font-size:13px;color:var(--muted)" style-hover="cursor:pointer;color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:16px;line-height:1;vertical-align:-3px;margin-right:5px">arrow_back</span>Dowody</div>
+                  <div onClick="{{ closeInspector }}" style="font-size:13px;color:var(--muted)" style-hover="cursor:pointer;color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:16px;line-height:1;vertical-align:-3px;margin-right:5px">arrow_back</span>Evidence</div>
                   <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">{{ inspectorIndex }}</div>
                 </div>
                 <div style="display:flex;flex-direction:column;gap:4px;padding:14px 18px;border-bottom:1px solid var(--line);background:var(--panel)">
@@ -383,12 +383,12 @@
                   <div style="font-size:13px;color:var(--faint);line-height:1.55">{{ inspectorPost }}</div>
                   <div style="display:flex;flex-direction:column;gap:8px;background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:13px 15px">
                     <div style="font-size:13px;color:var(--text2);line-height:1.45">Fragment podpiera: {{ inspectorSupports }}</div>
-                    <div style="font-size:12px;color:var(--faint)">Wiadomość: {{ inspectorMail }}</div>
+                    <div style="font-size:12px;color:var(--faint)">Message: {{ inspectorMail }}</div>
                   </div>
                 </div>
                 <div style="display:flex;gap:9px;flex-wrap:wrap;padding:14px 18px;border-top:1px solid var(--line);background:var(--panel)">
-                  <div onClick="{{ openInMail }}" style="font-size:13px;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:9px 16px" style-hover="opacity:0.88;cursor:pointer">Otwórz w poczcie <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:16px;line-height:1;vertical-align:-3px;margin-left:4px">arrow_forward</span></div>
-                  <div style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:7px;padding:9px 16px" style-hover="background:var(--rail);cursor:pointer">Dodaj do Sprawy</div>
+                  <div onClick="{{ openInMail }}" style="font-size:13px;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:9px 16px" style-hover="opacity:0.88;cursor:pointer">Open in mail <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:16px;line-height:1;vertical-align:-3px;margin-left:4px">arrow_forward</span></div>
+                  <div style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:7px;padding:9px 16px" style-hover="background:var(--rail);cursor:pointer">Add to Case</div>
                 </div>
               </div>
             </sc-if>
@@ -407,11 +407,11 @@
             <div onClick="{{ tb.activate }}" style="{{ tb.style }}" style-hover="cursor:pointer;color:var(--text)">
               <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:15px;line-height:1;color:var(--faint)">{{ tb.icon }}</span>
               <span style="{{ tb.titleStyle }}">{{ tb.title }}</span>
-              <span onClick="{{ tb.close }}" title="Zamknij zakładkę" style="font-size:11px;color:var(--faint);padding:0 2px" style-hover="color:var(--text);cursor:pointer"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:15px;line-height:1">close</span></span>
+              <span onClick="{{ tb.close }}" title="Close tab" style="font-size:11px;color:var(--faint);padding:0 2px" style-hover="color:var(--text);cursor:pointer"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:15px;line-height:1">close</span></span>
             </div>
           </sc-for>
         </div>
-        <div onClick="{{ askCloseAll }}" title="Zamknij wszystkie zakładki" style="{{ tabToolBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ tabToolIconStyle }}">cancel</span></div>
+        <div onClick="{{ askCloseAll }}" title="Close all tabs" style="{{ tabToolBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ tabToolIconStyle }}">cancel</span></div>
       </div>
     </sc-if>
     <sc-if value="{{ showMailToolbar }}" hint-placeholder-val="{{ true }}">
@@ -431,13 +431,13 @@
           <div style="display:flex;align-items:flex-start;gap:11px">
             <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:22px;line-height:1;color:var(--warn)">gpp_maybe</span>
             <div style="display:flex;flex-direction:column;gap:5px;min-width:0">
-              <div style="font-size:14.5px;font-weight:600">Pokazać pełny HTML?</div>
-              <div style="font-size:12.5px;line-height:1.55;color:var(--muted);text-wrap:pretty">Oryginalny HTML może zawierać piksele śledzące, układy podszywające się pod znane marki i odnośniki phishingowe. Skrypty i zdalne zasoby blokujemy, ale nadawca może rozpoznać, że wiadomość została otwarta.</div>
+              <div style="font-size:14.5px;font-weight:600">Show the full HTML?</div>
+              <div style="font-size:12.5px;line-height:1.55;color:var(--muted);text-wrap:pretty">The original HTML may contain tracking pixels, layouts impersonating known brands and phishing links. We block scripts and remote resources, but the sender may still be able to tell the message was opened.</div>
             </div>
           </div>
           <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;justify-content:flex-end">
-            <div onClick="{{ cancelHtmlAsk }}" style="font-size:13px;color:var(--text2);border-radius:9px;padding:9px 13px" style-hover="cursor:pointer;background:var(--hover)">Zostań w uproszczonym</div>
-            <div onClick="{{ confirmHtmlAsk }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:9px;padding:9px 16px" style-hover="cursor:pointer;opacity:0.9">Pokaż HTML</div>
+            <div onClick="{{ cancelHtmlAsk }}" style="font-size:13px;color:var(--text2);border-radius:9px;padding:9px 13px" style-hover="cursor:pointer;background:var(--hover)">Stay in simplified</div>
+            <div onClick="{{ confirmHtmlAsk }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:9px;padding:9px 16px" style-hover="cursor:pointer;opacity:0.9">Show HTML</div>
           </div>
         </div>
       </div>
@@ -448,14 +448,14 @@
           <div style="display:flex;align-items:flex-start;gap:11px">
             <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:22px;line-height:1;color:var(--warn)">edit_note</span>
             <div style="display:flex;flex-direction:column;gap:5px;min-width:0">
-              <div style="font-size:14.5px;font-weight:600">Zamknąć wiadomość?</div>
-              <div style="font-size:12.5px;line-height:1.55;color:var(--muted);text-wrap:pretty">Masz niezapisane zmiany. Możesz zachować je w Szkicach albo odrzucić — odrzucenie usuwa treść bezpowrotnie.</div>
+              <div style="font-size:14.5px;font-weight:600">Close this message?</div>
+              <div style="font-size:12.5px;line-height:1.55;color:var(--muted);text-wrap:pretty">You have unsaved changes. You can keep them in Drafts or discard them — discarding deletes the content permanently.</div>
             </div>
           </div>
           <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;justify-content:flex-end">
-            <div onClick="{{ keepEditing }}" style="font-size:13px;color:var(--text2);border-radius:9px;padding:9px 13px" style-hover="cursor:pointer;background:var(--hover)">Wróć do edycji</div>
-            <div onClick="{{ discardCompose }}" style="font-size:13px;color:var(--warn);border:1px solid var(--warn);border-radius:9px;padding:9px 14px" style-hover="cursor:pointer;background:var(--warn-soft)">Odrzuć</div>
-            <div onClick="{{ saveDraftAndClose }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:9px;padding:9px 16px" style-hover="cursor:pointer;opacity:0.9">Zapisz szkic</div>
+            <div onClick="{{ keepEditing }}" style="font-size:13px;color:var(--text2);border-radius:9px;padding:9px 13px" style-hover="cursor:pointer;background:var(--hover)">Back to editing</div>
+            <div onClick="{{ discardCompose }}" style="font-size:13px;color:var(--warn);border:1px solid var(--warn);border-radius:9px;padding:9px 14px" style-hover="cursor:pointer;background:var(--warn-soft)">Discard</div>
+            <div onClick="{{ saveDraftAndClose }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:9px;padding:9px 16px" style-hover="cursor:pointer;opacity:0.9">Save draft</div>
           </div>
         </div>
       </div>
@@ -466,9 +466,9 @@
           <div style="display:flex;align-items:flex-start;gap:11px">
             <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:22px;line-height:1;color:var(--accent)">send</span>
             <div style="display:flex;flex-direction:column;gap:5px;min-width:0">
-              <div style="font-size:14.5px;font-weight:600">Wysłać wiadomość?</div>
+              <div style="font-size:14.5px;font-weight:600">Send this message?</div>
               <div style="font-size:12.5px;line-height:1.55;color:var(--muted);text-wrap:pretty">Do: {{ sendSummaryTo }}</div>
-              <div style="font-size:12.5px;line-height:1.55;color:var(--muted);text-wrap:pretty">Temat: {{ sendSummarySubj }}</div>
+              <div style="font-size:12.5px;line-height:1.55;color:var(--muted);text-wrap:pretty">Subject: {{ sendSummarySubj }}</div>
             </div>
           </div>
           <sc-if value="{{ sendHasWarn }}" hint-placeholder-val="{{ false }}">
@@ -481,7 +481,7 @@
             </div>
           </sc-if>
           <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;justify-content:flex-end">
-            <div onClick="{{ keepEditing }}" style="font-size:13px;color:var(--text2);border-radius:9px;padding:9px 13px" style-hover="cursor:pointer;background:var(--hover)">Wróć do edycji</div>
+            <div onClick="{{ keepEditing }}" style="font-size:13px;color:var(--text2);border-radius:9px;padding:9px 13px" style-hover="cursor:pointer;background:var(--hover)">Back to editing</div>
             <div onClick="{{ confirmSend }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:9px;padding:9px 16px" style-hover="cursor:pointer;opacity:0.9">{{ sendConfirmLabel }}</div>
           </div>
         </div>
@@ -498,18 +498,18 @@
           <sc-for list="{{ moveFolders }}" as="mf" hint-placeholder-count="5">
             <div onClick="{{ mf.pick }}" style="{{ mf.style }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1;color:var(--muted)">folder</span>{{ mf.label }}</div>
           </sc-for>
-          <div style="display:flex;align-items:center;gap:11px;margin-top:4px;padding:10px 13px;border-top:1px solid var(--line2);font-size:13px;color:var(--accent-d)" style-hover="cursor:pointer"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1">create_new_folder</span>Nowy folder…</div>
+          <div style="display:flex;align-items:center;gap:11px;margin-top:4px;padding:10px 13px;border-top:1px solid var(--line2);font-size:13px;color:var(--accent-d)" style-hover="cursor:pointer"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1">create_new_folder</span>New folder…</div>
         </div>
       </div>
     </sc-if>
     <sc-if value="{{ deleteConvAskOpen }}" hint-placeholder-val="{{ false }}">
       <div style="{{ ovAsk95 }}">
         <div style="{{ dlgAsk }}">
-          <div style="font-size:16px;font-weight:600">Usunąć tę rozmowę?</div>
-          <div style="font-size:13px;color:var(--muted);line-height:1.5;text-wrap:pretty">Wiadomości w tej rozmowie z agentem zostaną trwale usunięte. Tej operacji nie można wycofać.</div>
+          <div style="font-size:16px;font-weight:600">Delete this conversation?</div>
+          <div style="font-size:13px;color:var(--muted);line-height:1.5;text-wrap:pretty">Messages in this conversation with the agent will be permanently deleted. This cannot be undone.</div>
           <div style="display:flex;gap:9px;justify-content:flex-end">
-            <div onClick="{{ cancelDeleteConv }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:8px 15px" style-hover="cursor:pointer;background:var(--hover)">Anuluj</div>
-            <div onClick="{{ confirmDeleteConv }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--warn);border-radius:8px;padding:8px 16px" style-hover="cursor:pointer;opacity:0.9">Usuń</div>
+            <div onClick="{{ cancelDeleteConv }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:8px 15px" style-hover="cursor:pointer;background:var(--hover)">Cancel</div>
+            <div onClick="{{ confirmDeleteConv }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--warn);border-radius:8px;padding:8px 16px" style-hover="cursor:pointer;opacity:0.9">Delete</div>
           </div>
         </div>
       </div>
@@ -517,11 +517,11 @@
     <sc-if value="{{ closeAllAsk }}" hint-placeholder-val="{{ false }}">
       <div style="{{ ovAsk95 }}">
         <div style="{{ dlgAsk }}">
-          <div style="font-size:16px;font-weight:600">Zamknąć wszystkie zakładki?</div>
+          <div style="font-size:16px;font-weight:600">Close all tabs?</div>
           <div style="font-size:13px;color:var(--muted);line-height:1.5;text-wrap:pretty">{{ closeAllInfo }}</div>
           <div style="display:flex;gap:9px;justify-content:flex-end">
-            <div onClick="{{ cancelCloseAll }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:8px 15px" style-hover="cursor:pointer;background:var(--hover)">Anuluj</div>
-            <div onClick="{{ confirmCloseAll }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:8px;padding:8px 16px" style-hover="cursor:pointer;opacity:0.9">Zamknij wszystkie</div>
+            <div onClick="{{ cancelCloseAll }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:8px 15px" style-hover="cursor:pointer;background:var(--hover)">Cancel</div>
+            <div onClick="{{ confirmCloseAll }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:8px;padding:8px 16px" style-hover="cursor:pointer;opacity:0.9">Close all</div>
           </div>
         </div>
       </div>
@@ -533,7 +533,7 @@
         <sc-for list="{{ selectionActions }}" as="a" hint-placeholder-count="4">
           <div onClick="{{ a.run }}" title="{{ a.title }}" style="{{ a.style }}" style-hover="cursor:pointer;background:var(--panel)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1;width:20px;text-align:center">{{ a.icon }}</span>{{ a.label }}</div>
         </sc-for>
-        <div onClick="{{ selectAllThreads }}" style="margin-left:auto;font-size:12px;color:var(--accent-d)" style-hover="cursor:pointer;text-decoration:underline">Zaznacz wszystkie</div>
+        <div onClick="{{ selectAllThreads }}" style="margin-left:auto;font-size:12px;color:var(--accent-d)" style-hover="cursor:pointer;text-decoration:underline">Select all</div>
       </div>
     </sc-if>
     <div style="flex:1;display:flex;min-width:0;min-height:0">
@@ -543,7 +543,7 @@
       <sc-if value="{{ showSide }}" hint-placeholder-val="{{ true }}">
         <div style="{{ sideStyle }}">
           <div onClick="{{ toggleSide }}" title="{{ sideToggleTitle }}" style="{{ sideTopStyle }}" style-hover="cursor:pointer;background:var(--hover)">
-            <sc-if value="{{ sideExpanded }}" hint-placeholder-val="{{ true }}"><span style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">KATALOGI</span></sc-if>
+            <sc-if value="{{ sideExpanded }}" hint-placeholder-val="{{ true }}"><span style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">FOLDERS</span></sc-if>
             <span style="margin-left:auto;font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1;color:var(--muted)">{{ sideToggleIcon }}</span>
           </div>
           <sc-for list="{{ sideGroups }}" as="g" hint-placeholder-count="3">
@@ -573,7 +573,7 @@
           </sc-for>
           <div style="{{ filtersWrapStyle }}">
             <sc-if value="{{ sideExpanded }}" hint-placeholder-val="{{ true }}">
-              <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">FILTRY AI</div>
+              <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">AI FILTERS</div>
             </sc-if>
             <sc-for list="{{ aiFilters }}" as="fl" hint-placeholder-count="3">
               <div title="{{ fl.title }}" style="{{ fl.style }}" style-hover="cursor:pointer;background:var(--hover)">
@@ -588,19 +588,19 @@
       <sc-if value="{{ showThreadList }}" hint-placeholder-val="{{ true }}">
         <div style="{{ threadListStyle }}">
           <sc-if value="{{ showFab }}" hint-placeholder-val="{{ false }}">
-            <div onClick="{{ openCompose }}" title="Nowa wiadomość" style="{{ mailFabStyle }}" style-hover="cursor:pointer;opacity:0.92"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:24px;line-height:1">edit_square</span></div>
+            <div onClick="{{ openCompose }}" title="New message" style="{{ mailFabStyle }}" style-hover="cursor:pointer;opacity:0.92"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:24px;line-height:1">edit_square</span></div>
           </sc-if>
           <div style="display:flex;align-items:center;gap:9px;padding:10px 12px;border-bottom:1px solid var(--line)">
             <sc-if value="{{ showFolderBtn }}" hint-placeholder-val="{{ false }}">
-              <div onClick="{{ openFolders }}" title="Katalogi i filtry" style="{{ folderBtnStyle }}" style-hover="cursor:pointer;background:var(--hover)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:19px;line-height:1">menu</span></div>
+              <div onClick="{{ openFolders }}" title="Folders and filters" style="{{ folderBtnStyle }}" style-hover="cursor:pointer;background:var(--hover)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:19px;line-height:1">menu</span></div>
             </sc-if>
             <sc-if value="{{ listSearchActive }}" hint-placeholder-val="{{ false }}">
-              <div style="{{ searchFieldStyle }}"><input ref="{{ listSearchRef }}" value="{{ listSearchValue }}" onChange="{{ onListSearch }}" placeholder="Szukaj lub opisz, czego potrzebujesz…" style="flex:1;min-width:0;border:none;outline:none;font-family:inherit;font-size:13px;color:var(--text);background:transparent" /></div>
+              <div style="{{ searchFieldStyle }}"><input ref="{{ listSearchRef }}" value="{{ listSearchValue }}" onChange="{{ onListSearch }}" placeholder="Search or describe what you need…" style="flex:1;min-width:0;border:none;outline:none;font-family:inherit;font-size:13px;color:var(--text);background:transparent" /></div>
             </sc-if>
             <sc-if value="{{ listSearchIdle }}" hint-placeholder-val="{{ true }}">
-              <div onClick="{{ openListSearch }}" style="{{ searchFieldStyle }}" style-hover="cursor:pointer;border-color:var(--border2)">Szukaj lub opisz, czego potrzebujesz…</div>
+              <div onClick="{{ openListSearch }}" style="{{ searchFieldStyle }}" style-hover="cursor:pointer;border-color:var(--border2)">Search or describe what you need…</div>
             </sc-if>
-            <div onClick="{{ openListSearch }}" title="Szukaj" style="{{ listIconBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:19px;line-height:1">search</span></div>
+            <div onClick="{{ openListSearch }}" title="Search" style="{{ listIconBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:19px;line-height:1">search</span></div>
             <div onClick="{{ toggleFilters }}" title="{{ filtersTitle }}" style="{{ filtersBtnStyle }}" style-hover="cursor:pointer;background:var(--hover)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:19px;line-height:1">{{ filtersIcon }}</span><sc-if value="{{ filtersActive }}" hint-placeholder-val="{{ false }}"><span style="font-size:10px;font-weight:600">{{ filtersCount }}</span></sc-if></div>
           </div>
           <sc-if value="{{ filtersOpen }}" hint-placeholder-val="{{ false }}">
@@ -611,7 +611,7 @@
                 </sc-for>
               </div>
               <div style="display:flex;flex-direction:column;gap:6px">
-                <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:10px;letter-spacing:0.08em;color:var(--muted)">SORTOWANIE</div>
+                <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:10px;letter-spacing:0.08em;color:var(--muted)">SORTING</div>
                 <div style="display:flex;gap:6px;flex-wrap:wrap">
                   <sc-for list="{{ sortOptions }}" as="so" hint-placeholder-count="3">
                     <div onClick="{{ so.pick }}" style="{{ so.style }}" style-hover="cursor:pointer;border-color:var(--accent)">{{ so.label }}</div>
@@ -619,21 +619,21 @@
                 </div>
               </div>
               <div style="display:flex;flex-direction:column;gap:6px">
-                <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:10px;letter-spacing:0.08em;color:var(--muted)">ZAKRES DAT</div>
+                <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:10px;letter-spacing:0.08em;color:var(--muted)">DATE RANGE</div>
                 <div style="display:flex;gap:6px;flex-wrap:wrap">
                   <sc-for list="{{ rangeOptions }}" as="ro" hint-placeholder-count="4">
                     <div onClick="{{ ro.pick }}" style="{{ ro.style }}" style-hover="cursor:pointer;border-color:var(--accent)">{{ ro.label }}</div>
                   </sc-for>
                 </div>
                 <div style="display:flex;gap:8px;flex-wrap:wrap;align-items:center">
-                  <label style="display:flex;flex-direction:column;gap:3px;font-size:10.5px;color:var(--muted)">od<input type="datetime-local" value="{{ filterFrom }}" onChange="{{ onFilterFrom }}" style="font-family:inherit;font-size:12.5px;color:var(--text);background:var(--panel);border:1px solid var(--line);border-radius:7px;padding:6px 8px" /></label>
-                  <label style="display:flex;flex-direction:column;gap:3px;font-size:10.5px;color:var(--muted)">do<input type="datetime-local" value="{{ filterTo }}" onChange="{{ onFilterTo }}" style="font-family:inherit;font-size:12.5px;color:var(--text);background:var(--panel);border:1px solid var(--line);border-radius:7px;padding:6px 8px" /></label>
+                  <label style="display:flex;flex-direction:column;gap:3px;font-size:10.5px;color:var(--muted)">from<input type="datetime-local" value="{{ filterFrom }}" onChange="{{ onFilterFrom }}" style="font-family:inherit;font-size:12.5px;color:var(--text);background:var(--panel);border:1px solid var(--line);border-radius:7px;padding:6px 8px" /></label>
+                  <label style="display:flex;flex-direction:column;gap:3px;font-size:10.5px;color:var(--muted)">to<input type="datetime-local" value="{{ filterTo }}" onChange="{{ onFilterTo }}" style="font-family:inherit;font-size:12.5px;color:var(--text);background:var(--panel);border:1px solid var(--line);border-radius:7px;padding:6px 8px" /></label>
                 </div>
               </div>
               <div style="display:flex;align-items:center;gap:10px;border-top:1px solid var(--line2);padding-top:9px">
                 <div style="font-size:11.5px;color:var(--muted)">{{ filtersSummary }}</div>
                 <sc-if value="{{ filtersActive }}" hint-placeholder-val="{{ false }}">
-                  <div onClick="{{ clearFilters }}" style="margin-left:auto;font-size:12px;color:var(--accent-d)" style-hover="cursor:pointer;text-decoration:underline">Wyczyść filtry</div>
+                  <div onClick="{{ clearFilters }}" style="margin-left:auto;font-size:12px;color:var(--accent-d)" style-hover="cursor:pointer;text-decoration:underline">Clear filters</div>
                 </sc-if>
               </div>
             </div>
@@ -660,7 +660,7 @@
                 <div style="{{ t.swipeBgStyle }}"><span style="{{ t.swipeIconStyle }}">{{ t.swipeIcon }}</span><span style="{{ t.swipeTextStyle }}">{{ t.swipeLabel }}</span></div>
               </sc-if>
               <div onClick="{{ t.select }}" onContextMenu="{{ t.longPress }}" onTouchStart="{{ t.touchStart }}" onTouchEnd="{{ t.touchEnd }}" onTouchMove="{{ t.touchMove }}" style="{{ t.rowStyle }}" style-hover="cursor:pointer;background:var(--hover)">
-                <div style="display:flex;align-items:center;gap:9px;min-width:0"><sc-if value="{{ t.selected }}" hint-placeholder-val="{{ false }}"><span style="align-self:center;width:17px;height:17px;flex:0 0 17px;border-radius:50%;background:var(--accent);color:var(--onaccent);display:flex;align-items:center;justify-content:center;font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:13px;line-height:1">check</span></sc-if><sc-if value="{{ t.hasAvatar }}" hint-placeholder-val="{{ false }}"><span title="{{ t.from }}" style="{{ t.avatarImgStyle }}"></span></sc-if><sc-if value="{{ t.noAvatar }}" hint-placeholder-val="{{ true }}"><span title="{{ t.from }}" style="{{ t.avatarStyle }}">{{ t.initials }}</span></sc-if><span style="{{ t.fromStyle }}">{{ t.from }}</span><span style="{{ t.orgStyle }}">{{ t.org }}</span><span style="margin-left:auto;flex:0 0 auto;display:flex;align-items:center;gap:7px"><sc-if value="{{ t.flagged }}" hint-placeholder-val="{{ false }}"><span title="Oflagowany" style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 400;font-size:15px;line-height:1;color:var(--warn)">flag</span></sc-if><sc-if value="{{ t.isUnread }}" hint-placeholder-val="{{ false }}"><span title="Nieprzeczytana" style="width:8px;height:8px;border-radius:50%;background:var(--accent)"></span></sc-if><sc-if value="{{ t.multi }}" hint-placeholder-val="{{ false }}"><span style="font-size:10px;color:var(--text2);background:var(--rail);border:1px solid var(--line2);border-radius:9px;padding:1px 6px">{{ t.count }}</span></sc-if><span style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;color:var(--faint)">{{ t.time }}</span></span></div>
+                <div style="display:flex;align-items:center;gap:9px;min-width:0"><sc-if value="{{ t.selected }}" hint-placeholder-val="{{ false }}"><span style="align-self:center;width:17px;height:17px;flex:0 0 17px;border-radius:50%;background:var(--accent);color:var(--onaccent);display:flex;align-items:center;justify-content:center;font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:13px;line-height:1">check</span></sc-if><sc-if value="{{ t.hasAvatar }}" hint-placeholder-val="{{ false }}"><span title="{{ t.from }}" style="{{ t.avatarImgStyle }}"></span></sc-if><sc-if value="{{ t.noAvatar }}" hint-placeholder-val="{{ true }}"><span title="{{ t.from }}" style="{{ t.avatarStyle }}">{{ t.initials }}</span></sc-if><span style="{{ t.fromStyle }}">{{ t.from }}</span><span style="{{ t.orgStyle }}">{{ t.org }}</span><span style="margin-left:auto;flex:0 0 auto;display:flex;align-items:center;gap:7px"><sc-if value="{{ t.flagged }}" hint-placeholder-val="{{ false }}"><span title="Flagged" style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 400;font-size:15px;line-height:1;color:var(--warn)">flag</span></sc-if><sc-if value="{{ t.isUnread }}" hint-placeholder-val="{{ false }}"><span title="Unread" style="width:8px;height:8px;border-radius:50%;background:var(--accent)"></span></sc-if><sc-if value="{{ t.multi }}" hint-placeholder-val="{{ false }}"><span style="font-size:10px;color:var(--text2);background:var(--rail);border:1px solid var(--line2);border-radius:9px;padding:1px 6px">{{ t.count }}</span></sc-if><span style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;color:var(--faint)">{{ t.time }}</span></span></div>
                 <div style="{{ t.subjStyle }}">{{ t.subject }}</div>
                 <sc-if value="{{ t.showMoved }}" hint-placeholder-val="{{ false }}">
                   <div style="display:flex;align-items:center;gap:5px;font-size:11px;color:var(--muted)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:13px;line-height:1">folder</span>{{ t.movedTo }}</div>
@@ -675,14 +675,14 @@
             </sc-if>
             <sc-if value="{{ undoShown }}" hint-placeholder-val="{{ false }}">
               <div style="position:absolute;left:12px;right:82px;bottom:16px;z-index:40;display:flex;align-items:center;gap:12px;min-height:50px;padding:0 10px 0 16px;border-radius:14px;background:var(--text);color:var(--bg);box-shadow:0 8px 24px var(--sh-3)">
-                <span style="flex:1;min-width:0;font-size:13px">Zarchiwizowano</span>
-                <div onClick="{{ undoDelete }}" style="flex:0 0 auto;display:flex;align-items:center;min-height:40px;padding:0 14px;border-radius:12px;font-size:13px;font-weight:600;color:var(--accent-2)" style-hover="cursor:pointer;background:var(--scrim)">Cofnij</div>
+                <span style="flex:1;min-width:0;font-size:13px">Archived</span>
+                <div onClick="{{ undoDelete }}" style="flex:0 0 auto;display:flex;align-items:center;min-height:40px;padding:0 14px;border-radius:12px;font-size:13px;font-weight:600;color:var(--accent-2)" style-hover="cursor:pointer;background:var(--scrim)">Undo</div>
               </div>
             </sc-if>
           </div>
         </div>
         <sc-if value="{{ showResizer }}" hint-placeholder-val="{{ true }}">
-          <div onMouseDown="{{ startResize }}" onDoubleClick="{{ resetResize }}" style="flex:0 0 5px;cursor:col-resize;background:var(--line);position:relative;z-index:5" style-hover="background:var(--accent-line)" title="Przeciągnij, aby zmienić szerokość listy (dwuklik = reset)"></div>
+          <div onMouseDown="{{ startResize }}" onDoubleClick="{{ resetResize }}" style="flex:0 0 5px;cursor:col-resize;background:var(--line);position:relative;z-index:5" style-hover="background:var(--accent-line)" title="Drag to resize the list (double-click to reset)"></div>
         </sc-if>
       </sc-if>
 
@@ -692,13 +692,13 @@
         <div style="flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:16px;min-width:0;min-height:0;background:var(--sub);padding:32px">
           <img src="./mailfathom-logo.png" alt="MailFathom" style="width:46px;height:46px;border-radius:12px;display:block" />
           <div style="display:flex;flex-direction:column;gap:7px;align-items:center;max-width:420px">
-            <div style="font-size:20px;font-weight:600;letter-spacing:-0.015em">Nic nie jest otwarte</div>
+            <div style="font-size:20px;font-weight:600;letter-spacing:-0.015em">Nothing open</div>
             <div style="font-size:14px;line-height:1.55;color:var(--muted);text-align:center;text-wrap:pretty">{{ emptyMailText }}</div>
           </div>
           <div style="display:flex;gap:9px;flex-wrap:wrap;justify-content:center">
-            <div onClick="{{ openCompose }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:8px;padding:9px 16px" style-hover="cursor:pointer;opacity:0.9">Nowa wiadomość</div>
-            <div onClick="{{ openLastThread }}" style="font-size:13px;color:var(--text2);background:var(--panel);border:1px solid var(--border2);border-radius:8px;padding:9px 16px" style-hover="cursor:pointer;background:var(--hover)">Otwórz ostatni wątek</div>
-            <div onClick="{{ goDiscover }}" style="font-size:13px;color:var(--text2);background:var(--panel);border:1px solid var(--border2);border-radius:8px;padding:9px 16px" style-hover="cursor:pointer;background:var(--hover)">Zapytaj o historię</div>
+            <div onClick="{{ openCompose }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:8px;padding:9px 16px" style-hover="cursor:pointer;opacity:0.9">New message</div>
+            <div onClick="{{ openLastThread }}" style="font-size:13px;color:var(--text2);background:var(--panel);border:1px solid var(--border2);border-radius:8px;padding:9px 16px" style-hover="cursor:pointer;background:var(--hover)">Open last thread</div>
+            <div onClick="{{ goDiscover }}" style="font-size:13px;color:var(--text2);background:var(--panel);border:1px solid var(--border2);border-radius:8px;padding:9px 16px" style-hover="cursor:pointer;background:var(--hover)">Ask about the history</div>
           </div>
         </div>
       </sc-if>
@@ -724,20 +724,20 @@
           </sc-if>
           <sc-if value="{{ cameFromResult }}" hint-placeholder-val="{{ false }}">
             <div onClick="{{ backToResult }}" style="{{ backBannerStyle }}" style-hover="cursor:pointer">
-              <div style="font-size:13px;color:var(--accent-d);font-weight:600;white-space:nowrap"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:15px;line-height:1;vertical-align:-3px;margin-right:5px">arrow_back</span>Wróć do wyniku</div>
-              <div style="font-size:12px;color:var(--accent-d);text-wrap:pretty">otwarte z cytowania {{ fromCitation }} · wynik pozostaje policzony</div>
+              <div style="font-size:13px;color:var(--accent-d);font-weight:600;white-space:nowrap"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:15px;line-height:1;vertical-align:-3px;margin-right:5px">arrow_back</span>Back to result</div>
+              <div style="font-size:12px;color:var(--accent-d);text-wrap:pretty">opened from citation {{ fromCitation }} · the result stays computed</div>
             </div>
           </sc-if>
           <sc-if value="{{ showThreadHead }}" hint-placeholder-val="{{ true }}">
           <div style="{{ threadHeadStyle }}">
             <div style="display:flex;align-items:center;gap:9px;min-width:0">
               <sc-if value="{{ showMailBack }}" hint-placeholder-val="{{ false }}">
-                <div onClick="{{ backToList }}" title="Wróć do listy" style="{{ backBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:20px;line-height:1">arrow_back</span></div>
+                <div onClick="{{ backToList }}" title="Back to list" style="{{ backBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:20px;line-height:1">arrow_back</span></div>
               </sc-if>
               <div style="{{ subjectStyle }}">{{ activeSubject }}</div>
               <div style="margin-left:auto;display:flex;align-items:center;gap:8px;flex:0 0 auto">
                 <sc-if value="{{ showAgentJump }}" hint-placeholder-val="{{ true }}">
-                  <div onClick="{{ askAgentThread }}" title="Przejdź do agenta z kontekstem wątku" style="{{ askSheetBtnStyle }}" style-hover="cursor:pointer;opacity:0.9"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">auto_awesome</span>Zapytaj</div>
+                  <div onClick="{{ askAgentThread }}" title="Go to the agent with the thread as context" style="{{ askSheetBtnStyle }}" style-hover="cursor:pointer;opacity:0.9"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">auto_awesome</span>Ask</div>
                 </sc-if>
                 <div style="display:flex;align-items:center;gap:3px">
                   <sc-for list="{{ threadActions }}" as="ta" hint-placeholder-count="3">
@@ -772,8 +772,8 @@
             <sc-if value="{{ isMobileState }}" hint-placeholder-val="{{ false }}">
               <span style="flex:0 0 auto;font-family:'Instrument Sans',system-ui,sans-serif;font-size:10px;color:var(--muted);border:1px solid var(--border2);border-radius:4px;padding:2px 6px">AI</span>
               <span style="flex:1;min-width:0;font-size:13px;line-height:1.35;color:var(--text2);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ threadAiLine }}</span>
-              <div onClick="{{ openThreadSheet }}" title="Stan wątku i gotowe pytania" style="{{ askSheetAltStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">insights</span>{{ askSheetLabel }}</div>
-              <div onClick="{{ askAgentThread }}" title="Przejdź do agenta z kontekstem wątku" style="{{ askSheetBtnStyle }}" style-hover="cursor:pointer;opacity:0.9"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">auto_awesome</span>Zapytaj</div>
+              <div onClick="{{ openThreadSheet }}" title="Thread state and ready-made questions" style="{{ askSheetAltStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">insights</span>{{ askSheetLabel }}</div>
+              <div onClick="{{ askAgentThread }}" title="Go to the agent with the thread as context" style="{{ askSheetBtnStyle }}" style-hover="cursor:pointer;opacity:0.9"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">auto_awesome</span>Ask</div>
             </sc-if>
             <sc-if value="{{ showStateCards }}" hint-placeholder-val="{{ true }}">
             <div style="{{ stateRowStyle }}">
@@ -819,7 +819,7 @@
                         <span style="font-size:14px;font-weight:600;white-space:nowrap">{{ m.from }}</span>
                         <span style="font-size:11px;color:var(--muted)">{{ m.role }}</span>
                         <sc-if value="{{ m.isActive }}" hint-placeholder-val="{{ false }}">
-                          <span style="flex:0 0 auto;display:flex;align-items:center;gap:4px;font-family:'Instrument Sans',system-ui,sans-serif;font-size:10px;letter-spacing:0.04em;color:var(--accent-d);background:var(--accent-soft);border-radius:5px;padding:2px 7px;white-space:nowrap"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:12px;line-height:1">arrow_right</span>Otwarta z listy</span>
+                          <span style="flex:0 0 auto;display:flex;align-items:center;gap:4px;font-family:'Instrument Sans',system-ui,sans-serif;font-size:10px;letter-spacing:0.04em;color:var(--accent-d);background:var(--accent-soft);border-radius:5px;padding:2px 7px;white-space:nowrap"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:12px;line-height:1">arrow_right</span>Opened from the list</span>
                         </sc-if>
                         <span style="margin-left:auto;display:flex;align-items:center;gap:9px;white-space:nowrap"><sc-if value="{{ m.hasAtts }}" hint-placeholder-val="{{ false }}"><span style="{{ m.clipStyle }}"><span style="{{ m.clipIconStyle }}">attach_file</span>{{ m.clipLabel }}</span></sc-if><sc-if value="{{ m.showHtmlBtn }}" hint-placeholder-val="{{ true }}"><span onClick="{{ m.openHtml }}" title="{{ m.htmlTitle }}" style="{{ m.htmlBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--accent-d)">code</span></sc-if><span style="{{ m.whenStyle }}">{{ m.when }}</span></span>
                       </div>
@@ -886,23 +886,23 @@
                       <sc-if value="{{ m.htmlView }}" hint-placeholder-val="{{ false }}">
                         <div style="display:flex;flex-direction:column;border:1px solid var(--line);border-radius:9px;overflow:hidden;background:#ffffff">
                           <div style="position:relative;overflow:hidden;background:#ffffff">
-                            <iframe srcDoc="{{ m.htmlEmbedSrc }}" ref="{{ m.htmlFrameRef }}" data-frame-id="{{ m.htmlFrameId }}" sandbox="allow-scripts" scrolling="no" title="Treść HTML wiadomości" style="width:100%;height:320px;border:0;display:block;background:#ffffff"></iframe>
+                            <iframe srcDoc="{{ m.htmlEmbedSrc }}" ref="{{ m.htmlFrameRef }}" data-frame-id="{{ m.htmlFrameId }}" sandbox="allow-scripts" scrolling="no" title="Message HTML content" style="width:100%;height:320px;border:0;display:block;background:#ffffff"></iframe>
                           </div>
-                          <div style="display:flex;align-items:center;gap:7px;padding:7px 11px;border-top:1px solid var(--line);background:var(--sub);font-size:10.5px;color:var(--muted)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:13px;line-height:1">lock</span><span data-fit-status="{{ m.htmlFrameId }}">Dopasowywanie wysokości do treści…</span></div>
+                          <div style="display:flex;align-items:center;gap:7px;padding:7px 11px;border-top:1px solid var(--line);background:var(--sub);font-size:10.5px;color:var(--muted)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:13px;line-height:1">lock</span><span data-fit-status="{{ m.htmlFrameId }}">Fitting height to content…</span></div>
                         </div>
                       </sc-if>
                       <sc-if value="{{ m.hasAtts }}" hint-placeholder-val="{{ false }}">
                         <div style="display:flex;gap:9px;flex-wrap:wrap;align-items:center">
                           <sc-for list="{{ m.atts }}" as="a" hint-placeholder-count="1">
                             <div style="display:flex;align-items:stretch;background:var(--sub);border:1px solid var(--line);border-radius:7px;overflow:hidden">
-                              <div onClick="{{ a.open }}" title="Otwórz podgląd" style="display:flex;align-items:center;gap:9px;padding:9px 12px" style-hover="cursor:pointer;background:var(--hover)">
+                              <div onClick="{{ a.open }}" title="Open preview" style="display:flex;align-items:center;gap:9px;padding:9px 12px" style-hover="cursor:pointer;background:var(--hover)">
                                 <span style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;color:var(--muted)">{{ a.type }}</span><span style="font-size:14px">{{ a.name }}</span><span style="font-size:12px;color:var(--faint)">{{ a.size }}</span>
                               </div>
-                              <div onClick="{{ a.download }}" title="Pobierz plik" style="display:flex;align-items:center;justify-content:center;width:32px;border-left:1px solid var(--line);color:var(--muted)" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">download</span></div>
+                              <div onClick="{{ a.download }}" title="Download file" style="display:flex;align-items:center;justify-content:center;width:32px;border-left:1px solid var(--line);color:var(--muted)" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">download</span></div>
                             </div>
                           </sc-for>
                           <sc-if value="{{ m.showDownloadAll }}" hint-placeholder-val="{{ false }}">
-                            <div onClick="{{ m.downloadAll }}" style="display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--accent-d);background:var(--accent-soft);border-radius:7px;padding:9px 12px" style-hover="cursor:pointer;background:var(--accent-2);color:var(--onaccent)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:16px;line-height:1">folder_zip</span>Pobierz wszystkie</div>
+                            <div onClick="{{ m.downloadAll }}" style="display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--accent-d);background:var(--accent-soft);border-radius:7px;padding:9px 12px" style-hover="cursor:pointer;background:var(--accent-2);color:var(--onaccent)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:16px;line-height:1">folder_zip</span>Download all</div>
                           </sc-if>
                         </div>
                       </sc-if>
@@ -912,13 +912,13 @@
               </sc-if>
             </sc-for>
             <sc-if value="{{ showCitationTag }}" hint-placeholder-val="{{ false }}">
-              <div style="display:flex;align-items:center;gap:11px;flex-wrap:wrap;font-family:'Instrument Sans',system-ui,sans-serif;font-size:12px;color:var(--muted)"><span style="background:var(--accent-soft);color:var(--accent-d);border-radius:5px;padding:4px 8px">cytowanie {{ fromCitation }}</span>fragment przywołany w wyniku „Odkrywaj”</div>
+              <div style="display:flex;align-items:center;gap:11px;flex-wrap:wrap;font-family:'Instrument Sans',system-ui,sans-serif;font-size:12px;color:var(--muted)"><span style="background:var(--accent-soft);color:var(--accent-d);border-radius:5px;padding:4px 8px">citation {{ fromCitation }}</span>passage cited in the “Discover” result</div>
             </sc-if>
             <sc-if value="{{ mailAnswer }}" hint-placeholder-val="{{ false }}">
               <div style="display:flex;flex-direction:column;gap:8px;background:var(--panel);border:1px solid var(--line);border-left:3px solid var(--accent);border-radius:9px;padding:14px 16px">
-                <div style="display:flex;align-items:center;gap:10px"><div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">SZKIC · LOKALNY</div><div style="{{ answerHintStyle }}">nic nie zostało wysłane</div></div>
-                <div style="font-size:15px;line-height:1.5;text-wrap:pretty">Dziękuję za aneks. Akceptujemy skrócenie SLA do 2 godzin, natomiast prosimy o wprowadzenie górnego limitu waloryzacji CPI na poziomie 5% rocznie — inaczej nie możemy zamknąć decyzji do 28.08.</div>
-                <div style="display:flex;gap:9px;flex-wrap:wrap"><div style="font-size:13px;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:8px 15px" style-hover="opacity:0.88;cursor:pointer">Otwórz w composerze</div><div onClick="{{ closeMailAnswer }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:7px;padding:8px 15px" style-hover="background:var(--rail);cursor:pointer">Odrzuć szkic</div></div>
+                <div style="display:flex;align-items:center;gap:10px"><div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">DRAFT · LOCAL</div><div style="{{ answerHintStyle }}">nothing has been sent</div></div>
+                <div style="font-size:15px;line-height:1.5;text-wrap:pretty">Thank you for the addendum. We accept shortening the SLA to 2 hours, but we do need an upper CPI indexation cap of 5% per year — otherwise we cannot close the decision by 28 Aug.</div>
+                <div style="display:flex;gap:9px;flex-wrap:wrap"><div style="font-size:13px;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:8px 15px" style-hover="opacity:0.88;cursor:pointer">Open in composer</div><div onClick="{{ closeMailAnswer }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:7px;padding:8px 15px" style-hover="background:var(--rail);cursor:pointer">Discard draft</div></div>
               </div>
             </sc-if>
           </div>
@@ -926,14 +926,14 @@
           <div style="{{ composerStyle }}">
             <div style="display:flex;align-items:center;gap:12px;border:2px solid var(--accent);border-radius:10px;padding:10px 13px">
               <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.06em;color:var(--onaccent);background:var(--accent);border-radius:5px;padding:4px 8px">AI</div>
-              <div style="flex:1;min-width:0;font-size:15px;color:var(--faint)">Zapytaj o wątek albo przygotuj odpowiedź…</div>
+              <div style="flex:1;min-width:0;font-size:15px;color:var(--faint)">Ask about the thread or draft a reply…</div>
               <div onClick="{{ askThread }}" style="{{ askThreadBtnStyle }}" style-hover="opacity:0.88;cursor:pointer">{{ askThreadLabel }}</div>
             </div>
             <sc-if value="{{ showComposerChips }}" hint-placeholder-val="{{ true }}">
               <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
-                <div style="font-size:12px;background:var(--accent-soft);color:var(--accent-d);border-radius:16px;padding:5px 11px">Zakres: ten wątek</div>
-                <div style="font-size:12px;background:var(--rail);border:1px solid var(--line);border-radius:16px;padding:5px 11px">+ zaznaczony fragment</div>
-                <div style="margin-left:auto;font-size:12px;color:var(--muted)">Szkic pozostaje lokalny do potwierdzenia</div>
+                <div style="font-size:12px;background:var(--accent-soft);color:var(--accent-d);border-radius:16px;padding:5px 11px">Scope: this thread</div>
+                <div style="font-size:12px;background:var(--rail);border:1px solid var(--line);border-radius:16px;padding:5px 11px">+ selected passage</div>
+                <div style="margin-left:auto;font-size:12px;color:var(--muted)">Draft stays local until confirmed</div>
               </div>
             </sc-if>
           </div>
@@ -945,7 +945,7 @@
         <div onClick="{{ closeThreadSheet }}" style="position:fixed;inset:0;z-index:92;display:flex;flex-direction:column;justify-content:flex-end;background:var(--scrim)">
           <div onClick="{{ stopProp }}" style="display:flex;flex-direction:column;gap:12px;max-height:82vh;overflow:auto;background:var(--panel);border-top-left-radius:18px;border-top-right-radius:18px;padding:10px 16px 20px 16px">
             <div style="align-self:center;width:38px;height:4px;border-radius:2px;background:var(--border2);margin:2px 0 4px 0"></div>
-            <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">STAN WĄTKU</div>
+            <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">THREAD STATE</div>
             <div style="display:flex;flex-direction:column;gap:8px">
               <sc-for list="{{ activeState }}" as="s" hint-placeholder-count="3">
                 <div style="display:flex;flex-direction:column;gap:3px;background:var(--sub);border:1px solid var(--line);border-radius:10px;padding:11px 13px">
@@ -957,12 +957,12 @@
                 </div>
               </sc-for>
             </div>
-            <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted);padding-top:4px">ZAPYTAJ O TEN WĄTEK</div>
+            <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted);padding-top:4px">ASK ABOUT THIS THREAD</div>
             <div style="display:flex;flex-direction:column;gap:8px">
               <sc-for list="{{ threadSheetAsks }}" as="q" hint-placeholder-count="3">
                 <div onClick="{{ q.run }}" style="display:flex;align-items:center;gap:11px;min-height:50px;padding:12px 14px;border:1px solid var(--line);border-radius:12px;font-size:14px;color:var(--text)" style-hover="cursor:pointer;background:var(--hover)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:19px;line-height:1;color:var(--accent)">auto_awesome</span>{{ q.label }}</div>
               </sc-for>
-              <div onClick="{{ askAgentThread }}" style="{{ goAgentBtnStyle }}" style-hover="cursor:pointer;background:var(--accent);color:var(--onaccent);border-color:var(--accent)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:19px;line-height:1">forum</span>Przejdź do agenta — zapytam po swojemu</div>
+              <div onClick="{{ askAgentThread }}" style="{{ goAgentBtnStyle }}" style-hover="cursor:pointer;background:var(--accent);color:var(--onaccent);border-color:var(--accent)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:19px;line-height:1">forum</span>Go to the agent — I'll ask in my own words</div>
             </div>
           </div>
         </div>
@@ -974,9 +974,9 @@
               <div style="font-size:14px;font-weight:600">{{ composeTitle }}</div>
               <div style="margin-left:auto;display:flex;align-items:center;gap:6px">
                 <sc-if value="{{ composeMinShown }}" hint-placeholder-val="{{ true }}">
-                  <div title="Zwiń / rozwiń okno" style="{{ composeMinBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ composeChromeIconStyle }}">{{ minLabel }}</span></div>
+                  <div title="Collapse / expand window" style="{{ composeMinBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ composeChromeIconStyle }}">{{ minLabel }}</span></div>
                 </sc-if>
-                <div onClick="{{ closeCompose }}" title="Zamknij okno wiadomości" style="{{ composeCloseBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ composeChromeIconStyle }}">close</span></div>
+                <div onClick="{{ closeCompose }}" title="Close message window" style="{{ composeCloseBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ composeChromeIconStyle }}">close</span></div>
               </div>
             </div>
           </sc-if>
@@ -987,8 +987,8 @@
                 <sc-for list="{{ composeToChips }}" as="ct" hint-placeholder-count="1">
                   <span style="display:flex;align-items:center;gap:7px;font-size:13px;background:var(--rail);border:1px solid var(--line);border-radius:14px;padding:3px 10px">{{ ct.name }} <span style="color:var(--faint)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:15px;line-height:1">close</span></span></span>
                 </sc-for>
-                <span style="flex:1;font-size:13px;color:var(--faint)">dodaj odbiorcę…</span>
-                <span onClick="{{ toggleCc }}" title="{{ ccTitle }}" style="{{ ccToggleStyle }}" style-hover="cursor:pointer;color:var(--text)">DW · UDW</span>
+                <span style="flex:1;font-size:13px;color:var(--faint)">add a recipient…</span>
+                <span onClick="{{ toggleCc }}" title="{{ ccTitle }}" style="{{ ccToggleStyle }}" style-hover="cursor:pointer;color:var(--text)">CC · BCC</span>
               </div>
               <sc-if value="{{ ccOpen }}" hint-placeholder-val="{{ false }}">
                 <div style="display:flex;align-items:center;gap:10px;padding:9px 15px;border-bottom:1px solid var(--line2)">
@@ -996,21 +996,21 @@
                   <sc-for list="{{ composeCcChips }}" as="cc" hint-placeholder-count="0">
                     <span style="display:flex;align-items:center;gap:7px;font-size:13px;background:var(--rail);border:1px solid var(--line);border-radius:14px;padding:3px 10px">{{ cc.name }} <span onClick="{{ cc.remove }}" style="color:var(--faint)" style-hover="cursor:pointer;color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:15px;line-height:1">close</span></span></span>
                   </sc-for>
-                  <input value="{{ ccValue }}" onChange="{{ onCcInput }}" onKeyDown="{{ onCcKey }}" placeholder="widoczni dla wszystkich…" style="flex:1;min-width:80px;font-family:inherit;font-size:13px;color:var(--text);background:transparent;border:none;outline:none;padding:0" />
+                  <input value="{{ ccValue }}" onChange="{{ onCcInput }}" onKeyDown="{{ onCcKey }}" placeholder="visible to everyone…" style="flex:1;min-width:80px;font-family:inherit;font-size:13px;color:var(--text);background:transparent;border:none;outline:none;padding:0" />
                 </div>
                 <div style="display:flex;align-items:flex-start;gap:9px;padding:9px 15px;border-bottom:1px solid var(--line2);background:var(--sub)">
                   <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1;color:var(--warn-text);width:88px;box-sizing:border-box;padding-left:1px">visibility</span>
-                  <span style="flex:1;min-width:0;font-size:12px;line-height:1.45;color:var(--text2);text-wrap:pretty">Adresy w DW widzi każdy odbiorca. Jeśli chcesz ukryć odbiorców przed sobą, użyj UDW.</span>
+                  <span style="flex:1;min-width:0;font-size:12px;line-height:1.45;color:var(--text2);text-wrap:pretty">Every recipient can see CC addresses. To hide recipients from each other, use BCC.</span>
                 </div>
                 <div style="display:flex;align-items:center;gap:10px;padding:9px 15px;border-bottom:1px solid var(--line2)">
                   <span style="font-size:12px;color:var(--muted);width:88px">UDW</span>
                   <sc-for list="{{ composeBccChips }}" as="bc" hint-placeholder-count="0">
                     <span style="display:flex;align-items:center;gap:7px;font-size:13px;background:var(--rail);border:1px solid var(--line);border-radius:14px;padding:3px 10px">{{ bc.name }} <span onClick="{{ bc.remove }}" style="color:var(--faint)" style-hover="cursor:pointer;color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:15px;line-height:1">close</span></span></span>
                   </sc-for>
-                  <input value="{{ bccValue }}" onChange="{{ onBccInput }}" onKeyDown="{{ onBccKey }}" placeholder="ukryci przed pozostałymi…" style="flex:1;min-width:80px;font-family:inherit;font-size:13px;color:var(--text);background:transparent;border:none;outline:none;padding:0" />
+                  <input value="{{ bccValue }}" onChange="{{ onBccInput }}" onKeyDown="{{ onBccKey }}" placeholder="hidden from the others…" style="flex:1;min-width:80px;font-family:inherit;font-size:13px;color:var(--text);background:transparent;border:none;outline:none;padding:0" />
                 </div>
                 <div style="display:flex;align-items:center;gap:10px;padding:9px 15px;border-bottom:1px solid var(--line2)">
-                  <span style="font-size:12px;color:var(--muted);width:88px;white-space:nowrap">Odpowiedź do</span>
+                  <span style="font-size:12px;color:var(--muted);width:88px;white-space:nowrap">Reply-to</span>
                   <sc-for list="{{ composeReplyToChips }}" as="rt" hint-placeholder-count="0">
                     <span style="display:flex;align-items:center;gap:7px;font-size:13px;background:var(--rail);border:1px solid var(--line);border-radius:14px;padding:3px 10px">{{ rt.name }} <span onClick="{{ rt.remove }}" style="color:var(--faint)" style-hover="cursor:pointer;color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:15px;line-height:1">close</span></span></span>
                   </sc-for>
@@ -1018,13 +1018,13 @@
                 </div>
               </sc-if>
               <div style="display:flex;align-items:center;gap:10px;padding:9px 15px;border-bottom:1px solid var(--line)">
-                <span style="font-size:12px;color:var(--muted);width:88px">Temat</span>
-                <input value="{{ composeSubjValue }}" onChange="{{ onComposeSubj }}" placeholder="Temat wiadomości" style="flex:1;min-width:0;font-family:inherit;font-size:14px;color:var(--text);background:transparent;border:none;outline:none;padding:0" />
+                <span style="font-size:12px;color:var(--muted);width:88px">Subject</span>
+                <input value="{{ composeSubjValue }}" onChange="{{ onComposeSubj }}" placeholder="Subject" style="flex:1;min-width:0;font-family:inherit;font-size:14px;color:var(--text);background:transparent;border:none;outline:none;padding:0" />
               </div>
               <div style="display:flex;flex-direction:column;gap:9px;background:var(--accent-soft);border-bottom:1px solid var(--accent-line);padding:11px 15px">
                 <div style="display:flex;align-items:center;gap:11px;background:var(--panel);border:2px solid var(--accent);border-radius:9px;padding:8px 11px">
                   <span style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:10px;letter-spacing:0.06em;color:var(--onaccent);background:var(--accent);border-radius:4px;padding:3px 7px">AI</span>
-                  <span style="flex:1;min-width:0;font-size:14px;color:var(--faint)">Napisz, o co chodzi — np. „akceptujemy SLA 2 h, ale prosimy o limit CPI 5%”</span>
+                  <span style="flex:1;min-width:0;font-size:14px;color:var(--faint)">Write what this is about — e.g. “we accept the 2 h SLA but ask for a 5% CPI cap”</span>
                 </div>
                 <div style="display:flex;align-items:center;gap:7px;flex-wrap:wrap">
                   <sc-for list="{{ aiActions }}" as="aa" hint-placeholder-count="4">
@@ -1037,7 +1037,7 @@
                 </div>
                 <div style="display:flex;align-items:center;gap:9px;flex-wrap:wrap;font-size:11px;color:var(--accent-d)">
                   <span style="background:var(--panel);border-radius:5px;padding:3px 8px">Kontekst: {{ composeContext }}</span>
-                  <span>szkic pozostaje lokalny do momentu wysłania</span>
+                  <span>the draft stays local until you send it</span>
                 </div>
               </div>
               <sc-if value="{{ fmtBarShown }}" hint-placeholder-val="{{ true }}">
@@ -1046,7 +1046,7 @@
                     <div onMouseDown="{{ fb.run }}" title="{{ fb.title }}" style="{{ fb.style }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)">{{ fb.label }}</div>
                   </sc-for>
                   <sc-if value="{{ fmtHintShown }}" hint-placeholder-val="{{ true }}">
-                    <div style="margin-left:auto;font-size:11px;color:var(--faint)">zaznacz fragment i użyj akcji AI, aby go przepisać</div>
+                    <div style="margin-left:auto;font-size:11px;color:var(--faint)">select a passage and use an AI action to rewrite it</div>
                   </sc-if>
                 </div>
               </sc-if>
@@ -1058,21 +1058,21 @@
                 </div>
               </sc-if>
               <sc-if value="{{ aiBusy }}" hint-placeholder-val="{{ false }}">
-                <div style="padding:7px 15px;background:var(--sub);border-bottom:1px solid var(--line2);font-size:12px;color:var(--muted)">AI pisze szkic…</div>
+                <div style="padding:7px 15px;background:var(--sub);border-bottom:1px solid var(--line2);font-size:12px;color:var(--muted)">AI is drafting…</div>
               </sc-if>
               <sc-if value="{{ aiDraftShown }}" hint-placeholder-val="{{ false }}">
                 <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;padding:8px 15px;background:var(--sub);border-bottom:1px solid var(--line2)">
-                  <span style="font-size:12px;color:var(--text2)">Szkic AI — sprawdź fakty i ton przed wysłaniem</span>
-                  <span onClick="{{ aiRevert }}" style="font-size:12px;color:var(--accent-d)" style-hover="cursor:pointer;text-decoration:underline">Przywróć moją wersję</span>
-                  <span onClick="{{ acceptDraft }}" style="font-size:12px;color:var(--muted)" style-hover="cursor:pointer;color:var(--text)">Akceptuję</span>
+                  <span style="font-size:12px;color:var(--text2)">AI draft — check the facts and tone before sending</span>
+                  <span onClick="{{ aiRevert }}" style="font-size:12px;color:var(--accent-d)" style-hover="cursor:pointer;text-decoration:underline">Restore my version</span>
+                  <span onClick="{{ acceptDraft }}" style="font-size:12px;color:var(--muted)" style-hover="cursor:pointer;color:var(--text)">Accept</span>
                 </div>
               </sc-if>
               <div contentEditable="true" suppressContentEditableWarning="{{ true }}" ref="{{ bodyRef }}" onKeyDown="{{ composeKeyDown }}" style="flex:1;min-height:170px;overflow:auto;padding:16px 17px;font-size:15px;line-height:1.65;color:var(--text2);outline:none"></div>
               <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;padding:11px 15px;border-top:1px solid var(--line);background:var(--sub)">
-                <div onClick="{{ askSend }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:8px;padding:9px 18px" style-hover="cursor:pointer;opacity:0.9">Wyślij</div>
-                <div style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:9px 13px" style-hover="cursor:pointer;background:var(--hover)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1;vertical-align:-3px;margin-right:6px">attach_file</span>Załącz</div>
-                <div onClick="{{ saveDraftAndClose }}" style="font-size:12px;color:var(--muted)" style-hover="cursor:pointer;color:var(--text)">Zapisz szkic</div>
-                <div style="margin-left:auto;font-size:11px;color:var(--faint)">Ctrl+Enter wysyła</div>
+                <div onClick="{{ askSend }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:8px;padding:9px 18px" style-hover="cursor:pointer;opacity:0.9">Send</div>
+                <div style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:9px 13px" style-hover="cursor:pointer;background:var(--hover)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1;vertical-align:-3px;margin-right:6px">attach_file</span>Attach</div>
+                <div onClick="{{ saveDraftAndClose }}" style="font-size:12px;color:var(--muted)" style-hover="cursor:pointer;color:var(--text)">Save draft</div>
+                <div style="margin-left:auto;font-size:11px;color:var(--faint)">Ctrl+Enter sends</div>
               </div>
             </div>
           </sc-if>
@@ -1088,11 +1088,11 @@
                 <span style="font-size:11px;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ htmlMeta }}</span>
               </div>
               <div style="margin-left:auto;display:flex;align-items:center;gap:8px">
-                <div onClick="{{ closeHtml }}" title="Zamknij podgląd" style="{{ docBtnStyle }}" style-hover="cursor:pointer;background:var(--hover)"><span style="{{ closeIconStyle }}">close</span></div>
+                <div onClick="{{ closeHtml }}" title="Close preview" style="{{ docBtnStyle }}" style-hover="cursor:pointer;background:var(--hover)"><span style="{{ closeIconStyle }}">close</span></div>
               </div>
             </div>
             <div style="position:relative;flex:1;min-height:0;display:flex">
-              <iframe srcDoc="{{ htmlSrc }}" sandbox="" title="Podgląd HTML wiadomości" style="{{ htmlFrameStyle }}"></iframe>
+              <iframe srcDoc="{{ htmlSrc }}" sandbox="" title="Message HTML preview" style="{{ htmlFrameStyle }}"></iframe>
               <sc-if value="{{ htmlLoading }}" hint-placeholder-val="{{ false }}">
                 <div style="{{ htmlSkelStyle }}">
                   <sc-for list="{{ htmlSkelLines }}" as="ln" hint-placeholder-count="6">
@@ -1102,7 +1102,7 @@
               </sc-if>
             </div>
             <div style="display:flex;align-items:center;gap:8px;padding:9px 14px;border-top:1px solid var(--line);background:var(--sub);font-size:11px;color:var(--muted)">
-              <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:14px;line-height:1">lock</span>Podgląd izolowany — skrypty i zdalne treści są zablokowane
+              <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:14px;line-height:1">lock</span>Isolated preview — scripts and remote content are blocked
             </div>
           </div>
         </div>
@@ -1115,13 +1115,13 @@
             <span style="font-size:14px;font-weight:600">{{ docName }}</span>
             <span style="font-size:12px;color:var(--faint)">{{ docMeta }}</span>
             <div style="margin-left:auto;display:flex;align-items:center;gap:6px">
-              <div onClick="{{ docZoomOut }}" title="Pomniejsz" style="{{ docBtnStyle }}" style-hover="cursor:pointer;background:var(--hover)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1">remove</span></div>
+              <div onClick="{{ docZoomOut }}" title="Zoom out" style="{{ docBtnStyle }}" style-hover="cursor:pointer;background:var(--hover)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1">remove</span></div>
               <span style="font-size:12px;color:var(--muted);min-width:42px;text-align:center">{{ docZoomLabel }}</span>
-              <div onClick="{{ docZoomIn }}" title="Powiększ" style="{{ docBtnStyle }}" style-hover="cursor:pointer;background:var(--hover)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1">add</span></div>
+              <div onClick="{{ docZoomIn }}" title="Zoom in" style="{{ docBtnStyle }}" style-hover="cursor:pointer;background:var(--hover)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1">add</span></div>
               <div style="width:1px;height:22px;background:var(--line);margin:0 4px"></div>
-              <div title="Pobierz" style="{{ docBtnStyle }}" style-hover="cursor:pointer;background:var(--hover)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1">download</span></div>
-              <div title="Drukuj" style="{{ docBtnStyle }}" style-hover="cursor:pointer;background:var(--hover)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1">print</span></div>
-              <div onClick="{{ closeDoc }}" title="Zamknij" style="{{ docBtnStyle }}" style-hover="cursor:pointer;background:var(--hover)"><span style="{{ closeIconStyle }}">close</span></div>
+              <div title="Download" style="{{ docBtnStyle }}" style-hover="cursor:pointer;background:var(--hover)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1">download</span></div>
+              <div title="Print" style="{{ docBtnStyle }}" style-hover="cursor:pointer;background:var(--hover)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1">print</span></div>
+              <div onClick="{{ closeDoc }}" title="Close" style="{{ docBtnStyle }}" style-hover="cursor:pointer;background:var(--hover)"><span style="{{ closeIconStyle }}">close</span></div>
             </div>
           </div>
           <div style="flex:1;min-height:0;overflow:auto;display:flex;flex-direction:column;align-items:center;gap:18px;padding:24px 20px;background:var(--sub)">
@@ -1140,7 +1140,7 @@
                 </sc-for>
               </div>
               <div style="margin-top:auto;display:flex;justify-content:space-between;font-size:11px;color:#9aa3ae;padding-top:28px">
-                <span>{{ docName }}</span><span>strona 1 z 1</span>
+                <span>{{ docName }}</span><span>page 1 of 1</span>
               </div>
             </div>
             </sc-if>
@@ -1157,7 +1157,7 @@
   <sc-if value="{{ isCases }}" hint-placeholder-val="{{ false }}">
     <div style="position:relative;flex:1;display:flex;flex-direction:column;min-width:0;min-height:0">
     <sc-if value="{{ showScreenFab }}" hint-placeholder-val="{{ false }}">
-      <div onClick="{{ openNewCase }}" title="Nowa sprawa" style="{{ fabStyle }}" style-hover="cursor:pointer;opacity:0.92"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:24px;line-height:1">create_new_folder</span></div>
+      <div onClick="{{ openNewCase }}" title="New case" style="{{ fabStyle }}" style-hover="cursor:pointer;opacity:0.92"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:24px;line-height:1">create_new_folder</span></div>
     </sc-if>
     <sc-if value="{{ selBarShown }}" hint-placeholder-val="{{ false }}">
       <div style="{{ selBarStyle }}">
@@ -1167,7 +1167,7 @@
             <div onClick="{{ sa.run }}" title="{{ sa.label }}" style="{{ sa.style }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:19px;line-height:1">{{ sa.icon }}</span>{{ sa.shown }}</div>
           </sc-for>
         </div>
-        <div onClick="{{ selClear }}" title="Anuluj zaznaczenie" style="{{ closeBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ closeIconStyle }}">close</span></div>
+        <div onClick="{{ selClear }}" title="Cancel selection" style="{{ closeBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ closeIconStyle }}">close</span></div>
       </div>
     </sc-if>
     <div ref="{{ tbRef }}" style="{{ toolbarStyle }}">
@@ -1183,8 +1183,8 @@
       <sc-if value="{{ showCaseList }}" hint-placeholder-val="{{ true }}">
         <div style="{{ caseListStyle }}">
           <div style="display:flex;align-items:center;gap:10px;padding:14px 16px;border-bottom:1px solid var(--line)">
-            <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">SPRAWY</div>
-            <div onClick="{{ openNewCase }}" style="margin-left:auto;font-size:12px;color:var(--accent-d)" style-hover="cursor:pointer;text-decoration:underline">Nowa sprawa</div>
+            <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">CASES</div>
+            <div onClick="{{ openNewCase }}" style="margin-left:auto;font-size:12px;color:var(--accent-d)" style-hover="cursor:pointer;text-decoration:underline">New case</div>
           </div>
           <div ref="{{ caseListRef }}" onScroll="{{ onCaseListScroll }}" style="flex:1;overflow:auto;min-height:0;background:var(--sub)">
             <sc-for list="{{ caseRows }}" as="c" hint-placeholder-count="3">
@@ -1209,7 +1209,7 @@
         <div style="flex:1;display:flex;flex-direction:column;min-width:0;min-height:0">
           <sc-if value="{{ showCaseBack }}" hint-placeholder-val="{{ false }}">
             <div onClick="{{ backToCases }}" style="display:flex;align-items:center;gap:8px;padding:11px 14px;border-bottom:1px solid var(--line);background:var(--sub)" style-hover="cursor:pointer">
-              <div style="font-size:14px;color:var(--text2);font-weight:600"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1;vertical-align:-3px;margin-right:5px">arrow_back</span>Sprawy</div>
+              <div style="font-size:14px;color:var(--text2);font-weight:600"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1;vertical-align:-3px;margin-right:5px">arrow_back</span>Cases</div>
             </div>
           </sc-if>
           <div style="{{ caseHeadStyle }}">
@@ -1217,7 +1217,7 @@
               <div style="{{ caseTitleStyle }}">{{ caseTitle }}</div>
               <div style="{{ caseStatusStyle }}">{{ caseStatus }}</div>
               <sc-if value="{{ caseHeadActionsShown }}" hint-placeholder-val="{{ true }}">
-                <div style="margin-left:auto;display:flex;gap:12px;font-size:13px;color:var(--muted)"><span style-hover="cursor:pointer;color:var(--text)">Dodaj wątek</span><span style-hover="cursor:pointer;color:var(--text)">Eksportuj</span></div>
+                <div style="margin-left:auto;display:flex;gap:12px;font-size:13px;color:var(--muted)"><span style-hover="cursor:pointer;color:var(--text)">Add thread</span><span style-hover="cursor:pointer;color:var(--text)">Export</span></div>
               </sc-if>
             </div>
             <sc-if value="{{ caseHeadFullShown }}" hint-placeholder-val="{{ true }}">
@@ -1248,11 +1248,11 @@
             </div>
 
             <div style="display:flex;flex-direction:column;gap:12px;background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:16px 18px">
-              <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">WARUNKI — CO SIĘ ZMIENIA</div>
+              <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">TERMS — WHAT CHANGES</div>
               <div style="display:flex;flex-direction:column">
                 <sc-if value="{{ caseFactHeadShown }}" hint-placeholder-val="{{ true }}">
                   <div style="{{ caseFactHeadStyle }}">
-                    <div style="flex:2;min-width:0">Parametr</div><div style="flex:1;min-width:0">Obecnie</div><div style="flex:1;min-width:0">Po aneksie</div><div style="flex:1;min-width:0">Źródło</div>
+                    <div style="flex:2;min-width:0">Parameter</div><div style="flex:1;min-width:0">Current</div><div style="flex:1;min-width:0">After addendum</div><div style="flex:1;min-width:0">Source</div>
                   </div>
                 </sc-if>
                 <sc-for list="{{ caseFacts }}" as="f" hint-placeholder-count="4">
@@ -1272,7 +1272,7 @@
             </div>
 
             <div style="display:flex;flex-direction:column;gap:12px;background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:16px 18px">
-              <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">OŚ SPRAWY</div>
+              <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">CASE TIMELINE</div>
               <div style="{{ caseTimelineStyle }}">
                 <sc-for list="{{ caseTimeline }}" as="tl" hint-placeholder-count="4">
                   <div style="{{ tl.style }}">
@@ -1285,7 +1285,7 @@
 
             <div style="{{ caseMaterialsStyle }}">
               <div style="flex:1;min-width:0;display:flex;flex-direction:column;gap:10px;background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:16px 18px">
-                <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">WĄTKI</div>
+                <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">THREADS</div>
                 <sc-for list="{{ caseThreads }}" as="ct" hint-placeholder-count="3">
                   <div onClick="{{ ct.open }}" style="display:flex;flex-direction:column;gap:3px;border-top:1px solid var(--line2);padding:9px 0 0 0" style-hover="cursor:pointer">
                     <div style="font-size:14px">{{ ct.label }}</div>
@@ -1294,7 +1294,7 @@
                 </sc-for>
               </div>
               <div style="flex:1;min-width:0;display:flex;flex-direction:column;gap:10px;background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:16px 18px">
-                <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">DOKUMENTY</div>
+                <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">DOCUMENTS</div>
                 <sc-for list="{{ caseDocs }}" as="cd" hint-placeholder-count="3">
                   <div onClick="{{ cd.open }}" style="display:flex;align-items:center;gap:9px;border-top:1px solid var(--line2);padding:9px 0 0 0" style-hover="cursor:pointer;color:var(--accent-d)">
                     <span style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;color:var(--muted)">{{ cd.type }}</span>
@@ -1303,13 +1303,13 @@
                   </div>
                 </sc-for>
                 <sc-if value="{{ caseNoDocs }}" hint-placeholder-val="{{ false }}">
-                  <div style="font-size:13px;color:var(--faint);border-top:1px solid var(--line2);padding-top:9px">Brak dokumentów przypiętych do sprawy</div>
+                  <div style="font-size:13px;color:var(--faint);border-top:1px solid var(--line2);padding-top:9px">No documents pinned to this case</div>
                 </sc-if>
               </div>
             </div>
 
             <div style="display:flex;flex-direction:column;gap:10px;background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:16px 18px">
-              <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">ZOBOWIĄZANIA</div>
+              <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">COMMITMENTS</div>
               <sc-for list="{{ caseDuties }}" as="d" hint-placeholder-count="3">
                 <div style="{{ d.rowStyle }}">
                   <div style="flex:0 0 90px;font-size:13px;color:var(--muted)">{{ d.who }}</div>
@@ -1325,12 +1325,12 @@
             <div onClick="{{ askAgentCase }}" style="{{ caseAskRowStyle }}" style-hover="cursor:pointer">
               <div style="{{ caseAskBadgeStyle }}">AI</div>
               <div style="{{ caseAskTextStyle }}">{{ caseAskPlaceholder }}</div>
-              <div onClick="{{ askAgentCase }}" style="font-size:13px;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:8px 15px;white-space:nowrap" style-hover="opacity:0.88;cursor:pointer">Zapytaj</div>
+              <div onClick="{{ askAgentCase }}" style="font-size:13px;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:8px 15px;white-space:nowrap" style-hover="opacity:0.88;cursor:pointer">Ask</div>
             </div>
             <sc-if value="{{ caseAskExtrasShown }}" hint-placeholder-val="{{ true }}">
               <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
                 <div style="font-size:12px;background:var(--accent-soft);color:var(--accent-d);border-radius:16px;padding:5px 11px">Zakres: {{ caseScope }}</div>
-                <div style="font-size:12px;color:var(--muted)">stan sprawy aktualizuje się przy każdej nowej wiadomości</div>
+                <div style="font-size:12px;color:var(--muted)">case state updates with every new message</div>
               </div>
             </sc-if>
           </div>
@@ -1354,16 +1354,16 @@
               </div>
             </sc-for>
           </div>
-          <div onClick="{{ agentNewConv }}" title="Nowa rozmowa" style="{{ tabToolBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ tabToolIconStyle }}">add</span></div>
+          <div onClick="{{ agentNewConv }}" title="New conversation" style="{{ tabToolBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ tabToolIconStyle }}">add</span></div>
         </div>
       </sc-if>
       <div style="{{ headerStyle }}">
-        <div onClick="{{ toggleHistory }}" title="Historia rozmów" style="display:flex;align-items:center;gap:8px;font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:7px;padding:7px 12px" style-hover="cursor:pointer;background:var(--rail)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">menu</span>{{ historyLabel }}</div>
-        <div onClick="{{ openHistorySearch }}" title="Szukaj w historii" style="display:flex;align-items:center;justify-content:center;font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:7px;padding:7px 10px" style-hover="cursor:pointer;background:var(--rail)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">search</span></div>
-        <div onClick="{{ agentNewConv }}" title="Nowa rozmowa" style="display:flex;align-items:center;gap:7px;font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);padding:7px 13px;border-radius:8px;white-space:nowrap;box-shadow:0 1px 2px var(--sh-2)" style-hover="cursor:pointer;opacity:0.9"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">add</span><sc-if value="{{ notMobile }}" hint-placeholder-val="{{ true }}">Nowa rozmowa</sc-if></div>
+        <div onClick="{{ toggleHistory }}" title="Conversation history" style="display:flex;align-items:center;gap:8px;font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:7px;padding:7px 12px" style-hover="cursor:pointer;background:var(--rail)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">menu</span>{{ historyLabel }}</div>
+        <div onClick="{{ openHistorySearch }}" title="Search history" style="display:flex;align-items:center;justify-content:center;font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:7px;padding:7px 10px" style-hover="cursor:pointer;background:var(--rail)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">search</span></div>
+        <div onClick="{{ agentNewConv }}" title="New conversation" style="display:flex;align-items:center;gap:7px;font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);padding:7px 13px;border-radius:8px;white-space:nowrap;box-shadow:0 1px 2px var(--sh-2)" style-hover="cursor:pointer;opacity:0.9"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">add</span><sc-if value="{{ notMobile }}" hint-placeholder-val="{{ true }}">New conversation</sc-if></div>
         <div style="font-size:16px;font-weight:600">{{ convTitle }}</div>
         <sc-if value="{{ notMobile }}" hint-placeholder-val="{{ true }}">
-          <div style="margin-left:auto;font-size:13px;color:var(--muted)">działa na Twojej poczcie, kalendarzu i sprawach</div>
+          <div style="margin-left:auto;font-size:13px;color:var(--muted)">works across your mail, calendar and cases</div>
         </sc-if>
       </div>
 
@@ -1371,10 +1371,10 @@
       <sc-if value="{{ historyOpen }}" hint-placeholder-val="{{ false }}">
         <div style="{{ historyPanelStyle }}">
           <div style="display:flex;align-items:center;gap:9px;padding:0 2px 4px 2px">
-            <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">HISTORIA</div>
-            <div onClick="{{ agentNewConv }}" style="margin-left:auto;font-size:12px;color:var(--accent-d)" style-hover="cursor:pointer;text-decoration:underline">Nowa</div>
+            <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">HISTORY</div>
+            <div onClick="{{ agentNewConv }}" style="margin-left:auto;font-size:12px;color:var(--accent-d)" style-hover="cursor:pointer;text-decoration:underline">New</div>
             <sc-if value="{{ historyCloseShown }}" hint-placeholder-val="{{ false }}">
-              <div onClick="{{ toggleHistory }}" title="Zamknij historię" style="{{ closeBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ closeIconStyle }}">close</span></div>
+              <div onClick="{{ toggleHistory }}" title="Close history" style="{{ closeBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ closeIconStyle }}">close</span></div>
             </sc-if>
           </div>
           <sc-if value="{{ selBarShown }}" hint-placeholder-val="{{ false }}">
@@ -1385,12 +1385,12 @@
                   <div onClick="{{ sa.run }}" title="{{ sa.label }}" style="{{ sa.style }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:19px;line-height:1">{{ sa.icon }}</span>{{ sa.shown }}</div>
                 </sc-for>
               </div>
-              <div onClick="{{ selClear }}" title="Anuluj zaznaczenie" style="{{ closeBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ closeIconStyle }}">close</span></div>
+              <div onClick="{{ selClear }}" title="Cancel selection" style="{{ closeBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ closeIconStyle }}">close</span></div>
             </div>
           </sc-if>
           <div style="display:flex;align-items:center;gap:8px;background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:6px 9px;margin-bottom:2px">
             <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:16px;line-height:1;color:var(--faint)">search</span>
-            <input ref="{{ historySearchRef }}" value="{{ historySearchValue }}" onChange="{{ onHistorySearch }}" placeholder="Szukaj w historii" style="flex:1;min-width:0;border:none;outline:none;font-size:13px;color:var(--text);background:transparent" />
+            <input ref="{{ historySearchRef }}" value="{{ historySearchValue }}" onChange="{{ onHistorySearch }}" placeholder="Search history" style="flex:1;min-width:0;border:none;outline:none;font-size:13px;color:var(--text);background:transparent" />
             <sc-if value="{{ historySearchValue }}" hint-placeholder-val="{{ false }}">
               <span onClick="{{ clearHistorySearch }}" style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:15px;line-height:1;color:var(--faint)" style-hover="cursor:pointer;color:var(--text)">close</span>
             </sc-if>
@@ -1404,7 +1404,7 @@
                 </div>
                 <sc-if value="{{ h.hasActions }}" hint-placeholder-val="{{ false }}">
                   <span onClick="{{ h.toggleArchive }}" title="{{ h.archiveTitle }}" style="flex:0 0 auto;font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:15px;line-height:1;color:var(--faint)" style-hover="color:var(--text);cursor:pointer">{{ h.archiveIcon }}</span>
-                  <span onClick="{{ h.askDelete }}" title="Usuń" style="flex:0 0 auto;font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:15px;line-height:1;color:var(--faint)" style-hover="color:var(--warn);cursor:pointer">delete</span>
+                  <span onClick="{{ h.askDelete }}" title="Delete" style="flex:0 0 auto;font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:15px;line-height:1;color:var(--faint)" style-hover="color:var(--warn);cursor:pointer">delete</span>
                 </sc-if>
               </div>
               <div style="font-size:12px;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ h.preview }}</div>
@@ -1424,7 +1424,7 @@
                       <span style="font-size:10px;color:var(--faint);white-space:nowrap">{{ h.when }}</span>
                     </div>
                     <span onClick="{{ h.toggleArchive }}" title="{{ h.archiveTitle }}" style="flex:0 0 auto;font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:15px;line-height:1;color:var(--faint)" style-hover="color:var(--text);cursor:pointer">{{ h.archiveIcon }}</span>
-                    <span onClick="{{ h.askDelete }}" title="Usuń" style="flex:0 0 auto;font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:15px;line-height:1;color:var(--faint)" style-hover="color:var(--warn);cursor:pointer">delete</span>
+                    <span onClick="{{ h.askDelete }}" title="Delete" style="flex:0 0 auto;font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:15px;line-height:1;color:var(--faint)" style-hover="color:var(--warn);cursor:pointer">delete</span>
                   </div>
                   <div style="font-size:12px;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ h.preview }}</div>
                 </div>
@@ -1473,7 +1473,7 @@
           </div>
         </sc-for>
         <sc-if value="{{ agentThinking }}" hint-placeholder-val="{{ false }}">
-          <div style="display:flex;align-items:center;gap:9px;font-size:13px;color:var(--muted);padding-left:2px">Agent przegląda pocztę…</div>
+          <div style="display:flex;align-items:center;gap:9px;font-size:13px;color:var(--muted);padding-left:2px">The agent is going through your mail…</div>
         </sc-if>
       </div>
       <div style="{{ agentInputWrapStyle }}">
@@ -1481,7 +1481,7 @@
           <div style="display:flex;align-items:center;gap:9px;align-self:flex-start;max-width:100%;background:var(--accent-soft);border:1px solid var(--accent-line);border-radius:11px;padding:8px 10px 8px 12px">
             <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1;color:var(--accent-d)">attach_file</span>
             <span style="flex:1;min-width:0;font-size:13px;color:var(--accent-d);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">Kontekst: {{ agentCtxLabel }}</span>
-            <span onClick="{{ clearAgentCtx }}" title="Usuń kontekst" style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1;color:var(--accent-d)" style-hover="cursor:pointer;color:var(--text)">close</span>
+            <span onClick="{{ clearAgentCtx }}" title="Remove context" style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1;color:var(--accent-d)" style-hover="cursor:pointer;color:var(--text)">close</span>
           </div>
         </sc-if>
         <sc-if value="{{ agentShowChips }}" hint-placeholder-val="{{ true }}">
@@ -1492,10 +1492,10 @@
           </div>
         </sc-if>
         <div style="{{ agentBoxStyle }}">
-          <input ref="{{ agentInputRef }}" value="{{ agentInput }}" onChange="{{ onAgentInput }}" onKeyDown="{{ onAgentKey }}" placeholder="Powiedz, co mam zrobić — napisać, zaplanować, sprawdzić" style="flex:1;min-width:0;border:none;outline:none;font-family:inherit;font-size:15px;color:var(--text);background:transparent" />
-          <div onClick="{{ agentSend }}" style="font-size:13px;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:8px 16px;white-space:nowrap" style-hover="cursor:pointer;opacity:0.88">Wyślij ⏎</div>
+          <input ref="{{ agentInputRef }}" value="{{ agentInput }}" onChange="{{ onAgentInput }}" onKeyDown="{{ onAgentKey }}" placeholder="Tell me what to do — write, schedule, check" style="flex:1;min-width:0;border:none;outline:none;font-family:inherit;font-size:15px;color:var(--text);background:transparent" />
+          <div onClick="{{ agentSend }}" style="font-size:13px;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:8px 16px;white-space:nowrap" style-hover="cursor:pointer;opacity:0.88">Send ⏎</div>
         </div>
-        <div style="font-size:11px;color:var(--faint)">Agent proponuje działania — nic nie wysyła bez Twojej akceptacji.</div>
+        <div style="font-size:11px;color:var(--faint)">The agent proposes actions — nothing is sent without your approval.</div>
       </div>
       </div>
       </div>
@@ -1506,7 +1506,7 @@
   <sc-if value="{{ isTasks }}" hint-placeholder-val="{{ false }}">
     <div style="position:relative;flex:1;display:flex;flex-direction:column;min-width:0;min-height:0">
       <sc-if value="{{ showScreenFab }}" hint-placeholder-val="{{ false }}">
-        <div onClick="{{ openNewTask }}" title="Nowe zadanie" style="{{ fabStyle }}" style-hover="cursor:pointer;opacity:0.92"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:24px;line-height:1">add_task</span></div>
+        <div onClick="{{ openNewTask }}" title="New task" style="{{ fabStyle }}" style-hover="cursor:pointer;opacity:0.92"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:24px;line-height:1">add_task</span></div>
       </sc-if>
     <sc-if value="{{ selBarShown }}" hint-placeholder-val="{{ false }}">
       <div style="{{ selBarStyle }}">
@@ -1516,7 +1516,7 @@
             <div onClick="{{ sa.run }}" title="{{ sa.label }}" style="{{ sa.style }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:19px;line-height:1">{{ sa.icon }}</span>{{ sa.shown }}</div>
           </sc-for>
         </div>
-        <div onClick="{{ selClear }}" title="Anuluj zaznaczenie" style="{{ closeBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ closeIconStyle }}">close</span></div>
+        <div onClick="{{ selClear }}" title="Cancel selection" style="{{ closeBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ closeIconStyle }}">close</span></div>
       </div>
     </sc-if>
       <div ref="{{ tbRef }}" style="{{ toolbarStyle }}">
@@ -1544,7 +1544,7 @@
                       <div style="display:flex;align-items:baseline;gap:9px;flex-wrap:wrap">
                         <span style="{{ t.titleStyle }}">{{ t.t }}</span>
                         <sc-if value="{{ t.ai }}" hint-placeholder-val="{{ false }}">
-                          <span style="font-size:10px;color:var(--accent-d);background:var(--accent-soft);border-radius:4px;padding:2px 6px">z poczty</span>
+                          <span style="font-size:10px;color:var(--accent-d);background:var(--accent-soft);border-radius:4px;padding:2px 6px">from mail</span>
                         </sc-if>
                       </div>
                       <div onClick="{{ t.openSrc }}" style="{{ srcLinkStyle }}" style-hover="cursor:pointer;background:var(--hover)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:15px;line-height:1">open_in_new</span>{{ t.src }}</div>
@@ -1565,8 +1565,8 @@
         </div>
         <div style="{{ tasksSideStyle }}">
           <div style="display:flex;align-items:center;gap:9px">
-            <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">DZIŚ W KALENDARZU</div>
-            <div onClick="{{ goCal }}" style="margin-left:auto;font-size:12px;color:var(--accent-d)" style-hover="cursor:pointer;text-decoration:underline">Otwórz</div>
+            <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">TODAY'S CALENDAR</div>
+            <div onClick="{{ goCal }}" style="margin-left:auto;font-size:12px;color:var(--accent-d)" style-hover="cursor:pointer;text-decoration:underline">Open</div>
           </div>
           <sc-for list="{{ taskAgenda }}" as="ta" hint-placeholder-count="3">
             <div style="display:flex;align-items:baseline;gap:10px;background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:9px 11px">
@@ -1577,10 +1577,10 @@
           <div style="display:flex;flex-direction:column;gap:8px;background:var(--accent-soft);border-radius:10px;padding:12px 13px">
             <div style="display:flex;align-items:center;gap:9px">
               <span style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:10px;color:var(--onaccent);background:var(--accent);border-radius:4px;padding:2px 6px">AI</span>
-              <span style="font-size:11px;letter-spacing:0.06em;color:var(--accent-d);font-family:'Instrument Sans',system-ui,sans-serif">POJEMNOŚĆ DNIA</span>
+              <span style="font-size:11px;letter-spacing:0.06em;color:var(--accent-d);font-family:'Instrument Sans',system-ui,sans-serif">DAY CAPACITY</span>
             </div>
             <div style="font-size:13px;line-height:1.5;color:var(--text2);text-wrap:pretty">{{ capacityText }}</div>
-            <div onClick="{{ autoSchedule }}" style="align-self:flex-start;font-size:12px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:7px 13px" style-hover="cursor:pointer;opacity:0.9">Rozplanuj dzisiejsze</div>
+            <div onClick="{{ autoSchedule }}" style="align-self:flex-start;font-size:12px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:7px 13px" style-hover="cursor:pointer;opacity:0.9">Lay out today</div>
           </div>
         </div>
       </div>
@@ -1607,41 +1607,41 @@
     <div onClick="{{ closeNewCase }}" style="{{ ovZ96 }}">
       <div onClick="{{ stopProp }}" style="width:520px;max-width:100%;display:flex;flex-direction:column;background:var(--panel);border:1px solid var(--line);border-radius:14px;box-shadow:0 22px 52px var(--sh-3);overflow:hidden">
         <div style="display:flex;align-items:center;gap:12px;padding:14px 18px;border-bottom:1px solid var(--line);background:var(--sub)">
-          <div style="font-size:15px;font-weight:600">Nowa sprawa</div>
+          <div style="font-size:15px;font-weight:600">New case</div>
           <div onClick="{{ closeNewCase }}" style="{{ closeBtnAutoStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ closeIconStyle }}">close</span></div>
         </div>
         <div style="display:flex;flex-direction:column;gap:13px;padding:18px">
           <div style="display:flex;flex-direction:column;gap:9px;background:var(--accent-soft);border-radius:10px;padding:12px 13px">
             <div style="display:flex;align-items:center;gap:9px">
               <span style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:10px;color:var(--onaccent);background:var(--accent);border-radius:4px;padding:3px 7px">AI</span>
-              <span style="font-size:12px;color:var(--accent-d)">Opisz sprawę — zbiorę wątki, dokumenty i terminy</span>
+              <span style="font-size:12px;color:var(--accent-d)">Describe the case — I'll gather threads, documents and deadlines</span>
             </div>
-            <input ref="{{ csPromptRef }}" placeholder="np. renegocjacja umowy z Adventure Works, SLA w weekendy" style="{{ promptFieldStyle }}" />
+            <input ref="{{ csPromptRef }}" placeholder="e.g. renegotiating the Adventure Works contract, weekend SLA" style="{{ promptFieldStyle }}" />
             <div style="display:flex;gap:7px;flex-wrap:wrap">
-              <div onClick="{{ csBuild }}" style="font-size:12px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:7px 13px" style-hover="cursor:pointer;opacity:0.9">Zbuduj sprawę</div>
-              <div onClick="{{ csFromThread }}" style="font-size:12px;color:var(--accent-d);background:var(--panel);border:1px solid var(--accent-line);border-radius:7px;padding:7px 13px" style-hover="cursor:pointer">Z otwartego wątku</div>
+              <div onClick="{{ csBuild }}" style="font-size:12px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:7px 13px" style-hover="cursor:pointer;opacity:0.9">Build the case</div>
+              <div onClick="{{ csFromThread }}" style="font-size:12px;color:var(--accent-d);background:var(--panel);border:1px solid var(--accent-line);border-radius:7px;padding:7px 13px" style-hover="cursor:pointer">From the open thread</div>
             </div>
             <sc-if value="{{ csFoundShown }}" hint-placeholder-val="{{ false }}">
               <div style="display:flex;flex-direction:column;gap:7px;border-top:1px solid var(--accent-line);padding-top:9px">
-                <div style="font-size:11px;color:var(--accent-d);letter-spacing:0.06em;font-family:'Instrument Sans',system-ui,sans-serif">ZNALEZIONE W SKRZYNCE</div>
+                <div style="font-size:11px;color:var(--accent-d);letter-spacing:0.06em;font-family:'Instrument Sans',system-ui,sans-serif">FOUND IN THE MAILBOX</div>
                 <sc-for list="{{ csFound }}" as="cf" hint-placeholder-count="3">
                   <div style="display:flex;align-items:center;gap:9px;background:var(--panel);border-radius:7px;padding:7px 10px">
                     <span style="font-size:11px;color:var(--muted);width:66px">{{ cf.kind }}</span>
                     <span style="font-size:13px;flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ cf.label }}</span>
-                    <span style="font-size:11px;color:var(--accent-d)">dołączone</span>
+                    <span style="font-size:11px;color:var(--accent-d)">included</span>
                   </div>
                 </sc-for>
               </div>
             </sc-if>
           </div>
-          <input ref="{{ csTitleRef }}" placeholder="Nazwa sprawy" style="{{ fieldStyle }}" />
+          <input ref="{{ csTitleRef }}" placeholder="Case name" style="{{ fieldStyle }}" />
           <div style="display:flex;gap:10px">
-            <input ref="{{ csPartiesRef }}" placeholder="Strony (np. Contoso · Nordwind)" style="{{ fieldStyle }}" />
-            <input ref="{{ csDueRef }}" placeholder="Termin (np. 12.09)" style="{{ fieldStyle }}" />
+            <input ref="{{ csPartiesRef }}" placeholder="Parties (e.g. Contoso · Nordwind)" style="{{ fieldStyle }}" />
+            <input ref="{{ csDueRef }}" placeholder="Due date (e.g. 12.09)" style="{{ fieldStyle }}" />
           </div>
           <div style="display:flex;gap:9px;justify-content:flex-end">
-            <div onClick="{{ closeNewCase }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:8px 15px" style-hover="cursor:pointer;background:var(--hover)">Anuluj</div>
-            <div onClick="{{ saveCase }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:8px;padding:8px 16px" style-hover="cursor:pointer;opacity:0.9">Utwórz sprawę</div>
+            <div onClick="{{ closeNewCase }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:8px 15px" style-hover="cursor:pointer;background:var(--hover)">Cancel</div>
+            <div onClick="{{ saveCase }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:8px;padding:8px 16px" style-hover="cursor:pointer;opacity:0.9">Create case</div>
           </div>
         </div>
       </div>
@@ -1652,27 +1652,27 @@
     <div onClick="{{ closeNewTask }}" style="{{ ovZ96 }}">
       <div onClick="{{ stopProp }}" style="{{ dlgFormWide }}">
         <div style="display:flex;align-items:center;gap:12px;padding:14px 18px;border-bottom:1px solid var(--line);background:var(--sub)">
-          <div style="font-size:15px;font-weight:600">Nowe zadanie</div>
+          <div style="font-size:15px;font-weight:600">New task</div>
           <div onClick="{{ closeNewTask }}" style="{{ closeBtnAutoStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ closeIconStyle }}">close</span></div>
         </div>
         <div style="display:flex;flex-direction:column;gap:13px;padding:18px">
           <div style="display:flex;flex-direction:column;gap:9px;background:var(--accent-soft);border-radius:10px;padding:12px 13px">
             <div style="display:flex;align-items:center;gap:9px">
               <span style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:10px;color:var(--onaccent);background:var(--accent);border-radius:4px;padding:3px 7px">AI</span>
-              <span style="font-size:12px;color:var(--accent-d)">Opisz zadanie — rozpoznam termin i czas</span>
+              <span style="font-size:12px;color:var(--accent-d)">Describe the task — I'll pick up the date and duration</span>
             </div>
-            <input ref="{{ tkPromptRef }}" placeholder="np. odpowiedzieć Ewie o SLA do poniedziałku, 30 min" style="{{ promptFieldStyle }}" />
-            <div onClick="{{ tkParse }}" style="align-self:flex-start;font-size:12px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:7px 13px" style-hover="cursor:pointer;opacity:0.9">Utwórz z opisu</div>
+            <input ref="{{ tkPromptRef }}" placeholder="e.g. reply to Emma about the SLA by Monday, 30 min" style="{{ promptFieldStyle }}" />
+            <div onClick="{{ tkParse }}" style="align-self:flex-start;font-size:12px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:7px 13px" style-hover="cursor:pointer;opacity:0.9">Create from description</div>
           </div>
-          <input ref="{{ tkTitleRef }}" placeholder="Treść zadania" style="{{ fieldStyle }}" />
+          <input ref="{{ tkTitleRef }}" placeholder="Task description" style="{{ fieldStyle }}" />
           <div style="display:flex;gap:10px">
-            <input ref="{{ tkDueRef }}" placeholder="Termin (np. 02.09)" style="{{ fieldStyle }}" />
-            <input ref="{{ tkEstRef }}" placeholder="Czas (np. 30 min)" style="{{ fieldStyle }}" />
+            <input ref="{{ tkDueRef }}" placeholder="Due date (e.g. 02.09)" style="{{ fieldStyle }}" />
+            <input ref="{{ tkEstRef }}" placeholder="Duration (e.g. 30 min)" style="{{ fieldStyle }}" />
           </div>
           <div style="display:flex;flex-direction:column;gap:9px;background:var(--sub);border:1px solid var(--line);border-radius:10px;padding:12px 13px">
             <div style="display:flex;align-items:center;gap:9px">
               <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1;color:var(--muted)">notifications_active</span>
-              <span style="flex:1;font-size:12.5px;font-weight:600">Przypomnienia</span>
+              <span style="flex:1;font-size:12.5px;font-weight:600">Reminders</span>
               <span style="{{ tkRem.countStyle }}">{{ tkRem.countLabel }}</span>
             </div>
             <div style="display:flex;flex-wrap:wrap;gap:7px">
@@ -1681,13 +1681,13 @@
               </sc-for>
             </div>
             <div style="{{ remRowStyle }}">
-              <input ref="{{ tkRem.numRef }}" type="number" min="1" placeholder="np. 45" style="width:78px;font-family:inherit;font-size:13px;color:var(--text);background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:7px 9px;outline:none" />
+              <input ref="{{ tkRem.numRef }}" type="number" min="1" placeholder="e.g. 45" style="width:78px;font-family:inherit;font-size:13px;color:var(--text);background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:7px 9px;outline:none" />
               <div style="display:flex;gap:2px;background:var(--panel);border:1px solid var(--line);border-radius:9px;padding:2px">
                 <sc-for list="{{ tkRem.units }}" as="u" hint-placeholder-count="3">
                   <div onClick="{{ u.pick }}" style="{{ u.style }}" style-hover="cursor:pointer">{{ u.label }}</div>
                 </sc-for>
               </div>
-              <div onClick="{{ tkRem.add }}" style="display:flex;align-items:center;height:32px;padding:0 12px;border:1px solid var(--accent-line);border-radius:9px;background:var(--accent-soft);font-size:12.5px;font-weight:600;color:var(--accent-d)" style-hover="cursor:pointer;background:var(--accent);color:var(--onaccent);border-color:var(--accent)">Dodaj</div>
+              <div onClick="{{ tkRem.add }}" style="display:flex;align-items:center;height:32px;padding:0 12px;border:1px solid var(--accent-line);border-radius:9px;background:var(--accent-soft);font-size:12.5px;font-weight:600;color:var(--accent-d)" style-hover="cursor:pointer;background:var(--accent);color:var(--onaccent);border-color:var(--accent)">Add</div>
               <span style="{{ remHintStyle }}">{{ tkRem.hint }}</span>
             </div>
             <sc-if value="{{ tkRem.any }}" hint-placeholder-val="{{ true }}">
@@ -1699,8 +1699,8 @@
             </sc-if>
           </div>
           <div style="display:flex;gap:9px;justify-content:flex-end">
-            <div onClick="{{ closeNewTask }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:8px 15px" style-hover="cursor:pointer;background:var(--hover)">Anuluj</div>
-            <div onClick="{{ saveTask }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:8px;padding:8px 16px" style-hover="cursor:pointer;opacity:0.9">Dodaj zadanie</div>
+            <div onClick="{{ closeNewTask }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:8px 15px" style-hover="cursor:pointer;background:var(--hover)">Cancel</div>
+            <div onClick="{{ saveTask }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:8px;padding:8px 16px" style-hover="cursor:pointer;opacity:0.9">Add task</div>
           </div>
         </div>
       </div>
@@ -1729,7 +1729,7 @@
         </div>
         <div style="font-size:13px;color:var(--muted);line-height:1.5;text-wrap:pretty">{{ confirmDelText }}</div>
         <div style="display:flex;gap:9px;justify-content:flex-end;margin-top:2px">
-          <div onClick="{{ cancelConfirmDel }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:8px 15px" style-hover="cursor:pointer;background:var(--hover)">Anuluj</div>
+          <div onClick="{{ cancelConfirmDel }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:8px 15px" style-hover="cursor:pointer;background:var(--hover)">Cancel</div>
           <div onClick="{{ runConfirmDel }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--err);border-radius:8px;padding:8px 16px" style-hover="cursor:pointer;opacity:0.9">{{ confirmDelLabel }}</div>
         </div>
       </div>
@@ -1742,7 +1742,7 @@
         <div style="display:flex;align-items:flex-start;gap:11px;padding:14px 18px;border-bottom:1px solid var(--line);background:var(--sub)">
           <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:20px;line-height:1;color:var(--muted);padding-top:1px">notifications_active</span>
           <div style="flex:1;min-width:0;display:flex;flex-direction:column;gap:2px">
-            <div style="font-size:15px;font-weight:600">Przypomnienia</div>
+            <div style="font-size:15px;font-weight:600">Reminders</div>
             <div style="font-size:12px;color:var(--muted);text-wrap:pretty">{{ remModalSubtitle }}</div>
           </div>
           <div onClick="{{ closeRemModal }}" style="{{ closeBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ closeIconStyle }}">close</span></div>
@@ -1754,18 +1754,18 @@
             </sc-for>
           </div>
           <div style="{{ remRowStyle }}">
-            <input ref="{{ remModal.numRef }}" type="number" min="1" placeholder="np. 45" style="width:78px;font-family:inherit;font-size:13px;color:var(--text);background:var(--sub);border:1px solid var(--line);border-radius:8px;padding:7px 9px;outline:none" />
+            <input ref="{{ remModal.numRef }}" type="number" min="1" placeholder="e.g. 45" style="width:78px;font-family:inherit;font-size:13px;color:var(--text);background:var(--sub);border:1px solid var(--line);border-radius:8px;padding:7px 9px;outline:none" />
             <div style="display:flex;gap:2px;background:var(--sub);border:1px solid var(--line);border-radius:9px;padding:2px">
               <sc-for list="{{ remModal.units }}" as="u" hint-placeholder-count="3">
                 <div onClick="{{ u.pick }}" style="{{ u.style }}" style-hover="cursor:pointer">{{ u.label }}</div>
               </sc-for>
             </div>
-            <div onClick="{{ remModal.add }}" style="display:flex;align-items:center;height:32px;padding:0 12px;border:1px solid var(--accent-line);border-radius:9px;background:var(--accent-soft);font-size:12.5px;font-weight:600;color:var(--accent-d)" style-hover="cursor:pointer;background:var(--accent);color:var(--onaccent);border-color:var(--accent)">Dodaj</div>
+            <div onClick="{{ remModal.add }}" style="display:flex;align-items:center;height:32px;padding:0 12px;border:1px solid var(--accent-line);border-radius:9px;background:var(--accent-soft);font-size:12.5px;font-weight:600;color:var(--accent-d)" style-hover="cursor:pointer;background:var(--accent);color:var(--onaccent);border-color:var(--accent)">Add</div>
             <span style="{{ remHintStyle }}">{{ remModal.hint }}</span>
           </div>
           <sc-if value="{{ remModal.any }}" hint-placeholder-val="{{ true }}">
             <div style="display:flex;flex-direction:column;gap:7px;border-top:1px solid var(--line2);padding-top:12px">
-              <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:10px;letter-spacing:0.08em;color:var(--muted)">USTAWIONE</div>
+              <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:10px;letter-spacing:0.08em;color:var(--muted)">SET</div>
               <div style="display:flex;flex-wrap:wrap;gap:6px">
                 <sc-for list="{{ remModal.list }}" as="r" hint-placeholder-count="2">
                   <span style="display:flex;align-items:center;gap:6px;font-size:12px;background:var(--sub);border:1px solid var(--accent-line);border-radius:13px;padding:4px 10px">{{ r.label }} <span onClick="{{ r.remove }}" style="color:var(--faint)" style-hover="cursor:pointer;color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:15px;line-height:1">close</span></span></span>
@@ -1775,11 +1775,11 @@
           </sc-if>
           <div style="display:flex;align-items:flex-start;gap:9px;font-size:12px;color:var(--muted);line-height:1.45;text-wrap:pretty">
             <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:16px;line-height:1;color:var(--faint);padding-top:1px">info</span>
-            <span style="flex:1;min-width:0">Każde przypomnienie trafia do centrum powiadomień i pokazuje komunikat w rogu ekranu.</span>
+            <span style="flex:1;min-width:0">Every reminder lands in the notification centre and shows a toast in the corner of the screen.</span>
           </div>
           <div style="display:flex;gap:9px;justify-content:space-between;align-items:center">
-            <div onClick="{{ remModalClear }}" style="font-size:12.5px;color:var(--text2)" style-hover="cursor:pointer;text-decoration:underline">Wyłącz wszystkie</div>
-            <div onClick="{{ closeRemModal }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:8px;padding:8px 16px" style-hover="cursor:pointer;opacity:0.9">Gotowe</div>
+            <div onClick="{{ remModalClear }}" style="font-size:12.5px;color:var(--text2)" style-hover="cursor:pointer;text-decoration:underline">Turn all off</div>
+            <div onClick="{{ closeRemModal }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:8px;padding:8px 16px" style-hover="cursor:pointer;opacity:0.9">Done</div>
           </div>
         </div>
       </div>
@@ -1789,7 +1789,7 @@
   <sc-if value="{{ isCal }}" hint-placeholder-val="{{ false }}">
     <div style="position:relative;flex:1;display:flex;flex-direction:column;min-width:0;min-height:0">
       <sc-if value="{{ showScreenFab }}" hint-placeholder-val="{{ false }}">
-        <div onClick="{{ openNewEvent }}" title="Nowe wydarzenie" style="{{ fabStyle }}" style-hover="cursor:pointer;opacity:0.92"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:24px;line-height:1">event</span></div>
+        <div onClick="{{ openNewEvent }}" title="New event" style="{{ fabStyle }}" style-hover="cursor:pointer;opacity:0.92"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:24px;line-height:1">event</span></div>
       </sc-if>
     <sc-if value="{{ selBarShown }}" hint-placeholder-val="{{ false }}">
       <div style="{{ selBarStyle }}">
@@ -1799,7 +1799,7 @@
             <div onClick="{{ sa.run }}" title="{{ sa.label }}" style="{{ sa.style }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:19px;line-height:1">{{ sa.icon }}</span>{{ sa.shown }}</div>
           </sc-for>
         </div>
-        <div onClick="{{ selClear }}" title="Anuluj zaznaczenie" style="{{ closeBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ closeIconStyle }}">close</span></div>
+        <div onClick="{{ selClear }}" title="Cancel selection" style="{{ closeBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ closeIconStyle }}">close</span></div>
       </div>
     </sc-if>
       <div ref="{{ tbRef }}" style="{{ toolbarStyle }}">
@@ -1814,12 +1814,12 @@
       <div style="{{ calHeadStyle }}">
         <div style="{{ calTitleRowStyle }}">
           <div style="display:flex;flex-direction:column;gap:2px;min-width:0">
-            <div style="font-size:19px;font-weight:600;letter-spacing:-0.015em">Sierpień 2026</div>
-            <div style="font-size:13px;color:var(--muted)">24–30 sierpnia · tydzień 35</div>
+            <div style="font-size:19px;font-weight:600;letter-spacing:-0.015em">August 2026</div>
+            <div style="font-size:13px;color:var(--muted)">24–30 August · week 35</div>
           </div>
           <div style="{{ calNavRowStyle }}">
             <div style="{{ calNavStyle }}" style-hover="cursor:pointer;background:var(--hover)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1">chevron_left</span></div>
-            <div style="{{ calTodayBtnStyle }}" style-hover="cursor:pointer;background:var(--hover)">Dziś</div>
+            <div style="{{ calTodayBtnStyle }}" style-hover="cursor:pointer;background:var(--hover)">Today</div>
             <div style="{{ calNavStyle }}" style-hover="cursor:pointer;background:var(--hover)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1">chevron_right</span></div>
           </div>
         </div>
@@ -1832,7 +1832,7 @@
       <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;background:var(--accent-soft);border-bottom:1px solid var(--accent-line);padding:10px 24px">
         <span style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:10px;letter-spacing:0.06em;color:var(--onaccent);background:var(--accent);border-radius:4px;padding:3px 7px">AI</span>
         <span style="font-size:14px;color:var(--text);text-wrap:pretty">{{ calBriefing }}</span>
-        <span style="font-size:12px;color:var(--accent-d);margin-left:auto" style-hover="cursor:pointer;text-decoration:underline">Zaplanuj mój dzień</span>
+        <span style="font-size:12px;color:var(--accent-d);margin-left:auto" style-hover="cursor:pointer;text-decoration:underline">Plan my day</span>
       </div>
       <div ref="{{ calScrollRef }}" onScroll="{{ onCalScroll }}" style="{{ calBodyStyle }}">
         <sc-if value="{{ calIsWeek }}" hint-placeholder-val="{{ true }}">
@@ -1915,7 +1915,7 @@
                 </div>
               </sc-for>
               <sc-if value="{{ calMonthDayEmpty }}" hint-placeholder-val="{{ false }}">
-                <div style="font-size:13px;color:var(--muted)">Brak wydarzeń tego dnia.</div>
+                <div style="font-size:13px;color:var(--muted)">No events on this day.</div>
               </sc-if>
             </div>
           </sc-if>
@@ -1950,10 +1950,10 @@
         </sc-if>
         <div style="{{ calSideStyle }}">
           <div style="display:flex;align-items:center;gap:9px">
-            <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">WYKRYTE W POCZCIE</div>
+            <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">DETECTED IN MAIL</div>
             <div style="font-size:10px;color:var(--onaccent);background:var(--accent);border-radius:4px;padding:2px 6px">AI</div>
           </div>
-          <div style="font-size:12px;color:var(--muted);line-height:1.5;text-wrap:pretty">Terminy znalezione w wątkach, jeszcze nie w kalendarzu.</div>
+          <div style="font-size:12px;color:var(--muted);line-height:1.5;text-wrap:pretty">Deadlines found in threads, not in the calendar yet.</div>
           <sc-for list="{{ calFocus }}" as="f" hint-placeholder-count="2">
             <div style="display:flex;flex-direction:column;gap:6px;background:var(--panel);border:1px solid var(--line);border-left:3px solid var(--accent);border-radius:9px;padding:11px 13px">
               <div style="display:flex;align-items:baseline;gap:9px">
@@ -1962,8 +1962,8 @@
               </div>
               <div style="font-size:11px;color:var(--muted);line-height:1.45;text-wrap:pretty">{{ f.why }}</div>
               <div style="display:flex;gap:7px">
-                <div onClick="{{ f.add }}" style="font-size:12px;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:6px 12px" style-hover="cursor:pointer;opacity:0.9">Zarezerwuj czas</div>
-                <div onClick="{{ f.skip }}" style="font-size:12px;color:var(--text2);border:1px solid var(--border2);border-radius:7px;padding:6px 12px" style-hover="cursor:pointer;background:var(--hover)">Nie teraz</div>
+                <div onClick="{{ f.add }}" style="font-size:12px;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:6px 12px" style-hover="cursor:pointer;opacity:0.9">Block time</div>
+                <div onClick="{{ f.skip }}" style="font-size:12px;color:var(--text2);border:1px solid var(--border2);border-radius:7px;padding:6px 12px" style-hover="cursor:pointer;background:var(--hover)">Not now</div>
               </div>
             </div>
           </sc-for>
@@ -1975,13 +1975,13 @@
               </div>
               <div style="font-size:11px;color:var(--muted)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:14px;line-height:1;vertical-align:-2px;margin-right:4px">open_in_new</span>{{ p.src }}</div>
               <div style="display:flex;gap:7px">
-                <div onClick="{{ p.add }}" style="font-size:12px;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:6px 12px" style-hover="cursor:pointer;opacity:0.9">Dodaj</div>
-                <div onClick="{{ p.skip }}" style="font-size:12px;color:var(--text2);border:1px solid var(--border2);border-radius:7px;padding:6px 12px" style-hover="cursor:pointer;background:var(--hover)">Odrzuć</div>
+                <div onClick="{{ p.add }}" style="font-size:12px;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:6px 12px" style-hover="cursor:pointer;opacity:0.9">Add</div>
+                <div onClick="{{ p.skip }}" style="font-size:12px;color:var(--text2);border:1px solid var(--border2);border-radius:7px;padding:6px 12px" style-hover="cursor:pointer;background:var(--hover)">Dismiss</div>
               </div>
             </div>
           </sc-for>
           <sc-if value="{{ calNoProposals }}" hint-placeholder-val="{{ false }}">
-            <div style="font-size:13px;color:var(--faint)">Wszystkie wykryte terminy zostały rozpatrzone.</div>
+            <div style="font-size:13px;color:var(--faint)">Every detected deadline has been handled.</div>
           </sc-if>
         </div>
       </div>
@@ -1991,7 +1991,7 @@
   <sc-if value="{{ isPeople }}" hint-placeholder-val="{{ false }}">
     <div style="position:relative;flex:1;display:flex;flex-direction:column;min-width:0;min-height:0">
     <sc-if value="{{ showScreenFab }}" hint-placeholder-val="{{ false }}">
-      <div onClick="{{ openNewContact }}" title="Nowy kontakt" style="{{ fabStyle }}" style-hover="cursor:pointer;opacity:0.92"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:24px;line-height:1">person_add</span></div>
+      <div onClick="{{ openNewContact }}" title="New contact" style="{{ fabStyle }}" style-hover="cursor:pointer;opacity:0.92"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:24px;line-height:1">person_add</span></div>
     </sc-if>
     <sc-if value="{{ selBarShown }}" hint-placeholder-val="{{ false }}">
       <div style="{{ selBarStyle }}">
@@ -2001,7 +2001,7 @@
             <div onClick="{{ sa.run }}" title="{{ sa.label }}" style="{{ sa.style }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:19px;line-height:1">{{ sa.icon }}</span>{{ sa.shown }}</div>
           </sc-for>
         </div>
-        <div onClick="{{ selClear }}" title="Anuluj zaznaczenie" style="{{ closeBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ closeIconStyle }}">close</span></div>
+        <div onClick="{{ selClear }}" title="Cancel selection" style="{{ closeBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ closeIconStyle }}">close</span></div>
       </div>
     </sc-if>
     <div ref="{{ tbRef }}" style="{{ toolbarStyle }}">
@@ -2018,8 +2018,8 @@
         <div style="{{ peopleListStyle }}">
           <div style="display:flex;flex-direction:column;gap:9px;padding:11px 12px 10px 12px;border-bottom:1px solid var(--line)">
             <div style="display:flex;align-items:center;gap:4px;background:var(--rail);border:1px solid var(--line);border-radius:9px;padding:3px">
-              <div onClick="{{ showOwnContacts }}" title="Kontakty z książki adresowej" style="{{ tabOwnStyle }}" style-hover="cursor:pointer;color:var(--text)">Własne</div>
-              <div onClick="{{ showCollectedContacts }}" title="Zebrane automatycznie z odebranej poczty" style="{{ tabCollectedStyle }}" style-hover="cursor:pointer;color:var(--text)">Zebrane</div>
+              <div onClick="{{ showOwnContacts }}" title="Contacts from the address book" style="{{ tabOwnStyle }}" style-hover="cursor:pointer;color:var(--text)">Own</div>
+              <div onClick="{{ showCollectedContacts }}" title="Collected automatically from received mail" style="{{ tabCollectedStyle }}" style-hover="cursor:pointer;color:var(--text)">Collected</div>
             </div>
             <div style="display:flex;align-items:center;gap:8px;padding:0 3px">
               <div style="font-size:12px;color:var(--faint)">{{ peopleCount }}</div>
@@ -2053,7 +2053,7 @@
         <div style="flex:1;display:flex;flex-direction:column;min-width:0;min-height:0">
           <sc-if value="{{ showPeopleBack }}" hint-placeholder-val="{{ false }}">
             <div onClick="{{ backToPeople }}" style="display:flex;align-items:center;gap:8px;padding:11px 14px;border-bottom:1px solid var(--line);background:var(--sub)" style-hover="cursor:pointer">
-              <div style="font-size:14px;color:var(--text2);font-weight:600"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1;vertical-align:-3px;margin-right:5px">arrow_back</span>Kontakty</div>
+              <div style="font-size:14px;color:var(--text2);font-weight:600"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1;vertical-align:-3px;margin-right:5px">arrow_back</span>Contacts</div>
             </div>
           </sc-if>
           <div style="{{ personHeadStyle }}">
@@ -2064,7 +2064,7 @@
                 <div style="display:flex;align-items:center;gap:9px;min-width:0">
                   <div style="font-size:20px;font-weight:600;letter-spacing:-0.015em;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ personName }}</div>
                   <sc-if value="{{ personCollected }}" hint-placeholder-val="{{ false }}">
-                    <div style="flex:0 0 auto;font-family:'Instrument Sans',system-ui,sans-serif;font-size:10px;letter-spacing:0.06em;color:var(--muted);border:1px solid var(--border2);border-radius:5px;padding:2px 7px">ZEBRANY</div>
+                    <div style="flex:0 0 auto;font-family:'Instrument Sans',system-ui,sans-serif;font-size:10px;letter-spacing:0.06em;color:var(--muted);border:1px solid var(--border2);border-radius:5px;padding:2px 7px">COLLECTED</div>
                   </sc-if>
                 </div>
                 <div style="font-size:13px;color:var(--muted)">{{ personRole }} · {{ personOrg }}</div>
@@ -2075,27 +2075,27 @@
               </div>
               <div style="margin-left:auto;display:flex;gap:9px;justify-content:flex-end;flex:0 0 auto">
                 <sc-if value="{{ personCollected }}" hint-placeholder-val="{{ false }}">
-                  <div onClick="{{ removeCollected }}" title="Usuń z zebranych" style="flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:38px;height:38px;color:var(--text2);background:var(--panel);border:1px solid var(--border2);border-radius:8px;font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1" style-hover="cursor:pointer;background:var(--hover);color:var(--warn-text)">delete</div>
-                  <div onClick="{{ addToOwn }}" title="Zapisz w książce adresowej" style="flex:0 0 auto;display:flex;align-items:center;gap:7px;font-size:13px;white-space:nowrap;color:var(--text2);background:var(--panel);border:1px solid var(--border2);border-radius:8px;padding:9px 14px" style-hover="cursor:pointer;background:var(--hover)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">person_add</span>{{ addToOwnLabel }}</div>
+                  <div onClick="{{ removeCollected }}" title="Remove from collected" style="flex:0 0 auto;display:flex;align-items:center;justify-content:center;width:38px;height:38px;color:var(--text2);background:var(--panel);border:1px solid var(--border2);border-radius:8px;font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1" style-hover="cursor:pointer;background:var(--hover);color:var(--warn-text)">delete</div>
+                  <div onClick="{{ addToOwn }}" title="Save to the address book" style="flex:0 0 auto;display:flex;align-items:center;gap:7px;font-size:13px;white-space:nowrap;color:var(--text2);background:var(--panel);border:1px solid var(--border2);border-radius:8px;padding:9px 14px" style-hover="cursor:pointer;background:var(--hover)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">person_add</span>{{ addToOwnLabel }}</div>
                 </sc-if>
-                <div onClick="{{ personWrite }}" style="flex:0 0 auto;font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:8px;padding:9px 15px" style-hover="cursor:pointer;opacity:0.9">Napisz</div>
+                <div onClick="{{ personWrite }}" style="flex:0 0 auto;font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:8px;padding:9px 15px" style-hover="cursor:pointer;opacity:0.9">Write</div>
               </div>
             </div>
           </div>
           <div style="{{ personBodyStyle }}">
             <div style="display:flex;flex-direction:column;gap:9px;background:var(--panel);border:1px solid var(--line);border-left:3px solid var(--accent);border-radius:10px;padding:15px 17px">
               <div style="display:flex;align-items:center;gap:9px">
-                <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">STAN RELACJI</div>
+                <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">RELATIONSHIP STATE</div>
                 <div style="font-size:10px;color:var(--onaccent);background:var(--accent);border-radius:4px;padding:2px 6px">AI</div>
               </div>
               <div style="font-size:15px;line-height:1.55;color:var(--text2);text-wrap:pretty">{{ personNote }}</div>
               <sc-if value="{{ personHasNext }}" hint-placeholder-val="{{ true }}">
                 <div style="display:flex;flex-direction:column;gap:8px;background:var(--accent-soft);border-radius:9px;padding:12px 14px">
-                  <div style="font-size:11px;letter-spacing:0.06em;color:var(--accent-d);font-family:'Instrument Sans',system-ui,sans-serif">SUGEROWANE NASTĘPNE DZIAŁANIE</div>
+                  <div style="font-size:11px;letter-spacing:0.06em;color:var(--accent-d);font-family:'Instrument Sans',system-ui,sans-serif">SUGGESTED NEXT ACTION</div>
                   <div style="font-size:14px;line-height:1.5;text-wrap:pretty">{{ personNext }}</div>
                   <div style="display:flex;gap:8px;flex-wrap:wrap">
-                    <div onClick="{{ personWrite }}" style="font-size:12px;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:7px 13px" style-hover="cursor:pointer;opacity:0.9">Przygotuj szkic</div>
-                    <div style="font-size:12px;color:var(--accent-d);border:1px solid var(--accent-line);border-radius:7px;padding:7px 13px" style-hover="cursor:pointer;background:var(--panel)">Zaplanuj przypomnienie</div>
+                    <div onClick="{{ personWrite }}" style="font-size:12px;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:7px 13px" style-hover="cursor:pointer;opacity:0.9">Draft a reply</div>
+                    <div style="font-size:12px;color:var(--accent-d);border:1px solid var(--accent-line);border-radius:7px;padding:7px 13px" style-hover="cursor:pointer;background:var(--panel)">Schedule a reminder</div>
                   </div>
                 </div>
               </sc-if>
@@ -2117,7 +2117,7 @@
             </div>
             <div style="{{ personColsStyle }}">
               <div style="flex:1;min-width:0;display:flex;flex-direction:column;gap:10px;background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:15px 17px">
-                <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">WSPÓLNE WĄTKI</div>
+                <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">SHARED THREADS</div>
                 <sc-for list="{{ personThreads }}" as="pt" hint-placeholder-count="2">
                   <div onClick="{{ pt.open }}" style="display:flex;flex-direction:column;gap:3px;border-top:1px solid var(--line2);padding-top:9px" style-hover="cursor:pointer">
                     <div style="font-size:14px">{{ pt.label }}</div>
@@ -2126,7 +2126,7 @@
                 </sc-for>
               </div>
               <div style="flex:1;min-width:0;display:flex;flex-direction:column;gap:10px;background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:15px 17px">
-                <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">DOKUMENTY OD TEJ OSOBY</div>
+                <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;letter-spacing:0.1em;color:var(--muted)">DOCUMENTS FROM THIS PERSON</div>
                 <sc-for list="{{ personDocs }}" as="pd" hint-placeholder-count="2">
                   <div onClick="{{ pd.open }}" style="display:flex;align-items:center;gap:9px;border-top:1px solid var(--line2);padding-top:9px" style-hover="cursor:pointer;color:var(--accent-d)">
                     <span style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;color:var(--muted)">{{ pd.type }}</span>
@@ -2135,7 +2135,7 @@
                   </div>
                 </sc-for>
                 <sc-if value="{{ personNoDocs }}" hint-placeholder-val="{{ false }}">
-                  <div style="font-size:13px;color:var(--faint);border-top:1px solid var(--line2);padding-top:9px">Brak załączników w korespondencji</div>
+                  <div style="font-size:13px;color:var(--faint);border-top:1px solid var(--line2);padding-top:9px">No attachments in this correspondence</div>
                 </sc-if>
               </div>
             </div>
@@ -2166,7 +2166,7 @@
           <div style="display:flex;flex-direction:column;gap:8px;background:var(--sub);border:1px solid var(--line);border-radius:9px;padding:11px 13px">
             <div style="display:flex;align-items:center;gap:9px">
               <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1;color:var(--muted)">notifications_active</span>
-              <span style="flex:1;font-size:12.5px;font-weight:600">Przypomnienia</span>
+              <span style="flex:1;font-size:12.5px;font-weight:600">Reminders</span>
               <div onClick="{{ eventOpenRem }}" style="font-size:12px;color:var(--accent-d)" style-hover="cursor:pointer;text-decoration:underline">{{ eventRemAction }}</div>
             </div>
             <sc-if value="{{ eventRemAny }}" hint-placeholder-val="{{ true }}">
@@ -2177,13 +2177,13 @@
               </div>
             </sc-if>
             <sc-if value="{{ eventRemNone }}" hint-placeholder-val="{{ false }}">
-              <div style="font-size:12px;color:var(--muted);line-height:1.45;text-wrap:pretty">Bez przypomnienia — o tym wydarzeniu nie dostaniesz powiadomienia.</div>
+              <div style="font-size:12px;color:var(--muted);line-height:1.45;text-wrap:pretty">No reminder — you won't be notified about this event.</div>
             </sc-if>
           </div>
           <div style="display:flex;gap:9px;justify-content:flex-end;flex-wrap:wrap">
-            <div onClick="{{ eventDelete }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:8px 15px" style-hover="cursor:pointer;background:var(--hover)">Usuń</div>
-            <div style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:8px 15px" style-hover="cursor:pointer;background:var(--hover)">Edytuj</div>
-            <div onClick="{{ eventOpenThread }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:8px;padding:8px 16px" style-hover="cursor:pointer;opacity:0.9">Otwórz wątek</div>
+            <div onClick="{{ eventDelete }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:8px 15px" style-hover="cursor:pointer;background:var(--hover)">Delete</div>
+            <div style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:8px 15px" style-hover="cursor:pointer;background:var(--hover)">Edit</div>
+            <div onClick="{{ eventOpenThread }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:8px;padding:8px 16px" style-hover="cursor:pointer;opacity:0.9">Open thread</div>
           </div>
         </div>
       </div>
@@ -2194,19 +2194,19 @@
     <div onClick="{{ closeNewEvent }}" style="{{ ovZ96 }}">
       <div onClick="{{ stopProp }}" style="{{ dlgForm }}">
         <div style="display:flex;align-items:center;gap:12px;padding:14px 18px;border-bottom:1px solid var(--line);background:var(--sub)">
-          <div style="font-size:15px;font-weight:600">Nowe wydarzenie</div>
+          <div style="font-size:15px;font-weight:600">New event</div>
           <div onClick="{{ closeNewEvent }}" style="{{ closeBtnAutoStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ closeIconStyle }}">close</span></div>
         </div>
         <div style="display:flex;flex-direction:column;gap:13px;padding:18px">
           <div style="display:flex;flex-direction:column;gap:9px;background:var(--accent-soft);border-radius:10px;padding:12px 13px">
             <div style="display:flex;align-items:center;gap:9px">
               <span style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:10px;color:var(--onaccent);background:var(--accent);border-radius:4px;padding:3px 7px">AI</span>
-              <span style="font-size:12px;color:var(--accent-d)">Opisz wydarzenie jednym zdaniem</span>
+              <span style="font-size:12px;color:var(--accent-d)">Describe the event in one sentence</span>
             </div>
-            <input ref="{{ evPromptRef }}" placeholder="np. call z Anną w piątek po 13, 45 min, o aneksie" style="{{ promptFieldStyle }}" />
+            <input ref="{{ evPromptRef }}" placeholder="e.g. call with Anna on Friday after 1pm, 45 min, about the addendum" style="{{ promptFieldStyle }}" />
             <div style="display:flex;gap:7px;flex-wrap:wrap">
-              <div onClick="{{ evParse }}" style="font-size:12px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:7px 13px" style-hover="cursor:pointer;opacity:0.9">Utwórz z opisu</div>
-              <div onClick="{{ evFromThread }}" style="font-size:12px;color:var(--accent-d);background:var(--panel);border:1px solid var(--accent-line);border-radius:7px;padding:7px 13px" style-hover="cursor:pointer">Z otwartego wątku</div>
+              <div onClick="{{ evParse }}" style="font-size:12px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:7px;padding:7px 13px" style-hover="cursor:pointer;opacity:0.9">Create from description</div>
+              <div onClick="{{ evFromThread }}" style="font-size:12px;color:var(--accent-d);background:var(--panel);border:1px solid var(--accent-line);border-radius:7px;padding:7px 13px" style-hover="cursor:pointer">From the open thread</div>
             </div>
             <sc-if value="{{ evParsedShown }}" hint-placeholder-val="{{ false }}">
               <div style="display:flex;gap:6px;flex-wrap:wrap;padding-top:2px">
@@ -2216,19 +2216,19 @@
               </div>
             </sc-if>
           </div>
-          <input ref="{{ evTitleRef }}" placeholder="Tytuł wydarzenia" style="{{ fieldStyle }}" />
+          <input ref="{{ evTitleRef }}" placeholder="Event title" style="{{ fieldStyle }}" />
           <div style="display:flex;gap:10px">
-            <input ref="{{ evDayRef }}" placeholder="Dzień (np. 28)" style="{{ fieldStyle }}" />
-            <input ref="{{ evTimeRef }}" placeholder="Godzina (np. 14:00)" style="{{ fieldStyle }}" />
+            <input ref="{{ evDayRef }}" placeholder="Day (e.g. 28)" style="{{ fieldStyle }}" />
+            <input ref="{{ evTimeRef }}" placeholder="Time (e.g. 14:00)" style="{{ fieldStyle }}" />
           </div>
           <div style="display:flex;align-items:center;gap:10px;background:var(--accent-soft);border-radius:9px;padding:11px 13px">
             <span style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:10px;color:var(--onaccent);background:var(--accent);border-radius:4px;padding:2px 6px">AI</span>
-            <span style="font-size:12px;color:var(--accent-d);line-height:1.45;text-wrap:pretty">Powiążę wydarzenie z wątkiem, jeśli tytuł pasuje do sprawy w skrzynce.</span>
+            <span style="font-size:12px;color:var(--accent-d);line-height:1.45;text-wrap:pretty">I'll link the event to a thread if the title matches a case in your mailbox.</span>
           </div>
           <div style="display:flex;flex-direction:column;gap:9px;background:var(--sub);border:1px solid var(--line);border-radius:10px;padding:12px 13px">
             <div style="display:flex;align-items:center;gap:9px">
               <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1;color:var(--muted)">notifications_active</span>
-              <span style="flex:1;font-size:12.5px;font-weight:600">Przypomnienia</span>
+              <span style="flex:1;font-size:12.5px;font-weight:600">Reminders</span>
               <span style="{{ evRem.countStyle }}">{{ evRem.countLabel }}</span>
             </div>
             <div style="display:flex;flex-wrap:wrap;gap:7px">
@@ -2237,13 +2237,13 @@
               </sc-for>
             </div>
             <div style="{{ remRowStyle }}">
-              <input ref="{{ evRem.numRef }}" type="number" min="1" placeholder="np. 90" style="width:78px;font-family:inherit;font-size:13px;color:var(--text);background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:7px 9px;outline:none" />
+              <input ref="{{ evRem.numRef }}" type="number" min="1" placeholder="e.g. 90" style="width:78px;font-family:inherit;font-size:13px;color:var(--text);background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:7px 9px;outline:none" />
               <div style="display:flex;gap:2px;background:var(--panel);border:1px solid var(--line);border-radius:9px;padding:2px">
                 <sc-for list="{{ evRem.units }}" as="u" hint-placeholder-count="3">
                   <div onClick="{{ u.pick }}" style="{{ u.style }}" style-hover="cursor:pointer">{{ u.label }}</div>
                 </sc-for>
               </div>
-              <div onClick="{{ evRem.add }}" style="display:flex;align-items:center;height:32px;padding:0 12px;border:1px solid var(--accent-line);border-radius:9px;background:var(--accent-soft);font-size:12.5px;font-weight:600;color:var(--accent-d)" style-hover="cursor:pointer;background:var(--accent);color:var(--onaccent);border-color:var(--accent)">Dodaj</div>
+              <div onClick="{{ evRem.add }}" style="display:flex;align-items:center;height:32px;padding:0 12px;border:1px solid var(--accent-line);border-radius:9px;background:var(--accent-soft);font-size:12.5px;font-weight:600;color:var(--accent-d)" style-hover="cursor:pointer;background:var(--accent);color:var(--onaccent);border-color:var(--accent)">Add</div>
               <span style="{{ remHintStyle }}">{{ evRem.hint }}</span>
             </div>
             <sc-if value="{{ evRem.any }}" hint-placeholder-val="{{ true }}">
@@ -2255,8 +2255,8 @@
             </sc-if>
           </div>
           <div style="display:flex;gap:9px;justify-content:flex-end">
-            <div onClick="{{ closeNewEvent }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:8px 15px" style-hover="cursor:pointer;background:var(--hover)">Anuluj</div>
-            <div onClick="{{ saveEvent }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:8px;padding:8px 16px" style-hover="cursor:pointer;opacity:0.9">Dodaj do kalendarza</div>
+            <div onClick="{{ closeNewEvent }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:8px 15px" style-hover="cursor:pointer;background:var(--hover)">Cancel</div>
+            <div onClick="{{ saveEvent }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:8px;padding:8px 16px" style-hover="cursor:pointer;opacity:0.9">Add to calendar</div>
           </div>
         </div>
       </div>
@@ -2267,23 +2267,23 @@
     <div onClick="{{ closeNewContact }}" style="{{ ovZ96 }}">
       <div onClick="{{ stopProp }}" style="{{ dlgForm }}">
         <div style="display:flex;align-items:center;gap:12px;padding:14px 18px;border-bottom:1px solid var(--line);background:var(--sub)">
-          <div style="font-size:15px;font-weight:600">Nowy kontakt</div>
+          <div style="font-size:15px;font-weight:600">New contact</div>
           <div onClick="{{ closeNewContact }}" style="{{ closeBtnAutoStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ closeIconStyle }}">close</span></div>
         </div>
         <div style="display:flex;flex-direction:column;gap:13px;padding:18px">
-          <input ref="{{ ctNameRef }}" placeholder="Imię i nazwisko" style="{{ fieldStyle }}" />
-          <input ref="{{ ctMailRef }}" placeholder="Adres e-mail" style="{{ fieldStyle }}" />
+          <input ref="{{ ctNameRef }}" placeholder="Full name" style="{{ fieldStyle }}" />
+          <input ref="{{ ctMailRef }}" placeholder="Email address" style="{{ fieldStyle }}" />
           <div style="display:flex;gap:10px">
-            <input ref="{{ ctOrgRef }}" placeholder="Firma" style="{{ fieldStyle }}" />
-            <input ref="{{ ctRoleRef }}" placeholder="Rola" style="{{ fieldStyle }}" />
+            <input ref="{{ ctOrgRef }}" placeholder="Company" style="{{ fieldStyle }}" />
+            <input ref="{{ ctRoleRef }}" placeholder="Role" style="{{ fieldStyle }}" />
           </div>
           <div style="display:flex;align-items:center;gap:10px;background:var(--accent-soft);border-radius:9px;padding:11px 13px">
             <span style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:10px;color:var(--onaccent);background:var(--accent);border-radius:4px;padding:2px 6px">AI</span>
-            <span style="font-size:12px;color:var(--accent-d);line-height:1.45;text-wrap:pretty">Po zapisaniu podpowiem wspólne wątki i dokumenty tej osoby ze skrzynki.</span>
+            <span style="font-size:12px;color:var(--accent-d);line-height:1.45;text-wrap:pretty">Once saved, I'll surface this person's shared threads and documents from your mailbox.</span>
           </div>
           <div style="display:flex;gap:9px;justify-content:flex-end">
-            <div onClick="{{ closeNewContact }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:8px 15px" style-hover="cursor:pointer;background:var(--hover)">Anuluj</div>
-            <div onClick="{{ saveContact }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:8px;padding:8px 16px" style-hover="cursor:pointer;opacity:0.9">Zapisz kontakt</div>
+            <div onClick="{{ closeNewContact }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:8px 15px" style-hover="cursor:pointer;background:var(--hover)">Cancel</div>
+            <div onClick="{{ saveContact }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);border-radius:8px;padding:8px 16px" style-hover="cursor:pointer;opacity:0.9">Save contact</div>
           </div>
         </div>
       </div>
@@ -2293,7 +2293,7 @@
     <div style="{{ settingsScrimStyle }}">
       <div style="{{ settingsCardStyle }}">
         <div style="{{ settingsHeadStyle }}">
-          <div style="{{ settingsTitleStyle }}">Ustawienia</div>
+          <div style="{{ settingsTitleStyle }}">Settings</div>
           <div onClick="{{ closeSettings }}" style="{{ closeBtnAutoStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ closeIconStyle }}">close</span></div>
         </div>
         <div style="display:flex;align-items:stretch;gap:14px;padding:0 14px;border-bottom:1px solid var(--line);background:var(--sub)">
@@ -2306,13 +2306,13 @@
           <div style="display:flex;align-items:center;gap:11px">
             <div style="{{ mePreviewStyle }}">{{ meInitials }}</div>
             <div style="flex:1;min-width:0;display:flex;flex-direction:column;gap:5px">
-              <input value="{{ meName }}" onChange="{{ onMeName }}" placeholder="Imię i nazwisko" style="width:100%;box-sizing:border-box;font-family:inherit;font-size:13px;color:var(--text);background:var(--sub);border:1px solid var(--border2);border-radius:8px;padding:7px 10px;outline:none" style-focus="border-color:var(--accent)" />
+              <input value="{{ meName }}" onChange="{{ onMeName }}" placeholder="Full name" style="width:100%;box-sizing:border-box;font-family:inherit;font-size:13px;color:var(--text);background:var(--sub);border:1px solid var(--border2);border-radius:8px;padding:7px 10px;outline:none" style-focus="border-color:var(--accent)" />
               <div style="display:flex;align-items:center;gap:5px;flex-wrap:wrap">
-                <div onClick="{{ pickPhoto }}" style="display:flex;align-items:center;gap:5px;font-size:11.5px;color:var(--text2);border:1px solid var(--border2);border-radius:7px;padding:4px 9px" style-hover="cursor:pointer;background:var(--hover)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:14px;line-height:1">add_a_photo</span>Zdjęcie</div>
+                <div onClick="{{ pickPhoto }}" style="display:flex;align-items:center;gap:5px;font-size:11.5px;color:var(--text2);border:1px solid var(--border2);border-radius:7px;padding:4px 9px" style-hover="cursor:pointer;background:var(--hover)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:14px;line-height:1">add_a_photo</span>Photo</div>
                 <sc-if value="{{ meHasPhoto }}" hint-placeholder-val="{{ false }}">
-                  <div onClick="{{ removePhoto }}" title="Usuń zdjęcie" style="display:flex;align-items:center;gap:4px;font-size:11.5px;color:var(--muted);border-radius:7px;padding:4px 8px" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:14px;line-height:1">delete</span>Usuń</div>
+                  <div onClick="{{ removePhoto }}" title="Remove photo" style="display:flex;align-items:center;gap:4px;font-size:11.5px;color:var(--muted);border-radius:7px;padding:4px 8px" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:14px;line-height:1">delete</span>Remove</div>
                 </sc-if>
-                <span style="font-size:10.5px;color:var(--faint)">JPG/PNG, maks. 1 MB</span>
+                <span style="font-size:10.5px;color:var(--faint)">JPG/PNG, max 1 MB</span>
               </div>
               <sc-if value="{{ photoError }}" hint-placeholder-val="{{ false }}">
                 <div style="font-size:10.5px;color:var(--warn)">{{ photoError }}</div>
@@ -2320,48 +2320,48 @@
             </div>
           </div>
           <input ref="{{ photoInputRef }}" type="file" accept="image/*" onChange="{{ onPhotoFile }}" style="display:none" />
-          <div style="font-size:11px;line-height:1.5;color:var(--muted);text-wrap:pretty">Nazwa i zdjęcie są zapisane na Twoim serwerze MailFathom i widoczne w każdym kliencie, w którym się zalogujesz — nie wysyłamy ich na serwer poczty.</div>
+          <div style="font-size:11px;line-height:1.5;color:var(--muted);text-wrap:pretty">Your name and photo are stored on your MailFathom server and visible in every client you sign in to — we never send them to the mail server.</div>
           </sc-if>
           <sc-if value="{{ tabApp }}" hint-placeholder-val="{{ false }}">
-          <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:9.5px;letter-spacing:0.1em;color:var(--faint)">JĘZYK</div>
+          <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:9.5px;letter-spacing:0.1em;color:var(--faint)">LANGUAGE</div>
           <div style="display:flex;flex-wrap:wrap;gap:5px">
             <sc-for list="{{ langOptions }}" as="lg" hint-placeholder-count="4">
               <div onClick="{{ lg.pick }}" style="{{ lg.style }}" style-hover="cursor:pointer">{{ lg.label }}</div>
             </sc-for>
           </div>
           <div style="height:1px;background:var(--line2);margin:4px 0"></div>
-          <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:9.5px;letter-spacing:0.1em;color:var(--faint)">WIDOK WIADOMOŚCI</div>
+          <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:9.5px;letter-spacing:0.1em;color:var(--faint)">MESSAGE VIEW</div>
           <div style="display:flex;gap:4px;padding:3px;border:1px solid var(--border2);border-radius:9px;background:var(--sub)">
-            <div onClick="{{ setViewSimple }}" style="{{ viewSimpleStyle }}" style-hover="cursor:pointer">Uproszczony</div>
+            <div onClick="{{ setViewSimple }}" style="{{ viewSimpleStyle }}" style-hover="cursor:pointer">Simplified</div>
             <div onClick="{{ setViewHtml }}" style="{{ viewHtmlStyle }}" style-hover="cursor:pointer">HTML</div>
           </div>
           <div style="font-size:11px;line-height:1.45;color:var(--muted);text-wrap:pretty">{{ viewHint }}</div>
           <div onClick="{{ toggleAutoExpand }}" style="display:flex;align-items:flex-start;gap:11px;padding:9px 10px;border:1px solid var(--line);border-radius:9px;background:var(--sub)" style-hover="cursor:pointer;background:var(--hover)">
             <div style="flex:1;min-width:0;display:flex;flex-direction:column;gap:3px">
-              <div style="font-size:13px">Rozwijaj cały wątek automatycznie</div>
-              <div style="font-size:11px;line-height:1.45;color:var(--muted);text-wrap:pretty">Bez tego wątek otwiera się na wybranej wiadomości, a pozostałe są pod przyciskiem.</div>
+              <div style="font-size:13px">Expand the whole thread automatically</div>
+              <div style="font-size:11px;line-height:1.45;color:var(--muted);text-wrap:pretty">Without this, a thread opens on the selected message and the rest sit behind a button.</div>
             </div>
             <span style="{{ autoExpandSwitchStyle }}"><span style="{{ denseKnobStyle }}"></span></span>
           </div>
           <sc-if value="{{ htmlModeWarn }}" hint-placeholder-val="{{ false }}">
             <div style="display:flex;align-items:flex-start;gap:8px;padding:9px 10px;border:1px solid var(--warn);border-radius:9px;background:var(--warn-soft);font-size:11.5px;line-height:1.5;color:var(--warn-text);text-wrap:pretty">
               <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:16px;line-height:1.3">gpp_maybe</span>
-              <span>Ryzyko bezpieczeństwa: HTML z wiadomości może zawierać ukryte piksele śledzące, podszywające się układy i odnośniki phishingowe. Renderujemy go w izolacji, ale sam podgląd może ujawnić nadawcy, że wiadomość została otwarta.</span>
+              <span>Security risk: message HTML can contain hidden tracking pixels, impersonating layouts and phishing links. We render it in isolation, but the preview alone can tell the sender the message was opened.</span>
             </div>
           </sc-if>
           <div style="height:1px;background:var(--line2);margin:4px 0"></div>
-          <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:9.5px;letter-spacing:0.1em;color:var(--faint)">PRYWATNOŚĆ</div>
+          <div style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:9.5px;letter-spacing:0.1em;color:var(--faint)">PRIVACY</div>
           <div onClick="{{ toggleTelemetry }}" style="display:flex;align-items:flex-start;gap:11px;padding:9px 10px;border:1px solid var(--line);border-radius:9px;background:var(--sub)" style-hover="cursor:pointer;background:var(--hover)">
             <div style="flex:1;min-width:0;display:flex;flex-direction:column;gap:3px">
-              <div style="font-size:13px">Nie wysyłaj danych telemetrycznych</div>
-              <div style="font-size:11px;line-height:1.45;color:var(--muted);text-wrap:pretty">Diagnostyka błędów i statystyki użycia zostają na tym urządzeniu.</div>
+              <div style="font-size:13px">Don't send telemetry data</div>
+              <div style="font-size:11px;line-height:1.45;color:var(--muted);text-wrap:pretty">Crash diagnostics and usage statistics stay on this device.</div>
             </div>
             <span style="{{ telemetrySwitchStyle }}"><span style="{{ denseKnobStyle }}"></span></span>
           </div>
           <sc-if value="{{ telemetryOptOut }}" hint-placeholder-val="{{ false }}">
             <div style="display:flex;align-items:flex-start;gap:8px;padding:9px 10px;border:1px solid var(--warn);border-radius:9px;background:var(--warn-soft);font-size:11.5px;line-height:1.5;color:var(--warn-text);text-wrap:pretty">
               <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:16px;line-height:1.3">info</span>
-              <span>Bez telemetrii pomoc techniczna będzie utrudniona — zgłoszenia trzeba będzie opisywać ręcznie, a części błędów nie da się odtworzyć po stronie wsparcia.</span>
+              <span>Without telemetry, support gets harder — reports have to be written out by hand and some bugs can't be reproduced on the support side.</span>
             </div>
           </sc-if>
           </sc-if>
@@ -2385,17 +2385,17 @@
       </sc-if>
       <div style="flex:0 0 auto;display:flex;align-items:center;gap:10px;padding:16px 16px 13px 18px;border-bottom:1px solid var(--line)">
         <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:21px;line-height:1;color:var(--muted)">notifications</span>
-        <div style="flex:1;min-width:0;font-size:16px;font-weight:600">Powiadomienia</div>
+        <div style="flex:1;min-width:0;font-size:16px;font-weight:600">Notifications</div>
         <sc-if value="{{ notifHasUnread }}" hint-placeholder-val="{{ true }}">
           <div style="{{ notifNewBadgeStyle }}">{{ notifCountLabel }} nowe</div>
         </sc-if>
-        <div onClick="{{ closeNotifCenter }}" title="Zamknij" style="{{ notifCloseStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ notifCloseIconStyle }}">close</span></div>
+        <div onClick="{{ closeNotifCenter }}" title="Close" style="{{ notifCloseStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ notifCloseIconStyle }}">close</span></div>
       </div>
       <div style="flex:0 0 auto;display:flex;align-items:center;gap:7px;padding:11px 16px;border-bottom:1px solid var(--line2);background:var(--sub)">
         <sc-for list="{{ notifTabs }}" as="nt" hint-placeholder-count="2">
           <div onClick="{{ nt.pick }}" style="{{ nt.style }}" style-hover="cursor:pointer;border-color:var(--accent)">{{ nt.label }}</div>
         </sc-for>
-        <div onClick="{{ markAllNotifsRead }}" style="margin-left:auto;font-size:12px;color:var(--accent-d)" style-hover="cursor:pointer;text-decoration:underline">Oznacz wszystkie</div>
+        <div onClick="{{ markAllNotifsRead }}" style="margin-left:auto;font-size:12px;color:var(--accent-d)" style-hover="cursor:pointer;text-decoration:underline">Mark all read</div>
       </div>
       <sc-if value="{{ selBarShown }}" hint-placeholder-val="{{ false }}">
         <div style="{{ selBarStyle }}">
@@ -2405,7 +2405,7 @@
               <div onClick="{{ sa.run }}" title="{{ sa.label }}" style="{{ sa.style }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:19px;line-height:1">{{ sa.icon }}</span>{{ sa.shown }}</div>
             </sc-for>
           </div>
-          <div onClick="{{ selClear }}" title="Anuluj zaznaczenie" style="{{ closeBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ closeIconStyle }}">close</span></div>
+          <div onClick="{{ selClear }}" title="Cancel selection" style="{{ closeBtnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="{{ closeIconStyle }}">close</span></div>
         </div>
       </sc-if>
       <div ref="{{ notifListRef }}" data-rail="1" style="flex:1;min-height:0;overflow-y:auto;display:flex;flex-direction:column">
@@ -2431,7 +2431,7 @@
         <sc-if value="{{ notifEmpty }}" hint-placeholder-val="{{ false }}">
           <div style="display:flex;flex-direction:column;align-items:center;gap:9px;padding:52px 26px;text-align:center">
             <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:34px;line-height:1;color:var(--faint)">notifications_off</span>
-            <div style="font-size:13px;color:var(--muted);text-wrap:pretty">Nic nowego. Wszystko przeczytane.</div>
+            <div style="font-size:13px;color:var(--muted);text-wrap:pretty">Nothing new. All read.</div>
           </div>
         </sc-if>
       </div>
@@ -2463,20 +2463,20 @@
         <div style="font-size:16px;font-weight:600">{{ cancelAskTitle }}</div>
         <div style="font-size:13px;color:var(--muted);line-height:1.5;text-wrap:pretty">{{ cancelAskText }}</div>
         <div style="display:flex;gap:9px;justify-content:flex-end;margin-top:2px">
-          <div onClick="{{ keepTask }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:8px 15px" style-hover="cursor:pointer;background:var(--hover)">Kontynuuj</div>
-          <div onClick="{{ abortTaskNow }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--err);border-radius:8px;padding:8px 16px" style-hover="cursor:pointer;opacity:0.9">Przerwij operację</div>
+          <div onClick="{{ keepTask }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:8px 15px" style-hover="cursor:pointer;background:var(--hover)">Continue</div>
+          <div onClick="{{ abortTaskNow }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--err);border-radius:8px;padding:8px 16px" style-hover="cursor:pointer;opacity:0.9">Abort operation</div>
         </div>
       </div>
     </div>
   </sc-if>
 </div>
 </x-dc>
-<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1440,&quot;height&quot;:900},&quot;theme&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;jasny&quot;,&quot;ciemny&quot;],&quot;default&quot;:&quot;ciemny&quot;,&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Układ&quot;},&quot;layout&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;auto&quot;,&quot;desktop&quot;,&quot;tablet&quot;,&quot;fold&quot;,&quot;telefon&quot;],&quot;default&quot;:&quot;auto&quot;,&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Układ&quot;},&quot;aiHints&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:true,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Zachowanie&quot;},&quot;showTrace&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:false,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Zachowanie&quot;},&quot;streamDelay&quot;:{&quot;editor&quot;:&quot;range&quot;,&quot;default&quot;:550,&quot;min&quot;:120,&quot;max&quot;:1200,&quot;step&quot;:50,&quot;unit&quot;:&quot;ms&quot;,&quot;tsType&quot;:&quot;number&quot;,&quot;section&quot;:&quot;Zachowanie&quot;}}">
-/* MARKDOWN W TREŚCI WIADOMOŚCI
-   Część korespondencji przychodzi dziś w Markdownie (raporty z narzędzi, notatki, boty CI),
-   więc połowa przykładów w prototypie jest w tej formie. Parser obsługuje: nagłówki, akapity,
-   pogrubienie/kursywę/przekreślenie, kod w linii i blokowy, listy zwykłe, numerowane i zadaniowe
-   (z zagnieżdżeniem), cytaty, tabele, linie poziome i odnośniki. */
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1440,&quot;height&quot;:900},&quot;theme&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;light&quot;,&quot;dark&quot;],&quot;default&quot;:&quot;dark&quot;,&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Layout&quot;},&quot;layout&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;auto&quot;,&quot;desktop&quot;,&quot;tablet&quot;,&quot;fold&quot;,&quot;phone&quot;],&quot;default&quot;:&quot;auto&quot;,&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Layout&quot;},&quot;aiHints&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:true,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Behavior&quot;},&quot;showTrace&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:false,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Behavior&quot;},&quot;streamDelay&quot;:{&quot;editor&quot;:&quot;range&quot;,&quot;default&quot;:550,&quot;min&quot;:120,&quot;max&quot;:1200,&quot;step&quot;:50,&quot;unit&quot;:&quot;ms&quot;,&quot;tsType&quot;:&quot;number&quot;,&quot;section&quot;:&quot;Behavior&quot;}}">
+/* MARKDOWN IN MESSAGE BODIES
+   Plenty of mail arrives as Markdown these days (tool reports, notes, CI bots),
+   so half the samples in this prototype use it. The parser handles: headings, paragraphs,
+   bold/italic/strikethrough, inline and block code, plain, ordered and task lists
+   (including nesting), quotes, tables, horizontal rules and links. */
 const mdInline = (s) => {
   const out = [];
   const re = /(\*\*[^*]+\*\*|__[^_]+__|~~[^~]+~~|`[^`]+`|\*[^*\n]+\*|\[[^\]]+\]\([^)]+\))/g;
@@ -2597,16 +2597,16 @@ const mdBlock = (b) => {
 };
 const mdView = (src) => mdParse(src).map(mdBlock);
 
-/* Wspólny „shimmer” dla wszystkich szkieletów ładowania. */
+/* Shared shimmer for every loading skeleton. */
 const SHIM = "border-radius:5px;background:linear-gradient(90deg,var(--line) 0%,var(--line2) 42%,var(--line) 78%);background-size:260% 100%;animation:mfshim 1.05s linear infinite;";
 
 function srcTypeInfo(type) {
   const M = {
-    mail: { icon: "mail", label: "wiadomość" },
-    zalacznik: { icon: "attach_file", label: "załącznik" },
-    kalendarz: { icon: "calendar_month", label: "wydarzenie" },
-    kontakt: { icon: "person", label: "kontakt" },
-    wiele: { icon: "layers", label: "wiele źródeł" },
+    mail: { icon: "mail", label: "message" },
+    attachment: { icon: "attach_file", label: "attachment" },
+    calendar: { icon: "calendar_month", label: "event" },
+    contact: { icon: "person", label: "contact" },
+    multi: { icon: "layers", label: "multiple sources" },
   };
   return M[type] || M.mail;
 }
@@ -2615,7 +2615,7 @@ const SRC_BADGE_ICON_STYLE = "font-family:'Material Symbols Rounded';font-variat
 function srcBadge(item) {
   const types = item.srcTypes && item.srcTypes.length > 1 ? item.srcTypes : [item.srcType || "mail"];
   if (types.length > 1) {
-    return { icon: "layers", label: "wiele źródeł", title: types.map(t => srcTypeInfo(t).label).join(", ") };
+    return { icon: "layers", label: "multiple sources", title: types.map(t => srcTypeInfo(t).label).join(", ") };
   }
   const si = srcTypeInfo(types[0]);
   return { icon: si.icon, label: si.label, title: si.label };
@@ -2623,214 +2623,214 @@ function srcBadge(item) {
 
 const PLANS = {
   contract: {
-    label: "Odpowiedź + Oś czasu + Tabela faktów",
-    confidence: "pewność wysoka",
-    gap: "1 luka: brak aneksu 2022",
-    meta: "run 7f3a · 41 dokumentów przeszukanych",
-    trace: "retrieval semantyczny → 41 kandydatów\nreguła deterministyczna: sortowanie po dacie aneksu\nmodel: streszczenie + wybór PresentationPlan",
-    action: "Przygotować szkic z kontrpropozycją limitu indeksacji? Termin decyzji: 28.08",
+    label: "Answer + Timeline + Fact table",
+    confidence: "high confidence",
+    gap: "1 gap: 2022 addendum missing",
+    meta: "run 7f3a · 41 documents searched",
+    trace: "semantic retrieval → 41 candidates\ndeterministic rule: sort by addendum date\nmodel: summary + PresentationPlan choice",
+    action: "Draft a counter-proposal capping indexation? Decision due 28.08",
     blocks: ["answer", "timeline", "table", "action"],
     parts: [
-      { text: "Warunki zmieniały się w trzech etapach: umowa ramowa z kwietnia 2021", cite: "1" },
-      { text: ", wprowadzenie indeksacji CPI bez górnego limitu w lutym 2023", cite: "3" },
-      { text: ", skrócenie SLA z 4 h do 2 h w aneksie z listopada 2025", cite: "5" },
-      { text: ". Propozycja na 2027 podnosi cenę o 8% i utrzymuje brak limitu indeksacji", cite: "7" },
+      { text: "The terms changed in three stages: the master agreement of April 2021", cite: "1" },
+      { text: ", CPI indexation with no upper cap introduced in February 2023", cite: "3" },
+      { text: ", the SLA cut from 4 h to 2 h in the November 2025 addendum", cite: "5" },
+      { text: ". The 2027 proposal raises the price by 8% and keeps indexation uncapped", cite: "7" },
     ],
     timeline: [
-      { date: "12.04.2021", title: "Umowa ramowa", detail: "1 200 zł/mies · SLA 4 h", cite: "1" },
-      { date: "03.02.2023", title: "Indeksacja CPI", detail: "bez górnego limitu", cite: "3" },
-      { date: "18.11.2025", title: "Aneks SLA", detail: "4 h → 2 h · +8%", cite: "5" },
-      { date: "26.08.2026", title: "Propozycja 2027", detail: "decyzja do 28.08", cite: "7" },
+      { date: "12.04.2021", title: "Master agreement", detail: "€1,200/mo · SLA 4 h", cite: "1" },
+      { date: "03.02.2023", title: "CPI indexation", detail: "no upper cap", cite: "3" },
+      { date: "18.11.2025", title: "SLA addendum", detail: "4 h → 2 h · +8%", cite: "5" },
+      { date: "26.08.2026", title: "2027 proposal", detail: "decision due 28.08", cite: "7" },
     ],
     table: [
-      { version: "Umowa 2021", versionCite: "1", price: "1 200 zł", priceCite: "1", sla: "4 h", slaCite: "1", index: "brak", indexCite: null },
-      { version: "Aneks 2023", versionCite: "3", price: "1 261 zł", priceCite: "1", sla: "4 h", slaCite: "1", index: "CPI, bez limitu", indexCite: "3" },
-      { version: "Aneks 2025", versionCite: "5", price: "1 452 zł", priceCite: "5", sla: "2 h", slaCite: "5", index: "CPI, bez limitu", indexCite: "3" },
-      { version: "Propozycja 2027", versionCite: "7", price: "1 568 zł", priceCite: "7", sla: "2 h", slaCite: "5", index: "CPI, bez limitu", indexCite: "3" },
+      { version: "Agreement 2021", versionCite: "1", price: "€1,200", priceCite: "1", sla: "4 h", slaCite: "1", index: "none", indexCite: null },
+      { version: "Addendum 2023", versionCite: "3", price: "€1,261", priceCite: "1", sla: "4 h", slaCite: "1", index: "CPI, uncapped", indexCite: "3" },
+      { version: "Addendum 2025", versionCite: "5", price: "€1,452", priceCite: "5", sla: "2 h", slaCite: "5", index: "CPI, uncapped", indexCite: "3" },
+      { version: "Proposal 2027", versionCite: "7", price: "€1,568", priceCite: "7", sla: "2 h", slaCite: "5", index: "CPI, uncapped", indexCite: "3" },
     ],
     evidence: [
-      { n: "1", title: "Umowa ramowa.pdf", srcType: "zalacznik", snippet: "„Wynagrodzenie miesięczne wynosi 1 200 zł netto…”", meta: "12.04.2021 · trafność 0,94 · str. 3",
-        pre: "§2 ust. 4 Zakres usług obejmuje utrzymanie środowiska produkcyjnego oraz wsparcie w dni robocze.",
-        quote: "§2 ust. 5 Wynagrodzenie miesięczne wynosi 1 200 zł netto. Czas reakcji na zgłoszenie krytyczne wynosi 4 godziny.",
-        post: "§2 ust. 6 Umowa zawarta na czas nieoznaczony z trzymiesięcznym okresem wypowiedzenia.",
-        supports: "cena bazowa 1 200 zł · SLA 4 h", mail: "„Umowa ramowa — wersja do podpisu”, 12.04.2021" },
-      { n: "3", title: "Re: indeksacja od 2023", srcType: "mail", snippet: "„…waloryzacja wg CPI, bez górnego limitu.”", meta: "03.02.2023 · A. Kowalska · 0,91",
-        pre: "Dzień dobry, wracam do tematu waloryzacji stawek na kolejny rok.",
-        quote: "Zgodnie z ustaleniami wynagrodzenie będzie waloryzowane wskaźnikiem CPI publikowanym przez GUS, bez górnego limitu.",
-        post: "Proszę o potwierdzenie, wtedy przygotujemy aneks do podpisu.",
-        supports: "indeksacja CPI · brak górnego limitu", mail: "„Re: indeksacja od 2023”, 03.02.2023" },
-      { n: "5", title: "Aneks SLA.pdf", srcType: "zalacznik", snippet: "„Czas reakcji skraca się do 2 godzin…”", meta: "18.11.2025 · trafność 0,89 · str. 2",
-        pre: "§3 ust. 1 Strony potwierdzają zakres usług objętych umową ramową z dnia 12 kwietnia 2021 r.",
-        quote: "§3 ust. 2 Czas reakcji na zgłoszenie krytyczne skraca się z 4 godzin do 2 godzin w dni robocze. Z tytułu podwyższonego poziomu usług wynagrodzenie ulega zwiększeniu o 8%.",
-        post: "§3 ust. 3 Pozostałe postanowienia, w tym zasady waloryzacji wskaźnikiem CPI, pozostają bez zmian.",
-        supports: "SLA 2 h · +8% ceny · brak zmiany indeksacji", mail: "„Aneks do umowy — podpisy”, 18.11.2025" },
-      { n: "7", title: "Propozycja 2027 — Contoso", srcType: "mail", snippet: "„…wzrost stawki o 8% od 1 stycznia 2027.”", meta: "26.08.2026 · A. Kowalska · 0,97",
-        pre: "Przesyłam propozycję warunków na rok 2027 wraz z kalkulacją.",
-        quote: "Proponujemy wzrost stawki o 8% od 1 stycznia 2027 przy utrzymaniu czasu reakcji 2 godzin. Waloryzacja CPI pozostaje bez górnego limitu.",
-        post: "Prosimy o decyzję do 28 sierpnia, żeby zdążyć z aneksem przed końcem roku.",
-        supports: "cena 1 568 zł · SLA 2 h · brak limitu CPI", mail: "„Propozycja warunków 2027”, 26.08.2026" },
+      { n: "1", title: "Master agreement.pdf", srcType: "attachment", snippet: "“Monthly remuneration is €1,200 net…”", meta: "12.04.2021 · relevance 0.94 · p. 3",
+        pre: "§2.4 The scope of services covers maintenance of the production environment and support on business days.",
+        quote: "§2.5 Monthly remuneration is €1,200 net. Response time for a critical incident is 4 hours.",
+        post: "§2.6 The agreement is concluded for an indefinite term with three months' notice.",
+        supports: "base price €1,200 · SLA 4 h", mail: "“Master agreement — version for signature”, 12.04.2021" },
+      { n: "3", title: "Re: indexation from 2023", srcType: "mail", snippet: "“…indexed to CPI, with no upper cap.”", meta: "03.02.2023 · A. Kowalska · 0,91",
+        pre: "Hello, coming back to the indexation of rates for next year.",
+        quote: "As agreed, remuneration will be indexed to the CPI published by the statistics office, with no upper cap.",
+        post: "Please confirm and we will prepare the addendum for signature.",
+        supports: "CPI indexation · no upper cap", mail: "“Re: indexation from 2023”, 03.02.2023" },
+      { n: "5", title: "SLA addendum.pdf", srcType: "attachment", snippet: "“Response time is shortened to 2 hours…”", meta: "18.11.2025 · relevance 0.89 · p. 2",
+        pre: "§3.1 The parties confirm the scope of services under the master agreement of 12 April 2021.",
+        quote: "§3.2 Response time for a critical incident is shortened from 4 hours to 2 hours on business days. In return for the higher service level, remuneration increases by 8%.",
+        post: "§3.3 All other provisions, including CPI indexation, remain unchanged.",
+        supports: "SLA 2 h · +8% price · indexation unchanged", mail: "“Contract addendum — signatures”, 18.11.2025" },
+      { n: "7", title: "2027 proposal — Contoso", srcType: "mail", snippet: "“…an 8% rate increase from 1 January 2027.”", meta: "26.08.2026 · A. Kowalska · 0.97",
+        pre: "Here is our proposal of terms for 2027, together with the calculation.",
+        quote: "We propose an 8% rate increase from 1 January 2027 while keeping the 2-hour response time. CPI indexation remains uncapped.",
+        post: "Please decide by 28 August so the addendum can be signed before year end.",
+        supports: "price €1,568 · SLA 2 h · CPI uncapped", mail: "“Proposed terms 2027”, 26.08.2026" },
     ],
   },
   files: {
-    label: "Odpowiedź + Załączniki",
-    confidence: "pewność wysoka",
+    label: "Answer + Attachments",
+    confidence: "high confidence",
     gap: "",
-    meta: "run 91c4 · 6 plików dopasowanych",
-    trace: "retrieval po znaczeniu w treści załączników\nreguła: najnowsza wersja dokumentu na wierzchu\nmodel: streszczenie + wybór PresentationPlan",
-    action: "Pobrać najnowszą polisę i dodać przypomnienie o odnowieniu?",
+    meta: "run 91c4 · 6 files matched",
+    trace: "semantic retrieval inside attachment contents\nrule: newest version of a document first\nmodel: summary + PresentationPlan choice",
+    action: "Download the latest policy and add a renewal reminder?",
     blocks: ["answer", "gallery", "action"],
     parts: [
-      { text: "Aktualna polisa obowiązuje do 31.12.2026 i przyszła jako załącznik do maila od agenta z 14.12.2025", cite: "2" },
-      { text: ". Starsze wersje leżą w koncie archiwum-2019", cite: "4" },
+      { text: "The current policy runs to 31.12.2026 and arrived attached to the broker's email of 14.12.2025", cite: "2" },
+      { text: ". Older versions sit in the archive-2019 account", cite: "4" },
     ],
     gallery: [
-      { type: "PDF", name: "Polisa_2026.pdf", meta: "14.12.2025 · 640 kB · aktualna", cite: "2" },
-      { type: "PDF", name: "Polisa_2025.pdf", meta: "09.12.2024 · 612 kB", cite: "4" },
-      { type: "DOCX", name: "Zakres_ochrony.docx", meta: "14.12.2025 · 88 kB", cite: "2" },
-      { type: "PNG", name: "Skan_podpisu.png", meta: "16.12.2025 · 1,4 MB", cite: "2" },
+      { type: "PDF", name: "Policy_2026.pdf", meta: "14.12.2025 · 640 kB · current", cite: "2" },
+      { type: "PDF", name: "Policy_2025.pdf", meta: "09.12.2024 · 612 kB", cite: "4" },
+      { type: "DOCX", name: "Coverage_scope.docx", meta: "14.12.2025 · 88 kB", cite: "2" },
+      { type: "PNG", name: "Signature_scan.png", meta: "16.12.2025 · 1.4 MB", cite: "2" },
     ],
     evidence: [
-      { n: "2", title: "Polisa_2026.pdf", srcType: "zalacznik", snippet: "„Okres ubezpieczenia: 01.01.2026 – 31.12.2026”", meta: "14.12.2025 · trafność 0,96 · str. 1",
-        pre: "Ubezpieczający: Firma sp. z o.o. Przedmiot ubezpieczenia: odpowiedzialność cywilna zawodowa.",
-        quote: "Okres ubezpieczenia: 01.01.2026 – 31.12.2026. Suma gwarancyjna: 2 000 000 zł na jedno i wszystkie zdarzenia.",
-        post: "Składka płatna w dwóch ratach, termin pierwszej raty: 15.01.2026.",
-        supports: "ważność do 31.12.2026 · suma 2 mln zł", mail: "„Polisa na 2026 — do akceptacji”, 14.12.2025" },
-      { n: "4", title: "Polisa_2025.pdf", srcType: "zalacznik", snippet: "„Okres ubezpieczenia: 01.01.2025 – 31.12.2025”", meta: "09.12.2024 · trafność 0,72 · archiwum-2019",
-        pre: "Poprzednia wersja dokumentu, konto archiwum-2019.",
-        quote: "Okres ubezpieczenia: 01.01.2025 – 31.12.2025. Suma gwarancyjna: 1 500 000 zł.",
-        post: "Dokument zachowany dla porównania sum gwarancyjnych.",
-        supports: "poprzednia suma 1,5 mln zł", mail: "„Polisa 2025”, 09.12.2024" },
+      { n: "2", title: "Policy_2026.pdf", srcType: "attachment", snippet: "“Period of insurance: 01.01.2026 – 31.12.2026”", meta: "14.12.2025 · relevance 0.96 · p. 1",
+        pre: "Policyholder: Northgate Ltd. Subject of insurance: professional indemnity.",
+        quote: "Period of insurance: 01.01.2026 – 31.12.2026. Limit of indemnity: €2,000,000 per claim and in the aggregate.",
+        post: "Premium payable in two instalments, the first due 15.01.2026.",
+        supports: "valid to 31.12.2026 · €2m limit", mail: "“Policy for 2026 — for approval”, 14.12.2025" },
+      { n: "4", title: "Policy_2025.pdf", srcType: "attachment", snippet: "“Period of insurance: 01.01.2025 – 31.12.2025”", meta: "09.12.2024 · relevance 0.72 · archive-2019",
+        pre: "Previous version of the document, archive-2019 account.",
+        quote: "Period of insurance: 01.01.2025 – 31.12.2025. Limit of indemnity: €1,500,000.",
+        post: "Kept for comparison of indemnity limits.",
+        supports: "previous limit €1.5m", mail: "“Policy 2025”, 09.12.2024" },
     ],
   },
   people: {
-    label: "Odpowiedź + Osoby",
-    confidence: "pewność średnia",
-    gap: "brak potwierdzenia mailowego od zarządu",
-    meta: "run c220 · 18 wiadomości, 3 osoby",
-    trace: "retrieval po osobach i rolach w wątkach\nreguła: kto odpowiedział na wątek decyzyjny\nmodel: streszczenie + wybór PresentationPlan",
-    action: "Dopisać ustalenie o zatwierdzeniu do Sprawy „Renegocjacja Contoso”?",
+    label: "Answer + People",
+    confidence: "medium confidence",
+    gap: "no email confirmation from the board",
+    meta: "run c220 · 18 messages, 3 people",
+    trace: "retrieval by people and roles across threads\nrule: who replied in the decision thread\nmodel: summary + PresentationPlan choice",
+    action: "Add the approval to the “Contoso renegotiation” case?",
     blocks: ["answer", "people", "action"],
     parts: [
-      { text: "Budżet indeksacji na 2023 zatwierdziła Marta Nowak z Finansów, po opinii prawnej Jacka Wrony", cite: "6" },
-      { text: ". Stroną Contoso w całej korespondencji była Anna Kowalska", cite: "3" },
+      { text: "The 2023 indexation budget was approved by Marta Nowak in Finance, after Jacek Wrona's legal opinion", cite: "6" },
+      { text: ". Anna Kowalska was Contoso's counterpart throughout the correspondence", cite: "3" },
     ],
     people: [
-      { initials: "MN", name: "Marta Nowak", role: "Finanse · zatwierdziła budżet 2023", last: "wczoraj", cite: "6" },
-      { initials: "JW", name: "Jacek Wrona", role: "Prawnik · opinia o limicie waloryzacji", last: "24.08", cite: "6" },
-      { initials: "AK", name: "Anna Kowalska", role: "Contoso · account manager", last: "dzisiaj", cite: "3" },
+      { initials: "MN", name: "Marta Nowak", role: "Finance · approved the 2023 budget", last: "yesterday", cite: "6" },
+      { initials: "JW", name: "Jacek Wrona", role: "Lawyer · opinion on the indexation cap", last: "24.08", cite: "6" },
+      { initials: "AK", name: "Anna Kowalska", role: "Contoso · account manager", last: "today", cite: "3" },
     ],
     evidence: [
-      { n: "6", title: "Re: budżet indeksacji 2023", srcType: "mail", snippet: "„Akceptuję kalkulację, wchodzimy w CPI.”", meta: "07.02.2023 · M. Nowak · 0,88",
-        pre: "Wątek: budżet indeksacji 2023, uczestnicy: Marta Nowak, Jacek Wrona, Krzysztof Kasprowicz.",
-        quote: "Akceptuję kalkulację, wchodzimy w waloryzację CPI. Zastrzeżenie prawne o limicie zostawiam do kolejnej renegocjacji.",
-        post: "Proszę o przekazanie decyzji do Contoso.",
-        supports: "zatwierdzenie budżetu · świadome pominięcie limitu", mail: "„Re: budżet indeksacji 2023”, 07.02.2023" },
-      { n: "3", title: "Re: indeksacja od 2023", srcType: "mail", snippet: "„…waloryzacja wg CPI, bez górnego limitu.”", meta: "03.02.2023 · A. Kowalska · 0,91",
-        pre: "Dzień dobry, wracam do tematu waloryzacji stawek na kolejny rok.",
-        quote: "Zgodnie z ustaleniami wynagrodzenie będzie waloryzowane wskaźnikiem CPI publikowanym przez GUS, bez górnego limitu.",
-        post: "Proszę o potwierdzenie, wtedy przygotujemy aneks do podpisu.",
-        supports: "rola Anny Kowalskiej w ustaleniu", mail: "„Re: indeksacja od 2023”, 03.02.2023" },
+      { n: "6", title: "Re: 2023 indexation budget", srcType: "mail", snippet: "“I approve the calculation, we go with CPI.”", meta: "07.02.2023 · M. Nowak · 0.88",
+        pre: "Thread: 2023 indexation budget, participants: Marta Nowak, Jacek Wrona, Chris Kasprowicz.",
+        quote: "I approve the calculation, we go with CPI indexation. I am leaving the legal caveat about a cap to the next renegotiation.",
+        post: "Please pass the decision on to Contoso.",
+        supports: "budget approval · cap knowingly omitted", mail: "“Re: 2023 indexation budget”, 07.02.2023" },
+      { n: "3", title: "Re: indexation from 2023", srcType: "mail", snippet: "“…indexed to CPI, with no upper cap.”", meta: "03.02.2023 · A. Kowalska · 0,91",
+        pre: "Hello, coming back to the indexation of rates for next year.",
+        quote: "As agreed, remuneration will be indexed to the CPI published by the statistics office, with no upper cap.",
+        post: "Please confirm and we will prepare the addendum for signature.",
+        supports: "Anna Kowalska's role in the agreement", mail: "“Re: indexation from 2023”, 03.02.2023" },
     ],
   },
 };
 
 const THREADS = [
-  { id: "contoso", from: "Anna Kowalska", org: "Contoso", time: "09:14", subject: "Aneks do umowy — podpisy",
-    ai: "Wymaga decyzji do piątku · zmiana SLA",
-    meta: "Anna Kowalska <a.kowalska@contoso.example> · dzisiaj 09:14 · wątek: 6 wiadomości",
+  { id: "contoso", from: "Anna Kowalska", org: "Contoso", time: "09:14", subject: "Contract addendum — signatures",
+    ai: "Needs a decision by Friday · SLA change",
+    meta: "Anna Kowalska <a.kowalska@contoso.example> · today 09:14 · thread: 6 messages",
     state: [
-      { label: "USTALENIA", value: "SLA 2 h · cena +8% od 2027" },
-      { label: "OTWARTE PYTANIE", value: "Górny limit indeksacji CPI" },
-      { label: "ZOBOWIĄZANIE", value: "Decyzja po naszej stronie do 28.08" },
+      { label: "AGREED", value: "SLA 2 h · price +8% from 2027" },
+      { label: "OPEN QUESTION", value: "Upper cap on CPI indexation" },
+      { label: "COMMITMENT", value: "Decision on our side by 28.08" },
     ],
     body: [
-      { md: `Dzień dobry, przesyłam **aneks nr 3** w wersji do podpisu. Względem umowy ramowej z 2021 roku zmienia się poziom usług i wynagrodzenie.
+      { md: `Hello, here is **addendum no. 3** in the version for signature. Compared with the 2021 master agreement, the service level and the fee change.
 
-## Co się zmienia
+## What changes
 
-| Parametr | Dziś | Po aneksie |
+| Parameter | Today | After addendum |
 | --- | --- | --- |
-| Czas reakcji (krytyczne) | 4 h | **2 h** |
-| Wynagrodzenie roczne | 236 000 zł | 254 880 zł |
-| Raport dostępności | kwartalny | miesięczny |
-| Limit waloryzacji CPI | brak | brak |
+| Response time (critical) | 4 h | **2 h** |
+| Annual fee | €236,000 | €254,880 |
+| Availability report | quarterly | monthly |
+| CPI indexation cap | none | none |
 
-> § 3. Zasady waloryzacji wynagrodzenia wskaźnikiem CPI pozostają bez zmian. Strony *nie ustalają* górnego limitu indeksacji.
+> § 3. The rules for indexing the fee to CPI remain unchanged. The parties *do not set* an upper cap on indexation.
 
-### Do zrobienia po Państwa stronie
-1. Akceptacja treści aneksu do **28 sierpnia**
-2. Wskazanie osoby podpisującej (imię, nazwisko, funkcja)
-3. Odesłanie skanu lub podpis elektroniczny w \`eSign\`
+### To do on your side
+1. Approve the addendum text by **28 August**
+2. Name the signatory (first name, surname, position)
+3. Return a scan or sign electronically in \`eSign\`
 
-Po 28 sierpnia przekazujemy dokument do podpisu w wersji obecnej. Pełna treść: [Aneks SLA.pdf](https://contoso.example/aneks-3).`, hl: true },
+After 28 August we send the document for signature as it stands. Full text: [SLA addendum.pdf](https://contoso.example/addendum-3).`, hl: true },
     ],
-    attachments: [ { type: "PDF", name: "Aneks SLA.pdf", size: "248 kB" }, { type: "PDF", name: "Umowa ramowa.pdf", size: "1,2 MB" } ] },
-  { id: "finanse", from: "Finanse", org: "", time: "08:02", subject: "Faktura 08/2026", ai: "Termin płatności: 29.08",
-    meta: "faktury@firma.pl · dzisiaj 08:02 · wątek: 1 wiadomość",
-    state: [ { label: "USTALENIA", value: "Kwota 1 452 zł netto" }, { label: "TERMIN", value: "Płatność do 29.08" }, { label: "ZOBOWIĄZANIE", value: "Brak akcji po naszej stronie" } ],
+    attachments: [ { type: "PDF", name: "SLA addendum.pdf", size: "248 kB" }, { type: "PDF", name: "Master agreement.pdf", size: "1.2 MB" } ] },
+  { id: "finanse", from: "Finance", org: "", time: "08:02", subject: "Invoice 08/2026", ai: "Payment due: 29.08",
+    meta: "invoices@company.example · today 08:02 · thread: 1 message",
+    state: [ { label: "AGREED", value: "€1,452 net" }, { label: "DEADLINE", value: "Payment by 29.08" }, { label: "COMMITMENT", value: "No action on our side" } ],
     body: [
-      { text: "W załączeniu faktura 08/2026 za sierpień. Kwota do zapłaty: 1 452,00 zł netto, 1 786,00 zł brutto." },
-      { text: "Pozycje: hosting aplikacji za sierpień oraz kopie zapasowe 250 GB. Rachunek do przelewu bez zmian, w tytule prosimy podać numer faktury." },
-      { text: "Termin płatności: 29.08.2026. Faktura nie wymaga podpisu." },
+      { text: "Attached is invoice 08/2026 for August. Amount due: €1,452.00 net, €1,786.00 gross." },
+      { text: "Line items: application hosting for August and 250 GB of backups. Bank details unchanged; please quote the invoice number in the transfer reference." },
+      { text: "Payment due 29.08.2026. The invoice does not require a signature." },
     ],
-    attachments: [ { type: "PDF", name: "FV_08_2026.pdf", size: "96 kB" } ] },
-  { id: "piotr", from: "Piotr Zieliński", org: "", time: "wcz.", subject: "Re: harmonogram wdrożenia", ai: "Potwierdził etap drugi",
-    meta: "p.zielinski@firma.pl · wczoraj 16:41 · wątek: 5 wiadomości",
-    state: [ { label: "USTALENIA", value: "Etap drugi potwierdzony" }, { label: "OTWARTE PYTANIE", value: "Data testów UAT" }, { label: "ZOBOWIĄZANIE", value: "Piotr przygotuje plan testów" } ],
+    attachments: [ { type: "PDF", name: "INV_08_2026.pdf", size: "96 kB" } ] },
+  { id: "piotr", from: "Piotr Zieliński", org: "", time: "yest.", subject: "Re: rollout schedule", ai: "Confirmed phase two",
+    meta: "p.zielinski@company.example · yesterday 16:41 · thread: 5 messages",
+    state: [ { label: "AGREED", value: "Phase two confirmed" }, { label: "OPEN QUESTION", value: "UAT test dates" }, { label: "COMMITMENT", value: "Piotr will prepare the test plan" } ],
     body: [
-      { text: "Potwierdzam zamknięcie etapu drugiego — integracja z Exchange jest gotowa do odbioru, zamknęliśmy 41 z 58 zadań." },
-      { text: "Dwa zadania pozostają zablokowane po stronie API Graph, ale nie wpływają na odbiór. Błędów krytycznych nie mamy." },
-      { text: "Do ustalenia zostaje termin testów UAT. Proponuję 15–19 września, żeby zdążyć przed szkoleniami w październiku. Ryzyko harmonogramu oceniam jako średnie." },
+      { text: "Confirming that phase two is closed — the Exchange integration is ready for acceptance, we closed 41 of 58 tasks." },
+      { text: "Two tasks remain blocked on the Graph API side, but they do not affect acceptance. No critical bugs open." },
+      { text: "The UAT window is still to be agreed. I suggest 15–19 September so we finish before the October training. I rate the schedule risk as medium." },
     ],
     attachments: [] },
-  { id: "marta", from: "Marta Nowak", org: "Finanse", time: "wcz.", subject: "Kalkulacja CPI 2027", ai: "Zobowiązanie: odpowiedź do 27.08",
-    meta: "m.nowak@firma.pl · wczoraj 11:20 · wątek: 4 wiadomości",
-    state: [ { label: "USTALENIA", value: "CPI prognozowane 4,1%" }, { label: "OTWARTE PYTANIE", value: "Czy proponujemy limit 5%" }, { label: "ZOBOWIĄZANIE", value: "Odpowiedź do 27.08" } ],
+  { id: "marta", from: "Marta Nowak", org: "Finance", time: "yest.", subject: "CPI calculation 2027", ai: "Commitment: reply by 27.08",
+    meta: "m.nowak@company.example · yesterday 11:20 · thread: 4 messages",
+    state: [ { label: "AGREED", value: "CPI forecast 4.1%" }, { label: "OPEN QUESTION", value: "Do we propose a 5% cap" }, { label: "COMMITMENT", value: "Reply by 27.08" } ],
     body: [
-      { md: `# Kalkulacja CPI 2027
+      { md: `# CPI calculation 2027
 
-Policzyłam wpływ nowych warunków na budżet. Baza: ryczałt **238 000 zł** netto rocznie.
+I ran the new terms through the budget. Base: a flat fee of **€238,000** net per year.
 
-| Scenariusz | CPI | Podwyżka 8% | Waloryzacja | Razem |
+| Scenario | CPI | 8% increase | Indexation | Total |
 | --- | ---: | ---: | ---: | ---: |
-| Bazowy | 4,1% | 19 040 zł | 10 542 zł | **267 582 zł** |
-| Pesymistyczny | 9,0% | 19 040 zł | 22 179 zł | 279 219 zł |
-| Z limitem 5% | 5,0% | 19 040 zł | 12 852 zł | 267 892 zł |
+| Base | 4.1% | €19,040 | €10,542 | **€267,582** |
+| Pessimistic | 9.0% | €19,040 | €22,179 | €279,219 |
+| With a 5% cap | 5.0% | €19,040 | €12,852 | €267,892 |
 
-Rok do roku to **+29 582 zł** w scenariuszu bazowym.
+Year on year that is **+€29,582** in the base scenario.
 
-## Rekomendacja
-- wynegocjować górny limit indeksacji **5% rocznie**
-- w najgorszym wariancie oszczędza to ~11,6 tys. zł
-- ~~rezygnacja z miesięcznego raportu~~ — Contoso nie zejdzie z tego punktu
+## Recommendation
+- negotiate an upper indexation cap of **5% per year**
+- in the worst case that saves about €11.6k
+- ~~dropping the monthly report~~ — Contoso will not budge on that
 
-Formuła użyta w arkuszu:
+Formula used in the sheet:
 
 \`\`\`
-razem = ryczalt * 1,08 * (1 + min(CPI; limit))
+total = flat_fee * 1.08 * (1 + min(CPI; cap))
 \`\`\`
 
-Odpowiedź potrzebna do **27 sierpnia**.` },
+Answer needed by **27 August**.` },
     ],
     attachments: [ { type: "XLSX", name: "CPI_2027.xlsx", size: "34 kB" } ] },
-  { id: "jacek", from: "Jacek Wrona", org: "", time: "24.08", subject: "Opinia prawna — limit waloryzacji", ai: "",
-    meta: "j.wrona@kancelaria.example · 24.08.2026 · wątek: 2 wiadomości",
-    state: [ { label: "USTALENIA", value: "Limit dopuszczalny umownie" }, { label: "OTWARTE PYTANIE", value: "Brak" }, { label: "ZOBOWIĄZANIE", value: "Brak" } ],
+  { id: "jacek", from: "Jacek Wrona", org: "", time: "24.08", subject: "Legal opinion — indexation cap", ai: "",
+    meta: "j.wrona@lawoffice.example · 24.08.2026 · thread: 2 messages",
+    state: [ { label: "AGREED", value: "A cap is contractually permissible" }, { label: "OPEN QUESTION", value: "None" }, { label: "COMMITMENT", value: "None" } ],
     body: [
-      { md: `## Opinia prawna — limit waloryzacji
+      { md: `## Legal opinion — indexation cap
 
-Wprowadzenie górnego limitu indeksacji jest **dopuszczalne** w świetle zasady swobody umów i nie wymaga zmiany pozostałych postanowień umowy ramowej.
+Introducing an upper cap on indexation is **permissible** under freedom of contract and requires no change to the other provisions of the master agreement.
 
-### Elementy klauzuli
-1. wskaźnik referencyjny (CPI, GUS, rok do roku)
-2. moment odczytu wskaźnika
-3. maksymalny poziom podwyżki w skali roku
+### Elements of the clause
+1. reference index (CPI, statistics office, year on year)
+2. the moment the index is read
+3. the maximum increase per year
 
-> Waloryzacja wynagrodzenia nie może przekroczyć **5% w skali roku**, niezależnie od wartości wskaźnika CPI ogłoszonego przez GUS.
+> Indexation of the fee may not exceed **5% per year**, regardless of the CPI figure published by the statistics office.
 
-Ryzyko sporu oceniam jako *niskie*. Brak limitu przy CPI powyżej 8% może natomiast prowadzić do istotnej zmiany równowagi kontraktowej.` },
-      { text: "Klauzula powinna wskazywać wskaźnik referencyjny, moment jego odczytu oraz maksymalny poziom podwyżki w skali roku. Proponowane brzmienie: waloryzacja nie może przekroczyć 5% w skali roku kalendarzowego, niezależnie od wskaźnika CPI ogłoszonego przez GUS." },
-      { text: "Ryzyko sporu oceniam jako niskie. Brak limitu przy CPI powyżej 8% może natomiast prowadzić do istotnej zmiany równowagi kontraktowej." },
+I rate the litigation risk as *low*. An uncapped clause with CPI above 8% could, however, materially shift the contractual balance.` },
+      { text: "The clause should name the reference index, the moment it is read and the maximum increase per year. Proposed wording: indexation may not exceed 5% per calendar year, regardless of the CPI figure published by the statistics office." },
+      { text: "I rate the litigation risk as low. An uncapped clause with CPI above 8% could, however, materially shift the contractual balance." },
     ],
     attachments: [] },
 ];
@@ -2838,171 +2838,171 @@ Ryzyko sporu oceniam jako *niskie*. Brak limitu przy CPI powyżej 8% może natom
 const A = (type, name, size) => ({ type, name, size });
 const T = (id, from, org, time, subject, ai, addr, when, count, s1, s2, s3, body, att) => ({
   id, from, org, time, subject, ai,
-  meta: addr + " · " + when + " · wątek: " + count,
-  state: [{ label: "USTALENIA", value: s1 }, { label: "OTWARTE PYTANIE", value: s2 }, { label: "ZOBOWIĄZANIE", value: s3 }],
+  meta: addr + " · " + when + " · thread: " + count,
+  state: [{ label: "AGREED", value: s1 }, { label: "OPEN QUESTION", value: s2 }, { label: "COMMITMENT", value: s3 }],
   body: body.map(x => typeof x === "string" ? { text: x } : x),
   attachments: att || [],
 });
 
 THREADS.push(
-  T("anna2", "Anna Kowalska", "Contoso", "08:47", "Re: propozycja warunków 2027", "Czeka na naszą odpowiedź", "a.kowalska@contoso.example", "dzisiaj 08:47", "3 wiadomości", "Trzy warianty na stole", "Czy akceptujemy wariant B", "Odpowiedź do 28.08", [
-    "Przypominam o propozycji z 26 sierpnia. Przygotowaliśmy trzy warianty współpracy na 2027 rok — bez zmian, rekomendowany oraz rozszerzony o weekendy.",
-    "Wariant rekomendowany to skrócenie czasu reakcji do dwóch godzin, dedykowany opiekun techniczny przez dwa dni w miesiącu i comiesięczny raport dostępności. Cena roczna: 257 040 zł netto.",
-    "Jeśli potrzebują Państwo dodatkowej kalkulacji albo porównania z rozliczeniem za 2026, przygotuję je do końca tygodnia. Propozycja wiąże nas do 28 sierpnia.",
-  ], [A("XLSX", "Kalkulacja_2027.xlsx", "42 kB")]),
-  T("hr1", "Dział HR", "", "07:55", "Ankieta satysfakcji — termin 05.09", "Termin: 05.09", "hr@firma.pl", "dzisiaj 07:55", "1 wiadomość", "Ankieta anonimowa, 7 minut", "Brak", "Wypełnić do 05.09", [
-    "Prosimy o wypełnienie corocznej ankiety satysfakcji. Zajmuje około siedmiu minut i jest w pełni anonimowa — odpowiedzi zbiera zewnętrzna platforma, a my widzimy wyłącznie wyniki zbiorcze.",
-    "W ankiecie jest sześć obszarów oceny i dwa pytania otwarte. W zeszłym roku wypełniło ją 78% zespołu; na tej podstawie powstał budżet szkoleniowy i elastyczne godziny startu pracy.",
-    "Termin: 5 września. Wyniki omówimy na spotkaniu wrześniowym.",
+  T("anna2", "Anna Kowalska", "Contoso", "08:47", "Re: proposed terms for 2027", "Waiting on our reply", "a.kowalska@contoso.example", "today 08:47", "3 messages", "Three options on the table", "Do we accept option B", "Reply by 28.08", [
+    "A reminder about our proposal of 26 August. We prepared three options for 2027 — unchanged, recommended, and extended to weekends.",
+    "The recommended option shortens the response time to two hours, adds a dedicated technical account manager for two days a month and a monthly availability report. Annual price: €257,040 net.",
+    "If you need a further calculation or a comparison with the 2026 settlement, I can prepare it by the end of the week. The proposal is binding on us until 28 August.",
+  ], [A("XLSX", "Calculation_2027.xlsx", "42 kB")]),
+  T("hr1", "HR Department", "", "07:55", "Satisfaction survey — due 05.09", "Due: 05.09", "hr@company.example", "today 07:55", "1 message", "Anonymous survey, 7 minutes", "None", "Complete by 05.09", [
+    "Please fill in the annual satisfaction survey. It takes about seven minutes and is fully anonymous — an external platform collects the answers and we only see aggregate results.",
+    "The survey covers six areas plus two open questions. Last year 78% of the team completed it; that is what the training budget and flexible start hours came from.",
+    "Deadline: 5 September. We will discuss the results at the September all-hands.",
   ]),
-  T("north1", "Robert Lis", "Northwind", "07:12", "Oferta na moduł raportowy", "Wymaga decyzji · oferta 30 dni", "r.lis@northwind.example", "dzisiaj 07:12", "2 wiadomości", "24 000 zł netto, wdrożenie 6 tygodni", "Zakres raportów własnych", "Decyzja do 30.09", [
-    { md: `# Oferta — moduł raportowy
+  T("north1", "Robert Lis", "Northwind", "07:12", "Quote for the reporting module", "Needs a decision · quote valid 30 days", "r.lis@northwind.example", "today 07:12", "2 messages", "€24,000 net, 6-week rollout", "Scope of custom reports", "Decision by 30.09", [
+    { md: `# Quote — reporting module
 
-## Zakres
-- 12 raportów standardowych (sprzedaż, SLA, zużycie licencji)
-- kreator raportów własnych
-- eksport do \`XLSX\` i \`PDF\`
-- harmonogram wysyłki na e-mail
+## Scope
+- 12 standard reports (sales, SLA, licence usage)
+- custom report builder
+- export to \`XLSX\` and \`PDF\`
+- scheduled delivery by e-mail
 
-## Wycena
+## Pricing
 
-| Pozycja | Kwota netto |
+| Item | Net amount |
 | --- | ---: |
-| Licencja roczna | 14 000 zł |
-| Wdrożenie | 8 400 zł |
-| Szkolenie (2 dni) | 1 600 zł |
-| **Razem** | **24 000 zł** |
+| Annual licence | €14,000 |
+| Implementation | €8,400 |
+| Training (2 days) | €1,600 |
+| **Total** | **€24,000** |
 
-Utrzymanie: *1 200 zł miesięcznie* od drugiego miesiąca po odbiorze.
+Maintenance: *€1,200 per month* from the second month after acceptance.
 
-## Harmonogram
-1. Konfiguracja źródeł danych — 2 tygodnie
-2. Budowa raportów — 2 tygodnie
-3. Testy i szkolenie — 2 tygodnie
+## Schedule
+1. Data source configuration — 2 weeks
+2. Report build — 2 weeks
+3. Testing and training — 2 weeks
 
 ---
 
-Oferta ważna do **30 września**. Szczegóły: [northwind.example/raporty](https://northwind.example/raporty).` },
-  ], [A("PDF", "Oferta_raporty.pdf", "310 kB")]),
-  T("bank1", "Bank Firmowy", "", "06:58", "Potwierdzenie przelewu 18 400 zł", "", "noreply@bank.example", "dzisiaj 06:58", "1 wiadomość", "Przelew zrealizowany 01.09", "Brak", "Brak", [
-    "Przelew na kwotę 18 400,00 zł został zrealizowany. Odbiorca: Contoso Sp. z o.o., rachunek PL 61 1090 1014 0000 0712 1981 2874.",
-    "Tytuł: aneks — rozliczenie sierpień 2026. Data księgowania: 1 września 2026, 06:58. Referencja operacji: TRN-8841-220916.",
-    "Wiadomość jest wyłącznie potwierdzeniem operacji i nie wymaga odpowiedzi.",
-  ], [A("PDF", "Potwierdzenie.pdf", "58 kB")]),
-  T("fabrikam1", "Tomasz Bąk", "Fabrikam", "wcz.", "Terminy dostawy Q4", "Zmiana terminu · listopad", "t.bak@fabrikam.example", "wczoraj 17:05", "7 wiadomości", "Dostawa przesunięta na 12.11", "Czy akceptujemy opóźnienie", "Potwierdzenie do 02.09", [
-    "Ze względu na przestój linii u producenta komponentu dostawa zamówienia ZAM-2026-0914 przesuwa się z 28 października na 12 listopada, okno 08:00–14:00.",
-    "Zakres bez zmian: cztery palety, 1 240 kg. Produkcja komponentów kończy się 2 września, kompletacja i kontrola jakości do 5 listopada.",
-    "Prosimy o potwierdzenie nowego okna do 2 września. Jeśli nie otrzymamy odpowiedzi, zarezerwujemy termin zapasowy 19 listopada. Pozostałe warunki handlowe pozostają bez zmian.",
+Quote valid until **30 September**. Details: [northwind.example/reports](https://northwind.example/reports).` },
+  ], [A("PDF", "Quote_reporting.pdf", "310 kB")]),
+  T("bank1", "Business Bank", "", "06:58", "Transfer confirmation €18,400", "", "noreply@bank.example", "today 06:58", "1 message", "Transfer completed 01.09", "None", "None", [
+    "A transfer of €18,400.00 has been completed. Beneficiary: Contoso Ltd, account DE61 1090 1014 0000 0712 19.",
+    "Reference: addendum — August 2026 settlement. Booking date: 1 September 2026, 06:58. Operation reference: TRN-8841-220916.",
+    "This message only confirms the operation and needs no reply.",
+  ], [A("PDF", "Confirmation.pdf", "58 kB")]),
+  T("fabrikam1", "Tomasz Bąk", "Fabrikam", "yest.", "Q4 delivery dates", "Date change · November", "t.bak@fabrikam.example", "yesterday 17:05", "7 messages", "Delivery moved to 12.11", "Do we accept the delay", "Confirm by 02.09", [
+    "Because of a line stoppage at the component manufacturer, delivery of order ORD-2026-0914 moves from 28 October to 12 November, window 08:00–14:00.",
+    "Scope unchanged: four pallets, 1,240 kg. Component production finishes on 2 September, picking and quality control by 5 November.",
+    "Please confirm the new window by 2 September. Without a reply we will book the fallback date of 19 November. All other commercial terms stay as they are.",
   ]),
-  T("audyt1", "Audyt wewnętrzny", "", "wcz.", "Zapytanie o rejestr umów", "Wymaga decyzji · dane do 03.09", "audyt@firma.pl", "wczoraj 16:12", "3 wiadomości", "Zakres: umowy IT 2024–2026", "Kto przygotuje wykaz", "Wykaz do 03.09", [
-    { md: `## Zapytanie o rejestr umów IT 2024–2026
+  T("audyt1", "Internal Audit", "", "yest.", "Request for the contract register", "Needs a decision · data by 03.09", "audit@company.example", "yesterday 16:12", "3 messages", "Scope: IT contracts 2024–2026", "Who prepares the list", "List due 03.09", [
+    { md: `## Request for the IT contract register 2024–2026
 
-W ramach cyklicznego przeglądu prosimy o **kompletny wykaz umów IT** wraz z aneksami.
+As part of the periodic review, please send a **complete list of IT contracts** including addenda.
 
-### Kolumny wymagane w wykazie
-- [ ] kontrahent i NIP
-- [ ] data zawarcia i okres obowiązywania
-- [ ] wartość roczna netto
-- [ ] okres wypowiedzenia
-- [ ] powierzenie danych osobowych (tak/nie)
-- [x] format pliku uzgodniony: \`XLSX\`
+### Columns required in the list
+- [ ] counterparty and tax ID
+- [ ] signature date and term
+- [ ] annual value, net
+- [ ] notice period
+- [ ] personal data processing (yes/no)
+- [x] file format agreed: \`XLSX\`
 
-| Etap | Termin |
+| Stage | Date |
 | --- | --- |
-| Przekazanie wykazu | 03.09 |
-| Pytania uzupełniające audytu | 08.09 |
-| Zamknięcie przeglądu | 15.09 |
+| List submitted | 03.09 |
+| Audit follow-up questions | 08.09 |
+| Review closed | 15.09 |
 
-> Zapytanie nie wymaga odpowiedzi formalnej — wystarczy przesłanie pliku na adres audytu z kopią do sekretariatu zarządu.` },
+> The request needs no formal reply — just send the file to the audit address, copying the board office.` },
   ]),
-  T("prawnik2", "Kancelaria Wrona", "", "wcz.", "Projekt NDA — Northwind", "Do podpisu", "j.wrona@kancelaria.example", "wczoraj 15:40", "2 wiadomości", "NDA na 3 lata, kara 50 tys.", "Czy druga strona przyjmie obniżenie kary", "Podpis do 05.09", [
-    "Przesyłam projekt NDA z Northwind w wersji drugiej. Skróciłem okres obowiązywania z pięciu do trzech lat od zakończenia współpracy.",
-    "Najważniejsza zmiana dotyczy paragrafu 5: proponuję obniżenie kary umownej ze 100 tys. zł do 50 tys. zł za każde naruszenie. Wyłączenia z paragrafu 7 zostają bez zmian.",
-    "Dokument jest gotowy do podpisu elektronicznego do 5 września. Jeśli druga strona nie zaakceptuje obniżenia, rekomenduję wariant z limitem łącznym 150 tys. zł.",
+  T("prawnik2", "Wrona Law Office", "", "yest.", "Draft NDA — Northwind", "For signature", "j.wrona@lawoffice.example", "yesterday 15:40", "2 messages", "3-year NDA, €50k penalty", "Will the other side accept the lower penalty", "Signature by 05.09", [
+    "Here is the second draft of the NDA with Northwind. I shortened the term from five to three years after the end of the engagement.",
+    "The key change is in clause 5: I propose lowering the contractual penalty from €100k to €50k per breach. The carve-outs in clause 7 stay unchanged.",
+    "The document is ready for electronic signature until 5 September. If the other side rejects the reduction, I recommend the variant with a €150k aggregate cap.",
   ], [A("DOCX", "NDA_Northwind.docx", "72 kB")]),
-  T("travel1", "Biuro podróży", "", "wcz.", "Bilety Kraków–Berlin 12.09", "Termin odprawy: 11.09", "rezerwacje@travel.example", "wczoraj 14:02", "1 wiadomość", "Lot 12.09, 07:40, PNR 7QX4MB", "Brak", "Odprawa online 11.09", [
-    { md: `## Rezerwacja potwierdzona — \`7QX4MB\`
+  T("travel1", "Travel Desk", "", "yest.", "Tickets Kraków–Berlin 12.09", "Check-in from: 11.09", "bookings@travel.example", "yesterday 14:02", "1 message", "Flight 12.09, 07:40, PNR 7QX4MB", "None", "Online check-in 11.09", [
+    { md: `## Booking confirmed — \`7QX4MB\`
 
-| | Wylot | Przylot |
+| | Departure | Arrival |
 | --- | --- | --- |
-| Miasto | Kraków (KRK) | Berlin (BER) |
-| Data | 12.09 | 12.09 |
-| Godzina | **07:40** | 09:05 |
+| City | Kraków (KRK) | Berlin (BER) |
+| Date | 12.09 | 12.09 |
+| Time | **07:40** | 09:05 |
 
-Lot bezpośredni, czas przelotu *1 h 25 min*. Miejsce **14C** przy przejściu.
+Direct flight, flying time *1 h 25 min*. Seat **14C**, aisle.
 
-### Taryfa Flex
-- bagaż rejestrowany 23 kg
-- bezpłatne zmiany do 24 h przed odlotem
-- zwrot 90% wartości biletu
+### Flex fare
+- 23 kg checked baggage
+- free changes up to 24 h before departure
+- 90% refund of the ticket price
 
 ---
 
-Odprawa online: **11.09 od 07:40**, zamknięcie 2 h przed odlotem — [odprawa online](https://travel.example/checkin/7QX4MB).` },
-  ], [A("PDF", "Bilety.pdf", "120 kB")]),
-  T("marketing1", "Marketing", "", "wcz.", "Materiały na targi 24.09", "Deadline: 10.09", "marketing@firma.pl", "wczoraj 12:30", "5 wiadomości", "Stoisko C18, 18 m²", "Kto prowadzi demo", "Materiały do 10.09", [
-    { md: `# Targi Poznań, 24–26.09
+Online check-in: **11.09 from 07:40**, closes 2 h before departure — [check in online](https://travel.example/checkin/7QX4MB).` },
+  ], [A("PDF", "Tickets.pdf", "120 kB")]),
+  T("marketing1", "Marketing", "", "yest.", "Trade show materials 24.09", "Deadline: 10.09", "marketing@company.example", "yesterday 12:30", "5 messages", "Stand C18, 18 m²", "Who runs the demo", "Materials by 10.09", [
+    { md: `# Trade show Poznań, 24–26.09
 
-Stoisko **C18**, 18 m². Koordynacja: Piotr Zieliński, druk: agencja Nord.
+Stand **C18**, 18 m². Coordination: Piotr Zieliński, print: Nord agency.
 
-## Status materiałów
-- [x] projekt zabudowy stoiska
-- [x] roll-up 1 — plik do druku
-- [ ] roll-up 2 — brak wersji angielskiej
-- [ ] ulotka produktowa \`PL\` / \`EN\`
-- [ ] **osoba prowadząca demo** — nie wyznaczona
+## Material status
+- [x] stand build design
+- [x] roll-up 1 — print-ready file
+- [ ] roll-up 2 — no English version
+- [ ] product leaflet \`PL\` / \`EN\`
+- [ ] **demo presenter** — not assigned
 
-| Element | Odpowiedzialny | Termin |
+| Item | Owner | Due |
 | --- | --- | --- |
-| Pliki do druku | Marketing | 10.09, 12:00 |
-| Odbiór wydruków | Nord | 18.09 |
-| Montaż stoiska | Piotr Z. | 23.09 |
+| Print-ready files | Marketing | 10.09, 12:00 |
+| Print pickup | Nord | 18.09 |
+| Stand assembly | Piotr Z. | 23.09 |
 
-> Po 10 września drukarnia dolicza **35% dopłaty** za tryb ekspresowy.` },
-  ], [A("PPTX", "Targi_2026.pptx", "4,1 MB")]),
-  T("klient3", "Ewa Sikora", "Adventure Works", "wcz.", "Pytanie o SLA w weekendy", "Wymaga odpowiedzi", "e.sikora@adventure.example", "wczoraj 10:15", "4 wiadomości", "Dziś wsparcie pn–pt 8:00–18:00", "Czy oferujemy soboty i za ile", "Odpowiedź do 01.09", [
-    { md: `Wracamy do tematu **wsparcia weekendowego** — od października uruchamiamy dyżury sobotnie u trzech naszych klientów.
+> After 10 September the printer adds a **35% surcharge** for rush turnaround.` },
+  ], [A("PPTX", "Tradeshow_2026.pptx", "4.1 MB")]),
+  T("klient3", "Ewa Sikora", "Adventure Works", "yest.", "Question about weekend SLA", "Needs a reply", "e.sikora@adventure.example", "yesterday 10:15", "4 messages", "Today: support Mon–Fri 8:00–18:00", "Do we offer Saturdays, and at what price", "Reply by 01.09", [
+    { md: `Coming back to **weekend support** — from October we are starting Saturday cover for three of our clients.
 
-## Czego potrzebujemy
+## What we need
 
-| Zakres | Dziś | Docelowo |
+| Scope | Today | Target |
 | --- | --- | --- |
-| Dni | pn–pt | pn–**sob** |
-| Godziny | 8:00–18:00 | 8:00–16:00 (sob) |
-| Reakcja (krytyczne) | 2 h | 4 h |
-| Kanał | portal | portal + telefon dyżurny |
+| Days | Mon–Fri | Mon–**Sat** |
+| Hours | 8:00–18:00 | 8:00–16:00 (Sat) |
+| Response (critical) | 2 h | 4 h |
+| Channel | portal | portal + on-call phone |
 
-1. Czy obecna umowa obejmuje soboty?
-2. Jeśli nie — jakie są widełki dopłaty?
-3. Od kiedy moglibyśmy ruszyć?
+1. Does the current contract cover Saturdays?
+2. If not — what is the price range for the add-on?
+3. How soon could we start?
 
-> Decyzję budżetową podejmujemy w przyszłym tygodniu, więc nawet orientacyjna kwota nam pomoże.` },
+> We take the budget decision next week, so even a ballpark figure helps.` },
   ]),
-  T("devops1", "CI Nordwind", "", "06:20", "Raport nocny — build #2418", "Build zielony · 2 ostrzeżenia", "ci@nordwind.example", "dzisiaj 06:20", "1 wiadomość", "Build zielony, 2 ostrzeżenia", "Czy wdrażamy na produkcję", "Decyzja do 09:00", [
-    { md: `# Raport nocny — build **#2418**
+  T("devops1", "Nordwind CI", "", "06:20", "Nightly report — build #2418", "Build green · 2 warnings", "ci@nordwind.example", "today 06:20", "1 message", "Build green, 2 warnings", "Do we ship to production", "Decision by 09:00", [
+    { md: `# Nightly report — build **#2418**
 
-Gałąź \`release/2.4\` · commit \`8f31c0d\` · czas 14 min 22 s
+Branch \`release/2.4\` · commit \`8f31c0d\` · duration 14 min 22 s
 
-| Etap | Status | Czas |
+| Stage | Status | Time |
 | --- | --- | ---: |
 | Lint | OK | 41 s |
-| Testy jednostkowe | OK (1 284) | 3 min 08 s |
-| Testy E2E | OK (96) | 8 min 51 s |
-| Skan bezpieczeństwa | **2 ostrzeżenia** | 1 min 42 s |
+| Unit tests | OK (1,284) | 3 min 08 s |
+| E2E tests | OK (96) | 8 min 51 s |
+| Security scan | **2 warnings** | 1 min 42 s |
 
-## Ostrzeżenia
-1. \`libxml2 2.9.14\` — podatność *średnia*, poprawka w 2.9.15
-2. Nieużywany klucz API w \`config/staging.yml\`
+## Warnings
+1. \`libxml2 2.9.14\` — *medium* severity, fixed in 2.9.15
+2. Unused API key in \`config/staging.yml\`
 
-> Żadne z ostrzeżeń nie blokuje wdrożenia. Rekomendacja zespołu: **wdrażać**, poprawkę libxml wziąć do najbliższego patcha.
+> Neither warning blocks the release. Team recommendation: **ship it**, take the libxml fix into the next patch.
 
-### Checklista przed wdrożeniem
-- [x] migracje bazy przetestowane na kopii
-- [x] plan wycofania opisany
-- [ ] okno serwisowe potwierdzone z klientem
-- [ ] notatka dla wsparcia
+### Pre-deploy checklist
+- [x] database migrations tested on a copy
+- [x] rollback plan written up
+- [ ] maintenance window confirmed with the client
+- [ ] note for support
 
-Polecenie wdrożenia:
+Deploy command:
 
 \`\`\`
 mf deploy --env prod --build 2418 --window 22:00-23:00
@@ -3010,65 +3010,65 @@ mf deploy --env prod --build 2418 --window 22:00-23:00
 
 ---
 
-Pełny log: [ci.nordwind.example/2418](https://ci.nordwind.example/2418). Decyzja potrzebna do **09:00**.` },
-  ], [A("PDF", "Raport_2418.pdf", "88 kB")]),
-  T("rekrutacja1", "Anna Bielska", "HR", "wcz.", "Podsumowanie rekrutacji — Frontend", "3 kandydatów do decyzji", "a.bielska@firma.pl", "wczoraj 13:50", "6 wiadomości", "Trzech finalistów", "Kogo zapraszamy na ostatni etap", "Decyzja do 04.09", [
-    { md: `## Rekrutacja: Frontend Engineer
+Full log: [ci.nordwind.example/2418](https://ci.nordwind.example/2418). Decision needed by **09:00**.` },
+  ], [A("PDF", "Report_2418.pdf", "88 kB")]),
+  T("rekrutacja1", "Anna Bielska", "HR", "yest.", "Hiring summary — Frontend", "3 candidates awaiting a decision", "a.bielska@company.example", "yesterday 13:50", "6 messages", "Three finalists", "Who goes to the final round", "Decision by 04.09", [
+    { md: `## Hiring: Frontend Engineer
 
-Po drugim etapie zostało **trzech kandydatów**. Poniżej skrót ocen — skala 1–5, wagi w nawiasach.
+**Three candidates** are left after the second round. Scores below — scale 1–5, weights in brackets.
 
-| Kandydat | Kod (40%) | Systemowo (30%) | Zespół (30%) | Razem |
+| Candidate | Code (40%) | Systems (30%) | Team (30%) | Total |
 | --- | ---: | ---: | ---: | ---: |
-| K. Adamiak | 5 | 4 | 4 | **4,4** |
-| M. Rutkowski | 4 | 5 | 3 | 4,0 |
-| J. Sowa | 4 | 3 | 5 | 4,0 |
+| K. Adamiak | 5 | 4 | 4 | **4.4** |
+| M. Rutkowski | 4 | 5 | 3 | 4.0 |
+| J. Sowa | 4 | 3 | 5 | 4.0 |
 
-### Uwagi rekruterów
-- **K. Adamiak** — najlepsze zadanie praktyczne, oczekiwania +12% ponad widełki
-- **M. Rutkowski** — mocna architektura, słabszy w parze; dostępny od zaraz
-- **J. Sowa** — świetne dopasowanie do zespołu, *wymaga wsparcia* przy testach
+### Interviewer notes
+- **K. Adamiak** — best practical task, expectations 12% above the band
+- **M. Rutkowski** — strong architecture, weaker in pairing; available immediately
+- **J. Sowa** — excellent team fit, *needs support* on testing
 
-> Widełki na to stanowisko: 16 000–19 000 zł B2B. Podniesienie górnej granicy wymaga zgody zarządu.
+> Band for this role: €3,600–4,300 per month, contract. Going above the top of the band needs board approval.
 
-### Co dalej
-1. Wybór dwóch osób na etap końcowy do **4 września**
-2. Rozmowy finałowe 8–10 września
-3. Oferta do 15 września
+### Next steps
+1. Pick two people for the final round by **4 September**
+2. Final interviews 8–10 September
+3. Offer by 15 September
 
-- [x] referencje sprawdzone (wszyscy trzej)
-- [ ] decyzja o widełkach dla K. Adamiak
-- [ ] rezerwacja sali na finały
+- [x] references checked (all three)
+- [ ] decision on the band for K. Adamiak
+- [ ] book a room for the finals
 
-Notatki i nagrania: [rekrutacja/frontend-2026](https://firma.pl/rekrutacja/frontend-2026).` },
-  ], [A("XLSX", "Oceny_kandydaci.xlsx", "28 kB")])
+Notes and recordings: [hiring/frontend-2026](https://company.example/hiring/frontend-2026).` },
+  ], [A("XLSX", "Candidate_scores.xlsx", "28 kB")])
 );
 
 
 const DEFAULT_UNREAD = {};
 THREADS.slice(0, 5).forEach(t => { DEFAULT_UNREAD[t.id] = true; });
 
-const FRAMES = { tablet: { w: 1024, h: 768 }, fold: { w: 884, h: 832 }, telefon: { w: 390, h: 844 } };
+const FRAMES = { tablet: { w: 1024, h: 768 }, fold: { w: 884, h: 832 }, phone: { w: 390, h: 844 } };
 
-/* GESTY CENTRUM POWIADOMIEŃ (telefon) — jedno miejsce z liczbami, z którego czyta implementacja.
-   commitFrac  0.32  droga jako część wysokości panelu, powyżej której gest się dokonuje
-   commitVel   0.5   px/ms — prędkość, przy której krótki rzut dokonuje gestu niezależnie od drogi
-   springMs    260   powrót, gdy nie spełniono ani drogi, ani prędkości
-   springEase        krzywa tego powrotu
-   barSlop     12    px w górę, po których belka nawigacji oddaje gest panelowi (i gubi swoje dotknięcie)
-   rowSlop     10    px, po których wiersz oddaje gest i kasuje swoje długie przytrzymanie */
+/* NOTIFICATION CENTRE GESTURES (phone) — one place for the numbers the implementation reads.
+   commitFrac  0.32  distance as a fraction of panel height above which the gesture commits
+   commitVel   0.5   px/ms — velocity at which a short flick commits regardless of distance
+   springMs    260   spring-back when neither distance nor velocity was met
+   springEase        the curve of that spring-back
+   barSlop     12    px upward after which the nav bar hands the gesture to the panel (losing its own touch)
+   rowSlop     10    px after which a row hands over the gesture and cancels its long-press */
 const NG = { commitFrac: 0.32, commitVel: 0.5, springMs: 260, springEase: "cubic-bezier(.32,.72,0,1)", barSlop: 12, rowSlop: 10 };
 const APP_VERSION = "2.4.2";
 const APP_BUILD = "build 20260907";
 
 const FONT = "display:flex;height:100vh;overflow:hidden;background:var(--bg);color:var(--text);font-family:'Instrument Sans',system-ui,sans-serif;font-size:15px";
 
-/* AWATARY KONTAKTÓW — PLACEHOLDERY.
-   Obrazki poniżej są wygenerowane na potrzeby prototypu i osadzone jako data URI (żeby demo działało też otwarte
-   z pliku / w nowej karcie, bez zależności od katalogu ./avatars/, gdzie leżą te same pliki PNG).
-   W aplikacji docelowej zdjęcie kontaktu pobieramy z serwera razem z kontaktem (pole photo/avatarUrl w odpowiedzi
-   książki adresowej: LDAP thumbnailPhoto, vCard PHOTO, Exchange/Graph /users/{id}/photo, własne API MailFathom),
-   cache'ujemy lokalnie i odświeżamy przy synchronizacji kontaktów. Klucz mapy = pełna nazwa nadawcy.
-   Brak wpisu = kontakt bez zdjęcia — UI musi działać bez awatara (nadawcy systemowi, listy wysyłkowe, nieznane adresy). */
+/* CONTACT AVATARS — PLACEHOLDERS.
+   The images below are generated for the prototype and embedded as data URIs (so the demo also works opened
+   from a file / in a new tab, with no dependency on ./avatars/, where the same PNG files live).
+   In the real app a contact photo comes from the server together with the contact (photo/avatarUrl field in the
+   address-book response: LDAP thumbnailPhoto, vCard PHOTO, Exchange/Graph /users/{id}/photo, MailFathom's own API),
+   is cached locally and refreshed on contact sync. Map key = full sender name.
+   No entry = contact without a photo — the UI must work without an avatar (system senders, mailing lists, unknown addresses). */
 const AVATARS = {
   "Anna Kowalska": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2072%2072%22%3E%3Crect%20width%3D%2272%22%20height%3D%2272%22%20fill%3D%22%23c9d6e8%22%2F%3E%3Ccircle%20cx%3D%2236%22%20cy%3D%2229%22%20r%3D%2211.2%22%20fill%3D%22%235b7ba6%22%2F%3E%3Cpath%20d%3D%22M14.4%2072c0-13.3%209.7-20.2%2021.6-20.2S57.6%2058.7%2057.6%2072z%22%20fill%3D%22%235b7ba6%22%2F%3E%3C%2Fsvg%3E",
   "Marta Nowak": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2072%2072%22%3E%3Crect%20width%3D%2272%22%20height%3D%2272%22%20fill%3D%22%23e8d9c9%22%2F%3E%3Ccircle%20cx%3D%2236%22%20cy%3D%2229%22%20r%3D%2211.2%22%20fill%3D%22%23a67f5b%22%2F%3E%3Cpath%20d%3D%22M14.4%2072c0-13.3%209.7-20.2%2021.6-20.2S57.6%2058.7%2057.6%2072z%22%20fill%3D%22%23a67f5b%22%2F%3E%3C%2Fsvg%3E",
@@ -3086,109 +3086,109 @@ const initialsOf = (n) => (n || "?").split(/\s+/).filter(Boolean).slice(0, 2).ma
 const lowerFirst = (s) => (s ? s.charAt(0).toLowerCase() + s.slice(1) : s);
 const M = (from, when, paras, atts, html) => ({ from, when, initials: initialsOf(from), mine: from === ME, paras, atts: atts || [], html: html || "" });
 
-/* Pełne wersje HTML wiadomości — to, co realnie przychodzi z serwera; w oknie wątku pokazujemy uproszczony tekst,
-   a pełny HTML otwiera się na żądanie (ikona "code") w osobnej zakładce / podglądzie. */
-const HTML_SHELL = (title, body) => '<!doctype html><html lang="pl"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>' + title + '</title></head>' +
+/* Full HTML versions of messages — what actually arrives from the server; the thread window shows simplified text
+   and the full HTML opens on demand (the "code" icon) in a separate tab / preview. */
+const HTML_SHELL = (title, body) => '<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>' + title + '</title></head>' +
   '<body style="margin:0;padding:0;background:#eef1f5;font-family:Georgia,\'Times New Roman\',serif;color:#1f2933">' + body + '</body></html>';
 
-const HTML_CONTOSO_CMP = HTML_SHELL("Wersja porównawcza aneksu", `
+const HTML_CONTOSO_CMP = HTML_SHELL("Addendum — comparison version", `
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#eef1f5;padding:24px 12px">
  <tr><td align="center">
   <table role="presentation" width="640" cellpadding="0" cellspacing="0" style="width:640px;max-width:100%;background:#ffffff;border:1px solid #d7dee7">
    <tr><td style="background:#14293f;padding:22px 28px">
      <table role="presentation" width="100%"><tr>
        <td style="color:#ffffff;font-size:19px;letter-spacing:.06em">CONTOSO <span style="font-weight:normal;opacity:.7">LEGAL</span></td>
-       <td align="right" style="color:#9fb3c8;font-size:12px;font-family:Arial,sans-serif">Dokument nr AN-2026/03</td>
+       <td align="right" style="color:#9fb3c8;font-size:12px;font-family:Arial,sans-serif">Document no. AN-2026/03</td>
      </tr></table>
    </td></tr>
    <tr><td style="padding:26px 28px 6px 28px">
-     <p style="margin:0 0 14px 0;font-size:15px;line-height:1.6">Szanowna Pani Karolino,</p>
-     <p style="margin:0 0 18px 0;font-size:15px;line-height:1.6">w załączeniu przekazujemy wersję porównawczą aneksu. Poniżej zestawienie zmian względem umowy ramowej z 14.06.2021.</p>
+     <p style="margin:0 0 14px 0;font-size:15px;line-height:1.6">Dear Karolina,</p>
+     <p style="margin:0 0 18px 0;font-size:15px;line-height:1.6">attached is the comparison version of the addendum. Below is a summary of the changes against the master agreement of 14.06.2021.</p>
      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;font-family:Arial,sans-serif;font-size:13px">
        <tr style="background:#f2f5f9">
-         <th align="left" style="padding:9px 10px;border:1px solid #d7dee7;width:26%">Zapis</th>
-         <th align="left" style="padding:9px 10px;border:1px solid #d7dee7">Obowiązuje</th>
-         <th align="left" style="padding:9px 10px;border:1px solid #d7dee7">Po zmianie</th>
+         <th align="left" style="padding:9px 10px;border:1px solid #d7dee7;width:26%">Provision</th>
+         <th align="left" style="padding:9px 10px;border:1px solid #d7dee7">In force</th>
+         <th align="left" style="padding:9px 10px;border:1px solid #d7dee7">After change</th>
        </tr>
-       <tr><td style="padding:9px 10px;border:1px solid #d7dee7">§ 4 ust. 2 — czas reakcji</td><td style="padding:9px 10px;border:1px solid #d7dee7;color:#8a94a6"><s>4 godziny</s></td><td style="padding:9px 10px;border:1px solid #d7dee7;background:#fff8e1"><strong>2 godziny</strong></td></tr>
-       <tr><td style="padding:9px 10px;border:1px solid #d7dee7">Załącznik nr 2 — wynagrodzenie</td><td style="padding:9px 10px;border:1px solid #d7dee7;color:#8a94a6"><s>ryczałt bazowy</s></td><td style="padding:9px 10px;border:1px solid #d7dee7;background:#fff8e1"><strong>+ 8% od 01.01.2027</strong></td></tr>
-       <tr><td style="padding:9px 10px;border:1px solid #d7dee7">§ 11 — waloryzacja CPI</td><td style="padding:9px 10px;border:1px solid #d7dee7">bez limitu</td><td style="padding:9px 10px;border:1px solid #d7dee7">bez limitu</td></tr>
+       <tr><td style="padding:9px 10px;border:1px solid #d7dee7">§ 4.2 — response time</td><td style="padding:9px 10px;border:1px solid #d7dee7;color:#8a94a6"><s>4 hours</s></td><td style="padding:9px 10px;border:1px solid #d7dee7;background:#fff8e1"><strong>2 hours</strong></td></tr>
+       <tr><td style="padding:9px 10px;border:1px solid #d7dee7">Schedule 2 — remuneration</td><td style="padding:9px 10px;border:1px solid #d7dee7;color:#8a94a6"><s>base flat fee</s></td><td style="padding:9px 10px;border:1px solid #d7dee7;background:#fff8e1"><strong>+ 8% from 01.01.2027</strong></td></tr>
+       <tr><td style="padding:9px 10px;border:1px solid #d7dee7">§ 11 — CPI indexation</td><td style="padding:9px 10px;border:1px solid #d7dee7">uncapped</td><td style="padding:9px 10px;border:1px solid #d7dee7">uncapped</td></tr>
      </table>
-     <p style="margin:18px 0 0 0;font-size:13px;line-height:1.6;font-family:Arial,sans-serif;color:#52606d">Termin na uwagi: <strong style="color:#9a3412">28.08.2026</strong>. Po tej dacie przekazujemy dokument do podpisu elektronicznego.</p>
+     <p style="margin:18px 0 0 0;font-size:13px;line-height:1.6;font-family:Arial,sans-serif;color:#52606d">Comments due: <strong style="color:#9a3412">28.08.2026</strong>. After that date we send the document for electronic signature.</p>
    </td></tr>
    <tr><td style="padding:18px 28px 26px 28px">
      <table role="presentation" cellpadding="0" cellspacing="0"><tr>
-       <td style="background:#14293f;border-radius:3px"><a href="#" style="display:inline-block;padding:11px 20px;color:#ffffff;text-decoration:none;font-family:Arial,sans-serif;font-size:13px">Otwórz w portalu dokumentów</a></td>
-       <td style="padding-left:12px;font-family:Arial,sans-serif;font-size:12px;color:#8a94a6">ważne 14 dni</td>
+       <td style="background:#14293f;border-radius:3px"><a href="#" style="display:inline-block;padding:11px 20px;color:#ffffff;text-decoration:none;font-family:Arial,sans-serif;font-size:13px">Open in the document portal</a></td>
+       <td style="padding-left:12px;font-family:Arial,sans-serif;font-size:12px;color:#8a94a6">valid 14 days</td>
      </tr></table>
    </td></tr>
    <tr><td style="border-top:1px solid #e3e8ee;padding:16px 28px;font-family:Arial,sans-serif;font-size:11px;line-height:1.6;color:#8a94a6">
-     Contoso Sp. z o.o., ul. Prosta 51, 00-838 Warszawa · KRS 0000123456 · NIP 525-000-00-00<br>
-     Wiadomość zawiera informacje poufne. <a href="#" style="color:#4a6fa5">Zasady przetwarzania danych</a>
+     Contoso Ltd, 51 Prosta St, 00-838 Warsaw · Reg. 0000123456 · VAT 525-000-00-00<br>
+     This message contains confidential information. <a href="#" style="color:#4a6fa5">Data processing policy</a>
    </td></tr>
   </table>
  </td></tr>
 </table>`);
 
-const HTML_CPI = HTML_SHELL("Kalkulacja CPI 2027", `
+const HTML_CPI = HTML_SHELL("CPI calculation 2027", `
 <div style="max-width:620px;margin:0 auto;padding:24px 16px;font-family:Arial,Helvetica,sans-serif">
  <div style="background:#ffffff;border:1px solid #dde3ea;border-top:4px solid #2f6f4f">
   <div style="padding:20px 24px 8px 24px">
-   <h1 style="margin:0 0 4px 0;font-size:18px;color:#14293f">Wpływ podwyżki 8% na budżet 2027</h1>
-   <p style="margin:0 0 16px 0;font-size:12px;color:#7b8794">Kalkulacja robocza · Marta Nowak · 25.08.2026</p>
+   <h1 style="margin:0 0 4px 0;font-size:18px;color:#14293f">Impact of the 8% increase on the 2027 budget</h1>
+   <p style="margin:0 0 16px 0;font-size:12px;color:#7b8794">Working calculation · Marta Nowak · 25.08.2026</p>
    <table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;font-size:13px">
-    <tr><td style="padding:7px 0;border-bottom:1px solid #eef1f5">Ryczałt roczny 2026</td><td align="right" style="padding:7px 0;border-bottom:1px solid #eef1f5">238 000 zł</td></tr>
-    <tr><td style="padding:7px 0;border-bottom:1px solid #eef1f5">Podwyżka kontraktowa 8%</td><td align="right" style="padding:7px 0;border-bottom:1px solid #eef1f5">+ 19 040 zł</td></tr>
-    <tr><td style="padding:7px 0;border-bottom:1px solid #eef1f5">Waloryzacja CPI (prognoza 4,1%)</td><td align="right" style="padding:7px 0;border-bottom:1px solid #eef1f5">+ 10 542 zł</td></tr>
-    <tr><td style="padding:9px 0;font-weight:bold">Razem 2027</td><td align="right" style="padding:9px 0;font-weight:bold;color:#9a3412">267 582 zł</td></tr>
+    <tr><td style="padding:7px 0;border-bottom:1px solid #eef1f5">Annual flat fee 2026</td><td align="right" style="padding:7px 0;border-bottom:1px solid #eef1f5">€238,000</td></tr>
+    <tr><td style="padding:7px 0;border-bottom:1px solid #eef1f5">Contractual increase 8%</td><td align="right" style="padding:7px 0;border-bottom:1px solid #eef1f5">+ €19,040</td></tr>
+    <tr><td style="padding:7px 0;border-bottom:1px solid #eef1f5">CPI indexation (4.1% forecast)</td><td align="right" style="padding:7px 0;border-bottom:1px solid #eef1f5">+ €10,542</td></tr>
+    <tr><td style="padding:9px 0;font-weight:bold">Total 2027</td><td align="right" style="padding:9px 0;font-weight:bold;color:#9a3412">€267,582</td></tr>
    </table>
-   <p style="margin:16px 0 6px 0;font-size:12px;color:#7b8794">Scenariusze przy różnym CPI</p>
+   <p style="margin:16px 0 6px 0;font-size:12px;color:#7b8794">Scenarios at different CPI levels</p>
    <table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;font-size:12px">
-    <tr><td style="width:64px;padding:4px 0">CPI 3%</td><td><div style="background:#cfe3d6;height:14px;width:62%"></div></td><td align="right" style="width:80px">264 970 zł</td></tr>
-    <tr><td style="padding:4px 0">CPI 4,1%</td><td><div style="background:#8fbfa4;height:14px;width:74%"></div></td><td align="right">267 582 zł</td></tr>
-    <tr><td style="padding:4px 0">CPI 6%</td><td><div style="background:#e0a97a;height:14px;width:92%"></div></td><td align="right">272 093 zł</td></tr>
-    <tr><td style="padding:4px 0">CPI 9%</td><td><div style="background:#d98282;height:14px;width:100%"></div></td><td align="right">279 219 zł</td></tr>
+    <tr><td style="width:64px;padding:4px 0">CPI 3%</td><td><div style="background:#cfe3d6;height:14px;width:62%"></div></td><td align="right" style="width:80px">€264,970</td></tr>
+    <tr><td style="padding:4px 0">CPI 4.1%</td><td><div style="background:#8fbfa4;height:14px;width:74%"></div></td><td align="right">€267,582</td></tr>
+    <tr><td style="padding:4px 0">CPI 6%</td><td><div style="background:#e0a97a;height:14px;width:92%"></div></td><td align="right">€272,093</td></tr>
+    <tr><td style="padding:4px 0">CPI 9%</td><td><div style="background:#d98282;height:14px;width:100%"></div></td><td align="right">€279,219</td></tr>
    </table>
    <div style="margin:18px 0 4px 0;padding:12px 14px;background:#fff8e1;border-left:3px solid #d9a441;font-size:13px;line-height:1.6">
-    Rekomendacja: wynegocjować <strong>górny limit indeksacji 5% rocznie</strong>. Przy CPI 9% oszczędność to ok. 11,6 tys. zł w skali roku.
+    Recommendation: negotiate an <strong>upper indexation cap of 5% per year</strong>. At CPI 9% that saves about €11.6k a year.
    </div>
   </div>
-  <div style="border-top:1px solid #eef1f5;padding:12px 24px;font-size:11px;color:#9aa5b1">Załącznik: CPI_2027.xlsx · arkusz roboczy, nie stanowi oferty</div>
+  <div style="border-top:1px solid #eef1f5;padding:12px 24px;font-size:11px;color:#9aa5b1">Attachment: CPI_2027.xlsx · working sheet, not an offer</div>
  </div>
 </div>`);
 
-const HTML_BANK = HTML_SHELL("Potwierdzenie przelewu", `
+const HTML_BANK = HTML_SHELL("Transfer confirmation", `
 <div style="padding:26px 12px;font-family:Arial,Helvetica,sans-serif">
  <table role="presentation" width="560" align="center" cellpadding="0" cellspacing="0" style="width:560px;max-width:100%;background:#ffffff;border-radius:6px;overflow:hidden;border:1px solid #d7dee7">
-  <tr><td style="background:#0d4f3c;padding:18px 24px;color:#ffffff;font-size:16px;letter-spacing:.04em">BANK FIRMOWY</td></tr>
+  <tr><td style="background:#0d4f3c;padding:18px 24px;color:#ffffff;font-size:16px;letter-spacing:.04em">BUSINESS BANK</td></tr>
   <tr><td style="padding:24px 24px 8px 24px">
-    <p style="margin:0 0 6px 0;font-size:12px;color:#7b8794;text-transform:uppercase;letter-spacing:.08em">Przelew zrealizowany</p>
-    <p style="margin:0 0 20px 0;font-size:30px;color:#0d4f3c"><strong>18 400,00 zł</strong></p>
+    <p style="margin:0 0 6px 0;font-size:12px;color:#7b8794;text-transform:uppercase;letter-spacing:.08em">Transfer completed</p>
+    <p style="margin:0 0 20px 0;font-size:30px;color:#0d4f3c"><strong>€18,400.00</strong></p>
     <table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;font-size:13px">
-     <tr><td style="padding:8px 0;color:#7b8794;width:38%">Odbiorca</td><td style="padding:8px 0">Contoso Sp. z o.o.</td></tr>
-     <tr><td style="padding:8px 0;color:#7b8794">Rachunek</td><td style="padding:8px 0;font-family:monospace">PL 61 1090 1014 0000 0712 1981 2874</td></tr>
-     <tr><td style="padding:8px 0;color:#7b8794">Tytuł</td><td style="padding:8px 0">Aneks — rozliczenie sierpień 2026</td></tr>
-     <tr><td style="padding:8px 0;color:#7b8794">Data księgowania</td><td style="padding:8px 0">01.09.2026, 06:58</td></tr>
-     <tr><td style="padding:8px 0;color:#7b8794">Referencja</td><td style="padding:8px 0;font-family:monospace">TRN-8841-220916</td></tr>
+     <tr><td style="padding:8px 0;color:#7b8794;width:38%">Beneficiary</td><td style="padding:8px 0">Contoso Ltd</td></tr>
+     <tr><td style="padding:8px 0;color:#7b8794">Account</td><td style="padding:8px 0;font-family:monospace">DE61 1090 1014 0000 0712 19</td></tr>
+     <tr><td style="padding:8px 0;color:#7b8794">Reference</td><td style="padding:8px 0">Addendum — August 2026 settlement</td></tr>
+     <tr><td style="padding:8px 0;color:#7b8794">Booking date</td><td style="padding:8px 0">01.09.2026, 06:58</td></tr>
+     <tr><td style="padding:8px 0;color:#7b8794">Operation ref</td><td style="padding:8px 0;font-family:monospace">TRN-8841-220916</td></tr>
     </table>
   </td></tr>
   <tr><td style="padding:4px 24px 22px 24px">
     <div style="background:#f2f7f4;border:1px solid #cfe3d6;padding:12px 14px;font-size:12px;line-height:1.6;color:#31513f">
-     Ten e-mail jest potwierdzeniem operacji. Bank nigdy nie prosi o hasło ani kod BLIK w wiadomości e-mail.
+     This e-mail confirms the operation. The bank never asks for your password or a payment code by e-mail.
     </div>
   </td></tr>
   <tr><td style="background:#f7f9fb;border-top:1px solid #e3e8ee;padding:14px 24px;font-size:11px;color:#9aa5b1;line-height:1.6">
-    Bank Firmowy S.A. · infolinia 801 000 000 · <a href="#" style="color:#0d4f3c">Regulamin</a> · <a href="#" style="color:#0d4f3c">Wyloguj z powiadomień</a>
+    Business Bank plc · helpline 801 000 000 · <a href="#" style="color:#0d4f3c">Terms</a> · <a href="#" style="color:#0d4f3c">Unsubscribe from alerts</a>
   </td></tr>
  </table>
 </div>`);
 
-const HTML_TRAVEL = HTML_SHELL("Bilety Kraków–Berlin", `
+const HTML_TRAVEL = HTML_SHELL("Tickets Kraków–Berlin", `
 <div style="padding:24px 12px;font-family:Arial,Helvetica,sans-serif">
  <table role="presentation" width="600" align="center" cellpadding="0" cellspacing="0" style="width:600px;max-width:100%;background:#ffffff;border:1px solid #d7dee7">
   <tr><td style="padding:18px 24px;border-bottom:2px dashed #d7dee7">
     <table width="100%"><tr>
-     <td style="font-size:15px;color:#14293f"><strong>REZERWACJA POTWIERDZONA</strong></td>
+     <td style="font-size:15px;color:#14293f"><strong>BOOKING CONFIRMED</strong></td>
      <td align="right" style="font-size:12px;color:#7b8794">PNR <strong style="color:#14293f;font-family:monospace">7QX4MB</strong></td>
     </tr></table>
   </td></tr>
@@ -3196,49 +3196,49 @@ const HTML_TRAVEL = HTML_SHELL("Bilety Kraków–Berlin", `
     <table width="100%" cellpadding="0" cellspacing="0">
      <tr>
       <td style="width:38%"><div style="font-size:30px;color:#14293f">KRK</div><div style="font-size:12px;color:#7b8794">Kraków Balice<br>12.09, 07:40</div></td>
-      <td align="center" style="width:24%;color:#9aa5b1;font-size:12px">✈<br>1 h 25 min<br>bez przesiadek</td>
+      <td align="center" style="width:24%;color:#9aa5b1;font-size:12px">✈<br>1 h 25 min<br>direct</td>
       <td align="right" style="width:38%"><div style="font-size:30px;color:#14293f">BER</div><div style="font-size:12px;color:#7b8794">Berlin Brandenburg<br>12.09, 09:05</div></td>
      </tr>
     </table>
     <table width="100%" cellpadding="0" cellspacing="0" style="margin-top:20px;border-collapse:collapse;font-size:13px">
-     <tr style="background:#f7f9fb"><td style="padding:8px 10px;border:1px solid #e3e8ee">Pasażer</td><td style="padding:8px 10px;border:1px solid #e3e8ee">KOWALSKA / KAROLINA</td></tr>
-     <tr><td style="padding:8px 10px;border:1px solid #e3e8ee">Taryfa</td><td style="padding:8px 10px;border:1px solid #e3e8ee">Flex · bagaż 23 kg w cenie</td></tr>
-     <tr style="background:#f7f9fb"><td style="padding:8px 10px;border:1px solid #e3e8ee">Miejsce</td><td style="padding:8px 10px;border:1px solid #e3e8ee">14C (przejście)</td></tr>
+     <tr style="background:#f7f9fb"><td style="padding:8px 10px;border:1px solid #e3e8ee">Passenger</td><td style="padding:8px 10px;border:1px solid #e3e8ee">KOWALSKA / KAROLINA</td></tr>
+     <tr><td style="padding:8px 10px;border:1px solid #e3e8ee">Fare</td><td style="padding:8px 10px;border:1px solid #e3e8ee">Flex · 23 kg baggage included</td></tr>
+     <tr style="background:#f7f9fb"><td style="padding:8px 10px;border:1px solid #e3e8ee">Seat</td><td style="padding:8px 10px;border:1px solid #e3e8ee">14C (aisle)</td></tr>
     </table>
     <div style="margin-top:18px;padding:12px 14px;background:#fdf0e4;border-left:3px solid #d9a441;font-size:13px;line-height:1.6">
-     Odprawa online otwiera się <strong>11.09 o 07:40</strong> i zamyka 2 h przed odlotem.
+     Online check-in opens <strong>11.09 at 07:40</strong> and closes 2 h before departure.
     </div>
-    <div style="margin-top:18px"><a href="#" style="display:inline-block;background:#14293f;color:#ffffff;text-decoration:none;padding:12px 22px;font-size:13px">Odpraw się online</a></div>
+    <div style="margin-top:18px"><a href="#" style="display:inline-block;background:#14293f;color:#ffffff;text-decoration:none;padding:12px 22px;font-size:13px">Check in online</a></div>
   </td></tr>
-  <tr><td style="background:#f7f9fb;border-top:1px solid #e3e8ee;padding:14px 24px;font-size:11px;color:#9aa5b1">Biuro Podróży · rezerwacje@travel.example · zmiany do 24 h przed odlotem bez opłat</td></tr>
+  <tr><td style="background:#f7f9fb;border-top:1px solid #e3e8ee;padding:14px 24px;font-size:11px;color:#9aa5b1">Travel Desk · bookings@travel.example · free changes up to 24 h before departure</td></tr>
  </table>
 </div>`);
 
-const HTML_NEWSLETTER = HTML_SHELL("Materiały na targi 24.09", `
+const HTML_NEWSLETTER = HTML_SHELL("Trade show materials 24.09", `
 <div style="padding:22px 12px;font-family:Arial,Helvetica,sans-serif">
  <table role="presentation" width="620" align="center" cellpadding="0" cellspacing="0" style="width:620px;max-width:100%;background:#ffffff;border:1px solid #dde3ea">
   <tr><td style="background:linear-gradient(90deg,#14293f,#2b5079);padding:26px 26px 22px 26px;color:#ffffff">
-    <div style="font-size:11px;letter-spacing:.16em;opacity:.75">MARKETING · WEWNĘTRZNE</div>
-    <div style="font-size:24px;margin-top:6px">Targi Branżowe 2026</div>
-    <div style="font-size:13px;opacity:.85;margin-top:4px">24–26.09 · Poznań · stoisko C18 (18 m²)</div>
+    <div style="font-size:11px;letter-spacing:.16em;opacity:.75">MARKETING · INTERNAL</div>
+    <div style="font-size:24px;margin-top:6px">Industry Trade Show 2026</div>
+    <div style="font-size:13px;opacity:.85;margin-top:4px">24–26.09 · Poznań · stand C18 (18 m²)</div>
   </td></tr>
   <tr><td style="padding:22px 26px 6px 26px">
    <table width="100%" cellpadding="0" cellspacing="0">
     <tr>
      <td width="50%" valign="top" style="padding-right:10px">
-      <div style="font-size:13px;font-weight:bold;color:#14293f;margin-bottom:6px">Do zamknięcia w tym tygodniu</div>
+      <div style="font-size:13px;font-weight:bold;color:#14293f;margin-bottom:6px">To close this week</div>
       <ul style="margin:0;padding-left:18px;font-size:13px;line-height:1.75;color:#3e4c59">
-       <li>Roll-upy — plik do druku <strong>do 10.09</strong></li>
-       <li>Ulotka produktowa (PL/EN)</li>
-       <li>Lista demo i osoba prowadząca</li>
+       <li>Roll-ups — print-ready file <strong>by 10.09</strong></li>
+       <li>Product leaflet (PL/EN)</li>
+       <li>Demo list and presenter</li>
       </ul>
      </td>
      <td width="50%" valign="top" style="padding-left:10px">
-      <div style="font-size:13px;font-weight:bold;color:#14293f;margin-bottom:6px">Kto odpowiada</div>
+      <div style="font-size:13px;font-weight:bold;color:#14293f;margin-bottom:6px">Who owns what</div>
       <table width="100%" style="font-size:12px;color:#3e4c59;border-collapse:collapse">
-       <tr><td style="padding:4px 0">Stoisko</td><td align="right">P. Zieliński</td></tr>
-       <tr><td style="padding:4px 0">Druk</td><td align="right">Agencja Nord</td></tr>
-       <tr><td style="padding:4px 0">Demo</td><td align="right" style="color:#9a3412">nieobsadzone</td></tr>
+       <tr><td style="padding:4px 0">Stand</td><td align="right">P. Zieliński</td></tr>
+       <tr><td style="padding:4px 0">Print</td><td align="right">Nord agency</td></tr>
+       <tr><td style="padding:4px 0">Demo</td><td align="right" style="color:#9a3412">unassigned</td></tr>
       </table>
      </td>
     </tr>
@@ -3246,147 +3246,147 @@ const HTML_NEWSLETTER = HTML_SHELL("Materiały na targi 24.09", `
   </td></tr>
   <tr><td style="padding:16px 26px 24px 26px">
     <div style="border:1px solid #e3e8ee;background:#f7f9fb;padding:14px 16px;font-size:13px;line-height:1.6;color:#3e4c59">
-     <strong>Deadline drukarni: 10.09, 12:00.</strong> Po tej godzinie dopłata 35% za tryb ekspresowy.
+     <strong>Printer deadline: 10.09, 12:00.</strong> After that, a 35% rush surcharge applies.
     </div>
-    <div style="margin-top:16px"><a href="#" style="display:inline-block;background:#2b5079;color:#ffffff;text-decoration:none;padding:11px 20px;font-size:13px">Otwórz folder z materiałami</a></div>
+    <div style="margin-top:16px"><a href="#" style="display:inline-block;background:#2b5079;color:#ffffff;text-decoration:none;padding:11px 20px;font-size:13px">Open the materials folder</a></div>
   </td></tr>
-  <tr><td style="border-top:1px solid #eef1f5;padding:14px 26px;font-size:11px;color:#9aa5b1">Wysłane do: zespół sprzedaży, marketing · <a href="#" style="color:#2b5079">wypisz się z powiadomień</a></td></tr>
+  <tr><td style="border-top:1px solid #eef1f5;padding:14px 26px;font-size:11px;color:#9aa5b1">Sent to: sales team, marketing · <a href="#" style="color:#2b5079">unsubscribe</a></td></tr>
  </table>
 </div>`);
 
-const HTML_INVOICE = HTML_SHELL("Faktura 07/2026 — hosting", `
+const HTML_INVOICE = HTML_SHELL("Invoice 07/2026 — hosting", `
 <div style="padding:24px 12px;font-family:Arial,Helvetica,sans-serif">
  <table role="presentation" width="600" align="center" cellpadding="0" cellspacing="0" style="width:600px;max-width:100%;background:#ffffff;border:1px solid #d7dee7">
   <tr><td style="padding:22px 26px;border-bottom:1px solid #eef1f5">
     <table width="100%"><tr>
-     <td style="font-size:17px;color:#14293f"><strong>Faktura VAT 07/2026</strong><div style="font-size:12px;color:#7b8794;margin-top:4px">wystawiona 28.08.2026</div></td>
-     <td align="right"><div style="display:inline-block;background:#fdf0e4;color:#9a3412;font-size:12px;padding:6px 12px;border-radius:3px">Termin: 04.09.2026</div></td>
+     <td style="font-size:17px;color:#14293f"><strong>Invoice 07/2026</strong><div style="font-size:12px;color:#7b8794;margin-top:4px">issued 28.08.2026</div></td>
+     <td align="right"><div style="display:inline-block;background:#fdf0e4;color:#9a3412;font-size:12px;padding:6px 12px;border-radius:3px">Due: 04.09.2026</div></td>
     </tr></table>
   </td></tr>
   <tr><td style="padding:20px 26px 6px 26px">
    <table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;font-size:13px">
-    <tr style="background:#f7f9fb"><th align="left" style="padding:9px 10px;border:1px solid #e3e8ee">Pozycja</th><th align="right" style="padding:9px 10px;border:1px solid #e3e8ee">Netto</th><th align="right" style="padding:9px 10px;border:1px solid #e3e8ee">VAT</th><th align="right" style="padding:9px 10px;border:1px solid #e3e8ee">Brutto</th></tr>
-    <tr><td style="padding:9px 10px;border:1px solid #e3e8ee">Hosting aplikacji — sierpień</td><td align="right" style="padding:9px 10px;border:1px solid #e3e8ee">1 600,00</td><td align="right" style="padding:9px 10px;border:1px solid #e3e8ee">368,00</td><td align="right" style="padding:9px 10px;border:1px solid #e3e8ee">1 968,00</td></tr>
-    <tr><td style="padding:9px 10px;border:1px solid #e3e8ee">Kopie zapasowe (250 GB)</td><td align="right" style="padding:9px 10px;border:1px solid #e3e8ee">302,44</td><td align="right" style="padding:9px 10px;border:1px solid #e3e8ee">69,56</td><td align="right" style="padding:9px 10px;border:1px solid #e3e8ee">372,00</td></tr>
-    <tr><td align="right" colspan="3" style="padding:11px 10px;border:1px solid #e3e8ee;background:#f7f9fb"><strong>Do zapłaty</strong></td><td align="right" style="padding:11px 10px;border:1px solid #e3e8ee;background:#f7f9fb"><strong>2 340,00 zł</strong></td></tr>
+    <tr style="background:#f7f9fb"><th align="left" style="padding:9px 10px;border:1px solid #e3e8ee">Item</th><th align="right" style="padding:9px 10px;border:1px solid #e3e8ee">Net</th><th align="right" style="padding:9px 10px;border:1px solid #e3e8ee">VAT</th><th align="right" style="padding:9px 10px;border:1px solid #e3e8ee">Gross</th></tr>
+    <tr><td style="padding:9px 10px;border:1px solid #e3e8ee">Application hosting — August</td><td align="right" style="padding:9px 10px;border:1px solid #e3e8ee">1 600,00</td><td align="right" style="padding:9px 10px;border:1px solid #e3e8ee">368,00</td><td align="right" style="padding:9px 10px;border:1px solid #e3e8ee">1 968,00</td></tr>
+    <tr><td style="padding:9px 10px;border:1px solid #e3e8ee">Backups (250 GB)</td><td align="right" style="padding:9px 10px;border:1px solid #e3e8ee">302,44</td><td align="right" style="padding:9px 10px;border:1px solid #e3e8ee">69,56</td><td align="right" style="padding:9px 10px;border:1px solid #e3e8ee">372,00</td></tr>
+    <tr><td align="right" colspan="3" style="padding:11px 10px;border:1px solid #e3e8ee;background:#f7f9fb"><strong>Amount due</strong></td><td align="right" style="padding:11px 10px;border:1px solid #e3e8ee;background:#f7f9fb"><strong>€2,340.00</strong></td></tr>
    </table>
-   <p style="font-size:12px;color:#7b8794;line-height:1.7;margin:16px 0 0 0">Rachunek: <span style="font-family:monospace">PL 27 1140 2004 0000 3002 0135 5387</span><br>W tytule prosimy podać numer faktury.</p>
+   <p style="font-size:12px;color:#7b8794;line-height:1.7;margin:16px 0 0 0">Account: <span style="font-family:monospace">DE27 1140 2004 0000 3002 01</span><br>Please quote the invoice number in the reference.</p>
   </td></tr>
-  <tr><td style="padding:16px 26px 24px 26px"><a href="#" style="display:inline-block;background:#14293f;color:#ffffff;text-decoration:none;padding:11px 22px;font-size:13px">Pobierz PDF</a></td></tr>
-  <tr><td style="background:#f7f9fb;border-top:1px solid #e3e8ee;padding:13px 26px;font-size:11px;color:#9aa5b1">Dostawca Chmury Sp. z o.o. · NIP 701-000-00-00 · billing@cloud.example</td></tr>
+  <tr><td style="padding:16px 26px 24px 26px"><a href="#" style="display:inline-block;background:#14293f;color:#ffffff;text-decoration:none;padding:11px 22px;font-size:13px">Download PDF</a></td></tr>
+  <tr><td style="background:#f7f9fb;border-top:1px solid #e3e8ee;padding:13px 26px;font-size:11px;color:#9aa5b1">Cloud Provider Ltd · VAT 701-000-00-00 · billing@cloud.example</td></tr>
  </table>
 </div>`);
 
 
-const HTML_STATUS = HTML_SHELL("Harmonogram wdrożenia — etap 2", `
+const HTML_STATUS = HTML_SHELL("Rollout schedule — phase 2", `
 <div style="padding:22px 12px;font-family:Arial,Helvetica,sans-serif">
  <table role="presentation" width="620" align="center" cellpadding="0" cellspacing="0" style="width:620px;max-width:100%;background:#ffffff;border:1px solid #dde3ea">
   <tr><td style="background:#1f3b57;padding:20px 24px;color:#ffffff">
-    <div style="font-size:11px;letter-spacing:.14em;opacity:.7">RAPORT TYGODNIOWY · WDROŻENIE NORDWIND</div>
-    <div style="font-size:21px;margin-top:6px">Etap 2 zamknięty — 41 z 58 zadań</div>
+    <div style="font-size:11px;letter-spacing:.14em;opacity:.7">WEEKLY REPORT · NORDWIND ROLLOUT</div>
+    <div style="font-size:21px;margin-top:6px">Phase 2 closed — 41 of 58 tasks</div>
   </td></tr>
   <tr><td style="padding:20px 24px 4px 24px">
    <table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;font-size:13px">
-    <tr style="background:#f4f7fa"><th align="left" style="padding:8px 10px;border:1px solid #e3e8ee">Etap</th><th align="left" style="padding:8px 10px;border:1px solid #e3e8ee">Termin</th><th align="left" style="padding:8px 10px;border:1px solid #e3e8ee">Status</th></tr>
-    <tr><td style="padding:8px 10px;border:1px solid #e3e8ee">1 · Analiza i migracja danych</td><td style="padding:8px 10px;border:1px solid #e3e8ee">zakończony 12.08</td><td style="padding:8px 10px;border:1px solid #e3e8ee;color:#2f6f4f">✔ odebrany</td></tr>
-    <tr><td style="padding:8px 10px;border:1px solid #e3e8ee">2 · Integracja z Exchange</td><td style="padding:8px 10px;border:1px solid #e3e8ee">31.08</td><td style="padding:8px 10px;border:1px solid #e3e8ee;color:#2f6f4f">✔ gotowy do odbioru</td></tr>
-    <tr style="background:#fff8e1"><td style="padding:8px 10px;border:1px solid #e3e8ee">3 · Testy UAT</td><td style="padding:8px 10px;border:1px solid #e3e8ee">termin nieustalony</td><td style="padding:8px 10px;border:1px solid #e3e8ee;color:#9a6b12">● czeka na datę</td></tr>
-    <tr><td style="padding:8px 10px;border:1px solid #e3e8ee">4 · Szkolenia i przekazanie</td><td style="padding:8px 10px;border:1px solid #e3e8ee">październik</td><td style="padding:8px 10px;border:1px solid #e3e8ee;color:#7b8794">planowany</td></tr>
+    <tr style="background:#f4f7fa"><th align="left" style="padding:8px 10px;border:1px solid #e3e8ee">Phase</th><th align="left" style="padding:8px 10px;border:1px solid #e3e8ee">Date</th><th align="left" style="padding:8px 10px;border:1px solid #e3e8ee">Status</th></tr>
+    <tr><td style="padding:8px 10px;border:1px solid #e3e8ee">1 · Analysis and data migration</td><td style="padding:8px 10px;border:1px solid #e3e8ee">completed 12.08</td><td style="padding:8px 10px;border:1px solid #e3e8ee;color:#2f6f4f">✔ accepted</td></tr>
+    <tr><td style="padding:8px 10px;border:1px solid #e3e8ee">2 · Exchange integration</td><td style="padding:8px 10px;border:1px solid #e3e8ee">31.08</td><td style="padding:8px 10px;border:1px solid #e3e8ee;color:#2f6f4f">✔ ready for acceptance</td></tr>
+    <tr style="background:#fff8e1"><td style="padding:8px 10px;border:1px solid #e3e8ee">3 · UAT testing</td><td style="padding:8px 10px;border:1px solid #e3e8ee">date not set</td><td style="padding:8px 10px;border:1px solid #e3e8ee;color:#9a6b12">● awaiting a date</td></tr>
+    <tr><td style="padding:8px 10px;border:1px solid #e3e8ee">4 · Training and handover</td><td style="padding:8px 10px;border:1px solid #e3e8ee">October</td><td style="padding:8px 10px;border:1px solid #e3e8ee;color:#7b8794">planned</td></tr>
    </table>
-   <p style="font-size:12px;color:#7b8794;margin:16px 0 6px 0">Postęp sprintu 34</p>
+   <p style="font-size:12px;color:#7b8794;margin:16px 0 6px 0">Sprint 34 progress</p>
    <div style="background:#eef1f5;height:16px"><div style="background:#1f3b57;height:16px;width:70%"></div></div>
    <table width="100%" style="margin-top:14px;font-size:12px;color:#3e4c59;border-collapse:collapse">
-    <tr><td style="padding:5px 0;border-bottom:1px solid #eef1f5">Zadania zablokowane</td><td align="right" style="border-bottom:1px solid #eef1f5">2 (API Graph)</td></tr>
-    <tr><td style="padding:5px 0;border-bottom:1px solid #eef1f5">Błędy krytyczne</td><td align="right" style="border-bottom:1px solid #eef1f5">0</td></tr>
-    <tr><td style="padding:5px 0">Ryzyko harmonogramu</td><td align="right" style="color:#9a3412">średnie</td></tr>
+    <tr><td style="padding:5px 0;border-bottom:1px solid #eef1f5">Blocked tasks</td><td align="right" style="border-bottom:1px solid #eef1f5">2 (API Graph)</td></tr>
+    <tr><td style="padding:5px 0;border-bottom:1px solid #eef1f5">Critical bugs</td><td align="right" style="border-bottom:1px solid #eef1f5">0</td></tr>
+    <tr><td style="padding:5px 0">Schedule risk</td><td align="right" style="color:#9a3412">medium</td></tr>
    </table>
-   <div style="margin:18px 0 4px 0;padding:12px 14px;background:#f4f7fa;border-left:3px solid #1f3b57;font-size:13px;line-height:1.6">Do decyzji: termin UAT. Proponuję 15–19.09, żeby zdążyć przed szkoleniami.</div>
+   <div style="margin:18px 0 4px 0;padding:12px 14px;background:#f4f7fa;border-left:3px solid #1f3b57;font-size:13px;line-height:1.6">To decide: the UAT window. I suggest 15–19.09 so we finish before the training.</div>
   </td></tr>
-  <tr><td style="padding:14px 24px 22px 24px"><a href="#" style="display:inline-block;background:#1f3b57;color:#ffffff;text-decoration:none;padding:11px 20px;font-size:13px">Otwórz tablicę sprintu</a></td></tr>
-  <tr><td style="background:#f7f9fb;border-top:1px solid #e3e8ee;padding:13px 24px;font-size:11px;color:#9aa5b1">Raport generowany automatycznie w poniedziałki · zespół wdrożeniowy</td></tr>
+  <tr><td style="padding:14px 24px 22px 24px"><a href="#" style="display:inline-block;background:#1f3b57;color:#ffffff;text-decoration:none;padding:11px 20px;font-size:13px">Open the sprint board</a></td></tr>
+  <tr><td style="background:#f7f9fb;border-top:1px solid #e3e8ee;padding:13px 24px;font-size:11px;color:#9aa5b1">Generated automatically every Monday · rollout team</td></tr>
  </table>
 </div>`);
 
-const HTML_OPINIA = HTML_SHELL("Opinia prawna — limit waloryzacji", `
+const HTML_OPINIA = HTML_SHELL("Legal opinion — indexation cap", `
 <div style="padding:26px 12px;font-family:Georgia,'Times New Roman',serif">
  <table role="presentation" width="640" align="center" cellpadding="0" cellspacing="0" style="width:640px;max-width:100%;background:#ffffff;border:1px solid #d9d2c5">
   <tr><td style="padding:26px 30px 12px 30px;border-bottom:3px double #b9ae97">
-    <div style="font-size:20px;letter-spacing:.14em;color:#3b3428">KANCELARIA WRONA</div>
-    <div style="font-size:11px;letter-spacing:.08em;color:#8c8271;font-family:Arial,sans-serif;margin-top:4px">RADCOWIE PRAWNI · WARSZAWA</div>
+    <div style="font-size:20px;letter-spacing:.14em;color:#3b3428">WRONA LAW OFFICE</div>
+    <div style="font-size:11px;letter-spacing:.08em;color:#8c8271;font-family:Arial,sans-serif;margin-top:4px">ATTORNEYS AT LAW · WARSAW</div>
   </td></tr>
   <tr><td style="padding:22px 30px 4px 30px">
     <table width="100%" style="font-family:Arial,sans-serif;font-size:12px;color:#6b6355">
-     <tr><td>Sygn. WR/2026/218</td><td align="right">Warszawa, 24 sierpnia 2026 r.</td></tr>
+     <tr><td>Ref. WR/2026/218</td><td align="right">Warsaw, 24 August 2026</td></tr>
     </table>
-    <h1 style="font-size:17px;margin:18px 0 14px 0;color:#3b3428">Opinia w przedmiocie wprowadzenia górnego limitu waloryzacji</h1>
-    <p style="font-size:15px;line-height:1.75;margin:0 0 12px 0">§ 1. Wprowadzenie górnego limitu indeksacji wynagrodzenia jest dopuszczalne w świetle zasady swobody umów i nie wymaga zmiany pozostałych postanowień umowy ramowej.</p>
-    <p style="font-size:15px;line-height:1.75;margin:0 0 12px 0">§ 2. Klauzula powinna wskazywać wskaźnik referencyjny, moment jego odczytu oraz maksymalny poziom podwyżki w skali roku. Rekomendowane brzmienie w załączniku.</p>
+    <h1 style="font-size:17px;margin:18px 0 14px 0;color:#3b3428">Opinion on the introduction of an upper indexation cap</h1>
+    <p style="font-size:15px;line-height:1.75;margin:0 0 12px 0">§ 1. Introducing an upper cap on fee indexation is permissible under freedom of contract and requires no change to the other provisions of the master agreement.</p>
+    <p style="font-size:15px;line-height:1.75;margin:0 0 12px 0">§ 2. The clause should name the reference index, the moment it is read and the maximum increase per year. Recommended wording is attached.</p>
     <div style="border-left:3px solid #b9ae97;background:#faf7f0;padding:14px 16px;margin:16px 0;font-size:14px;line-height:1.7">
-     „Waloryzacja nie może przekroczyć 5% w skali roku kalendarzowego, niezależnie od wysokości wskaźnika CPI ogłoszonego przez GUS."
+     “Indexation may not exceed 5% per calendar year, regardless of the CPI figure published by the statistics office.”
     </div>
-    <p style="font-size:15px;line-height:1.75;margin:0 0 12px 0">§ 3. Ryzyko sporu oceniam jako niskie. Brak limitu przy CPI powyżej 8% może natomiast prowadzić do istotnej zmiany równowagi kontraktowej.</p>
+    <p style="font-size:15px;line-height:1.75;margin:0 0 12px 0">§ 3. I rate the litigation risk as low. An uncapped clause with CPI above 8% could, however, materially shift the contractual balance.</p>
     <table width="100%" cellpadding="0" cellspacing="0" style="margin:18px 0 6px 0;border-collapse:collapse;font-family:Arial,sans-serif;font-size:12px">
-     <tr style="background:#faf7f0"><th align="left" style="padding:8px 10px;border:1px solid #e6dfd0">Scenariusz</th><th align="left" style="padding:8px 10px;border:1px solid #e6dfd0">Ocena</th></tr>
-     <tr><td style="padding:8px 10px;border:1px solid #e6dfd0">Limit 5% rocznie</td><td style="padding:8px 10px;border:1px solid #e6dfd0;color:#2f6f4f">rekomendowany</td></tr>
-     <tr><td style="padding:8px 10px;border:1px solid #e6dfd0">Limit sztywny 3%</td><td style="padding:8px 10px;border:1px solid #e6dfd0;color:#9a6b12">możliwy opór drugiej strony</td></tr>
-     <tr><td style="padding:8px 10px;border:1px solid #e6dfd0">Brak limitu</td><td style="padding:8px 10px;border:1px solid #e6dfd0;color:#9a3412">niekorzystny</td></tr>
+     <tr style="background:#faf7f0"><th align="left" style="padding:8px 10px;border:1px solid #e6dfd0">Scenario</th><th align="left" style="padding:8px 10px;border:1px solid #e6dfd0">Assessment</th></tr>
+     <tr><td style="padding:8px 10px;border:1px solid #e6dfd0">5% annual cap</td><td style="padding:8px 10px;border:1px solid #e6dfd0;color:#2f6f4f">recommended</td></tr>
+     <tr><td style="padding:8px 10px;border:1px solid #e6dfd0">Hard 3% cap</td><td style="padding:8px 10px;border:1px solid #e6dfd0;color:#9a6b12">the other side may resist</td></tr>
+     <tr><td style="padding:8px 10px;border:1px solid #e6dfd0">No cap</td><td style="padding:8px 10px;border:1px solid #e6dfd0;color:#9a3412">unfavourable</td></tr>
     </table>
   </td></tr>
   <tr><td style="padding:10px 30px 28px 30px">
-    <div style="font-size:14px;margin-top:18px">z poważaniem,<br><span style="font-family:'Brush Script MT',cursive;font-size:22px;color:#3b3428">Jacek Wrona</span><br><span style="font-family:Arial,sans-serif;font-size:12px;color:#8c8271">radca prawny · nr wpisu WA-8821</span></div>
+    <div style="font-size:14px;margin-top:18px">Yours faithfully,<br><span style="font-family:'Brush Script MT',cursive;font-size:22px;color:#3b3428">Jacek Wrona</span><br><span style="font-family:Arial,sans-serif;font-size:12px;color:#8c8271">attorney at law · bar no. WA-8821</span></div>
   </td></tr>
   <tr><td style="background:#faf7f0;border-top:1px solid #e6dfd0;padding:14px 30px;font-family:Arial,sans-serif;font-size:10px;line-height:1.7;color:#8c8271">
-   Kancelaria Wrona sp. k. · ul. Marszałkowska 12, 00-590 Warszawa · Opinia sporządzona wyłącznie dla adresata i nie może być udostępniana osobom trzecim bez zgody kancelarii.
+   Wrona Law Office · 12 Marszałkowska St, 00-590 Warsaw · This opinion is prepared solely for the addressee and may not be shared with third parties without the firm's consent.
   </td></tr>
  </table>
 </div>`);
 
-const HTML_PROPOZYCJA = HTML_SHELL("Propozycja warunków 2027", `
+const HTML_PROPOZYCJA = HTML_SHELL("Proposed terms 2027", `
 <div style="padding:24px 12px;font-family:Arial,Helvetica,sans-serif">
  <table role="presentation" width="620" align="center" cellpadding="0" cellspacing="0" style="width:620px;max-width:100%;background:#ffffff;border:1px solid #d7dee7">
   <tr><td style="background:#14293f;padding:20px 26px;color:#ffffff">
-    <table width="100%"><tr><td style="font-size:17px;letter-spacing:.06em">CONTOSO</td><td align="right" style="font-size:12px;color:#9fb3c8">Propozycja nr 2027/PL-04</td></tr></table>
+    <table width="100%"><tr><td style="font-size:17px;letter-spacing:.06em">CONTOSO</td><td align="right" style="font-size:12px;color:#9fb3c8">Proposal no. 2027/PL-04</td></tr></table>
   </td></tr>
   <tr><td style="padding:22px 26px 6px 26px">
-    <p style="font-size:14px;line-height:1.7;margin:0 0 16px 0;color:#3e4c59">Poniżej zestawienie trzech wariantów współpracy na 2027 rok. Wariant B jest naszą rekomendacją.</p>
+    <p style="font-size:14px;line-height:1.7;margin:0 0 16px 0;color:#3e4c59">Below are three options for 2027. Option B is our recommendation.</p>
     <table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;font-size:13px">
-     <tr style="background:#f2f5f9"><th align="left" style="padding:10px;border:1px solid #d7dee7">Wariant</th><th align="left" style="padding:10px;border:1px solid #d7dee7">SLA</th><th align="left" style="padding:10px;border:1px solid #d7dee7">Cena / rok</th><th align="left" style="padding:10px;border:1px solid #d7dee7">Waloryzacja</th></tr>
-     <tr><td style="padding:10px;border:1px solid #d7dee7">A · bez zmian</td><td style="padding:10px;border:1px solid #d7dee7">4 h</td><td style="padding:10px;border:1px solid #d7dee7">238 000 zł</td><td style="padding:10px;border:1px solid #d7dee7">CPI bez limitu</td></tr>
-     <tr style="background:#eef5ff"><td style="padding:10px;border:1px solid #d7dee7"><strong>B · rekomendowany</strong></td><td style="padding:10px;border:1px solid #d7dee7"><strong>2 h</strong></td><td style="padding:10px;border:1px solid #d7dee7"><strong>257 040 zł</strong></td><td style="padding:10px;border:1px solid #d7dee7">CPI, limit do uzgodnienia</td></tr>
-     <tr><td style="padding:10px;border:1px solid #d7dee7">C · rozszerzony</td><td style="padding:10px;border:1px solid #d7dee7">2 h + weekendy</td><td style="padding:10px;border:1px solid #d7dee7">289 000 zł</td><td style="padding:10px;border:1px solid #d7dee7">CPI + 1 p.p.</td></tr>
+     <tr style="background:#f2f5f9"><th align="left" style="padding:10px;border:1px solid #d7dee7">Option</th><th align="left" style="padding:10px;border:1px solid #d7dee7">SLA</th><th align="left" style="padding:10px;border:1px solid #d7dee7">Price / year</th><th align="left" style="padding:10px;border:1px solid #d7dee7">Indexation</th></tr>
+     <tr><td style="padding:10px;border:1px solid #d7dee7">A · unchanged</td><td style="padding:10px;border:1px solid #d7dee7">4 h</td><td style="padding:10px;border:1px solid #d7dee7">€238,000</td><td style="padding:10px;border:1px solid #d7dee7">CPI uncapped</td></tr>
+     <tr style="background:#eef5ff"><td style="padding:10px;border:1px solid #d7dee7"><strong>B · recommended</strong></td><td style="padding:10px;border:1px solid #d7dee7"><strong>2 h</strong></td><td style="padding:10px;border:1px solid #d7dee7"><strong>€257,040</strong></td><td style="padding:10px;border:1px solid #d7dee7">CPI, cap to be agreed</td></tr>
+     <tr><td style="padding:10px;border:1px solid #d7dee7">C · extended</td><td style="padding:10px;border:1px solid #d7dee7">2 h + weekends</td><td style="padding:10px;border:1px solid #d7dee7">€289,000</td><td style="padding:10px;border:1px solid #d7dee7">CPI + 1 pp</td></tr>
     </table>
-    <p style="font-size:12px;color:#7b8794;margin:14px 0 0 0">Ceny netto. Propozycja wiąże do <strong style="color:#9a3412">28.08.2026</strong>.</p>
+    <p style="font-size:12px;color:#7b8794;margin:14px 0 0 0">Prices net. The proposal is binding until <strong style="color:#9a3412">28.08.2026</strong>.</p>
     <div style="margin:18px 0 6px 0;padding:14px 16px;background:#f7f9fb;border:1px solid #e3e8ee">
-     <div style="font-size:13px;font-weight:bold;color:#14293f;margin-bottom:6px">Co zmienia się względem 2026</div>
+     <div style="font-size:13px;font-weight:bold;color:#14293f;margin-bottom:6px">What changes versus 2026</div>
      <ul style="margin:0;padding-left:18px;font-size:13px;line-height:1.7;color:#3e4c59">
-      <li>skrócony czas reakcji dla zgłoszeń krytycznych</li>
-      <li>dedykowany opiekun techniczny (2 dni w miesiącu)</li>
-      <li>raport dostępności co miesiąc zamiast kwartalnie</li>
+      <li>shorter response time for critical incidents</li>
+      <li>dedicated technical account manager (2 days a month)</li>
+      <li>availability report monthly instead of quarterly</li>
      </ul>
     </div>
   </td></tr>
   <tr><td style="padding:12px 26px 24px 26px">
    <table cellpadding="0" cellspacing="0"><tr>
-    <td style="background:#14293f"><a href="#" style="display:inline-block;padding:11px 20px;color:#ffffff;text-decoration:none;font-size:13px">Akceptuję wariant B</a></td>
-    <td style="padding-left:10px"><a href="#" style="display:inline-block;padding:11px 20px;color:#14293f;text-decoration:none;font-size:13px;border:1px solid #c3ccd8">Umów rozmowę</a></td>
+    <td style="background:#14293f"><a href="#" style="display:inline-block;padding:11px 20px;color:#ffffff;text-decoration:none;font-size:13px">Accept option B</a></td>
+    <td style="padding-left:10px"><a href="#" style="display:inline-block;padding:11px 20px;color:#14293f;text-decoration:none;font-size:13px;border:1px solid #c3ccd8">Book a call</a></td>
    </tr></table>
   </td></tr>
-  <tr><td style="background:#f7f9fb;border-top:1px solid #e3e8ee;padding:14px 26px;font-size:11px;color:#9aa5b1;line-height:1.6">Anna Kowalska · Key Account Manager · +48 22 000 00 00<br>Contoso Sp. z o.o., ul. Prosta 51, 00-838 Warszawa</td></tr>
+  <tr><td style="background:#f7f9fb;border-top:1px solid #e3e8ee;padding:14px 26px;font-size:11px;color:#9aa5b1;line-height:1.6">Anna Kowalska · Key Account Manager · +48 22 000 00 00<br>Contoso Ltd, 51 Prosta St, 00-838 Warsaw</td></tr>
  </table>
 </div>`);
 
-const HTML_ANKIETA = HTML_SHELL("Ankieta satysfakcji 2026", `
+const HTML_ANKIETA = HTML_SHELL("Satisfaction survey 2026", `
 <div style="padding:24px 12px;font-family:'Segoe UI',Arial,Helvetica,sans-serif;background:#eef1f5">
  <table role="presentation" width="600" align="center" cellpadding="0" cellspacing="0" style="width:600px;max-width:100%;background:#ffffff;border-radius:10px;overflow:hidden">
   <tr><td style="background:#4b3f8f;padding:30px 28px;text-align:center;color:#ffffff">
-    <div style="font-size:12px;letter-spacing:.18em;opacity:.8">DZIAŁ PERSONALNY</div>
-    <div style="font-size:26px;margin-top:8px">Jak Ci się u nas pracuje?</div>
-    <div style="font-size:13px;opacity:.85;margin-top:8px">7 minut · odpowiedzi w pełni anonimowe</div>
+    <div style="font-size:12px;letter-spacing:.18em;opacity:.8">PEOPLE TEAM</div>
+    <div style="font-size:26px;margin-top:8px">How is work going for you?</div>
+    <div style="font-size:13px;opacity:.85;margin-top:8px">7 minutes · answers fully anonymous</div>
   </td></tr>
   <tr><td style="padding:26px 28px 10px 28px">
-   <p style="font-size:14px;line-height:1.7;color:#3e4c59;margin:0 0 18px 0">Raz w roku pytamy o to samo, żeby dało się porównać wyniki. W zeszłym roku ankietę wypełniło 78% zespołu — dzięki temu powstał budżet szkoleniowy i elastyczne godziny startu.</p>
+   <p style="font-size:14px;line-height:1.7;color:#3e4c59;margin:0 0 18px 0">Once a year we ask the same questions so the results can be compared. Last year 78% of the team responded — that is where the training budget and flexible start hours came from.</p>
    <div style="text-align:center;padding:6px 0 14px 0">
-    <div style="font-size:13px;color:#6b7280;margin-bottom:10px">Zacznij od jednego kliknięcia — jak oceniasz ostatni kwartał?</div>
+    <div style="font-size:13px;color:#6b7280;margin-bottom:10px">Start with one click — how would you rate the last quarter?</div>
     <table align="center" cellpadding="0" cellspacing="0"><tr>
      <td style="padding:0 4px"><a href="#" style="display:inline-block;width:38px;height:38px;line-height:38px;border-radius:19px;background:#f3eefc;color:#4b3f8f;text-decoration:none;font-size:15px">1</a></td>
      <td style="padding:0 4px"><a href="#" style="display:inline-block;width:38px;height:38px;line-height:38px;border-radius:19px;background:#f3eefc;color:#4b3f8f;text-decoration:none;font-size:15px">2</a></td>
@@ -3396,100 +3396,100 @@ const HTML_ANKIETA = HTML_SHELL("Ankieta satysfakcji 2026", `
     </tr></table>
    </div>
    <table width="100%" style="border-collapse:collapse;font-size:13px;color:#3e4c59">
-    <tr><td style="padding:8px 0;border-top:1px solid #eef1f5">Obszary w ankiecie</td><td align="right" style="padding:8px 0;border-top:1px solid #eef1f5">6</td></tr>
-    <tr><td style="padding:8px 0;border-top:1px solid #eef1f5">Pytania otwarte</td><td align="right" style="padding:8px 0;border-top:1px solid #eef1f5">2</td></tr>
-    <tr><td style="padding:8px 0;border-top:1px solid #eef1f5">Termin</td><td align="right" style="padding:8px 0;border-top:1px solid #eef1f5;color:#9a3412"><strong>5 września</strong></td></tr>
+    <tr><td style="padding:8px 0;border-top:1px solid #eef1f5">Areas covered</td><td align="right" style="padding:8px 0;border-top:1px solid #eef1f5">6</td></tr>
+    <tr><td style="padding:8px 0;border-top:1px solid #eef1f5">Open questions</td><td align="right" style="padding:8px 0;border-top:1px solid #eef1f5">2</td></tr>
+    <tr><td style="padding:8px 0;border-top:1px solid #eef1f5">Deadline</td><td align="right" style="padding:8px 0;border-top:1px solid #eef1f5;color:#9a3412"><strong>5 September</strong></td></tr>
    </table>
   </td></tr>
-  <tr><td style="padding:8px 28px 28px 28px;text-align:center"><a href="#" style="display:inline-block;background:#4b3f8f;color:#ffffff;text-decoration:none;padding:14px 34px;border-radius:24px;font-size:14px">Wypełnij ankietę</a></td></tr>
-  <tr><td style="background:#f7f9fb;padding:16px 28px;font-size:11px;color:#9aa5b1;line-height:1.6;text-align:center">Odpowiedzi zbiera zewnętrzna platforma, wyniki widzimy wyłącznie zbiorczo.<br><a href="#" style="color:#4b3f8f">Zasady przetwarzania danych</a> · <a href="#" style="color:#4b3f8f">nie chcę przypomnień</a></td></tr>
+  <tr><td style="padding:8px 28px 28px 28px;text-align:center"><a href="#" style="display:inline-block;background:#4b3f8f;color:#ffffff;text-decoration:none;padding:14px 34px;border-radius:24px;font-size:14px">Take the survey</a></td></tr>
+  <tr><td style="background:#f7f9fb;padding:16px 28px;font-size:11px;color:#9aa5b1;line-height:1.6;text-align:center">An external platform collects the answers; we only see aggregate results.<br><a href="#" style="color:#4b3f8f">Data processing policy</a> · <a href="#" style="color:#4b3f8f">no reminders, please</a></td></tr>
  </table>
 </div>`);
 
-const HTML_OFERTA = HTML_SHELL("Oferta — moduł raportowy", `
+const HTML_OFERTA = HTML_SHELL("Quote — reporting module", `
 <div style="padding:24px 12px;font-family:Arial,Helvetica,sans-serif">
  <table role="presentation" width="620" align="center" cellpadding="0" cellspacing="0" style="width:620px;max-width:100%;background:#ffffff;border:1px solid #d7dee7">
   <tr><td style="padding:22px 26px;border-bottom:4px solid #b4531f">
     <table width="100%"><tr>
      <td style="font-size:19px;color:#7a3a15;letter-spacing:.04em"><strong>NORTHWIND</strong></td>
-     <td align="right" style="font-size:12px;color:#7b8794">Oferta OF/2026/311<br>ważna do 30.09.2026</td>
+     <td align="right" style="font-size:12px;color:#7b8794">Quote OF/2026/311<br>valid to 30.09.2026</td>
     </tr></table>
   </td></tr>
   <tr><td style="padding:22px 26px 6px 26px">
-   <h1 style="font-size:18px;margin:0 0 10px 0;color:#14293f">Moduł raportowy — wdrożenie i utrzymanie</h1>
-   <p style="font-size:14px;line-height:1.7;color:#3e4c59;margin:0 0 16px 0">Zakres obejmuje 12 raportów standardowych, kreator raportów własnych oraz eksport do XLSX i PDF. Wdrożenie realizujemy w trzech iteracjach po dwa tygodnie.</p>
+   <h1 style="font-size:18px;margin:0 0 10px 0;color:#14293f">Reporting module — implementation and support</h1>
+   <p style="font-size:14px;line-height:1.7;color:#3e4c59;margin:0 0 16px 0">The scope covers 12 standard reports, a custom report builder and export to XLSX and PDF. We deliver in three two-week iterations.</p>
    <table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;font-size:13px">
-    <tr style="background:#fdf3ec"><th align="left" style="padding:9px 10px;border:1px solid #ecd9cc">Pozycja</th><th align="right" style="padding:9px 10px;border:1px solid #ecd9cc">Ilość</th><th align="right" style="padding:9px 10px;border:1px solid #ecd9cc">Cena</th></tr>
-    <tr><td style="padding:9px 10px;border:1px solid #ecd9cc">Licencja modułu (bezterminowa)</td><td align="right" style="padding:9px 10px;border:1px solid #ecd9cc">1</td><td align="right" style="padding:9px 10px;border:1px solid #ecd9cc">14 000 zł</td></tr>
-    <tr><td style="padding:9px 10px;border:1px solid #ecd9cc">Wdrożenie i konfiguracja</td><td align="right" style="padding:9px 10px;border:1px solid #ecd9cc">60 h</td><td align="right" style="padding:9px 10px;border:1px solid #ecd9cc">8 400 zł</td></tr>
-    <tr><td style="padding:9px 10px;border:1px solid #ecd9cc">Szkolenie zespołu</td><td align="right" style="padding:9px 10px;border:1px solid #ecd9cc">1 dzień</td><td align="right" style="padding:9px 10px;border:1px solid #ecd9cc">1 600 zł</td></tr>
-    <tr style="background:#fdf3ec"><td colspan="2" style="padding:11px 10px;border:1px solid #ecd9cc"><strong>Razem netto</strong></td><td align="right" style="padding:11px 10px;border:1px solid #ecd9cc"><strong>24 000 zł</strong></td></tr>
+    <tr style="background:#fdf3ec"><th align="left" style="padding:9px 10px;border:1px solid #ecd9cc">Item</th><th align="right" style="padding:9px 10px;border:1px solid #ecd9cc">Qty</th><th align="right" style="padding:9px 10px;border:1px solid #ecd9cc">Price</th></tr>
+    <tr><td style="padding:9px 10px;border:1px solid #ecd9cc">Module licence (perpetual)</td><td align="right" style="padding:9px 10px;border:1px solid #ecd9cc">1</td><td align="right" style="padding:9px 10px;border:1px solid #ecd9cc">€14,000</td></tr>
+    <tr><td style="padding:9px 10px;border:1px solid #ecd9cc">Implementation and configuration</td><td align="right" style="padding:9px 10px;border:1px solid #ecd9cc">60 h</td><td align="right" style="padding:9px 10px;border:1px solid #ecd9cc">€8,400</td></tr>
+    <tr><td style="padding:9px 10px;border:1px solid #ecd9cc">Team training</td><td align="right" style="padding:9px 10px;border:1px solid #ecd9cc">1 day</td><td align="right" style="padding:9px 10px;border:1px solid #ecd9cc">€1,600</td></tr>
+    <tr style="background:#fdf3ec"><td colspan="2" style="padding:11px 10px;border:1px solid #ecd9cc"><strong>Total net</strong></td><td align="right" style="padding:11px 10px;border:1px solid #ecd9cc"><strong>€24,000</strong></td></tr>
    </table>
    <div style="margin:18px 0 6px 0;padding:13px 15px;background:#f7f9fb;border-left:3px solid #b4531f;font-size:13px;line-height:1.6;color:#3e4c59">
-    Harmonogram: start 2 tygodnie od podpisania, odbiór końcowy po 6 tygodniach. Utrzymanie 1 200 zł/mies. od drugiego miesiąca po odbiorze.
+    Schedule: start two weeks after signature, final acceptance after six weeks. Support €1,200/month from the second month after acceptance.
    </div>
   </td></tr>
-  <tr><td style="padding:12px 26px 24px 26px"><a href="#" style="display:inline-block;background:#b4531f;color:#ffffff;text-decoration:none;padding:12px 22px;font-size:13px">Pobierz ofertę PDF</a></td></tr>
-  <tr><td style="background:#f7f9fb;border-top:1px solid #e3e8ee;padding:14px 26px;font-size:11px;color:#9aa5b1">Robert Lis · Northwind Sp. z o.o. · r.lis@northwind.example · +48 61 000 00 00</td></tr>
+  <tr><td style="padding:12px 26px 24px 26px"><a href="#" style="display:inline-block;background:#b4531f;color:#ffffff;text-decoration:none;padding:12px 22px;font-size:13px">Download the quote as PDF</a></td></tr>
+  <tr><td style="background:#f7f9fb;border-top:1px solid #e3e8ee;padding:14px 26px;font-size:11px;color:#9aa5b1">Robert Lis · Northwind Ltd · r.lis@northwind.example · +48 61 000 00 00</td></tr>
  </table>
 </div>`);
 
-const HTML_DOSTAWA = HTML_SHELL("Zmiana terminu dostawy Q4", `
+const HTML_DOSTAWA = HTML_SHELL("Q4 delivery date change", `
 <div style="padding:24px 12px;font-family:Arial,Helvetica,sans-serif">
  <table role="presentation" width="620" align="center" cellpadding="0" cellspacing="0" style="width:620px;max-width:100%;background:#ffffff;border:1px solid #d7dee7">
-  <tr><td style="background:#5b3f2e;padding:18px 26px;color:#ffffff;font-size:16px;letter-spacing:.05em">FABRIKAM · LOGISTYKA</td></tr>
+  <tr><td style="background:#5b3f2e;padding:18px 26px;color:#ffffff;font-size:16px;letter-spacing:.05em">FABRIKAM · LOGISTICS</td></tr>
   <tr><td style="padding:22px 26px 8px 26px">
    <div style="background:#fdf0e4;border:1px solid #ecd0ae;padding:14px 16px;font-size:14px;line-height:1.6;color:#7a4a15">
-    <strong>Zmiana terminu:</strong> dostawa Q4 przesuwa się z 28.10 na <strong>12.11.2026</strong>.
+    <strong>Date change:</strong> the Q4 delivery moves from 28.10 to <strong>12.11.2026</strong>.
    </div>
    <table width="100%" cellpadding="0" cellspacing="0" style="margin-top:20px;border-collapse:collapse;font-size:13px">
-    <tr><td style="padding:10px;border:1px solid #e3e8ee;width:34%;background:#f7f9fb">Numer zamówienia</td><td style="padding:10px;border:1px solid #e3e8ee;font-family:monospace">ZAM-2026-0914</td></tr>
-    <tr><td style="padding:10px;border:1px solid #e3e8ee;background:#f7f9fb">Pozycje</td><td style="padding:10px;border:1px solid #e3e8ee">4 palety · 1 240 kg</td></tr>
-    <tr><td style="padding:10px;border:1px solid #e3e8ee;background:#f7f9fb">Pierwotny termin</td><td style="padding:10px;border:1px solid #e3e8ee;color:#8a94a6"><s>28.10.2026</s></td></tr>
-    <tr><td style="padding:10px;border:1px solid #e3e8ee;background:#f7f9fb">Nowy termin</td><td style="padding:10px;border:1px solid #e3e8ee"><strong>12.11.2026, okno 08:00–14:00</strong></td></tr>
-    <tr><td style="padding:10px;border:1px solid #e3e8ee;background:#f7f9fb">Przyczyna</td><td style="padding:10px;border:1px solid #e3e8ee">przestój linii u producenta komponentu</td></tr>
+    <tr><td style="padding:10px;border:1px solid #e3e8ee;width:34%;background:#f7f9fb">Order number</td><td style="padding:10px;border:1px solid #e3e8ee;font-family:monospace">ORD-2026-0914</td></tr>
+    <tr><td style="padding:10px;border:1px solid #e3e8ee;background:#f7f9fb">Items</td><td style="padding:10px;border:1px solid #e3e8ee">4 pallets · 1,240 kg</td></tr>
+    <tr><td style="padding:10px;border:1px solid #e3e8ee;background:#f7f9fb">Original date</td><td style="padding:10px;border:1px solid #e3e8ee;color:#8a94a6"><s>28.10.2026</s></td></tr>
+    <tr><td style="padding:10px;border:1px solid #e3e8ee;background:#f7f9fb">New date</td><td style="padding:10px;border:1px solid #e3e8ee"><strong>12.11.2026, window 08:00–14:00</strong></td></tr>
+    <tr><td style="padding:10px;border:1px solid #e3e8ee;background:#f7f9fb">Reason</td><td style="padding:10px;border:1px solid #e3e8ee">line stoppage at the component manufacturer</td></tr>
    </table>
-   <p style="font-size:12px;color:#7b8794;margin:16px 0 6px 0">Etapy realizacji</p>
+   <p style="font-size:12px;color:#7b8794;margin:16px 0 6px 0">Fulfilment stages</p>
    <table width="100%" style="font-size:12px;color:#3e4c59;border-collapse:collapse">
-    <tr><td style="padding:6px 0;width:24px;color:#2f6f4f">✔</td><td style="padding:6px 0">Zamówienie potwierdzone</td><td align="right">14.08</td></tr>
-    <tr><td style="padding:6px 0;color:#2f6f4f">✔</td><td style="padding:6px 0">Produkcja komponentów</td><td align="right">02.09</td></tr>
-    <tr><td style="padding:6px 0;color:#9a6b12">●</td><td style="padding:6px 0">Kompletacja i kontrola</td><td align="right">05.11</td></tr>
-    <tr><td style="padding:6px 0;color:#9aa5b1">○</td><td style="padding:6px 0">Transport i rozładunek</td><td align="right">12.11</td></tr>
+    <tr><td style="padding:6px 0;width:24px;color:#2f6f4f">✔</td><td style="padding:6px 0">Order confirmed</td><td align="right">14.08</td></tr>
+    <tr><td style="padding:6px 0;color:#2f6f4f">✔</td><td style="padding:6px 0">Component production</td><td align="right">02.09</td></tr>
+    <tr><td style="padding:6px 0;color:#9a6b12">●</td><td style="padding:6px 0">Picking and inspection</td><td align="right">05.11</td></tr>
+    <tr><td style="padding:6px 0;color:#9aa5b1">○</td><td style="padding:6px 0">Transport and unloading</td><td align="right">12.11</td></tr>
    </table>
-   <div style="margin-top:18px;font-size:13px;line-height:1.6;color:#3e4c59">Prosimy o potwierdzenie nowego okna dostawy <strong>do 02.09</strong>. Bez potwierdzenia rezerwujemy termin zapasowy 19.11.</div>
+   <div style="margin-top:18px;font-size:13px;line-height:1.6;color:#3e4c59">Please confirm the new delivery window <strong>by 02.09</strong>. Without confirmation we will book the fallback date of 19.11.</div>
   </td></tr>
   <tr><td style="padding:14px 26px 24px 26px">
    <table cellpadding="0" cellspacing="0"><tr>
     <td style="background:#5b3f2e"><a href="#" style="display:inline-block;padding:11px 20px;color:#ffffff;text-decoration:none;font-size:13px">Potwierdzam 12.11</a></td>
-    <td style="padding-left:10px"><a href="#" style="display:inline-block;padding:11px 20px;color:#5b3f2e;text-decoration:none;font-size:13px;border:1px solid #d9c9bb">Proponuję inny termin</a></td>
+    <td style="padding-left:10px"><a href="#" style="display:inline-block;padding:11px 20px;color:#5b3f2e;text-decoration:none;font-size:13px;border:1px solid #d9c9bb">Propose another date</a></td>
    </tr></table>
   </td></tr>
-  <tr><td style="background:#f7f9fb;border-top:1px solid #e3e8ee;padding:13px 26px;font-size:11px;color:#9aa5b1">Tomasz Bąk · Fabrikam · dział logistyki · t.bak@fabrikam.example</td></tr>
+  <tr><td style="background:#f7f9fb;border-top:1px solid #e3e8ee;padding:13px 26px;font-size:11px;color:#9aa5b1">Tomasz Bąk · Fabrikam · logistics · t.bak@fabrikam.example</td></tr>
  </table>
 </div>`);
 
-const HTML_AUDYT = HTML_SHELL("Zapytanie audytowe — rejestr umów IT", `
+const HTML_AUDYT = HTML_SHELL("Audit request — IT contract register", `
 <div style="padding:24px 12px;font-family:Arial,Helvetica,sans-serif">
  <table role="presentation" width="620" align="center" cellpadding="0" cellspacing="0" style="width:620px;max-width:100%;background:#ffffff;border:1px solid #d7dee7;border-top:5px solid #37474f">
   <tr><td style="padding:22px 26px 6px 26px">
-   <div style="font-size:11px;letter-spacing:.14em;color:#7b8794">AUDYT WEWNĘTRZNY · ZAPYTANIE NR A-2026/17</div>
-   <h1 style="font-size:19px;margin:8px 0 14px 0;color:#263238">Rejestr umów IT 2024–2026</h1>
-   <p style="font-size:14px;line-height:1.7;color:#3e4c59;margin:0 0 16px 0">W ramach cyklicznego przeglądu prosimy o kompletny wykaz umów IT wraz z aneksami. Poniżej lista wymaganych pól — prosimy zachować kolejność kolumn.</p>
+   <div style="font-size:11px;letter-spacing:.14em;color:#7b8794">INTERNAL AUDIT · REQUEST NO. A-2026/17</div>
+   <h1 style="font-size:19px;margin:8px 0 14px 0;color:#263238">IT contract register 2024–2026</h1>
+   <p style="font-size:14px;line-height:1.7;color:#3e4c59;margin:0 0 16px 0">As part of the periodic review, please send a complete list of IT contracts including addenda. The required fields are listed below — please keep the column order.</p>
    <table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;font-size:12px">
     <tr style="background:#eceff1"><th align="left" style="padding:8px 10px;border:1px solid #cfd8dc">Pole</th><th align="left" style="padding:8px 10px;border:1px solid #cfd8dc">Format</th><th align="left" style="padding:8px 10px;border:1px solid #cfd8dc">Wymagane</th></tr>
     <tr><td style="padding:8px 10px;border:1px solid #cfd8dc">Kontrahent / NIP</td><td style="padding:8px 10px;border:1px solid #cfd8dc">tekst</td><td style="padding:8px 10px;border:1px solid #cfd8dc">tak</td></tr>
-    <tr><td style="padding:8px 10px;border:1px solid #cfd8dc">Data zawarcia / obowiązywania</td><td style="padding:8px 10px;border:1px solid #cfd8dc">RRRR-MM-DD</td><td style="padding:8px 10px;border:1px solid #cfd8dc">tak</td></tr>
-    <tr><td style="padding:8px 10px;border:1px solid #cfd8dc">Wartość roczna netto</td><td style="padding:8px 10px;border:1px solid #cfd8dc">PLN</td><td style="padding:8px 10px;border:1px solid #cfd8dc">tak</td></tr>
-    <tr><td style="padding:8px 10px;border:1px solid #cfd8dc">Okres wypowiedzenia</td><td style="padding:8px 10px;border:1px solid #cfd8dc">miesiące</td><td style="padding:8px 10px;border:1px solid #cfd8dc">tak</td></tr>
-    <tr><td style="padding:8px 10px;border:1px solid #cfd8dc">Powierzenie danych (RODO)</td><td style="padding:8px 10px;border:1px solid #cfd8dc">tak / nie</td><td style="padding:8px 10px;border:1px solid #cfd8dc">jeśli dotyczy</td></tr>
+    <tr><td style="padding:8px 10px;border:1px solid #cfd8dc">Signature date / term</td><td style="padding:8px 10px;border:1px solid #cfd8dc">YYYY-MM-DD</td><td style="padding:8px 10px;border:1px solid #cfd8dc">yes</td></tr>
+    <tr><td style="padding:8px 10px;border:1px solid #cfd8dc">Annual value, net</td><td style="padding:8px 10px;border:1px solid #cfd8dc">EUR</td><td style="padding:8px 10px;border:1px solid #cfd8dc">yes</td></tr>
+    <tr><td style="padding:8px 10px;border:1px solid #cfd8dc">Notice period</td><td style="padding:8px 10px;border:1px solid #cfd8dc">months</td><td style="padding:8px 10px;border:1px solid #cfd8dc">yes</td></tr>
+    <tr><td style="padding:8px 10px;border:1px solid #cfd8dc">Data processing (GDPR)</td><td style="padding:8px 10px;border:1px solid #cfd8dc">yes / no</td><td style="padding:8px 10px;border:1px solid #cfd8dc">if applicable</td></tr>
    </table>
    <div style="margin:18px 0 6px 0;padding:13px 15px;background:#eceff1;font-size:13px;line-height:1.6;color:#37474f">
-    <strong>Termin przekazania danych: 3 września 2026.</strong> Wykaz prosimy przesłać w formacie XLSX na adres audyt@firma.pl, z kopią do sekretariatu zarządu.
+    <strong>Data due: 3 September 2026.</strong> Please send the list as XLSX to audit@company.example, copying the board office.
    </div>
-   <p style="font-size:12px;color:#7b8794;line-height:1.7;margin:14px 0 0 0">Podstawa: plan audytu na 2026 r., pkt 4.2. Zapytanie nie wymaga odpowiedzi formalnej, wystarczy przesłanie wykazu.</p>
+   <p style="font-size:12px;color:#7b8794;line-height:1.7;margin:14px 0 0 0">Basis: 2026 audit plan, point 4.2. The request needs no formal reply; sending the list is enough.</p>
   </td></tr>
-  <tr><td style="padding:14px 26px 24px 26px"><a href="#" style="display:inline-block;background:#37474f;color:#ffffff;text-decoration:none;padding:11px 20px;font-size:13px">Pobierz szablon XLSX</a></td></tr>
-  <tr><td style="background:#f7f9fb;border-top:1px solid #e3e8ee;padding:13px 26px;font-size:11px;color:#9aa5b1">Audyt wewnętrzny · wew. 412 · korespondencja podlega archiwizacji</td></tr>
+  <tr><td style="padding:14px 26px 24px 26px"><a href="#" style="display:inline-block;background:#37474f;color:#ffffff;text-decoration:none;padding:11px 20px;font-size:13px">Download the template XLSX</a></td></tr>
+  <tr><td style="background:#f7f9fb;border-top:1px solid #e3e8ee;padding:13px 26px;font-size:11px;color:#9aa5b1">Internal Audit · ext. 412 · correspondence is archived</td></tr>
  </table>
 </div>`);
 
@@ -3498,54 +3498,54 @@ const HTML_NDA = HTML_SHELL("Projekt NDA — Northwind", `
  <table role="presentation" width="640" align="center" cellpadding="0" cellspacing="0" style="width:640px;max-width:100%;background:#ffffff;border:1px solid #d9d2c5">
   <tr><td style="padding:24px 30px 10px 30px;border-bottom:1px solid #e6dfd0">
    <div style="font-family:Arial,sans-serif;font-size:11px;letter-spacing:.12em;color:#8c8271">KANCELARIA WRONA · PROJEKT DOKUMENTU</div>
-   <h1 style="font-size:19px;margin:10px 0 4px 0;color:#3b3428">Umowa o zachowaniu poufności (NDA)</h1>
-   <div style="font-family:Arial,sans-serif;font-size:12px;color:#8c8271">wersja 2 · zmiany zaznaczone kolorem</div>
+   <h1 style="font-size:19px;margin:10px 0 4px 0;color:#3b3428">Non-disclosure agreement (NDA)</h1>
+   <div style="font-family:Arial,sans-serif;font-size:12px;color:#8c8271">version 2 · changes marked in colour</div>
   </td></tr>
   <tr><td style="padding:20px 30px 6px 30px">
-   <p style="font-size:15px;line-height:1.75;margin:0 0 12px 0"><strong>§ 3 Okres obowiązywania.</strong> Zobowiązanie do zachowania poufności wiąże strony przez okres <span style="background:#fff3bf">trzech lat</span> od dnia zakończenia współpracy.</p>
-   <p style="font-size:15px;line-height:1.75;margin:0 0 12px 0"><strong>§ 5 Kara umowna.</strong> W razie naruszenia strona zobowiązana zapłaci karę w wysokości <s style="color:#a1887f">100 000 zł</s> <span style="background:#e6f4ea;color:#1b5e20">50 000 zł</span> za każde naruszenie.</p>
-   <p style="font-size:15px;line-height:1.75;margin:0 0 12px 0"><strong>§ 7 Wyłączenia.</strong> Poufnością nie są objęte informacje powszechnie dostępne oraz ujawnione na żądanie organu władzy publicznej.</p>
+   <p style="font-size:15px;line-height:1.75;margin:0 0 12px 0"><strong>§ 3 Term.</strong> The confidentiality obligation binds the parties for <span style="background:#fff3bf">three years</span> from the end of the engagement.</p>
+   <p style="font-size:15px;line-height:1.75;margin:0 0 12px 0"><strong>§ 5 Contractual penalty.</strong> In the event of a breach, the obliged party pays a penalty of <s style="color:#a1887f">€100,000</s> <span style="background:#e6f4ea;color:#1b5e20">€50,000</span> per breach.</p>
+   <p style="font-size:15px;line-height:1.75;margin:0 0 12px 0"><strong>§ 7 Carve-outs.</strong> Confidentiality does not cover publicly available information or disclosures required by a public authority.</p>
    <table width="100%" cellpadding="0" cellspacing="0" style="margin:18px 0 8px 0;border-collapse:collapse;font-family:Arial,sans-serif;font-size:12px">
     <tr style="background:#faf7f0"><th align="left" style="padding:8px 10px;border:1px solid #e6dfd0">Zmiana</th><th align="left" style="padding:8px 10px;border:1px solid #e6dfd0">Wersja 1</th><th align="left" style="padding:8px 10px;border:1px solid #e6dfd0">Wersja 2</th></tr>
-    <tr><td style="padding:8px 10px;border:1px solid #e6dfd0">Kara umowna</td><td style="padding:8px 10px;border:1px solid #e6dfd0">100 000 zł</td><td style="padding:8px 10px;border:1px solid #e6dfd0;background:#e6f4ea">50 000 zł</td></tr>
+    <tr><td style="padding:8px 10px;border:1px solid #e6dfd0">Contractual penalty</td><td style="padding:8px 10px;border:1px solid #e6dfd0">€100,000</td><td style="padding:8px 10px;border:1px solid #e6dfd0;background:#e6f4ea">€50,000</td></tr>
     <tr><td style="padding:8px 10px;border:1px solid #e6dfd0">Okres</td><td style="padding:8px 10px;border:1px solid #e6dfd0">5 lat</td><td style="padding:8px 10px;border:1px solid #e6dfd0;background:#e6f4ea">3 lata</td></tr>
-    <tr><td style="padding:8px 10px;border:1px solid #e6dfd0">Prawo właściwe</td><td style="padding:8px 10px;border:1px solid #e6dfd0">polskie</td><td style="padding:8px 10px;border:1px solid #e6dfd0">bez zmian</td></tr>
+    <tr><td style="padding:8px 10px;border:1px solid #e6dfd0">Governing law</td><td style="padding:8px 10px;border:1px solid #e6dfd0">Polish</td><td style="padding:8px 10px;border:1px solid #e6dfd0">unchanged</td></tr>
    </table>
    <div style="border-left:3px solid #b9ae97;background:#faf7f0;padding:13px 16px;margin:16px 0;font-family:Arial,sans-serif;font-size:13px;line-height:1.65;color:#5d5545">
-    Do podpisu <strong>do 5 września</strong>. Jeśli druga strona nie zaakceptuje obniżenia kary, rekomenduję wariant z limitem łącznym 150 000 zł.
+    For signature <strong>by 5 September</strong>. If the other side rejects the lower penalty, I recommend the variant with a €150,000 aggregate cap.
    </div>
   </td></tr>
   <tr><td style="padding:8px 30px 26px 30px"><a href="#" style="display:inline-block;background:#3b3428;color:#ffffff;text-decoration:none;padding:11px 22px;font-family:Arial,sans-serif;font-size:13px">Podpisz elektronicznie</a></td></tr>
-  <tr><td style="background:#faf7f0;border-top:1px solid #e6dfd0;padding:14px 30px;font-family:Arial,sans-serif;font-size:10px;color:#8c8271;line-height:1.7">Dokument roboczy · nie stanowi oferty w rozumieniu Kodeksu cywilnego · Kancelaria Wrona sp. k.</td></tr>
+  <tr><td style="background:#faf7f0;border-top:1px solid #e6dfd0;padding:14px 30px;font-family:Arial,sans-serif;font-size:10px;color:#8c8271;line-height:1.7">Working document · not an offer in the legal sense · Wrona Law Office</td></tr>
  </table>
 </div>`);
 
-const HTML_SLA = HTML_SHELL("Pytanie o SLA w weekendy", `
+const HTML_SLA = HTML_SHELL("Question about weekend SLA", `
 <div style="padding:24px 12px;font-family:Arial,Helvetica,sans-serif">
  <table role="presentation" width="600" align="center" cellpadding="0" cellspacing="0" style="width:600px;max-width:100%;background:#ffffff;border:1px solid #dde3ea">
   <tr><td style="padding:22px 26px 4px 26px">
-   <p style="font-size:15px;line-height:1.7;color:#2c3a47;margin:0 0 14px 0">Dzień dobry,</p>
-   <p style="font-size:15px;line-height:1.7;color:#2c3a47;margin:0 0 14px 0">wracamy do tematu wsparcia weekendowego. Od października uruchamiamy dyżury sobotnie u trzech naszych klientów i potrzebujemy wiedzieć, czy obecna umowa to obejmuje.</p>
+   <p style="font-size:15px;line-height:1.7;color:#2c3a47;margin:0 0 14px 0">Hello,</p>
+   <p style="font-size:15px;line-height:1.7;color:#2c3a47;margin:0 0 14px 0">coming back to weekend support. From October we are starting Saturday cover for three of our clients and we need to know whether the current contract covers it.</p>
    <table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;font-size:13px;margin:6px 0 14px 0">
-    <tr style="background:#f2f5f9"><th align="left" style="padding:9px 10px;border:1px solid #dde3ea">Parametr</th><th align="left" style="padding:9px 10px;border:1px solid #dde3ea">Dziś</th><th align="left" style="padding:9px 10px;border:1px solid #dde3ea">Oczekiwane</th></tr>
-    <tr><td style="padding:9px 10px;border:1px solid #dde3ea">Dni objęte wsparciem</td><td style="padding:9px 10px;border:1px solid #dde3ea">pn–pt</td><td style="padding:9px 10px;border:1px solid #dde3ea">pn–sb</td></tr>
-    <tr><td style="padding:9px 10px;border:1px solid #dde3ea">Czas reakcji (krytyczne)</td><td style="padding:9px 10px;border:1px solid #dde3ea">2 h</td><td style="padding:9px 10px;border:1px solid #dde3ea">4 h w sobotę</td></tr>
-    <tr><td style="padding:9px 10px;border:1px solid #dde3ea">Kanał zgłoszeń</td><td style="padding:9px 10px;border:1px solid #dde3ea">portal</td><td style="padding:9px 10px;border:1px solid #dde3ea">portal + telefon dyżurny</td></tr>
+    <tr style="background:#f2f5f9"><th align="left" style="padding:9px 10px;border:1px solid #dde3ea">Parameter</th><th align="left" style="padding:9px 10px;border:1px solid #dde3ea">Today</th><th align="left" style="padding:9px 10px;border:1px solid #dde3ea">Expected</th></tr>
+    <tr><td style="padding:9px 10px;border:1px solid #dde3ea">Days covered</td><td style="padding:9px 10px;border:1px solid #dde3ea">Mon–Fri</td><td style="padding:9px 10px;border:1px solid #dde3ea">Mon–Sat</td></tr>
+    <tr><td style="padding:9px 10px;border:1px solid #dde3ea">Response time (critical)</td><td style="padding:9px 10px;border:1px solid #dde3ea">2 h</td><td style="padding:9px 10px;border:1px solid #dde3ea">4 h on Saturday</td></tr>
+    <tr><td style="padding:9px 10px;border:1px solid #dde3ea">Ticket channel</td><td style="padding:9px 10px;border:1px solid #dde3ea">portal</td><td style="padding:9px 10px;border:1px solid #dde3ea">portal + on-call phone</td></tr>
    </table>
-   <p style="font-size:15px;line-height:1.7;color:#2c3a47;margin:0 0 14px 0">Jeśli wiąże się to z dopłatą, prosimy o widełki — decyzję budżetową podejmujemy w przyszłym tygodniu.</p>
+   <p style="font-size:15px;line-height:1.7;color:#2c3a47;margin:0 0 14px 0">If there is a surcharge, please give us a range — we take the budget decision next week.</p>
    <div style="border-left:3px solid #c3ccd8;padding:10px 14px;margin:18px 0 6px 0;color:#7b8794;font-size:13px;line-height:1.6">
-    <div style="font-size:11px;text-transform:uppercase;letter-spacing:.08em;margin-bottom:6px">Cytowana wcześniejsza wiadomość</div>
-    26.08.2026, Karolina Kowalska napisała:<br>„Obecny zakres wsparcia obejmuje dni robocze 8:00–18:00. Rozszerzenie jest możliwe, wymaga aneksu."
+    <div style="font-size:11px;text-transform:uppercase;letter-spacing:.08em;margin-bottom:6px">Quoted earlier message</div>
+    On 26.08.2026 Karolina Kowalska wrote:<br>“The current support scope covers business days 8:00–18:00. An extension is possible and requires an addendum.”
    </div>
   </td></tr>
   <tr><td style="padding:12px 26px 22px 26px">
    <table width="100%" style="border-top:1px solid #eef1f5;padding-top:12px"><tr><td style="padding-top:14px;font-size:12px;line-height:1.7;color:#5b6672">
      <strong style="color:#14293f;font-size:13px">Ewa Sikora</strong><br>
-     Kierownik działu wsparcia · Adventure Works<br>
+     Head of Support · Adventure Works<br>
      <span style="color:#9aa5b1">tel. +48 58 000 00 00 · e.sikora@adventure.example</span>
    </td></tr></table>
   </td></tr>
-  <tr><td style="background:#f7f9fb;border-top:1px solid #e3e8ee;padding:12px 26px;font-size:10px;color:#9aa5b1;line-height:1.6">Adventure Works Sp. z o.o. · Wiadomość może zawierać informacje poufne. Jeśli nie jesteś adresatem, usuń ją i poinformuj nadawcę.</td></tr>
+  <tr><td style="background:#f7f9fb;border-top:1px solid #e3e8ee;padding:12px 26px;font-size:10px;color:#9aa5b1;line-height:1.6">Adventure Works Ltd · This message may contain confidential information. If you are not the addressee, delete it and notify the sender.</td></tr>
  </table>
 </div>`);
 
@@ -3555,13 +3555,13 @@ const THREAD_HTML = {
   audyt1: HTML_AUDYT, prawnik2: HTML_NDA, travel1: HTML_TRAVEL, marketing1: HTML_NEWSLETTER, klient3: HTML_SLA,
 };
 
-/* Skrypt pomiarowy doklejany PRZED markupem wiadomości. Działa w opaque origin: jedyne,
-   co robi, to raportowanie wysokości przez parent.postMessage. Sam markup wiadomości nie
-   zawiera skryptów — jest oczyszczony, zanim trafi tutaj. */
+/* Measuring script injected BEFORE the message markup. It runs in an opaque origin and does
+   exactly one thing: report height via parent.postMessage. The message markup itself carries
+   no scripts — it is sanitised before it gets here. */
 const S_OPEN = "<" + "script>", S_CLOSE = "<" + "/script>";
 const FIT_SCRIPT = (frameId) => S_OPEN + '(function(){var ID=' + JSON.stringify(frameId) + ',last=0,sends=0;' +
-  /* Mierzymy przy zerowej wysokości viewportu, więc wynik nie zależy od wysokości ramki
-     — inaczej każde dopasowanie powiększałoby treść i pomiar rósłby bez końca. */
+  /* We measure with a zero-height viewport so the result does not depend on the frame height
+     — otherwise every fit would grow the content and the measurement would never settle. */
   'function measure(){var de=document.documentElement,b=document.body;if(!de||!b)return 0;' +
   'var prev=de.style.height;de.style.height="0px";' +
   'var h=Math.max(b.scrollHeight,b.offsetHeight,Math.ceil(b.getBoundingClientRect().height));' +
@@ -3570,7 +3570,7 @@ const FIT_SCRIPT = (frameId) => S_OPEN + '(function(){var ID=' + JSON.stringify(
   'if(h&&Math.abs(h-last)>3){last=h;sends++;try{parent.postMessage({frameId:ID,height:h},"*")}catch(e){}}}' +
   'function boot(){var de=document.documentElement,b=document.body;' +
   'if(de)de.style.overflow="hidden";if(b)b.style.overflow="hidden";' +
-  /* Obserwujemy treść (body), nie viewport — obserwacja documentElement zamykałaby pętlę. */
+  /* We observe the content (body), not the viewport — observing documentElement would close the loop. */
   'if(window.ResizeObserver&&b){try{new ResizeObserver(function(){send()}).observe(b)}catch(e){}}send()}' +
   'if(document.readyState==="loading")document.addEventListener("DOMContentLoaded",boot);else boot();' +
   'window.addEventListener("load",send);setTimeout(send,120);setTimeout(send,600);})()' + S_CLOSE;
@@ -3582,238 +3582,238 @@ const embedHtml = (src, frameId) => {
     : src.slice(0, i + 6) + FIT_SCRIPT(frameId) + src.slice(i + 6);
 };
 
-const htmlFallback = (m, subject) => HTML_SHELL(subject || "Wiadomość", `
+const htmlFallback = (m, subject) => HTML_SHELL(subject || "Message", `
 <div style="padding:24px 12px;font-family:Georgia,'Times New Roman',serif">
  <table role="presentation" width="600" align="center" cellpadding="0" cellspacing="0" style="width:600px;max-width:100%;background:#ffffff;border:1px solid #dde3ea">
   <tr><td style="padding:20px 24px;border-bottom:1px solid #eef1f5;font-family:Arial,sans-serif">
-   <div style="font-size:15px;color:#14293f"><strong>` + (subject || "Wiadomość") + `</strong></div>
+   <div style="font-size:15px;color:#14293f"><strong>` + (subject || "Message") + `</strong></div>
    <div style="font-size:12px;color:#7b8794;margin-top:4px">` + m.from + ` · ` + m.when + `</div>
   </td></tr>
   <tr><td style="padding:22px 24px;font-size:15px;line-height:1.7;color:#2c3a47">`
    + m.paras.map(p => '<p style="margin:0 0 14px 0">' + (p.text || mdPlain(p.md || "")) + '</p>').join("") +
   `</td></tr>
-  <tr><td style="background:#f7f9fb;border-top:1px solid #e3e8ee;padding:13px 24px;font-family:Arial,sans-serif;font-size:11px;color:#9aa5b1">Wiadomość w wersji HTML · MailFathom pokazuje domyślnie uproszczony tekst</td></tr>
+  <tr><td style="background:#f7f9fb;border-top:1px solid #e3e8ee;padding:13px 24px;font-family:Arial,sans-serif;font-size:11px;color:#9aa5b1">HTML version of the message · MailFathom shows simplified text by default</td></tr>
  </table>
 </div>`);
 
 const HERO_MSGS = {
-  /* Wątek do sprawdzenia wejścia „ze środka": z listy otwiera się wiadomość 3 z 5. */
+  /* Thread for testing entry "from the middle": the list opens message 3 of 5. */
   piotr: [
     M("Piotr Zieliński", "24.08, 09:40", [
-      { text: "Dzień dobry, wysyłam status po pierwszym tygodniu etapu drugiego. Integracja z Exchange działa na środowisku testowym, zostały nam mapowania kalendarzy." },
-      { text: "Zamknięte 26 z 58 zadań. Nie widzę na razie ryzyka dla terminu." },
+      { text: "Hello, here is the status after the first week of phase two. The Exchange integration works on the test environment; calendar mappings are what is left." },
+      { text: "26 of 58 tasks closed. I see no risk to the date so far." },
     ]),
     M(ME, "25.08, 11:15", [
-      { text: "Dziękuję. Proszę o informację, gdy mapowania kalendarzy będą gotowe — od tego zależy, kiedy możemy zaprosić użytkowników do testów." },
+      { text: "Thank you. Let me know when the calendar mappings are done — that decides when we can invite users to test." },
     ]),
     M("Piotr Zieliński", "26.08, 14:05", [
-      { text: "Mapowania kalendarzy gotowe. Przy okazji wyszedł problem ze strefami czasowymi dla spotkań cyklicznych — poprawka wchodzi w środę." },
-      { text: "Dwa zadania są zablokowane po stronie API Graph. Odblokowanie zależy od Microsoftu, mamy zgłoszenie o priorytecie B." },
-      { text: "Plan testów UAT przygotuję po odbiorze etapu. Potrzebuję od Was listy pięciu użytkowników testowych." },
+      { text: "Calendar mappings are done. Along the way we found a time-zone problem with recurring meetings — the fix ships on Wednesday." },
+      { text: "Two tasks are blocked on the Graph API side. Unblocking depends on Microsoft; we have a priority B ticket open." },
+      { text: "I will prepare the UAT test plan after the phase is accepted. I need a list of five test users from you." },
     ], [{ type: "PDF", name: "Status_etap2.pdf", size: "118 kB" }], HTML_STATUS),
     M(ME, "27.08, 08:20", [
-      { text: "Lista użytkowników do testów będzie u Pana w czwartek. Czy problem ze strefami czasowymi wymaga osobnego odbioru?" },
+      { text: "You will have the list of test users on Thursday. Does the time-zone problem need a separate acceptance?" },
     ]),
   ],
   contoso: [
-    M("Anna Kowalska", "21.08, 10:02", [{ text: "Dzień dobry, przesyłam zarys zmian do umowy ramowej z 2021 roku. Kluczowe obszary to poziom usług i wynagrodzenie — szczegóły w wersji formalnej, którą przygotujemy w tym tygodniu." }]),
-    M(ME, "21.08, 15:38", [{ text: "Dziękuję. Prosimy o wersję z zaznaczonymi zmianami względem obowiązującej umowy — inaczej trudno nam ocenić wpływ na koszty." }]),
-    M("Anna Kowalska", "22.08, 09:11", [{ text: "W załączeniu wersja porównawcza. Zmiany dotyczą paragrafu 4 (czas reakcji) oraz załącznika cenowego." }], [{ type: "PDF", name: "Aneks_porownanie.pdf", size: "204 kB" }], HTML_CONTOSO_CMP),
-    M("Marta Nowak", "25.08, 12:24", [{ text: "Policzyłam wpływ podwyżki 8% przy prognozie CPI 4,1% — to około 19 tys. zł rocznie więcej. Warto zapytać o górny limit waloryzacji." }], [{ type: "XLSX", name: "CPI_2027.xlsx", size: "34 kB" }], HTML_CPI),
-    M(ME, "26.08, 08:30", [{ text: "Czy zasady waloryzacji są do negocjacji? Rozważamy akceptację SLA 2 h pod warunkiem wprowadzenia górnego limitu indeksacji CPI." }]),
+    M("Anna Kowalska", "21.08, 10:02", [{ text: "Hello, here is an outline of the changes to the 2021 master agreement. The key areas are service level and fees — details in the formal version we will prepare this week." }]),
+    M(ME, "21.08, 15:38", [{ text: "Thank you. Please send a version with changes marked against the current contract — otherwise it is hard for us to judge the cost impact." }]),
+    M("Anna Kowalska", "22.08, 09:11", [{ text: "Attached is the comparison version. The changes affect clause 4 (response time) and the price schedule." }], [{ type: "PDF", name: "Addendum_comparison.pdf", size: "204 kB" }], HTML_CONTOSO_CMP),
+    M("Marta Nowak", "25.08, 12:24", [{ text: "I calculated the impact of the 8% increase at a 4.1% CPI forecast — about €19k more per year. Worth asking for an upper indexation cap." }], [{ type: "XLSX", name: "CPI_2027.xlsx", size: "34 kB" }], HTML_CPI),
+    M(ME, "26.08, 08:30", [{ text: "Are the indexation rules negotiable? We would accept the 2 h SLA on condition that an upper CPI cap is introduced." }]),
   ],
 };
 
 const msgsFor = (t) => {
   const when = (t.meta || "").split(" · ")[1] || "";
-  const last = M(t.from || "Nadawca", when, t.body || [], t.attachments || [], THREAD_HTML[t.id]);
+  const last = M(t.from || "Sender", when, t.body || [], t.attachments || [], THREAD_HTML[t.id]);
   const hero = HERO_MSGS[t.id];
   if (hero) return hero.concat([last]);
-  const count = parseInt(((t.meta || "").match(/wątek: (\d+)/) || [])[1] || "1", 10);
+  const count = parseInt(((t.meta || "").match(/thread: (\d+)/) || [])[1] || "1", 10);
   if (count < 2) return [last];
   const s1 = ((t.state || [])[0] || {}).value;
   const s2 = ((t.state || [])[1] || {}).value;
-  const prior = [M(t.from || "Nadawca", "wcześniej", [{ text: "W nawiązaniu do wcześniejszych ustaleń: " + lowerFirst(s1 || "temat wątku") + "." }])];
-  if (s2 && s2 !== "Brak") prior.push(M(ME, "wcześniej", [{ text: "Dziękuję. Do wyjaśnienia zostaje: " + lowerFirst(s2) + "." }]));
+  const prior = [M(t.from || "Sender", "earlier", [{ text: "Following up on what we agreed earlier: " + lowerFirst(s1 || "the thread topic") + "." }])];
+  if (s2 && s2 !== "None") prior.push(M(ME, "earlier", [{ text: "Thank you. Still open: " + lowerFirst(s2) + "." }]));
   return prior.concat([last]);
 };
 
 const docContent = (d) => {
   if (!d) return [];
   const n = d.name || "";
-  if (n.indexOf("Aneks") === 0 || n.indexOf("Aneks") > 0) return [
-    { s: true, text: "ANEKS NR 3 DO UMOWY RAMOWEJ Z DNIA 14.06.2021" },
-    { h: true, text: "Zmiana poziomu usług i wynagrodzenia" },
-    { text: "§ 1. Czas reakcji na zgłoszenie o priorytecie krytycznym skraca się z 4 godzin do 2 godzin w dni robocze, w godzinach 8:00–18:00." },
-    { text: "§ 2. Z tytułu podwyższonego poziomu usług wynagrodzenie ryczałtowe ulega zwiększeniu o 8% począwszy od okresu rozliczeniowego rozpoczynającego się 01.01.2027." },
-    { text: "§ 3. Zasady waloryzacji wynagrodzenia wskaźnikiem CPI pozostają bez zmian względem § 11 umowy ramowej. Strony nie ustalają górnego limitu indeksacji." },
-    { text: "§ 4. Pozostałe postanowienia umowy pozostają bez zmian. Aneks wchodzi w życie z dniem podpisania przez obie strony." },
-    { s: true, text: "PODPISY STRON" },
-    { text: "Contoso sp. z o.o. — Anna Kowalska, Dyrektor Operacyjny" },
-    { text: "Nordwind sp. z o.o. — ......................................" },
+  if (n.toLowerCase().indexOf("addendum") >= 0) return [
+    { s: true, text: "ADDENDUM NO. 3 TO THE MASTER AGREEMENT OF 14.06.2021" },
+    { h: true, text: "Change of service level and remuneration" },
+    { text: "§ 1. The response time for a critical-priority incident is shortened from 4 hours to 2 hours on business days, between 8:00 and 18:00." },
+    { text: "§ 2. In return for the higher service level, the flat fee increases by 8% from the settlement period beginning 01.01.2027." },
+    { text: "§ 3. The rules for indexing the fee to CPI remain unchanged from § 11 of the master agreement. The parties do not set an upper cap on indexation." },
+    { text: "§ 4. All other provisions remain unchanged. The addendum takes effect on the date both parties sign." },
+    { s: true, text: "SIGNATURES OF THE PARTIES" },
+    { text: "Contoso Ltd — Anna Kowalska, Chief Operating Officer" },
+    { text: "Nordwind Ltd — ......................................" },
   ];
   if (d.type === "XLSX") return [
-    { s: true, text: (n || "ARKUSZ").toUpperCase() },
-    { h: true, text: "Kalkulacja kosztu rocznego 2027" },
-    { text: "Wynagrodzenie bazowe 2026: 236 000 zł" },
-    { text: "Podwyżka wynikająca z aneksu (8%): 18 880 zł" },
-    { text: "Waloryzacja CPI (prognoza 4,1%): 10 448 zł" },
-    { text: "Koszt roczny po zmianach: 265 328 zł" },
-    { text: "Różnica względem 2026: +29 328 zł" },
+    { s: true, text: (n || "SPREADSHEET").toUpperCase() },
+    { h: true, text: "Annual cost calculation 2027" },
+    { text: "Base fee 2026: €236,000" },
+    { text: "Increase from the addendum (8%): €18,880" },
+    { text: "CPI indexation (4.1% forecast): €10,448" },
+    { text: "Annual cost after changes: €265,328" },
+    { text: "Difference versus 2026: +€29,328" },
   ];
   return [
-    { s: true, text: (d.type || "DOKUMENT") + " · " + (d.size || "") },
+    { s: true, text: (d.type || "DOCUMENT") + " · " + (d.size || "") },
     { h: true, text: n.replace(/\.[a-z]+$/i, "") },
-    { text: "Podgląd dokumentu otwarty w aplikacji — bez pobierania pliku na dysk. Zawartość pochodzi z załącznika wiadomości i jest indeksowana przez MailFathom na potrzeby cytowań." },
-    { text: "Fragmenty przywołane w wynikach „Odkrywaj” są podświetlane w miejscu, z którego pochodzą." },
+    { text: "Document preview opened in the app — no file downloaded to disk. The content comes from the message attachment and is indexed by MailFathom for citations." },
+    { text: "Passages cited in “Discover” results are highlighted where they came from." },
   ];
 };
 
 const CASES = [
   {
-    id: "contoso27", title: "Renegocjacja umowy Contoso 2027", parties: "Contoso · Nordwind",
-    status: "Decyzja do 28.08", statusKind: "pilne", owner: "KK",
-    summary: "Aneks nr 3 zmienia SLA i cenę. Akceptujemy skrócenie czasu reakcji, negocjujemy górny limit waloryzacji CPI.",
-    scope: "4 wątki · 3 dokumenty · 2 konta",
+    id: "contoso27", title: "Contoso contract renegotiation 2027", parties: "Contoso · Nordwind",
+    status: "Decision by 28.08", statusKind: "urgent", owner: "KK",
+    summary: "Addendum no. 3 changes the SLA and the price. We accept the shorter response time and are negotiating an upper CPI cap.",
+    scope: "4 threads · 3 documents · 2 accounts",
     agreed: [
-      { text: "SLA dla zgłoszeń krytycznych: 2 h w dni robocze", src: "Aneks SLA.pdf" },
-      { text: "Wynagrodzenie +8% od okresu 2027", src: "Aneks SLA.pdf" },
-      { text: "Limit waloryzacji dopuszczalny umownie", src: "Opinia prawna — Wrona" },
+      { text: "SLA for critical incidents: 2 h on business days", src: "SLA addendum.pdf" },
+      { text: "Fee +8% from the 2027 period", src: "SLA addendum.pdf" },
+      { text: "An indexation cap is contractually permissible", src: "Legal opinion — Wrona" },
     ],
     openQ: [
-      { text: "Czy Contoso zgodzi się na górny limit CPI 5%", src: "Wątek: Aneks do umowy" },
-      { text: "Kto podpisuje po naszej stronie", src: "Wątek: Re: propozycja warunków" },
+      { text: "Will Contoso accept a 5% CPI cap", src: "Thread: Contract addendum" },
+      { text: "Who signs on our side", src: "Thread: Re: proposed terms" },
     ],
     dates: [
-      { text: "Decyzja o aneksie", when: "28.08", src: "Wątek: Aneks do umowy" },
-      { text: "Odpowiedź do Marty w sprawie kalkulacji", when: "27.08", src: "Wątek: Kalkulacja CPI" },
-      { text: "Wejście w życie nowej ceny", when: "01.01.2027", src: "Aneks SLA.pdf" },
+      { text: "Decision on the addendum", when: "28.08", src: "Thread: Contract addendum" },
+      { text: "Reply to Marta about the calculation", when: "27.08", src: "Thread: CPI calculation" },
+      { text: "New price takes effect", when: "01.01.2027", src: "SLA addendum.pdf" },
     ],
     facts: [
-      { p: "Czas reakcji (krytyczne)", a: "4 h", b: "2 h", src: "§ 1 aneksu" },
-      { p: "Wynagrodzenie roczne", a: "236 000 zł", b: "254 880 zł", src: "§ 2 aneksu" },
-      { p: "Limit waloryzacji CPI", a: "brak", b: "brak — negocjowany 5%", src: "§ 3 aneksu" },
-      { p: "Okres wypowiedzenia", a: "3 miesiące", b: "bez zmian", src: "Umowa ramowa" },
+      { p: "Response time (critical)", a: "4 h", b: "2 h", src: "§ 1 of the addendum" },
+      { p: "Annual fee", a: "€236,000", b: "€254,880", src: "§ 2 of the addendum" },
+      { p: "CPI indexation cap", a: "none", b: "none — 5% under negotiation", src: "§ 3 of the addendum" },
+      { p: "Notice period", a: "3 months", b: "unchanged", src: "Master agreement" },
     ],
     timeline: [
-      { d: "14.06.2021", t: "Umowa ramowa podpisana" },
-      { d: "21.08.2026", t: "Zarys zmian od Contoso" },
-      { d: "25.08.2026", t: "Kalkulacja kosztu (Marta)" },
-      { d: "27.08.2026", t: "Opinia prawna o limicie" },
-      { d: "dzisiaj", t: "Aneks w wersji do podpisu" },
+      { d: "14.06.2021", t: "Master agreement signed" },
+      { d: "21.08.2026", t: "Outline of changes from Contoso" },
+      { d: "25.08.2026", t: "Cost calculation (Marta)" },
+      { d: "27.08.2026", t: "Legal opinion on the cap" },
+      { d: "today", t: "Addendum in signature version" },
     ],
     threads: [
-      { id: "contoso", label: "Aneks do umowy — podpisy", meta: "Contoso · 6 wiadomości" },
-      { id: "anna2", label: "Re: propozycja warunków 2027", meta: "Contoso · 3 wiadomości" },
-      { id: "marta", label: "Kalkulacja CPI 2027", meta: "Finanse · 4 wiadomości" },
-      { id: "jacek", label: "Opinia prawna — limit waloryzacji", meta: "Kancelaria · 2 wiadomości" },
+      { id: "contoso", label: "Contract addendum — signatures", meta: "Contoso · 6 messages" },
+      { id: "anna2", label: "Re: proposed terms for 2027", meta: "Contoso · 3 messages" },
+      { id: "marta", label: "CPI calculation 2027", meta: "Finance · 4 messages" },
+      { id: "jacek", label: "Legal opinion — indexation cap", meta: "Law office · 2 messages" },
     ],
     docs: [
-      { type: "PDF", name: "Aneks SLA.pdf", size: "248 kB" },
-      { type: "PDF", name: "Umowa ramowa.pdf", size: "1,2 MB" },
+      { type: "PDF", name: "SLA addendum.pdf", size: "248 kB" },
+      { type: "PDF", name: "Master agreement.pdf", size: "1.2 MB" },
       { type: "XLSX", name: "CPI_2027.xlsx", size: "34 kB" },
     ],
     duties: [
-      { who: "Karolina", what: "Odpowiedź z kontrpropozycją limitu 5%", when: "28.08", state: "otwarte" },
-      { who: "Marta", what: "Aktualizacja kalkulacji po decyzji", when: "30.08", state: "czeka" },
-      { who: "Contoso", what: "Wersja aneksu z limitem", when: "02.09", state: "po ich stronie" },
+      { who: "Karolina", what: "Reply with a 5% cap counter-proposal", when: "28.08", state: "open" },
+      { who: "Marta", what: "Update the calculation after the decision", when: "30.08", state: "waiting" },
+      { who: "Contoso", what: "Addendum version with the cap", when: "02.09", state: "on their side" },
     ],
   },
   {
-    id: "fabrikam", title: "Dostawy Fabrikam Q4", parties: "Fabrikam · Logistyka",
-    status: "Potwierdzenie do 02.09", statusKind: "uwaga", owner: "KK",
-    summary: "Producent przesunął dostawę z 28.10 na 12.11. Trzeba potwierdzić, czy akceptujemy opóźnienie.",
-    scope: "2 wątki · 1 dokument",
-    agreed: [{ text: "Warunki cenowe bez zmian", src: "Wątek: Terminy dostawy Q4" }],
-    openQ: [{ text: "Czy akceptujemy przesunięcie o 15 dni", src: "Wątek: Terminy dostawy Q4" }],
-    dates: [{ text: "Potwierdzenie terminu", when: "02.09", src: "Wątek: Terminy dostawy Q4" }],
+    id: "fabrikam", title: "Fabrikam Q4 deliveries", parties: "Fabrikam · Logistics",
+    status: "Confirmation by 02.09", statusKind: "attention", owner: "KK",
+    summary: "The manufacturer moved the delivery from 28.10 to 12.11. We need to confirm whether we accept the delay.",
+    scope: "2 threads · 1 document",
+    agreed: [{ text: "Commercial terms unchanged", src: "Thread: Q4 delivery dates" }],
+    openQ: [{ text: "Do we accept the 15-day slip", src: "Thread: Q4 delivery dates" }],
+    dates: [{ text: "Confirm the date", when: "02.09", src: "Thread: Q4 delivery dates" }],
     facts: [
-      { p: "Termin dostawy", a: "28.10", b: "12.11", src: "Wiadomość Fabrikam" },
-      { p: "Cena", a: "bez zmian", b: "bez zmian", src: "Wiadomość Fabrikam" },
+      { p: "Delivery date", a: "28.10", b: "12.11", src: "Fabrikam message" },
+      { p: "Price", a: "unchanged", b: "unchanged", src: "Fabrikam message" },
     ],
     timeline: [
-      { d: "12.08.2026", t: "Zamówienie potwierdzone" },
-      { d: "wczoraj", t: "Informacja o przestoju" },
+      { d: "12.08.2026", t: "Order confirmed" },
+      { d: "yesterday", t: "Notice of the line stoppage" },
     ],
-    threads: [{ id: "fabrikam1", label: "Terminy dostawy Q4", meta: "Fabrikam · 7 wiadomości" }],
+    threads: [{ id: "fabrikam1", label: "Q4 delivery dates", meta: "Fabrikam · 7 messages" }],
     docs: [],
-    duties: [{ who: "Karolina", what: "Decyzja o akceptacji terminu", when: "02.09", state: "otwarte" }],
+    duties: [{ who: "Karolina", what: "Decide whether to accept the date", when: "02.09", state: "open" }],
   },
   {
-    id: "audyt", title: "Audyt umów IT 2024–2026", parties: "Audyt wewnętrzny",
-    status: "Wykaz do 03.09", statusKind: "uwaga", owner: "KK",
-    summary: "Audyt prosi o wykaz umów IT wraz z aneksami i terminami wypowiedzenia.",
-    scope: "2 wątki · 1 dokument",
-    agreed: [{ text: "Zakres: umowy IT 2024–2026", src: "Wątek: Zapytanie o rejestr umów" }],
-    openQ: [{ text: "Kto przygotuje wykaz", src: "Wątek: Zapytanie o rejestr umów" }],
-    dates: [{ text: "Przekazanie wykazu", when: "03.09", src: "Wątek: Zapytanie o rejestr umów" }],
-    facts: [{ p: "Liczba umów w zakresie", a: "—", b: "12 (wstępnie)", src: "Rejestr umów" }],
-    timeline: [{ d: "wczoraj", t: "Zapytanie audytu" }],
-    threads: [{ id: "audyt1", label: "Zapytanie o rejestr umów", meta: "Audyt · 3 wiadomości" }],
+    id: "audyt", title: "IT contract audit 2024–2026", parties: "Internal Audit",
+    status: "List due 03.09", statusKind: "attention", owner: "KK",
+    summary: "Audit is asking for a list of IT contracts with addenda and notice periods.",
+    scope: "2 threads · 1 document",
+    agreed: [{ text: "Scope: IT contracts 2024–2026", src: "Thread: Contract register request" }],
+    openQ: [{ text: "Who prepares the list", src: "Thread: Contract register request" }],
+    dates: [{ text: "List submitted", when: "03.09", src: "Thread: Contract register request" }],
+    facts: [{ p: "Contracts in scope", a: "—", b: "12 (preliminary)", src: "Contract register" }],
+    timeline: [{ d: "yesterday", t: "Audit request" }],
+    threads: [{ id: "audyt1", label: "Contract register request", meta: "Audit · 3 messages" }],
     docs: [{ type: "DOCX", name: "NDA_Northwind.docx", size: "72 kB" }],
-    duties: [{ who: "Karolina", what: "Wykaz umów IT", when: "03.09", state: "otwarte" }],
+    duties: [{ who: "Karolina", what: "IT contract list", when: "03.09", state: "open" }],
   },
 ];
 
 const CAL_DAYS = [
-  { dow: "PON", d: "24", today: false, ev: [
-    { time: "11:00", h: 11, t: "Rozmowa z kancelarią Wrona", kind: "spotkanie", src: "Opinia prawna — limit waloryzacji" },
+  { dow: "MON", d: "24", today: false, ev: [
+    { time: "11:00", h: 11, t: "Call with Wrona Law Office", kind: "meeting", src: "Legal opinion — indexation cap" },
   ] },
-  { dow: "WT", d: "25", today: false, ev: [
-    { time: "12:30", h: 12, t: "Kalkulacja CPI od Marty", kind: "mail", src: "Kalkulacja CPI 2027" },
+  { dow: "TUE", d: "25", today: false, ev: [
+    { time: "12:30", h: 12, t: "CPI calculation from Marta", kind: "mail", src: "CPI calculation 2027" },
   ] },
-  { dow: "ŚR", d: "26", today: false, ev: [
-    { time: "09:00", h: 9, t: "Przegląd wdrożenia Fabrikam", kind: "spotkanie", src: "Terminy dostawy Q4" },
+  { dow: "WED", d: "26", today: false, ev: [
+    { time: "09:00", h: 9, t: "Fabrikam rollout review", kind: "meeting", src: "Q4 delivery dates" },
   ] },
-  { dow: "CZW", d: "27", today: true, ev: [
-    { time: "10:00", h: 10, t: "Odpowiedź do Marty — kalkulacja", kind: "termin", src: "Kalkulacja CPI 2027" },
-    { time: "15:00", h: 15, t: "Status wdrożenia z Piotrem", kind: "spotkanie", src: "Re: harmonogram wdrożenia" },
+  { dow: "THU", d: "27", today: true, ev: [
+    { time: "10:00", h: 10, t: "Reply to Marta — calculation", kind: "deadline", src: "CPI calculation 2027" },
+    { time: "15:00", h: 15, t: "Rollout status with Piotr", kind: "meeting", src: "Re: rollout schedule" },
   ] },
-  { dow: "PT", d: "28", today: false, ev: [
-    { time: "cały dzień", h: 0, t: "Decyzja: aneks Contoso", kind: "termin", src: "Aneks do umowy — podpisy" },
-    { time: "13:00", h: 13, t: "Call z Anną Kowalską", kind: "spotkanie", src: "Aneks do umowy — podpisy" },
+  { dow: "FRI", d: "28", today: false, ev: [
+    { time: "all day", h: 0, t: "Decision: Contoso addendum", kind: "deadline", src: "Contract addendum — signatures" },
+    { time: "13:00", h: 13, t: "Call with Anna Kowalska", kind: "meeting", src: "Contract addendum — signatures" },
   ] },
-  { dow: "SOB", d: "29", today: false, ev: [
-    { time: "cały dzień", h: 0, t: "Płatność FV 08/2026", kind: "termin", src: "Faktura 08/2026" },
+  { dow: "SAT", d: "29", today: false, ev: [
+    { time: "all day", h: 0, t: "Payment of invoice 08/2026", kind: "deadline", src: "Invoice 08/2026" },
   ] },
-  { dow: "NIE", d: "30", today: false, ev: [] },
+  { dow: "SUN", d: "30", today: false, ev: [] },
 ];
 
 const CAL_PROPOSED = [
-  { id: "p1", t: "Potwierdzenie terminu dostawy Fabrikam", when: "02.09", src: "Terminy dostawy Q4" },
-  { id: "p2", t: "Wykaz umów IT dla audytu", when: "03.09", src: "Zapytanie o rejestr umów" },
-  { id: "p3", t: "Ankieta satysfakcji", when: "05.09", src: "Dział HR" },
+  { id: "p1", t: "Confirm the Fabrikam delivery date", when: "02.09", src: "Q4 delivery dates" },
+  { id: "p2", t: "IT contract list for audit", when: "03.09", src: "Contract register request" },
+  { id: "p3", t: "Satisfaction survey", when: "05.09", src: "HR Department" },
 ];
 
 const REM_TIMED = [0, 5, 15, 30, 60, 1440];
 const REM_DATED = [0, 60, 240, 1440, 2880];
 const REM_DEFAULT = [15];
 const remLabel = (m, zero) => {
-  if (m === 0) return zero || "w momencie";
-  if (m < 60) return m + " min przed";
-  if (m < 1440) { const h = m / 60; return (h === Math.round(h) ? h : String(h).replace(".", ",")) + " godz przed"; }
+  if (m === 0) return zero || "at the time";
+  if (m < 60) return m + " min before";
+  if (m < 1440) { const h = m / 60; return h + (h === 1 ? " hour before" : " hours before"); }
   const d = m / 1440;
-  return (d === Math.round(d) ? d : String(d).replace(".", ",")) + (d === 1 ? " dzień przed" : " dni przed");
+  return d + (d === 1 ? " day before" : " days before");
 };
 
 const TASKS = [
-  { id: "t1", t: "Wyślij kontrpropozycję limitu CPI 5%", when: "dziś", day: "27", group: "Dziś", src: "Aneks do umowy — podpisy", tid: "contoso", ai: true, est: "45 min" },
-  { id: "t2", t: "Odpowiedz Marcie w sprawie kalkulacji", when: "dziś", day: "27", group: "Dziś", src: "Kalkulacja CPI 2027", tid: "marta", ai: true, est: "20 min" },
-  { id: "t3", t: "Potwierdź termin dostawy Fabrikam", when: "02.09", day: "02", group: "Ten tydzień", src: "Terminy dostawy Q4", tid: "fabrikam1", ai: true, est: "15 min" },
-  { id: "t4", t: "Przygotuj wykaz umów IT dla audytu", when: "03.09", day: "03", group: "Ten tydzień", src: "Zapytanie o rejestr umów", tid: "audyt1", ai: true, est: "2 godz." },
-  { id: "t5", t: "Odpowiedz Adventure Works o SLA w weekendy", when: "01.09", day: "01", group: "Ten tydzień", src: "Pytanie o SLA w weekendy", tid: "klient3", ai: true, est: "30 min" },
-  { id: "t6", t: "Zamknij budżet 2027 po decyzji Contoso", when: "10.09", day: "10", group: "Później", src: "Kalkulacja CPI 2027", tid: "marta", ai: false, est: "1 godz." },
-  { id: "t7", t: "Podpisz NDA z Northwind", when: "12.09", day: "12", group: "Później", src: "Projekt NDA — Northwind", tid: "prawnik2", ai: false, est: "10 min" },
+  { id: "t1", t: "Send the 5% CPI cap counter-proposal", when: "today", day: "27", group: "Today", src: "Contract addendum — signatures", tid: "contoso", ai: true, est: "45 min" },
+  { id: "t2", t: "Reply to Marta about the calculation", when: "today", day: "27", group: "Today", src: "CPI calculation 2027", tid: "marta", ai: true, est: "20 min" },
+  { id: "t3", t: "Confirm the Fabrikam delivery date", when: "02.09", day: "02", group: "This week", src: "Q4 delivery dates", tid: "fabrikam1", ai: true, est: "15 min" },
+  { id: "t4", t: "Prepare the IT contract list for audit", when: "03.09", day: "03", group: "This week", src: "Contract register request", tid: "audyt1", ai: true, est: "2 hrs" },
+  { id: "t5", t: "Answer Adventure Works on weekend SLA", when: "01.09", day: "01", group: "This week", src: "Question about weekend SLA", tid: "klient3", ai: true, est: "30 min" },
+  { id: "t6", t: "Close the 2027 budget after the Contoso decision", when: "10.09", day: "10", group: "Later", src: "CPI calculation 2027", tid: "marta", ai: false, est: "1 hr" },
+  { id: "t7", t: "Sign the Northwind NDA", when: "12.09", day: "12", group: "Later", src: "Draft NDA — Northwind", tid: "prawnik2", ai: false, est: "10 min" },
 ];
 
 const CAL_FOCUS = [
-  { day: "27", time: "16:00", len: "45 min", t: "Przygotowanie kontrpropozycji CPI", why: "Termin decyzji mija jutro, a szkic nie jest gotowy." },
-  { day: "28", time: "09:15", len: "30 min", t: "Przegląd aneksu przed callem", why: "Call z Anną o 13:00 — warto wejść z gotowym stanowiskiem." },
+  { day: "27", time: "16:00", len: "45 min", t: "Draft the CPI counter-proposal", why: "The decision is due tomorrow and the draft is not ready." },
+  { day: "28", time: "09:15", len: "30 min", t: "Review the addendum before the call", why: "The call with Anna is at 13:00 — better to go in with a position." },
 ];
 
-/* KONTAKTY ZEBRANE — budowane automatycznie z nagłówków odebranej poczty (nadawcy spoza książki adresowej).
-   W aplikacji docelowej ta lista powstaje przy indeksowaniu skrzynki i nie jest synchronizowana na serwer,
-   dopóki użytkownik nie przeniesie kontaktu do własnych. */
+/* COLLECTED CONTACTS — built automatically from the headers of received mail (senders not in the address book).
+   In the real app this list is produced while indexing the mailbox and is not synced to the server
+   until the user moves a contact into their own. */
 const collectFromMail = (known) => {
   const map = {};
   THREADS.forEach(t => {
@@ -3822,182 +3822,182 @@ const collectFromMail = (known) => {
     const mail = (meta.match(/[\w.+-]+@[\w.-]+/) || [""])[0];
     const when = meta.split(" · ")[1] || t.time;
     if (!map[t.from]) map[t.from] = {
-      id: "auto-" + t.id, name: t.from, role: "Kontakt zebrany z poczty", org: t.org || (mail ? mail.split("@")[1] : "—"),
+      id: "auto-" + t.id, name: t.from, role: "Collected from mail", org: t.org || (mail ? mail.split("@")[1] : "—"),
       mail: mail || "—", last: when, owed: "—", cases: "—", collected: true, msgs: 0,
       threads: [], docs: [],
     };
     const c = map[t.from];
-    c.msgs += parseInt((meta.match(/wątek: (\d+)/) || [])[1] || "1", 10);
-    c.threads.push({ id: t.id, label: t.subject, meta: (meta.split("wątek: ")[1] || "") });
+    c.msgs += parseInt((meta.match(/thread: (\d+)/) || [])[1] || "1", 10);
+    c.threads.push({ id: t.id, label: t.subject, meta: (meta.split("thread: ")[1] || "") });
     (t.attachments || []).forEach(a => c.docs.push(a));
   });
   return Object.keys(map).map(k => {
     const c = map[k];
-    c.note = "Kontakt utworzony automatycznie na podstawie odebranej poczty — " + c.msgs + (c.msgs === 1 ? " wiadomość" : c.msgs < 5 ? " wiadomości" : " wiadomości") +
-      " w " + c.threads.length + (c.threads.length === 1 ? " wątku" : " wątkach") + ". Nie ma go w książce adresowej; dodaj do własnych, żeby uzupełnić rolę i notatki.";
+    c.note = "Contact created automatically from received mail — " + c.msgs + (c.msgs === 1 ? " message" : " messages") +
+      " across " + c.threads.length + (c.threads.length === 1 ? " thread" : " threads") + ". Not in the address book; add to your own to fill in role and notes.";
     return c;
   });
 };
 
 const CONTACT_AI = {
-  anna: { reply: "≈ 3 h", peak: "rano 8–11", style: "Konkrety, liczby, krótkie akapity", next: "Wyślij kontrpropozycję limitu CPI 5% i potwierdź akceptację SLA 2 h.", wait: "czeka na nas 2 dni" },
-  marta: { reply: "≈ 1 h", peak: "południe", style: "Liczby i arkusze, bez ogólników", next: "Potwierdź kierunek negocjacji, żeby mogła zamknąć budżet 2027.", wait: "czeka na nas 1 dzień" },
-  piotr: { reply: "≈ 5 h", peak: "popołudnie", style: "Punkty i terminy", next: "Poproś o konkretną datę testów UAT — to jedyna otwarta pozycja.", wait: "" },
-  jacek: { reply: "≈ 1 dzień", peak: "rano", style: "Formalnie, z odniesieniem do paragrafów", next: "Poproś o gotowy zapis limitu waloryzacji do wklejenia w aneks.", wait: "" },
-  tomasz: { reply: "≈ 4 h", peak: "rano", style: "Rzeczowo, z datami", next: "Potwierdź lub zakwestionuj termin 12.11 — deadline 02.09.", wait: "czeka na nas 1 dzień" },
-  ewa: { reply: "≈ 2 h", peak: "rano", style: "Pytania wprost, oczekuje jednoznacznej odpowiedzi", next: "Odpowiedz, czy wsparcie weekendowe jest możliwe i na jakich warunkach.", wait: "czeka na nas 1 dzień" },
+  anna: { reply: "≈ 3 h", peak: "mornings 8–11", style: "Specifics, numbers, short paragraphs", next: "Send the 5% CPI cap counter-proposal and confirm you accept the 2 h SLA.", wait: "waiting on us for 2 days" },
+  marta: { reply: "≈ 1 h", peak: "midday", style: "Numbers and spreadsheets, no generalities", next: "Confirm the negotiating line so she can close the 2027 budget.", wait: "waiting on us for 1 day" },
+  piotr: { reply: "≈ 5 h", peak: "afternoons", style: "Bullet points and dates", next: "Ask for a firm UAT date — it is the only open item.", wait: "" },
+  jacek: { reply: "≈ 1 day", peak: "mornings", style: "Formal, with clause references", next: "Ask for ready wording of the indexation cap to paste into the addendum.", wait: "" },
+  tomasz: { reply: "≈ 4 h", peak: "mornings", style: "To the point, with dates", next: "Confirm or challenge the 12.11 date — deadline 02.09.", wait: "waiting on us for 1 day" },
+  ewa: { reply: "≈ 2 h", peak: "mornings", style: "Direct questions, expects a clear answer", next: "Answer whether weekend support is possible and on what terms.", wait: "waiting on us for 1 day" },
 };
 
 const CONTACTS = [
-  { id: "anna", name: "Anna Kowalska", role: "Dyrektor operacyjny", org: "Contoso", mail: "a.kowalska@contoso.example",
-    last: "dzisiaj 09:14", owed: "Decyzja o aneksie do 28.08", cases: "Renegocjacja umowy Contoso 2027",
-    note: "Prowadzi renegocjację aneksu. Odpowiada zwykle tego samego dnia; oczekuje naszej decyzji przed końcem tygodnia.",
-    threads: [{ id: "contoso", label: "Aneks do umowy — podpisy", meta: "6 wiadomości" }, { id: "anna2", label: "Re: propozycja warunków 2027", meta: "3 wiadomości" }],
-    docs: [{ type: "PDF", name: "Aneks SLA.pdf", size: "248 kB" }, { type: "XLSX", name: "Kalkulacja_2027.xlsx", size: "42 kB" }] },
-  { id: "marta", name: "Marta Nowak", role: "Kontroling", org: "Finanse · wewnętrzne", mail: "m.nowak@firma.pl",
-    last: "wczoraj 11:20", owed: "Nasza odpowiedź do 27.08", cases: "Renegocjacja umowy Contoso 2027",
-    note: "Policzyła wpływ podwyżki na koszt roczny. Czeka na decyzję, żeby zaktualizować budżet 2027.",
-    threads: [{ id: "marta", label: "Kalkulacja CPI 2027", meta: "4 wiadomości" }],
+  { id: "anna", name: "Anna Kowalska", role: "Chief Operating Officer", org: "Contoso", mail: "a.kowalska@contoso.example",
+    last: "today 09:14", owed: "Addendum decision by 28.08", cases: "Contoso contract renegotiation 2027",
+    note: "Leads the addendum renegotiation. Usually replies the same day; expects our decision before the end of the week.",
+    threads: [{ id: "contoso", label: "Contract addendum — signatures", meta: "6 messages" }, { id: "anna2", label: "Re: proposed terms for 2027", meta: "3 messages" }],
+    docs: [{ type: "PDF", name: "SLA addendum.pdf", size: "248 kB" }, { type: "XLSX", name: "Calculation_2027.xlsx", size: "42 kB" }] },
+  { id: "marta", name: "Marta Nowak", role: "Controlling", org: "Finance · internal", mail: "m.nowak@company.example",
+    last: "yesterday 11:20", owed: "Our reply by 27.08", cases: "Contoso contract renegotiation 2027",
+    note: "Calculated the impact of the increase on annual cost. Waiting on a decision to update the 2027 budget.",
+    threads: [{ id: "marta", label: "CPI calculation 2027", meta: "4 messages" }],
     docs: [{ type: "XLSX", name: "CPI_2027.xlsx", size: "34 kB" }] },
-  { id: "piotr", name: "Piotr Zieliński", role: "Kierownik wdrożeń", org: "Wdrożenia · wewnętrzne", mail: "p.zielinski@firma.pl",
-    last: "wczoraj 16:41", owed: "Piotr: plan testów UAT", cases: "—",
-    note: "Potwierdził etap drugi harmonogramu. Termin testów UAT wciąż nieustalony.",
-    threads: [{ id: "piotr", label: "Re: harmonogram wdrożenia", meta: "9 wiadomości" }],
+  { id: "piotr", name: "Piotr Zieliński", role: "Head of Delivery", org: "Delivery · internal", mail: "p.zielinski@company.example",
+    last: "yesterday 16:41", owed: "Piotr: UAT test plan", cases: "—",
+    note: "Confirmed phase two of the schedule. The UAT window is still unset.",
+    threads: [{ id: "piotr", label: "Re: rollout schedule", meta: "9 messages" }],
     docs: [] },
-  { id: "jacek", name: "Jacek Wrona", role: "Radca prawny", org: "Kancelaria Wrona", mail: "j.wrona@kancelaria.example",
-    last: "24.08.2026", owed: "Brak", cases: "Renegocjacja Contoso · Audyt umów IT",
-    note: "Potwierdził dopuszczalność limitu waloryzacji. Przygotowuje NDA dla Northwind.",
-    threads: [{ id: "jacek", label: "Opinia prawna — limit waloryzacji", meta: "2 wiadomości" }, { id: "prawnik2", label: "Projekt NDA — Northwind", meta: "2 wiadomości" }],
+  { id: "jacek", name: "Jacek Wrona", role: "Attorney at law", org: "Wrona Law Office", mail: "j.wrona@lawoffice.example",
+    last: "24.08.2026", owed: "None", cases: "Contoso renegotiation · IT contract audit",
+    note: "Confirmed that an indexation cap is permissible. Preparing the Northwind NDA.",
+    threads: [{ id: "jacek", label: "Legal opinion — indexation cap", meta: "2 messages" }, { id: "prawnik2", label: "Draft NDA — Northwind", meta: "2 messages" }],
     docs: [{ type: "DOCX", name: "NDA_Northwind.docx", size: "72 kB" }] },
-  { id: "tomasz", name: "Tomasz Bąk", role: "Opiekun klienta", org: "Fabrikam", mail: "t.bak@fabrikam.example",
-    last: "wczoraj 17:05", owed: "Nasze potwierdzenie do 02.09", cases: "Dostawy Fabrikam Q4",
-    note: "Zgłosił przesunięcie dostawy o 15 dni z powodu przestoju u producenta.",
-    threads: [{ id: "fabrikam1", label: "Terminy dostawy Q4", meta: "7 wiadomości" }],
+  { id: "tomasz", name: "Tomasz Bąk", role: "Account manager", org: "Fabrikam", mail: "t.bak@fabrikam.example",
+    last: "yesterday 17:05", owed: "Our confirmation by 02.09", cases: "Fabrikam Q4 deliveries",
+    note: "Reported a 15-day delivery slip caused by a stoppage at the manufacturer.",
+    threads: [{ id: "fabrikam1", label: "Q4 delivery dates", meta: "7 messages" }],
     docs: [] },
   { id: "ewa", name: "Ewa Sikora", role: "IT Manager", org: "Adventure Works", mail: "e.sikora@adventure.example",
-    last: "wczoraj 10:15", owed: "Odpowiedź o SLA w weekendy do 01.09", cases: "—",
-    note: "Pyta o rozszerzenie wsparcia na weekendy — obecna umowa obejmuje dni robocze.",
-    threads: [{ id: "klient3", label: "Pytanie o SLA w weekendy", meta: "4 wiadomości" }],
+    last: "yesterday 10:15", owed: "Weekend SLA answer by 01.09", cases: "—",
+    note: "Asking about extending support to weekends — the current contract covers business days.",
+    threads: [{ id: "klient3", label: "Question about weekend SLA", meta: "4 messages" }],
     docs: [] },
 ];
 
-const DOW_DAY = { "poniedziałek": "24", "wtorek": "25", "środ": "26", "czwartek": "27", "piątek": "28", "sobot": "29", "niedziel": "30", "dziś": "27", "dzisiaj": "27", "jutro": "28", "pojutrze": "29" };
+const DOW_DAY = { "monday": "24", "tuesday": "25", "wednesday": "26", "thursday": "27", "friday": "28", "saturday": "29", "sunday": "30", "today": "27", "tomorrow": "28", "day after tomorrow": "29" };
 
 const parseEventPrompt = (raw) => {
   const txt = (raw || "").trim();
   const low = txt.toLowerCase();
   let day = "";
   Object.keys(DOW_DAY).forEach(k => { if (!day && low.indexOf(k) >= 0) day = DOW_DAY[k]; });
-  const dm = low.match(/\b(\d{1,2})[.\s]?(?:sierpnia|08)\b/);
+  const dm = low.match(/\b(\d{1,2})[.\s]?(?:aug|august|08)\b/);
   if (dm) day = dm[1];
-  const tm = low.match(/\b(\d{1,2})[:.](\d{2})\b/) || low.match(/\b(?:o|po|na)\s+(\d{1,2})\b/);
+  const tm = low.match(/\b(\d{1,2})[:.](\d{2})\b/) || low.match(/\b(?:at|after|by)\s+(\d{1,2})\b/);
   const time = tm ? (tm[1].length < 2 ? "0" + tm[1] : tm[1]) + ":" + (tm[2] || "00") : "";
-  const dur = low.match(/\b(\d{2,3})\s*(?:min|minut)/) || low.match(/\b(\d)\s*(?:h|godz)/);
-  const who = txt.match(/z\s+([A-ZĄĆĘŁŃÓŚŹŻ][a-ząćęłńóśźż]+(?:\s+[A-ZĄĆĘŁŃÓŚŹŻ][a-ząćęłńóśźż]+)?)/);
+  const dur = low.match(/\b(\d{2,3})\s*(?:min|minutes?)/) || low.match(/\b(\d)\s*(?:h|hrs?|hours?)/);
+  const who = txt.match(/with\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)?)/i);
   let title = txt
-    .replace(/\b(w|we)\s+\w+\b/gi, " ")
-    .replace(/\b(o|po|na)\s+\d{1,2}([:.]\d{2})?\b/gi, " ")
-    .replace(/\b\d{1,3}\s*(min|minut|h|godz)\w*\b/gi, " ")
+    .replace(/\bon\s+\w+day\b/gi, " ")
+    .replace(/\b(at|after|by)\s+\d{1,2}([:.]\d{2})?(am|pm)?\b/gi, " ")
+    .replace(/\b\d{1,3}\s*(min|minutes?|h|hrs?|hours?)\b/gi, " ")
     .replace(/\s{2,}/g, " ")
     .replace(/[,;]\s*$/, "")
     .trim();
-  if (!title) title = "Nowe wydarzenie";
+  if (!title) title = "New event";
   title = title.charAt(0).toUpperCase() + title.slice(1);
   const chips = [];
-  chips.push(day ? day + ".08" : "28.08 (domyślnie)");
-  chips.push(time || "12:00 (domyślnie)");
+  chips.push(day ? day + ".08" : "28.08 (default)");
+  chips.push(time || "12:00 (default)");
   if (dur) chips.push(dur[0].replace(/\s+/g, " "));
-  if (who) chips.push("uczestnik: " + who[1]);
-  if (low.indexOf("aneks") >= 0 || low.indexOf("contoso") >= 0) chips.push("wątek: Aneks do umowy");
+  if (who) chips.push("attendee: " + who[1]);
+  if (low.indexOf("addendum") >= 0 || low.indexOf("contoso") >= 0) chips.push("thread: Contract addendum");
   return { title, day: day || "28", time: time || "12:00", chips };
 };
 
 const AGENT_REPLIES = [
   {
-    match: /(zaplanuj|plan).*(dzie|dzień)|zaplanuj mój dzień/i,
-    scope: "kalendarz · 14 nowych wiadomości",
-    text: "Dziś masz dwa spotkania i jeden termin krytyczny jutro. Proponuję taki układ dnia:",
+    match: /(plan|schedule).*(day)|plan my day/i,
+    scope: "calendar · 14 new messages",
+    text: "Today you have two meetings, and one critical deadline tomorrow. Here is how I would lay out the day:",
     bullets: [
-      "10:00–10:30 — odpowiedź do Marty w sprawie kalkulacji CPI",
-      "15:00–15:45 — status wdrożenia z Piotrem (już w kalendarzu)",
-      "16:00–16:45 — blok na kontrpropozycję limitu CPI dla Contoso",
+      "10:00–10:30 — reply to Marta about the CPI calculation",
+      "15:00–15:45 — rollout status with Piotr (already in the calendar)",
+      "16:00–16:45 — block for the CPI cap counter-proposal to Contoso",
     ],
     actions: [
-      { label: "Zarezerwuj bloki", kind: "cal" },
-      { label: "Otwórz kalendarz", kind: "gocal" },
+      { label: "Book the blocks", kind: "cal" },
+      { label: "Open the calendar", kind: "gocal" },
     ],
   },
   {
-    match: /umkn|przeoczy|zapomnia/i,
-    scope: "7 dni · 3 konta",
-    text: "Trzy rzeczy czekają na Ciebie dłużej niż dwa dni:",
+    match: /slip|missed|forgot|overdue/i,
+    scope: "7 days · 3 accounts",
+    text: "Three things have been waiting on you for more than two days:",
     bullets: [
-      "Contoso — kontrpropozycja limitu CPI (decyzja jutro)",
-      "Fabrikam — potwierdzenie terminu 12.11 (do 02.09)",
-      "Adventure Works — pytanie o SLA w weekendy (bez odpowiedzi od 5 dni)",
+      "Contoso — CPI cap counter-proposal (decision tomorrow)",
+      "Fabrikam — confirm the 12.11 date (by 02.09)",
+      "Adventure Works — weekend SLA question (unanswered for 5 days)",
     ],
     actions: [
-      { label: "Przygotuj odpowiedź do Contoso", kind: "draft" },
-      { label: "Otwórz wątek Fabrikam", kind: "thread", tid: "fabrikam1" },
+      { label: "Draft a reply to Contoso", kind: "draft" },
+      { label: "Open the Fabrikam thread", kind: "thread", tid: "fabrikam1" },
     ],
   },
   {
-    match: /contoso|aneks|cpi|odpowied|napisz|szkic/i,
-    scope: "wątek: Aneks do umowy — 6 wiadomości",
-    text: "Przygotowałem odpowiedź do Anny Kowalskiej: akceptujemy SLA 2 h, w zamian prosimy o górny limit waloryzacji CPI 5% rocznie. Szkic jest gotowy do sprawdzenia.",
+    match: /contoso|addendum|cpi|reply|write|draft/i,
+    scope: "thread: Contract addendum — 6 messages",
+    text: "I drafted a reply to Anna Kowalska: we accept the 2 h SLA and in return ask for a 5% annual cap on CPI indexation. The draft is ready for review.",
     bullets: [
-      "Powołuje się na § 3 aneksu i prognozę CPI 4,1%",
-      "Domyka decyzję terminem 28 sierpnia",
+      "Cites § 3 of the addendum and the 4.1% CPI forecast",
+      "Closes the decision with the 28 August deadline",
     ],
     actions: [
-      { label: "Otwórz szkic w edytorze", kind: "draft" },
-      { label: "Pokaż wątek", kind: "thread", tid: "contoso" },
+      { label: "Open the draft in the editor", kind: "draft" },
+      { label: "Show the thread", kind: "thread", tid: "contoso" },
     ],
     sources: [
-      { n: "1", title: "Aneks do umowy — podpisy", snippet: "„Czas reakcji skraca się z 4 do 2 godzin, wynagrodzenie +8%…”", meta: "18.11.2025 · Aneks SLA.pdf", tid: "contoso" },
-      { n: "2", title: "Kalkulacja CPI 2027", snippet: "„CPI prognozowane 4,1% dokłada 10 542 zł…”", meta: "wczoraj · Marta Nowak", tid: "marta" },
+      { n: "1", title: "Contract addendum — signatures", snippet: "“Response time drops from 4 to 2 hours, fee +8%…”", meta: "18.11.2025 · SLA addendum.pdf", tid: "contoso" },
+      { n: "2", title: "CPI calculation 2027", snippet: "“A 4.1% CPI forecast adds €10,542…”", meta: "yesterday · Marta Nowak", tid: "marta" },
     ],
   },
   {
-    match: /sprawa|status|contoso 2027|w toku/i,
-    scope: "3 sprawy w toku",
-    text: "Najgorętsza jest renegocjacja Contoso 2027 — jedna otwarta kwestia i decyzja jutro. Fabrikam i audyt mają terminy w przyszłym tygodniu.",
+    match: /case|status|contoso 2027|in progress/i,
+    scope: "3 cases in progress",
+    text: "The hottest one is the Contoso 2027 renegotiation — one open question and a decision tomorrow. Fabrikam and the audit have deadlines next week.",
     bullets: [],
     actions: [
-      { label: "Otwórz sprawę Contoso", kind: "case" },
-      { label: "Przygotuj odpowiedź", kind: "draft" },
+      { label: "Open the Contoso case", kind: "case" },
+      { label: "Draft a reply", kind: "draft" },
     ],
     sources: [
-      { n: "1", title: "Aneks do umowy — podpisy", snippet: "„Czas reakcji skraca się z 4 do 2 godzin, wynagrodzenie +8%…”", meta: "18.11.2025 · Aneks SLA.pdf", tid: "contoso" },
-      { n: "2", title: "Terminy dostawy Q4", snippet: "„Dostawa przesunięta na 12.11…”", meta: "wczoraj · Tomasz Bąk", tid: "fabrikam1" },
-      { n: "3", title: "Zapytanie o rejestr umów", snippet: "„Prosimy o kompletny wykaz umów IT z lat 2024–2026…”", meta: "wczoraj · Audyt wewnętrzny", tid: "audyt1" },
+      { n: "1", title: "Contract addendum — signatures", snippet: "“Response time drops from 4 to 2 hours, fee +8%…”", meta: "18.11.2025 · SLA addendum.pdf", tid: "contoso" },
+      { n: "2", title: "Q4 delivery dates", snippet: "“Delivery moved to 12.11…”", meta: "yesterday · Tomasz Bąk", tid: "fabrikam1" },
+      { n: "3", title: "Contract register request", snippet: "“Please send a complete list of IT contracts for 2024–2026…”", meta: "yesterday · Internal Audit", tid: "audyt1" },
     ],
   },
 ];
 
 const AGENT_FALLBACK = {
-  scope: "214 138 wiadomości w zakresie",
-  text: "Przejrzałem korespondencję w tym zakresie. Mogę przygotować odpowiedź, zarezerwować czas w kalendarzu albo pokazać wątki, z których to wynika — powiedz, co ma być dalej.",
+  scope: "214,138 messages in scope",
+  text: "I went through the correspondence in that scope. I can draft a reply, block time in the calendar or show the threads behind it — tell me what should happen next.",
   bullets: [],
   actions: [
-    { label: "Przygotuj odpowiedź", kind: "draft" },
-    { label: "Zaplanuj mój dzień", kind: "planday" },
+    { label: "Draft a reply", kind: "draft" },
+    { label: "Plan my day", kind: "planday" },
   ],
 };
 
-const AGENT_DRAFT_HTML = '<div id="ai-draft-block" style="border-left:3px solid var(--accent);padding-left:14px;margin-left:-14px"><p style="margin:0 0 12px 0">Dzień dobry,</p><p style="margin:0 0 12px 0">dziękuję za przesłany aneks. Akceptujemy skrócenie czasu reakcji na zgłoszenia krytyczne do 2 godzin w dni robocze.</p><p style="margin:0 0 12px 0">Prosimy jednocześnie o wprowadzenie górnego limitu waloryzacji CPI na poziomie 5% rocznie. Przy prognozie 4,1% daje to obu stronom przewidywalny koszt w perspektywie 2027 roku.</p><p style="margin:0">Jeżeli limit jest akceptowalny, jesteśmy gotowi zamknąć decyzję do 28 sierpnia.</p></div><p style="margin:12px 0 0 0">Pozdrawiam,<br />Karolina Kowalska</p>';
+const AGENT_DRAFT_HTML = '<div id="ai-draft-block" style="border-left:3px solid var(--accent);padding-left:14px;margin-left:-14px"><p style="margin:0 0 12px 0">Hello,</p><p style="margin:0 0 12px 0">thank you for the addendum. We accept shortening the response time for critical incidents to 2 hours on business days.</p><p style="margin:0 0 12px 0">At the same time we ask for an upper cap on CPI indexation of 5% per year. At the 4.1% forecast this gives both sides a predictable cost through 2027.</p><p style="margin:0">If the cap is acceptable, we are ready to close the decision by 28 August.</p></div><p style="margin:12px 0 0 0">Best regards,<br />Karolina Kowalska</p>';
 
 const STATE_SRC = { contoso: [5, 4, 5] };
 
-/* NAGŁÓWKI ADRESOWE WIADOMOŚCI — w realnej skrzynce przychodzą z serwera (From / Reply-To / To / Cc).
-   Tu adresy wyliczamy z książki kontaktów, a Reply-To i Kopię trzymamy jako dane wątku, bo tylko
-   część korespondencji je ma — i właśnie dlatego rozwijanie musi być opcjonalne. */
-const MY_MAIL = "k.kowalska@firma.pl";
+/* MESSAGE ADDRESS HEADERS — in a real mailbox these come from the server (From / Reply-To / To / Cc).
+   Here addresses are derived from the contact book, while Reply-To and CC are thread data, because only
+   some correspondence carries them — which is exactly why expanding has to be optional. */
+const MY_MAIL = "k.kowalska@company.example";
 const slugMail = (name) => {
   const p = (name || "").toLowerCase().replace(/ł/g, "l").replace(/ą/g, "a").replace(/ć/g, "c").replace(/ę/g, "e")
     .replace(/ń/g, "n").replace(/ó/g, "o").replace(/ś/g, "s").replace(/[żź]/g, "z").split(/\s+/).filter(Boolean);
   if (!p.length) return "";
-  return (p.length > 1 ? p[0][0] + "." + p[p.length - 1] : p[0]) + "@firma.pl";
+  return (p.length > 1 ? p[0][0] + "." + p[p.length - 1] : p[0]) + "@company.example";
 };
 const addrOf = (name) => {
   if (name === ME) return MY_MAIL;
@@ -4009,8 +4009,8 @@ const addrOf = (name) => {
 };
 const fullAddr = (name) => name === addrOf(name) ? name : name + " <" + addrOf(name) + ">";
 
-/* Reply-To i Kopia występują tylko tam, gdzie mają sens merytoryczny. */
-const HDR_REPLY_TO = { contoso: "Frida Iversen <frida.iversen@contoso.example>", audyt1: "Jacek Wrona <j.wrona@firma.pl>" };
+/* Reply-To and CC appear only where they make sense. */
+const HDR_REPLY_TO = { contoso: "Frida Iversen <frida.iversen@contoso.example>", audyt1: "Jacek Wrona <j.wrona@company.example>" };
 const HDR_CC = { contoso: ["Marta Nowak"], marta: ["Jacek Wrona"], klient3: ["Anna Kowalska"] };
 
 const msgAddrRows = (thread, m, msgs) => {
@@ -4019,7 +4019,7 @@ const msgAddrRows = (thread, m, msgs) => {
   const cc = (HDR_CC[thread.id] || []).filter(n => n !== m.from && to.indexOf(n) < 0);
   const replyTo = !m.mine && HDR_REPLY_TO[thread.id] ? HDR_REPLY_TO[thread.id] : "";
   const rows = [];
-  if (replyTo) rows.push({ label: "Odpowiedź do", value: replyTo });
+  if (replyTo) rows.push({ label: "Reply-to", value: replyTo });
   if (to.length) rows.push({ label: "Do", value: to.map(fullAddr).join(", ") });
   if (cc.length) rows.push({ label: "Kopia", value: cc.map(fullAddr).join(", ") });
   return { rows, count: (replyTo ? 1 : 0) + to.length + cc.length };
@@ -4030,9 +4030,9 @@ function formatMsgTime(ts) {
   const diff = Date.now() - ts;
   if (diff < 45000) return "teraz";
   const min = Math.floor(diff / 60000);
-  if (min < 60) return min + " " + (min === 1 ? "minutę" : (min >= 2 && min <= 4 ? "minuty" : "minut")) + " temu";
+  if (min < 60) return min + " " + (min === 1 ? "minute" : "minutes") + " ago";
   const hrs = Math.floor(diff / 3600000);
-  if (hrs < 24) return hrs + " " + (hrs === 1 ? "godzinę" : (hrs >= 2 && hrs <= 4 ? "godziny" : "godzin")) + " temu";
+  if (hrs < 24) return hrs + " " + (hrs === 1 ? "hour" : "hours") + " ago";
   const d = new Date(ts);
   const pad = (n) => String(n).padStart(2, "0");
   return pad(d.getDate()) + "." + pad(d.getMonth() + 1) + "." + d.getFullYear() + " " + pad(d.getHours()) + ":" + pad(d.getMinutes());
@@ -4052,35 +4052,35 @@ const notifTime = (mins) => {
   const m = Number(mins) || 0;
   if (m < 1) return "teraz";
   if (m < 60) return m + " min";
-  if (m < 1440) return Math.round(m / 60) + " godz";
-  if (m < 2880) return "wczoraj";
+  if (m < 1440) return Math.round(m / 60) + " h";
+  if (m < 2880) return "yesterday";
   return Math.round(m / 1440) + " dni";
 };
 
 const NOTIFS = [
-  { id: "n1", kind: "mail", unread: true, mins: 3, title: "Anna Kowalska odpowiedziała", body: "Kontrpropozycja limitu CPI — prosi o akceptację do jutra.", src: "Poczta · Contoso", go: { screen: "mail", thread: "contoso" } },
-  { id: "n2", kind: "cal", unread: true, mins: 26, title: "Spotkanie za 30 minut", body: "Przegląd aneksu Contoso · sala Nordwind i Teams.", src: "Kalendarz", go: { screen: "cal" } },
-  { id: "n3", kind: "case", unread: true, mins: 74, title: "Fabrikam czeka na potwierdzenie", body: "Termin potwierdzenia dostawy mija 02.09.", src: "Sprawy · Dostawy Fabrikam Q4", go: { screen: "cases" } },
-  { id: "n4", kind: "task", unread: false, mins: 150, title: "Zadanie: wykaz umów IT", body: "Audyt czeka na wykaz z terminami wypowiedzenia.", src: "Zadania", go: { screen: "tasks" } },
-  { id: "n5", kind: "mail", unread: false, mins: 320, title: "Nowy załącznik w wątku o audycie", body: "Marek Wiśniewski dodał dwa pliki do wątku „Audyt umów IT”.", src: "Poczta · Audyt", go: { screen: "mail", thread: "audyt" } },
-  { id: "n6", kind: "system", unread: false, mins: 700, title: "Synchronizacja zakończona", body: "3 konta, 12 nowych wątków, 1 konto wymaga ponownego logowania.", src: "System", go: null },
-  { id: "n7", kind: "cal", unread: false, mins: 1580, title: "Zaproszenie na spotkanie", body: "Nordwind — negocjacje SLA, wtorek 10:00.", src: "Kalendarz", go: { screen: "cal" } },
+  { id: "n1", kind: "mail", unread: true, mins: 3, title: "Anna Kowalska replied", body: "CPI cap counter-proposal — she asks for approval by tomorrow.", src: "Mail · Contoso", go: { screen: "mail", thread: "contoso" } },
+  { id: "n2", kind: "cal", unread: true, mins: 26, title: "Meeting in 30 minutes", body: "Contoso addendum review · Nordwind room and Teams.", src: "Calendar", go: { screen: "cal" } },
+  { id: "n3", kind: "case", unread: true, mins: 74, title: "Fabrikam is waiting for confirmation", body: "The delivery confirmation is due 02.09.", src: "Cases · Fabrikam Q4 deliveries", go: { screen: "cases" } },
+  { id: "n4", kind: "task", unread: false, mins: 150, title: "Task: IT contract list", body: "Audit is waiting for the list with notice periods.", src: "Tasks", go: { screen: "tasks" } },
+  { id: "n5", kind: "mail", unread: false, mins: 320, title: "New attachment in the audit thread", body: "Marek Wiśniewski added two files to “IT contract audit”.", src: "Mail · Audit", go: { screen: "mail", thread: "audyt" } },
+  { id: "n6", kind: "system", unread: false, mins: 700, title: "Sync finished", body: "3 accounts, 12 new threads, 1 account needs to sign in again.", src: "System", go: null },
+  { id: "n7", kind: "cal", unread: false, mins: 1580, title: "Meeting invitation", body: "Nordwind — SLA negotiations, Tuesday 10:00.", src: "Calendar", go: { screen: "cal" } },
 ];
 
 const INCOMING = [
-  { kind: "mail", title: "Tomasz Zieliński: potwierdzenie terminu", body: "Fabrikam potwierdza dostawę 12.11 — prosi o akceptację.", src: "Poczta · Fabrikam", go: { screen: "mail", thread: "fabrikam" } },
-  { kind: "cal", title: "Spotkanie za 10 minut", body: "Contoso — telekonferencja o limicie CPI.", src: "Kalendarz", go: { screen: "cal" } },
-  { kind: "case", title: "Nowy dokument w sprawie", body: "Aneks nr 3 (wersja 4) dołączony do sprawy Contoso 2027.", src: "Sprawy · Renegocjacja Contoso", go: { screen: "cases" } },
+  { kind: "mail", title: "Tomasz Zieliński: date confirmation", body: "Fabrikam confirms delivery on 12.11 — asks for approval.", src: "Mail · Fabrikam", go: { screen: "mail", thread: "fabrikam" } },
+  { kind: "cal", title: "Meeting in 10 minutes", body: "Contoso — call about the CPI cap.", src: "Calendar", go: { screen: "cal" } },
+  { kind: "case", title: "New document in a case", body: "Addendum no. 3 (version 4) attached to the Contoso 2027 case.", src: "Cases · Contoso renegotiation", go: { screen: "cases" } },
 ];
 
 class Component extends DCLogic {
-  state = { workMode: "normalny", tabs: [{ key: "thread:contoso", kind: "thread", id: "contoso" }], activeTab: "thread:contoso", screen: "discover", phase: "idle", query: "", planKey: null, ready: {}, ev: null, threadId: "contoso", fromCite: null, cameFrom: false, mailAnswer: false, mailPane: "list", themeOverride: null, stateOpen: false, vw: typeof window !== "undefined" ? window.innerWidth : 1440, listW: 340, remMap: { t1: [15], t3: [1440, 60] }, remUnit: "min" };
+  state = { workMode: "classic", tabs: [{ key: "thread:contoso", kind: "thread", id: "contoso" }], activeTab: "thread:contoso", screen: "discover", phase: "idle", query: "", planKey: null, ready: {}, ev: null, threadId: "contoso", fromCite: null, cameFrom: false, mailAnswer: false, mailPane: "list", themeOverride: null, stateOpen: false, vw: typeof window !== "undefined" ? window.innerWidth : 1440, listW: 340, remMap: { t1: [15], t3: [1440, 60] }, remUnit: "min" };
   timers = [];
   rootRef = React.createRef();
 
-  /* Pamięć przewinięcia list — na czas sesji, w pamięci (po zamknięciu aplikacji znika).
-     Każda lista ma swój klucz; ref i handler są memoizowane, żeby React nie odpinał ich
-     przy każdym renderze. */
+  /* List scroll memory — for the session only, held in memory (gone when the app closes).
+     Every list has its own key; the ref and handler are memoised so React does not detach them
+     on every render. */
   scrollY = {};
   scrollEls = {};
   scrollRefs = {};
@@ -4107,7 +4107,7 @@ class Component extends DCLogic {
   restoreScrolls = () => {
     Object.keys(this.scrollY).forEach(k => {
       const el = this.scrollEls[k], y = this.scrollY[k];
-      /* Odtwarzamy tylko gdy kontener wrócił na górę (remount albo koniec ładowania). */
+      /* We restore only when the container is back at the top (remount or end of loading). */
       if (el && y && el.scrollTop === 0 && el.scrollHeight > el.clientHeight + y) el.scrollTop = y;
     });
   };
@@ -4147,8 +4147,8 @@ class Component extends DCLogic {
     this.setState({ sel: sel.indexOf(id) >= 0 ? sel.filter(x => x !== id) : sel.concat([id]) });
   };
 
-  /* Ładowanie z serwera: krótki szkielet zamiast treści. Czas bierzemy z tweaka streamDelay,
-     ale trzymamy go w realnych granicach — kilkaset ms, nie sekundy. */
+  /* Loading from the server: a short skeleton instead of content. The duration comes from the
+     streamDelay tweak but is kept within realistic bounds — a few hundred ms, not seconds. */
   loadDelay = (f) => Math.round(Math.max(160, Math.min(900, (this.props.streamDelay ?? 550) * f)));
 
   loadList = (patch) => {
@@ -4158,7 +4158,7 @@ class Component extends DCLogic {
     this.timers.push(this._listLoadT);
   };
 
-  /* Podgląd HTML i podgląd załącznika też pobierają treść z serwera — ten sam szkielet co wiadomość. */
+  /* HTML preview and attachment preview also fetch content from the server — same skeleton as a message. */
   loadHtml = () => {
     clearTimeout(this._htmlLoadT);
     this._htmlLoadT = setTimeout(() => this.setState({ htmlLoading: false }), this.loadDelay(0.75));
@@ -4179,7 +4179,7 @@ class Component extends DCLogic {
   };
 
   pickFolder = (key, label) => {
-    if ((this.state.folderKey || "acc1·Odebrane") === key) return;
+    if ((this.state.folderKey || "acc1·Inbox") === key) return;
     this.resetScroll("mail");
     this.loadList({ folderKey: key, folderLabel: label, sel: [], sideDrawer: false });
   };
@@ -4190,8 +4190,8 @@ class Component extends DCLogic {
     if ((e && (e.ctrlKey || e.metaKey || e.shiftKey)) || sel.length) { this.toggleSelect(id); return; }
     const unread = Object.assign({}, this.state.unread || DEFAULT_UNREAD);
     delete unread[id];
-    /* Niektóre wątki mają na liście nieprzeczytaną wiadomość ze środka historii —
-       wchodzimy dokładnie w nią, nie w najnowszą. */
+    /* Some threads have an unread message from the middle of the history —
+       we open exactly that one, not the newest. */
     const entry = { piotr: 2 };
     const patch = { threadId: id, mailAnswer: false, cameFrom: this.state.cameFrom && id === "contoso", mailPane: "thread", threadOpen: true, unread: unread,
       activeMsg: Object.assign({}, this.state.activeMsg, { [id]: typeof entry[id] === "number" ? entry[id] : null }),
@@ -4255,15 +4255,15 @@ class Component extends DCLogic {
     lastArchived: null,
   }));
 
-  /* AKCJE PASKA POCZTY — prototyp: zmieniają stan lokalny i pokazują potwierdzenie,
-     nie wykonują operacji na serwerze. Cel działania: zaznaczenie, a gdy puste — otwarty wątek. */
+  /* MAIL TOOLBAR ACTIONS — prototype: they change local state and show a confirmation,
+     they do not perform server operations. Target: the selection, or the open thread when empty. */
   opTargets = (ids) => {
     if (ids && ids.length) return ids;
     const sel = Array.isArray(this.state.sel) ? this.state.sel : [];
     return sel.length ? sel.slice() : [this.state.threadId];
   };
 
-  countWord = (n) => (n === 1 ? "wątek" : n < 5 ? n + " wątki" : n + " wątków");
+  countWord = (n) => (n === 1 ? "1 thread" : n + " threads");
 
   notify = (text, opt) => {
     const o = (opt === true || opt === false || opt == null) ? { undo: opt === true } : opt;
@@ -4313,7 +4313,7 @@ class Component extends DCLogic {
 
   askCancelToast = (id) => {
     const t = (this.state.toasts || []).filter(x => x.id === id)[0];
-    this.setState({ cancelAsk: { id: id, title: "Przerwać operację?", text: (t && t.cancelText) || "Operacja jest w toku. Zamknięcie powiadomienia ją przerwie — częściowe efekty nie zostaną zapisane." } });
+    this.setState({ cancelAsk: { id: id, title: "Abort the operation?", text: (t && t.cancelText) || "The operation is running. Closing the notification aborts it — partial results will not be saved." } });
   };
 
   abortTask = () => {
@@ -4322,27 +4322,27 @@ class Component extends DCLogic {
     if (!ask) return;
     if (this._tasks && this._tasks[ask.id]) { clearTimeout(this._tasks[ask.id]); delete this._tasks[ask.id]; }
     this.dismissToast(ask.id);
-    this.notify("Operacja została przerwana. Nic nie zostało zapisane.", { kind: "warning", title: "Anulowano" });
+    this.notify("The operation was aborted. Nothing was saved.", { kind: "warning", title: "Cancelled" });
   };
 
   startReply = (mode, ids) => {
     const id = this.opTargets(ids)[0];
     const patch = { compose: true, composeMin: false, replyMode: mode, threadId: id, mailPane: "thread", threadOpen: true, sel: [] };
-    if (this.state.workMode === "zakladki") this.openTab("compose", patch);
+    if (this.state.workMode === "tabs") this.openTab("compose", patch);
     else this.setState(patch);
   };
 
   archiveThreads = (ids) => {
     const t = this.opTargets(ids);
     this.setState(s => ({ archived: (s.archived || []).concat(t), lastOp: { kind: "archive", ids: t }, sel: [], mailPane: "list" }));
-    this.notify("Zarchiwizowano " + this.countWord(t.length), true);
+    this.notify("Archived " + this.countWord(t.length), true);
   };
 
   ovStyle = (z, mobile) => "position:fixed;z-index:" + z + ";display:flex;background:var(--scrim);" +
     (mobile ? "top:0;left:0;right:0;bottom:" + this.barH() + "px;align-items:stretch;justify-content:stretch" : "inset:0;align-items:center;justify-content:center;padding:22px");
 
-  /* Krótkie potwierdzenia (tekst + max 3 przyciski) zawsze jako wyśrodkowany popup,
-     także na telefonie — pełny ekran zostaje dla okien z formularzami. */
+  /* Short confirmations (text + up to 3 buttons) always as a centred popup,
+     on phones too — full screen is reserved for windows with forms. */
   ovAskStyle = (z, mobile) => "position:fixed;z-index:" + z + ";display:flex;align-items:center;justify-content:center;background:var(--scrim);" +
     (mobile ? "top:0;left:0;right:0;bottom:" + this.barH() + "px;padding:20px" : "inset:0;padding:22px");
 
@@ -4376,8 +4376,8 @@ class Component extends DCLogic {
     };
   };
 
-  /* Po przytrzymaniu palcem przeglądarka wysyła jeszcze „ducha” kliknięcia w miejscu palca —
-     wypadał on na świeżo otwarte menu i natychmiast je zamykał. Menu jest więc chwilę nieklikalne. */
+  /* After a long press the browser still sends a "ghost" click where the finger was —
+     it landed on the freshly opened menu and closed it instantly. So the menu is briefly unclickable. */
   armCtx = (fromTouch) => {
     clearTimeout(this._ctxArmT);
     this._ctxArmed = !fromTouch;
@@ -4421,7 +4421,7 @@ class Component extends DCLogic {
     confirmDel: {
       title: title,
       text: text,
-      label: "Usu\u0144",
+      label: "Delete",
       run: () => this.setState(s2 => {
         const map = Object.assign({}, s2.hidden || {});
         map[kind] = (map[kind] || []).concat(ids);
@@ -4442,16 +4442,16 @@ class Component extends DCLogic {
     const t = this.opTargets(ids);
     if (!t.length) return;
     this.askDel({
-      title: t.length === 1 ? "Usunąć ten wątek?" : "Usunąć " + this.countWord(t.length) + "?",
-      text: "Przenosimy do kosza — " + this.countWord(t.length) + ". Z kosza znikną po 30 dniach.",
-      label: "Przenieś do kosza",
+      title: t.length === 1 ? "Delete this thread?" : "Delete " + this.countWord(t.length) + "?",
+      text: "Moving to trash — " + this.countWord(t.length) + ". They disappear from trash after 30 days.",
+      label: "Move to trash",
       run: () => this.doDeleteThreads(t),
     });
   };
 
   doDeleteThreads = (t) => {
     this.setState(s => ({ deleted: (s.deleted || []).concat(t), lastOp: { kind: "delete", ids: t }, sel: [], mailPane: "list" }));
-    this.notify("Przeniesiono do kosza — " + this.countWord(t.length), true);
+    this.notify("Moved to trash — " + this.countWord(t.length), true);
   };
 
   toggleFlagThreads = (ids) => {
@@ -4460,7 +4460,7 @@ class Component extends DCLogic {
     const turnOn = t.some(id => !flags[id]);
     t.forEach(id => { if (turnOn) flags[id] = true; else delete flags[id]; });
     this.setState({ flags: flags, sel: [] });
-    this.notify((turnOn ? "Oflagowano " : "Zdjęto flagę — ") + this.countWord(t.length), false);
+    this.notify((turnOn ? "Flagged " : "Flag removed — ") + this.countWord(t.length), false);
   };
 
   markUnread = (ids) => {
@@ -4468,7 +4468,7 @@ class Component extends DCLogic {
     const unread = Object.assign({}, this.state.unread || DEFAULT_UNREAD);
     t.forEach(id => { unread[id] = true; });
     this.setState({ unread: unread, sel: [] });
-    this.notify("Oznaczono jako nieprzeczytane — " + this.countWord(t.length), false);
+    this.notify("Marked as unread — " + this.countWord(t.length), false);
   };
 
   openMove = (ids) => this.setState({ moveFor: this.opTargets(ids) });
@@ -4481,7 +4481,7 @@ class Component extends DCLogic {
       t.forEach(id => { moved[id] = folder; });
       return { moved: moved, moveFor: null, sel: [], lastOp: { kind: "move", ids: t } };
     });
-    this.notify("Przeniesiono do „" + folder + "” — " + this.countWord(t.length), true);
+    this.notify("Moved to “" + folder + "” — " + this.countWord(t.length), true);
   };
 
   undoOp = () => {
@@ -4515,17 +4515,17 @@ class Component extends DCLogic {
     const p = this.localPt(cx || 0, cy || 0);
     this.setState({
       ctxMenu: {
-        x: p.x, y: p.y, kind: "mail", id: id, title: th.subject || "Wiadomo\u015b\u0107",
+        x: p.x, y: p.y, kind: "mail", id: id, title: th.subject || "Message",
         items: [
-          { icon: "check_box", label: "Zaznacz wiadomo\u015bci", run: () => this.toggleSelect(id) },
-          { icon: "auto_awesome", label: "Zapytaj agenta", run: () => this.goAgentWith("wątek „" + (th.subject || "poczta") + "”") },
-          { icon: "reply", label: "Odpowiedz", run: () => { this.setState({ threadId: id, mailPane: "thread", threadOpen: true }); this.startReply("reply"); } },
-          { icon: "forward", label: "Prze\u015blij dalej", run: () => { this.setState({ threadId: id, mailPane: "thread", threadOpen: true }); this.startReply("fwd"); } },
+          { icon: "check_box", label: "Select messages", run: () => this.toggleSelect(id) },
+          { icon: "auto_awesome", label: "Ask the agent", run: () => this.goAgentWith("thread “" + (th.subject || "mail") + "”") },
+          { icon: "reply", label: "Reply", run: () => { this.setState({ threadId: id, mailPane: "thread", threadOpen: true }); this.startReply("reply"); } },
+          { icon: "forward", label: "Forward", run: () => { this.setState({ threadId: id, mailPane: "thread", threadOpen: true }); this.startReply("fwd"); } },
           { icon: "archive", label: "Archiwizuj", run: () => this.archiveThreads([id]) },
-          { icon: "flag", label: flagged ? "Zdejmij flag\u0119" : "Oflaguj", run: () => this.toggleFlagThreads([id]) },
-          { icon: "mark_email_unread", label: "Oznacz jako nieprzeczytan\u0105", run: () => this.markUnread([id]) },
-          { icon: "drive_file_move", label: "Przenie\u015b\u2026", run: () => this.setState({ moveFor: [id] }) },
-          { icon: "delete", label: "Usu\u0144", danger: true, run: () => this.deleteThreads([id]) },
+          { icon: "flag", label: flagged ? "Remove flag" : "Flag", run: () => this.toggleFlagThreads([id]) },
+          { icon: "mark_email_unread", label: "Mark as unread", run: () => this.markUnread([id]) },
+          { icon: "drive_file_move", label: "Move\u2026", run: () => this.setState({ moveFor: [id] }) },
+          { icon: "delete", label: "Delete", danger: true, run: () => this.deleteThreads([id]) },
         ],
       },
     });
@@ -4564,24 +4564,24 @@ class Component extends DCLogic {
     const mode = this.props.layout ?? "auto";
     const F = FRAMES[mode];
     const w = F ? F.w : (this.state.vw || 1440);
-    return w >= 1180 && (this.state.workMode || "zakladki") === "zakladki";
+    return w >= 1180 && (this.state.workMode || "tabs") === "tabs";
   };
 
   tabKind = (key) => key === "compose" ? "compose"
     : key.indexOf("doc:") === 0 ? "doc"
     : key.indexOf("html:") === 0 ? "html" : "thread";
 
-  /* Osadzona treść wiadomości: ramka ma opaque origin (sandbox="allow-scripts" i nic więcej),
-     więc nie widzi DOM-u, storage'u ani ciasteczek aplikacji. Wysokość przychodzi wyłącznie
-     przez postMessage od skryptu pomiarowego doklejonego przed markupem wiadomości.
+  /* Embedded message content: the frame has an opaque origin (sandbox="allow-scripts" and nothing else),
+     so it cannot see the app's DOM, storage or cookies. Height arrives solely
+     via postMessage from the measuring script injected before the message markup.
 
-     Kryteria akceptacji #1507 — nazwane wysokości:
-     • wstępna (przed pierwszym raportem): 320px, bez animacji przy pierwszym dopasowaniu,
-       więc dołączenie wiadomości nie przesuwa rozmowy skokowo;
-     • awaryjna (raport nie przyszedł w 2,5 s): ramka 1600px w kontenerze 620px z overflow:auto
-       — to jedyny przypadek, w którym osadzony widok przewija się wewnętrznie;
-     • bardzo długa wiadomość: brak maksimum (clamp 40000px), ramka na pełnej wysokości,
-       przewija się rozmowa, żadnego zagnieżdżonego paska przewijania. */
+     Acceptance criteria #1507 — named heights:
+     • initial (before the first report): 320px, no animation on the first fit,
+       so attaching a message does not jump the conversation;
+     • fallback (no report within 2.5 s): a 1600px frame in a 620px container with overflow:auto
+       — the only case where the embedded view scrolls internally;
+     • very long message: no maximum (clamped at 40000px), frame at full height,
+       the conversation scrolls, no nested scrollbar. */
   htmlFrames = new Map();
 
   htmlFrameRef = (f) => {
@@ -4606,11 +4606,11 @@ class Component extends DCLogic {
     if (!rec || rec.measured) return;
     rec.fallback = true;
     const wrap = rec.frame.parentElement;
-    /* Jedyny przypadek z własnym przewijaniem: pomiar nie przyszedł, więc nie znamy
-       wysokości treści. Ramka dostaje 1600px w kontenerze 620px z overflow:auto. */
+    /* The only case with its own scrolling: no measurement arrived, so we do not know
+       the content height. The frame gets 1600px in a 620px container with overflow:auto. */
     rec.frame.style.height = "1600px";
     if (wrap) { wrap.style.height = "620px"; wrap.style.overflow = "auto"; }
-    this.htmlFrameStatus(id, "Nie udało się zmierzyć wysokości treści — ta jedna ramka przewija się osobno");
+    this.htmlFrameStatus(id, "Could not measure the content height — this one frame scrolls separately");
   };
 
   onHtmlFrameMessage = (e) => {
@@ -4624,14 +4624,14 @@ class Component extends DCLogic {
     if (rec.timer) { clearTimeout(rec.timer); rec.timer = null; }
     const next = Math.max(80, Math.min(Math.round(h) + 2, 40000));
     rec.applied = (rec.applied || 0) + 1;
-    /* Bezpiecznik: po kilkunastu korektach albo przy mikroskokach przestajemy słuchać,
-       żeby żadna treść nie mogła rozpychać ramki w nieskończoność. */
+    /* Safety net: after a dozen or so corrections, or on micro-jitter, we stop listening
+       so no content can grow the frame indefinitely. */
     if (rec.measured && (rec.applied > 16 || Math.abs(next - rec.height) <= 3)) return;
     rec.measured = true;
     rec.height = next;
-    /* Bez maksymalnej wysokości — ramka rośnie na całą treść, przewija się konwersacja. */
+    /* No maximum height — the frame grows to the full content, the conversation scrolls. */
     rec.frame.style.height = next + "px";
-    this.htmlFrameStatus(id, "Treść HTML w izolacji — skrypty i zdalne zasoby zablokowane");
+    this.htmlFrameStatus(id, "HTML content in isolation — scripts and remote resources blocked");
   };
 
   tabPatch = (tb) => {
@@ -4698,13 +4698,13 @@ class Component extends DCLogic {
     const list = this.remList(key).slice().sort((a, b) => b - a);
     const unit = this.state.remUnit || "min";
     const timed = !!o.timed;
-    const zero = o.zero || (timed ? "w momencie" : "w terminie");
+    const zero = o.zero || (timed ? "at the time" : "on the day");
     const chip = (on) => "display:flex;align-items:center;gap:5px;height:30px;padding:0 11px;border-radius:9px;font-size:12.5px;white-space:nowrap;border:1px solid " +
       (on ? "var(--accent);background:var(--accent-soft);color:var(--accent-d);font-weight:600" : "var(--line);background:var(--panel);color:var(--text2)");
     return {
       any: list.length > 0,
       hint: o.hint || "",
-      countLabel: list.length === 0 ? "wyłączone" : list.length === 1 ? "1 przypomnienie" : list.length < 5 ? list.length + " przypomnienia" : list.length + " przypomnień",
+      countLabel: list.length === 0 ? "off" : list.length === 1 ? "1 reminder" : list.length + " reminders",
       countStyle: "font-size:11px;padding:2px 8px;border-radius:10px;" + (list.length ? "background:var(--accent-soft);color:var(--accent-d)" : "background:var(--hover);color:var(--muted)"),
       presets: (timed ? REM_TIMED : REM_DATED).map(m => {
         const on = list.indexOf(m) >= 0;
@@ -4722,9 +4722,9 @@ class Component extends DCLogic {
     };
   };
 
-  remAnchor = (o) => (o.time && o.time !== "cały dzień"
-    ? "przed " + o.time + (o.day ? " · " + o.day + ".08" : "")
-    : "przed 09:00 w dniu " + (o.taskLike ? "terminu" : "wydarzenia"));
+  remAnchor = (o) => (o.time && o.time !== "all day"
+    ? "before " + o.time + (o.day ? " · " + o.day + ".08" : "")
+    : "09:00 on the day of the " + (o.taskLike ? "deadline" : "event"));
 
   remFire = (title, list, kind, src, go) => {
     if (!list || !list.length) return;
@@ -4735,18 +4735,18 @@ class Component extends DCLogic {
     this.remTimers = this.remTimers || [];
     this.remTimers.push(setTimeout(() => this.pushNotif({
       kind: kind,
-      title: "Przypomnienie: " + title,
-      body: m === 0 ? "Zaczyna się teraz." : "Zostało " + remLabel(m, "").replace(" przed", "") + ".",
+      title: "Reminder: " + title,
+      body: m === 0 ? "Starting now." : remLabel(m, "").replace(" before", "") + " left.",
       src: src,
       go: go,
     }), 18000));
   };
 
   goScreen = (id, patch) => {
-    /* Pierwsze wejście na pocztę zaczyna się od pustego panelu; później otwarta wiadomość
-       zostaje zapamiętana na czas sesji (stan w pamięci — po zamknięciu aplikacji znika). */
+    /* The first entry into mail starts with an empty panel; after that the open message
+       is remembered for the session (in-memory state — gone when the app closes). */
     const p = Object.assign({ screen: id }, patch || {});
-    /* Wejście na pocztę z innego ekranu = pobranie listy z serwera. */
+    /* Entering mail from another screen = fetching the list from the server. */
     if (id === "mail" && this.state.screen !== "mail") {
       if (p.mailPane === "thread") { p.msgLoading = true; this.loadMsg(); }
       this.loadList(p);
@@ -4784,11 +4784,11 @@ class Component extends DCLogic {
     if (this.state.notifCenter) this.closeNotifCenter(); else this.openNotifCenter();
   };
 
-  /* DWA GESTY NA CAŁEJ POWIERZCHNI (telefon, wskaźnik zgrubny).
-     „open"  — ruch w górę rozpoczęty gdziekolwiek na belce nawigacji wyciąga panel.
-     „close" — ruch w dół rozpoczęty gdziekolwiek na otwartym panelu (nagłówek, filtry,
-               wiersz, pusty stan) odsuwa go. Panel podąża za palcem 1:1, krycie przesłony
-               jest wprost przywiązane do przebytej drogi. Dotknięcie dzwonka zostaje bez zmian. */
+  /* TWO GESTURES ACROSS THE WHOLE SURFACE (phone, coarse pointer).
+     "open"  — an upward move started anywhere on the nav bar pulls the panel out.
+     "close" — a downward move started anywhere on the open panel (header, filters,
+               row, empty state) pushes it away. The panel follows the finger 1:1 and the
+               scrim opacity is tied directly to the distance travelled. Tapping the bell is unchanged. */
   notifPanelRef = React.createRef();
   notifListRef = React.createRef();
 
@@ -4828,7 +4828,7 @@ class Component extends DCLogic {
         if (!g.live) {
           if (dy > NG.barSlop) { this.notifGestDetach(); this._notifG = null; return; }
           if (-dy < NG.barSlop) return;
-          /* Belka oddaje gest: dopiero teraz jej dotknięcie przepada. */
+          /* The bar hands over the gesture: only now does its own touch get cancelled. */
           g.live = true; g.anchor = p.clientY; this._notifBarTap = true;
           const H = this.notifPanelH();
           this.setState({ notifCenter: true, notifShown: true, notifDrag: H, notifH: H, userMenu: false, more: false });
@@ -4841,12 +4841,12 @@ class Component extends DCLogic {
       }
 
       if (!g.live) {
-        /* Ruch ponad slop wiersza kasuje długie przytrzymanie — jedno albo drugie, nigdy oba. */
+        /* Movement beyond the row slop cancels the long press — one or the other, never both. */
         if (Math.abs(dy) > NG.rowSlop) clearTimeout(this._lpT);
         if (dy < NG.rowSlop) return;
         const list = this.notifListRef.current;
         if (list && list.scrollTop > 0.5) { g.y0 = p.clientY; return; }
-        /* Lista jest na górze — ten sam, nieprzerwany ruch staje się oddaleniem panelu. */
+        /* The list is at the top — the same uninterrupted move becomes a panel dismissal. */
         g.live = true; g.anchor = p.clientY;
         this.setState({ notifH: this.notifPanelH() });
         return;
@@ -4878,13 +4878,13 @@ class Component extends DCLogic {
     document.addEventListener("touchend", this._notifUp);
   };
 
-  /* Powrót na miejsce, gdy nie spełniono ani drogi, ani prędkości. */
+  /* Spring back when neither distance nor velocity was met. */
   notifSpringBack = () => this.setState({ notifDrag: 0, notifSpring: true }, () => {
     clearTimeout(this._notifSpringT);
     this._notifSpringT = setTimeout(() => this.setState({ notifSpring: false }), NG.springMs);
   });
 
-  /* Ruch w górę na belce zabiera dotknięcie elementowi, na którym się zaczął. */
+  /* An upward move on the bar takes the touch away from the element it started on. */
   railTapGuard = (e) => {
     if (!this._notifBarTap) return;
     this._notifBarTap = false;
@@ -4914,7 +4914,7 @@ class Component extends DCLogic {
     const kind = (NKIND[it.kind] || NKIND.system).toast;
     let tid;
     tid = this.notify(it.body, {
-      kind: kind, title: it.title, actionLabel: "Pokaż",
+      kind: kind, title: it.title, actionLabel: "Show",
       onAction: () => { this.dismissToast(tid); this.openNotif(n); },
     });
   };
@@ -4941,16 +4941,16 @@ class Component extends DCLogic {
     if (!el) return;
     this.aiUndo = el.innerHTML;
     const full = [
-      "Dzień dobry,",
-      "dziękuję za przesłany aneks. Akceptujemy skrócenie czasu reakcji na zgłoszenia krytyczne do 2 godzin w dni robocze.",
-      "Prosimy jednocześnie o wprowadzenie górnego limitu waloryzacji CPI na poziomie 5% rocznie. Przy prognozie 4,1% daje to obu stronom przewidywalny koszt w perspektywie 2027 roku.",
-      "Jeżeli limit jest akceptowalny, jesteśmy gotowi zamknąć decyzję do 28 sierpnia.",
-      "Pozdrawiam,<br />Karolina Kowalska",
+      "Hello,",
+      "thank you for the addendum. We accept shortening the response time for critical incidents to 2 hours on business days.",
+      "At the same time we ask for an upper cap on CPI indexation of 5% per year. At the 4.1% forecast this gives both sides a predictable cost through 2027.",
+      "If the cap is acceptable, we are ready to close the decision by 28 August.",
+      "Best regards,<br />Karolina Kowalska",
     ];
     const shortV = [
-      "Dzień dobry,",
-      "akceptujemy SLA 2 h. Prosimy o górny limit waloryzacji CPI 5% rocznie — wtedy zamykamy decyzję do 28.08.",
-      "Pozdrawiam,<br />Karolina Kowalska",
+      "Hello,",
+      "we accept the 2 h SLA. We ask for a 5% annual cap on CPI indexation — then we can close the decision by 28.08.",
+      "Best regards,<br />Karolina Kowalska",
     ];
     const paras = kind === "short" ? shortV : full;
     el.innerHTML = "";
@@ -5011,10 +5011,10 @@ class Component extends DCLogic {
 
   autoSchedule = () => {
     this.setState(s2 => {
-      const todo = TASKS.concat(s2.extraTasks || []).filter(t2 => t2.group === "Dziś" && (s2.taskDone || []).indexOf(t2.id) < 0 && (s2.taskSched || []).indexOf(t2.id) < 0);
+      const todo = TASKS.concat(s2.extraTasks || []).filter(t2 => t2.group === "Today" && (s2.taskDone || []).indexOf(t2.id) < 0 && (s2.taskSched || []).indexOf(t2.id) < 0);
       let h = 11;
       const blocks = todo.map(t2 => {
-        const slot = { day: "27", time: (h < 10 ? "0" : "") + h + ":00", h, t: t2.t, kind: "spotkanie", src: "zadanie" };
+        const slot = { day: "27", time: (h < 10 ? "0" : "") + h + ":00", h, t: t2.t, kind: "meeting", src: "zadanie" };
         h += 2;
         return slot;
       });
@@ -5049,22 +5049,22 @@ class Component extends DCLogic {
     } else if (a.kind === "cal") {
       this.setState(s2 => ({
         screen: "cal",
-        calView: "Dzień",
+        calView: "Day",
         calAdded: (s2.calAdded || []).concat([
-          { day: "27", time: "10:00", h: 10, t: "Odpowiedź do Marty — kalkulacja", kind: "spotkanie", src: "blok od agenta" },
-          { day: "27", time: "16:00", h: 16, t: "Kontrpropozycja limitu CPI", kind: "spotkanie", src: "blok od agenta" },
+          { day: "27", time: "10:00", h: 10, t: "Reply to Marta — calculation", kind: "meeting", src: "agent block" },
+          { day: "27", time: "16:00", h: 16, t: "CPI cap counter-proposal", kind: "meeting", src: "agent block" },
         ]),
       }));
-    } else if (a.kind === "gocal") this.setState({ screen: "cal", calView: "Dzień" });
+    } else if (a.kind === "gocal") this.setState({ screen: "cal", calView: "Day" });
     else if (a.kind === "case") this.setState({ screen: "cases", caseId: "contoso27", casePane: "detail" });
     else if (a.kind === "thread") this.setState({ screen: "mail", threadId: a.tid, mailPane: "thread", threadOpen: true, cameFrom: false });
-    else if (a.kind === "planday") this.agentAsk("Zaplanuj mój dzień");
+    else if (a.kind === "planday") this.agentAsk("Plan my day");
   };
 
-  /* Belka narzędzi — pełne etykiety, dopóki mieszczą się w dostępnej szerokości.
-     Nowy ekran renderujemy „na pełno", mierzymy realną szerokość treści i dopiero wtedy
-     ewentualnie zwijamy do ikon. Potrzebna szerokość jest cache'owana per belka,
-     więc przy zmianie rozmiaru okna decyzja jest natychmiastowa i bez migotania. */
+  /* Toolbar — full labels as long as they fit the available width.
+     A new screen is rendered "at full size", we measure the real content width and only then
+     collapse to icons if needed. The required width is cached per toolbar,
+     so on window resize the decision is instant and flicker-free. */
   _tbNeed = {};
   _tbNeedFab = {};
 
@@ -5079,11 +5079,11 @@ class Component extends DCLogic {
     this.tbMeasure();
   };
 
-  /* "full" = przycisk główny w belce + etykiety; "fab" = etykiety zostają, a przycisk główny
-     przenosi się do pływającego kółka (forma z telefonu); "icons" = same ikony. */
+  /* "full" = primary button in the bar + labels; "fab" = labels stay but the primary button
+     moves into a floating circle (the phone form); "icons" = icons only. */
   tbModeFor(key) { return (this.state.tbMode || {})[key] || "full"; }
 
-  /* Po doładowaniu fontu ikon (ligatury) szerokości się zmieniają — mierzymy od nowa. */
+  /* Once the icon font (ligatures) loads, widths change — we measure again. */
   tbReset = () => {
     this._tbNeed = {};
     this._tbNeedFab = {};
@@ -5099,15 +5099,15 @@ class Component extends DCLogic {
     if (!avail || !kids.length) return;
     const mode = this.tbModeFor(key);
     if (mode !== "icons") {
-      /* Suma rzeczywistych szerokości dzieci — nie krawędzie, bo „Zaznacz wszystkie”
-         ma margin-left:auto i rozciągałoby pomiar do pełnej belki. */
+      /* Sum of the children's real widths — not the edges, because "Select all"
+         has margin-left:auto and would stretch the measurement to the whole bar. */
       const cs = getComputedStyle(el);
       const gap = parseFloat(cs.columnGap || cs.gap || 0) || 0;
       let need = parseFloat(cs.paddingLeft || 0) + parseFloat(cs.paddingRight || 0) + gap * (kids.length - 1);
       kids.forEach(k => {
         const ks = getComputedStyle(k);
-        /* margin:auto rozpycha element do końca belki — liczymy tylko realne odstępy. */
-        const mg = m => { const v = parseFloat(m || 0); return isNaN(v) ? 0 : Math.min(v, 8); }; // margin:auto nie liczy się do potrzebnej szerokości
+        /* margin:auto pushes an element to the end of the bar — we count real gaps only. */
+        const mg = m => { const v = parseFloat(m || 0); return isNaN(v) ? 0 : Math.min(v, 8); }; // margin:auto does not count towards the required width
         need += k.offsetWidth + mg(ks.marginLeft) + mg(ks.marginRight);
       });
       if (mode === "full" && this._tbHasPri && kids.length > 2) {
@@ -5161,7 +5161,7 @@ class Component extends DCLogic {
     const k = tid + ":" + idx;
     this.setState(s => ({
       msgOpen: Object.assign({}, s.msgOpen, { [k]: true }),
-      /* Zostawiamy wątek zwinięty do wybranej wiadomości — pill oferuje „Pokaż wszystkie". */
+      /* We leave the thread collapsed to the selected message — the pill offers "Show all". */
       histOpen: Object.assign({}, s.histOpen, { [tid]: false }),
       activeMsg: Object.assign({}, s.activeMsg, { [tid]: idx }),
       msgFlash: k,
@@ -5221,7 +5221,7 @@ class Component extends DCLogic {
 
   planFor(q) {
     const s = (q || "").toLowerCase();
-    if (s.includes("polis") || s.includes("plik") || s.includes("dokument") || s.includes("załącz")) return "files";
+    if (s.includes("polic") || s.includes("file") || s.includes("document") || s.includes("attach")) return "files";
     if (s.includes("kto") || s.includes("osob") || s.includes("zatwierdz") || s.includes("kim")) return "people";
     return "contract";
   }
@@ -5278,7 +5278,7 @@ class Component extends DCLogic {
     const notifDrag = st.notifDrag || 0;
     const notifDragging = !!(this._notifG && this._notifG.live);
     const notifH = st.notifH || Math.max(320, (st.vh || 844) - this.barH());
-    /* Krycie przesłony wprost z przebytej drogi — panel i przesłona idą razem z palcem. */
+    /* Scrim opacity straight from the distance travelled — panel and scrim move with the finger. */
     const notifProg = notifIn ? Math.max(0, 1 - Math.min(1, notifDrag / notifH)) : 0;
     const notifShown = notifFilter === "unread" ? notifAll.filter(n => isNotifUnread(n, notifRead)) : notifAll;
     const avSz = isMobile ? 34 : 22;
@@ -5321,7 +5321,7 @@ class Component extends DCLogic {
     const themePref = st.themePref || "auto";
     const sysDark = typeof matchMedia === "function" && matchMedia("(prefers-color-scheme: dark)").matches;
     const theme = themePref === "auto"
-      ? (st.themeOverride || (this.props.theme ?? (sysDark ? "ciemny" : "jasny")))
+      ? (st.themeOverride || (this.props.theme ?? (sysDark ? "dark" : "light")))
       : themePref;
 
     const openEv = (cite) => () => {
@@ -5333,14 +5333,14 @@ class Component extends DCLogic {
     const thread = THREADS.find(t => t.id === st.threadId) || THREADS[0];
     const threadAddr = msgAddrRows(thread, (msgsFor(thread) || [])[0] || { from: thread.from, mine: false }, msgsFor(thread) || []);
     const flags = st.flags || {};
-    /* Demo startuje z pięcioma najnowszymi wątkami jako nieprzeczytane — wejście w wątek je czyści. */
+    /* The demo starts with the five newest threads unread — opening a thread clears it. */
     const unreadMap = st.unread || DEFAULT_UNREAD;
     const movedMap = st.moved || {};
     const actTargets = sel.length ? sel : [st.threadId];
     const flagOn = actTargets.every(id => !!flags[id]);
-    const wantTabs = (st.workMode || "zakladki") === "zakladki";
+    const wantTabs = (st.workMode || "tabs") === "tabs";
     const rmode = st.replyMode || null;
-    const composeKind = rmode === "reply" ? "Odpowiedź" : rmode === "all" ? "Odpowiedź wszystkim" : rmode === "fwd" ? "Przekaż dalej" : "Nowa wiadomość";
+    const composeKind = rmode === "reply" ? "Reply" : rmode === "all" ? "Reply all" : rmode === "fwd" ? "Forward" : "New message";
     const threadParticipants = (msgsFor(thread) || []).map(m => m.from).filter((n, i, a) => a.indexOf(n) === i);
     const composeTo = rmode === "fwd" ? [] : rmode === "all" ? threadParticipants : rmode === "reply" ? threadParticipants.slice(-1) : ["Anna Kowalska"];
     const composeSubj = rmode === "fwd" ? "Fwd: " + thread.subject : rmode ? "Re: " + thread.subject : "";
@@ -5351,15 +5351,15 @@ class Component extends DCLogic {
     };
     const finishCompose = () => {
       const patch = { compose: false, aiDraft: false, aiBusy: false, closeAsk: false, sendAsk: null, composeSubjEdit: undefined, ccOpen: false, composeCc: [], composeBcc: [], ccInput: "", bccInput: "", composeReplyTo: [], replyToInput: "" };
-      if ((st.workMode || "normalny") === "zakladki") this.closeTab("compose");
+      if ((st.workMode || "classic") === "tabs") this.closeTab("compose");
       this.setState(patch);
     };
     const askSend = () => {
       const w = [];
-      if (!curSubj.trim()) w.push("Wiadomość nie ma tematu.");
-      if (!bodyTxt()) w.push("Treść wiadomości jest pusta.");
+      if (!curSubj.trim()) w.push("The message has no subject.");
+      if (!bodyTxt()) w.push("The message body is empty.");
       if (!composeTo.length) w.push("Nie wybrano odbiorcy.");
-      if (st.aiDraft) w.push("Szkic AI nie został jeszcze zaakceptowany — sprawdź treść przed wysłaniem.");
+      if (st.aiDraft) w.push("The AI draft has not been accepted yet — check the text before sending.");
       this.setState({ sendAsk: { warnings: w } });
     };
     const mailAct = {
@@ -5381,7 +5381,7 @@ class Component extends DCLogic {
     const mKey = (i) => thread.id + ":" + i;
     const histRaw = (st.histOpen || {})[thread.id];
     const histOpen = typeof histRaw === "boolean" ? histRaw : !!st.autoExpand;
-    /* Wiadomość wybrana z listy; domyślnie najnowsza w wątku. */
+    /* The message picked from the list; the newest in the thread by default. */
     const rawActive = (st.activeMsg || {})[thread.id];
     const activeIdx = Math.max(0, Math.min(typeof rawActive === "number" ? rawActive : lastIdx, lastIdx));
     const activeIsNewest = activeIdx === lastIdx;
@@ -5391,16 +5391,16 @@ class Component extends DCLogic {
       items.push({
         isPill: true, isMsg: false, key: "pill",
         pillLabel: !hiddenCount
-          ? (activeIsNewest ? "Ukryj wcześniejsze wiadomości" : "Ukryj pozostałe wiadomości")
+          ? (activeIsNewest ? "Hide earlier messages" : "Hide the other messages")
           : activeIsNewest
-            ? "Pokaż " + hiddenCount + (hiddenCount === 1 ? " wcześniejszą wiadomość" : hiddenCount < 5 ? " wcześniejsze wiadomości" : " wcześniejszych wiadomości")
-            : "Pokaż wszystkie wiadomości",
+            ? "Show " + hiddenCount + (hiddenCount === 1 ? " earlier message" : " earlier messages")
+            : "Show all messages",
         togglePill: () => this.setState(s2 => ({ histOpen: Object.assign({}, s2.histOpen, { [thread.id]: !histOpen }) })),
       });
     }
     msgs.forEach((m, i) => {
-      /* Zwinięty wątek pokazuje wyłącznie wiadomość wybraną z listy — także gdy nie jest
-         najnowsza; pill odsłania wtedy i wcześniejsze, i nowsze. */
+      /* A collapsed thread shows only the message picked from the list — even when it is not
+         the newest; the pill then reveals both earlier and newer ones. */
       if (hiddenCount && i !== activeIdx) return;
       const k = mKey(i);
       const open = true;
@@ -5417,9 +5417,9 @@ class Component extends DCLogic {
         hasAtts: m.atts.length > 0,
         atts: m.atts.map(x => ({ type: x.type, name: x.name, size: x.size, open: () => (this.tabsMode()
           ? this.openTab("doc:" + x.name, { doc: x, docZoom: 1, docLoading: true }, { att: x })
-          : this.openDocLoad({ doc: x, docZoom: 1 })), download: (e) => { if (e && e.stopPropagation) e.stopPropagation(); this.notifyTask({ title: "Pobieranie pliku…", body: x.name, cancelText: "Pobieranie \u201E" + x.name + "\u201D jest w toku. Przerwanie usunie niepełny plik.", doneTitle: "Plik pobrany", doneBody: x.name, ms: 1800 }); } })),
+          : this.openDocLoad({ doc: x, docZoom: 1 })), download: (e) => { if (e && e.stopPropagation) e.stopPropagation(); this.notifyTask({ title: "Downloading file…", body: x.name, cancelText: "Downloading \u201C" + x.name + "\u201D is in progress. Aborting removes the incomplete file.", doneTitle: "File downloaded", doneBody: x.name, ms: 1800 }); } })),
         showDownloadAll: m.atts.length > 1,
-        downloadAll: () => this.notifyTask({ title: "Pakowanie załączników…", body: m.atts.length + " plików → zalaczniki.zip", cancelText: "Archiwum ZIP jest przygotowywane. Przerwanie odrzuci częściowo spakowany plik.", doneTitle: "Archiwum gotowe", doneBody: "zalaczniki.zip — " + m.atts.length + " plików", ms: 2600 }),
+        downloadAll: () => this.notifyTask({ title: "Packing attachments…", body: m.atts.length + " files → attachments.zip", cancelText: "The ZIP archive is being prepared. Aborting discards the partially packed file.", doneTitle: "Archive ready", doneBody: "attachments.zip — " + m.atts.length  + " files", ms: 2600 }),
         clipLabel: m.atts.length ? String(m.atts.length) : "",
         clipStyle: "display:flex;align-items:center;gap:3px;color:var(--faint);font-size:" + (touch ? 13 : 11) + "px",
         clipIconStyle: "font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;line-height:1;font-size:" + (touch ? 18 : 14) + "px",
@@ -5433,7 +5433,7 @@ class Component extends DCLogic {
         htmlEmbedSrc: htmlViewMode ? embedHtml(m.html || htmlFallback(m, thread.subject), "fit:" + thread.id + ":" + i) : "",
         htmlFrameRef: this.htmlFrameRef,
         htmlRich: !!m.html,
-        htmlTitle: m.html ? "Pokaż pełną wersję HTML (bogata treść)" : "Pokaż pełną wersję HTML",
+        htmlTitle: m.html ? "Show the full HTML version (rich content)" : "Show the full HTML version",
         openHtml: () => {
           const doc = { title: thread.subject, from: m.from, when: m.when, rich: !!m.html, src: m.html || htmlFallback(m, thread.subject) };
           this.setState({ htmlAsk: { key: "html:" + thread.id + ":" + i, doc } });
@@ -5472,10 +5472,10 @@ class Component extends DCLogic {
     const hiddenCollected = st.hiddenCollected || [];
     const collectedContacts = collectFromMail(ownContacts.map(c => c.name)).filter(c => hiddenCollected.indexOf(c.name) < 0);
     const allContacts = ownContacts.concat(collectedContacts);
-    const peopleTab = st.peopleTab || "wlasne";
-    const shownContacts = peopleTab === "zebrane" ? collectedContacts : ownContacts;
+    const peopleTab = st.peopleTab || "own";
+    const shownContacts = peopleTab === "collected" ? collectedContacts : ownContacts;
     const allTasks = TASKS.concat(st.extraTasks || []).filter(t2 => !hid("tasks", t2.id));
-    const openTodayTasks = allTasks.filter(t2 => t2.group === "Dziś" && (st.taskDone || []).indexOf(t2.id) < 0);
+    const openTodayTasks = allTasks.filter(t2 => t2.group === "Today" && (st.taskDone || []).indexOf(t2.id) < 0);
     const openToday = openTodayTasks.length;
     const estToday = openTodayTasks.reduce((a, t2) => a + (parseInt(t2.est, 10) || 30), 0) + " min";
     const convList = st.convs || [];
@@ -5487,24 +5487,24 @@ class Component extends DCLogic {
     const matchesHistQuery = (c) => {
       if (!histQuery) return true;
       const lastMsg = c.msgs[c.msgs.length - 1];
-      return ((c.title || "Nowa rozmowa") + " " + (lastMsg ? lastMsg.text : "")).toLowerCase().includes(histQuery);
+      return ((c.title || "New conversation") + " " + (lastMsg ? lastMsg.text : "")).toLowerCase().includes(histQuery);
     };
     const convRow = (c, isArchivedList) => {
       const lastMsg = c.msgs[c.msgs.length - 1];
       return {
-        title: c.title || "Nowa rozmowa",
-        when: c.when || "dziś",
-        preview: lastMsg ? lastMsg.text : "brak wiadomości",
+        title: c.title || "New conversation",
+        when: c.when || "today",
+        preview: lastMsg ? lastMsg.text : "no messages",
         activate: this.rowTap("convs", c.id, () => this.setState({ convId: c.id })),
-        press: this.pressFor("convs", c.id, c.title || "Nowa rozmowa", [
-          { icon: "check_box", label: "Zaznacz rozmowy", run: () => this.selStart("convs", c.id) },
-          { icon: "forum", label: "Otwórz rozmowę", run: () => this.setState({ convId: c.id }) },
-          { icon: isArchivedList ? "unarchive" : "archive", label: isArchivedList ? "Przywróć z archiwum" : "Zarchiwizuj", run: () => this.setState(s2 => ({ convs: (s2.convs || []).map(x => x.id === c.id ? Object.assign({}, x, { archived: !isArchivedList }) : x), convId: (!isArchivedList && s2.convId === c.id) ? null : s2.convId })) },
-          { icon: "delete", label: "Usuń rozmowę", danger: true, run: () => this.setState({ deleteConvAsk: c.id }) },
+        press: this.pressFor("convs", c.id, c.title || "New conversation", [
+          { icon: "check_box", label: "Select conversations", run: () => this.selStart("convs", c.id) },
+          { icon: "forum", label: "Open conversation", run: () => this.setState({ convId: c.id }) },
+          { icon: isArchivedList ? "unarchive" : "archive", label: isArchivedList ? "Restore from archive" : "Archive", run: () => this.setState(s2 => ({ convs: (s2.convs || []).map(x => x.id === c.id ? Object.assign({}, x, { archived: !isArchivedList }) : x), convId: (!isArchivedList && s2.convId === c.id) ? null : s2.convId })) },
+          { icon: "delete", label: "Delete conversation", danger: true, run: () => this.setState({ deleteConvAsk: c.id }) },
         ]),
         hasActions: !!c.id,
         archiveIcon: isArchivedList ? "unarchive" : "archive",
-        archiveTitle: isArchivedList ? "Przywróć z archiwum" : "Zarchiwizuj",
+        archiveTitle: isArchivedList ? "Restore from archive" : "Archive",
         toggleArchive: (e) => {
           if (e && e.stopPropagation) e.stopPropagation();
           this.setState(s2 => ({
@@ -5520,7 +5520,7 @@ class Component extends DCLogic {
     };
     const person = allContacts.find(c => c.id === st.personId) || allContacts[0];
     const personAi = CONTACT_AI[person.id] || {};
-    const evStyle = (kind) => "display:flex;flex-direction:column;gap:3px;border-radius:8px;padding:8px 11px;border:1px solid " + (kind === "termin"
+    const evStyle = (kind) => "display:flex;flex-direction:column;gap:3px;border-radius:8px;padding:8px 11px;border:1px solid " + (kind === "deadline"
       ? "var(--hl-line);background:var(--hl);"
       : kind === "mail"
       ? "var(--line);background:var(--sub);"
@@ -5533,9 +5533,9 @@ class Component extends DCLogic {
       const src = calAllDays.find(d => parseInt(d.d, 10) === n);
       monthCells.push({ n: String(n), today: n === 27, ev: src ? src.ev.slice(0, 2) : [], blank: false });
     }
-    const tabsMode = w >= 1180 && (st.workMode || "zakladki") === "zakladki";
+    const tabsMode = w >= 1180 && (st.workMode || "tabs") === "tabs";
     const emptyApp = false;
-    const filterCount = [!!st.fUnread, !!st.fFlagged, !!st.fAttach, !!st.fRange || !!st.fFrom || !!st.fTo, (st.fSort || "Najnowsze") !== "Najnowsze"].filter(Boolean).length;
+    const filterCount = [!!st.fUnread, !!st.fFlagged, !!st.fAttach, !!st.fRange || !!st.fFrom || !!st.fTo, (st.fSort || "Newest") !== "Newest"].filter(Boolean).length;
     const sideCollapsed = drawer ? false : (st.sideCollapsed !== undefined ? !!st.sideCollapsed : narrow);
     const sideW = drawer ? 0 : sideCollapsed ? 58 : 210;
     const listW = Math.max(232, Math.min(st.listW, w - railW - sideW - (narrow ? 300 : 420)));
@@ -5550,7 +5550,7 @@ class Component extends DCLogic {
       const active = st.activeTab === tb.key;
       return {
         key: tb.key,
-        title: isDoc ? tb.att.name : isHtml ? "HTML · " + (tb.htmlDoc ? tb.htmlDoc.title : "wiadomość") : th ? th.subject : "Nowa wiadomość",
+        title: isDoc ? tb.att.name : isHtml ? "HTML · " + (tb.htmlDoc ? tb.htmlDoc.title : "message") : th ? th.subject : "New message",
         icon: isDoc ? "description" : isHtml ? "code" : th ? "mail" : "edit_square",
         activate: () => this.setState(Object.assign({ activeTab: tb.key }, this.tabPatch(tb))),
         close: (e) => { if (e && e.stopPropagation) e.stopPropagation(); this.closeTab(tb.key); },
@@ -5561,18 +5561,18 @@ class Component extends DCLogic {
       };
     });
 
-    /* Pusty panel czytania: w trybie zakładek gdy nie ma otwartej zakładki, a poza nim —
-       dopóki w tej wizycie w poczcie nic nie zostało otwarte. */
+    /* Empty reading panel: in tab mode when no tab is open, and outside it —
+       until something has been opened during this visit to mail. */
     const emptyMail = !composeInPane && !docInPane && !htmlInPane &&
       (tabsMode ? tabItems.length === 0 : (!singlePane && !st.threadOpen));
 
     return {
       rootRef: this.rootRef,
       themeAttr: theme,
-      themeIcon: theme === "ciemny" ? "light_mode" : "dark_mode",
-      themeLabel: theme === "ciemny" ? "Jasny" : "Ciemny",
-      toggleTheme: () => this.setState({ themeOverride: theme === "ciemny" ? "jasny" : "ciemny" }),
-      themeMenuLabel: theme === "ciemny" ? "Motyw jasny" : "Motyw ciemny",
+      themeIcon: theme === "dark" ? "light_mode" : "dark_mode",
+      themeLabel: theme === "dark" ? "Light" : "Dark",
+      toggleTheme: () => this.setState({ themeOverride: theme === "dark" ? "light" : "dark" }),
+      themeMenuLabel: theme === "dark" ? "Light theme" : "Dark theme",
       isPhone: isMobile,
       userMenuRef: this.userMenuRef,
       userMenuOpen: !!st.userMenu,
@@ -5597,7 +5597,7 @@ class Component extends DCLogic {
       confirmDelOpen: !!st.confirmDel,
       confirmDelTitle: st.confirmDel ? st.confirmDel.title : "",
       confirmDelText: st.confirmDel ? st.confirmDel.text : "",
-      confirmDelLabel: st.confirmDel ? (st.confirmDel.label || "Usuń") : "",
+      confirmDelLabel: st.confirmDel ? (st.confirmDel.label || "Delete") : "",
       cancelConfirmDel: () => this.setState({ confirmDel: null }),
       runConfirmDel: () => {
         const c = st.confirmDel;
@@ -5605,9 +5605,9 @@ class Component extends DCLogic {
         if (c && c.run) c.run();
       },
       removePhoto: () => this.askDel({
-        title: "Usunąć zdjęcie profilowe?",
-        text: "Wrócimy do inicjałów. Plik trzeba będzie wgrać ponownie.",
-        label: "Usuń zdjęcie",
+        title: "Remove the profile photo?",
+        text: "We will fall back to initials. The file will have to be uploaded again.",
+        label: "Remove photo",
         run: () => this.setState({ myPhoto: "", photoError: "" }),
       }),
       mePreviewStyle: "width:46px;height:46px;flex:0 0 46px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:17px;letter-spacing:0.02em;background:var(--border2);color:var(--text2);" +
@@ -5623,24 +5623,24 @@ class Component extends DCLogic {
       toggleMore: () => this.setState(s2 => ({ more: !s2.more })),
       closeMore: () => this.setState({ more: false }),
       moreItems: [
-        { icon: "task_alt", label: "Zadania", go: { screen: "tasks" } },
-        { icon: "topic", label: "Sprawy", go: { screen: "cases", casePane: "list" } },
-        { icon: "calendar_month", label: "Kalendarz", go: { screen: "cal" } },
-        { icon: "group", label: "Kontakty", go: { screen: "people", peoplePane: "list" } },
-        { icon: "settings", label: "Ustawienia", settings: true },
+        { icon: "task_alt", label: "Tasks", go: { screen: "tasks" } },
+        { icon: "topic", label: "Cases", go: { screen: "cases", casePane: "list" } },
+        { icon: "calendar_month", label: "Calendar", go: { screen: "cal" } },
+        { icon: "group", label: "People", go: { screen: "people", peoplePane: "list" } },
+        { icon: "settings", label: "Settings", settings: true },
       ].map(mi => ({
         icon: mi.icon, label: mi.label,
         run: () => this.setState(Object.assign({ more: false }, mi.settings ? { settings: true } : mi.go)),
         style: "display:flex;align-items:center;gap:16px;min-height:52px;padding:14px;border-radius:13px;font-size:15px;color:var(--text)",
       })),
-      railLabelDiscover: "Odkrywaj",
-      railLabelMail: "Poczta",
-      railLabelCases: "Sprawy",
+      railLabelDiscover: "Discover",
+      railLabelMail: "Mail",
+      railLabelCases: "Cases",
       railLabelAgent: "Agent",
-      railLabelTasks: isMobile ? "Zadania" : "Zadania",
-      railLabelCal: "Kalendarz",
-      railLabelPeople: "Kontakty",
-      railLabelSettings: isMobile ? "Ustaw." : "Ustawienia",
+      railLabelTasks: "Tasks",
+      railLabelCal: "Calendar",
+      railLabelPeople: "People",
+      railLabelSettings: isMobile ? "Settings" : "Settings",
       railLabelStyle: isMobile
         ? "font-size:11.5px;line-height:1.1;text-align:center;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:100%"
         : tablet ? "font-size:10.5px;line-height:1.1;text-align:center" : "font-size:12px",
@@ -5670,7 +5670,7 @@ class Component extends DCLogic {
       })(),
       selBarShown: !!selBarIds.length,
       selClear: () => this.selClearKind(selBarKind),
-      selBarCount: selBarIds.length + " zaznaczone",
+      selBarCount: selBarIds.length + " selected",
       selBarStyle: "flex:0 0 auto;display:flex;align-items:center;gap:12px;background:var(--accent-soft);border-bottom:1px solid var(--accent-line);" +
         (isMobile ? "padding:9px 10px 9px 14px;" : "padding:8px 14px 8px 18px;"),
       selBarActions: (() => {
@@ -5683,31 +5683,31 @@ class Component extends DCLogic {
         });
         if (kind === "tasks") return [
           mk("check_circle", "Zrobione", () => this.setState(s3 => ({ taskDone: (s3.taskDone || []).concat(ids), selBy: Object.assign({}, s3.selBy || {}, { tasks: [] }) }))),
-          mk("calendar_month", "Zaplanuj", () => this.setState(s3 => ({ taskSched: (s3.taskSched || []).concat(ids), selBy: Object.assign({}, s3.selBy || {}, { tasks: [] }) }))),
-          mk("delete", "Usu\u0144", () => this.askHide("tasks", ids, "Usun\u0105\u0107 zadania?", ids.length + " zada\u0144 zniknie z listy."), true),
+          mk("calendar_month", "Schedule", () => this.setState(s3 => ({ taskSched: (s3.taskSched || []).concat(ids), selBy: Object.assign({}, s3.selBy || {}, { tasks: [] }) }))),
+          mk("delete", "Delete", () => this.askHide("tasks", ids, "Delete tasks?", ids.length + " tasks will disappear from the list."), true),
         ].map(st2);
         if (kind === "notifs") return [
-          mk("mark_email_read", "Przeczytane", () => this.setNotifsRead(ids, true)),
-          mk("mark_email_unread", "Nieprzeczytane", () => this.setNotifsRead(ids, false)),
-          mk("delete", "Usu\u0144", () => this.askHide("notifs", ids, "Usun\u0105\u0107 powiadomienia?", ids.length + " powiadomie\u0144 zniknie z centrum."), true),
+          mk("mark_email_read", "Read", () => this.setNotifsRead(ids, true)),
+          mk("mark_email_unread", "Unread", () => this.setNotifsRead(ids, false)),
+          mk("delete", "Delete", () => this.askHide("notifs", ids, "Delete notifications?", ids.length + " notifications will disappear from the centre."), true),
         ].map(st2);
         if (kind === "cases") return [
-          mk("check_circle", "Zamknij", () => { this.notify(ids.length + " spraw", { kind: "success", title: "Sprawy zamkni\u0119te" }); this.selClearKind(kind); }),
-          mk("download", "Eksportuj", () => { this.notifyTask({ title: "Eksport spraw\u2026", body: ids.length + " spraw", doneTitle: "Sprawy wyeksportowane", ms: 2000 }); this.selClearKind(kind); }),
-          mk("delete", "Usu\u0144", () => this.askHide("cases", ids, "Usun\u0105\u0107 sprawy?", ids.length + " spraw zniknie z listy."), true),
+          mk("check_circle", "Close", () => { this.notify(ids.length + " cases", { kind: "success", title: "Cases closed" }); this.selClearKind(kind); }),
+          mk("download", "Export", () => { this.notifyTask({ title: "Exporting cases\u2026", body: ids.length + " cases", doneTitle: "Cases exported", ms: 2000 }); this.selClearKind(kind); }),
+          mk("delete", "Delete", () => this.askHide("cases", ids, "Delete cases?", ids.length + " cases will disappear from the list."), true),
         ].map(st2);
         if (kind === "people") return [
-          mk("edit", "Napisz", () => { this.setState({ compose: true, composeMin: false, replyMode: null }); this.selClearKind(kind); }),
-          mk("download", "Eksportuj", () => { this.notifyTask({ title: "Eksport kontakt\u00f3w\u2026", body: ids.length + " kontakt\u00f3w", doneTitle: "Kontakty wyeksportowane", ms: 1800 }); this.selClearKind(kind); }),
-          mk("delete", "Usu\u0144", () => this.askHide("people", ids, "Usun\u0105\u0107 kontakty?", ids.length + " kontakt\u00f3w zniknie z listy."), true),
+          mk("edit", "Write", () => { this.setState({ compose: true, composeMin: false, replyMode: null }); this.selClearKind(kind); }),
+          mk("download", "Export", () => { this.notifyTask({ title: "Exporting contacts\u2026", body: ids.length + " contacts", doneTitle: "Contacts exported", ms: 1800 }); this.selClearKind(kind); }),
+          mk("delete", "Delete", () => this.askHide("people", ids, "Delete contacts?", ids.length + " contacts will disappear from the list."), true),
         ].map(st2);
         if (kind === "convs") return [
           mk("archive", "Zarchiwizuj", () => this.setState(s3 => ({ convs: (s3.convs || []).map(x => ids.indexOf(x.id) >= 0 ? Object.assign({}, x, { archived: true }) : x), selBy: Object.assign({}, s3.selBy || {}, { convs: [] }) }))),
-          mk("delete", "Usuń", () => this.askDel({ title: "Usunąć rozmowy?", text: ids.length + " rozmów zostanie trwale usuniętych.", label: "Usuń", run: () => this.setState(s3 => ({ convs: (s3.convs || []).filter(x => ids.indexOf(x.id) < 0), convId: ids.indexOf(s3.convId) >= 0 ? null : s3.convId, selBy: Object.assign({}, s3.selBy || {}, { convs: [] }) })) }), true),
+          mk("delete", "Delete", () => this.askDel({ title: "Delete conversations?", text: ids.length + " conversations will be permanently deleted.", label: "Delete", run: () => this.setState(s3 => ({ convs: (s3.convs || []).filter(x => ids.indexOf(x.id) < 0), convId: ids.indexOf(s3.convId) >= 0 ? null : s3.convId, selBy: Object.assign({}, s3.selBy || {}, { convs: [] }) })) }), true),
         ].map(st2);
         if (kind === "events") return [
-          mk("notifications_active", "Przypomnienia", () => { this.setState({ remFor: { key: ids[0], title: ids.length + " wydarze\u0144", timed: true, kind: "cal", hint: "przed godzin\u0105 wydarzenia", src: "Kalendarz" } }); this.selClearKind(kind); }),
-          mk("delete", "Usu\u0144", () => this.askDel({ title: "Usun\u0105\u0107 wydarzenia?", text: ids.length + " wydarze\u0144 zniknie z kalendarza.", label: "Usu\u0144", run: () => this.setState(s3 => ({ calAdded: (s3.calAdded || []).filter(x => ids.indexOf(x.day + "|" + x.time + "|" + x.t) < 0), selBy: Object.assign({}, s3.selBy || {}, { events: [] }) })) }), true),
+          mk("notifications_active", "Reminders", () => { this.setState({ remFor: { key: ids[0], title: ids.length + " events", timed: true, kind: "cal", hint: "before the event time", src: "Calendar" } }); this.selClearKind(kind); }),
+          mk("delete", "Delete", () => this.askDel({ title: "Delete events?", text: ids.length + " events will disappear from the calendar.", label: "Delete", run: () => this.setState(s3 => ({ calAdded: (s3.calAdded || []).filter(x => ids.indexOf(x.day + "|" + x.time + "|" + x.t) < 0), selBy: Object.assign({}, s3.selBy || {}, { events: [] }) })) }), true),
         ].map(st2);
         return [];
       })(),
@@ -5755,11 +5755,11 @@ class Component extends DCLogic {
       railTasksStyle: (isMobile ? "display:none;" : railBase + (st.screen === "tasks" ? activeStyle : idleColor)),
       railNotifStyle: railBase + (st.notifCenter ? activeStyle : idleColor),
       notifDotStyle: "position:absolute;top:-5px;right:-9px;min-width:17px;height:17px;box-sizing:border-box;padding:0 4px;display:flex;align-items:center;justify-content:center;border-radius:9px;background:var(--err);color:#fff;font-size:10px;font-weight:700;border:1.5px solid var(--rail)",
-      tbTaskLabel: tbFull ? "Nowe zadanie" : "",
+      tbTaskLabel: tbFull ? "New task" : "",
       taskActions: [
-        { icon: "search", label: "Znajdź w poczcie", run: () => this.setState({ screen: "agent" }) },
-        { icon: "event", label: "Rozplanuj dzień", run: () => this.autoSchedule() },
-        { icon: "check_circle", label: "Pokaż zrobione", run: () => this.setState(s2 => ({ showDone: !s2.showDone })) },
+        { icon: "search", label: "Find in mail", run: () => this.setState({ screen: "agent" }) },
+        { icon: "event", label: "Lay out the day", run: () => this.autoSchedule() },
+        { icon: "check_circle", label: "Show done", run: () => this.setState(s2 => ({ showDone: !s2.showDone })) },
         { icon: "download", label: "Eksportuj", run: () => {} },
       ].map(a => ({ icon: a.icon, label: tbFull ? a.label : "", run: a.run, style: tbFull ? tbBtn : tbIcon + ";flex:0 0 auto" })),
       tasksBodyStyle: isMobile || compact
@@ -5771,7 +5771,7 @@ class Component extends DCLogic {
       tasksSideStyle: isMobile || compact
         ? "display:flex;flex-direction:column;gap:10px;background:var(--sub);border:1px solid var(--line);border-radius:10px;padding:14px"
         : "width:310px;flex:0 0 310px;overflow:auto;display:flex;flex-direction:column;gap:10px;background:var(--sub);border-left:1px solid var(--line);padding:18px",
-      taskGroups: ["Dziś", "Ten tydzień", "Później"].map(g => {
+      taskGroups: ["Today", "This week", "Later"].map(g => {
         const items = allTasks.filter(t2 => t2.group === g && (st.showDone || (st.taskDone || []).indexOf(t2.id) < 0));
         return {
           label: g.toUpperCase(),
@@ -5783,23 +5783,23 @@ class Component extends DCLogic {
             return {
               t: t2.t, est: t2.est, when: t2.when, src: t2.src, ai: !!t2.ai,
               press: this.pressFor("tasks", t2.id, t2.t, [
-                { icon: "check_box", label: "Zaznacz zadania", run: () => this.selStart("tasks", t2.id) },
-                { icon: done ? "radio_button_unchecked" : "check_circle", label: done ? "Oznacz jako niezrobione" : "Oznacz jako zrobione", run: () => this.setState(s3 => ({ taskDone: done ? (s3.taskDone || []).filter(x => x !== t2.id) : (s3.taskDone || []).concat([t2.id]) })) },
-                { icon: "notifications_active", label: "Przypomnienia", run: () => this.setState({ remFor: { key: t2.id, title: t2.t, timed: false, kind: "task", hint: "przed 09:00 \u00b7 " + t2.when, src: "Zadania" } }) },
-                { icon: "calendar_month", label: "Zaplanuj w kalendarzu", run: () => this.setState(s3 => ({ taskSched: (s3.taskSched || []).concat([t2.id]), calAdded: (s3.calAdded || []).concat([{ day: t2.day || "27", time: "11:00", h: 11, t: t2.t, kind: "spotkanie", src: "zadanie" }]) })) },
-                { icon: "open_in_new", label: "Otw\u00f3rz w\u0105tek \u017ar\u00f3d\u0142owy", run: () => this.setState({ screen: "mail", threadId: t2.tid || "contoso", mailPane: "thread", threadOpen: true, cameFrom: false }) },
-                { icon: "delete", label: "Usu\u0144 zadanie", danger: true, run: () => this.askHide("tasks", [t2.id], "Usun\u0105\u0107 zadanie?", t2.t + " zniknie z listy zada\u0144.") },
+                { icon: "check_box", label: "Select tasks", run: () => this.selStart("tasks", t2.id) },
+                { icon: done ? "radio_button_unchecked" : "check_circle", label: done ? "Mark as not done" : "Mark as done", run: () => this.setState(s3 => ({ taskDone: done ? (s3.taskDone || []).filter(x => x !== t2.id) : (s3.taskDone || []).concat([t2.id]) })) },
+                { icon: "notifications_active", label: "Reminders", run: () => this.setState({ remFor: { key: t2.id, title: t2.t, timed: false, kind: "task", hint: "before 09:00 \u00b7 " + t2.when, src: "Tasks" } }) },
+                { icon: "calendar_month", label: "Schedule in the calendar", run: () => this.setState(s3 => ({ taskSched: (s3.taskSched || []).concat([t2.id]), calAdded: (s3.calAdded || []).concat([{ day: t2.day || "27", time: "11:00", h: 11, t: t2.t, kind: "meeting", src: "zadanie" }]) })) },
+                { icon: "open_in_new", label: "Open source thread", run: () => this.setState({ screen: "mail", threadId: t2.tid || "contoso", mailPane: "thread", threadOpen: true, cameFrom: false }) },
+                { icon: "delete", label: "Delete task", danger: true, run: () => this.askHide("tasks", [t2.id], "Delete task?", t2.t + " will disappear from the task list.") },
               ]),
               tap: this.rowTap("tasks", t2.id, () => {}),
               selected: isSel("tasks", t2.id),
               remCount: remN > 1 ? String(remN) : "",
               remIcon: remN ? "notifications_active" : "notifications",
-              remTitle: remN ? "Przypomnienia: " + remN : "Dodaj przypomnienie",
+              remTitle: remN ? "Reminders: " + remN : "Add a reminder",
               remStyle: "display:flex;align-items:center;gap:4px;border-radius:9px;font-weight:600;border:1px solid " +
                 (touch ? "" : "") + (remN ? "var(--accent-line);background:var(--accent-soft);color:var(--accent-d);" : "var(--line);background:var(--sub);color:var(--muted);") +
                 (touch ? "height:36px;padding:0 12px;font-size:12px;" : "height:28px;padding:0 9px;font-size:11px;"),
               remIconStyle: "font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;line-height:1;font-size:" + (touch ? 19 : 16) + "px",
-              openRem: () => this.setState({ remFor: { key: t2.id, title: t2.t, timed: false, kind: "task", hint: "przed 09:00 · " + t2.when, src: "Zadania" } }),
+              openRem: () => this.setState({ remFor: { key: t2.id, title: t2.t, timed: false, kind: "task", hint: "before 09:00 · " + t2.when, src: "Tasks" } }),
               check: done ? "check" : "",
               toggle: () => this.setState(s2 => ({
                 taskDone: (s2.taskDone || []).indexOf(t2.id) >= 0
@@ -5809,9 +5809,9 @@ class Component extends DCLogic {
               openSrc: () => this.setState({ screen: "mail", threadId: t2.tid || "contoso", mailPane: "thread", threadOpen: true, cameFrom: false }),
               schedule: () => this.setState(s2 => sched ? {} : ({
                 taskSched: (s2.taskSched || []).concat([t2.id]),
-                calAdded: (s2.calAdded || []).concat([{ day: t2.day || "27", time: "11:00", h: 11, t: t2.t, kind: "spotkanie", src: "zadanie" }]),
+                calAdded: (s2.calAdded || []).concat([{ day: t2.day || "27", time: "11:00", h: 11, t: t2.t, kind: "meeting", src: "zadanie" }]),
               })),
-              schedLabel: sched ? "w kalendarzu" : "Zaplanuj",
+              schedLabel: sched ? "in the calendar" : "Schedule",
               schedStyle: "border-radius:12px;white-space:nowrap;" + (touch ? "font-size:12.5px;padding:9px 14px;" : "font-size:11px;padding:5px 10px;") + (sched
                 ? "color:var(--muted);background:var(--rail);border:1px solid var(--line);"
                 : "color:var(--onaccent);background:var(--accent);"),
@@ -5832,11 +5832,11 @@ class Component extends DCLogic {
         };
       }),
       taskAgenda: (calAllDays.find(d => d.today) || { ev: [] }).ev.map(e => ({ time: e.time, t: e.t })),
-      capacityText: "Na dziś masz " + openToday + " zadania (≈ " + estToday + ") i 2 spotkania. Zmieści się, jeśli zaczniesz od kontrpropozycji CPI.",
+      capacityText: "Today you have " + openToday + " tasks (≈ " + estToday + ") and 2 meetings. It fits if you start with the CPI counter-proposal.",
       autoSchedule: () => this.autoSchedule(),
       newTaskOpen: !!st.newTask,
       openNewTask: () => { this.remSet("new:task", REM_DEFAULT); this.setState({ newTask: true }); },
-      tkRem: this.remBlock("new:task", { timed: false, numRef: this.remNumTaskRef, hint: "przed 09:00 w dniu terminu" }),
+      tkRem: this.remBlock("new:task", { timed: false, numRef: this.remNumTaskRef, hint: "09:00 on the day it is due" }),
       remModalOpen: !!st.remFor,
       remModalSubtitle: st.remFor ? st.remFor.title + (st.remFor.hint ? " — " + st.remFor.hint : "") : "",
       remModal: this.remBlock(st.remFor ? st.remFor.key : "none", {
@@ -5846,7 +5846,7 @@ class Component extends DCLogic {
       }),
       closeRemModal: () => {
         const f = st.remFor;
-        if (f) this.remFire(f.title, this.remList(f.key), f.kind === "task" ? "task" : "cal", f.src || "Kalendarz", { screen: f.kind === "task" ? "tasks" : "cal" });
+        if (f) this.remFire(f.title, this.remList(f.key), f.kind === "task" ? "task" : "cal", f.src || "Calendar", { screen: f.kind === "task" ? "tasks" : "cal" });
         this.setState({ remFor: null });
       },
       remModalClear: () => { if (st.remFor) this.remSet(st.remFor.key, []); },
@@ -5861,7 +5861,7 @@ class Component extends DCLogic {
         if (this.tkEstRef.current) this.tkEstRef.current.value = est;
       },
       saveTask: () => {
-        const t2 = (this.tkTitleRef.current || {}).value || "Nowe zadanie";
+        const t2 = (this.tkTitleRef.current || {}).value || "New task";
         const when = (this.tkDueRef.current || {}).value || "bez terminu";
         const est = (this.tkEstRef.current || {}).value || "30 min";
         const rem = this.remList("new:task");
@@ -5871,13 +5871,13 @@ class Component extends DCLogic {
           remMap: Object.assign({}, s2.remMap || {}, { [id]: rem.slice() }),
           extraTasks: (s2.extraTasks || []).concat([{
             id: id, t: t2, when, day: (when.match(/^(\d{1,2})/) || [])[1] || "28",
-            group: when === "dziś" ? "Dziś" : "Ten tydzień", src: "dodane ręcznie", tid: "contoso", ai: false, est,
+            group: when === "today" ? "Today" : "This week", src: "added manually", tid: "contoso", ai: false, est,
           }]),
         }));
         this.notify(rem.length
-          ? "Termin " + when + " · " + (rem.length === 1 ? remLabel(rem[0], "w terminie") : rem.length + " przypomnienia")
-          : "Termin " + when + " · bez przypomnienia", { kind: "success", title: "Zadanie dodane" });
-        this.remFire(t2, rem, "task", "Zadania", { screen: "tasks" });
+          ? "Due " + when + " · " + (rem.length === 1 ? remLabel(rem[0], "on the day") : rem.length + " reminders")
+          : "Due " + when + " · no reminder", { kind: "success", title: "Task added" });
+        this.remFire(t2, rem, "task", "Tasks", { screen: "tasks" });
       },
       isAgent: st.screen === "agent" && !emptyApp,
       goAgent: () => this.goScreen("agent"),
@@ -5893,7 +5893,7 @@ class Component extends DCLogic {
       convTitle: activeConv && activeConv.title ? activeConv.title : "Agent",
       convBarShown: tabsMode && convList.length > 1,
       convTabs: convList.map(c => ({
-        title: c.title || "Nowa rozmowa",
+        title: c.title || "New conversation",
         activate: () => this.setState({ convId: c.id }),
         close: (e) => {
           if (e && e.stopPropagation) e.stopPropagation();
@@ -5918,7 +5918,7 @@ class Component extends DCLogic {
       historyPanelStyle: isMobile
         ? "position:absolute;inset:0;z-index:45;display:flex;flex-direction:column;gap:8px;overflow:auto;background:var(--rail);padding:14px 14px 18px"
         : "width:" + Math.max(200, Math.min(480, st.historyPanelW || 250)) + "px;flex:0 0 " + Math.max(200, Math.min(480, st.historyPanelW || 250)) + "px;display:flex;flex-direction:column;gap:6px;overflow:auto;background:var(--rail);border-right:1px solid var(--line);padding:14px 12px",
-      convHistory: (activeConvList.length ? activeConvList : [{ id: null, title: "Nowa rozmowa", when: "teraz", msgs: [] }]).filter(matchesHistQuery).slice().reverse().map(c => convRow(c, false)),
+      convHistory: (activeConvList.length ? activeConvList : [{ id: null, title: "New conversation", when: "now", msgs: [] }]).filter(matchesHistQuery).slice().reverse().map(c => convRow(c, false)),
       hasArchived: archivedConvList.length > 0,
       archivedCount: archivedConvList.length,
       archiveSectionOpen: !!st.historyArchiveOpen,
@@ -5937,7 +5937,7 @@ class Component extends DCLogic {
         return { convs: rest, convId: s2.convId === s2.deleteConvAsk ? null : s2.convId, deleteConvAsk: null };
       }),
       agentShowChips: convMsgs.length < 2,
-      agentChips: ["Zaplanuj mój dzień", "Co mi umknęło w tym tygodniu?", "Przygotuj odpowiedź do Contoso", "Status spraw w toku"].map(c => ({
+      agentChips: ["Plan my day", "What slipped this week?", "Draft a reply to Contoso", "Status of open cases"].map(c => ({
         label: c, run: () => this.agentAsk(c),
       })),
       agentInput: st.agentInput || "",
@@ -5947,8 +5947,8 @@ class Component extends DCLogic {
 
       agentMsgs: (convMsgs.length ? convMsgs : [{
         role: "bot",
-        scope: "3 konta · poczta, kalendarz, sprawy",
-        text: "Cześć. Mogę napisać wiadomość, ułożyć dzień albo sprawdzić, co utknęło. Wynik zawsze pokazuję do akceptacji — nic nie wychodzi bez Ciebie.",
+        scope: "3 accounts · mail, calendar, cases",
+        text: "Hi. I can write a message, lay out your day or check what is stuck. I always show the result for approval — nothing goes out without you.",
         bullets: [],
         actions: [],
         ts: Date.now(),
@@ -6059,9 +6059,9 @@ class Component extends DCLogic {
         const q = st.query || "";
         this.setState(s2 => Object.assign({ convId: null }, this.pushMsg(Object.assign({}, s2, { convId: null }), [
           { role: "user", text: q },
-          { role: "bot", scope: "kontynuacja wyniku z Odkrywaj", text: "Mam kontekst tego wyniku: " + q + ". Mogę napisać odpowiedź, zarezerwować czas albo pokazać źródła.", bullets: [], actions: [
-            { label: "Przygotuj odpowiedź", kind: "draft" },
-            { label: "Otwórz sprawę", kind: "case" },
+          { role: "bot", scope: "continuing a Discover result", text: "I have the context of that result: " + q + ". I can draft a reply, block time or show the sources.", bullets: [], actions: [
+            { label: "Draft a reply", kind: "draft" },
+            { label: "Open the case", kind: "case" },
           ] },
         ])));
         this.setState({ screen: "agent" });
@@ -6072,9 +6072,9 @@ class Component extends DCLogic {
       homeRowStyle: "display:flex;flex-direction:column;gap:12px",
       homeCardStyle: "flex:1;min-width:0;display:flex;flex-direction:column;gap:9px;background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:15px 17px",
       todayItems: [
-        { title: "Kontrpropozycja limitu CPI", due: "jutro", why: "Contoso czeka na naszą odpowiedź od 2 dni.", src: "Aneks do umowy — podpisy", tid: "contoso", urgent: true },
-        { title: "Potwierdzenie terminu Fabrikam", due: "02.09", why: "Dostawa przesunięta o 15 dni, brak decyzji.", src: "Terminy dostawy Q4", tid: "fabrikam1", urgent: false },
-        { title: "Wykaz umów IT dla audytu", due: "03.09", why: "Audyt prosi o rejestr z aneksami.", src: "Zapytanie o rejestr umów", tid: "audyt1", urgent: false },
+        { title: "CPI cap counter-proposal", due: "tomorrow", why: "Contoso has been waiting on our reply for 2 days.", src: "Contract addendum — signatures", tid: "contoso", urgent: true },
+        { title: "Fabrikam date confirmation", due: "02.09", why: "Delivery slipped 15 days, no decision yet.", src: "Q4 delivery dates", tid: "fabrikam1", urgent: false },
+        { title: "IT contract list for audit", due: "03.09", why: "Audit is asking for the register with addenda.", src: "Contract register request", tid: "audyt1", urgent: false },
       ].slice(0, isMobile ? 2 : 3).map(t2 => ({
         title: t2.title, due: t2.due, why: t2.why, src: t2.src,
         open: () => this.setState({ screen: "mail", threadId: t2.tid, mailPane: "thread", threadOpen: true, cameFrom: false }),
@@ -6086,34 +6086,34 @@ class Component extends DCLogic {
       homeCases: CASES.map(c => ({
         title: c.title, status: c.status, scope: c.scope,
         open: () => this.setState({ screen: "cases", caseId: c.id, casePane: "detail" }),
-        statusStyle: "font-size:11px;white-space:nowrap;border-radius:10px;padding:3px 8px;" + (c.statusKind === "pilne"
+        statusStyle: "font-size:11px;white-space:nowrap;border-radius:10px;padding:3px 8px;" + (c.statusKind === "urgent"
           ? "background:var(--hl);color:var(--text);"
           : "background:var(--rail);color:var(--muted);border:1px solid var(--line);"),
       })),
       homeAgenda: [
-        { when: "dziś", t: "Status wdrożenia z Piotrem", kind: "spotkanie" },
-        { when: "jutro", t: "Decyzja: aneks Contoso", kind: "termin" },
-        { when: "jutro", t: "Call z Anną Kowalską", kind: "spotkanie" },
-        { when: "29.08", t: "Płatność FV 08/2026", kind: "termin" },
+        { when: "today", t: "Rollout status with Piotr", kind: "meeting" },
+        { when: "tomorrow", t: "Decision: Contoso addendum", kind: "deadline" },
+        { when: "tomorrow", t: "Call with Anna Kowalska", kind: "meeting" },
+        { when: "29.08", t: "Payment of invoice 08/2026", kind: "deadline" },
       ].map(a => ({
         when: a.when, t: a.t,
-        dotStyle: "width:8px;height:8px;flex:0 0 8px;border-radius:50%;background:" + (a.kind === "termin" ? "var(--hl-line)" : "var(--accent)"),
+        dotStyle: "width:8px;height:8px;flex:0 0 8px;border-radius:50%;background:" + (a.kind === "deadline" ? "var(--hl-line)" : "var(--accent)"),
       })),
-      briefingText: "Jutro mija decyzja o aneksie Contoso — kontrpropozycja limitu CPI wciąż nie wyszła. Fabrikam czeka na potwierdzenie terminu, a audyt na wykaz umów IT. Reszta poczty może poczekać.",
+      briefingText: "The Contoso addendum decision is due tomorrow — the CPI cap counter-proposal still has not gone out. Fabrikam is waiting for a date confirmation and audit for the IT contract list. The rest of the mail can wait.",
       briefingStatsStyle: isMobile
         ? "display:grid;grid-template-columns:1fr 1fr;gap:12px 16px;border-top:1px solid var(--line2);padding-top:11px"
         : "display:flex;gap:16px;flex-wrap:wrap;border-top:1px solid var(--line2);padding-top:11px",
       briefingStats: [
-        { n: "14", label: "nowych wiadomości" },
-        { n: "3", label: "wymagają decyzji" },
-        { n: "2", label: "spotkania dziś" },
-        { n: "1", label: "termin jutro" },
+        { n: "14", label: "new messages" },
+        { n: "3", label: "need a decision" },
+        { n: "2", label: "meetings today" },
+        { n: "1", label: "deadline tomorrow" },
       ],
       quickActions: [
-        { icon: "event", label: "Zaplanuj dzień", run: () => this.agentAsk("Zaplanuj mój dzień") },
-        { icon: "topic", label: "Sprawy w toku", run: () => this.setState({ screen: "cases", casePane: "list" }) },
-        { icon: "history", label: "Co mi umknęło?", run: () => this.agentAsk("Co mi umknęło w tym tygodniu?") },
-        { icon: "auto_awesome", label: "Zapytaj agenta", run: () => this.setState({ screen: "agent" }) },
+        { icon: "event", label: "Plan the day", run: () => this.agentAsk("Plan my day") },
+        { icon: "topic", label: "Open cases", run: () => this.setState({ screen: "cases", casePane: "list" }) },
+        { icon: "history", label: "What slipped?", run: () => this.agentAsk("What slipped this week?") },
+        { icon: "auto_awesome", label: "Ask the agent", run: () => this.setState({ screen: "agent" }) },
       ].map(a => ({
         icon: a.icon, label: a.label, run: a.run,
         style: "display:flex;align-items:center;gap:9px;font-size:13px;color:var(--text2);background:var(--panel);border:1px solid var(--border2);border-radius:9px;padding:9px 14px;white-space:nowrap",
@@ -6121,9 +6121,9 @@ class Component extends DCLogic {
       goMail: () => this.goScreen("mail", { mailPane: "list" }),
       digest: [
         { n: 5, label: "Klienci", note: "Contoso, Fabrikam, Adventure Works", tid: "contoso" },
-        { n: 4, label: "Wewnętrzne", note: "kontroling, wdrożenia, HR", tid: "marta" },
-        { n: 3, label: "Faktury i płatności", note: "dwie do zatwierdzenia", tid: "faktura1" },
-        { n: 2, label: "Do wiadomości", note: "nic nie wymaga odpowiedzi", tid: "hr1" },
+        { n: 4, label: "Internal", note: "controlling, delivery, HR", tid: "marta" },
+        { n: 3, label: "Invoices and payments", note: "two to approve", tid: "faktura1" },
+        { n: 2, label: "FYI", note: "nothing needs a reply", tid: "hr1" },
       ].map(d => ({
         n: d.n, label: d.label, note: d.note,
         open: () => this.setState({ screen: "mail", threadId: d.tid, mailPane: "thread", threadOpen: true, cameFrom: false }),
@@ -6131,9 +6131,9 @@ class Component extends DCLogic {
           (d.n > 3 ? "var(--accent-soft);color:var(--accent-d);" : "var(--rail);color:var(--text2);border:1px solid var(--line);"),
       })),
       savedAnswers: [
-        { q: "Jakie mamy zobowiązania SLA wobec klientów?", a: "4 umowy z SLA 4 h, jedna negocjowana na 2 h.", fresh: "aktualne" },
-        { q: "Kto odpowiada za odnowienia w Q4?", a: "Karolina (klienci), Marta (budżet), Jacek (zapisy).", fresh: "aktualne" },
-        { q: "Gdzie są polisy ubezpieczeniowe?", a: "3 pliki, najnowszy z 06.2026 w wątku od brokera.", fresh: "1 nowy mail" },
+        { q: "What SLA commitments do we have to clients?", a: "4 contracts with a 4 h SLA, one being negotiated to 2 h.", fresh: "up to date" },
+        { q: "Who owns Q4 renewals?", a: "Karolina (clients), Marta (budget), Jacek (wording).", fresh: "up to date" },
+        { q: "Where are the insurance policies?", a: "3 files, the newest from 06.2026 in the broker thread.", fresh: "1 new mail" },
       ].map(x => ({
         q: x.q, a: x.a, fresh: x.fresh,
         run: () => this.run(x.q),
@@ -6142,15 +6142,15 @@ class Component extends DCLogic {
           : "color:var(--accent-d);background:var(--accent-soft);"),
       })),
       suggestions: [
-        { text: "Jak zmieniały się warunki umowy z Contoso od 2021 roku?", plan: "Odpowiedź · Oś czasu · Tabela faktów", pick: () => this.run("Jak zmieniały się warunki umowy z Contoso od 2021 roku?") },
-        { text: "Gdzie jest ostatnia wersja polisy ubezpieczeniowej?", plan: "Odpowiedź · Załączniki", pick: () => this.run("Gdzie jest ostatnia wersja polisy ubezpieczeniowej?") },
-        { text: "Kto zatwierdzał budżet indeksacji w 2023?", plan: "Odpowiedź · Osoby", pick: () => this.run("Kto zatwierdzał budżet indeksacji w 2023?") },
+        { text: "How have the Contoso contract terms changed since 2021?", plan: "Answer · Timeline · Fact table", pick: () => this.run("How have the Contoso contract terms changed since 2021?") },
+        { text: "Where is the latest version of the insurance policy?", plan: "Answer · Attachments", pick: () => this.run("Where is the latest version of the insurance policy?") },
+        { text: "Who approved the indexation budget in 2023?", plan: "Answer · People", pick: () => this.run("Who approved the indexation budget in 2023?") },
       ],
 
       showIdle: st.phase === "idle",
       hasRun,
       running: st.phase === "running",
-      progressText: plan ? (isMobile ? "Retrieval semantyczny… bloki dojeżdżają pojedynczo" : "Retrieval semantyczny w zakresie 3 kont… bloki dojeżdżają pojedynczo") : "",
+      progressText: plan ? (isMobile ? "Semantic retrieval… blocks arrive one by one" : "Semantic retrieval across 3 accounts… blocks arrive one by one") : "",
       planLabel: plan ? plan.label : "",
       runMeta: plan ? plan.meta : "",
       confidence: plan ? plan.confidence : "",
@@ -6176,12 +6176,12 @@ class Component extends DCLogic {
       showTrace: hasRun && (this.props.showTrace ?? true) && st.phase === "done",
       traceText: plan ? plan.trace : "",
 
-      evidenceCount: plan ? plan.evidence.length + " źródeł · kliknij, aby zobaczyć fragment" : "",
+      evidenceCount: plan ? plan.evidence.length + " sources · click to see the passage" : "",
       evidence: plan && ready.evidence ? plan.evidence.map(e => { const sb = srcBadge(e); return { n: e.n, title: e.title, snippet: e.snippet, meta: e.meta, open: () => this.setState({ ev: e.n }), badgeStyle: SRC_BADGE_STYLE, badgeIconStyle: SRC_BADGE_ICON_STYLE, badgeIcon: sb.icon, badgeLabel: sb.label, badgeTitle: sb.title }; }) : [],
       inspectorOpen: !!evObj,
       inspectorClosed: !evObj,
       closeInspector: () => this.setState({ ev: null }),
-      inspectorIndex: evObj && plan ? "DOWÓD " + evObj.n + " z " + plan.evidence[plan.evidence.length - 1].n : "",
+      inspectorIndex: evObj && plan ? "EVIDENCE " + evObj.n + " of " + plan.evidence[plan.evidence.length - 1].n : "",
       inspectorTitle: evObj ? evObj.title : "",
       inspectorMeta: evObj ? evObj.meta : "",
       inspectorBadgeStyle: SRC_BADGE_STYLE,
@@ -6202,7 +6202,7 @@ class Component extends DCLogic {
         ? (() => this.setState({ sideDrawer: false }))
         : (() => this.setState(s2 => ({ sideCollapsed: !s2.sideCollapsed }))),
       sideToggleIcon: drawer ? "close" : sideCollapsed ? "chevron_right" : "chevron_left",
-      sideToggleTitle: drawer ? "Zamknij katalogi" : sideCollapsed ? "Rozwiń panel skrzynek" : "Zwiń panel skrzynek",
+      sideToggleTitle: drawer ? "Close folders" : sideCollapsed ? "Expand the mailbox panel" : "Collapse the mailbox panel",
       showSide: !drawer || drawerOpen,
       sideScrim: drawer && drawerOpen,
       closeDrawer: () => this.setState({ sideDrawer: false }),
@@ -6219,15 +6219,15 @@ class Component extends DCLogic {
       filtersActive: filterCount > 0,
       filtersCount: filterCount,
       filtersIcon: filterCount > 0 ? "filter_alt" : "tune",
-      filtersTitle: filterCount > 0 ? "Filtry (" + filterCount + ") — kliknij, aby pokazać" : "Filtry",
+      filtersTitle: filterCount > 0 ? "Filters (" + filterCount + ") — click to show" : "Filters",
       filtersBtnStyle: "flex:0 0 auto;min-width:34px;height:34px;display:flex;align-items:center;justify-content:center;gap:3px;padding:0 7px;border-radius:9px;" +
         (filterCount > 0 ? "color:var(--accent-d);background:var(--accent-soft);" : "color:var(--muted);"),
-      filtersSummary: filterCount > 0 ? "Aktywne filtry: " + filterCount : "Brak aktywnych filtrów",
-      clearFilters: () => this.setState({ fUnread: false, fFlagged: false, fAttach: false, fSort: "Najnowsze", fRange: "", fFrom: "", fTo: "" }),
+      filtersSummary: filterCount > 0 ? "Active filters: " + filterCount : "No active filters",
+      clearFilters: () => this.setState({ fUnread: false, fFlagged: false, fAttach: false, fSort: "Newest", fRange: "", fFrom: "", fTo: "" }),
       filterToggles: [
-        { key: "fUnread", label: "Nieprzeczytane", icon: "mark_email_unread" },
-        { key: "fFlagged", label: "Oflagowane", icon: "flag" },
-        { key: "fAttach", label: "Z załącznikami", icon: "attach_file" },
+        { key: "fUnread", label: "Unread", icon: "mark_email_unread" },
+        { key: "fFlagged", label: "Flagged", icon: "flag" },
+        { key: "fAttach", label: "With attachments", icon: "attach_file" },
       ].map(f => {
         const on = !!st[f.key];
         return {
@@ -6238,13 +6238,13 @@ class Component extends DCLogic {
             (on ? "var(--accent);background:var(--accent-soft);color:var(--accent-d);font-weight:600;" : "var(--line);background:var(--panel);color:var(--text2);"),
         };
       }),
-      sortOptions: ["Najnowsze", "Najstarsze", "Nadawca", "Temat"].map(s => ({
+      sortOptions: ["Newest", "Oldest", "Sender", "Subject"].map(s => ({
         label: s,
         pick: () => this.setState({ fSort: s }),
         style: "font-size:12.5px;border-radius:16px;padding:6px 11px;border:1px solid " +
-          ((st.fSort || "Najnowsze") === s ? "var(--accent);background:var(--accent-soft);color:var(--accent-d);font-weight:600;" : "var(--line);background:var(--panel);color:var(--text2);"),
+          ((st.fSort || "Newest") === s ? "var(--accent);background:var(--accent-soft);color:var(--accent-d);font-weight:600;" : "var(--line);background:var(--panel);color:var(--text2);"),
       })),
-      rangeOptions: ["Dziś", "Ostatnie 7 dni", "Ostatnie 30 dni", "Ten rok"].map(r => ({
+      rangeOptions: ["Today", "Last 7 days", "Last 30 days", "This year"].map(r => ({
         label: r,
         pick: () => this.setState(s2 => ({ fRange: s2.fRange === r ? "" : r, fFrom: "", fTo: "" })),
         style: "font-size:12.5px;border-radius:16px;padding:6px 11px;border:1px solid " +
@@ -6271,21 +6271,21 @@ class Component extends DCLogic {
         ? "margin-top:12px;display:flex;flex-direction:column;gap:4px;border-top:1px solid var(--line);padding-top:12px"
         : "margin-top:16px;display:flex;flex-direction:column;gap:6px;border-top:1px solid var(--line);padding-top:14px",
       sideGroups: [
-        { key: "all", label: "Wszystkie konta", title: "Katalogi globalne — dwa konta", dot: "linear-gradient(135deg,var(--accent) 50%,#4d9aa8 50%)", folders: [
-          { icon: "all_inbox", label: "Wszystkie", count: "12" },
-          { icon: "mark_email_unread", label: "Nieprzeczytane", count: "4" },
-          { icon: "star", label: "Ważne", count: "3" },
+        { key: "all", label: "All accounts", title: "Global folders — two accounts", dot: "linear-gradient(135deg,var(--accent) 50%,#4d9aa8 50%)", folders: [
+          { icon: "all_inbox", label: "All", count: "12" },
+          { icon: "mark_email_unread", label: "Unread", count: "4" },
+          { icon: "star", label: "Important", count: "3" },
         ] },
-        { key: "acc1", label: "Nordwind · służbowe", title: "k.kowalska@nordwind.pl", dot: "var(--accent)", folders: [
-          { icon: "inbox", label: "Odebrane", count: "8", active: true },
-          { icon: "send", label: "Wysłane", count: "" },
-          { icon: "draft", label: "Szkice", count: "2" },
-          { icon: "archive", label: "Archiwum", count: "" },
+        { key: "acc1", label: "Nordwind · work", title: "k.kowalska@nordwind.example", dot: "var(--accent)", folders: [
+          { icon: "inbox", label: "Inbox", count: "8", active: true },
+          { icon: "send", label: "Sent", count: "" },
+          { icon: "draft", label: "Drafts", count: "2" },
+          { icon: "archive", label: "Archive", count: "" },
         ] },
-        { key: "acc2", label: "Poczta prywatna", title: "kowalska.k@poczta.example", dot: "#4d9aa8", folders: [
-          { icon: "inbox", label: "Odebrane", count: "4" },
-          { icon: "send", label: "Wysłane", count: "" },
-          { icon: "delete", label: "Kosz", count: "" },
+        { key: "acc2", label: "Personal mail", title: "kowalska.k@mail.example", dot: "#4d9aa8", folders: [
+          { icon: "inbox", label: "Inbox", count: "4" },
+          { icon: "send", label: "Sent", count: "" },
+          { icon: "delete", label: "Trash", count: "" },
         ] },
       ].map(g => {
         const open = (st.accOpen || {})[g.key] !== false;
@@ -6298,7 +6298,7 @@ class Component extends DCLogic {
           dotStyle: "width:8px;height:8px;flex:0 0 8px;border-radius:50%;background:" + g.dot,
           folders: g.folders.map(mb0 => {
             const fk = g.key + "·" + mb0.label;
-            const mb = Object.assign({}, mb0, { active: (st.folderKey || "acc1·Odebrane") === fk });
+            const mb = Object.assign({}, mb0, { active: (st.folderKey || "acc1·Inbox") === fk });
             return {
             icon: mb.icon, label: mb.label, count: mb.count, expanded: !sideCollapsed,
             title: g.title + " — " + mb.label + (mb.count ? " · " + mb.count : ""),
@@ -6314,7 +6314,7 @@ class Component extends DCLogic {
         };
       }),
 
-      /* Szkielety ładowania — lista katalogu i okno wiadomości. */
+      /* Loading skeletons — folder list and message window. */
       listLoading: !!st.listLoading,
       listReady: !st.listLoading,
       listSkelStyle: "display:flex;flex-direction:column;gap:1px;padding:1px 0",
@@ -6337,7 +6337,7 @@ class Component extends DCLogic {
       })),
       aiFilters: [
         { icon: "pending_actions", label: "Wymaga decyzji" },
-        { icon: "handshake", label: "Zobowiązania" },
+        { icon: "handshake", label: "Commitments" },
         { icon: "schedule", label: "Terminy w tym tygodniu" },
       ].map(fl => ({
         icon: fl.icon, label: fl.label, expanded: !sideCollapsed, title: "Filtr AI: " + fl.label,
@@ -6348,18 +6348,18 @@ class Component extends DCLogic {
       })),
 
 
-      tbEventLabel: tbFull ? "Nowe wydarzenie" : "",
-      tbContactLabel: tbFull ? "Nowy kontakt" : "",
+      tbEventLabel: tbFull ? "New event" : "",
+      tbContactLabel: tbFull ? "New contact" : "",
       calActions: [
-        { icon: "today", label: "Dziś" },
-        { icon: "event_available", label: "Znajdź termin" },
-        { icon: "mail", label: "Zaproszenie" },
+        { icon: "today", label: "Today" },
+        { icon: "event_available", label: "Find a slot" },
+        { icon: "mail", label: "Invitation" },
         { icon: "download", label: "Eksportuj" },
-        { icon: "print", label: "Drukuj" },
+        { icon: "print", label: "Print" },
       ].map(a => ({ icon: a.icon, title: a.label, label: tbFull ? a.label : "", style: tbFull ? tbBtn : tbIcon + ";flex:0 0 auto" })),
       peopleActions: [
-        { icon: "edit", label: "Napisz" },
-        { icon: "event", label: "Zaplanuj spotkanie" },
+        { icon: "edit", label: "Write" },
+        { icon: "event", label: "Schedule a meeting" },
         { icon: "merge", label: "Scal duplikaty" },
         { icon: "upload", label: "Importuj" },
         { icon: "download", label: "Eksportuj" },
@@ -6367,7 +6367,7 @@ class Component extends DCLogic {
       fieldStyle: "flex:1;min-width:0;font-family:inherit;font-size:14px;color:var(--text);background:var(--sub);border:1px solid var(--line);border-radius:8px;padding:10px 12px;outline:none",
       newEventOpen: !!st.newEvent,
       openNewEvent: () => { this.remSet("new:event", REM_DEFAULT); this.setState({ newEvent: true }); },
-      evRem: this.remBlock("new:event", { timed: true, numRef: this.remNumEventRef, hint: "przed godziną wydarzenia" }),
+      evRem: this.remBlock("new:event", { timed: true, numRef: this.remNumEventRef, hint: "before the event time" }),
       closeNewEvent: () => this.setState({ newEvent: false, evParsed: null }),
       evTitleRef: this.evTitleRef, evDayRef: this.evDayRef, evTimeRef: this.evTimeRef, evPromptRef: this.evPromptRef,
       promptFieldStyle: "font-family:inherit;font-size:14px;color:var(--text);background:var(--panel);border:2px solid var(--accent);border-radius:9px;padding:10px 12px;outline:none",
@@ -6385,29 +6385,29 @@ class Component extends DCLogic {
         if (this.evTitleRef.current) this.evTitleRef.current.value = thread.subject;
         if (this.evDayRef.current) this.evDayRef.current.value = "28";
         if (this.evTimeRef.current) this.evTimeRef.current.value = "13:00";
-        this.setState({ evParsed: ["z wątku: " + thread.subject, "28.08", "13:00", "uczestnik: " + thread.from] });
+        this.setState({ evParsed: ["from thread: " + thread.subject, "28.08", "13:00", "attendee: " + thread.from] });
       },
       saveEvent: () => {
-        const t = (this.evTitleRef.current || {}).value || "Nowe wydarzenie";
+        const t = (this.evTitleRef.current || {}).value || "New event";
         const day = ((this.evDayRef.current || {}).value || "28").replace(/[^0-9]/g, "").slice(0, 2) || "28";
         const time = (this.evTimeRef.current || {}).value || "12:00";
         const rem = this.remList("new:event");
         this.setState(s2 => ({
           newEvent: false, evParsed: null,
           remMap: Object.assign({}, s2.remMap || {}, { [day + "|" + time + "|" + t]: rem.slice() }),
-          calAdded: (s2.calAdded || []).concat([{ day, time, h: parseInt(time, 10) || 12, t, kind: "spotkanie" }]),
+          calAdded: (s2.calAdded || []).concat([{ day, time, h: parseInt(time, 10) || 12, t, kind: "meeting" }]),
         }));
         this.notify(day + ".08, " + time + " · " + (rem.length
-          ? (rem.length === 1 ? remLabel(rem[0]) : rem.length + " przypomnienia")
-          : "bez przypomnienia"), { kind: "success", title: "Wydarzenie dodane" });
-        this.remFire(t, rem, "cal", "Kalendarz", { screen: "cal" });
+          ? (rem.length === 1 ? remLabel(rem[0]) : rem.length + " reminders")
+          : "no reminder"), { kind: "success", title: "Event added" });
+        this.remFire(t, rem, "cal", "Calendar", { screen: "cal" });
       },
       newContactOpen: !!st.newContact,
       openNewContact: () => this.setState({ newContact: true }),
       closeNewContact: () => this.setState({ newContact: false }),
       ctNameRef: this.ctNameRef, ctMailRef: this.ctMailRef, ctOrgRef: this.ctOrgRef, ctRoleRef: this.ctRoleRef,
       saveContact: () => {
-        const name = (this.ctNameRef.current || {}).value || "Nowy kontakt";
+        const name = (this.ctNameRef.current || {}).value || "New contact";
         const mail = (this.ctMailRef.current || {}).value || "";
         const org = (this.ctOrgRef.current || {}).value || "";
         const role = (this.ctRoleRef.current || {}).value || "";
@@ -6418,49 +6418,49 @@ class Component extends DCLogic {
           peoplePane: "detail",
           extraContacts: (s2.extraContacts || []).concat([{
             id, name, role: role || "—", org: org || "—", mail, last: "brak korespondencji",
-            owed: "—", cases: "—", note: "Kontakt dodany ręcznie. Po pierwszej wymianie wiadomości pojawi się tu stan relacji.",
+            owed: "—", cases: "—", note: "Contact added manually. After the first exchange of messages the relationship state appears here.",
             threads: [], docs: [],
           }]),
         }));
       },
       eventOpen: !!st.event,
       eventRemList: (st.event ? this.remList(st.event.day + "|" + st.event.time + "|" + st.event.t) : []).slice().sort((a, b) => b - a).map(m => ({
-        label: remLabel(m, st.event && st.event.time === "cały dzień" ? "w terminie" : "w momencie"),
+        label: remLabel(m, st.event && st.event.time === "all day" ? "on the day" : "at the time"),
         remove: () => this.remToggle(st.event.day + "|" + st.event.time + "|" + st.event.t, m),
       })),
       eventRemAny: !!(st.event && this.remList(st.event.day + "|" + st.event.time + "|" + st.event.t).length),
       eventRemNone: !!(st.event && !this.remList(st.event.day + "|" + st.event.time + "|" + st.event.t).length),
-      eventRemAction: st.event && this.remList(st.event.day + "|" + st.event.time + "|" + st.event.t).length ? "Zmień" : "Dodaj przypomnienie",
+      eventRemAction: st.event && this.remList(st.event.day + "|" + st.event.time + "|" + st.event.t).length ? "Change" : "Add a reminder",
       eventOpenRem: () => {
         const e = st.event;
         if (!e) return;
         const key = e.day + "|" + e.time + "|" + e.t;
         if (!this.remList(key).length) this.remSet(key, REM_DEFAULT);
-        this.setState({ remFor: { key: key, title: e.t, timed: e.time !== "cały dzień", kind: "cal", hint: this.remAnchor({ time: e.time, day: e.day }), src: "Kalendarz" } });
+        this.setState({ remFor: { key: key, title: e.t, timed: e.time !== "all day", kind: "cal", hint: this.remAnchor({ time: e.time, day: e.day }), src: "Calendar" } });
       },
       eventTitle: st.event ? st.event.t : "",
-      eventWhen: st.event ? (st.event.day ? st.event.day + " sierpnia · " : "") + st.event.time : "",
-      eventKind: st.event ? (st.event.kind === "termin" ? "Termin" : st.event.kind === "mail" ? "Z poczty" : "Spotkanie") : "",
-      eventKindStyle: "font-size:11px;border-radius:11px;padding:3px 9px;" + (st.event && st.event.kind === "termin"
+      eventWhen: st.event ? (st.event.day ? st.event.day + " August · " : "") + st.event.time : "",
+      eventKind: st.event ? (st.event.kind === "deadline" ? "Deadline" : st.event.kind === "mail" ? "From mail" : "Meeting") : "",
+      eventKindStyle: "font-size:11px;border-radius:11px;padding:3px 9px;" + (st.event && st.event.kind === "deadline"
         ? "background:var(--hl);color:var(--text);border:1px solid var(--hl-line);"
         : "background:var(--rail);color:var(--text2);border:1px solid var(--line);"),
       eventSrc: st.event ? (st.event.src || "") : "",
       eventHasSrc: !!(st.event && st.event.src),
-      eventNote: st.event && st.event.kind === "termin"
-        ? "Termin wykryty w korespondencji — zmiana daty w wątku zaktualizuje wpis."
-        : "Wydarzenie powiązane ze sprawą; uczestnicy pochodzą z wątku.",
+      eventNote: st.event && st.event.kind === "deadline"
+        ? "Deadline detected in the correspondence — changing the date in the thread updates this entry."
+        : "Event linked to a case; attendees come from the thread.",
       closeEvent: () => this.setState({ event: null }),
       eventOpenThread: () => this.setState({ event: null, screen: "mail", mailPane: "thread", threadOpen: true }),
       eventDelete: () => this.askDel({
-        title: "Usunąć to wydarzenie?",
-        text: (st.event ? "„" + st.event.t + "”" : "Wydarzenie") + " zniknie z kalendarza wraz z przypomnieniami.",
-        label: "Usuń wydarzenie",
+        title: "Delete this event?",
+        text: (st.event ? "“" + st.event.t + "”" : "The event") + " will disappear from the calendar along with its reminders.",
+        label: "Delete event",
         run: () => this.setState(s2 => ({
           event: null,
           calAdded: (s2.calAdded || []).filter(x => !(x.t === (s2.event || {}).t)),
         })),
       }),
-      calBriefing: "Dziś 1 termin krytyczny i 2 spotkania. Jutro mija decyzja o aneksie Contoso — szkic odpowiedzi wciąż nie jest gotowy.",
+      calBriefing: "One critical deadline today and 2 meetings. The Contoso addendum decision is due tomorrow — the draft reply still is not ready.",
       calTitleRowStyle: isMobile
         ? "display:flex;align-items:flex-start;gap:10px"
         : "display:flex;align-items:center;gap:14px;flex:1;min-width:0",
@@ -6472,18 +6472,18 @@ class Component extends DCLogic {
         : "display:flex;align-items:center;gap:7px;flex-wrap:wrap",
       calTodayBtnStyle: "color:var(--text2);border:1px solid var(--border2);border-radius:8px;white-space:nowrap;" +
         (touch ? "font-size:13px;padding:10px 14px" : "font-size:12px;padding:6px 12px"),
-      calViews: ["Dzień", "Tydzień", "Miesiąc", "Agenda"].map(v => ({
+      calViews: ["Day", "Week", "Month", "Agenda"].map(v => ({
         label: v,
         pick: () => this.setState({ calView: v }),
         style: "border-radius:8px;white-space:nowrap;text-align:center;" +
           (isMobile ? "flex:1;font-size:13px;padding:9px 4px;" : "font-size:12px;padding:6px 11px;") +
-          ((st.calView || "Tydzień") === v
+          ((st.calView || "Week") === v
             ? "background:var(--accent);color:var(--onaccent);font-weight:600;"
             : "color:var(--text2);border:1px solid var(--border2);"),
       })),
-      calIsWeek: (st.calView || "Tydzień") === "Tydzień",
-      calIsDay: st.calView === "Dzień",
-      calIsMonth: st.calView === "Miesiąc",
+      calIsWeek: (st.calView || "Week") === "Week",
+      calIsDay: st.calView === "Day",
+      calIsMonth: st.calView === "Month",
       calIsAgenda: st.calView === "Agenda",
       calDayWrapStyle: isMobile
         ? "flex:0 0 auto;display:flex;flex-direction:column;padding:6px 14px 16px 14px"
@@ -6496,11 +6496,11 @@ class Component extends DCLogic {
           t: e.t, time: e.time, src: e.src || "", hasSrc: !!e.src,
           style: evStyle(e.kind) + (isSel("events", calToday.d + "|" + e.time + "|" + e.t) ? "background:var(--accent-soft);border-color:var(--accent);box-shadow:inset 3px 0 0 var(--accent);" : ""),
           press: this.pressFor("events", (calToday.d) + "|" + e.time + "|" + e.t, e.t, [
-            { icon: "check_box", label: "Zaznacz wydarzenia", run: () => this.selStart("events", (calToday.d) + "|" + e.time + "|" + e.t) },
-            { icon: "event", label: "Otw\u00f3rz wydarzenie", run: () => this.setState({ event: Object.assign({ day: calToday.d }, e) }) },
-            { icon: "notifications_active", label: "Przypomnienia", run: () => this.setState({ remFor: { key: (calToday.d) + "|" + e.time + "|" + e.t, title: e.t, timed: e.time !== "ca\u0142y dzie\u0144", kind: "cal", hint: this.remAnchor({ time: e.time, day: calToday.d }), src: "Kalendarz" } }) },
-            { icon: "auto_awesome", label: "Zapytaj agenta", run: () => this.goAgentWith("wydarzenie \u201e" + e.t + "\u201d") },
-            { icon: "delete", label: "Usu\u0144 wydarzenie", danger: true, run: () => this.askDel({ title: "Usun\u0105\u0107 to wydarzenie?", text: "\u201e" + e.t + "\u201d zniknie z kalendarza wraz z przypomnieniami.", label: "Usu\u0144 wydarzenie", run: () => this.setState(s3 => ({ calAdded: (s3.calAdded || []).filter(x => x.t !== e.t) })) }) },
+            { icon: "check_box", label: "Select events", run: () => this.selStart("events", (calToday.d) + "|" + e.time + "|" + e.t) },
+            { icon: "event", label: "Open event", run: () => this.setState({ event: Object.assign({ day: calToday.d }, e) }) },
+            { icon: "notifications_active", label: "Reminders", run: () => this.setState({ remFor: { key: (calToday.d) + "|" + e.time + "|" + e.t, title: e.t, timed: e.time !== "all day", kind: "cal", hint: this.remAnchor({ time: e.time, day: calToday.d }), src: "Calendar" } }) },
+            { icon: "auto_awesome", label: "Ask the agent", run: () => this.goAgentWith("event \u201C" + e.t + "\u201D") },
+            { icon: "delete", label: "Delete event", danger: true, run: () => this.askDel({ title: "Delete this event?", text: "\u201C" + e.t + "\u201D will disappear from the calendar along with its reminders.", label: "Delete event", run: () => this.setState(s3 => ({ calAdded: (s3.calAdded || []).filter(x => x.t !== e.t) })) }) },
           ]),
           open: this.rowTap("events", calToday.d + "|" + e.time + "|" + e.t, () => this.setState({ event: Object.assign({ day: calToday.d }, e) })),
         })),
@@ -6516,13 +6516,13 @@ class Component extends DCLogic {
         : narrow
         ? "flex:1;min-width:0;overflow:auto;display:grid;grid-template-columns:repeat(7,1fr);gap:3px;padding:12px 14px"
         : "flex:1;min-width:0;overflow:auto;display:grid;grid-template-columns:repeat(7,1fr);gap:4px;padding:14px 24px 20px 24px;align-content:start",
-      calDowLabels: ["PON", "WT", "ŚR", "CZW", "PT", "SOB", "NIE"].map(l => ({ label: l })),
+      calDowLabels: ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"].map(l => ({ label: l })),
       calMonthCells: monthCells.map(c => ({
         n: c.n,
         pick: () => (c.blank ? null : this.setState({ calSelDay: c.n })),
         hasMarks: isMobile && !c.blank && c.ev.length > 0,
         marks: (isMobile ? c.ev.slice(0, 3) : []).map(e => ({
-          style: "width:5px;height:5px;border-radius:50%;background:" + (e.kind === "termin" ? "var(--hl-line)" : "var(--accent)"),
+          style: "width:5px;height:5px;border-radius:50%;background:" + (e.kind === "deadline" ? "var(--hl-line)" : "var(--accent)"),
         })),
         style: isMobile
           ? "aspect-ratio:1;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px;border-radius:11px;" +
@@ -6539,7 +6539,7 @@ class Component extends DCLogic {
         dots: (isMobile ? [] : c.ev).map(e => ({
           t: e.t, open: () => this.setState({ event: Object.assign({ day: c.n }, e) }),
           style: "font-size:10px;line-height:1.3;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;border-radius:4px;padding:2px 5px;" +
-            (e.kind === "termin" ? "background:var(--hl);color:var(--text);" : "background:var(--rail);color:var(--text2);"),
+            (e.kind === "deadline" ? "background:var(--hl);color:var(--text);" : "background:var(--rail);color:var(--text2);"),
         })),
       })),
       calMonthDayShown: isMobile,
@@ -6547,14 +6547,14 @@ class Component extends DCLogic {
       calMonthDayCount: (() => {
         const d = calAllDays.find(x => x.d === (st.calSelDay || "27"));
         const n = d ? d.ev.length : 0;
-        return n === 0 ? "" : n === 1 ? "1 wydarzenie" : n < 5 ? n + " wydarzenia" : n + " wydarzeń";
+        return n === 0 ? "" : n === 1 ? "1 event" : n + " events";
       })(),
       calMonthDayEmpty: !((calAllDays.find(x => x.d === (st.calSelDay || "27")) || { ev: [] }).ev.length),
       calMonthDayEvents: ((calAllDays.find(x => x.d === (st.calSelDay || "27")) || { ev: [] }).ev).map(e => ({
         t: e.t, time: e.time,
         open: () => this.setState({ event: Object.assign({ day: st.calSelDay || "27" }, e) }),
         style: "display:flex;flex-direction:column;gap:3px;border-radius:10px;padding:11px 13px;border:1px solid " +
-          (e.kind === "termin" ? "var(--hl-line);background:var(--hl);" : "var(--line);background:var(--panel);"),
+          (e.kind === "deadline" ? "var(--hl-line);background:var(--hl);" : "var(--line);background:var(--panel);"),
       })),
       calAgendaWrapStyle: isMobile
         ? "flex:0 0 auto;display:flex;flex-direction:column;padding:6px 14px 16px 14px"
@@ -6578,14 +6578,14 @@ class Component extends DCLogic {
         ev: d.ev.map(e => ({
           t: e.t, time: e.time, src: e.src || "", hasSrc: !!e.src,
           press: this.pressFor("events", (d.d) + "|" + e.time + "|" + e.t, e.t, [
-            { icon: "check_box", label: "Zaznacz wydarzenia", run: () => this.selStart("events", (d.d) + "|" + e.time + "|" + e.t) },
-            { icon: "event", label: "Otw\u00f3rz wydarzenie", run: () => this.setState({ event: Object.assign({ day: d.d }, e) }) },
-            { icon: "notifications_active", label: "Przypomnienia", run: () => this.setState({ remFor: { key: (d.d) + "|" + e.time + "|" + e.t, title: e.t, timed: e.time !== "ca\u0142y dzie\u0144", kind: "cal", hint: this.remAnchor({ time: e.time, day: d.d }), src: "Kalendarz" } }) },
-            { icon: "auto_awesome", label: "Zapytaj agenta", run: () => this.goAgentWith("wydarzenie \u201e" + e.t + "\u201d") },
-            { icon: "delete", label: "Usu\u0144 wydarzenie", danger: true, run: () => this.askDel({ title: "Usun\u0105\u0107 to wydarzenie?", text: "\u201e" + e.t + "\u201d zniknie z kalendarza wraz z przypomnieniami.", label: "Usu\u0144 wydarzenie", run: () => this.setState(s3 => ({ calAdded: (s3.calAdded || []).filter(x => x.t !== e.t) })) }) },
+            { icon: "check_box", label: "Select events", run: () => this.selStart("events", (d.d) + "|" + e.time + "|" + e.t) },
+            { icon: "event", label: "Open event", run: () => this.setState({ event: Object.assign({ day: d.d }, e) }) },
+            { icon: "notifications_active", label: "Reminders", run: () => this.setState({ remFor: { key: (d.d) + "|" + e.time + "|" + e.t, title: e.t, timed: e.time !== "all day", kind: "cal", hint: this.remAnchor({ time: e.time, day: d.d }), src: "Calendar" } }) },
+            { icon: "auto_awesome", label: "Ask the agent", run: () => this.goAgentWith("event \u201C" + e.t + "\u201D") },
+            { icon: "delete", label: "Delete event", danger: true, run: () => this.askDel({ title: "Delete this event?", text: "\u201C" + e.t + "\u201D will disappear from the calendar along with its reminders.", label: "Delete event", run: () => this.setState(s3 => ({ calAdded: (s3.calAdded || []).filter(x => x.t !== e.t) })) }) },
           ]),
           open: this.rowTap("events", d.d + "|" + e.time + "|" + e.t, () => this.setState({ event: Object.assign({ day: d.d }, e) })),
-          dotStyle: "width:8px;height:8px;flex:0 0 8px;border-radius:50%;background:" + (isSel("events", d.d + "|" + e.time + "|" + e.t) ? "var(--accent)" : e.kind === "termin" ? "var(--hl-line)" : e.kind === "mail" ? "var(--border2)" : "var(--accent)"),
+          dotStyle: "width:8px;height:8px;flex:0 0 8px;border-radius:50%;background:" + (isSel("events", d.d + "|" + e.time + "|" + e.t) ? "var(--accent)" : e.kind === "deadline" ? "var(--hl-line)" : e.kind === "mail" ? "var(--border2)" : "var(--accent)"),
           rowStyle: "display:flex;flex-direction:column;gap:3px;border-radius:9px;padding:6px 8px;margin:0 -8px;" + (isSel("events", d.d + "|" + e.time + "|" + e.t) ? "background:var(--accent-soft);box-shadow:inset 3px 0 0 var(--accent);" : ""),
         })),
       })),
@@ -6593,7 +6593,7 @@ class Component extends DCLogic {
         t: f.t, why: f.why, slot: f.day + ".08, " + f.time + " · " + f.len,
         add: () => this.setState(s2 => ({
           calDone: (s2.calDone || []).concat([f.t]),
-          calAdded: (s2.calAdded || []).concat([{ day: f.day, time: f.time, h: parseInt(f.time, 10), t: f.t, kind: "spotkanie", src: "blok od AI" }]),
+          calAdded: (s2.calAdded || []).concat([{ day: f.day, time: f.time, h: parseInt(f.time, 10), t: f.t, kind: "meeting", src: "blok od AI" }]),
         })),
         skip: () => this.setState(s2 => ({ calDone: (s2.calDone || []).concat([f.t]) })),
       })),
@@ -6621,14 +6621,14 @@ class Component extends DCLogic {
         ev: (d.ev.concat((st.calAdded || []).filter(x => x.day === d.d))).map(e => ({
           time: e.time, t: e.t, src: e.src || "", hasSrc: !!e.src,
           press: this.pressFor("events", (d.d) + "|" + e.time + "|" + e.t, e.t, [
-            { icon: "check_box", label: "Zaznacz wydarzenia", run: () => this.selStart("events", (d.d) + "|" + e.time + "|" + e.t) },
-            { icon: "event", label: "Otw\u00f3rz wydarzenie", run: () => this.setState({ event: Object.assign({ day: d.d }, e) }) },
-            { icon: "notifications_active", label: "Przypomnienia", run: () => this.setState({ remFor: { key: (d.d) + "|" + e.time + "|" + e.t, title: e.t, timed: e.time !== "ca\u0142y dzie\u0144", kind: "cal", hint: this.remAnchor({ time: e.time, day: d.d }), src: "Kalendarz" } }) },
-            { icon: "auto_awesome", label: "Zapytaj agenta", run: () => this.goAgentWith("wydarzenie \u201e" + e.t + "\u201d") },
-            { icon: "delete", label: "Usu\u0144 wydarzenie", danger: true, run: () => this.askDel({ title: "Usun\u0105\u0107 to wydarzenie?", text: "\u201e" + e.t + "\u201d zniknie z kalendarza wraz z przypomnieniami.", label: "Usu\u0144 wydarzenie", run: () => this.setState(s3 => ({ calAdded: (s3.calAdded || []).filter(x => x.t !== e.t) })) }) },
+            { icon: "check_box", label: "Select events", run: () => this.selStart("events", (d.d) + "|" + e.time + "|" + e.t) },
+            { icon: "event", label: "Open event", run: () => this.setState({ event: Object.assign({ day: d.d }, e) }) },
+            { icon: "notifications_active", label: "Reminders", run: () => this.setState({ remFor: { key: (d.d) + "|" + e.time + "|" + e.t, title: e.t, timed: e.time !== "all day", kind: "cal", hint: this.remAnchor({ time: e.time, day: d.d }), src: "Calendar" } }) },
+            { icon: "auto_awesome", label: "Ask the agent", run: () => this.goAgentWith("event \u201C" + e.t + "\u201D") },
+            { icon: "delete", label: "Delete event", danger: true, run: () => this.askDel({ title: "Delete this event?", text: "\u201C" + e.t + "\u201D will disappear from the calendar along with its reminders.", label: "Delete event", run: () => this.setState(s3 => ({ calAdded: (s3.calAdded || []).filter(x => x.t !== e.t) })) }) },
           ]),
           open: this.rowTap("events", d.d + "|" + e.time + "|" + e.t, () => this.setState({ event: Object.assign({ day: d.d }, e) })),
-          style: "display:flex;flex-direction:column;gap:3px;border-radius:8px;padding:8px 10px;border:1px solid " + (e.kind === "termin"
+          style: "display:flex;flex-direction:column;gap:3px;border-radius:8px;padding:8px 10px;border:1px solid " + (e.kind === "deadline"
             ? "var(--hl-line);background:var(--hl);"
             : e.kind === "mail"
             ? "var(--line);background:var(--sub);"
@@ -6643,7 +6643,7 @@ class Component extends DCLogic {
         t: p.t, when: p.when, src: p.src,
         add: () => this.setState(s2 => ({
           calDone: (s2.calDone || []).concat([p.id]),
-          calAdded: (s2.calAdded || []).concat([{ day: p.when.slice(0, 2), time: "cały dzień", t: p.t, kind: "termin" }]),
+          calAdded: (s2.calAdded || []).concat([{ day: p.when.slice(0, 2), time: "all day", t: p.t, kind: "deadline" }]),
         })),
         skip: () => this.setState(s2 => ({ calDone: (s2.calDone || []).concat([p.id]) })),
       })),
@@ -6653,41 +6653,41 @@ class Component extends DCLogic {
       showPersonDetail: !isMobile || st.peoplePane === "detail",
       showPeopleBack: isMobile && st.peoplePane === "detail",
       backToPeople: () => this.setState({ peoplePane: "list" }),
-      peopleCount: shownContacts.length + (shownContacts.length === 1 ? " osoba" : shownContacts.length < 5 ? " osoby" : " osób"),
-      peopleTabHint: peopleTab === "zebrane" ? "z nagłówków odebranej poczty" : "książka adresowa",
-      showOwnContacts: () => this.setState({ peopleTab: "wlasne" }),
-      showCollectedContacts: () => this.setState({ peopleTab: "zebrane" }),
-      tabOwnStyle: "flex:1;text-align:center;padding:6px 10px;border-radius:7px;font-size:13px;" + (peopleTab !== "zebrane"
+      peopleCount: shownContacts.length + (shownContacts.length === 1 ? " person" : " people"),
+      peopleTabHint: peopleTab === "collected" ? "from received mail headers" : "address book",
+      showOwnContacts: () => this.setState({ peopleTab: "own" }),
+      showCollectedContacts: () => this.setState({ peopleTab: "collected" }),
+      tabOwnStyle: "flex:1;text-align:center;padding:6px 10px;border-radius:7px;font-size:13px;" + (peopleTab !== "collected"
         ? "background:var(--panel);color:var(--text);font-weight:600;box-shadow:0 1px 2px var(--sh-1);"
         : "background:transparent;color:var(--muted);"),
-      tabCollectedStyle: "flex:1;text-align:center;padding:6px 10px;border-radius:7px;font-size:13px;" + (peopleTab === "zebrane"
+      tabCollectedStyle: "flex:1;text-align:center;padding:6px 10px;border-radius:7px;font-size:13px;" + (peopleTab === "collected"
         ? "background:var(--panel);color:var(--text);font-weight:600;box-shadow:0 1px 2px var(--sh-1);"
         : "background:transparent;color:var(--muted);"),
       personCollected: !!person.collected,
-      addToOwnLabel: narrow || isMobile ? "Dodaj" : "Dodaj do własnych",
-      personReadOnlyNote: "Tylko do odczytu — edycja po przeniesieniu do własnych",
+      addToOwnLabel: narrow || isMobile ? "Add" : "Add to my contacts",
+      personReadOnlyNote: "Read-only — editable once added to your contacts",
       removeCollected: () => this.askDel({
-        title: "Usunąć kontakt z zebranych?",
-        text: person.name + " zniknął z listy zebranych. Wróci automatycznie, jeśli napisze ponownie.",
-        label: "Usuń z zebranych",
+        title: "Remove contact from collected?",
+        text: person.name + " disappears from the collected list. They come back automatically if they write again.",
+        label: "Remove from collected",
         run: () => this.setState(s2 => {
         const rest = collectedContacts.filter(c => c.name !== person.name);
         const at = collectedContacts.findIndex(c => c.name === person.name);
         const nextOne = rest[Math.min(at, rest.length - 1)];
         return {
           hiddenCollected: (s2.hiddenCollected || []).concat([person.name]),
-          peopleTab: nextOne ? "zebrane" : "wlasne",
+          peopleTab: nextOne ? "collected" : "own",
           personId: nextOne ? nextOne.id : (CONTACTS[0] || {}).id,
           peoplePane: isMobile ? "list" : s2.peoplePane,
         };
         }),
       }),
       addToOwn: () => this.setState(s2 => ({
-        peopleTab: "wlasne",
+        peopleTab: "own",
         personId: "own-" + person.id,
         extraContacts: (s2.extraContacts || []).concat([Object.assign({}, person, {
-          id: "own-" + person.id, collected: false, role: person.role === "Kontakt zebrany z poczty" ? "—" : person.role,
-          note: "Kontakt przeniesiony z zebranych. Uzupełnij rolę i notatki — dane pochodzą wyłącznie z nagłówków poczty.",
+          id: "own-" + person.id, collected: false, role: person.role === "Collected from mail" ? "—" : person.role,
+          note: "Contact moved from collected. Fill in role and notes — the data comes only from mail headers.",
         })]),
       })),
       peopleListStyle: isMobile
@@ -6695,11 +6695,11 @@ class Component extends DCLogic {
         : "width:" + (narrow ? 268 : 300) + "px;flex:0 0 " + (narrow ? 268 : 300) + "px;display:flex;flex-direction:column;border-right:1px solid var(--line);min-height:0",
       peopleRows: shownContacts.map(c => ({
         press: this.pressFor("people", c.id, c.name, [
-          { icon: "check_box", label: "Zaznacz kontakty", run: () => this.selStart("people", c.id) },
-          { icon: "edit", label: "Napisz wiadomo\u015b\u0107", run: () => this.setState({ compose: true, composeMin: false, replyMode: null }) },
-          { icon: "person", label: "Otw\u00f3rz kontakt", run: () => this.setState({ personId: c.id, peoplePane: "detail" }) },
-          { icon: "event", label: "Zaproponuj spotkanie", run: () => this.setState({ screen: "cal", newEvent: true }) },
-          { icon: "delete", label: "Usu\u0144 kontakt", danger: true, run: () => this.askHide("people", [c.id], "Usun\u0105\u0107 kontakt?", c.name + " zniknie z listy kontakt\u00f3w.") },
+          { icon: "check_box", label: "Select contacts", run: () => this.selStart("people", c.id) },
+          { icon: "edit", label: "Write a message", run: () => this.setState({ compose: true, composeMin: false, replyMode: null }) },
+          { icon: "person", label: "Open contact", run: () => this.setState({ personId: c.id, peoplePane: "detail" }) },
+          { icon: "event", label: "Propose a meeting", run: () => this.setState({ screen: "cal", newEvent: true }) },
+          { icon: "delete", label: "Delete contact", danger: true, run: () => this.askHide("people", [c.id], "Delete contact?", c.name + " will disappear from the contact list.") },
         ]),
         name: c.name, org: c.org, last: c.last, initials: initialsOf(c.name),
         selected: isSel("people", c.id),
@@ -6735,13 +6735,13 @@ class Component extends DCLogic {
       personHasNext: !!personAi.next,
       personPatterns: [
         { label: "ODPOWIADA", value: personAi.reply || "" },
-        { label: "NAJCZĘŚCIEJ", value: personAi.peak || "" },
+        { label: "MOST ACTIVE", value: personAi.peak || "" },
         { label: "STYL", value: personAi.style || "" },
       ].filter(p => !!p.value),
       personStats: [
         { label: "OSTATNI KONTAKT", value: person.last },
         { label: "OTWARTE", value: person.owed },
-        { label: "SPRAWY", value: person.cases },
+        { label: "CASES", value: person.cases },
       ],
       personColsStyle: isMobile || narrow ? "display:flex;flex-direction:column;gap:12px" : "display:flex;gap:12px",
       personThreads: person.threads.map(t3 => ({
@@ -6756,12 +6756,12 @@ class Component extends DCLogic {
       })),
       personNoDocs: person.docs.length === 0,
 
-      tbCaseLabel: tbFull ? "Nowa sprawa" : "",
+      tbCaseLabel: tbFull ? "New case" : "",
       caseActions: [
         { icon: "summarize", label: "Podsumuj" },
-        { icon: "mail", label: "Dodaj wątek" },
+        { icon: "mail", label: "Add thread" },
         { icon: "download", label: "Eksportuj" },
-        { icon: "check_circle", label: "Zamknij sprawę" },
+        { icon: "check_circle", label: "Close case" },
       ].map(a => ({ icon: a.icon, title: a.label, label: tbFull ? a.label : "", style: tbFull ? tbBtn : tbIcon + ";flex:0 0 auto" })),
       newCaseOpen: !!st.newCase,
       openNewCase: () => this.setState({ newCase: true }),
@@ -6771,15 +6771,15 @@ class Component extends DCLogic {
       csFound: st.csFound || [],
       csBuild: () => {
         const raw = ((this.csPromptRef.current || {}).value || "").trim();
-        const title = raw ? raw.charAt(0).toUpperCase() + raw.slice(1) : "Nowa sprawa";
-        const org = (raw.match(/(Contoso|Fabrikam|Adventure Works|Northwind|Audyt)/i) || [])[1] || "Nowy kontrahent";
+        const title = raw ? raw.charAt(0).toUpperCase() + raw.slice(1) : "New case";
+        const org = (raw.match(/(Contoso|Fabrikam|Adventure Works|Northwind|Audit)/i) || [])[1] || "New counterparty";
         if (this.csTitleRef.current) this.csTitleRef.current.value = title;
         if (this.csPartiesRef.current) this.csPartiesRef.current.value = org + " · Nordwind";
         if (this.csDueRef.current) this.csDueRef.current.value = "12.09";
         this.setState({ csFound: [
-          { kind: "wątek", label: "Pytanie o SLA w weekendy — 4 wiadomości" },
-          { kind: "dokument", label: "Umowa ramowa.pdf" },
-          { kind: "termin", label: "Odpowiedź do 01.09" },
+          { kind: "thread", label: "Question about weekend SLA — 4 messages" },
+          { kind: "document", label: "Master agreement.pdf" },
+          { kind: "deadline", label: "Reply by 01.09" },
         ] });
       },
       csFromThread: () => {
@@ -6787,28 +6787,28 @@ class Component extends DCLogic {
         if (this.csPartiesRef.current) this.csPartiesRef.current.value = (thread.org || thread.from) + " · Nordwind";
         if (this.csDueRef.current) this.csDueRef.current.value = "28.08";
         this.setState({ csFound: [
-          { kind: "wątek", label: thread.subject },
+          { kind: "thread", label: thread.subject },
           { kind: "osoba", label: thread.from },
-          { kind: "termin", label: "Decyzja do 28.08" },
+          { kind: "deadline", label: "Decyzja do 28.08" },
         ] });
       },
       saveCase: () => {
-        const title = (this.csTitleRef.current || {}).value || "Nowa sprawa";
+        const title = (this.csTitleRef.current || {}).value || "New case";
         const parties = (this.csPartiesRef.current || {}).value || "—";
         const due = (this.csDueRef.current || {}).value || "";
         const id = "case" + Date.now();
         this.setState(s2 => ({
           newCase: false, csFound: null, caseId: id, casePane: "detail",
           extraCases: (s2.extraCases || []).concat([{
-            id, title, parties, status: due ? "Termin " + due : "Bez terminu", statusKind: "uwaga", owner: "KK",
-            summary: "Sprawa utworzona z opisu. Agent dołączył wątki i dokumenty znalezione w skrzynce; stan będzie się aktualizował przy nowych wiadomościach.",
-            scope: (s2.csFound || []).length + " powiązanych elementów",
-            agreed: [], openQ: [{ text: "Do ustalenia po pierwszej wymianie", src: "—" }],
-            dates: due ? [{ text: "Termin sprawy", when: due, src: "—" }] : [],
-            facts: [], timeline: [{ d: "dzisiaj", t: "Sprawa utworzona" }],
-            threads: (s2.csFound || []).filter(f => f.kind === "wątek").map(f => ({ id: "contoso", label: f.label, meta: "powiązany wątek" })),
-            docs: (s2.csFound || []).filter(f => f.kind === "dokument").map(f => ({ type: "PDF", name: f.label, size: "—" })),
-            duties: [{ who: "Karolina", what: "Pierwszy krok w sprawie", when: due || "—", state: "otwarte" }],
+            id, title, parties, status: due ? "Due " + due : "No deadline", statusKind: "attention", owner: "KK",
+            summary: "Case created from a description. The agent attached threads and documents found in the mailbox; the state updates as new messages arrive.",
+            scope: (s2.csFound || []).length + " linked items",
+            agreed: [], openQ: [{ text: "To be agreed after the first exchange", src: "—" }],
+            dates: due ? [{ text: "Case deadline", when: due, src: "—" }] : [],
+            facts: [], timeline: [{ d: "today", t: "Case created" }],
+            threads: (s2.csFound || []).filter(f => f.kind === "thread").map(f => ({ id: "contoso", label: f.label, meta: "linked thread" })),
+            docs: (s2.csFound || []).filter(f => f.kind === "document").map(f => ({ type: "PDF", name: f.label, size: "—" })),
+            duties: [{ who: "Karolina", what: "First step in the case", when: due || "—", state: "open" }],
           }]),
         }));
       },
@@ -6822,18 +6822,18 @@ class Component extends DCLogic {
       caseRows: allCases.map(c => ({
         selected: isSel("cases", c.id),
         press: this.pressFor("cases", c.id, c.title, [
-          { icon: "check_box", label: "Zaznacz sprawy", run: () => this.selStart("cases", c.id) },
-          { icon: "topic", label: "Otw\u00f3rz spraw\u0119", run: () => this.setState({ caseId: c.id, casePane: "detail" }) },
-          { icon: "auto_awesome", label: "Zapytaj agenta", run: () => this.goAgentWith("sprawa \u201e" + c.title + "\u201d") },
-          { icon: "download", label: "Eksportuj", run: () => this.notifyTask({ title: "Eksport sprawy\u2026", body: c.title, doneTitle: "Sprawa wyeksportowana", doneBody: c.title, ms: 1800 }) },
-          { icon: "check_circle", label: "Zamknij spraw\u0119", run: () => this.notify(c.title, { kind: "success", title: "Sprawa zamkni\u0119ta" }) },
-          { icon: "delete", label: "Usu\u0144 spraw\u0119", danger: true, run: () => this.askHide("cases", [c.id], "Usun\u0105\u0107 spraw\u0119?", c.title + " zniknie z listy spraw.") },
+          { icon: "check_box", label: "Select cases", run: () => this.selStart("cases", c.id) },
+          { icon: "topic", label: "Open case", run: () => this.setState({ caseId: c.id, casePane: "detail" }) },
+          { icon: "auto_awesome", label: "Ask the agent", run: () => this.goAgentWith("case \u201C" + c.title + "\u201D") },
+          { icon: "download", label: "Export", run: () => this.notifyTask({ title: "Exporting case\u2026", body: c.title, doneTitle: "Case exported", doneBody: c.title, ms: 1800 }) },
+          { icon: "check_circle", label: "Close case", run: () => this.notify(c.title, { kind: "success", title: "Case closed" }) },
+          { icon: "delete", label: "Delete case", danger: true, run: () => this.askHide("cases", [c.id], "Delete case?", c.title + " will disappear from the case list.") },
         ]),
         title: c.title, parties: c.parties, scope: c.scope, status: c.status, owner: c.owner,
         open: this.rowTap("cases", c.id, () => this.setState({ caseId: c.id, casePane: "detail" })),
         style: "display:flex;flex-direction:column;gap:6px;padding:13px 15px;background:" + (c.id === kase.id ? "var(--accent-soft)" : "var(--panel)") +
           ";box-shadow:inset 0 1px 0 var(--inset)," + (c.id === kase.id ? "inset 3px 0 0 var(--accent-2)," : "") + "0 1px 2px var(--sh-1);" + selMark("cases", c.id),
-        statusStyle: "font-size:11px;border-radius:12px;padding:3px 9px;" + (c.statusKind === "pilne"
+        statusStyle: "font-size:11px;border-radius:12px;padding:3px 9px;" + (c.statusKind === "urgent"
           ? "background:var(--hl);color:var(--text);"
           : "background:var(--rail);color:var(--text2);border:1px solid var(--line);"),
       })),
@@ -6842,7 +6842,7 @@ class Component extends DCLogic {
       caseScope: kase.scope,
       caseSummary: kase.summary,
       caseStatus: kase.status,
-      caseStatusStyle: "font-size:12px;font-weight:600;border-radius:13px;padding:5px 11px;" + (kase.statusKind === "pilne"
+      caseStatusStyle: "font-size:12px;font-weight:600;border-radius:13px;padding:5px 11px;" + (kase.statusKind === "urgent"
         ? "background:var(--hl);color:var(--text);border:1px solid var(--hl-line);"
         : "background:var(--rail);color:var(--text2);border:1px solid var(--line);"),
       caseTitleStyle: "font-weight:600;letter-spacing:-0.015em;text-wrap:pretty;font-size:" + (isMobile ? (st.caseScroll ? 15 : 18) : 21) + "px",
@@ -6854,7 +6854,7 @@ class Component extends DCLogic {
         if (c !== !!this.state.caseScroll) this.setState({ caseScroll: c });
       },
       caseAskExtrasShown: !isMobile,
-      caseAskPlaceholder: isMobile ? "Zapytaj o t\u0119 spraw\u0119\u2026" : "Zapytaj o t\u0119 spraw\u0119 \u2014 np. \u201eco obiecali\u015bmy w kwestii SLA?\u201d",
+      caseAskPlaceholder: isMobile ? "Ask about this case\u2026" : "Ask about this case \u2014 e.g. \u201Cwhat did we promise on the SLA?\u201D",
       caseAskRowStyle: "display:flex;align-items:center;gap:10px;border:2px solid var(--accent);border-radius:10px;" + (isMobile ? "padding:7px 9px" : "padding:10px 13px"),
       caseAskBadgeStyle: "font-family:'Instrument Sans',system-ui,sans-serif;letter-spacing:0.06em;color:var(--onaccent);background:var(--accent);border-radius:5px;" + (isMobile ? "font-size:10px;padding:3px 6px" : "font-size:11px;padding:4px 8px"),
       caseAskTextStyle: "flex:1;min-width:0;color:var(--faint);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:" + (isMobile ? 13 : 15) + "px",
@@ -6916,7 +6916,7 @@ class Component extends DCLogic {
       caseDuties: kase.duties.map((d, i) => ({
         who: d.who, what: d.what, when: d.when, state: d.state,
         rowStyle: "display:flex;gap:12px;align-items:baseline;padding:9px 0;" + (i ? "border-top:1px solid var(--line2);" : ""),
-        stateStyle: "flex:0 0 auto;font-size:11px;border-radius:11px;padding:3px 9px;" + (d.state === "otwarte"
+        stateStyle: "flex:0 0 auto;font-size:11px;border-radius:11px;padding:3px 9px;" + (d.state === "open"
           ? "background:var(--accent-soft);color:var(--accent-d);"
           : "background:var(--rail);color:var(--muted);border:1px solid var(--line);"),
       })),
@@ -6924,8 +6924,8 @@ class Component extends DCLogic {
         ? "flex:0 0 auto;display:flex;flex-direction:column;gap:7px;border-top:1px solid var(--line);background:var(--panel);padding:8px 12px 10px"
         : "display:flex;flex-direction:column;gap:9px;border-top:1px solid var(--line);background:var(--panel);padding:14px 24px",
 
-      /* Na tablecie i węższych ekranach „Ukryj panele” zabiera też listę wiadomości —
-         korespondencja dostaje całą szerokość (na desktopie lista zostaje, jest miejsce). */
+      /* On tablets and narrower screens "Hide panels" also removes the message list —
+         the correspondence gets the full width (on desktop the list stays, there is room). */
       showThreadList: (!singlePane || mailPane === "list") && !(tablet && st.stateBarOff && mailPane !== "list"),
       showContentPane: !singlePane || mailPane === "thread" || !!st.compose || !!st.doc,
       showThreadPane: (!singlePane || mailPane === "thread") && !composeInPane && !docInPane && !htmlInPane && !emptyMail,
@@ -6934,8 +6934,8 @@ class Component extends DCLogic {
       subjectStyle: singlePane
         ? "font-size:" + (thCollapsed ? 15 : 16) + "px;font-weight:600;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;transition:font-size 140ms ease"
         : "font-size:19px;font-weight:600;min-width:0",
-      /* Rozwijane szczegóły adresowe wątku — strzałka stoi w wierszu nadawcy, żeby zwinięta
-         nie zabierała osobnego wiersza w nagłówku. */
+      /* Expandable thread address details — the chevron sits in the sender row so that, collapsed,
+         it does not take a separate row in the header. */
       metaWrapStyle: singlePane && thCollapsed
         ? "display:none"
         : "display:flex;flex-direction:column;gap:2px;min-width:0",
@@ -6947,15 +6947,15 @@ class Component extends DCLogic {
         (st.threadAddrOpen ? ";transform:rotate(90deg)" : ""),
       threadAddrOpen: !!st.threadAddrOpen,
       threadAddrHasMore: !st.threadAddrOpen && threadAddr.count > 0,
-      threadAddrMore: "· pozostałe osoby (" + threadAddr.count + ")",
+      threadAddrMore: "· " + threadAddr.count + " more people",
       threadAddrRows: threadAddr.rows,
-      threadAddrTitle: st.threadAddrOpen ? "Zwiń szczegóły adresowe" : "Pozostałe osoby wskazane w tej wiadomości",
+      threadAddrTitle: st.threadAddrOpen ? "Collapse address details" : "Other people on this message",
       threadAddrRowsStyle: "display:flex;flex-direction:column;gap:3px;padding:2px 0 3px " + (singlePane ? "27px" : "22px"),
       toggleThreadAddr: () => this.setState(s2 => ({ threadAddrOpen: !s2.threadAddrOpen })),
       threadActions: [
-        { icon: "reply", label: "Odpowiedz", title: "Odpowiedz", run: () => this.startReply("reply", [thread.id]) },
-        { icon: "forward", label: "Przekaż", title: "Przekaż dalej", run: () => this.startReply("fwd", [thread.id]) },
-        { icon: "flag", label: flagOn ? "Bez flagi" : "Oflaguj", title: flagOn ? "Zdejmij flagę" : "Oflaguj", run: () => this.toggleFlagThreads([thread.id]) },
+        { icon: "reply", label: "Reply", title: "Reply", run: () => this.startReply("reply", [thread.id]) },
+        { icon: "forward", label: "Forward", title: "Forward", run: () => this.startReply("fwd", [thread.id]) },
+        { icon: "flag", label: flagOn ? "Unflag" : "Flag", title: flagOn ? "Remove flag" : "Flag", run: () => this.toggleFlagThreads([thread.id]) },
       ].map(a => ({
         title: a.title,
         run: a.run,
@@ -6965,7 +6965,7 @@ class Component extends DCLogic {
           : "display:flex;align-items:center;padding:5px 8px;border-radius:7px;font-size:13px;color:var(" + (a.icon === "flag" && flagOn ? "--warn" : "--muted") + ")",
       })),
       showComposerChips: !singlePane && !tablet,
-      askThreadLabel: singlePane ? "Szkic" : "Przygotuj szkic",
+      askThreadLabel: singlePane ? "Draft" : "Draft a reply",
       askThreadBtnStyle: "display:flex;align-items:center;justify-content:center;flex:0 0 auto;white-space:nowrap;color:var(--onaccent);background:var(--accent);border-radius:" + (isMobile ? 24 : 7) + "px;" + (isMobile
         ? "min-height:48px;padding:0 20px;font-size:14px;font-weight:600;"
         : "padding:8px 15px;font-size:13px;"),
@@ -6984,52 +6984,52 @@ class Component extends DCLogic {
       tbPrimaryShown: tbPriInBar,
       showFab: !st.compose && !st.doc && !selectionOn && (singlePane ? mailPane === "list" : tbFabForced),
       fabStyle: "position:absolute;right:16px;bottom:16px;z-index:30;width:54px;height:54px;border-radius:17px;display:flex;align-items:center;justify-content:center;font-size:20px;background:var(--accent);color:var(--onaccent);box-shadow:0 6px 18px var(--sh-2)",
-      /* W układzie wielopanelowym kółko siada nad listą wątków, nie nad panelem czytania —
-         inaczej zasłaniałoby kompozytor odpowiedzi. */
+      /* In multi-panel layouts the circle sits over the thread list, not the reading panel —
+         otherwise it would cover the reply composer. */
       mailFabStyle: "position:absolute;right:16px;bottom:16px;z-index:30;" +
         "width:54px;height:54px;border-radius:17px;display:flex;align-items:center;justify-content:center;font-size:20px;background:var(--accent);color:var(--onaccent);box-shadow:0 6px 18px var(--sh-2)",
-      selectionCount: sel.length + (sel.length === 1 ? " zaznaczona" : sel.length < 5 ? " zaznaczone" : " zaznaczonych"),
+      selectionCount: sel.length + " selected",
       clearSelection: () => this.setState({ sel: [] }),
       selectAllThreads: () => this.setState({ sel: THREADS.map(t => t.id) }),
       tbRef: this.tbRef,
       toolbarStyle: "flex:0 0 auto;display:flex;align-items:center;gap:2px;overflow-x:auto;padding:8px 12px;background:var(--panel);border-bottom:1px solid var(--line);box-shadow:0 1px 2px var(--sh-1)",
-      tbNewLabel: tbFull ? "Nowa wiadomość" : "",
+      tbNewLabel: tbFull ? "New message" : "",
       tbPrimaryStyle: tbFull
         ? "display:flex;align-items:center;gap:7px;flex:0 0 auto;font-size:13px;font-weight:600;color:var(--onaccent);background:var(--accent);padding:8px 13px;border-radius:8px;white-space:nowrap;box-shadow:0 1px 2px var(--sh-2)"
         : "display:flex;align-items:center;justify-content:center;border-radius:9px;background:var(--accent);color:var(--onaccent);flex:0 0 auto;" + (touch ? "width:42px;height:42px" : "width:34px;height:34px"),
       toolbarActions: [
-        { icon: "reply", label: "Odpowiedz", key: 1 },
-        { icon: "reply_all", label: "Odpowiedz wszystkim" },
-        { icon: "forward", label: "Prześlij dalej" },
+        { icon: "reply", label: "Reply", key: 1 },
+        { icon: "reply_all", label: "Reply all" },
+        { icon: "forward", label: "Forward" },
         { icon: "archive", label: "Archiwizuj", key: 1 },
-        { icon: "delete", label: "Usuń", key: 1 },
-        { icon: "flag", label: flagOn ? "Zdejmij flagę" : "Flaga", key: 1 },
-        { icon: "mark_email_unread", label: "Nieprzeczytana" },
-        { icon: "drive_file_move", label: "Przenieś" },
-        /* Widok skrócony: chowa pasek ustaleń/pytań pod nagłówkiem wątku.
-           Ustawienie jest globalne dla poczty, więc trzyma się przy zmianie wiadomości. */
-        /* Sam znak — pełny ekran/wyjście czyta się od razu, podpis tylko w tooltipie. */
-        { icon: st.stateBarOff ? "fullscreen_exit" : "fullscreen", label: st.stateBarOff ? "Pokaż panele wątku" : "Ukryj panele — sama korespondencja", iconOnly: true, key: 1 },
+        { icon: "delete", label: "Delete", key: 1 },
+        { icon: "flag", label: flagOn ? "Remove flag" : "Flag", key: 1 },
+        { icon: "mark_email_unread", label: "Unread" },
+        { icon: "drive_file_move", label: "Move" },
+        /* Condensed view: hides the agreed/questions bar under the thread header.
+           The setting is global for mail, so it survives switching messages. */
+        /* Glyph only — fullscreen/exit reads instantly, the label lives in the tooltip. */
+        { icon: st.stateBarOff ? "fullscreen_exit" : "fullscreen", label: st.stateBarOff ? "Show thread panels" : "Hide panels — correspondence only", iconOnly: true, key: 1 },
       ].map(a => ({
          icon: a.icon, title: a.label, label: (tbFull && !a.iconOnly) ? a.label : "", run: mailAct[a.icon],
          style: ((tbFull && !a.iconOnly) ? tbBtn : tbIcon + ";flex:0 0 auto") +
            (a.icon === "flag" && flagOn ? ";color:var(--warn);background:var(--warn-soft)" : "") +
            (a.icon === "fullscreen_exit" ? ";color:var(--accent-d);background:var(--accent-soft)" : "") +
-           /* Tryb skupienia to przełącznik widoku, nie akcja na wiadomości — trzymamy go osobno, przy prawej krawędzi. */
+           /* Focus mode is a view toggle, not a message action — kept separate, at the right edge. */
            (a.iconOnly ? ";margin-left:auto" : ""),
        })),
       selBarStyle: "flex:0 0 auto;display:flex;align-items:center;gap:2px;overflow-x:auto;padding:8px 12px;background:var(--accent-soft);border-bottom:1px solid var(--accent-line)",
       selectionActions: [
         { icon: "archive", label: "Archiwizuj" },
-        { icon: "delete", label: "Usuń" },
+        { icon: "delete", label: "Delete" },
         { icon: "flag", label: "Flaga" },
-        { icon: "mark_email_unread", label: "Nieprzeczytana" },
-        { icon: "drive_file_move", label: "Przenieś" },
+        { icon: "mark_email_unread", label: "Unread" },
+        { icon: "drive_file_move", label: "Move" },
       ].map(a => ({ icon: a.icon, title: a.label, label: tbFull ? a.label : "", run: mailAct[a.icon], style: tbFull ? selBtn : tbIcon + ";flex:0 0 auto;color:var(--accent-d)" })),
       moveOpen: !!(st.moveFor && st.moveFor.length),
-      moveTitle: st.moveFor ? "Przenieś " + this.countWord(st.moveFor.length) : "",
+      moveTitle: st.moveFor ? "Move " + this.countWord(st.moveFor.length) : "",
       closeMove: this.closeMove,
-      moveFolders: ["Sprawy", "Umowy", "Klienci", "Do decyzji", "Archiwum 2026"].map(f => ({
+      moveFolders: ["Cases", "Contracts", "Clients", "To decide", "Archive 2026"].map(f => ({
         label: f, pick: () => this.moveThreads(f),
         style: "display:flex;align-items:center;gap:11px;padding:" + (isMobile ? "13px 14px" : "10px 13px") + ";border-radius:9px;font-size:14px;color:var(--text2)",
       })),
@@ -7068,7 +7068,7 @@ class Component extends DCLogic {
               ? "transition:transform " + NG.springMs + "ms " + NG.springEase + ";"
               : "transition:transform 300ms cubic-bezier(.32,.72,0,1);")
           : "transform:translateX(" + (notifIn ? "0" : "-102%") + ");transition:transform 260ms cubic-bezier(.3,.7,.1,1);"),
-      notifTabs: [{ k: "all", label: "Wszystkie" }, { k: "unread", label: "Nieprzeczytane" + (notifUnreadCount ? " · " + notifUnreadCount : "") }].map(x => ({
+      notifTabs: [{ k: "all", label: "All" }, { k: "unread", label: "Unread" + (notifUnreadCount ? " · " + notifUnreadCount : "") }].map(x => ({
         label: x.label,
         pick: () => this.setState({ notifFilter: x.k }),
         style: "display:flex;align-items:center;height:30px;padding:0 12px;border-radius:9px;font-size:12.5px;border:1px solid " +
@@ -7082,15 +7082,15 @@ class Component extends DCLogic {
           title: n.title, body: n.body, src: n.src, icon: K.icon, unread: unread,
           time: notifTime(n.mins),
           press: this.pressFor("notifs", n.id, n.title, [
-            { icon: "check_box", label: "Zaznacz powiadomienia", run: () => this.selStart("notifs", n.id) },
-            { icon: unread ? "mark_email_read" : "mark_email_unread", label: unread ? "Oznacz jako przeczytane" : "Oznacz jako nieprzeczytane", run: () => this.toggleNotifRead(n) },
-            { icon: "open_in_new", label: "Otw\u00f3rz \u017ar\u00f3d\u0142o", run: () => this.openNotif(n) },
-            { icon: "delete", label: "Usu\u0144 powiadomienie", danger: true, run: () => this.askHide("notifs", [n.id], "Usun\u0105\u0107 powiadomienie?", n.title + " zniknie z centrum powiadomie\u0144.") },
+            { icon: "check_box", label: "Select notifications", run: () => this.selStart("notifs", n.id) },
+            { icon: unread ? "mark_email_read" : "mark_email_unread", label: unread ? "Mark as read" : "Mark as unread", run: () => this.toggleNotifRead(n) },
+            { icon: "open_in_new", label: "Open source", run: () => this.openNotif(n) },
+            { icon: "delete", label: "Delete notification", danger: true, run: () => this.askHide("notifs", [n.id], "Delete notification?", n.title + " will disappear from the notification centre.") },
           ], 420),
           open: this.rowTap("notifs", n.id, () => this.openNotif(n)),
           toggleRead: (e) => this.toggleNotifRead(n, e),
           readIcon: unread ? "mark_email_read" : "mark_email_unread",
-          readTitle: unread ? "Oznacz jako przeczytane" : "Oznacz jako nieprzeczytane",
+          readTitle: unread ? "Mark as read" : "Mark as unread",
           readBtnStyle: "flex:0 0 auto;display:flex;align-items:center;justify-content:center;border:1px solid " + (unread ? "var(--accent-line)" : "var(--line)") + ";border-radius:10px;" + (touch ? "width:38px;height:38px;" : "width:32px;height:32px;") + "background:" + (unread ? "var(--accent-soft)" : "var(--panel)") + ";color:" + (unread ? "var(--accent-d)" : "var(--muted)"),
           readIconStyle: "font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:" + (touch ? 21 : 19) + "px;line-height:1",
           titleStyle: "flex:1;min-width:0;font-size:14px;line-height:1.35;text-wrap:pretty;font-weight:" + (unread ? "600" : "500") + ";color:" + (unread ? "var(--text)" : "var(--text2)"),
@@ -7120,7 +7120,7 @@ class Component extends DCLogic {
           actionLabel: t.actionLabel,
           action: t.onAction || this.undoOp,
           close: loading ? () => this.askCancelToast(t.id) : () => this.dismissToast(t.id),
-          closeTitle: loading ? "Przerwij operację" : "Zamknij",
+          closeTitle: loading ? "Abort operation" : "Close",
           hasBar: !t.sticky && !t.out,
           barStyle: "position:absolute;left:0;right:0;bottom:0;height:2px;transform-origin:left;opacity:0.55;background:" + K[3] + ";animation:mftbar " + (t.ms || 5000) + "ms linear both",
           iconWrapStyle: "flex:0 0 auto;width:34px;height:34px;display:flex;align-items:center;justify-content:center;border-radius:10px;background:" + K[2],
@@ -7136,8 +7136,8 @@ class Component extends DCLogic {
       showResizer: !singlePane && !tablet,
       startResize: this.beginResize,
       resetResize: () => this.setState({ listW: 340 }),
-      /* Lista wątków znika z DOM przy wejściu w wiadomość (układ jednopanelowy),
-         więc pozycję przewinięcia trzymamy sami i odtwarzamy po powrocie. */
+      /* The thread list leaves the DOM when a message opens (single-panel layout),
+         so we keep the scroll position ourselves and restore it on return. */
       listScrollRef: this.keepScroll("mail"),
       onListScroll: this.keepScrollOn("mail"),
       caseListRef: this.keepScroll("cases"),
@@ -7154,7 +7154,7 @@ class Component extends DCLogic {
         ? "flex:0 0 auto;display:flex;flex-direction:column;gap:2px;padding:" + (thCollapsed ? "3px 6px" : "6px 8px 8px 8px") + ";border-bottom:1px solid var(--line);background:var(--panel);transition:padding 140ms ease"
         : "display:flex;flex-direction:column;gap:7px;padding:16px 22px;border-bottom:1px solid var(--line)",
       showThreadStateBar: (!singlePane || !thCollapsed) && !tablet && !st.stateBarOff,
-      /* Widok skrócony: zostaje sama korespondencja. Na wąskim ekranie nagłówek zostaje —
+      /* Condensed view: only the correspondence remains. On a narrow screen the header stays —
          mieszka w nim przycisk powrotu do listy. */
       showThreadHead: !st.stateBarOff || singlePane,
       showComposerBar: !st.stateBarOff,
@@ -7163,19 +7163,19 @@ class Component extends DCLogic {
       threadSheetOpen: !!st.threadSheet,
       showAgentJump: !isMobile && !st.stateBarOff,
       agentJumpRowStyle: "flex:0 0 auto;display:flex;align-items:center;gap:8px;flex-wrap:wrap;border-bottom:1px solid var(--line);background:var(--sub);padding:" + (tablet ? "9px 16px" : "10px 24px"),
-      askSheetLabel: isMobile || tablet ? "" : "Stan wątku",
+      askSheetLabel: isMobile || tablet ? "" : "Thread state",
       askSheetAltStyle: "flex:0 0 auto;display:flex;align-items:center;justify-content:center;gap:7px;border:1px solid var(--border2);border-radius:20px;color:var(--text2);white-space:nowrap;" +
         (isMobile ? "min-height:48px;padding:0 16px;font-size:14px" : "min-height:38px;padding:0 " + (tablet ? 12 : 14) + "px;font-size:13px"),
       askSheetBtnStyle: "flex:0 0 auto;display:flex;align-items:center;justify-content:center;gap:7px;min-height:" + (isMobile ? 48 : 34) + "px;padding:0 " + (isMobile ? 18 : 13) + "px;border-radius:24px;font-size:" + (isMobile ? 14 : 13) + "px;font-weight:600;color:var(--onaccent);background:var(--accent)",
       openThreadSheet: () => this.setState({ threadSheet: true }),
       threadSheetAsks: [
-        "Podsumuj, na czym stanęło",
-        "Czego druga strona oczekuje ode mnie",
-        "Przygotuj szkic odpowiedzi",
+        "Summarise where this stands",
+        "What the other side expects from me",
+        "Draft a reply for me",
       ].map(q => ({ label: q, run: () => this.setState({ threadSheet: false, mailAnswer: true }) })),
       goAgentBtnStyle: "display:flex;align-items:center;justify-content:center;gap:9px;border:1px solid var(--accent-line);border-radius:12px;background:var(--accent-soft);color:var(--accent-d);font-weight:600;" +
         (touch ? "min-height:50px;padding:0 14px;font-size:14px" : "min-height:40px;padding:0 14px;font-size:13px"),
-      askAgentThread: () => this.goAgentWith("wątek „" + thread.subject + "”"),
+      askAgentThread: () => this.goAgentWith("thread “" + thread.subject + "”"),
       askAgentCase: () => this.goAgentWith("sprawa „" + kase.title + "”"),
       agentCtxShown: !!st.agentCtx,
       agentInputRef: this.agentInputRef,
@@ -7240,7 +7240,7 @@ class Component extends DCLogic {
             ? "justify-content:flex-end;padding-right:22px;background:var(--accent-soft);color:var(--accent-d);"
             : "justify-content:flex-start;padding-left:22px;background:var(--ok-soft);color:var(--ok-text);"),
         swipeIcon: (st.swipeDx || 0) < 0 ? "reply" : "archive",
-        swipeLabel: (st.swipeDx || 0) < 0 ? "Odpowiedz" : "Archiwizuj",
+        swipeLabel: (st.swipeDx || 0) < 0 ? "Reply" : "Archive",
         swipeIconStyle: "font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:21px;line-height:1;margin-right:8px" + (Math.abs(st.swipeDx || 0) >= 96 ? ";font-variation-settings:'wght' 500" : ""),
         swipeTextStyle: "font-size:13px;font-weight:600;opacity:" + (Math.abs(st.swipeDx || 0) >= 96 ? "1" : "0.55"),
         aiStyle: isMobile ? "display:flex;align-items:center;gap:8px;font-size:13px;color:var(--muted);line-height:1.35" : "display:flex;align-items:center;gap:8px;font-size:12px;color:var(--muted)",
@@ -7266,8 +7266,8 @@ class Component extends DCLogic {
           (isMobile && st.swipeId === t.id
             ? "transform:translateX(" + (st.swipeDx || 0) + "px);"
             : "transform:translateX(0);transition:transform 160ms ease,background 120ms ease;"),
-        count: parseInt(((t.meta || "").match(/wątek: (\d+)/) || [])[1] || "1", 10),
-        multi: parseInt(((t.meta || "").match(/wątek: (\d+)/) || [])[1] || "1", 10) > 1,
+        count: parseInt(((t.meta || "").match(/thread: (\d+)/) || [])[1] || "1", 10),
+        multi: parseInt(((t.meta || "").match(/thread: (\d+)/) || [])[1] || "1", 10) > 1,
       })),
       activeSubject: thread.subject,
       activeMeta: thread.meta,
@@ -7277,7 +7277,7 @@ class Component extends DCLogic {
         return {
           label: s.label,
           value: s.value,
-          srcLabel: "wiadomość " + (idx + 1) + " · " + msgs[idx].from.split(" ")[0],
+          srcLabel: "message " + (idx + 1) + " · " + msgs[idx].from.split(" ")[0],
           showSrc: msgs.length > 1,
           openSrc: () => this.revealMessage(thread.id, idx),
         };
@@ -7302,25 +7302,25 @@ class Component extends DCLogic {
       onComposeSubj: (e) => this.setState({ composeSubjEdit: e.target.value }),
       closeCompose: () => (bodyTxt() || curSubj.trim() ? this.setState({ closeAsk: true }) : finishCompose()),
       keepEditing: () => this.setState({ closeAsk: false, sendAsk: null }),
-      discardCompose: () => { finishCompose(); this.notify("Szkic odrzucony", false); },
-      saveDraftAndClose: () => { finishCompose(); this.notify("Wiadomość czeka w folderze Szkice.", { kind: "success", title: "Zapisano szkic" }); },
+      discardCompose: () => { finishCompose(); this.notify("Draft discarded", false); },
+      saveDraftAndClose: () => { finishCompose(); this.notify("The message is waiting in Drafts.", { kind: "success", title: "Draft saved" }); },
       closeAskOpen: !!st.closeAsk,
       composeKeyDown: (e) => { if ((e.ctrlKey || e.metaKey) && e.key === "Enter") { e.preventDefault(); askSend(); } },
       askSend: askSend,
       sendAskOpen: !!st.sendAsk,
       sendWarnings: ((st.sendAsk && st.sendAsk.warnings) || []).map(w => ({ text: w })),
       sendHasWarn: !!(st.sendAsk && st.sendAsk.warnings.length),
-      sendConfirmLabel: st.sendAsk && st.sendAsk.warnings.length ? "Wyślij mimo to" : "Wyślij",
+      sendConfirmLabel: st.sendAsk && st.sendAsk.warnings.length ? "Send anyway" : "Send",
       sendSummaryTo: composeTo.length ? composeTo.join(", ") : "— brak odbiorcy —",
       sendSummarySubj: curSubj.trim() || "— brak tematu —",
       confirmSend: () => {
         const to = composeTo.length ? composeTo.join(", ") : "brak odbiorcy";
         finishCompose();
         this.notifyTask({
-          title: "Wysyłanie wiadomości…",
+          title: "Sending message…",
           body: "Do: " + to,
-          cancelText: "Wiadomość jest w trakcie wysyłki. Przerwanie zatrzyma wysyłkę i zapisze ją jako szkic.",
-          doneTitle: "Wiadomość wysłana",
+          cancelText: "The message is being sent. Aborting stops delivery and saves it as a draft.",
+          doneTitle: "Message sent",
           doneBody: "Do: " + to,
           ms: 2400,
         });
@@ -7331,17 +7331,17 @@ class Component extends DCLogic {
         : isMobile
         ? "position:fixed;inset:0;z-index:90;display:flex;flex-direction:column;background:var(--panel)"
         : "position:fixed;right:26px;bottom:0;width:680px;max-width:calc(100vw - 52px);max-height:86vh;z-index:90;display:flex;flex-direction:column;background:var(--panel);border:1px solid var(--line);border-bottom:none;border-radius:13px 13px 0 0;box-shadow:0 -1px 0 var(--inset) inset,0 18px 44px var(--sh-3)",
-      composeTitle: (st.composeMin ? composeKind + " — zwinięta" : composeKind),
+      composeTitle: (st.composeMin ? composeKind + " — collapsed" : composeKind),
       composeToChips: composeTo.map(n => ({ name: n })),
       ccOpen: !!st.ccOpen,
-      ccTitle: st.ccOpen ? "Ukryj pola DW i UDW" : "Pokaż pola DW i UDW",
+      ccTitle: st.ccOpen ? "Hide CC and BCC fields" : "Show CC and BCC fields",
       ccToggleStyle: "font-size:12px;padding:2px 8px;border-radius:7px;" + (st.ccOpen ? "color:var(--accent-d);background:var(--accent-soft)" : "color:var(--muted)"),
       toggleCc: () => this.setState(s => ({ ccOpen: !s.ccOpen })),
       composeCcChips: (st.composeCc || []).map((n, i) => ({ name: n, remove: () => this.setState(s => ({ composeCc: (s.composeCc || []).filter((_, j) => j !== i) })) })),
       composeBccChips: (st.composeBcc || []).map((n, i) => ({ name: n, remove: () => this.setState(s => ({ composeBcc: (s.composeBcc || []).filter((_, j) => j !== i) })) })),
       composeReplyToChips: (st.composeReplyTo || []).map((n, i) => ({ name: n, remove: () => this.setState(s => ({ composeReplyTo: (s.composeReplyTo || []).filter((_, j) => j !== i) })) })),
       replyToValue: st.replyToInput || "",
-      replyToPlaceholder: (st.composeReplyTo || []).length ? "kolejny adres…" : "domyślnie k.kowalska@nordwind.pl",
+      replyToPlaceholder: (st.composeReplyTo || []).length ? "another address…" : "default k.kowalska@nordwind.example",
       onReplyToInput: (e) => this.setState({ replyToInput: e.target.value }),
       onReplyToKey: (e) => {
         if (e.key !== "Enter" && e.key !== ",") return;
@@ -7374,7 +7374,7 @@ class Component extends DCLogic {
       composeChromeIconStyle: "font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:" + (touch ? 23 : 17) + "px;line-height:1",
       fmtBarShown: !touch || !!st.fmtBar,
       fmtToggleShown: touch,
-      fmtToggleLabel: st.fmtBar ? "Ukryj formatowanie" : "Formatowanie tekstu",
+      fmtToggleLabel: st.fmtBar ? "Hide formatting" : "Text formatting",
       fmtToggleIcon: st.fmtBar ? "expand_less" : "expand_more",
       toggleFmtBar: () => this.setState(s2 => ({ fmtBar: !s2.fmtBar })),
       fmtHintShown: !touch,
@@ -7442,19 +7442,19 @@ class Component extends DCLogic {
       })),
       userMailboxes: [
         { mail: "k.kowalska@nordwind.pl", dot: "var(--accent)" },
-        { mail: "kowalska.k@poczta.example", dot: "#4d9aa8" },
-        { mail: "zarzad@nordwind.pl", dot: "#b0873a" },
+        { mail: "kowalska.k@mail.example", dot: "#4d9aa8" },
+        { mail: "board@nordwind.example", dot: "#b0873a" },
       ].map(mb => ({
         mail: mb.mail, dot: mb.dot, current: false, pick: null,
         style: "display:flex;align-items:center;gap:8px;padding:3px 0;color:var(--muted)",
       })),
       tabsRowAvailable: w >= 1180,
       tabsRowStyle: "display:flex;align-items:center;gap:10px;padding:10px 13px;font-size:13px" + (w >= 1180 ? "" : ";opacity:0.5"),
-      tabsRowNote: w >= 1180 ? "" : "dostępne na szerszym ekranie",
+      tabsRowNote: w >= 1180 ? "" : "available on a wider screen",
       tabsSwitchStyle: "flex:0 0 auto;width:30px;height:17px;border-radius:9px;display:flex;align-items:center;padding:2px;background:var(" + (wantTabs ? "--accent" : "--border2") + ");justify-content:" + (wantTabs ? "flex-end" : "flex-start"),
-      toggleTabsMode: () => (w >= 1180 ? this.setState({ workMode: wantTabs ? "normalny" : "zakladki" }) : null),
+      toggleTabsMode: () => (w >= 1180 ? this.setState({ workMode: wantTabs ? "classic" : "tabs" }) : null),
       denseKnobStyle: "width:13px;height:13px;border-radius:50%;background:var(--panel)",
-      themeSegs: [["auto", "Auto"], ["jasny", "Jasny"], ["ciemny", "Ciemny"]].map(([v, label]) => ({
+      themeSegs: [["auto", "Auto"], ["light", "Light"], ["dark", "Dark"]].map(([v, label]) => ({
         label,
         pick: () => this.setState({ themePref: v, themeOverride: null }),
         style: "flex:1;text-align:center;font-size:11.5px;padding:5px 0;border-radius:7px;" + (themePref === v
@@ -7503,13 +7503,13 @@ class Component extends DCLogic {
         else this.setState({ htmlDoc: ask.doc, htmlSrcMode: false, htmlLoading: true });
         this.loadHtml();
       },
-      setViewSimple: () => this.setState({ msgView: "uproszczony" }),
+      setViewSimple: () => this.setState({ msgView: "simple" }),
       setViewHtml: () => this.setState({ msgView: "html", htmlDoc: null }),
       viewSimpleStyle: "flex:1;text-align:center;padding:6px 8px;border-radius:7px;font-size:12.5px;" + (st.msgView === "html" ? "color:var(--muted)" : "background:var(--accent);color:var(--onaccent)"),
       viewHtmlStyle: "flex:1;text-align:center;padding:6px 8px;border-radius:7px;font-size:12.5px;" + (st.msgView === "html" ? "background:var(--accent);color:var(--onaccent)" : "color:var(--muted)"),
       viewHint: st.msgView === "html"
-        ? "Wiadomości pokazują osadzoną treść HTML; przełącznik HTML przy nagłówku wiadomości znika."
-        : "Wiadomości pokazują oczyszczony tekst; pełny HTML otwierasz ikoną przy nagłówku.",
+        ? "Messages show embedded HTML content; the HTML toggle next to the message header disappears."
+        : "Messages show sanitised text; you open the full HTML with the icon next to the header.",
       telemetryOptOut: !!st.telemetryOptOut,
       telemetrySwitchStyle: "flex:0 0 auto;margin-top:2px;width:30px;height:17px;border-radius:9px;display:flex;align-items:center;padding:2px;background:var(" + (st.telemetryOptOut ? "--accent" : "--border2") + ");justify-content:" + (st.telemetryOptOut ? "flex-end" : "flex-start"),
       toggleTelemetry: () => this.setState(s => ({ telemetryOptOut: !s.telemetryOptOut })),
@@ -7523,68 +7523,68 @@ class Component extends DCLogic {
           ? "background:var(--accent);color:var(--onaccent);font-weight:600;"
           : "color:var(--text2);border:1px solid var(--line);background:var(--sub);"),
       })),
-      themeOptions: [["jasny", "Jasny"], ["ciemny", "Ciemny"]].map(([v, label]) => ({
+      themeOptions: [["light", "Light"], ["dark", "Dark"]].map(([v, label]) => ({
         label,
         pick: () => this.setState({ themeOverride: v }),
         style: "flex:1;text-align:center;font-size:13px;padding:9px 12px;border-radius:9px;" + (theme === v
           ? "background:var(--accent);color:var(--onaccent);font-weight:600;"
           : "color:var(--text2);border:1px solid var(--line);background:var(--sub);"),
       })),
-      workModeOptions: [["klasyczny", "Klasyczny"], ["zakladki", "Zakładki"]].map(([v, label]) => ({
+      workModeOptions: [["classic", "Classic"], ["tabs", "Tabs"]].map(([v, label]) => ({
         label,
         pick: () => this.setState(s2 => ({
           workMode: v,
-          tabs: v === "zakladki" ? [{ key: "thread:" + s2.threadId, kind: "thread", id: s2.threadId }] : [],
-          activeTab: v === "zakladki" ? "thread:" + s2.threadId : null,
+          tabs: v === "tabs" ? [{ key: "thread:" + s2.threadId, kind: "thread", id: s2.threadId }] : [],
+          activeTab: v === "tabs" ? "thread:" + s2.threadId : null,
         })),
-        style: "flex:1;text-align:center;font-size:13px;padding:9px 12px;border-radius:9px;" + ((st.workMode || "zakladki") === v
+        style: "flex:1;text-align:center;font-size:13px;padding:9px 12px;border-radius:9px;" + ((st.workMode || "tabs") === v
           ? "background:var(--accent);color:var(--onaccent);font-weight:600;"
           : "color:var(--text2);border:1px solid var(--line);background:var(--sub);"),
       })),
       workModeHint: tabsMode
-        ? "Każdy otwarty mail, załącznik i nowa wiadomość dostają własną zakładkę nad panelem treści."
-        : "Mail otwiera się w panelu obok listy, nowa wiadomość zastępuje panel treści.",
+        ? "Every open mail, attachment and new message gets its own tab above the content panel."
+        : "Mail opens in the panel next to the list; a new message replaces the content panel.",
       tabsBarShown: tabsMode && tabItems.length > 0,
       noTabsOpen: emptyMail,
       emptyMailText: tabsMode
-        ? "Wybierz wiadomość z listy, napisz nową albo zapytaj o całą historię korespondencji — każda z tych rzeczy otworzy się jako zakładka."
-        : "Wybierz wiadomość z listy, napisz nową albo zapytaj o całą historię korespondencji.",
+        ? "Pick a message from the list, write a new one or ask about the whole correspondence history — each opens as a tab."
+        : "Pick a message from the list, write a new one or ask about the whole correspondence history.",
       openLastThread: () => this.openTab("thread:" + thread.id, { screen: "mail", threadId: thread.id, mailPane: "thread", threadOpen: true }),
       closeAllAsk: !!st.closeAllAsk,
-      closeAllInfo: "Otwarte zakładki: " + tabItems.length + ". Niewysłany szkic zostanie odrzucony.",
+      closeAllInfo: "Open tabs: " + tabItems.length + ". An unsent draft will be discarded.",
       askCloseAll: () => this.setState({ closeAllAsk: true }),
       cancelCloseAll: () => this.setState({ closeAllAsk: false }),
       confirmCloseAll: () => this.setState({ tabs: [], activeTab: null, compose: false, closeAllAsk: false }),
       tabItems,
-      workModeLabel: tabsMode ? "Tryb: zakładki" : "Tryb: klasyczny",
+      workModeLabel: tabsMode ? "Mode: tabs" : "Mode: classic",
       toggleWorkMode: () => this.setState(s => ({
-        workMode: (s.workMode || "zakladki") === "zakladki" ? "klasyczny" : "zakladki",
+        workMode: (s.workMode || "tabs") === "tabs" ? "classic" : "tabs",
         userMenu: false,
-        tabs: (s.workMode || "zakladki") === "zakladki" ? [] : [{ key: "thread:" + s.threadId, kind: "thread", id: s.threadId }],
-        activeTab: (s.workMode || "zakladki") === "zakladki" ? null : "thread:" + s.threadId,
+        tabs: (s.workMode || "tabs") === "tabs" ? [] : [{ key: "thread:" + s.threadId, kind: "thread", id: s.threadId }],
+        activeTab: (s.workMode || "tabs") === "tabs" ? null : "thread:" + s.threadId,
       })),
       bodyRef: this.bodyRef,
       fmtButtons: [
         { key: "b", label: "B", title: "Pogrubienie", style: "font-weight:700", run: () => this.exec("bold") },
         { key: "i", label: "I", title: "Kursywa", style: "font-style:italic;font-family:Georgia,serif", run: () => this.exec("italic") },
-        { key: "u", label: "U", title: "Podkreślenie", style: "text-decoration:underline", run: () => this.exec("underline") },
-        { key: "s", label: "S", title: "Przekreślenie", style: "text-decoration:line-through", run: () => this.exec("strikeThrough") },
+        { key: "u", label: "U", title: "Underline", style: "text-decoration:underline", run: () => this.exec("underline") },
+        { key: "s", label: "S", title: "Strikethrough", style: "text-decoration:line-through", run: () => this.exec("strikeThrough") },
         { key: "ul", label: "•—", title: "Lista punktowana", style: "", run: () => this.exec("insertUnorderedList") },
         { key: "ol", label: "1.", title: "Lista numerowana", style: "", run: () => this.exec("insertOrderedList") },
         { key: "q", label: "format_quote", title: "Cytat", style: "font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1;", run: () => this.exec("formatBlock", "blockquote") },
         { key: "lnk", label: "link", title: "Wstaw link", style: "font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1;", run: () => this.exec("createLink", "https://") },
-        { key: "clr", label: "format_clear", title: "Wyczyść formatowanie", style: "font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1;", run: () => this.exec("removeFormat") },
+        { key: "clr", label: "format_clear", title: "Clear formatting", style: "font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1;", run: () => this.exec("removeFormat") },
       ].map(b => ({ key: b.key, label: b.label, title: b.title, style: "display:flex;align-items:center;justify-content:center;border-radius:" + (touch ? "9px;min-width:40px;height:40px;padding:0 9px;font-size:15px;border:1px solid var(--line);" : "7px;min-width:30px;height:30px;padding:0 7px;font-size:13px;") + "color:var(--text2);" + b.style, run: b.run })),
       aiActions: [
-        { label: "Napisz szkic", run: () => this.aiWrite("full") },
-        { label: "Skróć", run: () => this.aiWrite("short") },
-        { label: "Rozwiń", run: () => this.aiWrite("full") },
-        { label: "Popraw język", run: () => this.aiWrite("full") },
+        { label: "Write a draft", run: () => this.aiWrite("full") },
+        { label: "Shorten", run: () => this.aiWrite("short") },
+        { label: "Expand", run: () => this.aiWrite("full") },
+        { label: "Fix the language", run: () => this.aiWrite("full") },
       ].map(a => ({
         label: a.label, run: a.run,
         style: "font-size:12px;color:var(--accent-d);background:var(--panel);border:1px solid var(--accent-line);border-radius:15px;padding:6px 12px;white-space:nowrap",
       })),
-      tones: ["Formalny", "Neutralny", "Bezpośredni"].map(t => ({
+      tones: ["Formal", "Neutral", "Direct"].map(t => ({
         label: t,
         pick: () => this.setState({ tone: t }),
         style: "font-size:12px;padding:5px 11px;border-radius:14px;white-space:nowrap;" + ((st.tone || "Neutralny") === t

--- a/design/files/MailFathom Result Blocks.dc.html
+++ b/design/files/MailFathom Result Blocks.dc.html
@@ -12,11 +12,11 @@
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,300,0,0&display=block" rel="stylesheet" />
 <style>
   html, body { margin: 0; padding: 0; background: oklch(0.980 0.004 88); }
-  body:has([data-theme="ciemny"]) { background: oklch(0.183 0.016 262); }
+  body:has([data-theme="dark"]) { background: oklch(0.183 0.016 262); }
   a { color: var(--accent); }
   a:hover { color: var(--accent-2); }
-  [data-theme="jasny"] { color-scheme:light;--bg:oklch(0.980 0.004 88);--panel:#ffffff;--rail:oklch(0.951 0.006 88);--hover:oklch(0.906 0.010 88);--sub:oklch(0.969 0.005 88);--line:oklch(0.906 0.008 88);--line2:oklch(0.949 0.005 88);--border2:oklch(0.856 0.010 88);--text:oklch(0.240 0.014 262);--text2:oklch(0.420 0.012 240);--muted:oklch(0.565 0.010 200);--faint:oklch(0.690 0.009 160);--accent:oklch(0.555 0.185 262);--accent-2:oklch(0.465 0.175 262);--accent-d:oklch(0.385 0.150 262);--accent-soft:oklch(0.945 0.038 258);--accent-line:oklch(0.870 0.062 258);--onaccent:#ffffff;--ok:oklch(0.56 0.14 155);--ok-text:oklch(0.44 0.11 155);--ok-soft:oklch(0.945 0.038 155);--warn:oklch(0.62 0.155 62);--warn-soft:oklch(0.955 0.045 75);--warn-text:oklch(0.46 0.135 55);--hl:oklch(0.945 0.070 88);--hl-line:oklch(0.775 0.145 85);--inset:rgba(255,255,255,0.65);--sh-1:oklch(0.30 0.02 262 / 0.07);--sh-2:oklch(0.30 0.025 262 / 0.14);--sh-3:oklch(0.28 0.03 262 / 0.28);--scrim:oklch(0.26 0.03 262 / 0.36); }
-  [data-theme="ciemny"] { color-scheme:dark;--bg:oklch(0.183 0.016 262);--panel:oklch(0.246 0.016 262);--rail:oklch(0.212 0.017 262);--hover:oklch(0.325 0.021 262);--sub:oklch(0.277 0.016 262);--line:oklch(0.336 0.018 262);--line2:oklch(0.283 0.015 262);--border2:oklch(0.416 0.022 262);--text:oklch(0.945 0.007 262);--text2:oklch(0.835 0.011 262);--muted:oklch(0.705 0.013 262);--faint:oklch(0.585 0.015 262);--accent:oklch(0.615 0.175 262);--accent-2:oklch(0.735 0.150 262);--accent-d:oklch(0.865 0.085 262);--accent-soft:oklch(0.320 0.070 262);--accent-line:oklch(0.430 0.095 262);--onaccent:#ffffff;--ok:oklch(0.72 0.14 155);--ok-text:oklch(0.82 0.12 155);--ok-soft:oklch(0.30 0.045 155);--warn:oklch(0.74 0.13 55);--warn-soft:oklch(0.315 0.05 50);--warn-text:oklch(0.87 0.10 62);--hl:oklch(0.345 0.055 85);--hl-line:oklch(0.72 0.13 85);--inset:rgba(255,255,255,0.045);--sh-1:oklch(0.10 0.03 262 / 0.38);--sh-2:oklch(0.10 0.03 262 / 0.50);--sh-3:oklch(0.09 0.035 262 / 0.64);--scrim:oklch(0.12 0.045 262 / 0.66); }
+  [data-theme="light"] { color-scheme:light;--bg:oklch(0.980 0.004 88);--panel:#ffffff;--rail:oklch(0.951 0.006 88);--hover:oklch(0.906 0.010 88);--sub:oklch(0.969 0.005 88);--line:oklch(0.906 0.008 88);--line2:oklch(0.949 0.005 88);--border2:oklch(0.856 0.010 88);--text:oklch(0.240 0.014 262);--text2:oklch(0.420 0.012 240);--muted:oklch(0.565 0.010 200);--faint:oklch(0.690 0.009 160);--accent:oklch(0.555 0.185 262);--accent-2:oklch(0.465 0.175 262);--accent-d:oklch(0.385 0.150 262);--accent-soft:oklch(0.945 0.038 258);--accent-line:oklch(0.870 0.062 258);--onaccent:#ffffff;--ok:oklch(0.56 0.14 155);--ok-text:oklch(0.44 0.11 155);--ok-soft:oklch(0.945 0.038 155);--warn:oklch(0.62 0.155 62);--warn-soft:oklch(0.955 0.045 75);--warn-text:oklch(0.46 0.135 55);--hl:oklch(0.945 0.070 88);--hl-line:oklch(0.775 0.145 85);--inset:rgba(255,255,255,0.65);--sh-1:oklch(0.30 0.02 262 / 0.07);--sh-2:oklch(0.30 0.025 262 / 0.14);--sh-3:oklch(0.28 0.03 262 / 0.28);--scrim:oklch(0.26 0.03 262 / 0.36); }
+  [data-theme="dark"] { color-scheme:dark;--bg:oklch(0.183 0.016 262);--panel:oklch(0.246 0.016 262);--rail:oklch(0.212 0.017 262);--hover:oklch(0.325 0.021 262);--sub:oklch(0.277 0.016 262);--line:oklch(0.336 0.018 262);--line2:oklch(0.283 0.015 262);--border2:oklch(0.416 0.022 262);--text:oklch(0.945 0.007 262);--text2:oklch(0.835 0.011 262);--muted:oklch(0.705 0.013 262);--faint:oklch(0.585 0.015 262);--accent:oklch(0.615 0.175 262);--accent-2:oklch(0.735 0.150 262);--accent-d:oklch(0.865 0.085 262);--accent-soft:oklch(0.320 0.070 262);--accent-line:oklch(0.430 0.095 262);--onaccent:#ffffff;--ok:oklch(0.72 0.14 155);--ok-text:oklch(0.82 0.12 155);--ok-soft:oklch(0.30 0.045 155);--warn:oklch(0.74 0.13 55);--warn-soft:oklch(0.315 0.05 50);--warn-text:oklch(0.87 0.10 62);--hl:oklch(0.345 0.055 85);--hl-line:oklch(0.72 0.13 85);--inset:rgba(255,255,255,0.045);--sh-1:oklch(0.10 0.03 262 / 0.38);--sh-2:oklch(0.10 0.03 262 / 0.50);--sh-3:oklch(0.09 0.035 262 / 0.64);--scrim:oklch(0.12 0.045 262 / 0.66); }
   @keyframes mfpulse { 0%,100% { opacity: 0.35 } 50% { opacity: 1 } }
 </style>
 </helmet>
@@ -25,13 +25,13 @@
 
     <div style="{{ headerRowStyle }}">
       <div style="display:flex;flex-direction:column;gap:3px">
-        <div style="{{ pageTitleStyle }}">Bloki wyniku</div>
-        <div style="font-size:13px;color:var(--muted)">Katalog dziewięciu typów bloków z planu prezentacji — Odkrywaj</div>
+        <div style="{{ pageTitleStyle }}">Result blocks</div>
+        <div style="font-size:13px;color:var(--muted)">A catalogue of the nine block types in the presentation plan — Discover</div>
       </div>
       <div style="{{ badgeRowStyle }}">
-        <div style="{{ chipStyle }}">motyw: {{ themeAttr }}</div>
-        <div style="{{ chipStyle }}">układ: {{ layoutLabel }}</div>
-        <div style="{{ stanChipStyle }}">stan: {{ stanLabel }}</div>
+        <div style="{{ chipStyle }}">theme: {{ themeAttr }}</div>
+        <div style="{{ chipStyle }}">layout: {{ layoutLabel }}</div>
+        <div style="{{ stanChipStyle }}">state: {{ stanLabel }}</div>
       </div>
     </div>
 
@@ -41,13 +41,13 @@
         <div style="{{ noteStyle }}"><span style="{{ noteIconStyle }}">hourglass_top</span>{{ schemaBannerText }}</div>
 
         <div style="{{ cardStyle }}">
-          <div style="{{ headStyle }}"><div style="{{ labelStyle }}">ODPOWIEDŹ</div><div style="{{ metaStyle }}">{{ answerMeta }}</div></div>
+          <div style="{{ headStyle }}"><div style="{{ labelStyle }}">ANSWER</div><div style="{{ metaStyle }}">{{ answerMeta }}</div></div>
           <sc-if value="{{ isLoading }}" hint-placeholder-val="{{ false }}">
             <sc-for list="{{ skelRows }}" as="s" hint-placeholder-count="3"><div style="{{ s.style }}"></div></sc-for>
           </sc-if>
           <sc-if value="{{ bodyReady }}" hint-placeholder-val="{{ true }}">
             <div style="display:flex;align-items:center;gap:9px;flex-wrap:wrap">
-              <div style="font-size:11px;background:var(--ok-soft);color:var(--ok-text);border-radius:11px;padding:3px 9px">pewność wysoka</div>
+              <div style="font-size:11px;background:var(--ok-soft);color:var(--ok-text);border-radius:11px;padding:3px 9px">high confidence</div>
             </div>
             <div style="font-size:16px;line-height:1.55;text-wrap:pretty">
               <sc-for list="{{ answerParts }}" as="p" hint-placeholder-count="2">
@@ -60,7 +60,7 @@
             <div style="{{ emptyBodyStyle }}"><span style="{{ emptyIconStyle }}">forum</span><div style="{{ emptyTextStyle }}">{{ answerEmptyText }}</div></div>
           </sc-if>
           <sc-if value="{{ isError }}" hint-placeholder-val="{{ false }}">
-            <div style="{{ emptyBodyStyle }}"><span style="{{ errorIconStyle }}">error</span><div style="{{ emptyTextStyle }}">{{ answerErrorText }}</div><div style="{{ emptyReasonStyle }}">{{ answerErrorReason }}</div><div style="{{ retryBtnStyle }}">Spróbuj ponownie</div></div>
+            <div style="{{ emptyBodyStyle }}"><span style="{{ errorIconStyle }}">error</span><div style="{{ emptyTextStyle }}">{{ answerErrorText }}</div><div style="{{ emptyReasonStyle }}">{{ answerErrorReason }}</div><div style="{{ retryBtnStyle }}">Try again</div></div>
           </sc-if>
           <sc-if value="{{ isOffline }}" hint-placeholder-val="{{ false }}">
             <div style="{{ emptyBodyStyle }}"><span style="{{ emptyIconStyle }}">{{ offlineIcon }}</span><div style="{{ emptyTextStyle }}">{{ offlineText }}</div><div style="{{ retryBtnStyle }}">{{ offlineActionLabel }}</div></div>
@@ -68,7 +68,7 @@
         </div>
 
         <div style="{{ cardStyle }}">
-          <div style="{{ headStyle }}"><div style="{{ labelStyle }}">DOWODY</div><div style="{{ metaStyle }}">{{ evidenceMeta }}</div></div>
+          <div style="{{ headStyle }}"><div style="{{ labelStyle }}">EVIDENCE</div><div style="{{ metaStyle }}">{{ evidenceMeta }}</div></div>
           <sc-if value="{{ isLoading }}" hint-placeholder-val="{{ false }}">
             <sc-for list="{{ skelRows }}" as="s" hint-placeholder-count="3"><div style="{{ s.style }}"></div></sc-for>
           </sc-if>
@@ -77,23 +77,23 @@
               <div role="button" tabIndex="0" aria-label="{{ e.ariaLabel }}" style="display:flex;flex-direction:column;gap:5px;border-bottom:1px solid var(--line2);padding:10px 0;cursor:pointer" style-hover="background:var(--hover)" style-focus="outline:2px solid var(--accent);outline-offset:2px">
                 <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap"><div style="font-size:13.5px;font-weight:600">{{ e.source }}</div><span title="{{ e.badgeTitle }}" style="{{ e.badgeStyle }}"><span style="{{ e.badgeIconStyle }}">{{ e.badgeIcon }}</span>{{ e.badgeLabel }}</span><div style="{{ e.verdictChipStyle }}"><span style="{{ e.verdictIconStyle }}">{{ e.verdictIcon }}</span>{{ e.verdictLabel }}</div></div>
                 <div style="font-size:13px;color:var(--text2);text-wrap:pretty">{{ e.snippet }}</div>
-                <div style="display:flex;gap:10px;font-size:11.5px;color:var(--faint)"><span>trafność {{ e.relevance }}</span><span>{{ e.freshness }}</span></div>
+                <div style="display:flex;gap:10px;font-size:11.5px;color:var(--faint)"><span>relevance {{ e.relevance }}</span><span>{{ e.freshness }}</span></div>
               </div>
             </sc-for>
             <div role="button" tabIndex="0" aria-label="{{ evidencePrivate.ariaLabel }}" style="display:flex;flex-direction:column;gap:5px;padding:10px 0;cursor:pointer" style-hover="background:var(--hover)" style-focus="outline:2px solid var(--accent);outline-offset:2px">
-              <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap"><div style="font-size:13.5px;font-weight:600">{{ evidencePrivate.source }}</div><span title="{{ evidencePrivate.badgeTitle }}" style="{{ evidencePrivate.badgeStyle }}"><span style="{{ evidencePrivate.badgeIconStyle }}">{{ evidencePrivate.badgeIcon }}</span>{{ evidencePrivate.badgeLabel }}</span><div style="font-size:11px;background:var(--rail);color:var(--muted);border-radius:11px;padding:3px 9px;display:flex;align-items:center;gap:4px"><span style="{{ noteIconStyle }}">lock</span>źródło prywatne</div></div>
-              <div style="font-size:13px;color:var(--faint);font-style:italic">Treść niedostępna do wglądu — wniosek z tego źródła jest zachowany w wyniku.</div>
-              <div style="display:flex;gap:10px;font-size:11.5px;color:var(--faint)"><span>trafność {{ evidencePrivate.relevance }}</span><span>{{ evidencePrivate.freshness }}</span></div>
+              <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap"><div style="font-size:13.5px;font-weight:600">{{ evidencePrivate.source }}</div><span title="{{ evidencePrivate.badgeTitle }}" style="{{ evidencePrivate.badgeStyle }}"><span style="{{ evidencePrivate.badgeIconStyle }}">{{ evidencePrivate.badgeIcon }}</span>{{ evidencePrivate.badgeLabel }}</span><div style="font-size:11px;background:var(--rail);color:var(--muted);border-radius:11px;padding:3px 9px;display:flex;align-items:center;gap:4px"><span style="{{ noteIconStyle }}">lock</span>private source</div></div>
+              <div style="font-size:13px;color:var(--faint);font-style:italic">Content not available for review — the conclusion drawn from this source is kept in the result.</div>
+              <div style="display:flex;gap:10px;font-size:11.5px;color:var(--faint)"><span>relevance {{ evidencePrivate.relevance }}</span><span>{{ evidencePrivate.freshness }}</span></div>
             </div>
             <sc-if value="{{ isPartial }}" hint-placeholder-val="{{ false }}"><div style="{{ noteStyle }}"><span style="{{ noteIconStyle }}">hourglass_top</span>{{ evidencePartialNote }}</div></sc-if>
           </sc-if>
           <sc-if value="{{ isEmpty }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ emptyIconStyle }}">find_in_page</span><div style="{{ emptyTextStyle }}">{{ evidenceEmptyText }}</div></div></sc-if>
-          <sc-if value="{{ isError }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ errorIconStyle }}">error</span><div style="{{ emptyTextStyle }}">{{ evidenceErrorText }}</div><div style="{{ emptyReasonStyle }}">{{ evidenceErrorReason }}</div><div style="{{ retryBtnStyle }}">Spróbuj ponownie</div></div></sc-if>
+          <sc-if value="{{ isError }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ errorIconStyle }}">error</span><div style="{{ emptyTextStyle }}">{{ evidenceErrorText }}</div><div style="{{ emptyReasonStyle }}">{{ evidenceErrorReason }}</div><div style="{{ retryBtnStyle }}">Try again</div></div></sc-if>
           <sc-if value="{{ isOffline }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ emptyIconStyle }}">{{ offlineIcon }}</span><div style="{{ emptyTextStyle }}">{{ offlineText }}</div><div style="{{ retryBtnStyle }}">{{ offlineActionLabel }}</div></div></sc-if>
         </div>
 
         <div style="{{ cardStyle }}">
-          <div style="{{ headStyle }}"><div style="{{ labelStyle }}">OŚ CZASU</div><div style="{{ metaStyle }}">{{ timelineMeta }}</div></div>
+          <div style="{{ headStyle }}"><div style="{{ labelStyle }}">TIMELINE</div><div style="{{ metaStyle }}">{{ timelineMeta }}</div></div>
           <sc-if value="{{ isLoading }}" hint-placeholder-val="{{ false }}">
             <sc-for list="{{ skelRows }}" as="s" hint-placeholder-count="3"><div style="{{ s.style }}"></div></sc-for>
           </sc-if>
@@ -110,22 +110,22 @@
             <sc-if value="{{ isPartial }}" hint-placeholder-val="{{ false }}"><div style="{{ noteStyle }}"><span style="{{ noteIconStyle }}">hourglass_top</span>{{ timelinePartialNote }}</div></sc-if>
           </sc-if>
           <sc-if value="{{ isEmpty }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ emptyIconStyle }}">timeline</span><div style="{{ emptyTextStyle }}">{{ timelineEmptyText }}</div></div></sc-if>
-          <sc-if value="{{ isError }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ errorIconStyle }}">error</span><div style="{{ emptyTextStyle }}">{{ timelineErrorText }}</div><div style="{{ emptyReasonStyle }}">{{ timelineErrorReason }}</div><div style="{{ retryBtnStyle }}">Spróbuj ponownie</div></div></sc-if>
+          <sc-if value="{{ isError }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ errorIconStyle }}">error</span><div style="{{ emptyTextStyle }}">{{ timelineErrorText }}</div><div style="{{ emptyReasonStyle }}">{{ timelineErrorReason }}</div><div style="{{ retryBtnStyle }}">Try again</div></div></sc-if>
           <sc-if value="{{ isOffline }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ emptyIconStyle }}">{{ offlineIcon }}</span><div style="{{ emptyTextStyle }}">{{ offlineText }}</div><div style="{{ retryBtnStyle }}">{{ offlineActionLabel }}</div></div></sc-if>
         </div>
 
         <div style="{{ cardStyle }}">
-          <div style="{{ headStyle }}"><div style="{{ labelStyle }}">TABELA FAKTÓW</div><div style="{{ metaStyle }}">{{ tableMeta }}</div></div>
+          <div style="{{ headStyle }}"><div style="{{ labelStyle }}">FACT TABLE</div><div style="{{ metaStyle }}">{{ tableMeta }}</div></div>
           <sc-if value="{{ isLoading }}" hint-placeholder-val="{{ false }}">
             <sc-for list="{{ skelRows }}" as="s" hint-placeholder-count="3"><div style="{{ s.style }}"></div></sc-for>
           </sc-if>
           <sc-if value="{{ bodyReady }}" hint-placeholder-val="{{ true }}">
             <div style="overflow-x:auto">
               <div style="{{ tableGridStyle }}">
-                <div style="font-size:12px;color:var(--muted);border-bottom:1px solid var(--line);padding:0 10px 8px 0">Wersja</div>
-                <div style="font-size:12px;color:var(--muted);border-bottom:1px solid var(--line);padding:0 10px 8px 0">Cena</div>
+                <div style="font-size:12px;color:var(--muted);border-bottom:1px solid var(--line);padding:0 10px 8px 0">Version</div>
+                <div style="font-size:12px;color:var(--muted);border-bottom:1px solid var(--line);padding:0 10px 8px 0">Price</div>
                 <div style="font-size:12px;color:var(--muted);border-bottom:1px solid var(--line);padding:0 10px 8px 0">SLA</div>
-                <div style="font-size:12px;color:var(--muted);border-bottom:1px solid var(--line);padding:0 0 8px 0">Indeksacja</div>
+                <div style="font-size:12px;color:var(--muted);border-bottom:1px solid var(--line);padding:0 0 8px 0">Indexation</div>
                 <sc-for list="{{ tableRows }}" as="r" hint-placeholder-count="4">
                   <div style="{{ r.version.cellStyle }}"><span>{{ r.version.value }}</span><sc-if value="{{ r.version.hasCite }}" hint-placeholder-val="{{ false }}"><span role="button" tabIndex="0" aria-label="{{ r.version.ariaLabel }}" style="{{ citeChipStyle }}" style-hover="background:var(--accent-2);color:var(--onaccent)" style-focus="outline:2px solid var(--accent);outline-offset:2px">{{ r.version.cite }}</span></sc-if></div>
                   <div style="{{ r.price.cellStyle }}"><span>{{ r.price.value }}</span><sc-if value="{{ r.price.hasCite }}" hint-placeholder-val="{{ false }}"><span role="button" tabIndex="0" aria-label="{{ r.price.ariaLabel }}" style="{{ citeChipStyle }}" style-hover="background:var(--accent-2);color:var(--onaccent)" style-focus="outline:2px solid var(--accent);outline-offset:2px">{{ r.price.cite }}</span></sc-if><sc-if value="{{ r.price.hasVerdict }}" hint-placeholder-val="{{ false }}"><span style="{{ r.price.verdictChipStyle }}"><span style="{{ r.price.verdictIconStyle }}">{{ r.price.verdictIcon }}</span>{{ r.price.verdictLabel }}</span></sc-if></div>
@@ -137,12 +137,12 @@
             <sc-if value="{{ isPartial }}" hint-placeholder-val="{{ false }}"><div style="{{ noteStyle }}"><span style="{{ noteIconStyle }}">hourglass_top</span>{{ tablePartialNote }}</div></sc-if>
           </sc-if>
           <sc-if value="{{ isEmpty }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ emptyIconStyle }}">table_chart</span><div style="{{ emptyTextStyle }}">{{ tableEmptyText }}</div></div></sc-if>
-          <sc-if value="{{ isError }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ errorIconStyle }}">error</span><div style="{{ emptyTextStyle }}">{{ tableErrorText }}</div><div style="{{ emptyReasonStyle }}">{{ tableErrorReason }}</div><div style="{{ retryBtnStyle }}">Spróbuj ponownie</div></div></sc-if>
+          <sc-if value="{{ isError }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ errorIconStyle }}">error</span><div style="{{ emptyTextStyle }}">{{ tableErrorText }}</div><div style="{{ emptyReasonStyle }}">{{ tableErrorReason }}</div><div style="{{ retryBtnStyle }}">Try again</div></div></sc-if>
           <sc-if value="{{ isOffline }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ emptyIconStyle }}">{{ offlineIcon }}</span><div style="{{ emptyTextStyle }}">{{ offlineText }}</div><div style="{{ retryBtnStyle }}">{{ offlineActionLabel }}</div></div></sc-if>
         </div>
 
         <div style="{{ cardStyle }}">
-          <div style="{{ headStyle }}"><div style="{{ labelStyle }}">OSOBY</div><div style="{{ metaStyle }}">{{ peopleMeta }}</div></div>
+          <div style="{{ headStyle }}"><div style="{{ labelStyle }}">PEOPLE</div><div style="{{ metaStyle }}">{{ peopleMeta }}</div></div>
           <sc-if value="{{ isLoading }}" hint-placeholder-val="{{ false }}">
             <sc-for list="{{ skelRows }}" as="s" hint-placeholder-count="3"><div style="{{ s.style }}"></div></sc-for>
           </sc-if>
@@ -157,12 +157,12 @@
             <sc-if value="{{ isPartial }}" hint-placeholder-val="{{ false }}"><div style="{{ noteStyle }}"><span style="{{ noteIconStyle }}">hourglass_top</span>{{ peoplePartialNote }}</div></sc-if>
           </sc-if>
           <sc-if value="{{ isEmpty }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ emptyIconStyle }}">group_off</span><div style="{{ emptyTextStyle }}">{{ peopleEmptyText }}</div></div></sc-if>
-          <sc-if value="{{ isError }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ errorIconStyle }}">error</span><div style="{{ emptyTextStyle }}">{{ peopleErrorText }}</div><div style="{{ emptyReasonStyle }}">{{ peopleErrorReason }}</div><div style="{{ retryBtnStyle }}">Spróbuj ponownie</div></div></sc-if>
+          <sc-if value="{{ isError }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ errorIconStyle }}">error</span><div style="{{ emptyTextStyle }}">{{ peopleErrorText }}</div><div style="{{ emptyReasonStyle }}">{{ peopleErrorReason }}</div><div style="{{ retryBtnStyle }}">Try again</div></div></sc-if>
           <sc-if value="{{ isOffline }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ emptyIconStyle }}">{{ offlineIcon }}</span><div style="{{ emptyTextStyle }}">{{ offlineText }}</div><div style="{{ retryBtnStyle }}">{{ offlineActionLabel }}</div></div></sc-if>
         </div>
 
         <div style="{{ cardStyle }}">
-          <div style="{{ headStyle }}"><div style="{{ labelStyle }}">STAN WĄTKU</div><div style="{{ metaStyle }}">{{ threadMeta }}</div></div>
+          <div style="{{ headStyle }}"><div style="{{ labelStyle }}">THREAD STATE</div><div style="{{ metaStyle }}">{{ threadMeta }}</div></div>
           <sc-if value="{{ isLoading }}" hint-placeholder-val="{{ false }}">
             <sc-for list="{{ skelRows }}" as="s" hint-placeholder-count="3"><div style="{{ s.style }}"></div></sc-for>
           </sc-if>
@@ -175,27 +175,27 @@
             </div>
             <div style="{{ threadColsStyle }}">
               <div style="display:flex;flex-direction:column;gap:6px">
-                <div style="font-size:11px;letter-spacing:0.06em;color:var(--muted)">USTALENIA</div>
+                <div style="font-size:11px;letter-spacing:0.06em;color:var(--muted)">AGREED</div>
                 <sc-for list="{{ threadAgreed }}" as="a" hint-placeholder-count="2"><div style="font-size:13px;color:var(--text2)">{{ a.text }}</div></sc-for>
               </div>
               <div style="display:flex;flex-direction:column;gap:6px">
-                <div style="font-size:11px;letter-spacing:0.06em;color:var(--muted)">PYTANIA OTWARTE</div>
+                <div style="font-size:11px;letter-spacing:0.06em;color:var(--muted)">OPEN QUESTIONS</div>
                 <sc-for list="{{ threadOpenQuestions }}" as="q" hint-placeholder-count="1"><div style="font-size:13px;color:var(--text2)">{{ q.text }}</div></sc-for>
               </div>
               <div style="display:flex;flex-direction:column;gap:6px">
-                <div style="font-size:11px;letter-spacing:0.06em;color:var(--muted)">ZOBOWIĄZANIA</div>
+                <div style="font-size:11px;letter-spacing:0.06em;color:var(--muted)">COMMITMENTS</div>
                 <sc-for list="{{ threadCommitments }}" as="c" hint-placeholder-count="2"><div style="font-size:13px;color:var(--text2)"><strong>{{ c.who }}</strong> — {{ c.what }} <span style="color:var(--faint)">· {{ c.when }}</span></div></sc-for>
               </div>
             </div>
             <sc-if value="{{ isPartial }}" hint-placeholder-val="{{ false }}"><div style="{{ noteStyle }}"><span style="{{ noteIconStyle }}">hourglass_top</span>{{ threadPartialNote }}</div></sc-if>
           </sc-if>
           <sc-if value="{{ isEmpty }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ emptyIconStyle }}">forum</span><div style="{{ emptyTextStyle }}">{{ threadEmptyText }}</div></div></sc-if>
-          <sc-if value="{{ isError }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ errorIconStyle }}">error</span><div style="{{ emptyTextStyle }}">{{ threadErrorText }}</div><div style="{{ emptyReasonStyle }}">{{ threadErrorReason }}</div><div style="{{ retryBtnStyle }}">Spróbuj ponownie</div></div></sc-if>
+          <sc-if value="{{ isError }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ errorIconStyle }}">error</span><div style="{{ emptyTextStyle }}">{{ threadErrorText }}</div><div style="{{ emptyReasonStyle }}">{{ threadErrorReason }}</div><div style="{{ retryBtnStyle }}">Try again</div></div></sc-if>
           <sc-if value="{{ isOffline }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ emptyIconStyle }}">{{ offlineIcon }}</span><div style="{{ emptyTextStyle }}">{{ offlineText }}</div><div style="{{ retryBtnStyle }}">{{ offlineActionLabel }}</div></div></sc-if>
         </div>
 
         <div style="{{ cardStyle }}">
-          <div style="{{ headStyle }}"><div style="{{ labelStyle }}">ZAŁĄCZNIKI</div><div style="{{ metaStyle }}">{{ galleryMeta }}</div></div>
+          <div style="{{ headStyle }}"><div style="{{ labelStyle }}">ATTACHMENTS</div><div style="{{ metaStyle }}">{{ galleryMeta }}</div></div>
           <sc-if value="{{ isLoading }}" hint-placeholder-val="{{ false }}">
             <sc-for list="{{ skelRows }}" as="s" hint-placeholder-count="3"><div style="{{ s.style }}"></div></sc-for>
           </sc-if>
@@ -212,20 +212,20 @@
             <sc-if value="{{ isPartial }}" hint-placeholder-val="{{ false }}"><div style="{{ noteStyle }}"><span style="{{ noteIconStyle }}">hourglass_top</span>{{ galleryPartialNote }}</div></sc-if>
           </sc-if>
           <sc-if value="{{ isEmpty }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ emptyIconStyle }}">attach_file_off</span><div style="{{ emptyTextStyle }}">{{ galleryEmptyText }}</div></div></sc-if>
-          <sc-if value="{{ isError }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ errorIconStyle }}">error</span><div style="{{ emptyTextStyle }}">{{ galleryErrorText }}</div><div style="{{ emptyReasonStyle }}">{{ galleryErrorReason }}</div><div style="{{ retryBtnStyle }}">Spróbuj ponownie</div></div></sc-if>
+          <sc-if value="{{ isError }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ errorIconStyle }}">error</span><div style="{{ emptyTextStyle }}">{{ galleryErrorText }}</div><div style="{{ emptyReasonStyle }}">{{ galleryErrorReason }}</div><div style="{{ retryBtnStyle }}">Try again</div></div></sc-if>
           <sc-if value="{{ isOffline }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ emptyIconStyle }}">{{ offlineIcon }}</span><div style="{{ emptyTextStyle }}">{{ offlineText }}</div><div style="{{ retryBtnStyle }}">{{ offlineActionLabel }}</div></div></sc-if>
         </div>
 
         <div style="{{ cardStyle }}">
-          <div style="{{ headStyle }}"><div style="{{ labelStyle }}">SZKIC</div><div style="{{ metaStyle }}">{{ draftMeta }}</div></div>
+          <div style="{{ headStyle }}"><div style="{{ labelStyle }}">DRAFT</div><div style="{{ metaStyle }}">{{ draftMeta }}</div></div>
           <sc-if value="{{ isLoading }}" hint-placeholder-val="{{ false }}">
             <sc-for list="{{ skelRows }}" as="s" hint-placeholder-count="3"><div style="{{ s.style }}"></div></sc-for>
           </sc-if>
           <sc-if value="{{ bodyReady }}" hint-placeholder-val="{{ true }}">
             <div style="font-size:11px;background:var(--rail);color:var(--muted);border-radius:11px;padding:3px 9px;align-self:flex-start">{{ draftStatusLabel }}</div>
             <div style="display:flex;flex-direction:column;gap:8px;background:var(--sub);border:1px solid var(--line);border-radius:8px;padding:13px 15px">
-              <div style="display:flex;gap:8px;font-size:13px"><span style="color:var(--muted);flex:0 0 56px">Do:</span><span>{{ draftTo }}</span></div>
-              <div style="display:flex;gap:8px;font-size:13px"><span style="color:var(--muted);flex:0 0 56px">Temat:</span><span style="font-weight:600">{{ draftSubject }}</span></div>
+              <div style="display:flex;gap:8px;font-size:13px"><span style="color:var(--muted);flex:0 0 56px">To:</span><span>{{ draftTo }}</span></div>
+              <div style="display:flex;gap:8px;font-size:13px"><span style="color:var(--muted);flex:0 0 56px">Subject:</span><span style="font-weight:600">{{ draftSubject }}</span></div>
               <div style="font-size:13.5px;line-height:1.55;color:var(--text2);text-wrap:pretty;padding-top:2px">{{ draftBody }}</div>
               <div style="display:flex;gap:6px;padding-top:2px">
                 <sc-for list="{{ draftSources }}" as="d" hint-placeholder-count="2"><span role="button" tabIndex="0" aria-label="{{ d.ariaLabel }}" style="font-size:11px;color:var(--accent-d);background:var(--accent-soft);border-radius:4px;padding:2px 7px;cursor:pointer" style-hover="background:var(--accent-2);color:var(--onaccent)" style-focus="outline:2px solid var(--accent);outline-offset:2px">{{ d.n }}</span></sc-for>
@@ -234,12 +234,12 @@
             <sc-if value="{{ isPartial }}" hint-placeholder-val="{{ false }}"><div style="{{ noteStyle }}"><span style="{{ noteIconStyle }}">hourglass_top</span>{{ draftPartialNote }}</div></sc-if>
           </sc-if>
           <sc-if value="{{ isEmpty }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ emptyIconStyle }}">edit_note</span><div style="{{ emptyTextStyle }}">{{ draftEmptyText }}</div></div></sc-if>
-          <sc-if value="{{ isError }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ errorIconStyle }}">error</span><div style="{{ emptyTextStyle }}">{{ draftErrorText }}</div><div style="{{ emptyReasonStyle }}">{{ draftErrorReason }}</div><div style="{{ retryBtnStyle }}">Spróbuj ponownie</div></div></sc-if>
+          <sc-if value="{{ isError }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ errorIconStyle }}">error</span><div style="{{ emptyTextStyle }}">{{ draftErrorText }}</div><div style="{{ emptyReasonStyle }}">{{ draftErrorReason }}</div><div style="{{ retryBtnStyle }}">Try again</div></div></sc-if>
           <sc-if value="{{ isOffline }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ emptyIconStyle }}">{{ offlineIcon }}</span><div style="{{ emptyTextStyle }}">{{ offlineText }}</div><div style="{{ retryBtnStyle }}">{{ offlineActionLabel }}</div></div></sc-if>
         </div>
 
         <div style="{{ cardStyle }}">
-          <div style="{{ headStyle }}"><div style="{{ labelStyle }}">SUGEROWANE DZIAŁANIE</div><div style="{{ metaStyle }}">{{ actionMeta }}</div></div>
+          <div style="{{ headStyle }}"><div style="{{ labelStyle }}">SUGGESTED ACTION</div><div style="{{ metaStyle }}">{{ actionMeta }}</div></div>
           <sc-if value="{{ isLoading }}" hint-placeholder-val="{{ false }}">
             <sc-for list="{{ skelRows }}" as="s" hint-placeholder-count="3"><div style="{{ s.style }}"></div></sc-for>
           </sc-if>
@@ -249,26 +249,26 @@
               <div style="display:flex;flex-direction:column;gap:5px;min-width:0">
                 <div style="font-size:14px;font-weight:600">{{ actionTitle }}</div>
                 <div style="font-size:13px;color:var(--text2)">{{ actionReason }}</div>
-                <div style="font-size:12.5px;color:var(--muted)">Skutek: {{ actionEffect }}</div>
+                <div style="font-size:12.5px;color:var(--muted)">Effect: {{ actionEffect }}</div>
               </div>
               <div style="{{ actionConfirmStyle }}">{{ actionConfirmLabel }}</div>
             </div>
             <sc-if value="{{ isPartial }}" hint-placeholder-val="{{ false }}"><div style="{{ noteStyle }}"><span style="{{ noteIconStyle }}">hourglass_top</span>{{ actionPartialNote }}</div></sc-if>
           </sc-if>
           <sc-if value="{{ isEmpty }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ emptyIconStyle }}">task_alt</span><div style="{{ emptyTextStyle }}">{{ actionEmptyText }}</div></div></sc-if>
-          <sc-if value="{{ isError }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ errorIconStyle }}">error</span><div style="{{ emptyTextStyle }}">{{ actionErrorText }}</div><div style="{{ emptyReasonStyle }}">{{ actionErrorReason }}</div><div style="{{ retryBtnStyle }}">Spróbuj ponownie</div></div></sc-if>
+          <sc-if value="{{ isError }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ errorIconStyle }}">error</span><div style="{{ emptyTextStyle }}">{{ actionErrorText }}</div><div style="{{ emptyReasonStyle }}">{{ actionErrorReason }}</div><div style="{{ retryBtnStyle }}">Try again</div></div></sc-if>
           <sc-if value="{{ isOffline }}" hint-placeholder-val="{{ false }}"><div style="{{ emptyBodyStyle }}"><span style="{{ emptyIconStyle }}">{{ offlineIcon }}</span><div style="{{ emptyTextStyle }}">{{ offlineText }}</div><div style="{{ retryBtnStyle }}">{{ offlineActionLabel }}</div></div></sc-if>
         </div>
 
-        <div style="{{ crossHeadingStyle }}">Stany przekrojowe</div>
+        <div style="{{ crossHeadingStyle }}">Cross-cutting states</div>
         <div style="{{ crossRowStyle }}">
           <div style="{{ cardStyle }};flex:1">
-            <div style="{{ headStyle }}"><div style="{{ labelStyle }}">BLOK NIEZNANY</div><div style="{{ metaStyle }}">typ: {{ unknownBlockName }}</div></div>
+            <div style="{{ headStyle }}"><div style="{{ labelStyle }}">UNKNOWN BLOCK</div><div style="{{ metaStyle }}">type: {{ unknownBlockName }}</div></div>
             <div style="display:flex;gap:11px;align-items:flex-start">
               <span style="{{ emptyIconStyle }};flex:0 0 auto">extension_off</span>
               <div style="display:flex;flex-direction:column;gap:5px">
-                <div style="font-size:13.5px;color:var(--text2);text-wrap:pretty">Ten klient nie rozpoznaje typu bloku „{{ unknownBlockName }}”. Blok został pominięty — pozostałe elementy wyniku wyświetlono normalnie.</div>
-                <div style="{{ emptyReasonStyle }}">Aktualizacja aplikacji może odblokować ten typ bloku.</div>
+                <div style="font-size:13.5px;color:var(--text2);text-wrap:pretty">This client does not recognise the block type “{{ unknownBlockName }}”. The block was skipped — the rest of the result rendered normally.</div>
+                <div style="{{ emptyReasonStyle }}">Updating the app may unlock this block type.</div>
               </div>
             </div>
           </div>
@@ -278,10 +278,10 @@
 
       <div style="{{ evidenceColStyle }}">
         <div style="{{ legendCardStyle }}">
-          <div style="font-size:13px;font-weight:600">Cytowania i uczciwość źródeł</div>
-          <div style="font-size:12px;color:var(--muted);text-wrap:pretty">Cytowanie to zawsze element aktywowalny z własną nazwą (aria-label) — nigdy sam indeks górny.</div>
+          <div style="font-size:13px;font-weight:600">Citations and source honesty</div>
+          <div style="font-size:12px;color:var(--muted);text-wrap:pretty">A citation is always an activatable element with its own name (aria-label) — never a bare superscript.</div>
           <div style="display:flex;flex-direction:column;gap:10px;padding-top:4px;border-top:1px solid var(--line2)">
-            <div style="font-size:11px;letter-spacing:0.06em;color:var(--muted)">STAN ZNACZNIKA CYTOWANIA</div>
+            <div style="font-size:11px;letter-spacing:0.06em;color:var(--muted)">CITATION CHIP STATE</div>
             <div style="display:flex;gap:16px;align-items:center;flex-wrap:wrap">
               <sc-for list="{{ citationSamples }}" as="c" hint-placeholder-count="3">
                 <div style="display:flex;flex-direction:column;align-items:center;gap:6px">
@@ -292,7 +292,7 @@
             </div>
           </div>
           <div style="display:flex;flex-direction:column;gap:8px;padding-top:8px;border-top:1px solid var(--line2)">
-            <div style="font-size:11px;letter-spacing:0.06em;color:var(--muted)">ORZECZENIE O FAKCIE</div>
+            <div style="font-size:11px;letter-spacing:0.06em;color:var(--muted)">VERDICT ON A FACT</div>
             <sc-for list="{{ verdictLegend }}" as="v" hint-placeholder-count="4">
               <div style="display:flex;align-items:center;gap:9px">
                 <div style="{{ v.chipStyle }}"><span style="{{ v.iconStyle }}">{{ v.icon }}</span>{{ v.label }}</div>
@@ -301,10 +301,10 @@
             </sc-for>
           </div>
           <div style="display:flex;flex-direction:column;gap:6px;padding-top:8px;border-top:1px solid var(--line2)">
-            <div style="font-size:11px;letter-spacing:0.06em;color:var(--muted)">ŹRÓDŁO PRYWATNE</div>
+            <div style="font-size:11px;letter-spacing:0.06em;color:var(--muted)">PRIVATE SOURCE</div>
             <div style="display:flex;align-items:flex-start;gap:8px">
               <span style="{{ noteIconStyle }};font-size:16px">lock</span>
-              <div style="font-size:12.5px;color:var(--text2);text-wrap:pretty">Treść źródła nie jest widoczna, ale wniosek wyprowadzony z niego zostaje w wyniku. To nie jest błąd.</div>
+              <div style="font-size:12.5px;color:var(--text2);text-wrap:pretty">The source content is not visible, but the conclusion drawn from it stays in the result. This is not an error.</div>
             </div>
           </div>
         </div>
@@ -315,64 +315,64 @@
 </div>
 
 </x-dc>
-<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1440,&quot;height&quot;:900},&quot;theme&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;jasny&quot;,&quot;ciemny&quot;],&quot;default&quot;:&quot;ciemny&quot;,&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Układ&quot;},&quot;layout&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;auto&quot;,&quot;desktop&quot;,&quot;tablet&quot;,&quot;fold&quot;,&quot;telefon&quot;],&quot;default&quot;:&quot;auto&quot;,&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Układ&quot;},&quot;stan&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;gotowe&quot;,&quot;wczytywanie&quot;,&quot;częściowe&quot;,&quot;puste&quot;,&quot;błąd&quot;,&quot;offline&quot;],&quot;default&quot;:&quot;gotowe&quot;,&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Stan bloków&quot;}}">
-const FRAMES = { tablet: { w: 1024, h: 768 }, fold: { w: 884, h: 832 }, telefon: { w: 390, h: 844 } };
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1440,&quot;height&quot;:900},&quot;theme&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;light&quot;,&quot;dark&quot;],&quot;default&quot;:&quot;dark&quot;,&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Layout&quot;},&quot;layout&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;auto&quot;,&quot;desktop&quot;,&quot;tablet&quot;,&quot;fold&quot;,&quot;phone&quot;],&quot;default&quot;:&quot;auto&quot;,&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Layout&quot;},&quot;state&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;ready&quot;,&quot;loading&quot;,&quot;partial&quot;,&quot;empty&quot;,&quot;error&quot;,&quot;offline&quot;],&quot;default&quot;:&quot;ready&quot;,&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Block state&quot;}}">
+const FRAMES = { tablet: { w: 1024, h: 768 }, fold: { w: 884, h: 832 }, phone: { w: 390, h: 844 } };
 
 const ANSWER_PARTS_FULL = [
-  { text: "Warunki zmieniały się w trzech etapach: umowa ramowa z kwietnia 2021", cite: "1", source: "Umowa ramowa.pdf" },
-  { text: ", wprowadzenie indeksacji CPI bez górnego limitu w lutym 2023", cite: "3", source: "Aneks CPI 2023.pdf" },
-  { text: ", skrócenie SLA z 4 h do 2 h w aneksie z listopada 2025", cite: "5", source: "Aneks SLA.pdf" },
-  { text: ". Propozycja na 2027 podnosi cenę o 8% i utrzymuje brak limitu indeksacji", cite: "7", source: "Propozycja warunków 2027 — wiadomość" },
+  { text: "The terms changed in three stages: the master agreement of April 2021", cite: "1", source: "Master agreement.pdf" },
+  { text: ", CPI indexation with no upper cap introduced in February 2023", cite: "3", source: "CPI addendum 2023.pdf" },
+  { text: ", the SLA cut from 4 h to 2 h in the November 2025 addendum", cite: "5", source: "SLA addendum.pdf" },
+  { text: ". The 2027 proposal raises the price by 8% and keeps indexation uncapped", cite: "7", source: "Proposed terms 2027 — message" },
 ];
 
 const EVIDENCE_FULL = [
-  { n: "1", source: "Umowa ramowa.pdf", srcType: "zalacznik", snippet: "„Wynagrodzenie miesięczne wynosi 1 200 zł netto…”", relevance: "94%", freshness: "aktualne · 12.04.2021", verdict: "poparty" },
-  { n: "3", source: "Aneks SLA.pdf", srcType: "zalacznik", snippet: "„Czas reakcji skrócono z 4 h do 2 h…”", relevance: "88%", freshness: "aktualne · 18.11.2025", verdict: "przestarzały" },
-  { n: "5", source: "Kalkulacja_2027.xlsx", srcTypes: ["zalacznik", "mail"], snippet: "„Waloryzacja przy CPI 4,1% dokłada 10 542 zł…”", relevance: "81%", freshness: "świeże · wczoraj", verdict: "sprzeczny" },
+  { n: "1", source: "Master agreement.pdf", srcType: "attachment", snippet: "“Monthly remuneration is €1,200 net…”", relevance: "94%", freshness: "current · 12.04.2021", verdict: "supported" },
+  { n: "3", source: "SLA addendum.pdf", srcType: "attachment", snippet: "“Response time shortened from 4 h to 2 h…”", relevance: "88%", freshness: "current · 18.11.2025", verdict: "outdated" },
+  { n: "5", source: "Calculation_2027.xlsx", srcTypes: ["attachment", "mail"], snippet: "“Indexation at 4.1% CPI adds €10,542…”", relevance: "81%", freshness: "fresh · yesterday", verdict: "conflicting" },
 ];
-const EVIDENCE_PRIVATE = { n: "7", source: "Wiadomość prywatna — Karolina Kowalska", srcType: "mail", relevance: "76%", freshness: "dziś" };
+const EVIDENCE_PRIVATE = { n: "7", source: "Private message — Karolina Kowalska", srcType: "mail", relevance: "76%", freshness: "today" };
 
 const TIMELINE_FULL = [
-  { date: "12.04.2021", title: "Umowa ramowa", detail: "1 200 zł/mies · SLA 4 h", cite: "1" },
-  { date: "03.02.2023", title: "Indeksacja CPI", detail: "bez górnego limitu", cite: "3" },
-  { date: "18.11.2025", title: "Aneks SLA", detail: "4 h → 2 h · +8%", cite: "5" },
-  { date: "26.08.2026", title: "Propozycja 2027", detail: "decyzja do 28.08", cite: "7" },
+  { date: "12.04.2021", title: "Master agreement", detail: "€1,200/mo · SLA 4 h", cite: "1" },
+  { date: "03.02.2023", title: "CPI indexation", detail: "no upper cap", cite: "3" },
+  { date: "18.11.2025", title: "SLA addendum", detail: "4 h → 2 h · +8%", cite: "5" },
+  { date: "26.08.2026", title: "2027 proposal", detail: "decision due 28.08", cite: "7" },
 ];
 
 const TABLE_FULL = [
-  { version: "Umowa 2021", versionCite: "1", price: "1 200 zł", priceCite: "1", sla: "4 h", slaCite: "1", index: "brak", indexCite: null },
-  { version: "Aneks 2023", versionCite: "3", price: "1 261 zł", priceCite: "1", sla: "4 h", slaCite: "1", index: "CPI, bez limitu", indexCite: "3" },
-  { version: "Aneks 2025", versionCite: "5", price: "1 452 zł", priceCite: "5", sla: "2 h", slaCite: "5", index: "CPI, bez limitu", indexCite: "3" },
-  { version: "Propozycja 2027", versionCite: "7", price: "1 568 zł", priceCite: "7", priceVerdict: "niepoparty", sla: "2 h", slaCite: "5", index: "CPI, bez limitu", indexCite: "3" },
+  { version: "Agreement 2021", versionCite: "1", price: "€1,200", priceCite: "1", sla: "4 h", slaCite: "1", index: "none", indexCite: null },
+  { version: "Addendum 2023", versionCite: "3", price: "€1,261", priceCite: "1", sla: "4 h", slaCite: "1", index: "CPI, uncapped", indexCite: "3" },
+  { version: "Addendum 2025", versionCite: "5", price: "€1,452", priceCite: "5", sla: "2 h", slaCite: "5", index: "CPI, uncapped", indexCite: "3" },
+  { version: "Proposal 2027", versionCite: "7", price: "€1,568", priceCite: "7", priceVerdict: "unsupported", sla: "2 h", slaCite: "5", index: "CPI, uncapped", indexCite: "3" },
 ];
 
 const PEOPLE_FULL = [
-  { initials: "KK", name: "Karolina Kowalska", role: "Ty · nadawca", last: "dziś 08:47" },
-  { initials: "MN", name: "Marta Nowak", role: "Kontroling · Finanse", last: "wczoraj 11:20" },
-  { initials: "AK", name: "Anna Kowalska", role: "Contoso · czeka na odpowiedź", last: "dziś 08:47" },
+  { initials: "KK", name: "Karolina Kowalska", role: "You · sender", last: "today 08:47" },
+  { initials: "MN", name: "Marta Nowak", role: "Controlling · Finance", last: "yesterday 11:20" },
+  { initials: "AK", name: "Anna Kowalska", role: "Contoso · waiting for a reply", last: "today 08:47" },
 ];
 
 const GALLERY_FULL = [
-  { type: "PDF", name: "Umowa ramowa.pdf", meta: "312 kB · wiad.: „Umowa ramowa — podpisy”", avail: "dostępny" },
-  { type: "PDF", name: "Aneks SLA.pdf", meta: "248 kB · wiad.: „Aneks do umowy”", avail: "dostępny" },
-  { type: "XLSX", name: "Kalkulacja_2027.xlsx", meta: "42 kB · wiad.: „Kalkulacja CPI 2027”", avail: "wymaga uprawnień" },
+  { type: "PDF", name: "Master agreement.pdf", meta: "312 kB · msg: “Master agreement — signatures”", avail: "available" },
+  { type: "PDF", name: "SLA addendum.pdf", meta: "248 kB · msg: “Contract addendum”", avail: "available" },
+  { type: "XLSX", name: "Calculation_2027.xlsx", meta: "42 kB · msg: “CPI calculation 2027”", avail: "needs permission" },
 ];
 
 const COMMITMENTS_FULL = [
-  { who: "Karolina", what: "Kontrpropozycja limitu CPI 5%", when: "28.08" },
-  { who: "Contoso", what: "Wersja aneksu z limitem", when: "02.09" },
+  { who: "Karolina", what: "5% CPI cap counter-proposal", when: "28.08" },
+  { who: "Contoso", what: "Addendum version with the cap", when: "02.09" },
 ];
-const AGREED_FULL = [{ text: "SLA skrócone z 4 h do 2 h" }, { text: "Cena 2027: +8% względem 2025" }];
-const OPEN_Q_FULL = [{ text: "Czy przyjmujemy górny limit indeksacji 5%?" }];
+const AGREED_FULL = [{ text: "SLA cut from 4 h to 2 h" }, { text: "2027 price: +8% versus 2025" }];
+const OPEN_Q_FULL = [{ text: "Do we accept a 5% upper indexation cap?" }];
 const PARTICIPANTS = [{ initials: "KK", name: "Karolina Kowalska" }, { initials: "AK", name: "Anna Kowalska — Contoso" }];
 
 function srcTypeInfo(type) {
   const M = {
-    mail: { icon: "mail", label: "wiadomość" },
-    zalacznik: { icon: "attach_file", label: "załącznik" },
-    kalendarz: { icon: "calendar_month", label: "wydarzenie" },
-    kontakt: { icon: "person", label: "kontakt" },
-    wiele: { icon: "layers", label: "wiele źródeł" },
+    mail: { icon: "mail", label: "message" },
+    attachment: { icon: "attach_file", label: "attachment" },
+    calendar: { icon: "calendar_month", label: "event" },
+    contact: { icon: "person", label: "contact" },
+    multi: { icon: "layers", label: "multiple sources" },
   };
   return M[type] || M.mail;
 }
@@ -381,7 +381,7 @@ const SRC_BADGE_ICON_STYLE = "font-family:'Material Symbols Rounded';font-variat
 function srcBadge(item) {
   const types = item.srcTypes && item.srcTypes.length > 1 ? item.srcTypes : [item.srcType || "mail"];
   if (types.length > 1) {
-    return { icon: "layers", label: "wiele źródeł", title: types.map(t => srcTypeInfo(t).label).join(", ") };
+    return { icon: "layers", label: "multiple sources", title: types.map(t => srcTypeInfo(t).label).join(", ") };
   }
   const si = srcTypeInfo(types[0]);
   return { icon: si.icon, label: si.label, title: si.label };
@@ -389,12 +389,12 @@ function srcBadge(item) {
 
 function verdictInfo(v) {
   const M = {
-    poparty: { label: "poparty", icon: "check_circle", bg: "var(--ok-soft)", color: "var(--ok-text)" },
-    niepoparty: { label: "niepoparty", icon: "cancel", bg: "var(--warn-soft)", color: "var(--warn-text)" },
-    przestarzały: { label: "przestarzały", icon: "history", bg: "var(--warn-soft)", color: "var(--warn-text)" },
-    sprzeczny: { label: "sprzeczny z innym źródłem", icon: "sync_problem", bg: "var(--warn-soft)", color: "var(--warn-text)" },
+    supported: { label: "supported", icon: "check_circle", bg: "var(--ok-soft)", color: "var(--ok-text)" },
+    unsupported: { label: "unsupported", icon: "cancel", bg: "var(--warn-soft)", color: "var(--warn-text)" },
+    outdated: { label: "outdated", icon: "history", bg: "var(--warn-soft)", color: "var(--warn-text)" },
+    conflicting: { label: "conflicts with another source", icon: "sync_problem", bg: "var(--warn-soft)", color: "var(--warn-text)" },
   };
-  return M[v] || M.poparty;
+  return M[v] || M.supported;
 }
 function verdictChipStyle(v) {
   const i = verdictInfo(v);
@@ -407,7 +407,7 @@ function tableCell(row, fieldLabel, value, cite, verdict, isLast) {
   const vi = hasVerdict ? verdictInfo(verdict) : null;
   return {
     value, hasCite, cite,
-    ariaLabel: hasCite ? (fieldLabel + " „" + value + "”, wiersz " + row.version + ": cytowanie " + cite + (hasVerdict ? ", orzeczenie " + vi.label : "")) : "",
+    ariaLabel: hasCite ? (fieldLabel + " “" + value + "”, row " + row.version + ": citation " + cite + (hasVerdict ? ", verdict " + vi.label : "")) : "",
     hasVerdict, verdictLabel: vi ? vi.label : "", verdictIcon: vi ? vi.icon : "",
     verdictChipStyle: hasVerdict ? verdictChipStyle(verdict) : "",
     verdictIconStyle: "font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:11px;line-height:1",
@@ -438,19 +438,19 @@ class Component extends DCLogic {
   };
 
   renderVals() {
-    const theme = this.props.theme ?? "jasny";
-    const stan = this.props.stan ?? "gotowe";
+    const theme = this.props.theme ?? "light";
+    const stan = this.props.state ?? "ready";
     const mode = this.props.layout ?? "auto";
     const FR = FRAMES[mode] || null;
     const w = FR ? FR.w : (this.state.vw || 1440);
     const isMobile = w < 700;
     const stacked = isMobile || w < 1180;
 
-    const isReady = stan === "gotowe";
-    const isLoading = stan === "wczytywanie";
-    const isPartial = stan === "częściowe";
-    const isEmpty = stan === "puste";
-    const isError = stan === "błąd";
+    const isReady = stan === "ready";
+    const isLoading = stan === "loading";
+    const isPartial = stan === "partial";
+    const isEmpty = stan === "empty";
+    const isError = stan === "error";
     const isOffline = stan === "offline";
     const bodyReady = isReady || isPartial;
 
@@ -473,27 +473,27 @@ class Component extends DCLogic {
       const vi = verdictInfo(e.verdict);
       const sb = srcBadge(e);
       return Object.assign({}, e, {
-        ariaLabel: "Dowód: " + e.source + " — " + sb.title + " — trafność " + e.relevance + ", orzeczenie " + vi.label,
+        ariaLabel: "Evidence: " + e.source + " — " + sb.title + " — relevance " + e.relevance + ", verdict " + vi.label,
         verdictLabel: vi.label, verdictIcon: vi.icon, verdictChipStyle: verdictChipStyle(e.verdict),
         verdictIconStyle: "font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:12px;line-height:1",
         badgeStyle: SRC_BADGE_STYLE, badgeIconStyle: SRC_BADGE_ICON_STYLE, badgeIcon: sb.icon, badgeLabel: sb.label, badgeTitle: sb.title,
       });
     });
     const timelineItems = (isPartial ? TIMELINE_FULL.slice(0, 3) : TIMELINE_FULL).map(t => Object.assign({}, t, {
-      ariaLabel: "Zdarzenie: " + t.title + ", " + t.date + " — cytowanie " + t.cite,
+      ariaLabel: "Event: " + t.title + ", " + t.date + " — citation " + t.cite,
     }));
     const tableRows = (isPartial ? TABLE_FULL.slice(0, 2) : TABLE_FULL).map(r => ({
-      version: tableCell(r, "Wersja", r.version, r.versionCite),
-      price: tableCell(r, "Cena", r.price, r.priceCite, r.priceVerdict),
+      version: tableCell(r, "Version", r.version, r.versionCite),
+      price: tableCell(r, "Price", r.price, r.priceCite, r.priceVerdict),
       sla: tableCell(r, "SLA", r.sla, r.slaCite, r.slaVerdict),
-      index: tableCell(r, "Indeksacja", r.index, r.indexCite, r.indexVerdict, true),
+      index: tableCell(r, "Indexation", r.index, r.indexCite, r.indexVerdict, true),
     }));
     const peopleItems = (isPartial ? PEOPLE_FULL.slice(0, 2) : PEOPLE_FULL).map(p => Object.assign({}, p, {
-      ariaLabel: "Osoba: " + p.name + ", " + p.role,
+      ariaLabel: "Person: " + p.name + ", " + p.role,
     }));
     const galleryItems = (isPartial ? GALLERY_FULL.slice(0, 2) : GALLERY_FULL).map(g => Object.assign({}, g, {
-      ariaLabel: "Załącznik: " + g.name + ", " + g.avail,
-      availStyle: "font-size:10px;border-radius:9px;padding:2px 7px;" + (g.avail === "dostępny" ? "background:var(--ok-soft);color:var(--ok-text)" : "background:var(--warn-soft);color:var(--warn-text)"),
+      ariaLabel: "Attachment: " + g.name + ", " + g.avail,
+      availStyle: "font-size:10px;border-radius:9px;padding:2px 7px;" + (g.avail === "available" ? "background:var(--ok-soft);color:var(--ok-text)" : "background:var(--warn-soft);color:var(--warn-text)"),
     }));
     const threadCommitments = isPartial ? [] : COMMITMENTS_FULL;
     const threadAgreed = AGREED_FULL;
@@ -525,116 +525,116 @@ class Component extends DCLogic {
       isLoading, bodyReady, isPartial, isEmpty, isError, isOffline,
       skelRows,
       offlineIcon: "cloud_off",
-      offlineText: "Brak połączenia z serwerem — nie można wczytać tego bloku.",
-      offlineActionLabel: "Spróbuj ponownie",
+      offlineText: "No connection to the server — this block cannot be loaded.",
+      offlineActionLabel: "Try again",
 
-      answerMeta: isPartial ? "przetwarzanie w toku" : "1 akapit · 4 cytowania",
+      answerMeta: isPartial ? "processing" : "1 paragraph · 4 citations",
       answerParts,
-      answerPartialNote: "Brakuje akapitu o propozycji z 2027 — wciąż przetwarzany.",
-      answerEmptyText: "Zapytanie nie dotyczy żadnego wątku w tym zakresie — nie ma z czego złożyć odpowiedzi.",
-      answerErrorText: "Nie udało się złożyć odpowiedzi.",
-      answerErrorReason: "Model przekroczył limit czasu przy syntezie cytowań.",
+      answerPartialNote: "The paragraph about the 2027 proposal is missing — still processing.",
+      answerEmptyText: "The query does not touch any thread in this scope — there is nothing to build an answer from.",
+      answerErrorText: "Could not assemble an answer.",
+      answerErrorReason: "The model timed out while synthesising citations.",
 
-      evidenceMeta: (isPartial ? EVIDENCE_FULL.slice(0, 2).length : EVIDENCE_FULL.length) + " pozycje · sortowane po trafności",
+      evidenceMeta: (isPartial ? EVIDENCE_FULL.slice(0, 2).length : EVIDENCE_FULL.length) + " items · sorted by relevance",
       evidenceItems, evidencePrivate: Object.assign({}, EVIDENCE_PRIVATE, (() => { const sb = srcBadge(EVIDENCE_PRIVATE); return {
-        ariaLabel: "Dowód prywatny: " + EVIDENCE_PRIVATE.source + " — treść niedostępna",
+        ariaLabel: "Private evidence: " + EVIDENCE_PRIVATE.source + " — content unavailable",
         badgeStyle: SRC_BADGE_STYLE, badgeIconStyle: SRC_BADGE_ICON_STYLE, badgeIcon: sb.icon, badgeLabel: sb.label, badgeTitle: sb.title,
       }; })()),
-      evidencePartialNote: "Brakuje 1 pozycji — wciąż indeksowana.",
-      evidenceEmptyText: "Brak dokumentów spełniających próg trafności dla tego zapytania.",
-      evidenceErrorText: "Nie udało się pobrać fragmentów źródłowych.",
-      evidenceErrorReason: "Indeks wyszukiwania nie odpowiedział.",
+      evidencePartialNote: "1 item missing — still being indexed.",
+      evidenceEmptyText: "No documents met the relevance threshold for this query.",
+      evidenceErrorText: "Could not fetch the source passages.",
+      evidenceErrorReason: "The search index did not respond.",
 
-      timelineMeta: timelineItems.length + " zdarzenia · 2021–2026",
+      timelineMeta: timelineItems.length + " events · 2021–2026",
       timelineItems,
       timelineRowStyle: isMobile ? "display:flex;flex-direction:column;gap:0" : "display:flex;gap:0",
       tlItemStyle: isMobile
         ? "display:flex;flex-direction:column;gap:3px;border-top:2px solid var(--border2);padding:9px 0 11px 0"
         : "flex:1;display:flex;flex-direction:column;gap:5px;border-top:2px solid var(--border2);padding:10px 14px 0 0",
-      timelinePartialNote: "Brakuje zdarzenia z 2026 — źródło wciąż weryfikowane.",
-      timelineEmptyText: "Brak zdarzeń w wybranym zakresie dat.",
-      timelineErrorText: "Nie udało się ułożyć chronologii.",
-      timelineErrorReason: "Dwa źródła podają sprzeczne daty tego samego zdarzenia.",
+      timelinePartialNote: "The 2026 event is missing — its source is still being verified.",
+      timelineEmptyText: "No events in the selected date range.",
+      timelineErrorText: "Could not build the chronology.",
+      timelineErrorReason: "Two sources give conflicting dates for the same event.",
 
-      tableMeta: tableRows.length + " wersje umowy",
+      tableMeta: tableRows.length + " contract versions",
       tableGridStyle: "display:grid;grid-template-columns:1.3fr 1fr 0.8fr 1.4fr;gap:0" + (isMobile ? ";min-width:540px" : ""),
       tableRows,
-      tablePartialNote: "Brakuje 2 wersji bez potwierdzonej ceny.",
-      tableEmptyText: "Żadna kolumna nie miała pokrycia w źródłach — tabela pozostaje pusta.",
-      tableErrorText: "Nie udało się złożyć tabeli.",
-      tableErrorReason: "Niezgodna liczba kolumn między wierszami źródłowymi.",
+      tablePartialNote: "2 versions with unconfirmed prices are missing.",
+      tableEmptyText: "No column had coverage in the sources — the table stays empty.",
+      tableErrorText: "Could not assemble the table.",
+      tableErrorReason: "Mismatched column count between source rows.",
 
-      peopleMeta: peopleItems.length + " osoby · rola w sprawie",
+      peopleMeta: peopleItems.length + " people · role in the case",
       peopleItems,
-      peoplePartialNote: "Brakuje 1 osoby bez potwierdzonej roli.",
-      peopleEmptyText: "Nie znaleziono osób powiązanych z tym zapytaniem.",
-      peopleErrorText: "Nie udało się dopasować osób do wątków.",
-      peopleErrorReason: "Duplikaty tego samego kontaktu w dwóch skrzynkach.",
+      peoplePartialNote: "1 person with an unconfirmed role is missing.",
+      peopleEmptyText: "No people linked to this query were found.",
+      peopleErrorText: "Could not match people to threads.",
+      peopleErrorReason: "Duplicates of the same contact in two mailboxes.",
 
-      threadMeta: "wątek: Aneks do umowy · 6 wiadomości",
+      threadMeta: "thread: Contract addendum · 6 messages",
       threadParticipants: PARTICIPANTS,
-      threadParticipantsLabel: "2 uczestnicy",
+      threadParticipantsLabel: "2 participants",
       threadColsStyle: isMobile || stacked ? "display:flex;flex-direction:column;gap:14px" : "display:grid;grid-template-columns:repeat(3,1fr);gap:14px;align-items:start",
       threadAgreed, threadOpenQuestions, threadCommitments,
-      threadPartialNote: "Zobowiązania wciąż wyodrębniane z ostatniej wiadomości.",
-      threadEmptyText: "Wątek nie zawiera jeszcze ustaleń, pytań ani zobowiązań.",
-      threadErrorText: "Nie udało się wyodrębnić stanu wątku.",
-      threadErrorReason: "Wiadomość zawiera format cytowania, którego parser nie obsługuje.",
+      threadPartialNote: "Commitments are still being extracted from the latest message.",
+      threadEmptyText: "The thread holds no agreements, questions or commitments yet.",
+      threadErrorText: "Could not extract the thread state.",
+      threadErrorReason: "The message uses a quoting format the parser does not support.",
 
-      galleryMeta: galleryItems.length + " pliki · dostępność sprawdzona",
+      galleryMeta: galleryItems.length + " files · availability checked",
       galleryGridStyle: isMobile ? "display:grid;grid-template-columns:repeat(2,1fr);gap:10px" : "display:grid;grid-template-columns:repeat(3,1fr);gap:10px",
       galleryItems,
-      galleryPartialNote: "Brakuje 1 pliku — wciąż skanowany antywirusowo.",
-      galleryEmptyText: "Wiadomości w tym zakresie nie miały załączników.",
-      galleryErrorText: "Nie udało się sprawdzić dostępności plików.",
-      galleryErrorReason: "Magazyn załączników nie odpowiedział.",
+      galleryPartialNote: "1 file is missing — still being virus-scanned.",
+      galleryEmptyText: "Messages in this scope had no attachments.",
+      galleryErrorText: "Could not check file availability.",
+      galleryErrorReason: "The attachment store did not respond.",
 
-      draftMeta: "szkic lokalny",
-      draftStatusLabel: "Szkic lokalny — nic nie wysłano",
+      draftMeta: "local draft",
+      draftStatusLabel: "Local draft — nothing sent",
       draftTo: "Anna Kowalska — Contoso",
-      draftSubject: "Re: propozycja warunków 2027",
+      draftSubject: "Re: proposed terms for 2027",
       draftBody: isPartial
-        ? "Akceptujemy skrócenie czasu reakcji do 2 h. […] treść wciąż redagowana."
-        : "Akceptujemy skrócenie czasu reakcji do 2 h. W zamian prosimy o górny limit waloryzacji CPI na poziomie 5% rocznie, ze skutkiem od 1 stycznia 2027.",
-      draftSources: isPartial ? [] : [{ n: "3", ariaLabel: "Źródło szkicu: Aneks CPI 2023.pdf" }, { n: "5", ariaLabel: "Źródło szkicu: Aneks SLA.pdf" }],
-      draftPartialNote: "Treść wciąż redagowana, źródła jeszcze niedołączone.",
-      draftEmptyText: "Nie wygenerowano jeszcze szkicu dla tego zapytania.",
-      draftErrorText: "Nie udało się złożyć szkicu.",
-      draftErrorReason: "Cytowanie źródłowe wskazuje na usuniętą wiadomość.",
+        ? "We accept shortening the response time to 2 h. […] the text is still being edited."
+        : "We accept shortening the response time to 2 h. In return we ask for an upper CPI indexation cap of 5% per year, effective 1 January 2027.",
+      draftSources: isPartial ? [] : [{ n: "3", ariaLabel: "Draft source: CPI addendum 2023.pdf" }, { n: "5", ariaLabel: "Draft source: SLA addendum.pdf" }],
+      draftPartialNote: "The text is still being edited, sources not attached yet.",
+      draftEmptyText: "No draft has been generated for this query yet.",
+      draftErrorText: "Could not assemble the draft.",
+      draftErrorReason: "A source citation points to a deleted message.",
 
-      actionMeta: "1 działanie zaproponowane",
+      actionMeta: "1 action proposed",
       actionRowStyle: isMobile
         ? "display:flex;flex-direction:column;align-items:flex-start;gap:12px;background:var(--sub);border:1px solid var(--line);border-radius:9px;padding:14px 16px"
         : "display:flex;align-items:flex-start;gap:14px;background:var(--sub);border:1px solid var(--line);border-radius:9px;padding:14px 18px",
-      actionTitle: "Wyślij kontrpropozycję limitu CPI do Anny Kowalskiej (Contoso)",
-      actionReason: "Termin decyzji mija 28.08, Contoso czeka od 2 dni.",
-      actionEffect: isPartial ? "jeszcze nieokreślony — symulacja w toku" : "wiadomość trafi do wątku „Aneks do umowy” jako odpowiedź; nic nie wysyła się automatycznie",
-      actionConfirmLabel: "wymaga potwierdzenia",
+      actionTitle: "Send the CPI cap counter-proposal to Anna Kowalska (Contoso)",
+      actionReason: "The decision is due 28.08 and Contoso has been waiting for 2 days.",
+      actionEffect: isPartial ? "not determined yet — simulation running" : "the message goes into the “Contract addendum” thread as a reply; nothing is sent automatically",
+      actionConfirmLabel: "needs confirmation",
       actionConfirmStyle: (isMobile ? "" : "margin-left:auto;") + "flex:0 0 auto;font-size:11px;background:var(--warn-soft);color:var(--warn-text);border-radius:11px;padding:4px 10px;white-space:nowrap",
-      actionPartialNote: "Skutek działania nieokreślony — symulacja jeszcze się kończy.",
-      actionEmptyText: "Brak działań, które warto zaproponować w tym kontekście.",
-      actionErrorText: "Nie udało się przygotować sugestii działania.",
-      actionErrorReason: "Reguła bezpieczeństwa zablokowała automatyczne przygotowanie wysyłki.",
+      actionPartialNote: "The effect is undetermined — the simulation is still finishing.",
+      actionEmptyText: "No actions worth proposing in this context.",
+      actionErrorText: "Could not prepare an action suggestion.",
+      actionErrorReason: "A safety rule blocked automatic preparation of the send.",
 
       crossHeadingStyle: "font-size:13px;font-weight:600;color:var(--text2);margin-top:6px",
       crossRowStyle: isMobile ? "display:flex;flex-direction:column;gap:14px" : "display:flex;gap:14px;align-items:stretch",
       unknownBlockName: "RiskScore",
       schemaPlanVersion: "v3",
       schemaClientVersion: "v2",
-      schemaBannerText: "Ten wynik używa nowszej wersji schematu planu (v3) niż ta aplikacja obsługuje (v2). Część nowych typów bloków mogła zostać pominięta.",
+      schemaBannerText: "This result uses a newer plan schema version (v3) than this app supports (v2). Some new block types may have been skipped.",
 
       citationSamples: [
-        { label: "domyślnie", style: "font-size:11px;color:var(--accent-d);background:var(--accent-soft);border-radius:4px;padding:2px 7px;min-width:20px;text-align:center" },
-        { label: "po najechaniu", style: "font-size:11px;color:var(--onaccent);background:var(--accent-2);border-radius:4px;padding:2px 7px;min-width:20px;text-align:center" },
-        { label: "po fokusie (Tab)", style: "font-size:11px;color:var(--accent-d);background:var(--accent-soft);border-radius:4px;padding:2px 7px;min-width:20px;text-align:center;outline:2px solid var(--accent);outline-offset:2px" },
+        { label: "default", style: "font-size:11px;color:var(--accent-d);background:var(--accent-soft);border-radius:4px;padding:2px 7px;min-width:20px;text-align:center" },
+        { label: "hover", style: "font-size:11px;color:var(--onaccent);background:var(--accent-2);border-radius:4px;padding:2px 7px;min-width:20px;text-align:center" },
+        { label: "focus (Tab)", style: "font-size:11px;color:var(--accent-d);background:var(--accent-soft);border-radius:4px;padding:2px 7px;min-width:20px;text-align:center;outline:2px solid var(--accent);outline-offset:2px" },
       ],
-      verdictLegend: ["poparty", "niepoparty", "przestarzały", "sprzeczny"].map(v => {
+      verdictLegend: ["supported", "unsupported", "outdated", "conflicting"].map(v => {
         const vi = verdictInfo(v);
         const descs = {
-          poparty: "fakt zgodny ze źródłem",
-          niepoparty: "źródło nie potwierdza faktu",
-          przestarzały: "źródło było prawdziwe, ale nie jest już aktualne",
-          sprzeczny: "źródło przeczy innemu źródłu w wyniku",
+          supported: "the fact agrees with the source",
+          unsupported: "the source does not confirm the fact",
+          outdated: "the source was true but is no longer current",
+          conflicting: "the source contradicts another source in the result",
         };
         return {
           icon: vi.icon, label: vi.label, desc: descs[v],

--- a/design/files/MailFathom Sign-in.dc.html
+++ b/design/files/MailFathom Sign-in.dc.html
@@ -12,29 +12,29 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
 <link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
 <!--
-  IKONY — Material Symbols (Rounded), Google.  LICENCJA: Apache License 2.0.
-  Font webowy: https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded
-  Katalog / pobieranie SVG: https://fonts.google.com/icons
-  Repozytorium: https://github.com/google/material-design-icons  (licencja: .../blob/master/LICENSE)
-  Zamienniki MIT: Tabler https://github.com/tabler/tabler-icons · Feather https://github.com/feathericons/feather · Phosphor https://github.com/phosphor-icons/core
-  LOGO DOSTAWCÓW OAuth — Simple Icons (CC0), serwowane z https://cdn.simpleicons.org
-  Znaki towarowe należą do właścicieli; w produkcie podmień na pliki dostarczone przez dział marki.
+  ICONS — Material Symbols (Rounded), Google.  LICENCE: Apache License 2.0.
+  Web font: https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded
+  Catalogue / SVG download: https://fonts.google.com/icons
+  Repository: https://github.com/google/material-design-icons  (licence: .../blob/master/LICENSE)
+  MIT alternatives: Tabler https://github.com/tabler/tabler-icons · Feather https://github.com/feathericons/feather · Phosphor https://github.com/phosphor-icons/core
+  OAuth PROVIDER LOGOS — Simple Icons (CC0), served from https://cdn.simpleicons.org
+  Trademarks belong to their owners; in the product swap these for files supplied by the brand team.
 -->
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,300,0,0&display=block" rel="stylesheet" />
 <style>
   *, *::before, *::after { box-sizing: border-box; }
   html, body { margin: 0; padding: 0; background: oklch(0.980 0.004 88); }
-  body:has([data-theme="ciemny"]) { background: oklch(0.183 0.016 262); }
+  body:has([data-theme="dark"]) { background: oklch(0.183 0.016 262); }
   input::placeholder { color: var(--faint); }
-  [data-theme="jasny"] { color-scheme:light;--bg:oklch(0.980 0.004 88);--panel:#ffffff;--rail:oklch(0.951 0.006 88);--hover:oklch(0.906 0.010 88);--sub:oklch(0.969 0.005 88);--line:oklch(0.906 0.008 88);--line2:oklch(0.949 0.005 88);--border2:oklch(0.856 0.010 88);--text:oklch(0.240 0.014 262);--text2:oklch(0.420 0.012 240);--muted:oklch(0.565 0.010 200);--faint:oklch(0.690 0.009 160);--accent:oklch(0.555 0.185 262);--accent-2:oklch(0.465 0.175 262);--accent-d:oklch(0.385 0.150 262);--accent-soft:oklch(0.945 0.038 258);--accent-line:oklch(0.870 0.062 258);--onaccent:#ffffff;--ok:oklch(0.56 0.14 155);--ok-text:oklch(0.44 0.11 155);--ok-soft:oklch(0.945 0.038 155);--warn:oklch(0.62 0.155 62);--warn-soft:oklch(0.955 0.045 75);--warn-text:oklch(0.46 0.135 55);--hl:oklch(0.945 0.070 88);--hl-line:oklch(0.775 0.145 85);--inset:rgba(255,255,255,0.65);--sh-1:oklch(0.30 0.02 262 / 0.07);--sh-2:oklch(0.30 0.025 262 / 0.14);--sh-3:oklch(0.28 0.03 262 / 0.28);--scrim:oklch(0.26 0.03 262 / 0.36); }
-  [data-theme="ciemny"] { color-scheme:dark;--bg:oklch(0.183 0.016 262);--panel:oklch(0.246 0.016 262);--rail:oklch(0.212 0.017 262);--hover:oklch(0.325 0.021 262);--sub:oklch(0.277 0.016 262);--line:oklch(0.336 0.018 262);--line2:oklch(0.283 0.015 262);--border2:oklch(0.416 0.022 262);--text:oklch(0.945 0.007 262);--text2:oklch(0.835 0.011 262);--muted:oklch(0.705 0.013 262);--faint:oklch(0.585 0.015 262);--accent:oklch(0.615 0.175 262);--accent-2:oklch(0.735 0.150 262);--accent-d:oklch(0.865 0.085 262);--accent-soft:oklch(0.320 0.070 262);--accent-line:oklch(0.430 0.095 262);--onaccent:#ffffff;--ok:oklch(0.72 0.14 155);--ok-text:oklch(0.82 0.12 155);--ok-soft:oklch(0.30 0.045 155);--warn:oklch(0.74 0.13 55);--warn-soft:oklch(0.315 0.05 50);--warn-text:oklch(0.87 0.10 62);--hl:oklch(0.345 0.055 85);--hl-line:oklch(0.72 0.13 85);--inset:rgba(255,255,255,0.045);--sh-1:oklch(0.10 0.03 262 / 0.38);--sh-2:oklch(0.10 0.03 262 / 0.50);--sh-3:oklch(0.09 0.035 262 / 0.64);--scrim:oklch(0.12 0.045 262 / 0.66); }
+  [data-theme="light"] { color-scheme:light;--bg:oklch(0.980 0.004 88);--panel:#ffffff;--rail:oklch(0.951 0.006 88);--hover:oklch(0.906 0.010 88);--sub:oklch(0.969 0.005 88);--line:oklch(0.906 0.008 88);--line2:oklch(0.949 0.005 88);--border2:oklch(0.856 0.010 88);--text:oklch(0.240 0.014 262);--text2:oklch(0.420 0.012 240);--muted:oklch(0.565 0.010 200);--faint:oklch(0.690 0.009 160);--accent:oklch(0.555 0.185 262);--accent-2:oklch(0.465 0.175 262);--accent-d:oklch(0.385 0.150 262);--accent-soft:oklch(0.945 0.038 258);--accent-line:oklch(0.870 0.062 258);--onaccent:#ffffff;--ok:oklch(0.56 0.14 155);--ok-text:oklch(0.44 0.11 155);--ok-soft:oklch(0.945 0.038 155);--warn:oklch(0.62 0.155 62);--warn-soft:oklch(0.955 0.045 75);--warn-text:oklch(0.46 0.135 55);--hl:oklch(0.945 0.070 88);--hl-line:oklch(0.775 0.145 85);--inset:rgba(255,255,255,0.65);--sh-1:oklch(0.30 0.02 262 / 0.07);--sh-2:oklch(0.30 0.025 262 / 0.14);--sh-3:oklch(0.28 0.03 262 / 0.28);--scrim:oklch(0.26 0.03 262 / 0.36); }
+  [data-theme="dark"] { color-scheme:dark;--bg:oklch(0.183 0.016 262);--panel:oklch(0.246 0.016 262);--rail:oklch(0.212 0.017 262);--hover:oklch(0.325 0.021 262);--sub:oklch(0.277 0.016 262);--line:oklch(0.336 0.018 262);--line2:oklch(0.283 0.015 262);--border2:oklch(0.416 0.022 262);--text:oklch(0.945 0.007 262);--text2:oklch(0.835 0.011 262);--muted:oklch(0.705 0.013 262);--faint:oklch(0.585 0.015 262);--accent:oklch(0.615 0.175 262);--accent-2:oklch(0.735 0.150 262);--accent-d:oklch(0.865 0.085 262);--accent-soft:oklch(0.320 0.070 262);--accent-line:oklch(0.430 0.095 262);--onaccent:#ffffff;--ok:oklch(0.72 0.14 155);--ok-text:oklch(0.82 0.12 155);--ok-soft:oklch(0.30 0.045 155);--warn:oklch(0.74 0.13 55);--warn-soft:oklch(0.315 0.05 50);--warn-text:oklch(0.87 0.10 62);--hl:oklch(0.345 0.055 85);--hl-line:oklch(0.72 0.13 85);--inset:rgba(255,255,255,0.045);--sh-1:oklch(0.10 0.03 262 / 0.38);--sh-2:oklch(0.10 0.03 262 / 0.50);--sh-3:oklch(0.09 0.035 262 / 0.64);--scrim:oklch(0.12 0.045 262 / 0.66); }
   a { color: var(--accent); }
   a:hover { color: var(--accent-2); }
   input { font-family: inherit; }
   @keyframes mfspin { to { transform: rotate(360deg) } }
 </style>
 </helmet>
-<div ref="{{ rootRef }}" data-theme="{{ themeAttr }}" data-screen-label="Logowanie" style="{{ rootStyle }}">
+<div ref="{{ rootRef }}" data-theme="{{ themeAttr }}" data-screen-label="Sign in" style="{{ rootStyle }}">
 
   <div style="{{ brandStyle }}">
     <div style="{{ brandRowStyle }}">
@@ -43,8 +43,8 @@
     </div>
     <sc-if value="{{ showPitch }}" hint-placeholder-val="{{ true }}">
       <div style="display:flex;flex-direction:column;justify-content:center;flex:1;gap:18px;max-width:400px;padding-bottom:40px">
-        <div style="font-size:34px;font-weight:600;line-height:1.15;letter-spacing:-0.02em;text-wrap:pretty">Twoja poczta zostaje na Twoim serwerze.</div>
-        <div style="font-size:15px;line-height:1.6;color:var(--muted);text-wrap:pretty">Łączysz się z serwerem MailFathom swojej organizacji. Indeksowanie i analiza wiadomości dzieją się po jego stronie — nic nie trafia do chmury bez Twojej zgody.</div>
+        <div style="font-size:34px;font-weight:600;line-height:1.15;letter-spacing:-0.02em;text-wrap:pretty">Your mail stays on your server.</div>
+        <div style="font-size:15px;line-height:1.6;color:var(--muted);text-wrap:pretty">You connect to your organisation's MailFathom server. Indexing and analysis happen on its side — nothing goes to the cloud without your consent.</div>
       </div>
     </sc-if>
   </div>
@@ -75,19 +75,19 @@
         <div style="display:flex;flex-direction:column;gap:{{ sectionGap }}px">
 
           <div style="display:flex;flex-direction:column;gap:5px">
-            <div style="{{ titleStyle }}">Połącz skrzynkę</div>
+            <div style="{{ titleStyle }}">Connect your mailbox</div>
             <div style="display:flex;align-items:center;gap:7px;flex-wrap:wrap;font-size:12.5px;color:var(--muted)">
               <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:15px;line-height:1;color:{{ lockColor }}">{{ lockIcon }}</span>
               <span style="font-family:'Instrument Sans',system-ui,sans-serif;color:var(--text2)">{{ serverLabel }}</span>
               <sc-if value="{{ insecure }}" hint-placeholder-val="{{ false }}">
-                <span style="font-size:10.5px;font-weight:500;color:var(--warn-text);background:var(--warn-soft);border-radius:5px;padding:2px 7px">bez TLS</span>
+                <span style="font-size:10.5px;font-weight:500;color:var(--warn-text);background:var(--warn-soft);border-radius:5px;padding:2px 7px">no TLS</span>
               </sc-if>
             </div>
           </div>
 
           <sc-if value="{{ showOauth }}" hint-placeholder-val="{{ true }}">
             <div style="display:flex;flex-direction:column;gap:9px">
-                <div style="font-size:11.5px;font-weight:500;letter-spacing:0.02em;color:var(--faint)">Logowanie przez dostawcę</div>
+                <div style="font-size:11.5px;font-weight:500;letter-spacing:0.02em;color:var(--faint)">Sign in with a provider</div>
                 <div style="display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px">
                   <sc-for list="{{ oauthBtns }}" as="ob" hint-placeholder-count="3">
                     <div onClick="{{ ob.click }}" title="{{ ob.title }}" style="{{ ob.style }}" style-hover="cursor:pointer;border-color:var(--border2);background:var(--hover)">
@@ -102,7 +102,7 @@
           <sc-if value="{{ showDivider }}" hint-placeholder-val="{{ true }}">
             <div style="display:flex;align-items:center;gap:11px">
               <div style="flex:1;height:1px;background:var(--line)"></div>
-              <div style="font-size:11px;color:var(--faint)">lub hasłem</div>
+              <div style="font-size:11px;color:var(--faint)">or with a password</div>
               <div style="flex:1;height:1px;background:var(--line)"></div>
             </div>
           </sc-if>
@@ -110,14 +110,14 @@
           <sc-if value="{{ showBasic }}" hint-placeholder-val="{{ true }}">
             <div style="display:flex;flex-direction:column;gap:{{ sectionGap }}px">
               <div style="display:flex;flex-direction:column;gap:6px">
-                <label style="font-size:12px;font-weight:500;color:var(--text2)">Login</label>
+                <label style="font-size:12px;font-weight:500;color:var(--text2)">Username</label>
                 <div style="{{ userBoxStyle }}">
-                  <input value="{{ user }}" onChange="{{ onUser }}" onFocus="{{ focusUser }}" onBlur="{{ blurAny }}" onKeyDown="{{ onKey }}" placeholder="k.kowalska@nordwind.pl" style="{{ fieldStyle }}" />
+                  <input value="{{ user }}" onChange="{{ onUser }}" onFocus="{{ focusUser }}" onBlur="{{ blurAny }}" onKeyDown="{{ onKey }}" placeholder="k.kowalska@nordwind.example" style="{{ fieldStyle }}" />
                 </div>
               </div>
 
               <div style="display:flex;flex-direction:column;gap:6px">
-                <label style="font-size:12px;font-weight:500;color:var(--text2)">Hasło</label>
+                <label style="font-size:12px;font-weight:500;color:var(--text2)">Password</label>
                 <div style="{{ passBoxStyle }}">
                   <input value="{{ pass }}" onChange="{{ onPass }}" onFocus="{{ focusPass }}" onBlur="{{ blurAny }}" onKeyDown="{{ onKey }}" type="{{ passType }}" placeholder="••••••••••" style="{{ fieldStyle }}" />
                   <span onClick="{{ toggleReveal }}" style="{{ revealStyle }}" style-hover="cursor:pointer;color:var(--text);background:var(--hover)">{{ revealLabel }}</span>
@@ -142,20 +142,20 @@
           <sc-if value="{{ noMethods }}" hint-placeholder-val="{{ false }}">
             <div style="display:flex;gap:9px;align-items:flex-start;background:var(--warn-soft);border:1px solid var(--warn);border-radius:9px;padding:11px 13px">
               <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:16px;line-height:1;color:var(--warn-text)">block</span>
-              <div style="font-size:12px;line-height:1.5;color:var(--warn-text);text-wrap:pretty">Ten serwer nie udostępnia żadnej metody logowania. Sprawdź adres albo skontaktuj się z administratorem.</div>
+              <div style="font-size:12px;line-height:1.5;color:var(--warn-text);text-wrap:pretty">This server offers no sign-in method. Check the address or contact your administrator.</div>
             </div>
           </sc-if>
 
           <div style="display:flex;flex-direction:column;gap:11px">
             <div onClick="{{ toggleAdvanced }}" style="{{ advancedBtnStyle }}" style-hover="cursor:pointer;color:var(--accent-2);background:var(--hover)">
-              <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1;{{ chevronRotate }}">chevron_right</span>Zaawansowane<sc-if value="{{ insecure }}" hint-placeholder-val="{{ false }}"><span style="margin-left:2px;font-size:11px;color:var(--warn-text);background:var(--warn-soft);border-radius:5px;padding:2px 7px">bez TLS</span></sc-if>
+              <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1;{{ chevronRotate }}">chevron_right</span>Advanced<sc-if value="{{ insecure }}" hint-placeholder-val="{{ false }}"><span style="margin-left:2px;font-size:11px;color:var(--warn-text);background:var(--warn-soft);border-radius:5px;padding:2px 7px">no TLS</span></sc-if>
             </div>
 
             <sc-if value="{{ advanced }}" hint-placeholder-val="{{ false }}">
               <div style="display:flex;flex-direction:column;gap:11px">
                 <div style="display:flex;flex-direction:column;gap:11px;background:var(--sub);border:1px solid var(--line);border-radius:10px;padding:13px 15px">
                   <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;font-size:12px">
-                    <span style="color:var(--muted)">Protokół</span>
+                    <span style="color:var(--muted)">Protocol</span>
                     <span style="font-weight:500">{{ protoLabel }}</span>
                   </div>
                   <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;font-size:12px">
@@ -167,14 +167,14 @@
                     <span style="font-weight:500;font-family:'Instrument Sans',system-ui,sans-serif">{{ parsedPort }}</span>
                   </div>
                   <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;font-size:12px;border-top:1px solid var(--line2);padding-top:11px">
-                    <span style="color:var(--muted)">Weryfikacja certyfikatu</span>
+                    <span style="color:var(--muted)">Certificate verification</span>
                     <span style="font-weight:500;color:{{ certColor }}">{{ certLabel }}</span>
                   </div>
                 </div>
 
                 <sc-if value="{{ canChangeServer }}" hint-placeholder-val="{{ true }}">
                   <div onClick="{{ openServer }}" style="{{ ghostBtnStyle }}" style-hover="cursor:pointer;border-color:var(--accent);color:var(--accent-2);background:var(--hover)">
-                    <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">dns</span>Zmień serwer
+                    <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">dns</span>Change server
                   </div>
                 </sc-if>
 
@@ -190,16 +190,16 @@
 
           <div style="display:flex;flex-direction:column;gap:5px">
             <div onClick="{{ closeServer }}" style="{{ backBtnStyle }}" style-hover="cursor:pointer;color:var(--accent-2);background:var(--hover)">
-              <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1">arrow_back</span>Wróć do logowania
+              <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1">arrow_back</span>Back to sign-in
             </div>
-            <div style="{{ titleStyle }}">Adres serwera</div>
-            <div style="font-size:13px;color:var(--muted);text-wrap:pretty">Zapisujemy go na tym urządzeniu. Serwer decyduje, jakie metody logowania zobaczysz.</div>
+            <div style="{{ titleStyle }}">Server address</div>
+            <div style="font-size:13px;color:var(--muted);text-wrap:pretty">We store it on this device. The server decides which sign-in methods you see.</div>
           </div>
 
           <div style="display:flex;flex-direction:column;gap:6px">
-            <label style="font-size:12px;font-weight:500;color:var(--text2)">Serwer</label>
+            <label style="font-size:12px;font-weight:500;color:var(--text2)">Server</label>
             <div style="{{ hostBoxStyle }}">
-              <input value="{{ host }}" onChange="{{ onHost }}" onFocus="{{ focusHost }}" onBlur="{{ blurAny }}" onKeyDown="{{ onServerKey }}" placeholder="mail.firma.pl:7443" style="{{ fieldStyle }}" />
+              <input value="{{ host }}" onChange="{{ onHost }}" onFocus="{{ focusHost }}" onBlur="{{ blurAny }}" onKeyDown="{{ onServerKey }}" placeholder="mail.company.example:7443" style="{{ fieldStyle }}" />
               <span style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;color:var(--faint);white-space:nowrap">{{ portHint }}</span>
             </div>
             <div style="font-size:11px;line-height:1.5;color:var(--faint);text-wrap:pretty">{{ hostNote }}</div>
@@ -208,27 +208,27 @@
           <div onClick="{{ toggleInsecure }}" style="{{ insecureRowStyle }}" style-hover="cursor:pointer;border-color:var(--border2)">
             <div style="{{ checkboxStyle }}">{{ checkMark }}</div>
             <div style="display:flex;flex-direction:column;gap:3px;min-width:0">
-              <div style="font-size:13px;font-weight:500">Zezwalaj na niezabezpieczone połączenia</div>
+              <div style="font-size:13px;font-weight:500">Allow insecure connections</div>
               <div style="font-size:11px;line-height:1.5;color:var(--muted);text-wrap:pretty">{{ insecureNote }}</div>
             </div>
           </div>
 
           <sc-if value="{{ customized }}" hint-placeholder-val="{{ false }}">
             <div onClick="{{ restoreDefaults }}" style="{{ restoreBtnStyle }}" style-hover="cursor:pointer;border-color:var(--border2);background:var(--hover);color:var(--text)">
-              <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">restart_alt</span>Przywróć domyślne<span style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;color:var(--faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis">{{ defaultServerLabel }}</span>
+              <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">restart_alt</span>Restore defaults<span style="font-family:'Instrument Sans',system-ui,sans-serif;font-size:11px;color:var(--faint);white-space:nowrap;overflow:hidden;text-overflow:ellipsis">{{ defaultServerLabel }}</span>
             </div>
           </sc-if>
 
           <sc-if value="{{ insecure }}" hint-placeholder-val="{{ false }}">
             <div style="display:flex;gap:9px;align-items:flex-start;background:var(--warn-soft);border:1px solid var(--warn);border-radius:9px;padding:10px 12px">
               <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:16px;line-height:1;color:var(--warn-text)">warning</span>
-              <div style="font-size:12px;line-height:1.5;color:var(--warn-text);text-wrap:pretty">Certyfikat serwera nie będzie weryfikowany. Używaj tylko w sieci wewnętrznej lub przez VPN.</div>
+              <div style="font-size:12px;line-height:1.5;color:var(--warn-text);text-wrap:pretty">The server certificate will not be verified. Use only on an internal network or over VPN.</div>
             </div>
           </sc-if>
 
           <div style="display:flex;flex-direction:column;gap:11px;background:var(--sub);border:1px solid var(--line);border-radius:10px;padding:13px 15px">
             <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;font-size:12px">
-              <span style="color:var(--muted)">Protokół</span>
+              <span style="color:var(--muted)">Protocol</span>
               <span style="font-weight:500">{{ protoLabel }}</span>
             </div>
             <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;font-size:12px">
@@ -240,7 +240,7 @@
               <span style="font-weight:500;font-family:'Instrument Sans',system-ui,sans-serif">{{ parsedPort }}</span>
             </div>
             <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;font-size:12px;border-top:1px solid var(--line2);padding-top:11px">
-              <span style="color:var(--muted)">Weryfikacja certyfikatu</span>
+              <span style="color:var(--muted)">Certificate verification</span>
               <span style="font-weight:500;color:{{ certColor }}">{{ certLabel }}</span>
             </div>
           </div>
@@ -260,7 +260,7 @@
       </sc-if>
 
       <div style="{{ footRowStyle }}">
-        <span style="{{ helpRowStyle }}">Nie pamiętasz hasła?&nbsp;<a href="#">Pomoc IT</a></span>
+        <span style="{{ helpRowStyle }}">Forgot your password?&nbsp;<a href="#">IT help</a></span>
         <span style="font-size:10.5px;color:var(--faint);white-space:nowrap">MailFathom v<span style="font-family:'Instrument Sans',system-ui,sans-serif">{{ appVersion }}</span></span>
       </div>
 
@@ -268,13 +268,13 @@
   </div>
 </div>
 </x-dc>
-<script type="text/x-dc" data-dc-script data-props="{&quot;layout&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;auto&quot;,&quot;desktop&quot;,&quot;tablet&quot;,&quot;fold&quot;,&quot;telefon&quot;],&quot;default&quot;:&quot;auto&quot;,&quot;tsType&quot;:&quot;string&quot;},&quot;theme&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;jasny&quot;,&quot;ciemny&quot;],&quot;default&quot;:&quot;ciemny&quot;,&quot;tsType&quot;:&quot;string&quot;},&quot;serwerDomyslny&quot;:{&quot;editor&quot;:&quot;text&quot;,&quot;default&quot;:&quot;mail.nordwind.pl:7443&quot;,&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Serwer&quot;,&quot;label&quot;:&quot;Domyślny serwer (z instalatora)&quot;},&quot;serwerWymuszony&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:false,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Serwer&quot;,&quot;label&quot;:&quot;Serwer wymuszony przez env config&quot;},&quot;basicDostepne&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:true,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Serwer&quot;,&quot;label&quot;:&quot;Serwer udostępnia basic auth&quot;},&quot;oauthDostepne&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:true,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Serwer&quot;,&quot;label&quot;:&quot;Serwer udostępnia OAuth&quot;},&quot;liczbaOauth&quot;:{&quot;editor&quot;:&quot;range&quot;,&quot;default&quot;:3,&quot;min&quot;:1,&quot;max&quot;:12,&quot;step&quot;:1,&quot;tsType&quot;:&quot;number&quot;,&quot;section&quot;:&quot;Serwer&quot;,&quot;label&quot;:&quot;Liczba metod OAuth (demo)&quot;}}">
-const FRAMES = { tablet: { w: 1024, h: 768 }, fold: { w: 884, h: 832 }, telefon: { w: 390, h: 844 } };
+<script type="text/x-dc" data-dc-script data-props="{&quot;layout&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;auto&quot;,&quot;desktop&quot;,&quot;tablet&quot;,&quot;fold&quot;,&quot;phone&quot;],&quot;default&quot;:&quot;auto&quot;,&quot;tsType&quot;:&quot;string&quot;},&quot;theme&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;light&quot;,&quot;dark&quot;],&quot;default&quot;:&quot;dark&quot;,&quot;tsType&quot;:&quot;string&quot;},&quot;defaultServer&quot;:{&quot;editor&quot;:&quot;text&quot;,&quot;default&quot;:&quot;mail.nordwind.example:7443&quot;,&quot;tsType&quot;:&quot;string&quot;,&quot;section&quot;:&quot;Server&quot;,&quot;label&quot;:&quot;Default server (from the installer)&quot;},&quot;forcedServer&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:false,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Server&quot;,&quot;label&quot;:&quot;Server forced by env config&quot;},&quot;basicAvailable&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:true,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Server&quot;,&quot;label&quot;:&quot;Server offers basic auth&quot;},&quot;oauthAvailable&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:true,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Server&quot;,&quot;label&quot;:&quot;Server offers OAuth&quot;},&quot;oauthCount&quot;:{&quot;editor&quot;:&quot;range&quot;,&quot;default&quot;:3,&quot;min&quot;:1,&quot;max&quot;:12,&quot;step&quot;:1,&quot;tsType&quot;:&quot;number&quot;,&quot;section&quot;:&quot;Server&quot;,&quot;label&quot;:&quot;Number of OAuth methods (demo)&quot;}}">
+const FRAMES = { tablet: { w: 1024, h: 768 }, fold: { w: 884, h: 832 }, phone: { w: 390, h: 844 } };
 const APP_VERSION = "2.4.2";
-const LS_SRV = "mailfathom.serwer";
-const LS_TLS = "mailfathom.brakTls";
+const LS_SRV = "mailfathom.server";
+const LS_TLS = "mailfathom.noTls";
 
-/* Logo dostawców: Simple Icons (CC0) z cdn.simpleicons.org — w produkcie podmień na lokalne pliki. */
+/* Provider logos: Simple Icons (CC0) from cdn.simpleicons.org — swap for local files in the product. */
 const OAUTH = [
   { id: "github", label: "GitHub", slug: "github", dark: "e8e8e8", light: "181717" },
   { id: "gmail", label: "Gmail", slug: "gmail", dark: "ea4335", light: "ea4335" },
@@ -298,10 +298,10 @@ class Component extends DCLogic {
 
   state = {
     view: "login",
-    srv: this._saved.srv,           // null = domyślny z konfiguracji
+    srv: this._saved.srv,           // null = default from configuration
     notls: this._saved.tls === "1",
     user: "", pass: "", reveal: false, advanced: false, focus: null,
-    connecting: false, probing: false, oauth: null, error: "", vw: 1440, theme: null, lang: "pl",
+    connecting: false, probing: false, oauth: null, error: "", vw: 1440, theme: null, lang: "en",
   };
 
   rootRef = React.createRef();
@@ -326,12 +326,12 @@ class Component extends DCLogic {
     window.removeEventListener("resize", this._onResize);
   }
 
-  defaultServer() { return (this.props.serwerDomyslny ?? "mail.nordwind.pl:7443").trim(); }
-  /* Konfiguracja przekazana aplikacji (env / MDM) wygrywa: adres i tryb TLS są wtedy niezmienne. */
-  envLocked() { return !!this.props.serwerWymuszony; }
+  defaultServer() { return (this.props.defaultServer ?? "mail.nordwind.example:7443").trim(); }
+  /* Configuration handed to the app (env / MDM) wins: the address and TLS mode are then immutable. */
+  envLocked() { return !!this.props.forcedServer; }
   server() { return (this.envLocked() || this.state.srv == null) ? this.defaultServer() : this.state.srv; }
   notls() { return this.envLocked() ? false : this.state.notls; }
-  /* Niedomyślny serwer albo wyjątek TLS — wtedy oferujemy powrót do konfiguracji z instalatora. */
+  /* Non-default server or a TLS exception — then we offer a way back to the installer configuration. */
   customized() { return this.server().trim() !== this.defaultServer() || this.state.notls; }
 
   save(srv, notls) {
@@ -365,8 +365,8 @@ class Component extends DCLogic {
   }
 
   go = () => {
-    if (!this.state.user.trim()) return this.setState({ error: "Podaj login." });
-    if (!this.state.pass) return this.setState({ error: "Podaj hasło." });
+    if (!this.state.user.trim()) return this.setState({ error: "Enter a username." });
+    if (!this.state.pass) return this.setState({ error: "Enter a password." });
     this.setState({ connecting: true, error: "" });
     clearTimeout(this._t);
     this._t = setTimeout(() => this.setState({ connecting: false }), 1600);
@@ -378,9 +378,9 @@ class Component extends DCLogic {
     this._t = setTimeout(() => this.setState({ oauth: null }), 1800);
   };
 
-  /* „Połącz” na ekranie serwera = sprawdzenie adresu i powrót do logowania z nowymi metodami. */
+  /* "Connect" on the server screen = check the address and return to sign-in with the new methods. */
   connectServer = () => {
-    if (!this.parse().host) return this.setState({ error: "Podaj adres serwera, np. mail.firma.pl" });
+    if (!this.parse().host) return this.setState({ error: "Enter the server address, e.g. mail.company.example" });
     this.setState({ probing: true, error: "" });
     clearTimeout(this._p);
     this._p = setTimeout(() => this.setState({ probing: false, view: "login", advanced: false }), 1100);
@@ -394,14 +394,14 @@ class Component extends DCLogic {
       ";border-radius:10px;padding:0 13px;transition:border-color 0.12s,box-shadow 0.12s";
   }
 
-  themeChoice() { return this.state.theme ?? this.props.theme ?? "jasny"; }
+  themeChoice() { return this.state.theme ?? this.props.theme ?? "light"; }
 
   resolvedTheme() {
     const t = this.themeChoice();
     if (t !== "auto") return t;
     const dark = typeof window !== "undefined" && window.matchMedia
       && window.matchMedia("(prefers-color-scheme: dark)").matches;
-    return dark ? "ciemny" : "jasny";
+    return dark ? "dark" : "light";
   }
 
   renderVals() {
@@ -413,27 +413,27 @@ class Component extends DCLogic {
     const stacked = w < 940;
     const pad = phone ? "22px 18px 28px 18px" : stacked ? "30px 34px" : "44px 46px";
     const tapH = phone ? 52 : 44;
-    /* Kompozycje dotykowe (telefon, fold, tablet) — reguła dostępności podnosi każdy cel pod
-       palcem do min. 44×44 px, więc przełączniki motywu i języka muszą to mieć w projekcie. */
+    /* Touch layouts (phone, fold, tablet) — the accessibility rule raises every finger target
+       to at least 44×44 px, so the theme and language switches must honour that in the design. */
     const touchPick = w < 1180;
     const pickBase = touchPick
       ? "min-width:44px;min-height:44px;display:flex;align-items:center;justify-content:center;text-align:center;padding:0 7px;"
       : "min-width:26px;text-align:center;padding:4px 7px;";
-    const dark = this.resolvedTheme() === "ciemny";
+    const dark = this.resolvedTheme() === "dark";
     const locked = this.envLocked();
     const notls = this.notls();
     const secure = !notls;
     const defPort = secure ? "7443" : "7080";
     const port = p.port || defPort;
     const busy = s.connecting || !!s.oauth;
-    const onServer = s.view === "serwer" && !locked;
-    const oauthOn = this.props.oauthDostepne ?? true;
-    const basicOn = this.props.basicDostepne ?? true;
+    const onServer = s.view === "server" && !locked;
+    const oauthOn = this.props.oauthAvailable ?? true;
+    const basicOn = this.props.basicAvailable ?? true;
     const provider = OAUTH.find(o => o.id === s.oauth);
     return {
       rootRef: this.rootRef,
       themeAttr: this.resolvedTheme(),
-      themePicks: [["auto", "Auto", "A"], ["jasny", "Jasny", "☀"], ["ciemny", "Ciemny", "☾"]].map(([v, label, short]) => ({
+      themePicks: [["auto", "Auto", "A"], ["light", "Light", "☀"], ["dark", "Dark", "☾"]].map(([v, label, short]) => ({
         label, short,
         pick: () => this.setState({ theme: v }),
         style: pickBase + "border-radius:6px;font-size:11.5px;line-height:1.35;" +
@@ -441,11 +441,11 @@ class Component extends DCLogic {
             ? "background:var(--accent);color:var(--onaccent);font-weight:600;"
             : "color:var(--muted);"),
       })),
-      langPicks: [["pl", "Polski", "PL"], ["en", "English", "EN"]].map(([v, label, short]) => ({
+      langPicks: [["en", "English", "EN"], ["pl", "Polski", "PL"]].map(([v, label, short]) => ({
         label, short,
         pick: () => this.setState({ lang: v }),
         style: pickBase + "border-radius:6px;font-size:11.5px;line-height:1.35;letter-spacing:0.04em;" +
-          ((s.lang ?? "pl") === v
+          ((s.lang ?? "en") === v
             ? "background:var(--accent);color:var(--onaccent);font-weight:600;"
             : "color:var(--muted);"),
       })),
@@ -477,7 +477,7 @@ class Component extends DCLogic {
       isServer: onServer,
       envLocked: locked,
       canChangeServer: !locked,
-      openServer: locked ? () => {} : () => this.setState({ view: "serwer", error: "", focus: null }),
+      openServer: locked ? () => {} : () => this.setState({ view: "server", error: "", focus: null }),
       closeServer: () => this.setState({ view: "login", error: "", focus: null }),
 
       serverLabel: this.server() || "—",
@@ -487,14 +487,14 @@ class Component extends DCLogic {
       lockIcon: secure ? "lock" : "lock_open",
       lockColor: secure ? "var(--ok-text)" : "var(--warn-text)",
 
-      /* Metody logowania deklaruje serwer — w demie: basic auth + trzej dostawcy OAuth. */
+      /* The server declares the sign-in methods — in this demo: basic auth + three OAuth providers. */
       showOauth: oauthOn,
       showBasic: basicOn,
       showDivider: oauthOn && basicOn,
       noMethods: !oauthOn && !basicOn,
-      oauthBtns: OAUTH.slice(0, Math.max(1, Math.min(12, Math.round(this.props.liczbaOauth ?? 3)))).map(o => ({
+      oauthBtns: OAUTH.slice(0, Math.max(1, Math.min(12, Math.round(this.props.oauthCount ?? 3)))).map(o => ({
         label: o.label,
-        title: "Przejdź do " + o.label + " (OAuth)",
+        title: "Continue to " + o.label + " (OAuth)",
         click: this.goOauth(o.id),
         iconStyle: "width:17px;height:17px;display:block;flex:0 0 auto;background-repeat:no-repeat;background-position:center;background-size:contain;background-image:url(https://cdn.simpleicons.org/" +
           o.slug + "/" + (dark ? o.dark : o.light) + ")" + (s.oauth === o.id ? ";opacity:0.5" : ""),
@@ -503,7 +503,7 @@ class Component extends DCLogic {
       })),
 
       host: this.server(), user: s.user, pass: s.pass,
-      hostNote: "Port opcjonalny — bez niego " + (secure ? "użyjemy 7443 (MFP przez TLS)" : "użyjemy 7080 (MFP)") + ". Zapisany lokalnie na tym urządzeniu.",
+      hostNote: "Port optional — without it we " + (secure ? "use 7443 (MFP over TLS)" : "use 7080 (MFP)") + ". Stored locally on this device.",
       onHost: this.setServer,
       onUser: e => this.setState({ user: e.target.value, error: "" }),
       onPass: e => this.setState({ pass: e.target.value, error: "" }),
@@ -518,7 +518,7 @@ class Component extends DCLogic {
       passBoxStyle: this.box("pass", tapH),
       portHint: p.port ? "port " + p.port : ":" + defPort,
       passType: s.reveal ? "text" : "password",
-      revealLabel: s.reveal ? "Ukryj" : "Pokaż",
+      revealLabel: s.reveal ? "Hide" : "Show",
       toggleReveal: () => this.setState({ reveal: !s.reveal }),
       toggleInsecure: this.toggleInsecure,
       insecure: notls,
@@ -530,15 +530,15 @@ class Component extends DCLogic {
         (notls ? "var(--warn)" : "transparent") + ";color:var(--onaccent)",
       checkMark: notls ? "check" : "",
       insecureNote: notls
-        ? "TLS wyłączony — logowanie i wiadomości pójdą otwartym tekstem."
-        : "Pozwala połączyć się z serwerem bez ważnego certyfikatu TLS.",
+        ? "TLS off — sign-in and messages will travel in plain text."
+        : "Lets you connect to a server without a valid TLS certificate.",
 
       hasError: !!s.error,
       errorText: s.error,
       connecting: busy,
       probing: s.probing,
-      submitLabel: provider ? "Przekierowanie do " + provider.label + "…" : busy ? "Łączenie z " + (p.host || "serwerem") + "…" : "Połącz",
-      serverBtnLabel: s.probing ? "Sprawdzanie " + (p.host || "serwera") + "…" : "Połącz",
+      submitLabel: provider ? "Redirecting to " + provider.label + "…" : busy ? "Connecting to " + (p.host || "the server") + "…" : "Connect",
+      serverBtnLabel: s.probing ? "Checking " + (p.host || "the server") + "…" : "Connect",
       submitStyle: "display:flex;align-items:center;justify-content:center;gap:9px;min-height:" + (phone ? 52 : 46) + "px;background:var(--accent);color:var(--onaccent);border-radius:" + (phone ? 26 : 10) + "px;padding:0 18px;font-size:" + (phone ? 15 : 14) + "px;font-weight:600;user-select:none;opacity:" + ((busy || s.probing) ? "0.7" : "1"),
       submitHover: (busy || s.probing) ? "cursor:default" : "cursor:pointer;background:var(--accent-2)",
       submit: busy ? () => {} : this.go,
@@ -549,10 +549,10 @@ class Component extends DCLogic {
       footRowStyle: "display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap;width:100%;max-width:" + (phone ? "100%" : "392px") + ";font-size:12px;color:var(--muted)",
       appVersion: APP_VERSION,
       toggleAdvanced: () => this.setState({ advanced: !s.advanced }),
-      protoLabel: secure ? "MFP przez TLS" : "MFP bez szyfrowania",
+      protoLabel: secure ? "MFP over TLS" : "MFP unencrypted",
       parsedHost: p.host || "—",
-      parsedPort: port + (p.port ? "" : " (domyślny)"),
-      certLabel: secure ? "Wymagana" : "Pominięta",
+      parsedPort: port + (p.port ? "" : " (default)"),
+      certLabel: secure ? "Required" : "Skipped",
       certColor: secure ? "var(--ok-text)" : "var(--warn-text)",
     };
   }

--- a/design/files/MailFathom Toasts.dc.html
+++ b/design/files/MailFathom Toasts.dc.html
@@ -12,11 +12,11 @@
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,300,0,0&display=block" rel="stylesheet" />
 <style>
   html, body { margin: 0; padding: 0; background: oklch(0.980 0.004 88); }
-  body:has([data-theme="ciemny"]) { background: oklch(0.183 0.016 262); }
+  body:has([data-theme="dark"]) { background: oklch(0.183 0.016 262); }
   a { color: var(--accent); }
   a:hover { color: var(--accent-2); }
-  [data-theme="jasny"] { color-scheme:light;--bg:oklch(0.980 0.004 88);--panel:#ffffff;--rail:oklch(0.951 0.006 88);--hover:oklch(0.906 0.010 88);--sub:oklch(0.969 0.005 88);--line:oklch(0.906 0.008 88);--line2:oklch(0.949 0.005 88);--border2:oklch(0.856 0.010 88);--text:oklch(0.240 0.014 262);--text2:oklch(0.420 0.012 240);--muted:oklch(0.565 0.010 200);--faint:oklch(0.690 0.009 160);--accent:oklch(0.555 0.185 262);--accent-2:oklch(0.465 0.175 262);--accent-d:oklch(0.385 0.150 262);--accent-soft:oklch(0.945 0.038 258);--accent-line:oklch(0.870 0.062 258);--onaccent:#ffffff;--ok:oklch(0.56 0.14 155);--ok-text:oklch(0.44 0.11 155);--ok-soft:oklch(0.945 0.038 155);--warn:oklch(0.62 0.155 62);--warn-soft:oklch(0.955 0.045 75);--warn-text:oklch(0.46 0.135 55);--err:oklch(0.545 0.195 25);--err-soft:oklch(0.958 0.028 25);--err-text:oklch(0.470 0.180 25);--hl:oklch(0.945 0.070 88);--hl-line:oklch(0.775 0.145 85);--inset:rgba(255,255,255,0.65);--sh-1:oklch(0.30 0.02 262 / 0.07);--sh-2:oklch(0.30 0.025 262 / 0.14);--sh-3:oklch(0.28 0.03 262 / 0.28);--scrim:oklch(0.26 0.03 262 / 0.36); }
-  [data-theme="ciemny"] { color-scheme:dark;--bg:oklch(0.183 0.016 262);--panel:oklch(0.246 0.016 262);--rail:oklch(0.212 0.017 262);--hover:oklch(0.325 0.021 262);--sub:oklch(0.277 0.016 262);--line:oklch(0.336 0.018 262);--line2:oklch(0.283 0.015 262);--border2:oklch(0.416 0.022 262);--text:oklch(0.945 0.007 262);--text2:oklch(0.835 0.011 262);--muted:oklch(0.705 0.013 262);--faint:oklch(0.585 0.015 262);--accent:oklch(0.615 0.175 262);--accent-2:oklch(0.735 0.150 262);--accent-d:oklch(0.865 0.085 262);--accent-soft:oklch(0.320 0.070 262);--accent-line:oklch(0.430 0.095 262);--onaccent:#ffffff;--ok:oklch(0.72 0.14 155);--ok-text:oklch(0.82 0.12 155);--ok-soft:oklch(0.30 0.045 155);--warn:oklch(0.74 0.13 55);--warn-soft:oklch(0.315 0.05 50);--warn-text:oklch(0.87 0.10 62);--err:oklch(0.660 0.190 25);--err-soft:oklch(0.325 0.078 22);--err-text:oklch(0.845 0.105 25);--hl:oklch(0.345 0.055 85);--hl-line:oklch(0.72 0.13 85);--inset:rgba(255,255,255,0.045);--sh-1:oklch(0.10 0.03 262 / 0.38);--sh-2:oklch(0.10 0.03 262 / 0.50);--sh-3:oklch(0.09 0.035 262 / 0.64);--scrim:oklch(0.12 0.045 262 / 0.66); }
+  [data-theme="light"] { color-scheme:light;--bg:oklch(0.980 0.004 88);--panel:#ffffff;--rail:oklch(0.951 0.006 88);--hover:oklch(0.906 0.010 88);--sub:oklch(0.969 0.005 88);--line:oklch(0.906 0.008 88);--line2:oklch(0.949 0.005 88);--border2:oklch(0.856 0.010 88);--text:oklch(0.240 0.014 262);--text2:oklch(0.420 0.012 240);--muted:oklch(0.565 0.010 200);--faint:oklch(0.690 0.009 160);--accent:oklch(0.555 0.185 262);--accent-2:oklch(0.465 0.175 262);--accent-d:oklch(0.385 0.150 262);--accent-soft:oklch(0.945 0.038 258);--accent-line:oklch(0.870 0.062 258);--onaccent:#ffffff;--ok:oklch(0.56 0.14 155);--ok-text:oklch(0.44 0.11 155);--ok-soft:oklch(0.945 0.038 155);--warn:oklch(0.62 0.155 62);--warn-soft:oklch(0.955 0.045 75);--warn-text:oklch(0.46 0.135 55);--err:oklch(0.545 0.195 25);--err-soft:oklch(0.958 0.028 25);--err-text:oklch(0.470 0.180 25);--hl:oklch(0.945 0.070 88);--hl-line:oklch(0.775 0.145 85);--inset:rgba(255,255,255,0.65);--sh-1:oklch(0.30 0.02 262 / 0.07);--sh-2:oklch(0.30 0.025 262 / 0.14);--sh-3:oklch(0.28 0.03 262 / 0.28);--scrim:oklch(0.26 0.03 262 / 0.36); }
+  [data-theme="dark"] { color-scheme:dark;--bg:oklch(0.183 0.016 262);--panel:oklch(0.246 0.016 262);--rail:oklch(0.212 0.017 262);--hover:oklch(0.325 0.021 262);--sub:oklch(0.277 0.016 262);--line:oklch(0.336 0.018 262);--line2:oklch(0.283 0.015 262);--border2:oklch(0.416 0.022 262);--text:oklch(0.945 0.007 262);--text2:oklch(0.835 0.011 262);--muted:oklch(0.705 0.013 262);--faint:oklch(0.585 0.015 262);--accent:oklch(0.615 0.175 262);--accent-2:oklch(0.735 0.150 262);--accent-d:oklch(0.865 0.085 262);--accent-soft:oklch(0.320 0.070 262);--accent-line:oklch(0.430 0.095 262);--onaccent:#ffffff;--ok:oklch(0.72 0.14 155);--ok-text:oklch(0.82 0.12 155);--ok-soft:oklch(0.30 0.045 155);--warn:oklch(0.74 0.13 55);--warn-soft:oklch(0.315 0.05 50);--warn-text:oklch(0.87 0.10 62);--err:oklch(0.660 0.190 25);--err-soft:oklch(0.325 0.078 22);--err-text:oklch(0.845 0.105 25);--hl:oklch(0.345 0.055 85);--hl-line:oklch(0.72 0.13 85);--inset:rgba(255,255,255,0.045);--sh-1:oklch(0.10 0.03 262 / 0.38);--sh-2:oklch(0.10 0.03 262 / 0.50);--sh-3:oklch(0.09 0.035 262 / 0.64);--scrim:oklch(0.12 0.045 262 / 0.66); }
   @keyframes mftin { from { opacity: 0; transform: translateX(22px) scale(0.97) } }
   @keyframes mftout { to { opacity: 0; transform: translateX(22px) scale(0.97) } }
   @keyframes mfspin { to { transform: rotate(360deg) } }
@@ -31,17 +31,17 @@
     <div style="display:flex;align-items:flex-end;justify-content:space-between;gap:18px;flex-wrap:wrap">
       <div style="display:flex;flex-direction:column;gap:4px">
         <div style="font-size:11px;letter-spacing:0.10em;text-transform:uppercase;color:var(--muted)">MailFathom — system</div>
-        <div style="font-size:27px;font-weight:600;letter-spacing:-0.02em">Komunikaty</div>
-        <div style="font-size:13.5px;color:var(--muted);max-width:62ch;text-wrap:pretty">Ulotna odpowiedź systemu na to, co użytkownik właśnie zrobił. Prawy górny róg, znikają po {{ secLabel }}, stackują się od najnowszego, każdy ma przycisk zamknięcia. Komunikat o operacji w toku nie znika sam — jego zamknięcie przerywa operację.</div>
+        <div style="font-size:27px;font-weight:600;letter-spacing:-0.02em">Toasts</div>
+        <div style="font-size:13.5px;color:var(--muted);max-width:62ch;text-wrap:pretty">The system's fleeting response to what the user just did. Top right corner, gone after {{ secLabel }}, stacked newest first, each with a close button. A toast for a running operation does not vanish on its own — closing it aborts the operation.</div>
       </div>
       <div style="display:flex;align-items:center;gap:8px">
         <div onClick="{{ toggleTheme }}" style="display:flex;align-items:center;gap:8px;height:36px;padding:0 14px;border:1px solid var(--border2);border-radius:10px;font-size:13px;color:var(--text2)" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1">{{ themeIcon }}</span>{{ themeAttr }}</div>
-        <div onClick="{{ clearAll }}" style="display:flex;align-items:center;gap:8px;height:36px;padding:0 14px;border:1px solid var(--border2);border-radius:10px;font-size:13px;color:var(--text2)" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1">layers_clear</span>Wyczyść stos</div>
+        <div onClick="{{ clearAll }}" style="display:flex;align-items:center;gap:8px;height:36px;padding:0 14px;border:1px solid var(--border2);border-radius:10px;font-size:13px;color:var(--text2)" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:18px;line-height:1">layers_clear</span>Clear the stack</div>
       </div>
     </div>
 
     <div style="display:flex;flex-direction:column;gap:14px;background:var(--sub);border:1px solid var(--line);border-radius:16px;padding:18px">
-      <div style="font-size:15px;font-weight:600">Komunikat to nie powiadomienie</div>
+      <div style="font-size:15px;font-weight:600">A toast is not a notification</div>
       <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(270px,1fr));gap:12px">
         <sc-for list="{{ compare }}" as="c" hint-placeholder-count="2">
           <div style="{{ c.cardStyle }}">
@@ -64,7 +64,7 @@
       </div>
       <div style="display:flex;align-items:flex-start;gap:10px;background:var(--panel);border:1px solid var(--line2);border-radius:12px;padding:12px 14px">
         <span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:19px;line-height:1;color:var(--accent-2);padding-top:1px">swap_horiz</span>
-        <div style="flex:1;min-width:0;font-size:13px;line-height:1.5;color:var(--text2);text-wrap:pretty">Punkt styku: <strong style="font-weight:600;color:var(--text)">nowe powiadomienie pokazuje też komunikat</strong> z przyciskiem „Pokaż”. Komunikat po chwili znika, powiadomienie zostaje na liście jako nieprzeczytane. Ta strona opisuje wyłącznie komunikaty.</div>
+        <div style="flex:1;min-width:0;font-size:13px;line-height:1.5;color:var(--text2);text-wrap:pretty">Where they meet: <strong style="font-weight:600;color:var(--text)">a new notification also raises a toast</strong> with a “Show” button. The toast disappears after a moment; the notification stays in the list as unread. This page describes toasts only.</div>
       </div>
     </div>
 
@@ -92,20 +92,20 @@
               <div style="{{ s.demo.barStyle }}"></div>
             </sc-if>
           </div>
-          <div onClick="{{ s.spawn }}" style="display:flex;align-items:center;justify-content:center;gap:8px;height:36px;border:1px solid var(--accent-line);border-radius:10px;background:var(--accent-soft);font-size:13px;font-weight:600;color:var(--accent-d)" style-hover="cursor:pointer;background:var(--accent);color:var(--onaccent);border-color:var(--accent)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">north_east</span>Pokaż na ekranie</div>
+          <div onClick="{{ s.spawn }}" style="display:flex;align-items:center;justify-content:center;gap:8px;height:36px;border:1px solid var(--accent-line);border-radius:10px;background:var(--accent-soft);font-size:13px;font-weight:600;color:var(--accent-d)" style-hover="cursor:pointer;background:var(--accent);color:var(--onaccent);border-color:var(--accent)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">north_east</span>Show on screen</div>
         </div>
       </sc-for>
     </div>
 
     <div style="display:flex;flex-direction:column;gap:14px;background:var(--panel);border:1px solid var(--line);border-radius:16px;padding:18px 18px 20px">
       <div style="display:flex;flex-direction:column;gap:3px">
-        <div style="font-size:15px;font-weight:600">Stos i zachowanie</div>
-        <div style="font-size:13px;color:var(--muted);text-wrap:pretty">Najnowsze wchodzi na górę, starsze przesuwają się w dół. Powyżej {{ maxLabel }} widocznych najstarsze jest usuwane. Kursor nad kartą zdejmuje przezroczystość, żeby dało się przeczytać treść pod spodem.</div>
+        <div style="font-size:15px;font-weight:600">Stack and behaviour</div>
+        <div style="font-size:13px;color:var(--muted);text-wrap:pretty">The newest enters at the top and older ones move down. Above {{ maxLabel }} visible, the oldest is dropped. Hovering a card removes the transparency so the content underneath stays readable.</div>
       </div>
       <div style="display:flex;gap:9px;flex-wrap:wrap">
-        <div onClick="{{ burst }}" style="{{ btnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">stacks</span>Pokaż pięć naraz</div>
-        <div onClick="{{ runTask }}" style="{{ btnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">progress_activity</span>Operacja w toku → sukces</div>
-        <div onClick="{{ runFail }}" style="{{ btnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">cloud_off</span>Operacja w toku → błąd</div>
+        <div onClick="{{ burst }}" style="{{ btnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">stacks</span>Show five at once</div>
+        <div onClick="{{ runTask }}" style="{{ btnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">progress_activity</span>Running operation → success</div>
+        <div onClick="{{ runFail }}" style="{{ btnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">cloud_off</span>Running operation → error</div>
       </div>
       <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px;margin-top:2px">
         <sc-for list="{{ specs }}" as="sp" hint-placeholder-count="4">
@@ -119,12 +119,12 @@
 
     <div style="display:flex;flex-direction:column;gap:14px;background:var(--panel);border:1px solid var(--line);border-radius:16px;padding:18px 18px 20px">
       <div style="display:flex;flex-direction:column;gap:3px">
-        <div style="font-size:15px;font-weight:600">Overlay blokujący</div>
-        <div style="font-size:13px;color:var(--muted);text-wrap:pretty">Dla operacji, których nie wolno przerwać w połowie przypadkowym kliknięciem w tle: migracja skrzynki, masowa zmiana, eksport. Zasłania całą aplikację, nie zamyka się klikiem obok — tylko przyciskiem Anuluj, a ten pyta o potwierdzenie.</div>
+        <div style="font-size:15px;font-weight:600">Blocking overlay</div>
+        <div style="font-size:13px;color:var(--muted);text-wrap:pretty">For operations that must not be interrupted halfway by a stray click in the background: mailbox migration, bulk change, export. It covers the whole app and does not close on an outside click — only via Cancel, which asks for confirmation.</div>
       </div>
       <div style="display:flex;gap:9px;flex-wrap:wrap">
-        <div onClick="{{ startBlocking }}" style="{{ btnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">hourglass_top</span>Overlay z postępem</div>
-        <div onClick="{{ startBlockingIndet }}" style="{{ btnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">autorenew</span>Bez znanego postępu</div>
+        <div onClick="{{ startBlocking }}" style="{{ btnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">hourglass_top</span>Overlay with progress</div>
+        <div onClick="{{ startBlockingIndet }}" style="{{ btnStyle }}" style-hover="cursor:pointer;background:var(--hover);color:var(--text)"><span style="font-family:'Material Symbols Rounded';font-variation-settings:'wght' 300;font-size:17px;line-height:1">autorenew</span>Without known progress</div>
       </div>
       <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:10px;margin-top:2px">
         <sc-for list="{{ blockSpecs }}" as="bs" hint-placeholder-count="3">
@@ -169,8 +169,8 @@
           <div style="{{ blockFillStyle }}"></div>
         </div>
         <div style="font-size:12px;color:var(--muted)">{{ blockPctLabel }}</div>
-        <div onClick="{{ askBlockCancel }}" style="margin-top:5px;display:flex;align-items:center;justify-content:center;height:38px;padding:0 20px;border:1px solid var(--border2);border-radius:10px;font-size:13px;font-weight:600;color:var(--text2)" style-hover="cursor:pointer;background:var(--hover);color:var(--text)">Anuluj</div>
-        <div style="font-size:11.5px;color:var(--faint);text-align:center;text-wrap:pretty">Nie zamykaj aplikacji — operacja jest w toku.</div>
+        <div onClick="{{ askBlockCancel }}" style="margin-top:5px;display:flex;align-items:center;justify-content:center;height:38px;padding:0 20px;border:1px solid var(--border2);border-radius:10px;font-size:13px;font-weight:600;color:var(--text2)" style-hover="cursor:pointer;background:var(--hover);color:var(--text)">Cancel</div>
+        <div style="font-size:11.5px;color:var(--faint);text-align:center;text-wrap:pretty">Do not close the app — the operation is running.</div>
       </div>
     </div>
   </sc-if>
@@ -178,11 +178,11 @@
   <sc-if value="{{ blockAskOpen }}" hint-placeholder-val="{{ false }}">
     <div style="{{ ovAskStyle }}">
       <div style="box-sizing:border-box;width:min(380px,100%);display:flex;flex-direction:column;gap:13px;background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:20px 20px;box-shadow:0 24px 56px var(--sh-3)">
-        <div style="font-size:16px;font-weight:600">Na pewno przerwać?</div>
+        <div style="font-size:16px;font-weight:600">Really abort?</div>
         <div style="font-size:13px;color:var(--muted);line-height:1.5;text-wrap:pretty">{{ blockAskText }}</div>
         <div style="display:flex;gap:9px;justify-content:flex-end;margin-top:2px">
-          <div onClick="{{ keepBlocking }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:8px 15px" style-hover="cursor:pointer;background:var(--hover)">Kontynuuj operację</div>
-          <div onClick="{{ abortBlocking }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--err);border-radius:8px;padding:8px 16px" style-hover="cursor:pointer;opacity:0.9">Tak, przerwij</div>
+          <div onClick="{{ keepBlocking }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:8px 15px" style-hover="cursor:pointer;background:var(--hover)">Continue the operation</div>
+          <div onClick="{{ abortBlocking }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--err);border-radius:8px;padding:8px 16px" style-hover="cursor:pointer;opacity:0.9">Yes, abort</div>
         </div>
       </div>
     </div>
@@ -191,11 +191,11 @@
   <sc-if value="{{ cancelAskOpen }}" hint-placeholder-val="{{ false }}">
     <div style="{{ ovCancelStyle }}">
       <div style="box-sizing:border-box;width:min(370px,100%);display:flex;flex-direction:column;gap:13px;background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:20px 20px;box-shadow:0 20px 48px var(--sh-3)">
-        <div style="font-size:16px;font-weight:600">Przerwać operację?</div>
+        <div style="font-size:16px;font-weight:600">Abort the operation?</div>
         <div style="font-size:13px;color:var(--muted);line-height:1.5;text-wrap:pretty">{{ cancelAskText }}</div>
         <div style="display:flex;gap:9px;justify-content:flex-end;margin-top:2px">
-          <div onClick="{{ keepTask }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:8px 15px" style-hover="cursor:pointer;background:var(--hover)">Kontynuuj</div>
-          <div onClick="{{ abortTaskNow }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--err);border-radius:8px;padding:8px 16px" style-hover="cursor:pointer;opacity:0.9">Przerwij operację</div>
+          <div onClick="{{ keepTask }}" style="font-size:13px;color:var(--text2);border:1px solid var(--border2);border-radius:8px;padding:8px 15px" style-hover="cursor:pointer;background:var(--hover)">Continue</div>
+          <div onClick="{{ abortTaskNow }}" style="font-size:13px;font-weight:600;color:var(--onaccent);background:var(--err);border-radius:8px;padding:8px 16px" style-hover="cursor:pointer;opacity:0.9">Abort operation</div>
         </div>
       </div>
     </div>
@@ -203,8 +203,8 @@
   </div>
 </div>
 </x-dc>
-<script type="text/x-dc" data-dc-script data-props="{&quot;layout&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;auto&quot;,&quot;desktop&quot;,&quot;tablet&quot;,&quot;fold&quot;,&quot;telefon&quot;],&quot;default&quot;:&quot;auto&quot;,&quot;tsType&quot;:&quot;string&quot;},&quot;theme&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;jasny&quot;,&quot;ciemny&quot;],&quot;default&quot;:&quot;ciemny&quot;,&quot;tsType&quot;:&quot;string&quot;},&quot;autoHideMs&quot;:{&quot;editor&quot;:&quot;range&quot;,&quot;default&quot;:5000,&quot;min&quot;:2000,&quot;max&quot;:12000,&quot;step&quot;:500,&quot;unit&quot;:&quot;ms&quot;,&quot;tsType&quot;:&quot;number&quot;,&quot;section&quot;:&quot;Zachowanie&quot;},&quot;maxStack&quot;:{&quot;editor&quot;:&quot;int&quot;,&quot;default&quot;:4,&quot;min&quot;:1,&quot;max&quot;:8,&quot;tsType&quot;:&quot;number&quot;,&quot;section&quot;:&quot;Zachowanie&quot;},&quot;showProgressBar&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:true,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Zachowanie&quot;}}">
-const FRAMES = { tablet: { w: 1024, h: 768 }, fold: { w: 884, h: 832 }, telefon: { w: 390, h: 844 } };
+<script type="text/x-dc" data-dc-script data-props="{&quot;layout&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;auto&quot;,&quot;desktop&quot;,&quot;tablet&quot;,&quot;fold&quot;,&quot;phone&quot;],&quot;default&quot;:&quot;auto&quot;,&quot;tsType&quot;:&quot;string&quot;},&quot;theme&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;light&quot;,&quot;dark&quot;],&quot;default&quot;:&quot;dark&quot;,&quot;tsType&quot;:&quot;string&quot;},&quot;autoHideMs&quot;:{&quot;editor&quot;:&quot;range&quot;,&quot;default&quot;:5000,&quot;min&quot;:2000,&quot;max&quot;:12000,&quot;step&quot;:500,&quot;unit&quot;:&quot;ms&quot;,&quot;tsType&quot;:&quot;number&quot;,&quot;section&quot;:&quot;Behavior&quot;},&quot;maxStack&quot;:{&quot;editor&quot;:&quot;int&quot;,&quot;default&quot;:4,&quot;min&quot;:1,&quot;max&quot;:8,&quot;tsType&quot;:&quot;number&quot;,&quot;section&quot;:&quot;Behavior&quot;},&quot;showProgressBar&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:true,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Behavior&quot;}}">
+const FRAMES = { tablet: { w: 1024, h: 768 }, fold: { w: 884, h: 832 }, phone: { w: 390, h: 844 } };
 
 const KINDS = {
   neutral: { icon: "info", c: "var(--text2)", soft: "var(--hover)", bar: "var(--border2)" },
@@ -216,18 +216,18 @@ const KINDS = {
 };
 
 const SAMPLES = [
-  { kind: "neutral", name: "Neutralne", title: "Zarchiwizowano 3 wątki", body: "", action: "Cofnij",
-    desc: "Potwierdzenie zwykłej operacji. Bez barwy — nie zabiera uwagi, ale daje drogę powrotną." },
-  { kind: "success", name: "Sukces", title: "Wiadomość wysłana", body: "Do: anna.kowalska@lexmar.pl", action: "",
-    desc: "Operacja zakończona. Zielony akcent tylko na ikonie i pasku czasu." },
-  { kind: "error", name: "Błąd", title: "Nie udało się wysłać", body: "Serwer SMTP odrzucił połączenie (421). Treść zapisano w Szkicach.", action: "Ponów",
-    desc: "Coś nie zadziałało i wymaga decyzji. Zawsze z przyczyną i akcją naprawczą." },
-  { kind: "warning", name: "Ostrzeżenie", title: "Anulowano", body: "Operacja przerwana przed zapisem — nic nie zostało zmienione.", action: "",
-    desc: "Skutek uboczny albo przerwanie. Nie błąd, ale użytkownik musi wiedzieć." },
-  { kind: "info", name: "Informacja", title: "Indeks rozszerzony", body: "Wyszukiwanie obejmuje teraz treść załączników PDF.", action: "",
-    desc: "Komunikat systemu niezwiązany z ostatnim kliknięciem." },
-  { kind: "loading", name: "Operacja w toku", title: "Pakowanie załączników…", body: "14 plików → zalaczniki.zip", action: "",
-    desc: "Nie znika samo. Zamknięcie krzyżykiem pyta o potwierdzenie i przerywa operację." },
+  { kind: "neutral", name: "Neutral", title: "Archived 3 threads", body: "", action: "Undo",
+    desc: "Confirmation of an ordinary operation. No colour — it does not take attention but offers a way back." },
+  { kind: "success", name: "Success", title: "Message sent", body: "To: anna.kowalska@lexmar.example", action: "",
+    desc: "Operation finished. Green accent only on the icon and the timer bar." },
+  { kind: "error", name: "Error", title: "Could not send", body: "The SMTP server refused the connection (421). The text was saved to Drafts.", action: "Retry",
+    desc: "Something failed and needs a decision. Always with a cause and a way to fix it." },
+  { kind: "warning", name: "Warning", title: "Cancelled", body: "The operation was aborted before saving — nothing was changed.", action: "",
+    desc: "A side effect or an interruption. Not an error, but the user needs to know." },
+  { kind: "info", name: "Information", title: "Index extended", body: "Search now covers the contents of PDF attachments.", action: "",
+    desc: "A system message unrelated to the last click." },
+  { kind: "loading", name: "Running operation", title: "Packing attachments…", body: "14 files → attachments.zip", action: "",
+    desc: "Does not vanish on its own. Closing it asks for confirmation and aborts the operation." },
 ];
 
 class Component extends DCLogic {
@@ -297,7 +297,7 @@ class Component extends DCLogic {
 
   askCancel = (id) => {
     const t = (this.state.toasts || []).filter(x => x.id === id)[0];
-    this.setState({ cancelAsk: { id: id, text: (t && t.cancelText) || "Operacja jest w toku. Zamknięcie komunikatu ją przerwie — częściowe efekty nie zostaną zapisane." } });
+    this.setState({ cancelAsk: { id: id, text: (t && t.cancelText) || "The operation is running. Closing the toast aborts it — partial results will not be saved." } });
   };
 
   abort = () => {
@@ -306,11 +306,11 @@ class Component extends DCLogic {
     if (!ask) return;
     if (this._tasks && this._tasks[ask.id]) { clearTimeout(this._tasks[ask.id]); delete this._tasks[ask.id]; }
     this.dismiss(ask.id);
-    this.notify({ kind: "warning", title: "Anulowano", body: "Operacja przerwana przed zapisem — nic nie zostało zmienione." });
+    this.notify({ kind: "warning", title: "Cancelled", body: "The operation was aborted before saving — nothing was changed." });
   };
 
   startBlock = (det) => {
-    this.setState({ block: { title: det ? "Migracja skrzynki w toku" : "Przebudowa indeksu", body: det ? "Przenosimy 3 800 wiadomości i 214 załączników na nowy serwer. Aplikacja jest zablokowana, żeby nic nie zginęło w połowie." : "Trwa przebudowa indeksu wyszukiwania. Czas zależy od liczby wiadomości.", det: !!det, pct: det ? 4 : null } });
+    this.setState({ block: { title: det ? "Mailbox migration in progress" : "Rebuilding the index", body: det ? "Moving 3,800 messages and 214 attachments to the new server. The app is locked so nothing is lost halfway." : "The search index is being rebuilt. The time depends on the number of messages.", det: !!det, pct: det ? 4 : null } });
     this.runBlock(!!det);
   };
 
@@ -325,13 +325,13 @@ class Component extends DCLogic {
         if (pct >= 100) {
           clearInterval(this._blockI);
           this.setState({ block: null });
-          this.notify({ kind: "success", title: "Migracja zakończona", body: "3 800 wiadomości na nowym serwerze, 0 błędów." });
+          this.notify({ kind: "success", title: "Migration finished", body: "3,800 messages on the new server, 0 errors." });
         } else this.setState({ block: Object.assign({}, b, { pct: pct }) });
       }, 520);
     } else {
       this._blockI = setTimeout(() => {
         this.setState({ block: null });
-        this.notify({ kind: "success", title: "Indeks przebudowany", body: "Wyszukiwanie działa na świeżym indeksie." });
+        this.notify({ kind: "success", title: "Index rebuilt", body: "Search now runs on a fresh index." });
       }, 7000);
     }
   };
@@ -341,7 +341,7 @@ class Component extends DCLogic {
     clearTimeout(this._blockI);
     const b = this.state.block;
     this.setState({ block: null, blockAsk: false });
-    this.notify({ kind: "warning", title: "Operacja przerwana", body: b && b.det ? "Przeniesione wiadomości pozostały na nowym serwerze, reszta bez zmian." : "Indeks został przywrócony do poprzedniej wersji." });
+    this.notify({ kind: "warning", title: "Operation aborted", body: b && b.det ? "Messages already moved stay on the new server, the rest is unchanged." : "The index was restored to its previous version." });
   };
 
   vis = (t, live) => {
@@ -363,12 +363,12 @@ class Component extends DCLogic {
 
   renderVals() {
     const st = this.state;
-    const theme = st.theme || this.props.theme || "jasny";
+    const theme = st.theme || this.props.theme || "light";
     const mode = this.props.layout ?? "auto";
     const FR = FRAMES[mode] || null;
     const w = FR ? FR.w : (st.vw || 1200);
     const isMobile = w < 700;
-    /* W trybie ramki nakładki są absolutne wewnątrz ramki, żeby nie wychodziły poza ekran telefonu. */
+    /* In frame mode the overlays are absolute inside the frame so they do not spill past the phone screen. */
     const ovBase = (z) => (FR ? "position:absolute" : "position:fixed") + ";inset:0;z-index:" + z + ";display:flex;align-items:center;justify-content:center;padding:" + (isMobile ? 18 : 24) + "px;background:var(--scrim);";
     const btn = "display:flex;align-items:center;gap:8px;height:38px;padding:0 15px;border:1px solid var(--border2);border-radius:10px;font-size:13px;font-weight:500;color:var(--text2)";
     const bar = this.props.showProgressBar ?? true;
@@ -376,8 +376,8 @@ class Component extends DCLogic {
     return {
       rootRef: this.rootRef,
       themeAttr: theme,
-      themeIcon: theme === "ciemny" ? "dark_mode" : "light_mode",
-      toggleTheme: () => this.setState({ theme: theme === "ciemny" ? "jasny" : "ciemny" }),
+      themeIcon: theme === "dark" ? "dark_mode" : "light_mode",
+      toggleTheme: () => this.setState({ theme: theme === "dark" ? "light" : "dark" }),
       outerStyle: "min-height:100vh;display:flex;justify-content:center;background:var(--bg);color:var(--text);font-family:'Instrument Sans',system-ui,sans-serif;padding:" + (FR ? "26px 20px 40px" : isMobile ? "20px 14px 44px" : "34px 28px 60px"),
       frameStyle: FR
         ? "box-sizing:border-box;width:" + FR.w + "px;max-width:100%;height:" + FR.h + "px;max-height:calc(100vh - 66px);position:relative;overflow:hidden;display:flex;flex-direction:column;background:var(--bg);border:1px solid var(--border2);border-radius:" + (isMobile ? 20 : 16) + "px;box-shadow:0 20px 60px var(--sh-3)"
@@ -392,21 +392,21 @@ class Component extends DCLogic {
       btnStyle: btn,
       compare: [
         {
-          name: "Komunikat (toast)", where: "Prawy górny róg, ulotny", icon: "bolt", c: "var(--accent-2)", soft: "var(--accent-soft)",
+          name: "Toast", where: "Top right corner, fleeting", icon: "bolt", c: "var(--accent-2)", soft: "var(--accent-soft)",
           points: [
-            "Reakcja na moją własną akcję — wysłałem, usunąłem, pobrałem.",
-            "Żyje " + Math.round(this.ms() / 1000) + " sekund i nie zostawia śladu.",
-            "Nie ma stanu przeczytania ani historii.",
-            "Najwyżej jedna akcja: Cofnij, Ponów, Pokaż.",
+            "A response to my own action — I sent, deleted, downloaded.",
+            "Lives " + Math.round(this.ms() / 1000) + " seconds and leaves no trace.",
+            "Has no read state and no history.",
+            "At most one action: Undo, Retry, Show.",
           ],
         },
         {
-          name: "Powiadomienie", where: "Kafelek w szynie i centrum powiadomień", icon: "notifications", c: "var(--warn-text)", soft: "var(--warn-soft)",
+          name: "Notification", where: "Badge in the rail and the notification centre", icon: "notifications", c: "var(--warn-text)", soft: "var(--warn-soft)",
           points: [
-            "Zdarzenie z zewnątrz — nowa poczta, kalendarz, zmiana w sprawie.",
-            "Zostaje do czasu przeczytania, ma licznik nieprzeczytanych.",
-            "Można je oznaczyć jako przeczytane lub nieprzeczytane.",
-            "Klik prowadzi do wątku, wydarzenia albo sprawy.",
+            "An event from outside — new mail, calendar, a change in a case.",
+            "Stays until read and has an unread counter.",
+            "Can be marked as read or unread.",
+            "A click leads to the thread, event or case.",
           ],
         },
       ].map(c => ({
@@ -434,7 +434,7 @@ class Component extends DCLogic {
           demo: Object.assign({}, v, { hasBar: v.hasBar && bar }),
           spawn: () => {
             if (s.kind === "loading") {
-              this.task({ title: s.title, body: s.body, cancelText: "Archiwum ZIP jest przygotowywane. Przerwanie odrzuci częściowo spakowany plik.", doneTitle: "Archiwum gotowe", doneBody: "zalaczniki.zip — 14 plików", ms: 6000 });
+              this.task({ title: s.title, body: s.body, cancelText: "The ZIP archive is being prepared. Aborting discards the partially packed file.", doneTitle: "Archive ready", doneBody: "attachments.zip — 14 files", ms: 6000 });
             } else {
               this.notify({ kind: s.kind, title: s.title, body: s.body, action: s.action });
             }
@@ -451,31 +451,31 @@ class Component extends DCLogic {
           hasBar: v.hasBar && bar,
           hasAction: !!t.actionLabel,
           actionLabel: t.actionLabel,
-          action: () => { this.dismiss(t.id); this.notify({ kind: "neutral", title: "Przywrócono 3 wątki", body: "Wątki wróciły do skrzynki odbiorczej." }); },
+          action: () => { this.dismiss(t.id); this.notify({ kind: "neutral", title: "Restored 3 threads", body: "The threads are back in the inbox." }); },
           close: loading ? () => this.askCancel(t.id) : () => this.dismiss(t.id),
-          closeTitle: loading ? "Przerwij operację" : "Zamknij",
+          closeTitle: loading ? "Abort operation" : "Close",
         });
       }),
       toastWrapStyle: (FR ? "position:absolute" : "position:fixed") + ";z-index:97;top:" + (isMobile ? 12 : 18) + "px;" + (isMobile ? "left:12px;right:12px;" : (FR ? "right:18px;width:min(400px,calc(100% - 36px));" : "right:18px;width:min(400px,calc(100vw - 36px));")) + "display:flex;flex-direction:column;gap:10px;pointer-events:none",
 
       burst: () => {
         const seq = [
-          { kind: "neutral", title: "Zarchiwizowano 3 wątki", action: "Cofnij" },
-          { kind: "success", title: "Wiadomość wysłana", body: "Do: zespol@lexmar.pl" },
-          { kind: "info", title: "Indeks rozszerzony", body: "Wyszukiwanie obejmuje teraz treść załączników PDF." },
-          { kind: "warning", title: "Pominięto 2 odbiorców", body: "Adresy poza domeną wymagają zgody działu prawnego." },
-          { kind: "error", title: "Nie udało się wysłać", body: "Serwer SMTP odrzucił połączenie (421).", action: "Ponów" },
+          { kind: "neutral", title: "Archived 3 threads", action: "Undo" },
+          { kind: "success", title: "Message sent", body: "To: team@lexmar.example" },
+          { kind: "info", title: "Index extended", body: "Search now covers the contents of PDF attachments." },
+          { kind: "warning", title: "2 recipients skipped", body: "Addresses outside the domain need legal approval." },
+          { kind: "error", title: "Could not send", body: "The SMTP server refused the connection (421).", action: "Retry" },
         ];
         seq.forEach((o, i) => setTimeout(() => this.notify(o), i * 420));
       },
-      runTask: () => this.task({ title: "Synchronizacja skrzynki…", body: "1 240 z 3 800 wiadomości", cancelText: "Synchronizacja jest w toku. Przerwanie zatrzyma ją na obecnym miejscu — pobrane wiadomości zostaną, resztę trzeba pobrać ponownie.", doneTitle: "Skrzynka zsynchronizowana", doneBody: "3 800 wiadomości, 12 nowych wątków", ms: 5200 }),
-      runFail: () => this.task({ title: "Wysyłanie wiadomości…", body: "Do: anna.kowalska@lexmar.pl", cancelText: "Wiadomość jest w trakcie wysyłki. Przerwanie zatrzyma wysyłkę i zapisze ją jako szkic.", doneKind: "error", doneTitle: "Nie udało się wysłać", doneBody: "Serwer SMTP odrzucił połączenie (421). Treść zapisano w Szkicach.", doneAction: "Ponów", ms: 3400 }),
+      runTask: () => this.task({ title: "Syncing the mailbox…", body: "1,240 of 3,800 messages", cancelText: "The sync is running. Aborting stops it where it is — downloaded messages stay, the rest has to be fetched again.", doneTitle: "Mailbox synced", doneBody: "3,800 messages, 12 new threads", ms: 5200 }),
+      runFail: () => this.task({ title: "Sending message…", body: "To: anna.kowalska@lexmar.example", cancelText: "The message is being sent. Aborting stops delivery and saves it as a draft.", doneKind: "error", doneTitle: "Could not send", doneBody: "The SMTP server refused the connection (421). The text was saved to Drafts.", doneAction: "Retry", ms: 3400 }),
 
       specs: [
-        { k: "Pozycja", v: "Prawy górny róg, 18 px od krawędzi. Na wąskim ekranie pełna szerokość u góry." },
-        { k: "Czas", v: "Auto-zamknięcie po " + Math.round(this.ms() / 1000) + " s, pasek u dołu pokazuje resztę czasu." },
-        { k: "Przezroczystość", v: "0,8 w spoczynku, 1,0 pod kursorem — treść pod stosem pozostaje czytelna." },
-        { k: "Krzyżyk", v: "Zawsze obecny. Przy operacji w toku oznacza przerwanie i wymaga potwierdzenia." },
+        { k: "Position", v: "Top right corner, 18 px from the edge. On a narrow screen, full width at the top." },
+        { k: "Timing", v: "Auto-close after " + Math.round(this.ms() / 1000) + " s; the bar at the bottom shows the time left." },
+        { k: "Transparency", v: "0.8 at rest, 1.0 under the cursor — content beneath the stack stays readable." },
+        { k: "Close button", v: "Always present. For a running operation it means abort and asks for confirmation." },
       ],
 
       startBlocking: () => this.startBlock(true),
@@ -483,7 +483,7 @@ class Component extends DCLogic {
       blockOpen: !!st.block,
       blockTitle: st.block ? st.block.title : "",
       blockBody: st.block ? st.block.body : "",
-      blockPctLabel: st.block ? (st.block.det ? st.block.pct + "% — nie zamykaj karty" : "Bez znanego czasu zakończenia") : "",
+      blockPctLabel: st.block ? (st.block.det ? st.block.pct + "% — do not close the tab" : "No known completion time") : "",
       blockFillStyle: "height:100%;border-radius:3px;background:var(--accent);" +
         (st.block && st.block.det
           ? "width:" + (st.block ? st.block.pct : 0) + "%;transition:width .45s linear"
@@ -491,14 +491,14 @@ class Component extends DCLogic {
       askBlockCancel: () => { clearInterval(this._blockI); clearTimeout(this._blockI); this.setState({ blockAsk: true }); },
       blockAskOpen: !!st.blockAsk,
       blockAskText: st.block && st.block.det
-        ? "Migracja jest w " + (st.block ? st.block.pct : 0) + "%. Przerwanie zostawi część wiadomości na starym serwerze — trzeba będzie uruchomić migrację ponownie."
-        : "Przebudowa indeksu nie została ukończona. Do jej zakończenia wyszukiwanie będzie działać na starym indeksie.",
+        ? "The migration is " + (st.block ? st.block.pct : 0) + "% done. Aborting leaves some messages on the old server — the migration will have to be run again."
+        : "The index rebuild is not finished. Until it completes, search runs on the old index.",
       keepBlocking: () => { this.setState({ blockAsk: false }); this.runBlock(!!(st.block && st.block.det)); },
       abortBlocking: this.abortBlock,
       blockSpecs: [
-        { k: "Kiedy", v: "Tylko operacje, których przerwanie w połowie psuje dane — migracja, masowa zmiana, eksport." },
-        { k: "Wyjście", v: "Klik w tło i Esc nie działają. Jedyna droga to Anuluj → pytanie „Na pewno przerwać?”." },
-        { k: "Po przerwaniu", v: "Overlay znika, a ostrzegawczy toast mówi, co zostało zapisane i co nie." },
+        { k: "When", v: "Only operations where aborting halfway corrupts data — migration, bulk change, export." },
+        { k: "Exit", v: "Background clicks and Esc do nothing. The only way out is Cancel → “Really abort?”." },
+        { k: "After aborting", v: "The overlay disappears and a warning toast says what was saved and what was not." },
       ],
       cancelAskOpen: !!st.cancelAsk,
       cancelAskText: st.cancelAsk ? st.cancelAsk.text : "",

--- a/design/manifest.json
+++ b/design/manifest.json
@@ -1,38 +1,38 @@
 [
   {
-    "etag": "1788885256132624",
+    "etag": "1788947703444059",
     "path": ".thumbnail",
-    "size": 10994
+    "size": 12752
   },
   {
-    "etag": "1788449225230011",
-    "path": "MailFathom Bloki wyniku.dc.html",
-    "size": 58155
+    "etag": "1788947636854293",
+    "path": "MailFathom Mail Search.html",
+    "size": 12473
   },
   {
-    "etag": "1788513451211191",
-    "path": "MailFathom Gest powiadomień.dc.html",
-    "size": 28105
+    "etag": "1788947592503572",
+    "path": "MailFathom Notification Gesture.dc.html",
+    "size": 27967
   },
   {
-    "etag": "1788511282774586",
-    "path": "MailFathom Komunikaty.dc.html",
-    "size": 38985
+    "etag": "1788947699833967",
+    "path": "MailFathom Prototype.dc.html",
+    "size": 575130
   },
   {
-    "etag": "1788798465998467",
-    "path": "MailFathom Logowanie.dc.html",
-    "size": 38901
+    "etag": "1788947540991746",
+    "path": "MailFathom Result Blocks.dc.html",
+    "size": 57740
   },
   {
-    "etag": "1788884674568640",
-    "path": "MailFathom Prototyp.dc.html",
-    "size": 580764
+    "etag": "1788947541036770",
+    "path": "MailFathom Sign-in.dc.html",
+    "size": 38778
   },
   {
-    "etag": "1788447607228539",
-    "path": "MailFathom Wyszukiwanie poczty.html",
-    "size": 12709
+    "etag": "1788947540979039",
+    "path": "MailFathom Toasts.dc.html",
+    "size": 38566
   },
   {
     "etag": "1788293486908274",

--- a/design/parity.json
+++ b/design/parity.json
@@ -1,52 +1,52 @@
 {
-  "stamp": "25200f246227ea7e",
+  "stamp": "099857782525a732",
   "screens": {
     "sign-in": {
-      "file": "MailFathom Logowanie.dc.html",
+      "file": "MailFathom Sign-in.dc.html",
       "properties": {
         "theme": null
       },
       "steps": [
         {
           "expect": {
-            "text": "Połącz skrzynkę"
+            "text": "Connect your mailbox"
           }
         }
       ]
     },
     "mail-list": {
-      "file": "MailFathom Prototyp.dc.html",
+      "file": "MailFathom Prototype.dc.html",
       "properties": {
         "theme": null
       },
       "steps": [
         {
           "click": {
-            "text": "Poczta"
+            "text": "Mail"
           }
         }
       ]
     },
     "mail-thread": {
-      "file": "MailFathom Prototyp.dc.html",
+      "file": "MailFathom Prototype.dc.html",
       "properties": {
         "theme": null
       },
       "steps": [
         {
           "click": {
-            "text": "Poczta"
+            "text": "Mail"
           }
         },
         {
           "click": {
-            "text": "Aneks do umowy — podpisy"
+            "text": "Contract addendum — signatures"
           }
         }
       ]
     },
     "settings-profile": {
-      "file": "MailFathom Prototyp.dc.html",
+      "file": "MailFathom Prototype.dc.html",
       "properties": {
         "theme": null
       },
@@ -58,7 +58,7 @@
         },
         {
           "click": {
-            "text": "settingsUstawienia"
+            "text": "settingsSettings"
           }
         },
         {
@@ -69,7 +69,7 @@
       ]
     },
     "settings-application": {
-      "file": "MailFathom Prototyp.dc.html",
+      "file": "MailFathom Prototype.dc.html",
       "properties": {
         "theme": null
       },
@@ -81,7 +81,7 @@
         },
         {
           "click": {
-            "text": "settingsUstawienia"
+            "text": "settingsSettings"
           }
         },
         {
@@ -91,13 +91,13 @@
         },
         {
           "expect": {
-            "text": "JĘZYK"
+            "text": "LANGUAGE"
           }
         }
       ]
     },
     "notifications": {
-      "file": "MailFathom Prototyp.dc.html",
+      "file": "MailFathom Prototype.dc.html",
       "properties": {
         "theme": null
       },
@@ -109,20 +109,20 @@
         },
         {
           "expect": {
-            "text": "Powiadomienia"
+            "text": "Notifications"
           }
         }
       ]
     },
     "account-menu": {
-      "file": "MailFathom Prototyp.dc.html",
+      "file": "MailFathom Prototype.dc.html",
       "properties": {
         "theme": null
       },
       "steps": [
         {
           "click": {
-            "text": "Poczta"
+            "text": "Mail"
           }
         },
         {
@@ -132,25 +132,25 @@
         },
         {
           "expect": {
-            "text": "settingsUstawienia"
+            "text": "settingsSettings"
           }
         }
       ]
     },
     "full-html": {
-      "file": "MailFathom Prototyp.dc.html",
+      "file": "MailFathom Prototype.dc.html",
       "properties": {
         "theme": null
       },
       "steps": [
         {
           "click": {
-            "text": "Poczta"
+            "text": "Mail"
           }
         },
         {
           "click": {
-            "text": "Aneks do umowy — podpisy"
+            "text": "Contract addendum — signatures"
           }
         },
         {
@@ -160,30 +160,30 @@
         },
         {
           "click": {
-            "text": "Pokaż HTML"
+            "text": "Show HTML"
           }
         },
         {
           "expect": {
-            "text": "lockPodgląd izolowany — skrypty i zdalne treści są zablokowane"
+            "text": "lockIsolated preview — scripts and remote content are blocked"
           }
         }
       ]
     },
     "full-html-ask": {
-      "file": "MailFathom Prototyp.dc.html",
+      "file": "MailFathom Prototype.dc.html",
       "properties": {
         "theme": null
       },
       "steps": [
         {
           "click": {
-            "text": "Poczta"
+            "text": "Mail"
           }
         },
         {
           "click": {
-            "text": "Aneks do umowy — podpisy"
+            "text": "Contract addendum — signatures"
           }
         },
         {
@@ -193,7 +193,7 @@
         },
         {
           "expect": {
-            "text": "Pokazać pełny HTML?"
+            "text": "Show the full HTML?"
           }
         }
       ]

--- a/design/state-inventory.md
+++ b/design/state-inventory.md
@@ -1,6 +1,6 @@
 # The design's state inventory
 
-**Mirror stamp `25200f246227ea7e`** — the etag set this was extracted from. Run
+**Mirror stamp `099857782525a732`** — the etag set this was extracted from. Run
 `bash scripts/design-mirror.sh stamp`; a different answer means the design moved and this file
 describes something older than the mirror beside it. Refresh with `$mf-sync-design` rather than reading
 around it.
@@ -17,26 +17,28 @@ This file and the sources it was extracted from are tracked, so every clone read
 
 | Mirrored file | What it settles |
 |---|---|
-| `MailFathom Prototyp.dc.html` | The whole signed-in application: seven screens, every overlay, every composition. 6 960 lines, and the only file that carries navigation |
-| `MailFathom Logowanie.dc.html` | Sign-in, and the server screen behind it |
-| `MailFathom Komunikaty.dc.html` | Toasts and the blocking overlay — the system's answer to what somebody just did |
-| `MailFathom Gest powiadomień.dc.html` | The phone's notification-panel gesture, as four frames plus the numbers behind them |
-| `MailFathom Bloki wyniku.dc.html` | The Discover answer's block types |
-| `MailFathom Wyszukiwanie poczty.html` | Mail search: results, empty, waiting, lexical-only, failure |
+| `MailFathom Prototype.dc.html` | The whole signed-in application: seven screens, every overlay, every composition. 7 604 lines, and the only file that carries navigation |
+| `MailFathom Sign-in.dc.html` | Sign-in, and the server screen behind it |
+| `MailFathom Toasts.dc.html` | Toasts and the blocking overlay — the system's answer to what somebody just did |
+| `MailFathom Notification Gesture.dc.html` | The phone's notification-panel gesture, as four frames plus the numbers behind them |
+| `MailFathom Result Blocks.dc.html` | The Discover answer's block types |
+| `MailFathom Mail Search.html` | Mail search: results, empty, waiting, lexical-only, failure |
 
-Two files in the project are **not** mirrored and nothing about a screen is in them: `deck-stage.js`
-is a copied slide-deck starter, and `support.js` is the generated `dc-runtime` bundle. The manifest
-still records both, so their moving is visible.
+What the mirror carries is the list written into `scripts/design-mirror.sh` — those six files and
+`support.js`, the generated `dc-runtime` bundle that boots them. Everything else the project holds is
+left where it is: `deck-stage.js` is a copied slide-deck starter, and the rest are images. The
+manifest still records every one of them, so a file arriving or leaving is visible in the diff, and a
+new one is reported by `bash scripts/design-mirror.sh plan` rather than copied.
 
 ## How a state is named here
 
 The prototype is one component. A screen is a region of one template gated by a flag, and every flag
 is computed once in `renderVals()`. So a state's name in this file **is** the flag name in the
-source: `grep -n 'showThreadPane' 'design/files/MailFathom Prototyp.dc.html'` gives both
+source: `grep -n 'showThreadPane' 'design/files/MailFathom Prototype.dc.html'` gives both
 the gate in the template and the one line that decides it. *Reveal* is what makes it true.
 
 Three things decide composition before any state does, and they are read from the width alone
-(`renderVals`, lines 4703–4725):
+(`renderVals`, lines 5266–5287):
 
 | Name | Condition | What it changes |
 |---|---|---|
@@ -47,7 +49,7 @@ Three things decide composition before any state does, and they are read from th
 | `touch` | `isMobile \|\| tablet` | Every `pointer: coarse` affordance |
 | `drawer` | `tablet \|\| isMobile` | The side list arrives as a drawer rather than a column |
 
-`FRAMES` (line 2608) is the design's own four sizes: `telefon` 390 × 844, `fold` 884 × 832,
+`FRAMES` (line 3050) is the design's own four sizes: `phone` 390 × 844, `fold` 884 × 832,
 `tablet` 1024 × 768, and the artboard's 1440 × 900. A `fold` is a *tablet-class* width with two panes.
 
 ## Discover — `isDiscover`
@@ -70,10 +72,10 @@ The run is a phase machine (`st.phase`), and the blocks arrive one at a time (`r
 | Evidence inspector open | `inspectorOpen` | a citation is pressed |
 | Evidence inspector closed | `inspectorClosed` | nothing selected — the resting state |
 
-Which blocks a run produces is the plan, and there are three (`PLANS`, line 2378): `contract`
+Which blocks a run produces is the plan, and there are three (`PLANS`, line 2624): `contract`
 (answer + timeline + table + action), `files` (answer + gallery + action), `people`
 (answer + people + action). **No single run draws every block**, so a screenshot of one plan is not
-the block set to build against; `MailFathom Bloki wyniku.dc.html` is where the block types stand
+the block set to build against; `MailFathom Result Blocks.dc.html` is where the block types stand
 together.
 
 ## Mail — `isMail`
@@ -106,7 +108,7 @@ together.
 | Arrived from a citation | `showCitationTag` / `cameFromResult` | reached from a Discover citation, and only for the `contoso` thread |
 | Answer drawn in mail | `mailAnswer` | `st.mailAnswer` and the `contoso` thread |
 | Thread actions sheet | `threadSheetOpen` | the sheet control, phone-shaped |
-| Reveal the earlier messages | `showEarlier` in the thread head | *Pokaż N wcześniejszych wiadomości* / *Ukryj wcześniejsze wiadomości*, in the pane already open |
+| Reveal the earlier messages | `showEarlier` in the thread head | *Show N earlier messages* / *Hide earlier messages*, in the pane already open |
 | Expand every message | `showExpandAll` | **constant `false`** — the source hands the screen no per-message collapse at all, so a revealed message is drawn in full |
 
 ### Waiting
@@ -162,9 +164,9 @@ Added to the prototype after this inventory was first written, and read against 
 
 ### Tabs
 
-Tabs are a **work mode**, not a layout: `tabsMode = w >= 1180 && workMode === "zakladki"`. The
-prototype's initial state is `workMode: "normalny"`, so **every tab state is invisible until Settings
-switches the mode on a screen at least 1180 px wide**.
+Tabs are a **work mode**, not a layout: `tabsMode = w >= 1180 && workMode === "tabs"`. The
+prototype's initial state is `workMode: "classic"`, so **every tab state is invisible until the user
+menu's *Tab mode* switch is turned on at a width of at least 1180 px**.
 
 | State | Flag | Reveal |
 |---|---|---|
@@ -172,7 +174,7 @@ switches the mode on a screen at least 1180 px wide**.
 | Nothing open | `noTabsOpen` | tabs mode with none — the tabbed empty state |
 | Close one | `closeAskOpen` | closing a tab with unsaved work |
 | Close all | `closeAllAsk` | the close-all control |
-| The row does not fit | `tabsRowNote` | `w < 1180`, and it says *dostępne na szerszym ekranie* |
+| The row does not fit | `tabsRowNote` | `w < 1180`, and it says *available on a wider screen* |
 
 ## Cases — `isCases`
 
@@ -255,8 +257,8 @@ switches the mode on a screen at least 1180 px wide**.
 | Mail FAB | `showFab` | no composer, no document, no selection; on one pane it needs the list |
 | User menu | `userMenuOpen` | the avatar |
 | Settings | `settingsOpen` | the settings control |
-| Settings: profile tab | `tabProfil` | the default tab |
-| Settings: application tab | `tabApp` | the tab control |
+| Settings: profile tab | `tabProfil` | the default tab, labelled *Profil* |
+| Settings: application tab | `tabApp` | the tab control, labelled *Aplikacja* |
 | Own photo | `meHasPhoto` | a photo was uploaded |
 | **Photo rejected** | `photoError` | a file over 1 MB — a real file has to be chosen, so **no click reaches this** |
 | Telemetry off | `telemetryOptOut` | the telemetry switch |
@@ -265,9 +267,15 @@ switches the mode on a screen at least 1180 px wide**.
 | **No notifications** | `notifEmpty` | the shown list is empty — reachable by filtering to unread after reading them all |
 | Move dialog | `moveOpen` | the move action on a selection |
 | Cancel confirmation | `cancelAskOpen` | closing a toast that carries a running operation |
-| Toasts | `toasts` | any operation that reports; `MailFathom Komunikaty.dc.html` is the whole of it |
+| Toasts | `toasts` | any operation that reports; `MailFathom Toasts.dc.html` is the whole of it |
 
-## Sign-in — `MailFathom Logowanie.dc.html`
+Three labels in the prototype are still Polish where every other string is English: the two Settings
+tabs, *Profil* and *Aplikacja* (line 7483), the user menu's sign-out item, *Wyloguj* (line 135), and
+the single-pane state toggle beside the thread head, *ukryj* (line 7217). They are named here because
+`design/parity.json` presses two of them and because the client is English everywhere: copy the
+English the rest of the design uses rather than these three, and expect them to move in the project.
+
+## Sign-in — `MailFathom Sign-in.dc.html`
 
 Two views in one file, `isLogin` and `isServer`, and the server view is unreachable when the address
 is forced by configuration.
@@ -275,24 +283,24 @@ is forced by configuration.
 | State | Flag | Reveal |
 |---|---|---|
 | Sign-in | `isLogin` | the opening view |
-| Server address | `isServer` | *Zmień serwer* under *Zaawansowane* — and `envLocked` refuses it |
-| OAuth offered | `showOauth` | the server declares it (prop `oauthDostepne`) |
-| Password offered | `showBasic` | the server declares it (prop `basicDostepne`) |
+| Server address | `isServer` | *Change server* under *Advanced* — and `envLocked` refuses it |
+| OAuth offered | `showOauth` | the server declares it (prop `oauthAvailable`) |
+| Password offered | `showBasic` | the server declares it (prop `basicAvailable`) |
 | Both, so a divider | `showDivider` | both of the above |
 | **No method at all** | `noMethods` | neither — a **prop pair**, so only a property change reaches it |
-| Connecting | `connecting` | pressing *Połącz*, or an OAuth provider |
-| Advanced open | `advanced` | the *Zaawansowane* control |
+| Connecting | `connecting` | pressing *Connect*, or an OAuth provider |
+| Advanced open | `advanced` | the *Advanced* control |
 | Insecure allowed | `insecure` | the checkbox on the server view; it changes the lock glyph, the port hint and the certificate row |
-| Server was customised | `customized` | a non-default address or the TLS exception; it reveals *Przywróć domyślne* |
-| Probing an address | `probing` | *Połącz* on the server view |
+| Server was customised | `customized` | a non-default address or the TLS exception; it reveals *Restore defaults* |
+| Probing an address | `probing` | *Connect* on the server view |
 | An error | `hasError` | an empty login, an empty password, or an address with no host |
-| Theme is auto | — | `themePicks` carries `auto`, `jasny`, `ciemny`; `auto` resolves through `prefers-color-scheme` |
+| Theme is auto | — | `themePicks` carries `auto`, `light`, `dark`; `auto` resolves through `prefers-color-scheme` |
 
 The layout collapses twice rather than once: `stacked` at `w < 940` puts the brand above the form,
 and `phone` at `w < 700` changes every target size. The pitch beside the form (`showPitch`) exists
 **only when not stacked**.
 
-## Toasts — `MailFathom Komunikaty.dc.html`
+## Toasts — `MailFathom Toasts.dc.html`
 
 Six kinds — `neutral`, `success`, `error`, `warning`, `info`, `loading` — and the kind decides the
 glyph, the colour and the bar. What is worth reading in the source rather than in a screenshot:
@@ -302,10 +310,10 @@ glyph, the colour and the bar. What is worth reading in the source rather than i
 - The stack is newest-first and capped at `maxStack` (4 by default); past it the oldest is dropped.
 - Resting opacity is 0.8 and 1.0 under the pointer, so the content beneath stays readable.
 - The **blocking overlay** is a separate thing from a toast: determinate (a percentage) or
-  indeterminate, no dismissal by scrim or Escape, and its *Anuluj* asks before it aborts.
+  indeterminate, no dismissal by scrim or Escape, and its *Cancel* asks before it aborts.
 - On a narrow screen the stack is full-width at the top instead of a 400 px column on the right.
 
-## The notification gesture — `MailFathom Gest powiadomień.dc.html`
+## The notification gesture — `MailFathom Notification Gesture.dc.html`
 
 Numbers the implementation reads, not decoration: 1 : 1 finger tracking with no easing, scrim opacity
 **equal to** the travelled fraction, a **0.32** distance threshold, a **0.5 px/ms** velocity
@@ -317,7 +325,7 @@ mutually exclusive, and the navigation bar hands over past 12 px and cancels its
 **Phone composition and `pointer: coarse` only.** The fold, the tablet and the desktop keep the panel
 they draw today, and there is no drag gesture there at all.
 
-## Mail search — `MailFathom Wyszukiwanie poczty.html`
+## Mail search — `MailFathom Mail Search.html`
 
 Five states, all drawn side by side in the file: results, empty, waiting, a lexical-only banner, and
 a failure banner. Worth carrying out of it:
@@ -332,14 +340,14 @@ a failure banner. Worth carrying out of it:
   or telemetry.
 - The file itself says the prototype's mail column is wrong in one place: the field promises a
   description of what somebody needs while the server matches words only, and it names the correction
-  — *Słowa z wiadomości, której szukasz*.
+  — *Words from the message you are looking for*.
 
 ## States the source has and a preview does not reach
 
 This is the class the inventory exists for. Each is in the source, and none of them can be reached by
 clicking a preview.
 
-- **The application with no mailbox at all.** `const emptyApp = false;` (line 4971) is a constant, and
+- **The application with no mailbox at all.** `const emptyApp = false;` (line 5537) is a constant, and
   every one of the seven screen gates is `st.screen === "…" && !emptyApp`. Nothing anywhere draws the
   true branch, so **the design does not cover a deployment with no mailbox** — a session that needs
   that screen is designing something the project has not settled, and it goes to the owner rather than
@@ -347,8 +355,8 @@ clicking a preview.
 - **A rejected profile photo** (`photoError`). Set only by choosing a file over 1 MB; no control in
   the prototype can produce one.
 - **Every tab state** (`tabsBarShown`, `noTabsOpen`, `convBarShown`, `closeAllAsk`). Two conditions at
-  once: Settings switched to *Zakładki* and a width of at least 1180 px. The initial state is
-  `normalny`, so a preview opened at any width shows none of it.
+  once: the user menu's *Tab mode* switch turned on and a width of at least 1180 px. The initial state
+  is `classic`, so a preview opened at any width shows none of it.
 - **The run trace** (`showTrace`). A component property, off unless the property is set.
 - **No sign-in method offered** (`noMethods`). Two properties turned off together.
 - **A case or a person with no documents** (`caseNoDocs`, `personNoDocs`). No mock record has an empty

--- a/scripts/design-mirror.sh
+++ b/scripts/design-mirror.sh
@@ -49,18 +49,35 @@ design_directory="$repository_root/design"
 manifest="$design_directory/manifest.json"
 mirror="$(realpath -m -- "$design_directory/files")"
 
-# A screen source is an HTML file, and everything else the project holds is an asset, a copied
-# slide-deck starter or a thumbnail. Mirroring is therefore one rule rather than a list nobody
-# updates: the manifest still covers every file, so an asset appearing or disappearing stays visible
-# without several megabytes of it being committed and re-committed at every refresh.
-is_screen_source='(.path | endswith(".html"))'
+# What the mirror carries is a named list rather than a pattern. The repository is public and the
+# project is not, so which of its files are copied into a public tree is a decision somebody takes,
+# once, by editing the list below — a file the project gains is reported by `plan` as having appeared
+# and is then left alone, instead of arriving in the next refresh because its name happened to end in
+# `.html`. The manifest still covers every file, so nothing becomes invisible by being left out.
+#
+# Adding a screen to the mirror is one line here. Removing one is the same line, deleted.
+mirrored_screen_sources=(
+  "MailFathom Mail Search.html"
+  "MailFathom Notification Gesture.dc.html"
+  "MailFathom Prototype.dc.html"
+  "MailFathom Result Blocks.dc.html"
+  "MailFathom Sign-in.dc.html"
+  "MailFathom Toasts.dc.html"
+)
 
 # The generated runtime is mirrored beside them, and it is the one file that is not a screen source
 # and is still read. An artboard is a component that runtime boots rather than a document a browser
 # draws, so a mirror without it renders nothing at all — which is what `scripts/capture-design.sh`
 # needs it for. It is text, so it travels the way a screen source does; the project's images are not
 # text and none of them is mirrored.
-is_runtime='(.path == "support.js")'
+mirrored_runtime=(
+  "support.js"
+)
+
+as_json_array() { printf '%s\n' "$@" | jq -R . | jq -s -c .; }
+
+is_screen_source="(.path | IN($(as_json_array "${mirrored_screen_sources[@]}")[]))"
+is_runtime="(.path | IN($(as_json_array "${mirrored_runtime[@]}")[]))"
 
 is_mirrored="($is_screen_source or $is_runtime)"
 
@@ -129,7 +146,7 @@ case "$command" in
     listing="$(read_listing "${2:-}")"
 
     if [[ ! -f "$manifest" ]]; then
-      printf 'No manifest yet — every screen source and the runtime have to be read:\n'
+      printf 'No manifest yet — every file the mirrored list names has to be read:\n'
       jq -r "map(select($is_mirrored)) | .[] | \"  read  \(.path)\"" <<<"$listing"
       exit 0
     fi
@@ -154,7 +171,20 @@ case "$command" in
       | \$now
       | map(select($is_mirrored))
       | map(select((\$before[.path] | not) or (\$before[.path].etag != .etag)))
-      | if length == 0 then \"  none — what moved is neither a screen source nor the runtime\" else .[] | \"  \(.path)\" end" -r
+      | if length == 0 then \"  none — nothing that moved is on the mirrored list\" else .[] | \"  \(.path)\" end" -r
+
+    # A file the project gained that the list does not name is reported rather than copied. Saying so
+    # here is what keeps the omission a decision somebody can revisit instead of one nobody notices:
+    # the alternative is a reader comparing the `new` lines above against the list by eye.
+    unlisted="$(jq -n --argjson was "$(cat "$manifest")" --argjson now "$listing" "
+      (\$was | INDEX(.path)) as \$before
+      | \$now
+      | map(select((\$before[.path] | not) and (($is_mirrored) | not)))
+      | .[] | \"  \(.path)\"" -r)"
+    if [[ -n "$unlisted" ]]; then
+      printf '\nThese appeared and the mirror does not carry them. Add one to the list in this script\n'
+      printf 'if it should be copied:\n%s\n' "$unlisted"
+    fi
     ;;
 
   record)

--- a/scripts/test-agent-workflow.sh
+++ b/scripts/test-agent-workflow.sh
@@ -8791,12 +8791,19 @@ no_two_tracked_paths_differ_only_by_case() {
 #
 # The listing is written rather than fetched here for the same reason: what is under test is the
 # comparison, and a fixture listing states the etags a server would have.
+#
+# The screen source it names is one of the real ones, because what the script mirrors is a list
+# written into it rather than a pattern. That couples this fixture to that list on purpose: renaming
+# a mirrored screen is a refresh that edits the list, and a test still naming the old one is the
+# reminder that both halves move together.
+mirrored_test_screen="MailFathom Toasts.dc.html"
+
 write_design_listing() {
   local target="$1" prototype_etag="$2" runtime_etag="${3:-200}"
 
   cat >"$target" <<LISTING
 [
-  { "path": "Screen.dc.html", "size": 6, "etag": "$prototype_etag" },
+  { "path": "$mirrored_test_screen", "size": 6, "etag": "$prototype_etag" },
   { "path": "avatars/somebody.png", "size": 4, "etag": "100" },
   { "path": "support.js", "size": 3, "etag": "$runtime_etag" }
 ]
@@ -8815,12 +8822,12 @@ the_design_mirror_reads_only_what_the_etags_say_moved() {
   # than text and no screen is built from it.
   (cd "$repository_root" && bash "$source_repository_root/scripts/design-mirror.sh" \
     plan "$work/listing.json") >"$output"
-  assert_contains 'Screen.dc.html' "$output"
+  assert_contains "$mirrored_test_screen" "$output"
   assert_contains 'support.js' "$output"
   assert_excludes 'avatars/somebody.png' "$output"
 
   mkdir -p "$repository_root/design/files"
-  printf 'screen' >"$repository_root/design/files/Screen.dc.html"
+  printf 'screen' >"$repository_root/design/files/$mirrored_test_screen"
   printf 'run' >"$repository_root/design/files/support.js"
   (cd "$repository_root" && bash "$source_repository_root/scripts/design-mirror.sh" \
     record "$work/listing.json") >"$output"
@@ -8831,6 +8838,17 @@ the_design_mirror_reads_only_what_the_etags_say_moved() {
     plan "$work/listing.json") >"$output"
   assert_contains 'Nothing moved' "$output"
 
+  # A file the project gained that the list does not name is reported and not read. This repository
+  # is public and the project is not, so a screen arriving upstream is somebody's decision to copy
+  # rather than a file that turns up in the next refresh because its name ends in `.html`.
+  jq '. + [{ "path": "Unlisted.dc.html", "size": 5, "etag": "400" }]' \
+    "$work/listing.json" >"$work/listing-unlisted.json"
+  (cd "$repository_root" && bash "$source_repository_root/scripts/design-mirror.sh" \
+    plan "$work/listing-unlisted.json") >"$output"
+  assert_contains 'new       Unlisted.dc.html' "$output"
+  assert_contains 'the mirror does not carry them' "$output"
+  assert_contains 'none — nothing that moved is on the mirrored list' "$output"
+
   local stamp
   stamp="$(cd "$repository_root" && bash "$source_repository_root/scripts/design-mirror.sh" stamp)"
 
@@ -8838,7 +8856,7 @@ the_design_mirror_reads_only_what_the_etags_say_moved() {
   write_design_listing "$work/listing.json" "301"
   (cd "$repository_root" && bash "$source_repository_root/scripts/design-mirror.sh" \
     plan "$work/listing.json") >"$output"
-  assert_contains 'changed   Screen.dc.html' "$output"
+  assert_contains "changed   $mirrored_test_screen" "$output"
   assert_excludes 'avatars/somebody.png' "$output"
 
   # The runtime is read like a screen source and stamped unlike one. It is mirrored because an
@@ -8869,7 +8887,7 @@ the_design_mirror_refuses_a_transcription_that_lost_a_window() {
 
   # A windowed read that dropped or doubled a window arrives as a file of the wrong length, and the
   # size the project itself states is the only check available that costs no second read of it.
-  printf 'scree' >"$repository_root/design/files/Screen.dc.html"
+  printf 'scree' >"$repository_root/design/files/$mirrored_test_screen"
   if (cd "$repository_root" && bash "$source_repository_root/scripts/design-mirror.sh" \
     record "$work/listing.json") >"$output" 2>&1; then
     printf 'The mirror recorded a screen source of the wrong length\n' >&2
@@ -8886,7 +8904,7 @@ the_design_mirror_refuses_a_transcription_that_lost_a_window() {
   fi
 
   # A mirrored file that never arrived is the same failure said differently.
-  rm -f "$repository_root/design/files/Screen.dc.html"
+  rm -f "$repository_root/design/files/$mirrored_test_screen"
   if (cd "$repository_root" && bash "$source_repository_root/scripts/design-mirror.sh" \
     record "$work/listing.json") >"$output" 2>&1; then
     printf 'The mirror recorded a screen source that is not there\n' >&2
@@ -9025,7 +9043,7 @@ MANIFEST
 MANIFEST
   fi
 
-  printf 'screen' >"$repository_root/design/files/Screen.dc.html"
+  printf 'screen' >"$repository_root/design/files/$mirrored_test_screen"
   printf 'run' >"$repository_root/design/files/support.js"
   write_design_listing "$test_directory/parity-listing.json" "300"
   (cd "$repository_root" && bash "$source_repository_root/scripts/design-mirror.sh" \
@@ -9039,8 +9057,8 @@ write_parity_pairing() {
 {
   "stamp": "$stamp",
   "screens": {
-    "first": { "file": "Screen.dc.html", "properties": { "theme": null }, "steps": [] },
-    "second": { "file": "Screen.dc.html", "properties": { "theme": null }, "steps": [] }
+    "first": { "file": "$mirrored_test_screen", "properties": { "theme": null }, "steps": [] },
+    "second": { "file": "$mirrored_test_screen", "properties": { "theme": null }, "steps": [] }
   }
 }
 PAIRING


### PR DESCRIPTION
The design project was translated into English: every screen source was renamed from its Polish name to an English one, and the demo copy inside them — subjects, labels, button text, the sign-in props — went with it. The layout did not move at all, which is what makes this a mirror refresh rather than a screen change.

**Stamp `25200f246227ea7e` → `099857782525a732`.** That pair is what a later capture is checked against.

## What moved

| | |
|---|---|
| Appeared | `MailFathom Mail Search.html`, `MailFathom Notification Gesture.dc.html`, `MailFathom Prototype.dc.html`, `MailFathom Result Blocks.dc.html`, `MailFathom Sign-in.dc.html`, `MailFathom Toasts.dc.html` |
| Gone | the six Polish-named equivalents of exactly those |
| Changed, not mirrored | the project thumbnail |
| Unchanged | `support.js`, at the etag `THIRD_PARTY_LICENSES.md` points at through the manifest |

Every mirrored file was checked against the byte count the project states, so `record` passes and no window was dropped or doubled.

## What the inventory now says that it did not

- The prototype is **7 604 lines**, and the line references moved with it: composition at 5266–5287, `FRAMES` at 3050, `PLANS` at 2624, `const emptyApp = false;` at 5537.
- `FRAMES` names its narrowest size **`phone`** rather than `telefon`, and the prototype's `layout` property offers `auto`, `desktop`, `tablet`, `fold`, `phone`. The four sizes themselves are unchanged: 390 × 844, 884 × 832, 1024 × 768, 1440 × 900.
- Tabs are a work mode reached from the user menu's **Tab mode** switch: `tabsMode = w >= 1180 && workMode === "tabs"`, and the initial state is `classic` rather than `normalny`. Below 1180 px the row says *available on a wider screen*.
- Sign-in reads its methods from `oauthAvailable` and `basicAvailable` rather than `oauthDostepne` and `basicDostepne`, its theme picker offers `auto`, `light`, `dark`, and the controls are *Change server*, *Advanced*, *Connect* and *Restore defaults*.
- Mail search names its own correction to the prototype as *Words from the message you are looking for*.
- **Three labels in the prototype are still Polish** where everything around them is English: the Settings tabs *Profil* and *Aplikacja*, the user menu's *Wyloguj*, and the single-pane state toggle *ukryj*. The inventory names them so a client screen is not built from them, and `design/parity.json` still presses two of them because they are what the artboard draws today.

`design/parity.json` was re-read against the new sources rather than renamed: every text target it pressed was a Polish string no artboard carries any more, so a capture run would have failed at its first step. It now presses *Mail*, *Contract addendum — signatures*, *settingsSettings*, *Show HTML*, *Show the full HTML?* and *lockIsolated preview — scripts and remote content are blocked*.

## The mirror now carries a named list

`scripts/design-mirror.sh` decided what to copy from a rule — every `.html` file, plus `support.js`. It now decides from a list written at the top of the script. This repository is public and the design project is not, so which of its files reach a public tree is a decision somebody takes rather than a consequence of a filename:

- a file the project gains is reported by `plan` under *These appeared and the mirror does not carry them*, and is not read;
- the manifest still covers **every** file, so nothing becomes invisible by being left out;
- adding a screen to the mirror is one line in that list, and removing one is the same line deleted.

`design/README.md` and `$mf-sync-design` describe the list instead of the rule they replace. The design-mirror contract tests in `scripts/test-agent-workflow.sh` now build their fixture from a real listed name — deliberately coupling the fixture to the list, so a rename that edits one and not the other fails — and a new assertion covers an unlisted file appearing: reported, and not read.

## Verification

- `bash scripts/verify-full.sh` — passed, 300 of 300 contract tests.
- `bash scripts/design-mirror.sh record` — every mirrored file matches the byte count the project states.
- No parity capture was run: this change refreshes what a capture reads, and holding a running screen against it is its own step.

Closes #1780
