### PR TITLE
[#1788] Draw the folder tree as the design does: the special folders, one mailbox, the open row

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -444,8 +444,15 @@ than the machine's.
 
 `src/folders/` is what writes that scope. It draws the user's mailboxes and their folders as one tree, read from the
 folders route in a single exchange, with the roles that span every mailbox above them — so asking about every inbox at
-once is one act rather than three. A folder is placed and named by the role the deployment gave it rather than by what
-its server calls it, because a name is whatever a provider chose in whatever language. The same tree is what the folded
+once is one act rather than three. That group is what several mailboxes are for, so a user holding one is not offered
+it: it would draw that account's folders a second time under a heading meaning the same thing. Either way the client
+opens on the inbox — every mailbox's at once where that row is drawn, the one mailbox's own where it is not — because
+the widest scope is every folder at once, deleted and sent mail among them. A folder is placed and named by the role
+the deployment gave it rather than by what
+its server calls it, because a name is whatever a provider chose in whatever language, and pressing a mailbox's own row
+means its inbox rather than every folder it has. Nothing in the tree says how a local copy is doing: the column's foot
+carries that for every mailbox at once, which is where the design puts it and where one sentence cannot squeeze a
+mailbox's name off its own row. The same tree is what the folded
 column draws: a row keeps its place and its symbol and loses its label, a mailbox is marked by its colour where its name
 stood, and the two folds stay independent — narrowing the column changes nothing about which mailboxes are open in it.
 

--- a/frontend/src/Client.App/src/folders/FolderRow.tsx
+++ b/frontend/src/Client.App/src/folders/FolderRow.tsx
@@ -9,7 +9,6 @@ import { MailboxMark } from '../controls/MailboxMark';
 import type { IconName } from '../controls/icons';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
-import { isCurrent, needsAttention, synchronizationStateLabel } from '../synchronization/synchronizationState';
 import { folderRoleLabels } from '../workspace/mailScope';
 import type { FolderTreeRow } from './folderTreeRows';
 
@@ -28,8 +27,13 @@ import type { FolderTreeRow } from './folderTreeRows';
 // Each of those two is drawn twice again, because the column it stands in folds to a rail. Folded, a group is its mark
 // alone — the colour is what tells one mailbox from the next once the name is gone — and a folder is its symbol alone,
 // drawn larger, because a narrower column still has to be hit reliably. What goes is the drawing rather than the
-// saying: the name, the state, and the count stay in the row for a reader who is not looking at it, which is what
-// keeps a rail of unlabelled symbols something a screen reader can still work through.
+// saying: the name and the count stay in the row for a reader who is not looking at it, which is what keeps a rail of
+// unlabelled symbols something a screen reader can still work through.
+//
+// What a row never says is how the local copy is doing. The design draws no such sentence in this column, and one
+// there costs the thing the column is for: a mailbox called *Club* whose copy has stopped becomes a row reading
+// *Stopped synchronizing* with the mailbox's own name squeezed out of it. The column's foot is where that is said,
+// once, for every account at a time — `shell/ConnectionSummary.tsx` — and the account menu says it per account.
 
 // How far in each level under a group sits. Stated as one list rather than as a width worked out from the level,
 // because a computed indentation is a value written outside the token layer however it is arrived at. Anything deeper
@@ -142,7 +146,6 @@ export function FolderRow({
             <span className={folded ? 'sr-only' : 'flex min-w-0 flex-1 items-center gap-2'}>
                 <span className="min-w-0 flex-1 truncate">{nameOf(row, translate)}</span>
 
-                <State row={row} />
                 <Unread count={row.role === 'Inbox' ? row.unreadEmailCount : null} />
             </span>
 
@@ -186,22 +189,6 @@ function Twist({ expanded, onToggle }: { readonly expanded: boolean | null; read
             }}
         >
             <Icon name="chevron_right" className={`size-3.5 transition ${expanded ? 'rotate-90' : ''}`} />
-        </span>
-    );
-}
-
-// Said in words rather than in a colour, and only where there is something to say: a row whose last attempt succeeded
-// and left nothing behind carries nothing, so the two rows that do are the ones a reader's eye lands on.
-function State({ row }: { readonly row: FolderTreeRow }) {
-    const { translate } = useLocalization();
-
-    if (row.state === null || isCurrent(row.state, row.behind)) {
-        return null;
-    }
-
-    return (
-        <span className={`shrink-0 text-xs ${needsAttention(row.state) ? 'text-warning' : 'text-muted'}`}>
-            {translate(synchronizationStateLabel(row.state, row.behind))}
         </span>
     );
 }

--- a/frontend/src/Client.App/src/folders/FolderTree.test.tsx
+++ b/frontend/src/Client.App/src/folders/FolderTree.test.tsx
@@ -126,7 +126,7 @@ function foldTheColumnAway(): void {
     fireEvent.click(screen.getByRole('button', { name: foldTheColumn }));
 }
 
-/** The part of a row that carries its name, its state, and its count — drawn beside the symbol, or said and not drawn. */
+/** The part of a row that carries its name and its count — drawn beside the symbol, or said and not drawn. */
 function saidOn(named: HTMLElement): HTMLElement {
     const said = named.querySelector<HTMLElement>('span:not([aria-hidden])');
 
@@ -318,7 +318,7 @@ describe('FolderTree', () => {
 
         await drawn();
 
-        expect(row(/^Inbox.*[^0-9]3 unread/).textContent).toContain('3 unread');
+        expect(row(/^Inbox3 unread/).textContent).toContain('3 unread');
     });
 
     it('offers every mailbox at once as the scope everything else is read under', async () => {
@@ -329,6 +329,30 @@ describe('FolderTree', () => {
 
         expect(carried().scope).toEqual({ kind: 'everything' });
         expect(row(/^All mailboxes/).getAttribute('aria-selected')).toBe('true');
+    });
+
+    it('lands on a mailbox’s inbox when its own row is pressed, which is what pressing a mailbox’s name means', async () => {
+        renderTree(answering(JSON.stringify(tree)));
+
+        await drawn();
+        fireEvent.click(row(/^Work/));
+
+        expect(carried().scope).toEqual({ kind: 'folder', accountId: 'work', alias: 'INBOX' });
+        expect(row(/^Inbox12 unread/).getAttribute('aria-selected')).toBe('true');
+    });
+
+    it('offers a user with one mailbox no group spanning every mailbox, and opens on that mailbox’s inbox', async () => {
+        renderTree(answering(JSON.stringify({ ...tree, accounts: [tree.accounts[0]] })));
+
+        await drawn();
+
+        expect(screen.queryByRole('treeitem', { name: /^All mailboxes/ })).toBeNull();
+
+        await waitFor(() => {
+            expect(carried().scope).toEqual({ kind: 'folder', accountId: 'work', alias: 'INBOX' });
+        });
+
+        expect(row(/^Inbox12 unread/).getAttribute('aria-selected')).toBe('true');
     });
 
     it('offers a special-use folder across every mailbox playing that role, counting all of them', async () => {
@@ -360,7 +384,7 @@ describe('FolderTree', () => {
         { gone: 'a folder', gap: { kind: 'folder', accountId: 'work', alias: 'ARCHIVE-2019' } },
         { gone: 'a mailbox', gap: { kind: 'account', accountId: 'retired' } },
         { gone: 'the last folder playing a role', gap: { kind: 'role', role: 'Junk' } },
-    ])('opens on every mailbox where what was scoped to is $gone the deployment no longer offers', async ({ gap }) => {
+    ])('opens on the inbox where what was scoped to is $gone the deployment no longer offers', async ({ gap }) => {
         window.sessionStorage.setItem('mailfathom.workspace', JSON.stringify({ ...emptyWorkspace, scope: gap }));
         renderTree(answering(JSON.stringify(tree)));
 
@@ -369,7 +393,7 @@ describe('FolderTree', () => {
         // Awaited rather than asserted outright: the tree is drawn from the answer and the scope is corrected against
         // that same answer, so the correction lands on the render after the one that first drew a row.
         await waitFor(() => {
-            expect(carried().scope).toEqual({ kind: 'everything' });
+            expect(carried().scope).toEqual({ kind: 'role', role: 'Inbox' });
         });
     });
 
@@ -384,13 +408,13 @@ describe('FolderTree', () => {
         expect(carried().scope).toEqual(kept);
     });
 
-    it('says which folder is behind and which one nothing could reach, rather than showing either as waiting', async () => {
+    it('says nothing on a row about how the local copy is doing, which the column’s foot says instead', async () => {
         renderTree(answering(JSON.stringify(tree)));
 
         await drawn();
 
-        expect(row(/^2024/).textContent).toContain('Catching up');
-        expect(row(/^InboxThe mail server did not answer/)).toBeDefined();
+        expect(screen.getByRole('tree').textContent).not.toContain('Catching up');
+        expect(screen.getByRole('tree').textContent).not.toContain('The mail server did not answer');
         expect(screen.queryByRole('progressbar')).toBeNull();
     });
 
@@ -472,7 +496,7 @@ describe('FolderTree', () => {
         first.focus();
         fireEvent.keyDown(first, { key: 'End' });
 
-        expect(document.activeElement).toBe(row(/^InboxThe mail server did not answer/));
+        expect(document.activeElement).toBe(row(/^Inbox3 unread/));
 
         fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'Home' });
 

--- a/frontend/src/Client.App/src/folders/FolderTree.tsx
+++ b/frontend/src/Client.App/src/folders/FolderTree.tsx
@@ -16,10 +16,10 @@ import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
 import { useReadMarking } from '../readMarking/useReadMarking';
 import { useSignalledChanges } from '../signals/signalledChanges';
-import { everything, scopeKey, scopeStillOffered } from '../workspace/mailScope';
+import { scopeKey } from '../workspace/mailScope';
 import { useWorkspace } from '../workspace/useWorkspace';
 import { FolderRow } from './FolderRow';
-import { folderTreeOf, visibleRows, type VisibleRow } from './folderTreeRows';
+import { folderTreeOf, openingScope, visibleRows, type VisibleRow } from './folderTreeRows';
 import { unreadAfterMarking } from './unreadAfterMarking';
 
 // The client's scope selector: which mailbox and which folder everything else is about. It is a tree because the
@@ -46,6 +46,9 @@ const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
     unreadable: 'failure.unreadable',
     missing: 'failure.missing',
 };
+
+// Asking which rows the tree holds rather than which a reader can see, which is what the fallback below is about.
+const nothingFolded: ReadonlySet<string> = new Set();
 
 /** What one attempt answered, tagged with the attempt, so whether a read is in flight is worked out rather than kept. */
 interface Answered {
@@ -113,19 +116,31 @@ export function FolderTree({
     // A scope outlives the tree it was chosen from, so the answer that arrives is also what says whether it still
     // names anything: the session's store carries a folder across a reload, and a folder deleted on the mail server in
     // between would otherwise leave the list asking for a mailbox nobody can reach and the tree highlighting no row.
-    // Falling back to the widest scope is what the client opens with, so a folder that has gone reads as never having
-    // been chosen rather than as an error somebody has to press through.
+    // Falling back to what the tree opens on is what the client starts at, so a folder that has gone reads as never
+    // having been chosen rather than as an error somebody has to press through.
+    //
+    // The question is asked of the rows rather than of the directory, and that is what makes the fallback right for a
+    // user holding one account: the tree offers them no row spanning every account, so `everything` is a scope nothing
+    // draws even though the directory still allows it, and a column whose open row is nowhere is the defect. Every
+    // row, folded or not, because what is folded away is still a row somebody chose.
     //
     // An effect rather than a derivation, which § *State* would otherwise prefer: the scope is one value the whole
     // client reads and this tree is one of its readers, so deriving a second scope here would be the two-values-that
     // -must-agree defect rather than a cure for it. It is also not the reconciling effect that rule refuses — nothing
     // is being kept in step, and this runs once per answer that disagrees rather than on every render.
     useEffect(() => {
-        if (answered?.result.outcome !== 'read' || scopeStillOffered(workspace.scope, answered.result.value)) {
+        if (answered?.result.outcome !== 'read') {
             return;
         }
 
-        revise({ scope: everything });
+        const offered = answered.result.value;
+        const inScope = scopeKey(workspace.scope);
+
+        if (visibleRows(folderTreeOf(offered), nothingFolded).some((visible) => visible.row.key === inScope)) {
+            return;
+        }
+
+        revise({ scope: openingScope(offered) });
     }, [answered, workspace.scope, revise]);
 
     // Three of the five kinds move this tree, because all three move a count it draws: mail arriving in a folder, a

--- a/frontend/src/Client.App/src/folders/folderTreeRows.test.ts
+++ b/frontend/src/Client.App/src/folders/folderTreeRows.test.ts
@@ -3,8 +3,8 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { describe, expect, it } from 'vitest';
-import type { MailAccount, MailFolder, MailFolderDirectory } from '@mailfathom/client-backend';
-import { folderTreeOf, visibleRows, type FolderTreeRow } from './folderTreeRows';
+import type { MailAccount, MailAccountFolders, MailFolder, MailFolderDirectory } from '@mailfathom/client-backend';
+import { folderTreeOf, openingScope, visibleRows, type FolderTreeRow } from './folderTreeRows';
 
 function account(id: string, displayName: string): MailAccount {
     return {
@@ -29,23 +29,22 @@ function folder(folder: Partial<MailFolder> & Pick<MailFolder, 'alias'>): MailFo
     };
 }
 
+const work: MailAccountFolders = {
+    account: account('work', 'Work'),
+    folders: [
+        folder({ alias: 'INBOX', role: 'Inbox', path: ['INBOX'], unreadEmailCount: 12, storedEmailCount: 4213 }),
+        folder({ alias: 'SENT', role: 'Sent', path: ['Wysłane'], storedEmailCount: 300 }),
+        folder({ alias: 'ARCHIVE-2024', path: ['Archiwum', '2024'], storedEmailCount: 980 }),
+    ],
+};
+
+/** The one mailbox above and nothing else, which is the case with no group spanning every mailbox. */
+const alone: MailFolderDirectory = { synchronizationEnabled: true, accounts: [work] };
+
 const directory: MailFolderDirectory = {
     synchronizationEnabled: true,
     accounts: [
-        {
-            account: account('work', 'Work'),
-            folders: [
-                folder({
-                    alias: 'INBOX',
-                    role: 'Inbox',
-                    path: ['INBOX'],
-                    unreadEmailCount: 12,
-                    storedEmailCount: 4213,
-                }),
-                folder({ alias: 'SENT', role: 'Sent', path: ['Wysłane'], storedEmailCount: 300 }),
-                folder({ alias: 'ARCHIVE-2024', path: ['Archiwum', '2024'], storedEmailCount: 980 }),
-            ],
-        },
+        work,
         {
             account: account('personal', 'Personal'),
             folders: [
@@ -115,14 +114,105 @@ describe('folderTreeOf', () => {
     });
 
     it('shows a folder nothing has bound to a remote folder under the name MailFathom knows it by', () => {
-        const news = find(folderTreeOf(directory), 'folder:personal:NEWS');
+        expect(find(folderTreeOf(directory), 'folder:personal:NEWS')?.name).toBe('NEWS');
+    });
 
-        expect(news?.name).toBe('NEWS');
-        expect(news?.state).toBe('NeverSynchronized');
+    it('offers the special folders before the rest, in the order a reader reaches for them', () => {
+        const special = {
+            synchronizationEnabled: true,
+            accounts: [
+                {
+                    account: account('work', 'Work'),
+                    folders: [
+                        folder({ alias: 'ARCHIVE', role: 'Archive', path: ['Archive'] }),
+                        folder({ alias: 'TRASH', role: 'Trash', path: ['Trash'] }),
+                        folder({ alias: 'DRAFTS', role: 'Drafts', path: ['Drafts'] }),
+                        folder({ alias: 'SENT', role: 'Sent', path: ['Sent'] }),
+                        folder({ alias: 'INBOX', role: 'Inbox', path: ['INBOX'] }),
+                    ],
+                },
+                { account: account('personal', 'Personal'), folders: [] },
+            ],
+        };
+
+        expect(keysOf(find(folderTreeOf(special), 'everything')?.children ?? [])).toEqual([
+            'role:Inbox',
+            'role:Sent',
+            'role:Drafts',
+            'role:Archive',
+            'role:Trash',
+        ]);
+
+        expect(keysOf(find(folderTreeOf(special), 'account:work')?.children ?? [])).toEqual([
+            'folder:work:INBOX',
+            'folder:work:SENT',
+            'folder:work:DRAFTS',
+            'folder:work:ARCHIVE',
+            'folder:work:TRASH',
+        ]);
+    });
+
+    it('scopes a mailbox’s own row to its inbox, because that is what pressing a mailbox’s name means', () => {
+        expect(find(folderTreeOf(directory), 'account:work')?.scope).toEqual({
+            kind: 'folder',
+            accountId: 'work',
+            alias: 'INBOX',
+        });
+    });
+
+    it('scopes a mailbox with no inbox to the mailbox itself', () => {
+        const inboxless = {
+            synchronizationEnabled: true,
+            accounts: [
+                { account: account('work', 'Work'), folders: [folder({ alias: 'NEWS', path: ['NEWS'] })] },
+                { account: account('personal', 'Personal'), folders: [] },
+            ],
+        };
+
+        expect(find(folderTreeOf(inboxless), 'account:work')?.scope).toEqual({ kind: 'account', accountId: 'work' });
+    });
+
+    it('offers no group spanning every mailbox to a user who has exactly one', () => {
+        expect(keysOf(folderTreeOf(alone))).toEqual(['account:work']);
     });
 
     it('reads a user with no mailbox as a tree with no rows rather than as a row with nothing under it', () => {
         expect(folderTreeOf({ synchronizationEnabled: true, accounts: [] })).toEqual([]);
+    });
+});
+
+describe('openingScope', () => {
+    it('opens on every mailbox’s inbox at once where the tree draws a row for that', () => {
+        expect(openingScope(directory)).toEqual({ kind: 'role', role: 'Inbox' });
+    });
+
+    it('opens on every mailbox at once where no mailbox plays an inbox to open on', () => {
+        const inboxless = {
+            synchronizationEnabled: true,
+            accounts: [
+                { account: account('work', 'Work'), folders: [folder({ alias: 'NEWS', path: ['NEWS'] })] },
+                { account: account('personal', 'Personal'), folders: [] },
+            ],
+        };
+
+        expect(openingScope(inboxless)).toEqual({ kind: 'everything' });
+    });
+
+    it('opens on the one mailbox’s inbox where there is no row spanning every mailbox', () => {
+        expect(openingScope(alone)).toEqual({ kind: 'folder', accountId: 'work', alias: 'INBOX' });
+    });
+
+    it('opens on the one mailbox itself where it plays no inbox', () => {
+        const inboxless = {
+            synchronizationEnabled: true,
+            accounts: [{ account: account('work', 'Work'), folders: [folder({ alias: 'NEWS', path: ['NEWS'] })] }],
+        };
+
+        expect(openingScope(inboxless)).toEqual({ kind: 'account', accountId: 'work' });
+    });
+
+    it('opens on every mailbox at once where the user has none, which is the widest scope rather than a place', () => {
+        expect(openingScope({ synchronizationEnabled: true, accounts: [] })).toEqual({ kind: 'everything' });
     });
 });
 

--- a/frontend/src/Client.App/src/folders/folderTreeRows.ts
+++ b/frontend/src/Client.App/src/folders/folderTreeRows.ts
@@ -2,31 +2,34 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import type {
-    MailAccountFolders,
-    MailFolder,
-    MailFolderDirectory,
-    MailFolderRole,
-    MailSynchronizationState,
-} from '@mailfathom/client-backend';
+import type { MailAccountFolders, MailFolder, MailFolderDirectory, MailFolderRole } from '@mailfathom/client-backend';
 import { everything, roleRank, scopeKey, type MailScope } from '../workspace/mailScope';
 
 // What the service answered, turned into the rows a tree draws. It is a function over values rather than anything a
 // component does while rendering: the shape of the tree is the interesting decision here, and a decision that can be
 // read as a value can be tested as one.
 //
-// Three things it decides. The user's mailboxes are one workspace rather than four applications, so the tree opens
-// with every account at once and the roles that span them — the inbox of all three accounts is a thing somebody wants
-// as often as the inbox of one. Below that each account carries its own folders, nested the way its mail server nests
-// them, which is what the levels of a folder's path are for. And a folder that plays a role is placed by that role
-// rather than by its name, because a name is whatever a provider chose in whatever language.
+// Four things it decides. The user's mailboxes are one workspace rather than four applications, so the tree opens with
+// every account at once and the roles that span them — the inbox of all three accounts is a thing somebody wants as
+// often as the inbox of one. That group is what several mailboxes are for, so a user holding exactly one account is
+// not offered it: it would draw that account's folders a second time under a heading meaning the same thing. Below it
+// each account carries its own folders, nested the way its mail server nests them, which is what the levels of a
+// folder's path are for. And a folder that plays a role is placed by that role rather than by its name, because a name
+// is whatever a provider chose in whatever language.
 
 /** One row of the tree, whatever it stands for: the whole workspace, a role across it, an account, or a folder. */
 export interface FolderTreeRow {
     /** What identifies the row — what is folded, what is focused, and what is compared against the current scope. */
     readonly key: string;
 
-    /** What selecting the row scopes the client to, or `null` for a level of a path the service named no folder for. */
+    /**
+     * What selecting the row scopes the client to, or `null` for a level of a path the service named no folder for.
+     *
+     * Not the same thing as the key, and an account's row is where the two part: pressing a mailbox's name means its
+     * inbox rather than every folder it has at once, so the row is keyed by the account and scopes to the inbox. What
+     * that leaves is a heading that selects without ever drawing as the selected row, which is how the design draws a
+     * group: the row that lights up is the inbox beneath it, and that is the row somebody was pointing at.
+     */
     readonly scope: MailScope | null;
 
     /** The name whatever this row stands for has: a mailbox's display name, a level of a path, or a folder's alias. */
@@ -37,12 +40,6 @@ export interface FolderTreeRow {
 
     /** How deep the row sits, counted from one, which is what a tree reports as its level. */
     readonly level: number;
-
-    /** How current the local copy is, or `null` for a row that stands for more than one thing. */
-    readonly state: MailSynchronizationState | null;
-
-    /** Whether the last attempt ended with mail it had not yet taken in. */
-    readonly behind: boolean;
 
     /** How many unread messages the deployment holds here, or `null` where nothing counted any. */
     readonly unreadEmailCount: number | null;
@@ -82,7 +79,42 @@ export function folderTreeOf(directory: MailFolderDirectory): readonly FolderTre
         return [];
     }
 
-    return [everythingRow(directory), ...directory.accounts.map(accountRow)];
+    const accounts = directory.accounts.map(accountRow);
+
+    return directory.accounts.length === 1 ? accounts : [everythingRow(directory), ...accounts];
+}
+
+/**
+ * Where the client opens, and where it lands again when what it was scoped to has gone.
+ *
+ * The inbox, which is where the design opens and where a mail client has opened for thirty years: mail arrives there,
+ * and the widest scope is every folder at once — sent, drafts and deleted mail among them, which is a list nobody
+ * opens an application to read. Every account's inbox at once where the tree draws that row, and the one account's own
+ * where it does not.
+ *
+ * Answered from the tree's shape rather than from the directory's, which is the whole of why it is answered here: a
+ * user with one account is offered no row spanning every account, so a scope the directory still allows can be one
+ * nothing draws — and a column with no row drawn as the open one is a column that has stopped saying the one thing it
+ * is for.
+ */
+export function openingScope(directory: MailFolderDirectory): MailScope {
+    const [only, ...rest] = directory.accounts;
+
+    if (only === undefined) {
+        return everything;
+    }
+
+    if (rest.length > 0) {
+        return directory.accounts.some((entry) => entry.folders.some((folder) => folder.role === 'Inbox'))
+            ? { kind: 'role', role: 'Inbox' }
+            : everything;
+    }
+
+    const inbox = only.folders.find((folder) => folder.role === 'Inbox');
+
+    return inbox === undefined
+        ? { kind: 'account', accountId: only.account.id }
+        : { kind: 'folder', accountId: only.account.id, alias: inbox.alias };
 }
 
 /**
@@ -124,8 +156,6 @@ function everythingRow(directory: MailFolderDirectory): FolderTreeRow {
         name: '',
         role: null,
         level: 1,
-        state: null,
-        behind: false,
         unreadEmailCount: totalOf(directory, (folder) => folder.unreadEmailCount),
         storedEmailCount: totalOf(directory, (folder) => folder.storedEmailCount),
         children: [...roles.entries()]
@@ -143,8 +173,6 @@ function roleRow(role: MailFolderRole, folders: readonly MailFolder[]): FolderTr
         name: '',
         role,
         level: 2,
-        state: null,
-        behind: false,
         unreadEmailCount: sumOf(folders, (folder) => folder.unreadEmailCount),
         storedEmailCount: sumOf(folders, (folder) => folder.storedEmailCount),
         children: [],
@@ -152,16 +180,15 @@ function roleRow(role: MailFolderRole, folders: readonly MailFolder[]): FolderTr
 }
 
 function accountRow(entry: MailAccountFolders): FolderTreeRow {
-    const scope: MailScope = { kind: 'account', accountId: entry.account.id };
+    const whole: MailScope = { kind: 'account', accountId: entry.account.id };
+    const inbox = entry.folders.find((folder) => folder.role === 'Inbox');
 
     return {
-        key: scopeKey(scope),
-        scope,
+        key: scopeKey(whole),
+        scope: inbox === undefined ? whole : { kind: 'folder', accountId: entry.account.id, alias: inbox.alias },
         name: entry.account.displayName,
         role: null,
         level: 1,
-        state: entry.account.synchronizationState,
-        behind: entry.account.behind,
         unreadEmailCount: sumOf(entry.folders, (folder) => folder.unreadEmailCount),
         storedEmailCount: sumOf(entry.folders, (folder) => folder.storedEmailCount),
         children: folderRows(entry),
@@ -221,8 +248,6 @@ function rowOfLevel(level: PathLevel, accountId: string, above: readonly string[
             name: level.name,
             role: null,
             level: depth,
-            state: null,
-            behind: false,
             unreadEmailCount: null,
             storedEmailCount: null,
             children,
@@ -247,8 +272,6 @@ function folderRow(
         name,
         role: folder.role,
         level: depth,
-        state: folder.synchronizationState,
-        behind: folder.behind,
         unreadEmailCount: folder.unreadEmailCount,
         storedEmailCount: folder.storedEmailCount,
         children,

--- a/frontend/src/Client.App/src/styles.css
+++ b/frontend/src/Client.App/src/styles.css
@@ -249,8 +249,8 @@
     --spacing-rail: 6rem;
     --spacing-rail-narrow: 4.125rem;
     --spacing-mailboxes: 13.125rem;
-    --spacing-mailboxes-folded: 4.8125rem;
-    --spacing-drawer: 18.125rem;
+    --spacing-mailboxes-folded: 3.625rem;
+    --spacing-drawer: 16.375rem;
 
     /* The message list at the tablet and the fold, where the project draws it at one width and offers no boundary to
        move: the list's width is somebody's to set only in the desktop composition, which is the one wide enough for

--- a/frontend/src/Client.App/src/workspace/mailScope.test.ts
+++ b/frontend/src/Client.App/src/workspace/mailScope.test.ts
@@ -3,7 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { describe, expect, it } from 'vitest';
-import type { MailFolderDirectory } from '@mailfathom/client-backend';
+import type { MailFolderDirectory, MailFolderRole } from '@mailfathom/client-backend';
 import {
     accountInScope,
     everything,
@@ -116,6 +116,13 @@ describe('isMailFolderRole', () => {
 describe('roleRank', () => {
     it('offers the inbox before everything else', () => {
         expect(roleRank('Inbox')).toBeLessThan(roleRank('Sent'));
+    });
+
+    it('offers the five folders a reader reaches for in the order they are reached for', () => {
+        const reachedFor: readonly MailFolderRole[] = ['Inbox', 'Sent', 'Drafts', 'Archive', 'Trash'];
+
+        expect([...reachedFor].sort((one, other) => roleRank(one) - roleRank(other))).toEqual(reachedFor);
+        expect(roleRank('Trash')).toBeLessThan(roleRank('Junk'));
     });
 
     it('offers a folder playing no role after every folder that plays one', () => {

--- a/frontend/src/Client.App/src/workspace/mailScope.ts
+++ b/frontend/src/Client.App/src/workspace/mailScope.ts
@@ -35,11 +35,11 @@ export const everything: MailScope = { kind: 'everything' };
 // fails to compile here until somebody has decided where it belongs.
 const roleOrder: Readonly<Record<MailFolderRole, number>> = {
     Inbox: 0,
-    Drafts: 1,
-    Sent: 2,
+    Sent: 1,
+    Drafts: 2,
     Archive: 3,
-    Junk: 4,
-    Trash: 5,
+    Trash: 4,
+    Junk: 5,
     Flagged: 6,
     Important: 7,
     All: 8,


### PR DESCRIPTION
Closes #1788

An owner's read of the running client against the design project found the folder tree drawing
something other than what `MailFathom Prototype.dc.html` draws. Five things move, and two of them
depart from the design deliberately — both named below, both the owner's own decision, and both
owing the design project an edit that is theirs to make.

## What changed

**The special folders are ordered the way somebody reaches for them.** `roleRank` now ranks inbox,
sent, drafts, archive, trash, and then junk, flagged, important, all and outbox. Every place a role
decides where a row sits reads that one order, so a mailbox's own folders and the rows spanning
every mailbox cannot disagree about where sent sits relative to drafts. A role no account plays gets
no row, unchanged: not every mailbox has every folder.

**A user holding one mailbox is offered no group spanning every mailbox.** That group is what
several mailboxes are for; with one it drew that account's folders a second time under a heading
meaning the same thing.

**The client opens on the inbox.** Every mailbox's inbox at once where that row is drawn, the one
mailbox's own where it is not, and every mailbox at once only where no mailbox plays an inbox to
open on. That is where the design opens — its prototype's own default is `acc1·Inbox` — and it is
what leaves a row drawn as the open row on first paint, which is the missing highlight the report
named. The widest scope is every folder at once, sent and deleted mail among them, which is not a
list anybody opens a mail client to read.

**The fallback a vanished scope lands on is the same answer, and it is now asked of the tree.**
`scopeStillOffered` answered whether the *directory* still allows a scope; what a column needs is
whether a *row* is drawn for it, and with one account those two disagree — `everything` is allowed
and drawn nowhere. So the effect walks the rows, unfolded ones included, and falls back to where the
tree opens.

**Pressing a mailbox's own row means its inbox.** The row keeps its key and parts with its scope to
do it, which is why the two are now documented as different things. A mailbox playing no inbox still
scopes to the whole mailbox.

**No row says how a local copy is doing.** `Nothing taken in yet`, `Stopped synchronizing` and
`Catching up` are gone from the tree and unchanged everywhere else — the account menu, the account
line, and the connection summary at the column's foot. The design draws no such sentence in this
column, and one cost the column what it is for: a mailbox called *Club* whose copy had stopped read
as a row saying *Stopped synchronizing* with the mailbox's own name squeezed out of it. `state` and
`behind` leave `FolderTreeRow` with the component that read them.

**The rail and the drawer take the design's own widths**, `58px` and `262px` rather than `77px` and
`290px`. The open column is unchanged: it already stood at the design's `210px`, measured off the
capture at 1440 × 900 — the border at x = 95 and the next at x = 305.

## What did not change, and why

The unread count still appears on a folder playing the `Inbox` role and on no other row, and the
symbols are still the role's own with the generic folder for a role-less one. Both were settled by
#1753 and both already held; what hid them in the report was the synchronisation sentence beside
them and the absence of an open row.

## The two departures from the design

Neither is a difference to live with, and each needs the design project to gain what the code now
does — the owner's edit, not this change's:

1. **The aggregate group.** The design's first group is `All accounts` and what hangs under it is
   `All` · `Unread` · `Important` — a standing view of the mailbox rather than the special folders.
   This client offers the special folders across every account instead.
2. **The mailbox row.** In the design a group header only folds and selects nothing. Here it selects,
   and lands on that mailbox's inbox.

## One difference this change leaves open

With **several** mailboxes and nothing yet stored, the client still opens on `All mailboxes` rather
than on the aggregate inbox, because the stored default is that scope and the tree draws a row for
it — so the fallback never fires. Making it open on the inbox there needs the workspace to be able
to say *nobody has chosen yet*, which is a change to a value the whole client reads and belongs in an
issue of its own. A user with one mailbox — the case reported — opens on the inbox, and the fallback
lands on the inbox in every case.

## Verification

- `scripts/verify-full.sh` — 300 passed, 0 failed.
- Client unit suite: 3543 passed.
- Design parity: `scripts/capture-design.sh` and `scripts/capture-client.sh` for `mail-list` at the
  design project's four compositions, held side by side at the desktop artboard. The column's
  structure, ordering, symbols, widths and the absence of the synchronisation sentence were read
  region by region against the design's own source values rather than by eye.
- The folded rail was driven in a real browser at 1440 × 900 after the token change: it renders from
  x = 96 to x = 154, which is the design's 58, with nothing clipped.
