### PR TITLE
[#1799] Assert the tree and the download the client actually draws

### DIFF
--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -854,22 +854,31 @@ test('keeps the folder tree as it was left, across a reload', async ({ page }) =
     await openSignedIn(page, '/#/mail');
 
     const tree = page.getByRole('tree', { name: 'Mailboxes and folders' });
-    const everyMailbox = tree.getByRole('treeitem', { name: /^All mailboxes/ });
-
-    await everyMailbox.click();
-    await page.keyboard.press('ArrowLeft');
-    await expect(everyMailbox).toHaveAttribute('aria-expanded', 'false');
-
     const nested = tree.getByRole('treeitem', { name: /^2024/ });
+
     await nested.click();
     await expect(nested).toHaveAttribute('aria-selected', 'true');
+
+    // The level the corpus nests that folder under, folded away with it. The corpus holds one mailbox, which is a
+    // user the tree offers no row spanning every mailbox to, so what folds here is a level of a folder's own path.
+    const above = tree.getByRole('treeitem', { name: /^Archive/ });
+
+    await above.click();
+    await page.keyboard.press('ArrowLeft');
+    await expect(above).toHaveAttribute('aria-expanded', 'false');
 
     await page.reload();
 
     // A reload is a cold start, so what somebody was looking at is kept where the credential is kept and read back the
     // same way. Only a real document reloaded proves it was written rather than held: a remount in jsdom re-reads the
     // same process's storage, and what this asks is that a browser wrote it.
-    await expect(tree.getByRole('treeitem', { name: /^All mailboxes/ })).toHaveAttribute('aria-expanded', 'false');
+    const foldedAgain = tree.getByRole('treeitem', { name: /^Archive/ });
+
+    await expect(foldedAgain).toHaveAttribute('aria-expanded', 'false');
+
+    // The scope outlives the fold that hid the row standing for it, which is the other half of what was left here.
+    await foldedAgain.click();
+    await page.keyboard.press('ArrowRight');
     await expect(tree.getByRole('treeitem', { name: /^2024/ })).toHaveAttribute('aria-selected', 'true');
 });
 
@@ -980,7 +989,7 @@ test('describes an attached file before it is fetched, and fetches it only when 
 
     // The file reaches the person as a file rather than as a page, which is a browser event and nothing jsdom has.
     expect((await offered).suggestedFilename()).toBe('orders.csv');
-    await expect(page.getByText('orders.csv was downloaded.')).toBeVisible();
+    await expect(page.getByText('File downloaded')).toBeVisible();
 });
 
 test('opens an attached file inside the client rather than handing it to the machine', async ({ page }) => {


### PR DESCRIPTION
The browser suite has been red on `main` since #1790 and doubly red since #1791, both merged with the
failure already standing in their own pull request runs. Nothing in either is a defect in the client: two
tests kept asserting a shape the client deliberately stopped drawing, and no local gate runs the browser
suite, so the only place that says so is `CI` after the merge.

**The folder tree.** `keeps the folder tree as it was left, across a reload` folded the row spanning every
mailbox. #1790 decided that a user holding exactly one mailbox is offered no such row — it would draw that
account's folders a second time under a heading meaning the same thing — and the corpus holds exactly one
mailbox, so the row is not drawn and the click waited out the whole 30 s timeout. What folds now is a level
of a folder's own path, the corpus's `Archive` over `2024`, which is a row that mailbox actually has. The
test still asserts both halves of what was left: the fold survives the reload, and so does the scope, which
is read back by opening the level again — a scope whose row is folded away is still a scope somebody chose,
and that is the part a shorter test would have quietly stopped proving.

**The download.** `describes an attached file before it is fetched…` waited for *orders.csv was
downloaded.* #1791 moved a finished download from a line under the words to a task reported from the
corner, so the client says *File downloaded* over the file's name and the old sentence exists nowhere. The
assertion reads the corner.

No production source moved, and the fixtures did not either: both changes are in
`frontend/tests/client.spec.ts`.

## Verification

- `pnpm --dir frontend build && pnpm --dir frontend exec playwright test` — 53 passed. Five unrelated
  navigation tests failed on the first parallel run under load and passed on a serial re-run, which is the
  known flake shape rather than anything this branch touches.
- `scripts/verify-fast.sh` — passed.
- `$check-docs-licenses` — `n/a`: no dependency, service, image, model, generated asset, or copied code
  moved, and the file already carries its licensing header.

Closes #1799
