### PR TITLE
[#1795] Attach into the composer rather than into the deployment, and let the panel travel

### DIFF
--- a/frontend/src/Client.App/src/composer/Composer.test.tsx
+++ b/frontend/src/Client.App/src/composer/Composer.test.tsx
@@ -603,8 +603,8 @@ describe('Composer, a message of its own', () => {
         expect(screen.queryByRole('dialog', { name: 'Send this message?' })).toBeNull();
     });
 
-    it('stages a file against the draft and draws what it is called and how large', async () => {
-        drawComposer();
+    it('holds a chosen file and draws what it is called and how large, without asking the deployment', async () => {
+        const { asked } = drawComposer();
 
         const file = new File(['0123'], 'invoice.pdf', { type: 'application/pdf' });
         const picker = document.querySelector<HTMLInputElement>('input[type=file]');
@@ -623,12 +623,13 @@ describe('Composer, a message of its own', () => {
 
         expect(staged.textContent).toContain('invoice.pdf');
         expect(within(staged).getByRole('button', { name: 'Remove invoice.pdf' })).toBeDefined();
+        expect(asked).toHaveLength(0);
     });
 
-    it('stages several chosen files against one draft rather than filing a draft for each', async () => {
-        // Where the octets went, which is the whole question: the draft one file is staged against is written by
-        // whichever save answers first, so uploads started together would each carry a draft of their own and every
-        // file but the last would hang off one nothing ever sends.
+    it('asks the deployment nothing until the message is filed, and then puts every file up against one draft', async () => {
+        // Where the octets went, and when. Choosing a file is not filing the message: nothing leaves the client until
+        // somebody presses save or send, and then every file goes up against the one draft that save wrote rather than
+        // against a draft apiece.
         const stagedAgainst: string[] = [];
 
         const uploadsEachFile: AttachmentUpload = (request) => {
@@ -661,6 +662,12 @@ describe('Composer, a message of its own', () => {
 
             return Promise.resolve();
         });
+
+        expect(await screen.findByRole('list', { name: 'Attached files' })).toBeDefined();
+        expect(stagedAgainst).toHaveLength(0);
+        expect(asked).toHaveLength(0);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save draft' }));
 
         await waitFor(() => {
             expect(stagedAgainst).toHaveLength(2);
@@ -716,9 +723,9 @@ describe('Composer, a message of its own', () => {
         expect(document.activeElement).toBe(last);
     });
 
-    it('does not put a removed file back when an older save answers after the removal', async () => {
-        // A save answers with the whole list the deployment held when it was asked, so one still in flight while a
-        // file is taken off would otherwise draw that file back onto a message that no longer carries it.
+    it('never puts up a file taken off while the save that would have was still writing the draft', async () => {
+        // The draft goes first and the files after it, so a file taken off inside that window is one the deployment
+        // never hears about — and one a save answering afterwards must not draw back onto a message without it.
         let releaseTheSave = (): void => undefined;
         const stagedAtTheDeployment = JSON.parse(draftBody({ attachments: [stagedFile] })) as unknown;
 
@@ -791,7 +798,7 @@ describe('Composer, a message of its own', () => {
         expect(screen.queryByRole('list', { name: 'Attached files' })).toBeNull();
     });
 
-    it('takes a staged file off the draft at the deployment as well as off the screen', async () => {
+    it('takes a chosen file off without asking a deployment that never had it', async () => {
         const { asked } = drawComposer();
 
         const picker = document.querySelector<HTMLInputElement>('input[type=file]');
@@ -806,18 +813,150 @@ describe('Composer, a message of its own', () => {
             return Promise.resolve();
         });
 
-        const staged = await screen.findByRole('list', { name: 'Attached files' });
+        const attached = await screen.findByRole('list', { name: 'Attached files' });
 
         await act(() => {
-            fireEvent.click(within(staged).getByRole('button', { name: 'Remove invoice.pdf' }));
+            fireEvent.click(within(attached).getByRole('button', { name: 'Remove invoice.pdf' }));
 
             return Promise.resolve();
         });
 
         expect(screen.queryByRole('list', { name: 'Attached files' })).toBeNull();
+        expect(asked).toHaveLength(0);
+    });
+
+    it('takes a file the deployment already holds off there as well', async () => {
+        // The one way a file is at the deployment while the composer is still open: a save writes the draft, puts the
+        // files up one at a time, and one of them does not arrive — which stops the save and leaves the composer
+        // standing over a message whose earlier files did.
+        const stagedAgainst: string[] = [];
+
+        const secondFileNeverArrives: AttachmentUpload = (request) => {
+            stagedAgainst.push(request.path);
+
+            return Promise.resolve(
+                stagedAgainst.length === 1
+                    ? { status: 200, body: JSON.stringify(stagedFile), headers: {} }
+                    : { status: 503, body: '', headers: {} },
+            );
+        };
+
+        const { asked } = drawComposer({ kind: 'new' }, {}, [work], true, secondFileNeverArrives);
+
+        const picker = document.querySelector<HTMLInputElement>('input[type=file]');
+
+        if (picker === null) {
+            throw new Error('The composer drew no file picker to attach with.');
+        }
+
+        await act(() => {
+            fireEvent.change(picker, {
+                target: { files: [new File(['0'], 'invoice.pdf'), new File(['1'], 'terms.pdf')] },
+            });
+
+            return Promise.resolve();
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save draft' }));
+
+        await waitFor(() => {
+            expect(stagedAgainst).toHaveLength(2);
+        });
+
+        const attached = await screen.findByRole('list', { name: 'Attached files' });
+
+        await act(() => {
+            fireEvent.click(within(attached).getByRole('button', { name: 'Remove invoice.pdf' }));
+
+            return Promise.resolve();
+        });
+
         expect(asked.some((request) => request.method === 'DELETE' && request.path.endsWith('/attachments/a1'))).toBe(
             true,
         );
+    });
+
+    it('takes a file off the deployment where it was taken off the message while it was going up', async () => {
+        // The author's act stands over an upload that was already in flight: what arrived is taken back off rather
+        // than left staged against a message that would then carry a file they removed.
+        let theFileArrives = (): void => undefined;
+        const stagedAgainst: string[] = [];
+
+        const holdsTheUpload: AttachmentUpload = (request) => {
+            stagedAgainst.push(request.path);
+
+            return new Promise((answer) => {
+                theFileArrives = () => {
+                    answer({ status: 200, body: JSON.stringify(stagedFile), headers: {} });
+                };
+            });
+        };
+
+        const { asked } = drawComposer({ kind: 'new' }, {}, [work], true, holdsTheUpload);
+
+        const picker = document.querySelector<HTMLInputElement>('input[type=file]');
+
+        if (picker === null) {
+            throw new Error('The composer drew no file picker to attach with.');
+        }
+
+        await act(() => {
+            fireEvent.change(picker, { target: { files: [new File(['0'], 'invoice.pdf')] } });
+
+            return Promise.resolve();
+        });
+
+        const attached = await screen.findByRole('list', { name: 'Attached files' });
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save draft' }));
+
+        await waitFor(() => {
+            expect(stagedAgainst).toHaveLength(1);
+        });
+
+        await act(() => {
+            fireEvent.click(within(attached).getByRole('button', { name: 'Remove invoice.pdf' }));
+
+            return Promise.resolve();
+        });
+
+        await act(() => {
+            theFileArrives();
+
+            return Promise.resolve();
+        });
+
+        await waitFor(() => {
+            expect(
+                asked.some((request) => request.method === 'DELETE' && request.path.endsWith('/attachments/a1')),
+            ).toBe(true);
+        });
+
+        expect(screen.queryByRole('list', { name: 'Attached files' })).toBeNull();
+    });
+
+    it('closes on discard without asking a deployment that is holding nothing', async () => {
+        const { asked, closed } = drawComposer();
+
+        writeWords('Never filed.');
+
+        fireEvent.click(screen.getByRole('button', { name: 'Close the message' }));
+
+        await act(() => {
+            fireEvent.click(
+                within(screen.getByRole('dialog', { name: 'Discard this message?' })).getByRole('button', {
+                    name: 'Discard',
+                }),
+            );
+
+            return Promise.resolve();
+        });
+
+        await waitFor(() => {
+            expect(closed).toHaveBeenCalledTimes(1);
+        });
+
+        expect(asked).toHaveLength(0);
     });
 
     it('closes without asking where nothing has been written', async () => {

--- a/frontend/src/Client.App/src/composer/Composer.tsx
+++ b/frontend/src/Client.App/src/composer/Composer.tsx
@@ -10,7 +10,6 @@ import {
     type MailAccount,
     type MailDraftAnswer,
     type MailFathomTransport,
-    type MailStagedAttachment,
 } from '@mailfathom/client-backend';
 import { Icon } from '../controls/Icon';
 import type { MessageKey } from '../localization/en';
@@ -24,7 +23,7 @@ import { DiscardConfirmation } from './DiscardConfirmation';
 import { forgetComposition, rememberComposition, rememberedComposition } from './keptComposition';
 import { RecipientField } from './RecipientField';
 import { SendConfirmation } from './SendConfirmation';
-import { useDraftAtDeployment, type DraftStanding } from './useDraftAtDeployment';
+import { useDraftAtDeployment, type AttachedFile, type DraftStanding } from './useDraftAtDeployment';
 import { WrittenMessage } from './WrittenMessage';
 
 // Writing a message, as the design project composes it: one model in two shapes, decided by the width the client has
@@ -244,19 +243,6 @@ export function Composer({
         }
     }
 
-    // One file at a time. The draft this stages against is written by whichever save answers first, so two uploads
-    // started together would each file a draft of their own and every file but the last would be staged against one
-    // nothing sends.
-    async function attachInTurn(chosen: readonly File[]): Promise<void> {
-        if (composition === null) {
-            return;
-        }
-
-        for (const file of chosen) {
-            await draft.attach(composition, file);
-        }
-    }
-
     function close(): void {
         forgetComposition();
         onClosed();
@@ -338,11 +324,15 @@ export function Composer({
         }
     }
 
-    // Whether this message may still be acted on, read by every control that writes to the draft: the send itself,
-    // the shortcut that asks the same question, and saving and attaching. Two presses would queue the same message
-    // twice — while the first is still in flight, and equally once it is queued — and a save or an attach after that
-    // would say what is happening over the queued state and take the way to withdraw off the screen with it.
-    const sendable = online && draft.standing.kind !== 'sending' && draft.standing.kind !== 'queued';
+    // Whether the message is still being written rather than on its way, read by every control that changes it. Two
+    // presses would queue the same message twice — while the first is still in flight, and equally once it is
+    // queued — and a save or an attach after that would say what is happening over the queued state and take the way
+    // to withdraw off the screen with it.
+    const stillBeingWritten = draft.standing.kind !== 'sending' && draft.standing.kind !== 'queued';
+
+    // Whether it may be filed, which is the same question and a deployment that answers. Attaching does not ask it:
+    // a chosen file is held here until the message is saved or sent, so it costs nothing and is offered offline.
+    const sendable = online && stillBeingWritten;
 
     const title = translate(titles[opening.kind === 'new' ? 'new' : opening.answers]);
 
@@ -366,7 +356,7 @@ export function Composer({
                 <div className="ms-auto flex items-center">
                     <DiscardConfirmation
                         edged={!wide}
-                        written={authored || draft.staged.length > 0}
+                        written={authored || draft.attached.length > 0}
                         onDiscard={() => {
                             // The same rule the keep path holds to: a deployment that refused is one the composer
                             // stays open on, because closing on it is how what somebody wrote is lost quietly.
@@ -510,11 +500,11 @@ export function Composer({
                         }}
                     />
 
-                    <StagedFiles
-                        staged={draft.staged}
+                    <AttachedFiles
+                        attached={draft.attached}
                         locale={locale}
-                        onUnstage={(attachmentId) => {
-                            void draft.unstage(attachmentId);
+                        onDetach={(attachmentId) => {
+                            void draft.detach(attachmentId);
                         }}
                     />
 
@@ -532,7 +522,7 @@ export function Composer({
 
                         <button
                             type="button"
-                            disabled={!sendable}
+                            disabled={!stillBeingWritten}
                             className="flex items-center gap-1.75 rounded-lg border border-line-strong px-3 py-2 text-sm text-text-soft transition hover:bg-hover disabled:opacity-60"
                             onClick={() => {
                                 files.current?.click();
@@ -555,7 +545,10 @@ export function Composer({
                                 const chosen = [...(event.target.files ?? [])];
 
                                 event.target.value = '';
-                                void attachInTurn(chosen);
+
+                                for (const file of chosen) {
+                                    draft.attach(file);
+                                }
                             }}
                         />
 
@@ -611,20 +604,22 @@ function BeforeAnythingIsWritten({ reading }: { readonly reading: Reading }) {
     );
 }
 
-// The files staged against the draft, drawn as the reading pane draws the files a message carries: what each one is
-// called and how large it is, before anything is fetched or sent.
-function StagedFiles({
-    staged,
+// The files the message carries, drawn as the reading pane draws the files a message already has: what each one is
+// called and how large it is, before anything is fetched or sent. Whether the deployment holds one yet is not drawn
+// and is deliberately not drawable — a file is part of the message from the moment it was chosen, and where it
+// currently sits is the hook's business rather than something its author has to follow.
+function AttachedFiles({
+    attached,
     locale,
-    onUnstage,
+    onDetach,
 }: {
-    readonly staged: readonly MailStagedAttachment[];
+    readonly attached: readonly AttachedFile[];
     readonly locale: Locale;
-    readonly onUnstage: (attachmentId: string) => void;
+    readonly onDetach: (attachmentId: string) => void;
 }) {
     const { translate } = useLocalization();
 
-    if (staged.length === 0) {
+    if (attached.length === 0) {
         return null;
     }
 
@@ -633,7 +628,7 @@ function StagedFiles({
             aria-label={translate('compose.attachedFiles')}
             className="flex shrink-0 flex-wrap gap-2 border-t border-line-soft px-4.25 py-2.5"
         >
-            {staged.map((file) => (
+            {attached.map((file) => (
                 <li
                     key={file.attachmentId}
                     className="flex items-center gap-2 rounded-xl border border-line bg-rail px-2.5 py-1.25 text-base"
@@ -647,7 +642,7 @@ function StagedFiles({
                         aria-label={translate('compose.removeFile', { name: file.fileName })}
                         className="flex items-center rounded-xs text-faint transition hover:text-text"
                         onClick={() => {
-                            onUnstage(file.attachmentId);
+                            onDetach(file.attachmentId);
                         }}
                     >
                         <Icon name="close" className="size-3.5" />

--- a/frontend/src/Client.App/src/composer/DiscardConfirmation.test.tsx
+++ b/frontend/src/Client.App/src/composer/DiscardConfirmation.test.tsx
@@ -67,7 +67,7 @@ describe('DiscardConfirmation', () => {
         const asked = screen.getByRole('dialog').textContent;
 
         expect(asked).toContain('Discard this message?');
-        expect(asked).toContain('along with the draft your deployment is holding for it');
+        expect(asked).toContain('along with any draft your deployment is already holding for it');
     });
 
     it('says that nothing files the words first, so the cost of discarding is read before it is paid', () => {

--- a/frontend/src/Client.App/src/composer/useDraftAtDeployment.ts
+++ b/frontend/src/Client.App/src/composer/useDraftAtDeployment.ts
@@ -17,7 +17,6 @@ import {
     type MailFathomTransport,
     type MailSendRefusal,
     type MailSendWithdrawal,
-    type MailStagedAttachment,
 } from '@mailfathom/client-backend';
 import { useAttachmentUpload } from '../deployment/attachmentUpload';
 import { wireComposition, type Composition } from './composition';
@@ -27,15 +26,14 @@ import { wireComposition, type Composition } from './composition';
 // the files staged against it, and what became of a send are all the deployment's, and each act is a sequence with an
 // outcome rather than a value to render.
 //
-// **Attaching and sending both need a draft the deployment holds**, because a file is staged against one and a send is
-// queued from one. So each saves first where nothing has been saved yet, which is what makes the design's two controls
-// work without a third that says "save before attaching" — and it is still a save the person asked for, because
-// attaching and sending are both acts they asked for.
+// **Two acts file the message and no others do**: saving it, and sending it. Each writes the draft the deployment
+// holds and then puts up whatever files the author chose that have not reached it yet. Choosing a file is not one of
+// them — a file somebody picked is part of what they are writing, exactly as the words are, so it is held here until
+// one of those two acts says to file the message. That is what keeps attaching offered on a deployment nobody has
+// needed yet, and it is what leaves nothing behind for closing the composer to have to delete.
 
-// Which act asked for the write, which is not the same question as which request went out: attaching and sending both
-// write the draft first, and a refusal met there is the refusal that act met. Only two words exist for one because
-// only two are true of the person — they pressed save, or they pressed send — and an attach is a save with a file
-// behind it.
+// Which act asked for the write, which is what the refusal it meets is worded as. Only two words exist because only
+// two are true of the person: they pressed save, or they pressed send.
 type DraftAct = 'save' | 'send';
 
 /** What the composer is doing about the deployment, which is one piece of state rather than a set of flags. */
@@ -51,21 +49,44 @@ export type DraftStanding =
     | { readonly kind: 'refusedSave'; readonly refusal: MailSendRefusal }
     | { readonly kind: 'failed'; readonly reason: ClientFailureReason };
 
+/**
+ * One file the message carries, as the composer draws it.
+ *
+ * It says nothing about whether the deployment has it yet, because nothing on the screen says that either: a file is
+ * part of the message from the moment it was chosen, and where it currently sits is this hook's business.
+ */
+export interface AttachedFile {
+    /** This composer's own name for it, which never changes once the file is chosen. */
+    readonly attachmentId: string;
+
+    readonly fileName: string;
+    readonly sizeOctets: number;
+}
+
+/** One chosen file as this hook holds it: the file itself, and what the deployment calls it once it has it. */
+interface HeldFile {
+    readonly attachmentId: string;
+    readonly file: File;
+
+    /** What the deployment named it when it was staged, or `null` while the deployment does not have it. */
+    readonly stagedAs: string | null;
+}
+
 /** The draft the deployment holds for what is being written, and what a person does to it. */
 export interface DraftAtDeployment {
     readonly standing: DraftStanding;
 
-    /** The files staged against it, oldest first, which is nothing until one is attached. */
-    readonly staged: readonly MailStagedAttachment[];
+    /** The files the message carries, oldest first, which is nothing until one is chosen. */
+    readonly attached: readonly AttachedFile[];
 
-    /** Files the draft in the user's own drafts folder, creating it where nothing has been saved yet. */
+    /** Files the draft in the user's own drafts folder, putting up whatever was attached and not yet staged. */
     readonly save: (composition: Composition) => Promise<boolean>;
 
-    /** Stages one file against the draft, saving it first where nothing has been saved yet. */
-    readonly attach: (composition: Composition, file: File) => Promise<void>;
+    /** Takes a chosen file into the message. Nothing leaves the client: a save or a send is what puts it up. */
+    readonly attach: (file: File) => void;
 
-    /** Takes one staged file back off. */
-    readonly unstage: (attachmentId: string) => Promise<void>;
+    /** Takes one file back off, and off the deployment as well where it had already reached it. */
+    readonly detach: (attachmentId: string) => Promise<void>;
 
     /**
      * Queues the message, saving what has been written since first, and answers what it came to.
@@ -86,24 +107,33 @@ export interface DraftAtDeployment {
      */
     readonly withdraw: () => Promise<DraftStanding>;
 
-    /** Gives the draft up, taking its copies back out of the user's drafts folder. */
+    /**
+     * Gives the draft up, taking its copies back out of the user's drafts folder.
+     *
+     * It reaches the deployment only where the deployment is actually holding something, which after the rule at the
+     * head of this file is a send that was refused or failed. Closing a composer nothing was filed for asks nothing of
+     * anybody.
+     */
     readonly discard: () => Promise<boolean>;
 }
 
 export function useDraftAtDeployment(session: ClientSession, transport: MailFathomTransport): DraftAtDeployment {
     const upload = useAttachmentUpload();
     const [standing, setStanding] = useState<DraftStanding>({ kind: 'held' });
-    const [staged, setStaged] = useState<readonly MailStagedAttachment[]>([]);
+    const [attached, setAttached] = useState<readonly AttachedFile[]>([]);
 
     // The draft the deployment holds, as a ref rather than as state: two acts in the same turn have to see the
     // identifier the first of them wrote, and nothing on the screen is drawn from it.
     const draftId = useRef<string | null>(null);
 
-    // Which change to the staged files is the newest. A save answers with the whole list the deployment holds, so
-    // one that started before a file was taken off would put that file back on the screen when it lands afterwards —
-    // the deployment having discarded it already, and the screen then saying a message carries something it does not.
-    // Every act that changes the list takes a number on the way out and writes only while it is still the newest.
-    const staging = useRef(0);
+    // The files themselves, beside the state that draws them, for the reason the standing is kept twice: a save runs
+    // through them one at a time and each round has to see what the round before it recorded, and what somebody took
+    // off while a file was going up.
+    const held = useRef<readonly HeldFile[]>([]);
+
+    // What this composer calls the next file chosen. A counter rather than a random name because nothing outside this
+    // composer ever sees it and a test should not have to fix a generator to read the list.
+    const named = useRef(0);
 
     // The save in flight, if any. `saved` reads `draftId.current` and only writes it back once its own request has
     // answered, so two acts starting inside that window would each write a draft and strand whatever the loser staged
@@ -127,6 +157,17 @@ export function useDraftAtDeployment(session: ClientSession, transport: MailFath
         setStanding(next);
 
         return next;
+    }
+
+    function holdFiles(next: readonly HeldFile[]): void {
+        held.current = next;
+        setAttached(
+            next.map(({ attachmentId, file }) => ({
+                attachmentId,
+                fileName: file.name,
+                sizeOctets: file.size,
+            })),
+        );
     }
 
     // An upload whose composer has gone is an upload nobody is waiting for, and letting it finish would stage a file
@@ -155,14 +196,13 @@ export function useDraftAtDeployment(session: ClientSession, transport: MailFath
     }
 
     async function write(composition: Composition, asked: DraftAct): Promise<string | null> {
-        const held = draftId.current;
+        const draft = draftId.current;
         const wire = wireComposition(composition);
-        const at = ++staging.current;
 
         const answer =
-            held === null
+            draft === null
                 ? await writeMailDraft(session, transport, wire)
-                : await reviseMailDraft(session, transport, held, wire);
+                : await reviseMailDraft(session, transport, draft, wire);
 
         if (answer.outcome === 'failed') {
             hold({ kind: 'failed', reason: answer.failure.reason });
@@ -185,15 +225,72 @@ export function useDraftAtDeployment(session: ClientSession, transport: MailFath
             return null;
         }
 
-        const written = answer.value.draft;
+        draftId.current = answer.value.draft.draftId;
 
-        draftId.current = written.draftId;
+        return answer.value.draft.draftId;
+    }
 
-        if (at === staging.current) {
-            setStaged(written.attachments);
+    /**
+     * Puts up every file the deployment does not have yet, oldest first, and answers whether all of them arrived.
+     *
+     * One at a time, because each is a request of its own against one draft and a failure part way through has to stop
+     * the act rather than leave the rest going up behind a message that will not be sent. The list is re-read on every
+     * round rather than walked as a snapshot: a file somebody took off while it was going up is taken off the
+     * deployment too, so nothing they removed travels with the message.
+     */
+    async function stageHeld(draft: string): Promise<boolean> {
+        for (;;) {
+            const next = held.current.find((file) => file.stagedAs === null);
+
+            if (next === undefined) {
+                return true;
+            }
+
+            hold({ kind: 'attaching', fileName: next.file.name });
+
+            const abandoning = new AbortController();
+            uploading.current = abandoning;
+
+            const answer = await stageMailDraftAttachment(
+                session,
+                draft,
+                next.file.name,
+                // What the file declares itself to be, which is what the author's own system said. A file the system
+                // could not name is the general binary type, which is what the deployment reads a request declaring
+                // none as anyway.
+                next.file.type === '' ? 'application/octet-stream' : next.file.type,
+                (request) => upload(request, next.file, abandoning.signal),
+            );
+
+            uploading.current = null;
+
+            if (answer.outcome === 'failed') {
+                hold({ kind: 'failed', reason: answer.failure.reason });
+
+                return false;
+            }
+
+            if (held.current.some((file) => file.attachmentId === next.attachmentId)) {
+                holdFiles(
+                    held.current.map((file) =>
+                        file.attachmentId === next.attachmentId
+                            ? { ...file, stagedAs: answer.value.attachmentId }
+                            : file,
+                    ),
+                );
+            } else {
+                // Taken off while it was going up. The author's act stands, so what arrived is taken back off the
+                // deployment rather than left staged against a message that would then carry it — and a removal the
+                // deployment refused stops the act, because carrying on would send a file somebody took off.
+                const removed = await unstageMailDraftAttachment(session, transport, draft, answer.value.attachmentId);
+
+                if (removed.outcome === 'failed') {
+                    hold({ kind: 'failed', reason: removed.failure.reason });
+
+                    return false;
+                }
+            }
         }
-
-        return written.draftId;
     }
 
     // Every act ends by saying what happened, and a failure says which of the five it was rather than that something
@@ -207,9 +304,9 @@ export function useDraftAtDeployment(session: ClientSession, transport: MailFath
     async function send(composition: Composition): Promise<DraftStanding> {
         hold({ kind: 'sending' });
 
-        const held = await saved(composition, 'send');
+        const draft = await saved(composition, 'send');
 
-        if (held === null) {
+        if (draft === null) {
             // The write said what stopped it and in the words of the send, so what this answers is that same
             // statement rather than a second, vaguer one made here. A stop asked while it was in flight goes with it:
             // it was asked about a message that never left.
@@ -218,7 +315,17 @@ export function useDraftAtDeployment(session: ClientSession, transport: MailFath
             return settledAs.current;
         }
 
-        const outcome = settled(await sendMailDraft(session, transport, held), (sent) => {
+        if (!(await stageHeld(draft))) {
+            // A message goes out whole or not at all: a file that did not arrive is one the reader would never know
+            // was meant to be there, so the send stops on it and the draft stays where the author can try again.
+            stopping.current = false;
+
+            return settledAs.current;
+        }
+
+        hold({ kind: 'sending' });
+
+        const outcome = settled(await sendMailDraft(session, transport, draft), (sent) => {
             if (!sent.queued) {
                 return { kind: 'refused', refusal: sent.refusal };
             }
@@ -259,12 +366,14 @@ export function useDraftAtDeployment(session: ClientSession, transport: MailFath
 
     return {
         standing,
-        staged,
+        attached,
 
         save: async (composition) => {
             hold({ kind: 'saving' });
 
-            if ((await saved(composition, 'save')) === null) {
+            const draft = await saved(composition, 'save');
+
+            if (draft === null || !(await stageHeld(draft))) {
                 return false;
             }
 
@@ -273,54 +382,32 @@ export function useDraftAtDeployment(session: ClientSession, transport: MailFath
             return true;
         },
 
-        attach: async (composition, file) => {
-            hold({ kind: 'attaching', fileName: file.name });
+        attach: (file) => {
+            named.current += 1;
 
-            const held = await saved(composition, 'save');
-
-            if (held === null) {
-                return;
-            }
-
-            const abandoning = new AbortController();
-            uploading.current = abandoning;
-
-            const answer = await stageMailDraftAttachment(
-                session,
-                held,
-                file.name,
-                // What the file declares itself to be, which is what the author's own system said. A file the system
-                // could not name is the general binary type, which is what the deployment reads a request declaring
-                // none as anyway.
-                file.type === '' ? 'application/octet-stream' : file.type,
-                (request) => upload(request, file, abandoning.signal),
-            );
-
-            uploading.current = null;
-
-            settled(answer, (attachment) => {
-                setStaged((already) => [...already, attachment]);
-
-                return { kind: 'held' };
-            });
+            holdFiles([...held.current, { attachmentId: String(named.current), file, stagedAs: null }]);
         },
 
-        unstage: async (attachmentId) => {
-            const held = draftId.current;
+        detach: async (attachmentId) => {
+            const going = held.current.find((file) => file.attachmentId === attachmentId);
 
-            if (held === null) {
+            if (going === undefined) {
                 return;
             }
 
-            const at = ++staging.current;
+            // Off the screen first: the author asked for it, and what the deployment still holds is this hook's
+            // business rather than something they should watch happen.
+            holdFiles(held.current.filter((file) => file.attachmentId !== attachmentId));
 
-            settled(await unstageMailDraftAttachment(session, transport, held, attachmentId), () => {
-                if (at === staging.current) {
-                    setStaged((already) => already.filter((file) => file.attachmentId !== attachmentId));
-                }
+            const draft = draftId.current;
 
-                return { kind: 'held' };
-            });
+            if (going.stagedAs === null || draft === null) {
+                return;
+            }
+
+            settled(await unstageMailDraftAttachment(session, transport, draft, going.stagedAs), () => ({
+                kind: 'held',
+            }));
         },
 
         send,
@@ -331,13 +418,13 @@ export function useDraftAtDeployment(session: ClientSession, transport: MailFath
             // one it leaves behind because the identifier had not landed yet.
             await saving.current;
 
-            const held = draftId.current;
+            const draft = draftId.current;
 
-            if (held === null) {
+            if (draft === null) {
                 return true;
             }
 
-            const answer = await discardMailDraft(session, transport, held);
+            const answer = await discardMailDraft(session, transport, draft);
 
             if (answer.outcome === 'failed') {
                 // Said rather than swallowed: closing on a refused delete would tell somebody their words are gone

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -379,7 +379,8 @@ export const en = {
     'compose.cautionNoSubject': 'It goes out without a subject.',
     'compose.cautionNoWords': 'It goes out with nothing written in it.',
     'compose.discardQuestion': 'Discard this message?',
-    'compose.discardExplanation': 'What you have written goes, along with the draft your deployment is holding for it.',
+    'compose.discardExplanation':
+        'What you have written goes, along with any draft your deployment is already holding for it.',
     'compose.discardIsFinal': 'Nothing files it first, so there is no way back to these words.',
     'compose.discard': 'Discard',
     'compose.saving': 'Filing the draft…',

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -382,7 +382,7 @@ export const pl: Catalogue = {
     'compose.cautionNoWords': 'Wiadomość pójdzie bez treści.',
     'compose.discardQuestion': 'Odrzucić tę wiadomość?',
     'compose.discardExplanation':
-        'To, co zostało napisane, przepadnie razem ze szkicem, który trzyma dla niej Twoje wdrożenie.',
+        'To, co zostało napisane, przepadnie razem ze szkicem, który Twoje wdrożenie zdążyło już dla niej zapisać.',
     'compose.discardIsFinal': 'Nic jej wcześniej nie zapisze, więc do tego tekstu nie ma powrotu.',
     'compose.discard': 'Odrzuć',
     'compose.saving': 'Zapisujemy szkic…',

--- a/frontend/src/Client.App/src/styles.css
+++ b/frontend/src/Client.App/src/styles.css
@@ -495,25 +495,32 @@
    threshold makes. Each is a duration and a curve together rather than two utilities on the element, for the reason
    the token block gives about motion being decided once — and the durations are here rather than in the theme because
    nothing else in the client is timed against them. `prefers-reduced-motion` removes all three by the rule at the foot
-   of this file, which leaves the panel arriving at where it was going without travelling there. */
+   of this file, which leaves the panel arriving at where it was going without travelling there.
+
+   `translate` is named beside `transform` because the two are separate properties and the panel uses both: a position
+   written as a `translate-y-*` or `-translate-x-*` utility is the `translate` property, while a position measured under
+   a finger and written as an inline style is a `transform`. A list naming only the second watches a property those
+   utilities never set, so the panel arrives at its open position in one frame — which is the whole of what a missing
+   motion looks like from the outside. */
 @utility motion-sheet {
-    /* `display` and `overlay` are in the list beside the transform because a dialog is taken out of the document and
-       off the top layer the moment it is closed, so a panel that travelled away without them would vanish instead. */
-    transition-property: transform, opacity, display, overlay;
+    /* `display` and `overlay` are in the list beside the two position properties because a dialog is taken out of the
+       document and off the top layer the moment it is closed, so a panel that travelled away without them would vanish
+       instead. */
+    transition-property: translate, transform, opacity, display, overlay;
     transition-duration: 300ms;
     transition-timing-function: var(--ease-sheet);
     transition-behavior: allow-discrete;
 }
 
 @utility motion-panel {
-    transition-property: transform, opacity, display, overlay;
+    transition-property: translate, transform, opacity, display, overlay;
     transition-duration: 260ms;
     transition-timing-function: var(--ease-panel);
     transition-behavior: allow-discrete;
 }
 
 @utility motion-spring {
-    transition-property: transform, opacity;
+    transition-property: translate, transform, opacity;
     transition-duration: 260ms;
     transition-timing-function: var(--ease-sheet);
 }


### PR DESCRIPTION
Closes #1795

Three defects in the client, one of which caused two of the three reports.

## Attaching a file is local, and so is closing on it

`attach` in `useDraftAtDeployment.ts` wrote a draft into the user's drafts folder before it staged the
chosen file against it, so pressing **Attach** against a deployment that did not answer reported *Your
deployment did not answer* over a message nobody had asked to file — and it left a draft identifier
behind, which is what made the next press of **Discard** issue a delete and report the same failure
over an act that is local by definition. One cause, both reports.

The hook now holds the chosen files itself and puts them up at the two acts that say *file this
message*: **Save draft** and **Send**. Each writes the draft and then stages, oldest first, whatever
the deployment does not already have. Three things follow, and each is a test:

- Choosing a file issues nothing at all, so attaching is offered offline as readily as online — the
  control is now refused only while a message is being sent or is queued, rather than by the same
  `sendable` a save asks.
- Taking a file off before it reached the deployment issues nothing either; taking one off after it
  did also unstages it there. The second case is still reachable — a save whose first file arrived
  and whose second did not leaves the composer standing over both.
- A file taken off *while* the save is putting it up is unstaged at the deployment rather than sent,
  and a removal the deployment refuses stops the act instead of letting the message carry a file its
  author removed.

`Discard` is unchanged and still deletes a draft the deployment is holding. What changed is that
nothing creates one implicitly any more, so in every path the report described no request goes out.
`compose.discardExplanation` moved with it — it promised *the* draft the deployment is holding, which
is now usually none, and says *any* draft it has already saved.

## The notification centre travels

`motion-sheet`, `motion-panel`, and `motion-spring` transitioned `transform`, while the panel's closed
and open positions are written with the `translate-y-*` and `-translate-x-*` utilities — and Tailwind
v4 emits those as the standalone **`translate`** property, not as a `transform`. The transition was
live at its full duration and watching a property the panel never sets, so it arrived in one frame.

Measured in Chromium against the built stylesheet, on the panel's own class list:

| | before | after |
|---|---|---|
| ~30 ms | `translate: none` | `translate: 0px 100%` |
| 150 ms | `translate: none` | `translate: 0px 6.27%` |
| 500 ms | `translate: none` | `translate: 0px` |

Both properties are named now rather than one swapped for the other: the same element carries an
inline `transform` for the swipe offset under a finger, so the sheet, the panel and the spring back
each need both.

## The loading skeletons: measured, and nothing found to fix

The third report was that the skeleton animation does not work. It was measured on the running client
under a six second fixture latency rather than reasoned about, and it does: the message list draws 24
shimmering blocks, the reading pane 12, and the full HTML surface 9, each with the `shimmering`
animation live and its `background-position` travelling, in a browser reporting
`prefers-reduced-motion` as false. The attachment preview shares the same two components and cannot be
reached from the fixture corpus, which answers no file octets.

Nothing in this change touches them. The rule at the foot of `styles.css` freezes every animation in
the client under `prefers-reduced-motion: reduce`, which is an accessibility obligation rather than a
defect and which the design's own prototype does not honour — so a still skeleton is most likely being
read under that preference. #1795 says the same and carries it as out of scope; a separate issue
follows if it is reproduced under a browser that does not.

## Verification

`scripts/verify-full.sh`, and the client suite in full. The four behaviours above are covered in
`Composer.test.tsx`: attaching without a request, discarding without a request, one draft carrying
every file a save puts up, and a file taken off mid-upload not surviving it.
