### PR TITLE
[#1183] Carry every scope the screen is pointing at into the intent field

### DIFF
--- a/frontend/src/Client.App/src/App.deployment.test.tsx
+++ b/frontend/src/Client.App/src/App.deployment.test.tsx
@@ -286,7 +286,10 @@ describe('App deployment', () => {
         await framed();
 
         expect(screen.getByRole('searchbox', { name: 'Ask your mail' })).toHaveProperty('value', '');
-        expect(screen.getByRole('combobox', { name: 'What the question is asked about' })).toHaveProperty('value', '');
+        expect(screen.getByRole('combobox', { name: 'What the question is asked about' })).toHaveProperty(
+            'value',
+            'everything',
+        );
     });
 
     it('signs in against the next deployment of its own, and never reads the one before it again', async () => {

--- a/frontend/src/Client.App/src/App.signIn.test.tsx
+++ b/frontend/src/Client.App/src/App.signIn.test.tsx
@@ -261,7 +261,10 @@ describe('App sign-in', () => {
         // The next person to sign in on this machine reads their own empty screen rather than the last one's question
         // and the mailbox it was scoped to.
         expect(screen.getByRole('searchbox', { name: 'Ask your mail' })).toHaveProperty('value', '');
-        expect(screen.getByRole('combobox', { name: 'What the question is asked about' })).toHaveProperty('value', '');
+        expect(screen.getByRole('combobox', { name: 'What the question is asked about' })).toHaveProperty(
+            'value',
+            'everything',
+        );
     });
 
     it('says the password was not kept when the store would not write it, without refusing the sign-in', async () => {

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -64,6 +64,8 @@ export const en = {
     'scope.allMailboxes': 'All mailboxes',
     'scope.everyMailbox': '{folder}, every mailbox',
     'scope.folderIn': '{folder} in {mailbox}',
+    'scope.selectedText': 'The part you selected',
+    'scope.message': 'This message',
     'scope.thread': 'This correspondence',
     'scope.selection.one': '{count} selected message',
     'scope.selection.few': '{count} selected messages',
@@ -828,7 +830,6 @@ export const en = {
         'This message carries a winmail.dat part, which was recorded without being opened, so whatever it holds is not listed above.',
 
     'scope.fragment': 'Asking about the part of this message you selected: “{fragment}”',
-    'scope.wholeMessage': 'Ask about the whole message instead',
 
     'blocking.progress': 'How far the operation has got',
     'blocking.progressReading': '{percentage} — do not close this window',

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -63,6 +63,8 @@ export const pl: Catalogue = {
     'scope.allMailboxes': 'Wszystkie skrzynki',
     'scope.everyMailbox': '{folder} we wszystkich skrzynkach',
     'scope.folderIn': '{folder} w skrzynce {mailbox}',
+    'scope.selectedText': 'Zaznaczony fragment',
+    'scope.message': 'Ta wiadomość',
     'scope.thread': 'Ta korespondencja',
     'scope.selection.one': '{count} zaznaczona wiadomość',
     'scope.selection.few': '{count} zaznaczone wiadomości',
@@ -837,7 +839,6 @@ export const pl: Catalogue = {
         'Ta wiadomość zawiera część winmail.dat, którą zapisano bez otwierania, więc to, co się w niej znajduje, nie jest wymienione powyżej.',
 
     'scope.fragment': 'Pytanie dotyczy zaznaczonego fragmentu tej wiadomości: „{fragment}”',
-    'scope.wholeMessage': 'Pytaj o całą wiadomość',
 
     'blocking.progress': 'Jak daleko zaszła operacja',
     'blocking.progressReading': '{percentage} — nie zamykaj tego okna',

--- a/frontend/src/Client.App/src/readingPane/OpenedMessage.tsx
+++ b/frontend/src/Client.App/src/readingPane/OpenedMessage.tsx
@@ -83,9 +83,9 @@ export function OpenedMessage({
             return;
         }
 
-        const fragment = selected.toString().trim().slice(0, longestFragment);
+        const text = selected.toString().trim().slice(0, longestFragment);
 
-        revise({ fragment: fragment === '' ? null : fragment });
+        revise({ fragment: text === '' ? null : { messageId: storedEmailId, text } });
     }
 
     return (

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
@@ -2,6 +2,7 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+import { useEffect } from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type {
@@ -788,10 +789,24 @@ describe('ReadingPane following a cited file', () => {
 });
 
 describe('ReadingPane selection', () => {
+    // The message being read is `workspace.selection` in the application — `App.tsx` hands the pane that very value —
+    // and the passage in scope is read against it, so the harness sets it rather than leaving the pane drawing a
+    // message the workspace has never heard of.
+    function Opened(): null {
+        const { revise } = useWorkspace();
+
+        useEffect(() => {
+            revise({ selection: messageId });
+        }, [revise]);
+
+        return null;
+    }
+
     function readingBeside(): void {
         render(
             <LocalizationProvider>
                 <WorkspaceProvider>
+                    <Opened />
                     <LinkOpenerContext value={() => Promise.resolve()}>
                         <AttachmentExchangeContext value={deliversNothing}>
                             <OpenAttachmentContext value={() => undefined}>
@@ -816,8 +831,8 @@ describe('ReadingPane selection', () => {
         await screen.findByText('The invoice is attached.');
 
         expect(
-            screen.queryByText('Asking about the part of this message you selected: “The invoice is attached.”'),
-        ).toBeNull();
+            screen.queryAllByText('Asking about the part of this message you selected: “The invoice is attached.”'),
+        ).toHaveLength(0);
     });
 
     it('carries the words somebody selected into the scope the next question is asked under', async () => {
@@ -828,8 +843,10 @@ describe('ReadingPane selection', () => {
         fireEvent.mouseUp(words);
 
         expect(
-            await screen.findByText('Asking about the part of this message you selected: “The invoice is attached.”'),
-        ).toBeDefined();
+            await screen.findAllByText(
+                'Asking about the part of this message you selected: “The invoice is attached.”',
+            ),
+        ).toHaveLength(2);
     });
 
     it('gives back the whole message as the scope when that is asked for', async () => {
@@ -838,11 +855,15 @@ describe('ReadingPane selection', () => {
 
         select(words);
         fireEvent.mouseUp(words);
-        fireEvent.click(await screen.findByRole('button', { name: 'Ask about the whole message instead' }));
+        await screen.findAllByText('Asking about the part of this message you selected: “The invoice is attached.”');
+
+        fireEvent.change(screen.getByRole('combobox', { name: 'What the question is asked about' }), {
+            target: { value: `message:${messageId}` },
+        });
 
         expect(
-            screen.queryByText('Asking about the part of this message you selected: “The invoice is attached.”'),
-        ).toBeNull();
+            screen.queryAllByText('Asking about the part of this message you selected: “The invoice is attached.”'),
+        ).toHaveLength(0);
     });
 
     // Opening a message is its words having reached the pane, and where it stands travels with it, because the folder

--- a/frontend/src/Client.App/src/shell/IntentField.test.tsx
+++ b/frontend/src/Client.App/src/shell/IntentField.test.tsx
@@ -65,7 +65,10 @@ describe('IntentField', () => {
     it('says every mailbox is in scope until one is chosen', () => {
         renderField();
 
-        expect(screen.getByRole('combobox', { name: 'What the question is asked about' })).toHaveProperty('value', '');
+        expect(screen.getByRole('combobox', { name: 'What the question is asked about' })).toHaveProperty(
+            'value',
+            'everything',
+        );
         expect(screen.getByRole('option', { name: 'All mailboxes' })).toBeDefined();
     });
 
@@ -135,58 +138,92 @@ function fieldStanding(as: Partial<Workspace>, accounts: readonly MailAccount[] 
 }
 
 describe('IntentField scope', () => {
-    it('says nothing about a fragment while the whole message is the scope', () => {
-        renderField();
+    it('says nothing about a passage while the whole message is the scope', () => {
+        fieldStanding({ selection: 'AAMkAD-42' });
 
-        expect(screen.queryByRole('button', { name: 'Ask about the whole message instead' })).toBeNull();
+        expect(screen.queryByRole('option', { name: 'The part you selected' })).toBeNull();
+        expect(screen.getByRole('option', { name: 'This message', selected: true })).toBeDefined();
     });
 
-    it('quotes the words a question would be asked about, rather than saying a fragment exists', () => {
-        fieldStanding({ fragment: 'the part of the message somebody pointed at' });
+    it('quotes the words a question would be asked about, rather than saying a passage exists', () => {
+        fieldStanding({
+            selection: 'AAMkAD-42',
+            fragment: { messageId: 'AAMkAD-42', text: 'the part of the message somebody pointed at' },
+        });
 
-        expect(
-            screen.getByText(
-                'Asking about the part of this message you selected: “the part of the message somebody pointed at”',
-            ),
-        ).toBeDefined();
+        // Drawn beside the control and said to a reader who cannot see it, which is why the sentence is on the screen
+        // twice: being told only that something was narrowed to, and not what, is the disclosure this field prevents.
+        const quoted =
+            'Asking about the part of this message you selected: \u201Cthe part of the message somebody pointed at\u201D';
+
+        expect(screen.getAllByText(quoted)).toHaveLength(2);
+        expect(screen.getByRole('status')).toHaveProperty('textContent', quoted);
     });
 
-    it('gives the whole message back as the scope when that is asked for', () => {
-        fieldStanding({ fragment: 'the part of the message somebody pointed at' });
+    // Widening away from a passage is the same control every other scope is chosen with, and it must not take the
+    // highlight off the message: the reader is still looking at the words they selected.
+    it('gives the whole message back as the scope without unselecting the words', () => {
+        const reported = fieldStanding({
+            selection: 'AAMkAD-42',
+            fragment: { messageId: 'AAMkAD-42', text: 'the part of the message somebody pointed at' },
+        });
 
-        fireEvent.click(screen.getByRole('button', { name: 'Ask about the whole message instead' }));
+        fireEvent.change(screen.getByRole('combobox', { name: 'What the question is asked about' }), {
+            target: { value: 'message:AAMkAD-42' },
+        });
 
-        expect(screen.queryByRole('button', { name: 'Ask about the whole message instead' })).toBeNull();
-    });
-
-    // Widening the scope takes the control that did it off the screen, so where focus lands is the behaviour:
-    // left to the browser it falls to the document, which is where reading from a keyboard silently stops.
-    it('puts focus on the question when the control that widened the scope goes', () => {
-        fieldStanding({ fragment: 'the part of the message somebody pointed at' });
-
-        fireEvent.click(screen.getByRole('button', { name: 'Ask about the whole message instead' }));
-
-        expect(screen.getByRole('searchbox', { name: 'Ask your mail' })).toBe(document.activeElement);
+        expect(screen.queryByText(/Asking about the part of this message/)).toBeNull();
+        expect(reported().fragment).toEqual({
+            messageId: 'AAMkAD-42',
+            text: 'the part of the message somebody pointed at',
+        });
     });
 
     it('names the correspondence being read as what the question is about', () => {
         fieldStanding({ conversation: { threadId: 'thread-1', openAt: null } });
 
-        expect(screen.getByRole('combobox', { name: 'What the question is asked about' })).toHaveProperty('value', '');
+        expect(screen.getByRole('combobox', { name: 'What the question is asked about' })).toHaveProperty(
+            'value',
+            'thread:thread-1',
+        );
         expect(screen.getByRole('option', { name: 'This correspondence' })).toBeDefined();
     });
 
     it('counts the messages picked out, which are narrower than the correspondence holding them', () => {
         fieldStanding({ conversation: { threadId: 'thread-1', openAt: null }, selected: ['one', 'two', 'three'] });
 
-        expect(screen.getByRole('option', { name: '3 selected messages' })).toBeDefined();
-        expect(screen.queryByRole('option', { name: 'This correspondence' })).toBeNull();
+        expect(screen.getByRole('option', { name: '3 selected messages', selected: true })).toBeDefined();
+        expect(screen.getByRole('option', { name: 'This correspondence' })).toBeDefined();
     });
 
     it('names the folder and the mailbox it is in', () => {
         fieldStanding({ scope: { kind: 'folder', accountId: 'work', alias: 'Invoices' } });
 
         expect(screen.getByRole('option', { name: 'Invoices in Work' })).toBeDefined();
+    });
+
+    // Four scopes at once, and the person has to be able to reach any of them without deselecting anything: this is
+    // the case the issue describes and the one the ladder exists for.
+    it('offers the folder, the correspondence, the messages ticked and the passage all at once', () => {
+        fieldStanding({
+            scope: { kind: 'folder', accountId: 'work', alias: 'Invoices' },
+            conversation: { threadId: 'thread-1', openAt: null },
+            selection: 'AAMkAD-42',
+            selected: ['AAMkAD-42', 'AAMkAD-43'],
+            fragment: { messageId: 'AAMkAD-42', text: 'by the end of the month' },
+        });
+
+        for (const name of [
+            'The part you selected',
+            '2 selected messages',
+            'This correspondence',
+            'This message',
+            'Invoices in Work',
+            'Work',
+            'All mailboxes',
+        ]) {
+            expect(screen.getByRole('option', { name })).toBeDefined();
+        }
     });
 
     // The whole point of the field owning a scope of its own: widening a question must not move the list out from
@@ -203,17 +240,57 @@ describe('IntentField scope', () => {
 
         expect(reported().scope).toEqual({ kind: 'folder', accountId: 'work', alias: 'Invoices' });
         expect(reported().selected).toEqual(['one']);
-        expect(reported().askScope).toEqual({ kind: 'everything' });
+        expect(reported().askScopeKey).toBe('everything');
     });
 
-    // The list the control renders drops the mailbox the mail space is already showing, so that it is not offered
-    // twice. A reader who names a mailbox here and then walks the folder tree to it is the case where those two meet,
-    // and the control has to keep saying what the question is about rather than falling blank between them.
+    // Narrowing is the other half of the same promise, and it is the half a field offering only mailboxes could not
+    // keep: the list still shows the folder and the rows stay ticked while the question is about one message.
+    it('narrows to one message without changing what the mail space is showing', () => {
+        const reported = fieldStanding({
+            scope: { kind: 'folder', accountId: 'work', alias: 'Invoices' },
+            selection: 'AAMkAD-42',
+            selected: ['AAMkAD-42', 'AAMkAD-43'],
+        });
+
+        fireEvent.change(screen.getByRole('combobox', { name: 'What the question is asked about' }), {
+            target: { value: 'message:AAMkAD-42' },
+        });
+
+        expect(reported().scope).toEqual({ kind: 'folder', accountId: 'work', alias: 'Invoices' });
+        expect(reported().selected).toEqual(['AAMkAD-42', 'AAMkAD-43']);
+        expect(screen.getByRole('option', { name: 'This message', selected: true })).toBeDefined();
+    });
+
+    // What is in scope is what is read and sent, so the words beside the question and the scope the run is started
+    // with are asserted as one value rather than trusted to have stayed in step.
+    it('records the scope it was showing when the question is asked', () => {
+        const reported = fieldStanding({
+            selection: 'AAMkAD-42',
+            fragment: { messageId: 'AAMkAD-42', text: 'by the end of the month' },
+        });
+
+        expect(screen.getByRole('option', { name: 'The part you selected', selected: true })).toBeDefined();
+
+        fireEvent.change(screen.getByRole('searchbox', { name: 'Ask your mail' }), {
+            target: { value: 'when did they say it would arrive' },
+        });
+        fireEvent.submit(screen.getByRole('search'));
+
+        expect(reported().askedBefore).toEqual([
+            {
+                question: 'when did they say it would arrive',
+                scope: { kind: 'fragment', messageId: 'AAMkAD-42', text: 'by the end of the month' },
+            },
+        ]);
+    });
+
+    // A reader who names a mailbox here and then walks the folder tree to it is where the named scope and the screen's
+    // own meet, and the control has to keep saying what the question is about rather than falling blank between them.
     it('keeps saying what is in scope when the mail space arrives at the mailbox the field was pointed at', () => {
-        fieldStanding(
-            { askScope: { kind: 'account', accountId: 'home' }, scope: { kind: 'account', accountId: 'home' } },
-            [workAccount, homeAccount],
-        );
+        fieldStanding({ askScopeKey: 'account:home', scope: { kind: 'account', accountId: 'home' } }, [
+            workAccount,
+            homeAccount,
+        ]);
 
         expect(screen.getByRole('option', { name: 'Home', selected: true })).toBeDefined();
     });
@@ -225,10 +302,10 @@ describe('IntentField scope', () => {
             target: { value: 'account:home' },
         });
         fireEvent.change(screen.getByRole('combobox', { name: 'What the question is asked about' }), {
-            target: { value: '' },
+            target: { value: 'everything' },
         });
 
-        expect(reported().askScope).toBeNull();
+        expect(reported().askScopeKey).toBeNull();
     });
 });
 

--- a/frontend/src/Client.App/src/shell/IntentField.tsx
+++ b/frontend/src/Client.App/src/shell/IntentField.tsx
@@ -5,21 +5,21 @@
 import { useEffect, useRef } from 'react';
 import type { MailAccount } from '@mailfathom/client-backend';
 import { chip } from '../controls/chrome';
-import { Icon } from '../controls/Icon';
 import { SecondaryButton } from '../controls/SecondaryButton';
 import type { MessageKey } from '../localization/en';
 import type { Locale } from '../localization/locale';
 import { useLocalization, type Translate } from '../localization/useLocalization';
 import { goToSpace } from '../routing/useSpace';
-import { askScopeInForce, askScopeOnScreen, withAsked, type AskedQuestion, type AskScope } from '../workspace/askScope';
 import {
-    everything,
-    folderRoleLabels,
-    sameScope,
-    scopeKey,
-    scopeOfAccount,
-    type MailScope,
-} from '../workspace/mailScope';
+    askScopeInForce,
+    askScopeKey,
+    askScopeOnScreen,
+    askScopesOffered,
+    withAsked,
+    type AskedQuestion,
+    type AskScope,
+} from '../workspace/askScope';
+import { folderRoleLabels, type MailScope } from '../workspace/mailScope';
 import { useWorkspace } from '../workspace/useWorkspace';
 
 // What the product puts in front of the person in every space: the question they are composing, drawn as the design
@@ -44,16 +44,7 @@ export function IntentField({ accounts }: { readonly accounts: readonly MailAcco
 
     const onScreen = askScopeOnScreen(workspace);
     const inForce = askScopeInForce(workspace, accounts);
-    const offered = scopesOffered(onScreen, accounts, translate, locale);
-
-    // Read out of the list the control renders rather than out of the workspace, because the list is the shorter of
-    // the two: a mailbox somebody named in the field stops being offered separately the moment the mail space moves to
-    // it, and a value naming an option that is no longer there leaves the control drawing nothing selected while the
-    // question is still scoped to it. The first option is what answers then, and it is the same scope under another
-    // name — following the screen, where the screen now shows what was named.
-    const named = workspace.askScope;
-    const chosen =
-        named === null ? undefined : offered.find((one) => one.scope !== null && sameScope(one.scope, named));
+    const offered = askScopesOffered(workspace, accounts);
 
     // The front door is reachable without hunting for it, which is what "from anywhere in the application" costs: a
     // reader inside a list of messages would otherwise tab back out of it to reach the field. An imperative browser
@@ -130,56 +121,47 @@ export function IntentField({ accounts }: { readonly accounts: readonly MailAcco
 
             {/* Said as well as drawn: the scope changes because somebody opened a correspondence or ticked a row, which
                 is a change a reader who cannot see the chip would otherwise not be told about at all — and this is the
-                one place where not being told is a disclosure rather than a missed detail. */}
+                one place where not being told is a disclosure rather than a missed detail. A passage is said with its
+                words for that same reason: naming it as a passage would tell a reader who cannot see the quote beside
+                the control that something was narrowed to, and not what. */}
             <p className="sr-only" role="status">
-                {translate('scope.asking', { scope: scopeName(inForce, accounts, translate, locale) })}
+                {inForce.kind === 'fragment'
+                    ? translate('scope.fragment', { fragment: inForce.text })
+                    : translate('scope.asking', { scope: scopeName(inForce, accounts, translate, locale) })}
             </p>
 
             <div className="flex flex-wrap items-center gap-2">
+                {/* Choosing what the screen is already showing is choosing to keep following it, which is why that
+                    option is kept as nothing named rather than pinned: somebody who picks the correspondence they are
+                    reading and then opens another one means the one in front of them. */}
                 <select
                     aria-label={translate('scope.inScope')}
-                    value={chosen?.value ?? ''}
+                    value={askScopeKey(inForce)}
                     onChange={(event) => {
-                        revise({ askScope: offered.find((one) => one.value === event.target.value)?.scope ?? null });
+                        revise({
+                            askScopeKey: event.target.value === askScopeKey(onScreen) ? null : event.target.value,
+                        });
                     }}
                     className={`px-2.75 py-1.25 text-sm ${chip}`}
                 >
                     {offered.map((one) => (
-                        <option key={one.value} value={one.value}>
-                            {one.label}
+                        <option key={askScopeKey(one)} value={askScopeKey(one)}>
+                            {scopeName(one, accounts, translate, locale)}
                         </option>
                     ))}
                 </select>
 
-                {/* The other half of the scope, and the one a person set by pointing at something rather than by
-                    choosing from a list. It is shown rather than assumed, because a question silently narrowed to
-                    words somebody selected minutes ago is a question answered about the wrong thing — and it carries
-                    the words themselves rather than that a fragment exists, so what the next question is about is
-                    readable before it is asked. */}
-                {workspace.fragment === null ? null : (
+                {/* The words themselves, beside the control that named them. The list above can only say that a
+                    passage is in scope; a question silently asked about words somebody highlighted minutes ago is a
+                    question answered about the wrong thing, so what is quoted here is what will be read. Widening away
+                    from it is the control beside this rather than a close button on the chip, because giving the scope
+                    back must not take the highlight off the message the reader is still looking at. */}
+                {inForce.kind !== 'fragment' ? null : (
                     <span
                         className={`flex min-w-0 max-w-full items-center gap-1.5 border-accent-line bg-accent-soft px-2.75 py-1.25 text-sm text-accent-deep ${chip}`}
-                        title={translate('scope.fragment', { fragment: workspace.fragment })}
+                        title={translate('scope.fragment', { fragment: inForce.text })}
                     >
-                        <span className="truncate">
-                            {translate('scope.fragment', { fragment: workspace.fragment })}
-                        </span>
-
-                        {/* Giving the scope back takes this chip off the screen, and the control somebody pressed
-                            with it, so focus is placed rather than left to fall to the document: it goes to the
-                            question itself, which is what widening the scope was in aid of asking. */}
-                        <button
-                            type="button"
-                            aria-label={translate('scope.wholeMessage')}
-                            title={translate('scope.wholeMessage')}
-                            className="flex shrink-0 items-center rounded-full transition hover:bg-hover"
-                            onClick={() => {
-                                revise({ fragment: null });
-                                question.current?.focus();
-                            }}
-                        >
-                            <Icon name="close" className="size-3.5" />
-                        </button>
+                        <span className="truncate">{translate('scope.fragment', { fragment: inForce.text })}</span>
                     </span>
                 )}
             </div>
@@ -220,45 +202,14 @@ const selectionCounted: Readonly<Record<Intl.LDMLPluralRule, MessageKey>> = {
     other: 'scope.selection.other',
 };
 
-/** One thing the field offers to ask about: what to show for it, and the mailbox to pin, or `null` to follow the screen. */
-interface OfferedScope {
-    readonly value: string;
-    readonly label: string;
-    readonly scope: MailScope | null;
-}
-
-/**
- * What the field offers to ask about.
- *
- * What the mail space is showing comes first, and choosing it is choosing to keep following the screen — so opening a
- * correspondence or ticking a row moves the scope without anybody touching the control. Everything after it is a
- * mailbox to hold the question to whatever the screen does next, which is what widening after too narrow an answer
- * actually is. The screen's own scope is not offered twice.
- */
-function scopesOffered(
-    onScreen: AskScope,
-    accounts: readonly MailAccount[],
-    translate: Translate,
-    locale: Locale,
-): readonly OfferedScope[] {
-    const mailboxes = [everything, ...accounts.map((account) => scopeOfAccount(account.id))].filter(
-        (scope) => onScreen.kind !== 'mail' || !sameScope(onScreen.scope, scope),
-    );
-
-    return [
-        { value: '', label: scopeName(onScreen, accounts, translate, locale), scope: null },
-        ...mailboxes.map((scope) => ({
-            value: scopeKey(scope),
-            label: mailScopeName(scope, accounts, translate),
-            scope,
-        })),
-    ];
-}
-
 // What a scope is called on the screen, which is the whole of what the field promises: the words beside the question
 // are what the question will be asked about.
 function scopeName(scope: AskScope, accounts: readonly MailAccount[], translate: Translate, locale: Locale): string {
     switch (scope.kind) {
+        case 'fragment':
+            return translate('scope.selectedText');
+        case 'message':
+            return translate('scope.message');
         case 'thread':
             return translate('scope.thread');
         case 'selection':

--- a/frontend/src/Client.App/src/workspace/Workspace.test.tsx
+++ b/frontend/src/Client.App/src/workspace/Workspace.test.tsx
@@ -69,7 +69,7 @@ describe('WorkspaceProvider', () => {
         { scope: { kind: 'account', accountId: 'work' } },
         { collapsed: ['account:work'] },
         { selection: 'AAMkAD-42' },
-        { fragment: 'the part of the message somebody pointed at' },
+        { fragment: { messageId: 'AAMkAD-42', text: 'the part of the message somebody pointed at' } },
         { question: 'what did Nordwind send' },
     ])('changes %o and leaves the rest of the workspace as it was', (change) => {
         renderProbe(change);

--- a/frontend/src/Client.App/src/workspace/askScope.test.ts
+++ b/frontend/src/Client.App/src/workspace/askScope.test.ts
@@ -4,7 +4,15 @@
 
 import { describe, expect, it } from 'vitest';
 import type { MailAccount } from '@mailfathom/client-backend';
-import { askScopeInForce, askScopeOnScreen, mostAskedQuestions, withAsked } from './askScope';
+import {
+    askScopeInForce,
+    askScopeKey,
+    askScopeOnScreen,
+    askScopesOffered,
+    mostAskedQuestions,
+    withAsked,
+    withoutFragmentText,
+} from './askScope';
 import { emptyWorkspace, type Workspace } from './useWorkspace';
 
 const workAccount: MailAccount = {
@@ -45,6 +53,80 @@ describe('askScopeOnScreen', () => {
             ),
         ).toEqual({ kind: 'selection', messages: ['one', 'two'] });
     });
+
+    it('is the message being read rather than the folder it was opened from', () => {
+        expect(
+            askScopeOnScreen(
+                looking({ scope: { kind: 'folder', accountId: 'work', alias: 'Invoices' }, selection: 'message-1' }),
+            ),
+        ).toEqual({ kind: 'message', messageId: 'message-1' });
+    });
+
+    it('is the passage highlighted, which is narrower than the message carrying it', () => {
+        expect(
+            askScopeOnScreen(
+                looking({
+                    selection: 'message-1',
+                    fragment: { messageId: 'message-1', text: 'the delivery date we agreed' },
+                }),
+            ),
+        ).toEqual({ kind: 'fragment', messageId: 'message-1', text: 'the delivery date we agreed' });
+    });
+
+    // A question scoped to words nobody can see any more is the disclosure the field exists to prevent, so the passage
+    // stops counting the moment the reader moves on rather than waiting for something to clear it.
+    it('ignores a passage whose message is no longer the one being read', () => {
+        expect(
+            askScopeOnScreen(
+                looking({
+                    selection: 'message-2',
+                    fragment: { messageId: 'message-1', text: 'the delivery date we agreed' },
+                }),
+            ),
+        ).toEqual({ kind: 'message', messageId: 'message-2' });
+    });
+});
+
+describe('askScopesOffered', () => {
+    // Four scopes at once, in increasing specificity, and every one of them reachable without deselecting anything:
+    // this is the whole of what the field promises somebody who ticked rows inside a correspondence and then read a
+    // paragraph of one of them.
+    it('offers every scope the screen is pointing at, what is in force first', () => {
+        const offered = askScopesOffered(
+            looking({
+                scope: { kind: 'folder', accountId: 'work', alias: 'Invoices' },
+                conversation: { threadId: 'thread-1', openAt: null },
+                selection: 'message-1',
+                selected: ['message-1', 'message-2'],
+                fragment: { messageId: 'message-1', text: 'the delivery date' },
+            }),
+            [workAccount],
+        );
+
+        expect(offered.map(askScopeKey)).toEqual([
+            'fragment:message-1',
+            'selection',
+            'thread:thread-1',
+            'message:message-1',
+            'folder:work:Invoices',
+            'account:work',
+            'everything',
+        ]);
+    });
+
+    it('offers the mailbox a folder in scope belongs to, so widening does not jump to every mailbox', () => {
+        const offered = askScopesOffered(looking({ scope: { kind: 'folder', accountId: 'work', alias: 'Invoices' } }), [
+            workAccount,
+        ]);
+
+        expect(offered.map(askScopeKey)).toEqual(['folder:work:Invoices', 'account:work', 'everything']);
+    });
+
+    it('offers no scope twice where the screen is already reading one of the mailboxes', () => {
+        const offered = askScopesOffered(looking({ scope: { kind: 'account', accountId: 'work' } }), [workAccount]);
+
+        expect(offered.map(askScopeKey)).toEqual(['account:work', 'everything']);
+    });
 });
 
 describe('askScopeInForce', () => {
@@ -53,20 +135,69 @@ describe('askScopeInForce', () => {
             askScopeInForce(
                 looking({
                     conversation: { threadId: 'thread-1', openAt: null },
-                    askScope: { kind: 'everything' },
+                    askScopeKey: 'everything',
                 }),
                 [workAccount],
             ),
         ).toEqual({ kind: 'mail', scope: { kind: 'everything' } });
     });
 
+    // Narrowing is the same act as widening and costs the same one control: the screen keeps showing the folder and
+    // the correspondence, and the next question is about the paragraph alone.
+    it('is a passage somebody narrowed to while the screen still shows the correspondence', () => {
+        expect(
+            askScopeInForce(
+                looking({
+                    conversation: { threadId: 'thread-1', openAt: null },
+                    selection: 'message-1',
+                    selected: ['message-1', 'message-2'],
+                    fragment: { messageId: 'message-1', text: 'the delivery date' },
+                    askScopeKey: 'fragment:message-1',
+                }),
+                [workAccount],
+            ),
+        ).toEqual({ kind: 'fragment', messageId: 'message-1', text: 'the delivery date' });
+    });
+
     // A scope outlives the answer it was chosen from, so a mailbox whose declaration has gone since would otherwise be
     // a question asked about nothing at all, named on the line whose whole job is to say what is in scope.
     it('falls back to the screen where the mailbox named is no longer declared', () => {
-        expect(askScopeInForce(looking({ askScope: { kind: 'account', accountId: 'gone' } }), [workAccount])).toEqual({
+        expect(askScopeInForce(looking({ askScopeKey: 'account:gone' }), [workAccount])).toEqual({
             kind: 'mail',
             scope: { kind: 'everything' },
         });
+    });
+
+    it('falls back to the screen where the correspondence named has been closed', () => {
+        expect(askScopeInForce(looking({ askScopeKey: 'thread:thread-1' }), [workAccount])).toEqual({
+            kind: 'mail',
+            scope: { kind: 'everything' },
+        });
+    });
+
+    // Ticking a fifth row is not choosing something else, so the selection stays named and answers with what is ticked
+    // now — which is what "changing the selection updates the scope immediately" has to mean for a named one too.
+    it('follows the selection somebody named as rows are ticked and unticked', () => {
+        expect(
+            askScopeInForce(looking({ selected: ['one', 'two', 'three'], askScopeKey: 'selection' }), [workAccount]),
+        ).toEqual({ kind: 'selection', messages: ['one', 'two', 'three'] });
+    });
+});
+
+describe('withoutFragmentText', () => {
+    it('keeps the question and reduces a passage to the message it came from', () => {
+        expect(
+            withoutFragmentText({
+                question: 'what did they promise',
+                scope: { kind: 'fragment', messageId: 'message-1', text: 'by the end of the month' },
+            }),
+        ).toEqual({ question: 'what did they promise', scope: { kind: 'message', messageId: 'message-1' } });
+    });
+
+    it('leaves a scope carrying no mail content as it was', () => {
+        const asked = { question: 'who signed it', scope: { kind: 'thread', threadId: 'thread-1' } } as const;
+
+        expect(withoutFragmentText(asked)).toBe(asked);
     });
 });
 

--- a/frontend/src/Client.App/src/workspace/askScope.ts
+++ b/frontend/src/Client.App/src/workspace/askScope.ts
@@ -3,18 +3,28 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import type { MailAccount } from '@mailfathom/client-backend';
-import type { MailScope } from './mailScope';
+import { accountInScope, everything, scopeKey, scopeOfAccount, type MailScope } from './mailScope';
 import type { Workspace } from './useWorkspace';
 
 // What a question is asked about, which is not the same thing as what the mail space is showing. Somebody reading one
-// correspondence out of a folder means that correspondence when they ask, and somebody who has ticked four rows means
-// those four — so the scope is named beside the field before the question is sent rather than discovered in the answer.
+// correspondence out of a folder means that correspondence when they ask, somebody who has ticked four rows means those
+// four, and somebody who has highlighted a paragraph means the paragraph rather than the message around it — so the
+// scope is named beside the field before the question is sent rather than discovered in the answer.
 //
 // It is one value derived from two, rather than a second scope kept beside the mail space's own: what is on the screen
 // answers unless the person named something else in the field, and naming something else there changes what the next
 // question reads without moving the list out from under them. Two scopes free to disagree would be a field that says
 // one thing and asks another, which here is a disclosure rather than a display defect — what is in scope is what is
 // read and sent.
+
+/** A passage of one message somebody selected, which is a scope of its own rather than a mark on the message. */
+export interface SelectedFragment {
+    /** The message the words were selected in, which is what makes the passage distinguishable from the message. */
+    readonly messageId: string;
+
+    /** The words themselves, because what the field does with a fragment is quote it back before the question is sent. */
+    readonly text: string;
+}
 
 /** What a question is asked about. */
 export type AskScope =
@@ -25,7 +35,13 @@ export type AskScope =
     | { readonly kind: 'thread'; readonly threadId: string }
 
     /** The messages picked out of the list, in the order the list draws them. */
-    | { readonly kind: 'selection'; readonly messages: readonly string[] };
+    | { readonly kind: 'selection'; readonly messages: readonly string[] }
+
+    /** The one message being read, whether on its own or inside a correspondence. */
+    | { readonly kind: 'message'; readonly messageId: string }
+
+    /** The passage of a message somebody selected, which is narrower than the message that carries it. */
+    | { readonly kind: 'fragment'; readonly messageId: string; readonly text: string };
 
 /** A question that was asked, and the scope it was asked under. */
 export interface AskedQuestion {
@@ -42,36 +58,98 @@ export interface AskedQuestion {
 export const mostAskedQuestions = 8;
 
 /**
+ * The scope's identity as one string, which is what the field names a scope by and what the workspace keeps.
+ *
+ * A key rather than the scope itself, because what somebody chose in the field only means anything against what the
+ * field is offering: a passage they highlighted stops being on offer the moment they read something else, and a scope
+ * that outlived the screen it was chosen from would ask about words nobody can see. Resolving a key against the offered
+ * list is what makes the scope shown and the scope used the same value rather than two that have to be kept in step.
+ *
+ * A selection is keyed by being one, not by which messages are in it: ticking a fifth row after choosing the selection
+ * is still choosing the selection, and re-keying it there would silently drop the choice back to the screen.
+ *
+ * A fragment is keyed by the message it was taken from and never by the words, because a key is written to a store and
+ * a passage of somebody's mail is not.
+ */
+export function askScopeKey(scope: AskScope): string {
+    switch (scope.kind) {
+        case 'mail':
+            return scopeKey(scope.scope);
+        case 'thread':
+            return `thread:${scope.threadId}`;
+        case 'selection':
+            return 'selection';
+        case 'message':
+            return `message:${scope.messageId}`;
+        case 'fragment':
+            return `fragment:${scope.messageId}`;
+    }
+}
+
+/**
  * What the mail space is pointing at, narrowest first.
  *
- * A selection is narrower than the correspondence it was made in, and that is narrower than the mailbox it was reached
- * from. Nothing here is a guess about what somebody meant: it is what the screen is showing, and the field draws it
- * so that choosing differently is one control away rather than something to discover afterwards.
+ * A highlighted passage is narrower than the message it is in, a set of ticked rows is what somebody picked out on
+ * purpose, and a correspondence is narrower than the mailbox it was reached from. Nothing here is a guess about what
+ * somebody meant: it is what the screen is showing, and the field draws it so that choosing differently is one control
+ * away rather than something to discover afterwards.
  */
 export function askScopeOnScreen(workspace: Workspace): AskScope {
-    if (workspace.selected.length > 0) {
-        return { kind: 'selection', messages: workspace.selected };
-    }
+    const [narrowest] = narrowerThanMail(workspace);
 
-    if (workspace.conversation !== null) {
-        return { kind: 'thread', threadId: workspace.conversation.threadId };
-    }
+    return narrowest ?? { kind: 'mail', scope: workspace.scope };
+}
 
-    return { kind: 'mail', scope: workspace.scope };
+/**
+ * Everything the field offers to ask about, what is in force first.
+ *
+ * The order is precedence rather than width: the first entry is what the next question would be asked under with
+ * nothing chosen, and everything after it is a way to widen or narrow without moving the mail space. What the screen is
+ * showing comes first, then the mailbox the folder in scope belongs to, then every mailbox at once and each of them by
+ * name — which is what widening after too narrow an answer actually is. Nothing is offered twice: a screen already
+ * reading one mailbox does not offer it again below.
+ */
+export function askScopesOffered(workspace: Workspace, accounts: readonly MailAccount[]): readonly AskScope[] {
+    const account = accountInScope(workspace.scope);
+
+    const mailboxes: readonly MailScope[] = [
+        workspace.scope,
+        ...(account === null ? [] : [scopeOfAccount(account)]),
+        everything,
+        ...accounts.map((one) => scopeOfAccount(one.id)),
+    ];
+
+    const offered: AskScope[] = [
+        ...narrowerThanMail(workspace),
+        ...mailboxes.map((scope): AskScope => ({ kind: 'mail', scope })),
+    ];
+
+    const seen = new Set<string>();
+
+    return offered.filter((scope) => {
+        const key = askScopeKey(scope);
+        const first = !seen.has(key);
+        seen.add(key);
+
+        return first;
+    });
 }
 
 /**
  * The scope the next question would actually be asked under.
  *
- * What the person named in the field wins over what is on the screen. A mailbox they named that the deployment no
- * longer declares is not one — a chosen scope outlives the answer it was chosen from — so it falls back to the screen
- * rather than asking about a mailbox nobody has. What that check has to cover is decided by what may reach this value
- * at all, which `stillOffered` below states.
+ * What the person named in the field wins over what is on the screen, for as long as the field is still offering it.
+ * A mailbox the deployment no longer declares, a correspondence that has been closed, and a passage whose message is no
+ * longer being read all stop being offered — and a name that answers nothing falls back to the screen rather than
+ * scoping a question to something nobody can see.
  */
 export function askScopeInForce(workspace: Workspace, accounts: readonly MailAccount[]): AskScope {
-    return workspace.askScope !== null && stillOffered(workspace.askScope, accounts)
-        ? { kind: 'mail', scope: workspace.askScope }
-        : askScopeOnScreen(workspace);
+    const named = workspace.askScopeKey;
+
+    return (
+        askScopesOffered(workspace, accounts).find((scope) => askScopeKey(scope) === named) ??
+        askScopeOnScreen(workspace)
+    );
 }
 
 /**
@@ -93,11 +171,47 @@ export function withAsked(
     );
 }
 
-// A mailbox somebody pointed the field at is offered while the deployment still declares the account it names. The
-// account is the only kind that has to be asked about: the field offers every mailbox at once or one of them and
-// nothing else, and `rememberedWorkspace.ts` refuses anything else on the way back in, so a folder or a role never
-// reaches this value to go stale in it. Checking the account against the accounts is therefore the whole of it rather
-// than a narrower reading of `mailScope.ts`'s own check, which needs the folder directory this field is never handed.
-function stillOffered(scope: MailScope, accounts: readonly MailAccount[]): boolean {
-    return scope.kind !== 'account' || accounts.some((account) => account.id === scope.accountId);
+/**
+ * The same question and the scope it was asked under with a passage reduced to the message it came from.
+ *
+ * A question asked about a highlighted paragraph is kept; the paragraph is not. What was asked is a sentence somebody
+ * typed and the message is a name the service assigned, but the passage is mail content, and this is what lets the list
+ * outlive a reload without a store holding any — `rememberedWorkspace.ts` is the one caller and says why.
+ */
+export function withoutFragmentText(asked: AskedQuestion): AskedQuestion {
+    return asked.scope.kind === 'fragment'
+        ? { question: asked.question, scope: { kind: 'message', messageId: asked.scope.messageId } }
+        : asked;
+}
+
+// Everything the screen is showing that is narrower than a mailbox, in the order the field reads them. Written once
+// because the scope in force and the list the field offers are the same ladder read to different depths, and a second
+// copy of it is how the chip and the control would come to disagree about which of the four is in force.
+function narrowerThanMail(workspace: Workspace): readonly AskScope[] {
+    const fragment = fragmentBeingRead(workspace);
+
+    return [
+        ...(fragment === null
+            ? []
+            : [{ kind: 'fragment', messageId: fragment.messageId, text: fragment.text } as const]),
+        ...(workspace.selected.length > 0 ? [{ kind: 'selection', messages: workspace.selected } as const] : []),
+        ...(workspace.conversation === null
+            ? []
+            : [{ kind: 'thread', threadId: workspace.conversation.threadId } as const]),
+        ...(workspace.selection === null ? [] : [{ kind: 'message', messageId: workspace.selection } as const]),
+    ];
+}
+
+// A passage counts while the message it was taken from is one of the messages being read: the message opened on its
+// own, or any of the ones a correspondence draws, which the workspace names collectively rather than one at a time.
+// Reading it this way rather than clearing the value from each screen that closes is what keeps a scope from outliving
+// its words — a question scoped to a paragraph nobody can see any more is the disclosure this field exists to prevent.
+function fragmentBeingRead(workspace: Workspace): SelectedFragment | null {
+    if (workspace.fragment === null) {
+        return null;
+    }
+
+    return workspace.conversation !== null || workspace.selection === workspace.fragment.messageId
+        ? workspace.fragment
+        : null;
 }

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.test.ts
@@ -21,7 +21,7 @@ const kept: Workspace = {
     fragment: null,
     selected: ['AAMkAD-42', 'AAMkAD-43'],
     question: 'what did Nordwind send',
-    askScope: { kind: 'account', accountId: 'work' },
+    askScopeKey: 'account:work',
     askedBefore: [{ question: 'what did they promise', scope: { kind: 'thread', threadId: 'thread-1' } }],
     recentSearches: ['quarterly figures'],
 };
@@ -44,10 +44,32 @@ describe('rememberWorkspace', () => {
 
     // The one part of the workspace that is mail rather than a name for one, so it is the one part a store never sees.
     it('keeps no part of the message somebody had selected', () => {
-        rememberWorkspace({ ...kept, fragment: 'the part of the message somebody pointed at' });
+        rememberWorkspace({
+            ...kept,
+            fragment: { messageId: 'AAMkAD-42', text: 'the part of the message somebody pointed at' },
+        });
 
         expect(window.sessionStorage.getItem(storageKey)).not.toContain('somebody pointed at');
         expect(rememberedWorkspace().fragment).toBeNull();
+    });
+
+    // The same rule reaching the one other place a passage could get into the store. What somebody asked is theirs and
+    // is kept; the words they highlighted to ask it are somebody's mail and are not.
+    it('keeps a question asked about a passage under the message rather than under the words', () => {
+        rememberWorkspace({
+            ...kept,
+            askedBefore: [
+                {
+                    question: 'when did they say it would arrive',
+                    scope: { kind: 'fragment', messageId: 'AAMkAD-42', text: 'by the end of the month' },
+                },
+            ],
+        });
+
+        expect(window.sessionStorage.getItem(storageKey)).not.toContain('by the end of the month');
+        expect(rememberedWorkspace().askedBefore).toEqual([
+            { question: 'when did they say it would arrive', scope: { kind: 'message', messageId: 'AAMkAD-42' } },
+        ]);
     });
 
     // A consent given for one message after being told what a stranger's markup can carry, which is why a reload finds
@@ -183,19 +205,19 @@ describe('rememberedWorkspace', () => {
     // its own: it is one this client wrote, so it opens on what was kept, asking about whatever is on the screen and
     // with nothing offered back.
     it('reads a workspace kept before the field held a scope and a history as one holding neither', () => {
-        const { askScope, askedBefore, ...before } = kept;
+        const { askScopeKey, askedBefore, ...before } = kept;
 
         stored(before);
 
-        expect(rememberedWorkspace()).toEqual({ ...kept, askScope: null, askedBefore: [] });
-        expect(askScope).not.toBeNull();
+        expect(rememberedWorkspace()).toEqual({ ...kept, askScopeKey: null, askedBefore: [] });
+        expect(askScopeKey).not.toBeNull();
         expect(askedBefore).toHaveLength(1);
     });
 
     it('opens on the mailbox the field was pointed at and the questions asked under it', () => {
         stored(kept);
 
-        expect(rememberedWorkspace().askScope).toEqual({ kind: 'account', accountId: 'work' });
+        expect(rememberedWorkspace().askScopeKey).toBe('account:work');
         expect(rememberedWorkspace().askedBefore).toEqual([
             { question: 'what did they promise', scope: { kind: 'thread', threadId: 'thread-1' } },
         ]);

--- a/frontend/src/Client.App/src/workspace/rememberedWorkspace.ts
+++ b/frontend/src/Client.App/src/workspace/rememberedWorkspace.ts
@@ -3,7 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { longestSearchText } from '@mailfathom/client-backend';
-import { mostAskedQuestions, type AskedQuestion, type AskScope } from './askScope';
+import { mostAskedQuestions, withoutFragmentText, type AskedQuestion, type AskScope } from './askScope';
 import { everything, isMailFolderRole, type MailScope } from './mailScope';
 import type { OpenConversation } from './openConversation';
 import { emptyWorkspace, type Workspace } from './useWorkspace';
@@ -82,12 +82,23 @@ export function rememberedWorkspace(): Workspace {
  * fetch the file again on a reload nobody meant as a request for it — so a reload returns to the message, which is
  * where the file was opened from and is one press away. A file a search result cited goes with it, being the same act
  * half finished.
+ *
+ * A question asked about a passage is kept and the passage is not, for the same reason the selected fragment is left
+ * out: the question is a sentence somebody typed, and the words they highlighted are a piece of somebody's mail. What
+ * is stored beside the question is the message the passage came from, which is a name the service assigned.
  */
 export function rememberWorkspace(workspace: Workspace): void {
     try {
         window.sessionStorage.setItem(
             storageKey,
-            JSON.stringify({ ...workspace, fragment: null, fullHtml: null, attachment: null, citedAttachment: null }),
+            JSON.stringify({
+                ...workspace,
+                fragment: null,
+                fullHtml: null,
+                attachment: null,
+                citedAttachment: null,
+                askedBefore: workspace.askedBefore.map(withoutFragmentText),
+            }),
         );
     } catch {
         // A browser refusing storage still runs the client; what a person was looking at then lasts the run rather
@@ -105,8 +116,8 @@ function workspaceIn(value: unknown): Workspace | null {
 
     const record = value as Record<string, unknown>;
     const scope = scopeIn(record['scope']);
-    const chosen = record['askScope'] ?? null;
-    const askScope = chosen === null ? null : namedScopeIn(chosen);
+    const chosen = record['askScopeKey'] ?? null;
+    const askScopeKey = chosen === null ? null : namedScopeKeyIn(chosen);
     const askedBefore = askedBeforeIn(record['askedBefore'] ?? []);
     const collapsed = collapsedIn(record['collapsed']);
     const mailboxesFolded = record['mailboxesFolded'] ?? false;
@@ -119,7 +130,7 @@ function workspaceIn(value: unknown): Workspace | null {
 
     if (
         scope === null ||
-        (chosen !== null && askScope === null) ||
+        (chosen !== null && askScopeKey === null) ||
         askedBefore === null ||
         collapsed === null ||
         selected === null ||
@@ -157,7 +168,7 @@ function workspaceIn(value: unknown): Workspace | null {
         fragment: null,
         selected,
         question,
-        askScope,
+        askScopeKey,
         askedBefore,
         recentSearches,
     };
@@ -195,19 +206,21 @@ function askedBeforeIn(value: unknown): readonly AskedQuestion[] | null {
     return asked;
 }
 
-// The mailbox somebody pointed the field at, held to the two shapes the field can actually offer: every mailbox at
-// once, or one of them. A folder or a role read back here would be a scope no control in the client can produce and
-// nothing anywhere drops when the deployment stops declaring it — the mail space watches its own scope and not this
-// one — so it would ask about a folder nobody has until the tab was closed. Refusing it at the boundary is what makes
-// `askScope.ts` right to re-check the account alone.
-function namedScopeIn(value: unknown): MailScope | null {
-    const scope = scopeIn(value);
-
-    return scope === null || scope.kind === 'everything' || scope.kind === 'account' ? scope : null;
+// What somebody pointed the field at, which is a key rather than a scope and is checked as one: it names a scope only
+// against the list the field is offering, and `askScope.ts` falls back to the screen for a key that names nothing there
+// now. So nothing here has to know which scopes a control can produce, and a key that has gone stale costs a fallback
+// rather than a question asked about a folder nobody has. The bound is a folded row's, that being the same shape — an
+// account and a folder's whole place on its mail server.
+function namedScopeKeyIn(value: unknown): string | null {
+    return typeof value === 'string' && value.length > 0 && value.length <= longestRow ? value : null;
 }
 
-// Read through the same three checks the workspace's own values are read through, because that is exactly what the
-// three shapes hold: a mail scope, a correspondence the deployment named, and a list of messages it named.
+// Read through the same checks the workspace's own values are read through, because that is exactly what these shapes
+// hold: a mail scope, a correspondence the deployment named, a list of messages it named, and one message.
+//
+// A passage is refused rather than read, because none was written: `rememberWorkspace` reduces a question asked about
+// one to the message it came from, so a fragment scope in a store is somebody's own writing and reading it back would
+// be this client putting a stranger's words into a question's scope.
 function askScopeIn(value: unknown): AskScope | null {
     if (typeof value !== 'object' || value === null || Array.isArray(value)) {
         return null;
@@ -215,6 +228,7 @@ function askScopeIn(value: unknown): AskScope | null {
 
     const record = value as Record<string, unknown>;
     const threadId = record['threadId'];
+    const messageId = record['messageId'];
 
     switch (record['kind']) {
         case 'mail': {
@@ -224,6 +238,8 @@ function askScopeIn(value: unknown): AskScope | null {
         }
         case 'thread':
             return isIdentifier(threadId) ? { kind: 'thread', threadId } : null;
+        case 'message':
+            return isIdentifier(messageId) ? { kind: 'message', messageId } : null;
         case 'selection': {
             const messages = selectedIn(record['messages']);
 

--- a/frontend/src/Client.App/src/workspace/useWorkspace.ts
+++ b/frontend/src/Client.App/src/workspace/useWorkspace.ts
@@ -3,7 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { createContext, useContext } from 'react';
-import type { AskedQuestion } from './askScope';
+import type { AskedQuestion, SelectedFragment } from './askScope';
 import { everything, type MailScope } from './mailScope';
 import type { CitedAttachment, OpenedAttachment } from './openAttachment';
 import type { OpenConversation } from './openConversation';
@@ -100,8 +100,12 @@ export interface Workspace {
      * It is the words a person selected rather than a position in anything, because what the intent field does with it
      * is quote it: a range would have to be resolved against a document that is drawn again on every read, and against
      * the same message read a second time under a different ask.
+     *
+     * It names the message the words were taken from as well as the words, because a passage is a scope of its own and
+     * the message around it is the next one out — a fragment that could not say which message it belonged to could
+     * neither be widened to that message nor be told apart from one taken out of a different one.
      */
-    readonly fragment: string | null;
+    readonly fragment: SelectedFragment | null;
 
     /**
      * The messages the person has picked out, in the order the list draws them.
@@ -116,17 +120,17 @@ export interface Workspace {
     readonly question: string;
 
     /**
-     * The mailbox the intent field was pointed at, or `null` where the field asks about what the mail space is showing.
+     * What the intent field was pointed at, by its key, or `null` where the field asks about what the mail space shows.
      *
      * Beside the scope the list is read under rather than instead of it, because the two answer different questions:
      * one says what is drawn, and the other what the next question is about. Widening a question after an answer that
-     * was too narrow is exactly the second changing while the first does not, so a person who asks again about every
-     * mailbox keeps the folder they were reading and the messages they had picked out.
+     * was too narrow, and narrowing it to the paragraph in front of somebody, are both exactly the second changing
+     * while the first does not — so either keeps the folder they were reading and the messages they had picked out.
      *
-     * Only what the field itself offers ever reaches it — every mailbox at once, or one of them — and
-     * `workspace/askScope.ts` is where it is read against what is on the screen.
+     * A key rather than the scope, because it means nothing except against what the field is offering: `askScope.ts`
+     * resolves it there and falls back to the screen where the thing it named has gone.
      */
-    readonly askScope: MailScope | null;
+    readonly askScopeKey: string | null;
 
     /**
      * What was asked before, newest first, each with the scope it was asked under.
@@ -170,7 +174,7 @@ export const emptyWorkspace: Workspace = {
     fragment: null,
     selected: [],
     question: '',
-    askScope: null,
+    askScopeKey: null,
     askedBefore: [],
     recentSearches: [],
 };


### PR DESCRIPTION
Closes #1183

## What was wrong

The intent field carried three scopes — the mailbox, the correspondence, the rows somebody had ticked — and could be pointed at a mailbox and at nothing else. Two things followed from that, and both are what this issue is about.

**A message read on its own was not a scope.** With no correspondence open and no row ticked, the field said the *folder*, so asking about what was in front of somebody asked about everything around it.

**A highlighted passage was drawn beside the scope rather than being one.** The chip quoted the words while `askScopeOnScreen` answered with the message or the folder, so the sentence beside the question and the scope a run would be started with were two values free to disagree. That is the disclosure the issue names: what is in scope is what is read and sent.

**And there was no way to narrow.** The field offered *every mailbox* and each mailbox by name. Widening from a paragraph to the message it is in, or holding a question to one message inside a correspondence, could not be said at all.

## What it does now

`AskScope` gains two members — the message being read, and the passage highlighted in it — so what the screen is pointing at is one ladder read narrowest first: **the passage, the ticked rows, the correspondence, the message, the mailbox**. That is the order the issue states, and the first rung is what the next question is asked under with nothing chosen.

`askScopesOffered` publishes the whole ladder plus the mailbox a folder in scope belongs to, every mailbox at once, and each mailbox by name, deduplicated. So the case the issue describes — a folder selected, a correspondence open, three rows ticked, a paragraph highlighted — puts all four on the control at once, and choosing any of them changes nothing the mail space displays: the folder stays, the correspondence stays open, the rows stay ticked, and the highlight stays on the message.

A passage names the message it was taken from. That is what makes it *distinct from the message that contains it*, what lets the next rung out be that message, and what lets it stop counting the moment the reader moves on — `askScopeOnScreen` reads a passage as in force only while its message is the one being read, rather than waiting for a screen to clear it.

## What the field holds, and why it is a key

`workspace.askScope` (a `MailScope | null`) becomes `workspace.askScopeKey` (a `string | null`): the key of the scope chosen, resolved against what is being offered *now*.

This is the change that makes *the scope shown is exactly the scope read* structurally true rather than maintained. The value is a pointer into the list the control renders, so there is no second scope to keep in step, and the staleness cases collapse into one rule — a key that names nothing on offer falls back to the screen:

- a mailbox the deployment stopped declaring;
- a correspondence that has been closed;
- a passage whose message is no longer open.

A selection is keyed by *being* one rather than by which messages are in it, so ticking a fifth row after choosing the selection still asks about what is ticked now.

## Privacy

The session's store already refused the selected passage, because it is a piece of somebody's mail rather than a name the service assigned. That rule reached one place it did not cover: a question asked *about* a passage carried the words in its own recorded scope. `rememberWorkspace` now reduces such a scope to the message it came from, so the question survives a reload and the words do not, and `askScopeIn` refuses a fragment scope read back — nothing wrote one.

Nothing about the scope, the selection, or the passage reaches a log or telemetry; none of the three was ever passed to one.

The passage is now also *said* and not only drawn: the field's status region quotes it for a reader who cannot see the chip. Being told that something was narrowed to, and not what, is the same disclosure in the other direction.

## The control that went

The fragment chip's close button is gone. It gave the scope back by clearing `workspace.fragment` — a mail-space value — which is exactly the "without changing what the mail screens display or have selected" the acceptance asks for. Widening away from a passage is now the same control every other scope is chosen with, and the highlight stays on the message the reader is still looking at. `scope.wholeMessage` went with it; `scope.selectedText` and `scope.message` are the two keys added, in both catalogues.

## Design

The design project draws the ask bar under a correspondence as a field with a placeholder and no scope control at all; the selector and the chip are the client's own, settled in #1175 and unchanged in shape here. So there is no artboard this ladder can be held against, and the `mail-thread` parity number measures two corpora and two languages rather than this change — the design's demo copy went English in #1780 while the client capture is Polish. What changed visually is one option label in the existing `select` and one small button leaving the existing chip, and both are asserted in the suite.

## Verification

- `scripts/verify-full.sh` — **300 passed, 0 failed**, run after the rebase onto `87b29ae9b`.
- Client unit suite: **3470 passed** across 200 files.
- New behaviour is covered where it is: the ladder and its precedence, the four-scopes-at-once case, each fallback, the selection following the ticks, the passage ignored once its message is closed, narrowing without moving the mail space, the recorded scope matching the one drawn when a question is asked, and the store keeping a question about a passage under its message.

## Out of scope

Answering. The run surface is #1174's; what this carries is the scope, which survives moving between spaces because the frame owns the workspace.
