### PR TITLE
[#1807] Bring an authored mailbox change's run forward, and keep the client's own screen through a reconnect

### DIFF
--- a/backend/src/Application/Mail/Mutations/Authoring/MailDeletionRecorder.cs
+++ b/backend/src/Application/Mail/Mutations/Authoring/MailDeletionRecorder.cs
@@ -5,6 +5,7 @@
 using MailFathom.Application.Access;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Persistence;
+using MailFathom.Application.Synchronization;
 using MailFathom.Domain.Access;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Mutations;
@@ -46,6 +47,7 @@ public sealed class MailDeletionRecorder
     private readonly IAuthoredDeleteEmailDispositionReader deleteDispositions;
     private readonly IMailboxMutationRecordStore records;
     private readonly OptimisticConcurrencyRetryPolicy commitPolicy;
+    private readonly MailAccountRunSignal runSignal;
 
     /// <summary>Initializes the use case over the grant it asks first, the email it is about, and the record it writes.</summary>
     /// <param name="authorization">Answers which principal reached this use case.</param>
@@ -54,6 +56,7 @@ public sealed class MailDeletionRecorder
     /// <param name="deleteDispositions">Answers what the account keeps locally of mail the server has let go of.</param>
     /// <param name="records">Opens the durable record the delete is carried by.</param>
     /// <param name="commitPolicy">Commits the record, retrying an optimistic conflict.</param>
+    /// <param name="runSignal">Brings the account's next synchronization run forward, which is what carries the delete to the mail server.</param>
     /// <exception cref="ArgumentNullException">Thrown when a required collaborator is <see langword="null" />.</exception>
     public MailDeletionRecorder(
         AccessAuthorization authorization,
@@ -61,7 +64,8 @@ public sealed class MailDeletionRecorder
         IAuthoredMailboxTargetReader targets,
         IAuthoredDeleteEmailDispositionReader deleteDispositions,
         IMailboxMutationRecordStore records,
-        OptimisticConcurrencyRetryPolicy commitPolicy)
+        OptimisticConcurrencyRetryPolicy commitPolicy,
+        MailAccountRunSignal runSignal)
     {
         ArgumentNullException.ThrowIfNull(authorization);
         ArgumentNullException.ThrowIfNull(scopeResolver);
@@ -69,6 +73,7 @@ public sealed class MailDeletionRecorder
         ArgumentNullException.ThrowIfNull(deleteDispositions);
         ArgumentNullException.ThrowIfNull(records);
         ArgumentNullException.ThrowIfNull(commitPolicy);
+        ArgumentNullException.ThrowIfNull(runSignal);
 
         this.authorization = authorization;
         this.scopeResolver = scopeResolver;
@@ -76,6 +81,7 @@ public sealed class MailDeletionRecorder
         this.deleteDispositions = deleteDispositions;
         this.records = records;
         this.commitPolicy = commitPolicy;
+        this.runSignal = runSignal;
     }
 
     /// <summary>Writes down one delete, against the email a caller named.</summary>
@@ -124,6 +130,11 @@ public sealed class MailDeletionRecorder
         var record = await this.commitPolicy.CommitAsync(
             (session, attemptCancellationToken) => this.records.OpenAsync(session, request, attemptCancellationToken),
             cancellationToken);
+
+        // Raised once the record is durable, for the reason MailFlagChangeRecorder gives: the run reads the records
+        // rather than the raise. A delete waits on the convergence pass exactly as a move does, so it waits on the
+        // same raise.
+        this.runSignal.BringForward(target.Occurrence.AccountId);
 
         return AuthoredMailDeletionResult.Recorded(record.Id, record.Lifecycle);
     }

--- a/backend/src/Application/Mail/Mutations/Authoring/MailFlagChangeRecorder.cs
+++ b/backend/src/Application/Mail/Mutations/Authoring/MailFlagChangeRecorder.cs
@@ -6,6 +6,7 @@ using MailFathom.Application.Access;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Mail.Mutations.Authoring.Failures;
 using MailFathom.Application.Persistence;
+using MailFathom.Application.Synchronization;
 using MailFathom.Domain.Access;
 using MailFathom.Domain.Mutations;
 
@@ -47,6 +48,7 @@ public sealed class MailFlagChangeRecorder
     private readonly IAuthoredMailboxTargetReader targets;
     private readonly IMailboxMutationRecordStore records;
     private readonly OptimisticConcurrencyRetryPolicy commitPolicy;
+    private readonly MailAccountRunSignal runSignal;
 
     /// <summary>Initializes the use case over the grant it asks first and the record it writes.</summary>
     /// <param name="authorization">Answers which principal reached this use case.</param>
@@ -54,25 +56,29 @@ public sealed class MailFlagChangeRecorder
     /// <param name="targets">Answers where the named email currently is.</param>
     /// <param name="records">Opens the durable record one change is carried by.</param>
     /// <param name="commitPolicy">Commits a call's records together, retrying an optimistic conflict.</param>
+    /// <param name="runSignal">Brings the account's next synchronization run forward, which is what carries the change to the mail server.</param>
     /// <exception cref="ArgumentNullException">Thrown when a required collaborator is <see langword="null" />.</exception>
     public MailFlagChangeRecorder(
         AccessAuthorization authorization,
         MailboxScopeResolver scopeResolver,
         IAuthoredMailboxTargetReader targets,
         IMailboxMutationRecordStore records,
-        OptimisticConcurrencyRetryPolicy commitPolicy)
+        OptimisticConcurrencyRetryPolicy commitPolicy,
+        MailAccountRunSignal runSignal)
     {
         ArgumentNullException.ThrowIfNull(authorization);
         ArgumentNullException.ThrowIfNull(scopeResolver);
         ArgumentNullException.ThrowIfNull(targets);
         ArgumentNullException.ThrowIfNull(records);
         ArgumentNullException.ThrowIfNull(commitPolicy);
+        ArgumentNullException.ThrowIfNull(runSignal);
 
         this.authorization = authorization;
         this.scopeResolver = scopeResolver;
         this.targets = targets;
         this.records = records;
         this.commitPolicy = commitPolicy;
+        this.runSignal = runSignal;
     }
 
     /// <summary>Writes down every value one change asks for, against the email it names.</summary>
@@ -136,6 +142,12 @@ public sealed class MailFlagChangeRecorder
                 }
             },
             cancellationToken);
+
+        // Raised once the records are durable, and never before: the run this brings forward reads the records rather
+        // than the raise, so a raise ahead of the commit would be a run that found nothing and a change that then waited
+        // out the interval anyway. It is a hint and nothing is done about it failing — the account's own schedule is
+        // what makes the change correct, and this only decides whether it is prompt.
+        this.runSignal.BringForward(target.Occurrence.AccountId);
 
         return new AuthoredMailFlagChangeResult(
             change.StoredEmailId,

--- a/backend/src/Application/Mail/Mutations/Authoring/MailRelocationRecorder.cs
+++ b/backend/src/Application/Mail/Mutations/Authoring/MailRelocationRecorder.cs
@@ -6,6 +6,7 @@ using MailFathom.Application.Access;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Mail.Mutations.Destinations;
 using MailFathom.Application.Persistence;
+using MailFathom.Application.Synchronization;
 using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
@@ -51,6 +52,7 @@ public sealed class MailRelocationRecorder
     private readonly IAuthoredDeleteEmailDispositionReader deleteDispositions;
     private readonly IMailboxMutationRecordStore records;
     private readonly OptimisticConcurrencyRetryPolicy commitPolicy;
+    private readonly MailAccountRunSignal runSignal;
 
     /// <summary>Initializes the use case over the grant it asks first, the folder it files into, and the record it writes.</summary>
     /// <param name="authorization">Answers which principal reached this use case.</param>
@@ -60,6 +62,7 @@ public sealed class MailRelocationRecorder
     /// <param name="deleteDispositions">Answers what the account keeps locally of mail that leaves the mirror for good.</param>
     /// <param name="records">Opens the durable record the move is carried by.</param>
     /// <param name="commitPolicy">Commits the record, retrying an optimistic conflict.</param>
+    /// <param name="runSignal">Brings the account's next synchronization run forward, which is what carries the move to the mail server.</param>
     /// <exception cref="ArgumentNullException">Thrown when a required collaborator is <see langword="null" />.</exception>
     public MailRelocationRecorder(
         AccessAuthorization authorization,
@@ -68,7 +71,8 @@ public sealed class MailRelocationRecorder
         MailboxDestinationResolver destinations,
         IAuthoredDeleteEmailDispositionReader deleteDispositions,
         IMailboxMutationRecordStore records,
-        OptimisticConcurrencyRetryPolicy commitPolicy)
+        OptimisticConcurrencyRetryPolicy commitPolicy,
+        MailAccountRunSignal runSignal)
     {
         ArgumentNullException.ThrowIfNull(authorization);
         ArgumentNullException.ThrowIfNull(scopeResolver);
@@ -77,6 +81,7 @@ public sealed class MailRelocationRecorder
         ArgumentNullException.ThrowIfNull(deleteDispositions);
         ArgumentNullException.ThrowIfNull(records);
         ArgumentNullException.ThrowIfNull(commitPolicy);
+        ArgumentNullException.ThrowIfNull(runSignal);
 
         this.authorization = authorization;
         this.scopeResolver = scopeResolver;
@@ -85,6 +90,7 @@ public sealed class MailRelocationRecorder
         this.deleteDispositions = deleteDispositions;
         this.records = records;
         this.commitPolicy = commitPolicy;
+        this.runSignal = runSignal;
     }
 
     /// <summary>Writes down one move, against the email and the folder a caller named.</summary>
@@ -173,6 +179,10 @@ public sealed class MailRelocationRecorder
         var record = await this.commitPolicy.CommitAsync(
             (session, attemptCancellationToken) => this.records.OpenAsync(session, request, attemptCancellationToken),
             cancellationToken);
+
+        // Raised once the record is durable, for the reason MailFlagChangeRecorder gives: the run reads the records
+        // rather than the raise.
+        this.runSignal.BringForward(target.Occurrence.AccountId);
 
         return AuthoredMailRelocationResult.Recorded(folder.Alias, record.Id, record.Lifecycle);
     }

--- a/backend/src/Application/Synchronization/MailAccountRunSignal.cs
+++ b/backend/src/Application/Synchronization/MailAccountRunSignal.cs
@@ -1,0 +1,157 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Concurrent;
+using MailFathom.Domain.Accounts;
+
+namespace MailFathom.Application.Synchronization;
+
+/// <summary>Ends an account's wait between synchronization runs, where something written here is waiting on that run.</summary>
+/// <remarks>
+/// <para>
+/// It exists because of latency and nothing else, exactly as the outbox's own signal does. A mailbox change somebody
+/// authored is written down durably, and the account's next run is what tells the mail server; that run is what makes
+/// the change correct, and it happens whether or not anything here is called. What it cannot do is happen promptly —
+/// the wait between runs is the configured interval, and where the account is watched in push mode that wait ends only
+/// when the mail *server* reports something, which a change authored here is not. So a message somebody deleted stayed
+/// under <i>moving to trash</i> until the interval was out.
+/// </para>
+/// <para>
+/// A raise is therefore a hint rather than a queue entry: it is never awaited, never retried, and losing one delays a
+/// change rather than dropping it. Nothing carries what the change was, because the run reads the records.
+/// </para>
+/// <para>
+/// A raise arriving while nothing is waiting is kept, which is the case that has to be right rather than a corner: the
+/// record is often written while the account is mid-run, and a raise dropped there would be a change waiting out the
+/// whole of the next interval. It is kept per account rather than per change, so a hundred messages filed at once bring
+/// one run forward instead of a hundred, and it is spent by the wait that takes it — a raise never survives into a
+/// second wait, which would be a run brought forward for work already done.
+/// </para>
+/// </remarks>
+public sealed class MailAccountRunSignal
+{
+    private readonly ConcurrentDictionary<MailAccountId, AccountWait> accounts = new();
+
+    /// <summary>Says that an account has something written down that its next run should not wait an interval for.</summary>
+    /// <param name="account">The account whose run is worth bringing forward.</param>
+    public void BringForward(MailAccountId account) => this.WaitFor(account).BringForward();
+
+    /// <summary>Registers the wait an account is about to make, so a raise can end it.</summary>
+    /// <param name="account">The account about to wait.</param>
+    /// <param name="stopping">Ends the wait for the other reason it ends — the host having stopped scheduling.</param>
+    /// <returns>The wait, whose token the caller waits under and which the caller disposes when the wait is over.</returns>
+    /// <remarks>
+    /// A raise that arrived while nothing was registered is spent here, so the token comes back already cancelled and
+    /// the wait ends without starting. That is what carries a change written during a run into the run after it rather
+    /// than the one after that.
+    /// </remarks>
+    public Wait Register(MailAccountId account, CancellationToken stopping) =>
+        this.WaitFor(account).Register(stopping);
+
+    private AccountWait WaitFor(MailAccountId account) =>
+        this.accounts.GetOrAdd(account, static _ => new AccountWait());
+
+    /// <summary>One registered wait, as the thing that ends it.</summary>
+    /// <remarks>
+    /// Nested because what it holds is one account's registration, which is this class's own state and nothing another
+    /// type has business naming. Telling the two endings apart is the caller's and it is one question: a wait that
+    /// ended while scheduling continues ended because something local asked for the run.
+    /// </remarks>
+    public sealed class Wait : IDisposable
+    {
+        private readonly AccountWait waiting;
+        private readonly CancellationTokenSource ending;
+
+        internal Wait(AccountWait waiting, CancellationTokenSource ending)
+        {
+            this.waiting = waiting;
+            this.ending = ending;
+        }
+
+        /// <summary>Gets the token the wait is made under, cancelled by a raise or by whatever it was linked to.</summary>
+        public CancellationToken Token => this.ending.Token;
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// Taking the registration off is what makes the next raise a kept one rather than a cancellation of a source
+        /// nobody is waiting on — which would be a raise spent on nothing and a change waiting out the interval it was
+        /// raised to avoid.
+        /// </remarks>
+        public void Dispose()
+        {
+            this.waiting.Unregister(this.ending);
+            this.ending.Dispose();
+        }
+    }
+
+    /// <summary>One account's registered wait and whether a raise is standing unspent against it.</summary>
+    internal sealed class AccountWait
+    {
+        private readonly Lock gate = new();
+        private CancellationTokenSource? registered;
+        private bool raised;
+
+        internal void BringForward()
+        {
+            CancellationTokenSource? waiting;
+
+            lock (this.gate)
+            {
+                waiting = this.registered;
+
+                if (waiting is null)
+                {
+                    this.raised = true;
+
+                    return;
+                }
+
+                // Taken off here rather than when it is disposed, so this raise is the one that ends this wait and a
+                // second raise arriving behind it is kept for the wait after rather than cancelling the same source.
+                this.registered = null;
+            }
+
+            // Cancelled outside the lock, because a cancellation callback runs on the thread that cancels and this one
+            // is on the path a person's own request returns through.
+            waiting.Cancel();
+        }
+
+        internal Wait Register(CancellationToken stopping)
+        {
+            var ending = CancellationTokenSource.CreateLinkedTokenSource(stopping);
+            var alreadyRaised = false;
+
+            lock (this.gate)
+            {
+                if (this.raised)
+                {
+                    this.raised = false;
+                    alreadyRaised = true;
+                }
+                else
+                {
+                    this.registered = ending;
+                }
+            }
+
+            if (alreadyRaised)
+            {
+                ending.Cancel();
+            }
+
+            return new Wait(this, ending);
+        }
+
+        internal void Unregister(CancellationTokenSource ending)
+        {
+            lock (this.gate)
+            {
+                if (ReferenceEquals(this.registered, ending))
+                {
+                    this.registered = null;
+                }
+            }
+        }
+    }
+}

--- a/backend/src/Application/Synchronization/MailAccountRunSignal.cs
+++ b/backend/src/Application/Synchronization/MailAccountRunSignal.cs
@@ -60,28 +60,41 @@ public sealed class MailAccountRunSignal
     /// </remarks>
     public sealed class Wait : IDisposable
     {
-        private readonly AccountWait waiting;
+        private readonly AccountWait? registration;
         private readonly CancellationTokenSource ending;
 
-        internal Wait(AccountWait waiting, CancellationTokenSource ending)
+        /// <summary>Holds one wait, and where it is registered decides what ends the source behind it.</summary>
+        /// <param name="registration">The account this wait is registered against, or <see langword="null" /> where a standing raise was spent instead of registering it — in which case nothing else can reach the source and this wait ends it itself.</param>
+        /// <param name="ending">The source the wait is made under.</param>
+        internal Wait(AccountWait? registration, CancellationTokenSource ending)
         {
-            this.waiting = waiting;
+            this.registration = registration;
             this.ending = ending;
+
+            // Read once rather than on demand: a raise that takes this wait disposes the source it took, and a token
+            // stays readable after its source is disposed while the source itself does not.
+            this.Token = ending.Token;
         }
 
         /// <summary>Gets the token the wait is made under, cancelled by a raise or by whatever it was linked to.</summary>
-        public CancellationToken Token => this.ending.Token;
+        public CancellationToken Token { get; }
 
         /// <inheritdoc />
         /// <remarks>
-        /// Taking the registration off is what makes the next raise a kept one rather than a cancellation of a source
+        /// Giving the registration back is what makes the next raise a kept one rather than a cancellation of a source
         /// nobody is waiting on — which would be a raise spent on nothing and a change waiting out the interval it was
-        /// raised to avoid.
+        /// raised to avoid. A raise that got there first owns the source instead, so this ends without disposing it.
         /// </remarks>
         public void Dispose()
         {
-            this.waiting.Unregister(this.ending);
-            this.ending.Dispose();
+            if (this.registration is null)
+            {
+                this.ending.Dispose();
+
+                return;
+            }
+
+            this.registration.Release(this.ending);
         }
     }
 
@@ -94,64 +107,70 @@ public sealed class MailAccountRunSignal
 
         internal void BringForward()
         {
-            CancellationTokenSource? waiting;
+            CancellationTokenSource? claimed;
 
             lock (this.gate)
             {
-                waiting = this.registered;
+                claimed = this.registered;
 
-                if (waiting is null)
+                if (claimed is null)
                 {
                     this.raised = true;
 
                     return;
                 }
 
-                // Taken off here rather than when it is disposed, so this raise is the one that ends this wait and a
-                // second raise arriving behind it is kept for the wait after rather than cancelling the same source.
+                // Taken off here rather than when the wait is disposed, so this raise is the one that ends this wait,
+                // a second raise arriving behind it is kept for the wait after rather than cancelling the same source,
+                // and the wait that held it stops owning it — which is what makes the two lines below safe outside the
+                // gate rather than a race against that wait's own disposal.
                 this.registered = null;
             }
 
-            // Cancelled outside the lock, because a cancellation callback runs on the thread that cancels and this one
-            // is on the path a person's own request returns through.
-            waiting.Cancel();
+            // Cancelled outside the gate, because a cancellation callback runs on the thread that cancels: this one is
+            // on the path a person's own request returns through, and a run woken here must not resume holding the
+            // account's gate.
+            claimed.Cancel();
+            claimed.Dispose();
         }
 
         internal Wait Register(CancellationToken stopping)
         {
             var ending = CancellationTokenSource.CreateLinkedTokenSource(stopping);
-            var alreadyRaised = false;
 
             lock (this.gate)
             {
-                if (this.raised)
-                {
-                    this.raised = false;
-                    alreadyRaised = true;
-                }
-                else
+                if (!this.raised)
                 {
                     this.registered = ending;
+
+                    return new Wait(this, ending);
                 }
+
+                this.raised = false;
             }
 
-            if (alreadyRaised)
-            {
-                ending.Cancel();
-            }
+            // Nothing holds this token yet, so spending the raise runs no callback, and nothing was registered, so no
+            // raise can reach the source: the wait it is handed to is the only thing that ends it.
+            ending.Cancel();
 
-            return new Wait(this, ending);
+            return new Wait(registration: null, ending);
         }
 
-        internal void Unregister(CancellationTokenSource ending)
+        internal void Release(CancellationTokenSource ending)
         {
             lock (this.gate)
             {
-                if (ReferenceEquals(this.registered, ending))
+                if (!ReferenceEquals(this.registered, ending))
                 {
-                    this.registered = null;
+                    // A raise claimed it and owns what becomes of it.
+                    return;
                 }
+
+                this.registered = null;
             }
+
+            ending.Dispose();
         }
     }
 }

--- a/backend/src/Host/Api/ClientDraftEndpoints.cs
+++ b/backend/src/Host/Api/ClientDraftEndpoints.cs
@@ -90,6 +90,15 @@ internal static class ClientDraftEndpoints
     /// </remarks>
     internal const int MaxWriteRequestBytes = 2 * 1024 * 1024;
 
+    /// <summary>What the upload route declares it takes, which is octets of whatever the file says it is.</summary>
+    /// <remarks>
+    /// The declared type is recorded against the file rather than checked, because what an author attaches is theirs to
+    /// name and this deployment stages it either way. Naming one type here instead would be enforced rather than
+    /// documented: the routing pipeline answers <c>415</c> to a request declaring anything the metadata does not list,
+    /// so a single concrete type refuses every file whose system could name it and admits only the ones it could not.
+    /// </remarks>
+    internal const string AnyUploadedMediaType = "*/*";
+
     /// <summary>Maps the draft routes into the client group, so they inherit its requirement, its policy, and its limits.</summary>
     /// <param name="api">The client route group.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="api" /> is <see langword="null" />.</exception>
@@ -134,7 +143,7 @@ internal static class ClientDraftEndpoints
 
         api.MapPost(DraftAttachmentsRoute, StageAttachmentAsync)
             .WithMetadata(new RequestSizeLimitAttribute(uploadLimit))
-            .Accepts<Stream>(AttachmentContentResponse.FallbackMediaType)
+            .Accepts<Stream>(AnyUploadedMediaType)
             .RequirePermission(MailFathomPermission.MailDraftsWrite);
 
         api.MapDelete(DraftAttachmentRoute, UnstageAttachmentAsync)

--- a/backend/src/Host/Api/ClientTelemetryEndpoint.cs
+++ b/backend/src/Host/Api/ClientTelemetryEndpoint.cs
@@ -5,6 +5,7 @@
 using System.Globalization;
 using MailFathom.Application.Access;
 using MailFathom.Host.Observability.ClientTelemetry;
+using MailFathom.Host.Security.Basic;
 using MailFathom.Host.Security.Endpoints;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Net.Http.Headers;
@@ -124,6 +125,12 @@ internal static class ClientTelemetryEndpoint
                 // reach it: it implements IRequestSizeLimitMetadata, so a body over the bound is stopped by the request
                 // body feature instead of being buffered here first.
                 .WithMetadata(new RequestSizeLimitAttribute(MaxRequestBytes))
+
+                // The one route family on this surface a browser reaches without the client having composed the call.
+                // The exporter builds its own request and takes no option for the credentials mode, so it defaults to
+                // sending them — and a refusal naming the password method then opens the browser's own dialog over
+                // somebody's mail. NoPasswordChallenge is what leaves the bearer challenge alone there.
+                .WithMetadata(NoPasswordChallenge.Instance)
                 .Accepts<Stream>(ClientTelemetryForwarder.ProtobufMediaType)
                 .Produces<Stream>(StatusCodes.Status200OK, ClientTelemetryForwarder.ProtobufMediaType)
                 .RequireNoPermission();

--- a/backend/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
+++ b/backend/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
@@ -54,6 +54,7 @@ internal sealed partial class AccountSynchronizationSupervisor
     private readonly AccountPushNotificationWatch pushNotifications;
     private readonly MailSynchronizationTelemetry telemetry;
     private readonly MailSynchronizationRunLedger runLedger;
+    private readonly MailAccountRunSignal runSignal;
     private readonly ClientSignals signals;
     private readonly ILogger<AccountSynchronizationSupervisor> logger;
 
@@ -65,6 +66,7 @@ internal sealed partial class AccountSynchronizationSupervisor
     /// <param name="pushNotifications">Ends the wait between runs early when a watched folder changes; owned by this supervisor and disposed with it.</param>
     /// <param name="telemetry">Publishes the run as a span with its folders beneath it, and the counts and waits an operator reads without opening a log; it also measures how long a run took.</param>
     /// <param name="runLedger">Holds what this supervisor is doing for the administrative surface, which is what an operator without a metrics stack reads it from.</param>
+    /// <param name="runSignal">Ends the wait between runs early when a change is authored here, which is the one event push cannot report.</param>
     /// <param name="signals">Tells whatever the user has open that mail arrived and that the run finished, so a screen catches up without waiting for its own interval.</param>
     /// <param name="logger">Records run outcomes, which carry account and folder aliases and no message-level data.</param>
     public AccountSynchronizationSupervisor(
@@ -75,6 +77,7 @@ internal sealed partial class AccountSynchronizationSupervisor
         AccountPushNotificationWatch pushNotifications,
         MailSynchronizationTelemetry telemetry,
         MailSynchronizationRunLedger runLedger,
+        MailAccountRunSignal runSignal,
         ClientSignals signals,
         ILogger<AccountSynchronizationSupervisor> logger)
     {
@@ -85,6 +88,7 @@ internal sealed partial class AccountSynchronizationSupervisor
         this.pushNotifications = pushNotifications;
         this.telemetry = telemetry;
         this.runLedger = runLedger;
+        this.runSignal = runSignal;
         this.signals = signals;
         this.logger = logger;
     }
@@ -183,7 +187,24 @@ internal sealed partial class AccountSynchronizationSupervisor
                 run.ResolvedFolders,
                 schedulingToken);
 
-            await this.pushNotifications.WaitForNextPassAsync(runSettings, delayBeforeNextRun, schedulingToken);
+            // The other event that ends the wait, and the one push cannot report: a change somebody authored here. It
+            // is registered before the wait rather than raced against it, so a record written between the run above and
+            // the wait below still brings this account's next run forward instead of being waited out — which is the
+            // ordinary timing, the record being written while the account is busy.
+            using var authoredChange = this.runSignal.Register(this.account.Id, schedulingToken);
+
+            try
+            {
+                await this.pushNotifications.WaitForNextPassAsync(
+                    runSettings,
+                    delayBeforeNextRun,
+                    authoredChange.Token);
+            }
+            catch (OperationCanceledException) when (!schedulingToken.IsCancellationRequested)
+            {
+                // Something local asked for this account's run. The backoff it was waiting out is not reset by that —
+                // the next run recomputes it from the failure count, which nothing here touched.
+            }
         }
     }
 

--- a/backend/src/Host/Hosting/Workers/MailSynchronizationCoordinator.cs
+++ b/backend/src/Host/Hosting/Workers/MailSynchronizationCoordinator.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics.CodeAnalysis;
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Signals;
+using MailFathom.Application.Synchronization;
 using MailFathom.Application.Synchronization.Administration;
 using MailFathom.Domain.Accounts;
 using MailFathom.Host.Configuration;
@@ -36,6 +37,7 @@ internal sealed partial class MailSynchronizationCoordinator : BackgroundService
     private readonly ISettingsSnapshot<MailSynchronizationOptions> settings;
     private readonly MailSynchronizationTelemetry telemetry;
     private readonly MailSynchronizationRunLedger runLedger;
+    private readonly MailAccountRunSignal runSignal;
     private readonly ClientSignals signals;
     private readonly ILoggerFactory loggerFactory;
     private readonly ILogger<MailSynchronizationCoordinator> logger;
@@ -46,6 +48,7 @@ internal sealed partial class MailSynchronizationCoordinator : BackgroundService
     /// <param name="settings">Supplies the snapshot the supervised account set is read from.</param>
     /// <param name="telemetry">Published to by every supervisor this coordinator starts, which is why one instance is handed to all of them.</param>
     /// <param name="runLedger">Written to by every supervisor this coordinator starts, for the reason the telemetry is: it is one account of what the whole process is doing.</param>
+    /// <param name="runSignal">Handed to every supervisor this coordinator starts, for the reason the telemetry is: one registry carries what was authored for any account to the supervisor waiting on that account.</param>
     /// <param name="signals">Handed to every supervisor this coordinator starts, for the reason the telemetry is: one publisher folds what every account observed rather than one per account.</param>
     /// <param name="loggerFactory">Supplies this coordinator's logger and the logger of every supervisor it starts, so a supervisor logs under its own category.</param>
     /// <param name="timeProvider">Drives the supervision interval and bounds the shutdown drain.</param>
@@ -54,6 +57,7 @@ internal sealed partial class MailSynchronizationCoordinator : BackgroundService
         ISettingsSnapshot<MailSynchronizationOptions> settings,
         MailSynchronizationTelemetry telemetry,
         MailSynchronizationRunLedger runLedger,
+        MailAccountRunSignal runSignal,
         ClientSignals signals,
         ILoggerFactory loggerFactory,
         TimeProvider timeProvider)
@@ -64,6 +68,7 @@ internal sealed partial class MailSynchronizationCoordinator : BackgroundService
         this.settings = settings;
         this.telemetry = telemetry;
         this.runLedger = runLedger;
+        this.runSignal = runSignal;
         this.signals = signals;
         this.loggerFactory = loggerFactory;
         this.logger = loggerFactory.CreateLogger<MailSynchronizationCoordinator>();
@@ -224,6 +229,7 @@ internal sealed partial class MailSynchronizationCoordinator : BackgroundService
             pushNotifications,
             this.telemetry,
             this.runLedger,
+            this.runSignal,
             this.signals,
             this.loggerFactory.CreateLogger<AccountSynchronizationSupervisor>());
 

--- a/backend/src/Host/Security/Basic/BasicAuthentication.cs
+++ b/backend/src/Host/Security/Basic/BasicAuthentication.cs
@@ -57,19 +57,30 @@ internal static class BasicAuthentication
         $"{BasicCredentialHeader.HttpAuthenticationScheme} realm=\"{ApiKeyAuthentication.Realm}\", charset=\"UTF-8\"";
 
     /// <summary>Answers a request with the <c>401</c> a surface accepting passwords produces.</summary>
-    /// <param name="response">The response to write the refusal onto.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="response" /> is <see langword="null" />.</exception>
+    /// <param name="context">The request being refused, whose route decides whether the password half is offered.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context" /> is <see langword="null" />.</exception>
     /// <remarks>
     /// The bare bearer challenge every method on the surface produces, and the password challenge beside it, as two
     /// values of one header. The bearer half is written by the method that owns it rather than restated here, so a
     /// surface accepting both offers exactly what it would have offered without this one.
+    /// <para>
+    /// A route carrying <see cref="NoPasswordChallenge" /> takes the bearer half alone, for the reason that marker
+    /// gives: the password half is an instruction to a browser, and a route no person navigates to is a route where
+    /// obeying it opens a dialog over what somebody was reading.
+    /// </para>
     /// </remarks>
-    internal static void WriteChallenge(HttpResponse response)
+    internal static void WriteChallenge(HttpContext context)
     {
-        ArgumentNullException.ThrowIfNull(response);
+        ArgumentNullException.ThrowIfNull(context);
 
-        ApiKeyAuthentication.WriteBareChallenge(response);
+        ApiKeyAuthentication.WriteBareChallenge(context.Response);
 
-        response.Headers.WWWAuthenticate = response.Headers.WWWAuthenticate.Append(PasswordChallenge).ToArray();
+        if (context.GetEndpoint()?.Metadata.GetMetadata<NoPasswordChallenge>() is not null)
+        {
+            return;
+        }
+
+        context.Response.Headers.WWWAuthenticate =
+            context.Response.Headers.WWWAuthenticate.Append(PasswordChallenge).ToArray();
     }
 }

--- a/backend/src/Host/Security/Basic/BasicAuthenticationHandler.cs
+++ b/backend/src/Host/Security/Basic/BasicAuthenticationHandler.cs
@@ -173,7 +173,7 @@ internal sealed class BasicAuthenticationHandler : AuthenticationHandler<BasicAu
     /// </remarks>
     protected override Task HandleChallengeAsync(AuthenticationProperties properties)
     {
-        BasicAuthentication.WriteChallenge(this.Response);
+        BasicAuthentication.WriteChallenge(this.Context);
 
         return Task.CompletedTask;
     }

--- a/backend/src/Host/Security/Basic/NoPasswordChallenge.cs
+++ b/backend/src/Host/Security/Basic/NoPasswordChallenge.cs
@@ -1,0 +1,31 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Host.Security.Basic;
+
+/// <summary>Marks a route whose refusal must not name the password method, because a browser would answer it itself.</summary>
+/// <remarks>
+/// <para>
+/// The password challenge exists for a person: a client only asks for a username and a password when
+/// <c>WWW-Authenticate: Basic</c> tells it to. A browser is that client, and it answers such a challenge with a dialog
+/// of its own — which is the right thing on a page somebody navigated to and the wrong thing on a background request
+/// a page made, where the dialog opens over whatever they were reading and asks for a credential the page already
+/// holds.
+/// </para>
+/// <para>
+/// Every request the client makes on its own behalf opts out of that by omitting its credentials, which is what the
+/// Fetch Standard turns the prompt off for. This marker is for the requests it does not compose: a route reached by a
+/// library that builds its own call and takes no option for the credentials mode. Marking such a route leaves the bare
+/// bearer challenge every method on the surface produces, which is what the caller was carrying anyway.
+/// </para>
+/// </remarks>
+internal sealed class NoPasswordChallenge
+{
+    /// <summary>The one instance, since the type carries nothing and is read by its presence alone.</summary>
+    internal static readonly NoPasswordChallenge Instance = new();
+
+    private NoPasswordChallenge()
+    {
+    }
+}

--- a/backend/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -747,6 +747,11 @@ public static class ServiceCollectionExtensions
         // not this deployment synchronizes, because a deployment that switched it off is exactly the one whose operator
         // is asking why no mail arrives, and the status surface answers that from the switch rather than from silence.
         services.AddSingleton<MailSynchronizationRunLedger>();
+        // A singleton for the reason the outbox's own signal is one: it carries a raise from the scope that wrote a
+        // mailbox change to the supervisor waiting between that account's runs, so one per scope would be a registry
+        // nobody is waiting in. Registered whether or not this deployment synchronizes, because the use case that
+        // raises it does not ask first and a raise nothing is waiting on is already nothing.
+        services.AddSingleton<MailAccountRunSignal>();
         services.AddScoped<IMailFolderSynchronizationProgressReader, MailFolderSynchronizationProgressReader>();
         services.AddScoped<MailSynchronizationStatusReader>();
         // The one write a read path performs. It joins no session for the reason its port states, so it is registered

--- a/backend/tests/Application.UnitTests/Mail/Mutations/Authoring/MailDeletionRecorderTests.cs
+++ b/backend/tests/Application.UnitTests/Mail/Mutations/Authoring/MailDeletionRecorderTests.cs
@@ -7,6 +7,7 @@ using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Mail.Mutations.Authoring;
 using MailFathom.Application.Persistence;
+using MailFathom.Application.Synchronization;
 using MailFathom.Application.UnitTests.TestDoubles;
 using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
@@ -200,9 +201,27 @@ public sealed class MailDeletionRecorderTests
         Assert.Equal(MailboxMutation.Delete, Assert.Single(this.records.OpenedRequests).Mutation);
     }
 
+    /// <summary>A delete waits on the convergence pass exactly as a move does, so it must not sit there until the interval is out.</summary>
+    [Fact]
+    public async Task RecordAsync_ADelete_BringsTheAccountsNextSynchronizationRunForward()
+    {
+        // Arrange
+        var runSignal = new MailAccountRunSignal();
+        var recorder = this.Recorder(TargetIn(Trash), runSignal: runSignal);
+
+        // Act
+        await recorder.RecordAsync(LocalEmail, Requester, TestContext.Current.CancellationToken);
+
+        // Assert
+        using var waiting = runSignal.Register(Account.Id, TestContext.Current.CancellationToken);
+
+        Assert.True(waiting.Token.IsCancellationRequested);
+    }
+
     private MailDeletionRecorder Recorder(
         AuthoredMailboxTarget? target,
-        AccessAuthorization? authorization = null)
+        AccessAuthorization? authorization = null,
+        MailAccountRunSignal? runSignal = null)
     {
         var callerAuthorization =
             authorization ?? AccessAuthorizations.ForCallerGranted(MailFathomPermission.MailDelete);
@@ -231,7 +250,8 @@ public sealed class MailDeletionRecorderTests
             new OptimisticConcurrencyRetryPolicy(
                 sessions,
                 new PersistenceConcurrencyOptions(),
-                new FakeTimeProvider(RecordedAt)));
+                new FakeTimeProvider(RecordedAt)),
+            runSignal ?? new MailAccountRunSignal());
     }
 
     private static AuthoredMailboxTarget TargetIn(MailFolderAlias folderAlias)

--- a/backend/tests/Application.UnitTests/Mail/Mutations/Authoring/MailFlagChangeRecorderTests.cs
+++ b/backend/tests/Application.UnitTests/Mail/Mutations/Authoring/MailFlagChangeRecorderTests.cs
@@ -7,6 +7,7 @@ using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Mail.Mutations.Authoring;
 using MailFathom.Application.Mail.Mutations.Authoring.Failures;
 using MailFathom.Application.Persistence;
+using MailFathom.Application.Synchronization;
 using MailFathom.Application.UnitTests.TestDoubles;
 using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
@@ -305,12 +306,36 @@ public sealed class MailFlagChangeRecorderTests
         Assert.Equal(3, records.OpenedRecordCount);
     }
 
+    /// <summary>The record is what the mail server is eventually told from, and the interval is what deciding to wait for it costs.</summary>
+    /// <remarks>
+    /// The account's own run is what issues the IMAP command, so a change written here is correct whether or not the
+    /// wait between runs is cut short. What this covers is that it is cut short: a person who deleted a message watched
+    /// it stay where it was until the interval was out, which is the defect this call answers.
+    /// </remarks>
+    [Fact]
+    public async Task RecordAsync_AChange_BringsTheAccountsNextSynchronizationRunForward()
+    {
+        // Arrange
+        var runSignal = new MailAccountRunSignal();
+        var recorder = RecorderOver(new InMemoryMailboxMutationRecordStore(), TargetIn(Inbox), runSignal: runSignal);
+        var change = AuthoredMailFlagChange.Create(LocalEmail, seen: true, null, null, null);
+
+        // Act
+        await recorder.RecordAsync(change, Requester, TestContext.Current.CancellationToken);
+
+        // Assert
+        using var waiting = runSignal.Register(Account.Id, TestContext.Current.CancellationToken);
+
+        Assert.True(waiting.Token.IsCancellationRequested);
+    }
+
     private static MailFlagChangeRecorder RecorderOver(
         InMemoryMailboxMutationRecordStore records,
         AuthoredMailboxTarget? target,
         AccessAuthorization? authorization = null,
         Func<IPersistenceSession>? sessionFactory = null,
-        FakeTimeProvider? clock = null)
+        FakeTimeProvider? clock = null,
+        MailAccountRunSignal? runSignal = null)
     {
         var callerAuthorization =
             authorization ?? AccessAuthorizations.ForCallerGranted(MailFathomPermission.MailFlagsWrite);
@@ -340,7 +365,8 @@ public sealed class MailFlagChangeRecorderTests
             new OptimisticConcurrencyRetryPolicy(
                 sessions,
                 new PersistenceConcurrencyOptions(),
-                clock ?? new FakeTimeProvider()));
+                clock ?? new FakeTimeProvider()),
+            runSignal ?? new MailAccountRunSignal());
     }
 
     private static AuthoredMailboxTarget TargetIn(MailFolderAlias folderAlias)

--- a/backend/tests/Application.UnitTests/Mail/Mutations/Authoring/MailRelocationRecorderTests.cs
+++ b/backend/tests/Application.UnitTests/Mail/Mutations/Authoring/MailRelocationRecorderTests.cs
@@ -336,7 +336,6 @@ public sealed class MailRelocationRecorderTests
         this.bindings.Bind(Account.Id, alias, remotePath);
     }
 
-    /// <summary>Maps a folder no run schedules, which is resolved against what the server advertises at the moment it is needed.</summary>
     /// <summary>A move a person watched themselves ask for must not sit under <i>moving to trash</i> until the interval is out.</summary>
     [Fact]
     public async Task RecordAsync_AMove_BringsTheAccountsNextSynchronizationRunForward()
@@ -355,6 +354,7 @@ public sealed class MailRelocationRecorderTests
         Assert.True(waiting.Token.IsCancellationRequested);
     }
 
+    /// <summary>Maps a folder no run schedules, which is resolved against what the server advertises at the moment it is needed.</summary>
     private void MapUnmirrored(MailFolderAlias alias, string remotePath)
     {
         this.mappings.With(

--- a/backend/tests/Application.UnitTests/Mail/Mutations/Authoring/MailRelocationRecorderTests.cs
+++ b/backend/tests/Application.UnitTests/Mail/Mutations/Authoring/MailRelocationRecorderTests.cs
@@ -10,6 +10,7 @@ using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Mail.Mutations.Authoring;
 using MailFathom.Application.Mail.Mutations.Destinations;
 using MailFathom.Application.Persistence;
+using MailFathom.Application.Synchronization;
 using MailFathom.Application.UnitTests.TestDoubles;
 using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
@@ -336,6 +337,24 @@ public sealed class MailRelocationRecorderTests
     }
 
     /// <summary>Maps a folder no run schedules, which is resolved against what the server advertises at the moment it is needed.</summary>
+    /// <summary>A move a person watched themselves ask for must not sit under <i>moving to trash</i> until the interval is out.</summary>
+    [Fact]
+    public async Task RecordAsync_AMove_BringsTheAccountsNextSynchronizationRunForward()
+    {
+        // Arrange
+        this.MapMirrored(Archive, "Archive");
+        var runSignal = new MailAccountRunSignal();
+        var recorder = this.Recorder(TargetIn(Inbox), runSignal: runSignal);
+
+        // Act
+        await recorder.RecordAsync(LocalEmail, Archive, Requester, TestContext.Current.CancellationToken);
+
+        // Assert
+        using var waiting = runSignal.Register(Account.Id, TestContext.Current.CancellationToken);
+
+        Assert.True(waiting.Token.IsCancellationRequested);
+    }
+
     private void MapUnmirrored(MailFolderAlias alias, string remotePath)
     {
         this.mappings.With(
@@ -349,7 +368,8 @@ public sealed class MailRelocationRecorderTests
 
     private MailRelocationRecorder Recorder(
         AuthoredMailboxTarget? target,
-        AccessAuthorization? authorization = null)
+        AccessAuthorization? authorization = null,
+        MailAccountRunSignal? runSignal = null)
     {
         var callerAuthorization =
             authorization ?? AccessAuthorizations.ForCallerGranted(MailFathomPermission.MailMove);
@@ -379,7 +399,8 @@ public sealed class MailRelocationRecorderTests
             new OptimisticConcurrencyRetryPolicy(
                 sessions,
                 new PersistenceConcurrencyOptions(),
-                new FakeTimeProvider(RecordedAt)));
+                new FakeTimeProvider(RecordedAt)),
+            runSignal ?? new MailAccountRunSignal());
     }
 
     private MailboxDestinationResolver DestinationResolver(IPersistenceSessionFactory sessionFactory)

--- a/backend/tests/Application.UnitTests/Synchronization/MailAccountRunSignalTests.cs
+++ b/backend/tests/Application.UnitTests/Synchronization/MailAccountRunSignalTests.cs
@@ -98,6 +98,28 @@ public sealed class MailAccountRunSignalTests
         Assert.True(waiting.Token.IsCancellationRequested);
     }
 
+    /// <summary>The raise that ended a wait owns what is behind it from that moment, and the waiter still reads and ends that wait on the way out.</summary>
+    [Fact]
+    public void Dispose_AWaitARaiseAlreadyEnded_EndsWithoutDisturbingTheSignal()
+    {
+        // Arrange
+        var signal = new MailAccountRunSignal();
+        var waiting = signal.Register(Account, CancellationToken.None);
+        signal.BringForward(Account);
+
+        // Act
+        waiting.Dispose();
+
+        // Assert
+        Assert.True(waiting.Token.IsCancellationRequested);
+
+        signal.BringForward(Account);
+
+        using var next = signal.Register(Account, CancellationToken.None);
+
+        Assert.True(next.Token.IsCancellationRequested);
+    }
+
     /// <summary>A wait already over must not take the next one's, which would be a change waiting out the interval it was raised to avoid.</summary>
     [Fact]
     public void BringForward_AfterTheWaitItWouldHaveEndedWasDisposed_IsKeptForTheNextWait()

--- a/backend/tests/Application.UnitTests/Synchronization/MailAccountRunSignalTests.cs
+++ b/backend/tests/Application.UnitTests/Synchronization/MailAccountRunSignalTests.cs
@@ -1,0 +1,120 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Synchronization;
+using MailFathom.Domain.Accounts;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Synchronization;
+
+/// <summary>Covers what ends an account's wait between synchronization runs, and what a wait it arrived beside does with it.</summary>
+/// <remarks>
+/// The whole of this type is about timing, so the cases are the orderings: brought forward while a wait is registered,
+/// brought forward while none is, and brought forward for another account. Each is a real sequence — the record is
+/// written by a request whose timing against the account's own loop nothing coordinates.
+/// </remarks>
+public sealed class MailAccountRunSignalTests
+{
+    private static readonly MailAccountId Account = MailAccountId.Create("personal");
+    private static readonly MailAccountId Another = MailAccountId.Create("work");
+
+    [Fact]
+    public void BringForward_AWaitAlreadyRegistered_EndsThatWait()
+    {
+        // Arrange
+        var signal = new MailAccountRunSignal();
+        using var waiting = signal.Register(Account, CancellationToken.None);
+
+        // Act
+        signal.BringForward(Account);
+
+        // Assert
+        Assert.True(waiting.Token.IsCancellationRequested);
+    }
+
+    /// <summary>The ordinary timing, because the record is written while the account is mid-run rather than while it waits.</summary>
+    [Fact]
+    public void Register_BroughtForwardWhileNothingWaited_ComesBackAlreadyEnded()
+    {
+        // Arrange
+        var signal = new MailAccountRunSignal();
+
+        // Act
+        signal.BringForward(Account);
+
+        using var waiting = signal.Register(Account, CancellationToken.None);
+
+        // Assert
+        Assert.True(waiting.Token.IsCancellationRequested);
+    }
+
+    /// <summary>A run brought forward for work already done would be a second early run on every change.</summary>
+    [Fact]
+    public void Register_AfterAWaitTookTheOneBroughtForward_WaitsAgain()
+    {
+        // Arrange
+        var signal = new MailAccountRunSignal();
+        signal.BringForward(Account);
+
+        using (signal.Register(Account, CancellationToken.None))
+        {
+        }
+
+        // Act
+        using var waiting = signal.Register(Account, CancellationToken.None);
+
+        // Assert
+        Assert.False(waiting.Token.IsCancellationRequested);
+    }
+
+    [Fact]
+    public void BringForward_AnotherAccount_LeavesThisAccountWaiting()
+    {
+        // Arrange
+        var signal = new MailAccountRunSignal();
+        using var waiting = signal.Register(Account, CancellationToken.None);
+
+        // Act
+        signal.BringForward(Another);
+
+        // Assert
+        Assert.False(waiting.Token.IsCancellationRequested);
+    }
+
+    /// <summary>The other reason a wait ends, which the caller tells apart from this one by reading its own token.</summary>
+    [Fact]
+    public void Register_TheHostStoppingScheduling_EndsTheWait()
+    {
+        // Arrange
+        var signal = new MailAccountRunSignal();
+        using var stopping = new CancellationTokenSource();
+        using var waiting = signal.Register(Account, stopping.Token);
+
+        // Act
+        stopping.Cancel();
+
+        // Assert
+        Assert.True(waiting.Token.IsCancellationRequested);
+    }
+
+    /// <summary>A wait already over must not take the next one's, which would be a change waiting out the interval it was raised to avoid.</summary>
+    [Fact]
+    public void BringForward_AfterTheWaitItWouldHaveEndedWasDisposed_IsKeptForTheNextWait()
+    {
+        // Arrange
+        var signal = new MailAccountRunSignal();
+
+        using (signal.Register(Account, CancellationToken.None))
+        {
+        }
+
+        // Act
+        signal.BringForward(Account);
+
+        // Assert
+        using var waiting = signal.Register(Account, CancellationToken.None);
+
+        Assert.True(waiting.Token.IsCancellationRequested);
+    }
+}

--- a/backend/tests/Host.UnitTests/Api/ClientDraftEndpointTests.cs
+++ b/backend/tests/Host.UnitTests/Api/ClientDraftEndpointTests.cs
@@ -13,9 +13,15 @@ using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Delivery;
 using MailFathom.Domain.Delivery.Drafts;
 using MailFathom.Host.Api;
+using MailFathom.Host.Configuration.Mail;
+using MailFathom.Host.UnitTests.TestDoubles;
 using MailFathom.TestSupport;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using Xunit;
@@ -56,6 +62,36 @@ public sealed class ClientDraftEndpointTests
         Assert.Equal(
             "/drafts/{draftId:guid}/attachments/{attachmentId:guid}",
             ClientDraftEndpoints.DraftAttachmentRoute);
+    }
+
+    /// <summary>
+    /// A single concrete media type here is enforced rather than documented: the routing pipeline answers <c>415</c> to
+    /// a request declaring anything the metadata does not list, and the client sends the file's own type. So naming one
+    /// refused every file the author's system could name and admitted only the ones it could not, which is what a
+    /// message with an attachment failed on.
+    /// </summary>
+    [Fact]
+    public void MapClientDrafts_TheUploadRoute_AdmitsWhateverTheFileDeclaresItselfToBe()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddRouting();
+        services.AddOptions<MailDeliveryOptions>();
+        var endpoints = new TestEndpointRouteBuilder(services.BuildServiceProvider());
+
+        // Act
+        endpoints.MapGroup(string.Empty).MapClientDrafts();
+
+        // Assert
+        var upload = endpoints.Materialize()
+            .OfType<RouteEndpoint>()
+            .Single(endpoint =>
+                endpoint.RoutePattern.RawText == ClientDraftEndpoints.DraftAttachmentsRoute
+                && endpoint.Metadata.GetMetadata<IAcceptsMetadata>() is not null);
+
+        Assert.Equal(
+            [ClientDraftEndpoints.AnyUploadedMediaType],
+            upload.Metadata.GetMetadata<IAcceptsMetadata>()!.ContentTypes);
     }
 
     /// <summary>The three published answer values, pinned because a client sends one of them as written text.</summary>

--- a/backend/tests/Host.UnitTests/Api/ClientMailMutationsEndpointTests.cs
+++ b/backend/tests/Host.UnitTests/Api/ClientMailMutationsEndpointTests.cs
@@ -621,7 +621,8 @@ public sealed class ClientMailMutationsEndpointTests
             targets,
             dispositions,
             this.records,
-            CommitPolicy());
+            CommitPolicy(),
+            new MailAccountRunSignal());
     }
 
     /// <summary>Builds a destination resolver that reaches nothing, because no test here gets as far as resolving a folder.</summary>

--- a/backend/tests/Host.UnitTests/Api/ClientMailMutationsEndpointTests.cs
+++ b/backend/tests/Host.UnitTests/Api/ClientMailMutationsEndpointTests.cs
@@ -10,6 +10,7 @@ using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Mail.Mutations.Authoring;
 using MailFathom.Application.Mail.Mutations.Destinations;
 using MailFathom.Application.Persistence;
+using MailFathom.Application.Synchronization;
 using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
@@ -585,7 +586,8 @@ public sealed class ClientMailMutationsEndpointTests
                     : StubMailFolderParticipation.Mapping(new MailFolderIdentity(ServedAccount, Inbox))),
             targets,
             this.records,
-            CommitPolicy());
+            CommitPolicy(),
+            new MailAccountRunSignal());
     }
 
     private MailRelocationRecorder RelocationRecorder() => new(
@@ -595,7 +597,8 @@ public sealed class ClientMailMutationsEndpointTests
         DestinationResolver(),
         Substitute.For<IAuthoredDeleteEmailDispositionReader>(),
         this.records,
-        CommitPolicy());
+        CommitPolicy(),
+        new MailAccountRunSignal());
 
     /// <summary>Builds the deleting use case the route is given, under the grant that route carries.</summary>
     /// <param name="target">The message the caller names, defaulting to none, which is the absence the recorder reports as a message that has gone.</param>

--- a/backend/tests/Host.UnitTests/Api/ClientTelemetryEndpointTests.cs
+++ b/backend/tests/Host.UnitTests/Api/ClientTelemetryEndpointTests.cs
@@ -10,6 +10,7 @@ using MailFathom.Domain.Access;
 using MailFathom.Host.Api;
 using MailFathom.Host.Configuration.Endpoints;
 using MailFathom.Host.Observability.ClientTelemetry;
+using MailFathom.Host.Security.Basic;
 using MailFathom.Host.UnitTests.TestDoubles;
 using MailFathom.TestSupport;
 using Microsoft.AspNetCore.Builder;
@@ -72,6 +73,28 @@ public sealed class ClientTelemetryEndpointTests
                 .OfType<RouteEndpoint>()
                 .Select(endpoint => endpoint.RoutePattern.RawText)
                 .Order(StringComparer.Ordinal));
+    }
+
+    /// <summary>
+    /// The exporter builds its own request and takes no option for the credentials mode, so it sends them — and a
+    /// refusal naming the password method then opens the browser's own username-and-password dialog over whatever the
+    /// person was reading. Every request the client composes itself omits credentials instead, which is why these three
+    /// routes are the only ones marked.
+    /// </summary>
+    [Fact]
+    public void MapClientTelemetry_WithADestinationConfigured_AnswersNoPasswordChallengeOnAnySignalRoute()
+    {
+        // Arrange
+        var endpoints = BuildRouteBuilder();
+
+        // Act
+        endpoints.MapGroup(ClientEndpointOptions.RoutePrefix).MapClientTelemetry();
+
+        // Assert
+        var mapped = endpoints.Materialize();
+
+        Assert.NotEmpty(mapped);
+        Assert.All(mapped, endpoint => Assert.NotNull(endpoint.Metadata.GetMetadata<NoPasswordChallenge>()));
     }
 
     /// <summary>The claim the whole feature rests on, asserted at the wire rather than at the argument.</summary>

--- a/backend/tests/Host.UnitTests/Hosting/Workers/AccountSynchronizationSupervisorTests.cs
+++ b/backend/tests/Host.UnitTests/Hosting/Workers/AccountSynchronizationSupervisorTests.cs
@@ -423,6 +423,48 @@ public sealed class AccountSynchronizationSupervisorTests
     }
 
     /// <summary>
+    /// A change somebody authored reaches the mail server through this run and through nothing else, so the wait in
+    /// front of it is what a person watching a message stay where they deleted it is waiting out. The clock never moves
+    /// in this test, which is what makes the second run attributable to the signal rather than to the interval.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_AChangeBroughtTheRunForward_RunsAgainWithoutWaitingOutTheInterval()
+    {
+        // Arrange
+        var attemptCount = 0;
+        var secondRunStarted = new TaskCompletionSource();
+        await using var emptyMailbox = CreateEmptyMailbox();
+        var sessionFactory = Substitute.For<IMailboxSessionFactory>();
+        sessionFactory
+            .OpenReadOnlyAsync(
+                Arg.Any<MailAccountId>(),
+                Arg.Any<MailFolderResolution>(),
+                Arg.Any<MailTransportSecurityPolicy>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                if (Interlocked.Increment(ref attemptCount) == 2)
+                {
+                    secondRunStarted.TrySetResult();
+                }
+
+                return Task.FromResult(emptyMailbox);
+            });
+        await using var harness = CreateHarness(
+            SynchronizationTestHost.CreateSingleAccountOptions(enabled: true, "INBOX"),
+            sessionFactory);
+        var supervision = harness.StartSupervision();
+
+        // Act: kept where it lands, so whether it arrives before or during the first run decides nothing.
+        harness.RunSignal.BringForward(MailAccountId.Create("primary"));
+
+        // Assert
+        await secondRunStarted.Task.WaitAsync(DeadlockGuard, TestContext.Current.CancellationToken);
+        await harness.StopSchedulingAsync();
+        await supervision.WaitAsync(DeadlockGuard, TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
     /// The ledger is what an operator without a metrics stack reads, so a folder the mail server refused has to reach
     /// it classified rather than only reach the log. The wait beside it is the other half: a folder that is failing and
     /// an account that is approaching its server less often for it are one event read two ways.
@@ -1377,6 +1419,7 @@ public sealed class AccountSynchronizationSupervisorTests
             this.Logger = new RecordingLogger<AccountSynchronizationSupervisor>();
             this.PushLogger = new RecordingLogger<AccountPushNotificationWatch>();
             this.RunLedger = new MailSynchronizationRunLedger(clock);
+            this.RunSignal = new MailAccountRunSignal();
             this.Signals = new ClientSignals([this.SignalChannel], this.SignalClock);
             this.supervisor = new AccountSynchronizationSupervisor(
                 account,
@@ -1390,11 +1433,15 @@ public sealed class AccountSynchronizationSupervisorTests
                     clock),
                 services.GetRequiredService<MailSynchronizationTelemetry>(),
                 this.RunLedger,
+                this.RunSignal,
                 this.Signals,
                 this.Logger);
         }
 
         internal MailSynchronizationRunLedger RunLedger { get; }
+
+        /// <summary>Gets the registry a change authored here brings this account's next run forward through.</summary>
+        internal MailAccountRunSignal RunSignal { get; }
 
         /// <summary>Gets what this run told a client, which most tests here have no claim about.</summary>
         internal RecordingClientSignalChannel SignalChannel { get; } = new();

--- a/backend/tests/Host.UnitTests/Hosting/Workers/MailSynchronizationCoordinatorTests.cs
+++ b/backend/tests/Host.UnitTests/Hosting/Workers/MailSynchronizationCoordinatorTests.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Folders;
+using MailFathom.Application.Synchronization;
 using MailFathom.Application.Synchronization.Administration;
 using MailFathom.Application.Synchronization.Sessions;
 using MailFathom.Domain.Accounts;
@@ -366,6 +367,7 @@ public sealed class MailSynchronizationCoordinatorTests
                 settings,
                 services.GetRequiredService<MailSynchronizationTelemetry>(),
                 new MailSynchronizationRunLedger(clock),
+                new MailAccountRunSignal(),
                 ClientSignalPublishers.ReachingNobody,
                 this.loggerFactory,
                 clock);

--- a/backend/tests/Host.UnitTests/Security/Basic/BasicAuthenticationHandlerTests.cs
+++ b/backend/tests/Host.UnitTests/Security/Basic/BasicAuthenticationHandlerTests.cs
@@ -200,6 +200,30 @@ public sealed class BasicAuthenticationHandlerTests
         Assert.Contains("Bearer", challenges, StringComparison.Ordinal);
     }
 
+    /// <summary>The marker is metadata on the route, so it only reaches the challenge if the handler refuses on the whole context rather than on the response alone.</summary>
+    [Fact]
+    public async Task ChallengeAsync_OnARouteThatAnswersNoPasswordChallenge_OffersTheBearerSchemeAlone()
+    {
+        // Arrange
+        using var harness = new HandlerHarness();
+        var context = new DefaultHttpContext();
+        context.SetEndpoint(
+            new Endpoint(
+                requestDelegate: null,
+                new EndpointMetadataCollection(NoPasswordChallenge.Instance),
+                displayName: "telemetry"));
+
+        var handler = await harness.InitializeAsync(authorizationHeaderValue: string.Empty, https: true, context);
+
+        // Act
+        await handler.ChallengeAsync(new AuthenticationProperties());
+
+        // Assert
+        var challenges = context.Response.Headers[HeaderNames.WWWAuthenticate].ToString();
+        Assert.DoesNotContain("Basic", challenges, StringComparison.Ordinal);
+        Assert.Contains("Bearer", challenges, StringComparison.Ordinal);
+    }
+
     /// <summary>Nothing was declared in front, so the peer is the caller and one host guessing at many users spends the allowance it is bounded by.</summary>
     [Fact]
     public async Task AuthenticateAsync_TwoUsernamesFromOnePeerWithNoProxyDeclared_SpendsThatPeersAllowance()

--- a/backend/tests/Host.UnitTests/Security/Basic/BasicAuthenticationTests.cs
+++ b/backend/tests/Host.UnitTests/Security/Basic/BasicAuthenticationTests.cs
@@ -27,7 +27,7 @@ public sealed class BasicAuthenticationTests
         context.Response.Body = body;
 
         // Act
-        BasicAuthentication.WriteChallenge(context.Response);
+        BasicAuthentication.WriteChallenge(context);
 
         // Assert
         Assert.Equal(StatusCodes.Status401Unauthorized, context.Response.StatusCode);
@@ -42,7 +42,7 @@ public sealed class BasicAuthenticationTests
         var context = new DefaultHttpContext();
 
         // Act
-        BasicAuthentication.WriteChallenge(context.Response);
+        BasicAuthentication.WriteChallenge(context);
 
         // Assert
         Assert.Equal(
@@ -58,7 +58,7 @@ public sealed class BasicAuthenticationTests
         var context = new DefaultHttpContext();
 
         // Act
-        BasicAuthentication.WriteChallenge(context.Response);
+        BasicAuthentication.WriteChallenge(context);
 
         // Assert
         Assert.Contains(
@@ -75,12 +75,29 @@ public sealed class BasicAuthenticationTests
         var context = new DefaultHttpContext();
 
         // Act
-        BasicAuthentication.WriteChallenge(context.Response);
+        BasicAuthentication.WriteChallenge(context);
 
         // Assert
         var challenge = context.Response.Headers[HeaderNames.WWWAuthenticate].ToString();
 
         Assert.DoesNotContain("error", challenge, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("user", challenge, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>The password half is an instruction to a browser, and a route nothing navigates to is one where obeying it opens a dialog over what somebody was reading.</summary>
+    [Fact]
+    public void WriteChallenge_ARouteThatAnswersNoPasswordChallenge_OffersTheBearerSchemeAlone()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        context.SetEndpoint(new Endpoint(null, new EndpointMetadataCollection(NoPasswordChallenge.Instance), "telemetry"));
+
+        // Act
+        BasicAuthentication.WriteChallenge(context);
+
+        // Assert
+        Assert.Equal(
+            ["Bearer realm=\"MailFathom\""],
+            context.Response.Headers[HeaderNames.WWWAuthenticate].Select(value => value ?? string.Empty));
     }
 }

--- a/backend/tests/Mcp.UnitTests/Tools/SetMailFlagsToolTests.cs
+++ b/backend/tests/Mcp.UnitTests/Tools/SetMailFlagsToolTests.cs
@@ -10,6 +10,7 @@ using MailFathom.Application.Mail.Mutations.Authoring;
 using MailFathom.Application.Mail.Mutations.Authoring.Failures;
 using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
+using MailFathom.Application.Synchronization;
 using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
@@ -354,7 +355,8 @@ public sealed class SetMailFlagsToolTests
             new OptimisticConcurrencyRetryPolicy(
                 sessionFactory,
                 new PersistenceConcurrencyOptions(),
-                new FakeTimeProvider())));
+                new FakeTimeProvider()),
+            new MailAccountRunSignal()));
     }
 
     /// <summary>A record store that keeps what a call asked to have written down.</summary>

--- a/backend/tests/PublicSurfaces.UnitTests/http-api-contract.json
+++ b/backend/tests/PublicSurfaces.UnitTests/http-api-contract.json
@@ -11412,7 +11412,7 @@
         ],
         "requestBody": {
           "content": {
-            "application/octet-stream": {
+            "*/*": {
               "schema": {
                 "$ref": "#/components/schemas/Stream"
               }

--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -564,6 +564,15 @@ on a server without `MOVE` is a copy, a flag, and an expunge, and a process that
 mailbox nothing can interpret afterwards. A second run reads the record and continues from the stage it names, so the
 message ends up filed once whichever command the stop landed between.
 
+**Writing the record also ends the account's wait.** What issues the change is the account's ordinary synchronization
+run, so without that the change would sit until the interval was out — and on an account in push mode until the mail
+*server* reported something, which a change authored here never is. The raise carries nothing, because the run reads
+the records rather than the raise, and it is one per account rather than one per change, so a hundred messages filed at
+once bring a single run forward. It is a hint and not a queue entry: never awaited, never retried, and one lost delays
+a change to the interval rather than dropping it. One arriving while the account is mid-run is the ordinary case rather
+than a corner, since the record is usually written while a run is under way, so it is kept and spent by the wait that
+follows — which is what carries the change into the next run instead of the one after that.
+
 The record answers three questions with one row.
 
 **Whether asking again is the same request.** Its identity is the email occurrence, the mutation, and who asked — a rule

--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -564,10 +564,13 @@ on a server without `MOVE` is a copy, a flag, and an expunge, and a process that
 mailbox nothing can interpret afterwards. A second run reads the record and continues from the stage it names, so the
 message ends up filed once whichever command the stop landed between.
 
-**Writing the record also ends the account's wait.** What issues the change is the account's ordinary synchronization
-run, so without that the change would sit until the interval was out — and on an account in push mode until the mail
-*server* reported something, which a change authored here never is. The raise carries nothing, because the run reads
-the records rather than the raise, and it is one per account rather than one per change, so a hundred messages filed at
+**A change somebody asked for also ends the account's wait** — a change recorded by the client's mutation routes or by
+`set_mail_flags`, and not the other two origins above. What issues any of them is the account's ordinary
+synchronization run, so a change nothing brought that run forward for sits until the interval is out, and on an account
+in push mode until the mail *server* reports something, which a change authored here never is. A rule's action and a
+spam verdict's keep that wait: both are recorded inside a pass that is already running, and the run that carries them
+is the next one whether or not anything ends the wait early. The raise carries nothing, because the run reads the
+records rather than the raise, and it is one per account rather than one per change, so a hundred messages filed at
 once bring a single run forward. It is a hint and not a queue entry: never awaited, never retried, and one lost delays
 a change to the interval rather than dropping it. One arriving while the account is mid-run is the ordinary case rather
 than a corner, since the record is usually written while a run is under way, so it is kept and spent by the wait that

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -1420,6 +1420,13 @@ write session and the same path a rule, a spam verdict, and an MCP tool go down.
 else's mail server to redraw, a change asked for while the account is unreachable is kept rather than lost, and a
 process that dies between a copy and a delete leaves a record saying what was half done.
 
+**The pass is brought forward rather than waited for.** A record written here ends the account's wait between
+synchronization runs, so the change is issued on the run that follows within seconds instead of at the next interval.
+Push does not cover this: what a watched folder reports is the mail *server* changing, and a change authored here is
+not that. Nothing about correctness turns on it — the account's own schedule reaches the record either way, which is
+why a raise that is lost delays a change rather than dropping one — and it is what keeps a deleted message from sitting
+under *moving to trash* for minutes.
+
 **A submission is a batch, and the answer is per message.** At most 200 messages per request — and at most 100 records
 per read, because a read names them in the request line. The route enforces that hundred itself, answering a longer one
 with an ordinary `400`; it is set well under the request line Kestrel will actually accept, so a longer path or a proxy
@@ -1876,7 +1883,9 @@ reply stays a reply. One of that pair without the other names nothing and is ref
 **An upload is the request body and nothing else.** There is no form to parse and no boundary to trust: the octets are
 the body, the file's name is the `fileName` query value, and what it declares itself to be is the request's own
 `Content-Type` without its parameters — a request declaring none is read as `application/octet-stream` rather than
-having its content examined. The bound is the deployment's own configured attachment size, applied by the routing
+having its content examined. **The route admits any media type**, because the declared one is recorded against the file
+rather than checked: naming a single one would be enforced by the routing pipeline as a `415` on everything else, which
+is every file the author's system could name. The bound is the deployment's own configured attachment size, applied by the routing
 pipeline as well as by the use case, so a body past it is refused before it is buffered; how many files a draft may
 carry is the deployment's configured attachment count. Cancelling an upload leaves nothing behind, and a file already
 taken in is removed by naming it.
@@ -2174,6 +2183,16 @@ user are written here from the authenticated credential and **replace** whatever
 page cannot report as somebody else however its bundle was modified. Nothing else in the payload is transformed: the
 batch is forwarded as it arrived, so a signal a client's own instrumentation names arrives at the collector under that
 name.
+
+**A refusal here offers no password challenge**, which is the one way their `401` differs from every other route's on
+this surface. A route a person reaches answers with the `Bearer` challenge and a `Basic` one beside it, because a
+username and a password are typed by somebody whose client only asks for them when a challenge tells it to. Nobody
+navigates to these three: the caller is the client's own OTLP exporter, which builds its own `fetch` with an
+`Authorization` header it was constructed with and no credentials mode, so the browser is left holding a `Basic`
+challenge on a request made from a page that is already signed in — and what a browser does with one is open its own
+sign-in dialog over whatever somebody was reading. So the refusal carries the bearer challenge alone, under the same
+`MailFathom` realm as everywhere else, and the exporter is unaffected: it reads the status rather than the challenge,
+and a credential that has expired is renewed by the page rather than retyped into a dialog the page cannot see.
 
 **Read attribution off the resource, which is the level this holds at.** A client is free to write anything into a
 span, a log record, or a metric data point, a key spelled like the user one included, exactly as it is free to write

--- a/frontend/src/Client.App/src/shell/useConnection.test.ts
+++ b/frontend/src/Client.App/src/shell/useConnection.test.ts
@@ -180,6 +180,47 @@ describe('useConnection', () => {
         expect(result.current.readAt).toEqual(readAt);
     });
 
+    // The other half of keeping what was read: a grant that stopped reading mail asks for no accounts at all, so
+    // nothing later in the attempt replaces the tree that stands — and one left up goes on offering mail the
+    // deployment has begun refusing, for as long as that person stays signed in.
+    it('drops what it read once the grant it read under stops reading mail', async () => {
+        const readsNothing = answering({
+            service: 'MailFathom',
+            version: '0.8.7',
+            permissions: [],
+        });
+
+        let narrowed = false;
+        const narrowingTheGrant: DeploymentTransport = () => (request) => {
+            if (request.path.endsWith('/session')) {
+                return Promise.resolve(narrowed ? readsNothing : readsMail);
+            }
+
+            return Promise.resolve(oneAccount);
+        };
+
+        const { result } = renderHook(() =>
+            useConnection(baseAddress, firstPerson, narrowingTheGrant, nothingToDo, clock),
+        );
+
+        await waitFor(() => {
+            expect(result.current.accounts?.outcome).toBe('read');
+        });
+
+        narrowed = true;
+
+        act(() => {
+            result.current.reread();
+        });
+
+        await waitFor(() => {
+            expect(result.current.accounts).toBeNull();
+        });
+
+        expect(result.current.readAt).toBeNull();
+        expect(result.current.session?.outcome).toBe('read');
+    });
+
     // The comparison that decides what is drawn is the address and the person, and only they: the previous user's
     // accounts and the previous user's grants must not stand while the next person's read is out.
     it('draws nothing of the last person once somebody else signs in', async () => {

--- a/frontend/src/Client.App/src/shell/useConnection.test.ts
+++ b/frontend/src/Client.App/src/shell/useConnection.test.ts
@@ -142,6 +142,63 @@ describe('useConnection', () => {
         expect(presented.at(-1)).toBe('Bearer mfs_renewed.c2Vzc2lvbg');
     });
 
+    // The account signals one re-read every time a synchronization run finishes, which in push mode is every message
+    // that arrives. A hook that discarded its answer for the duration would empty the frame on each of them: every
+    // screen below unmounts, their reads are abandoned and reported as a deployment that is not answering, the list
+    // returns to the top of the folder, and the signal channel is closed and opened again.
+    it('keeps what it read on the screen while it reads again for the same person', async () => {
+        let answer: ((response: ClientResponse) => void) | null = null;
+        const holdingTheSecondRead: DeploymentTransport = () => (request) => {
+            const response = request.path.endsWith('/session') ? readsMail : oneAccount;
+
+            if (answer === null) {
+                return Promise.resolve(response);
+            }
+
+            return new Promise<ClientResponse>((settle) => {
+                answer = settle;
+            }).then(() => response);
+        };
+
+        const { result } = renderHook(() =>
+            useConnection(baseAddress, firstPerson, holdingTheSecondRead, nothingToDo, clock),
+        );
+
+        await waitFor(() => {
+            expect(result.current.accounts?.outcome).toBe('read');
+        });
+
+        // Held from here on, so the re-read below stays in flight for the whole of the assertion.
+        answer = () => undefined;
+
+        act(() => {
+            result.current.reread();
+        });
+
+        expect(result.current.session?.outcome).toBe('read');
+        expect(result.current.accounts?.outcome).toBe('read');
+        expect(result.current.readAt).toEqual(readAt);
+    });
+
+    // The comparison that decides what is drawn is the address and the person, and only they: the previous user's
+    // accounts and the previous user's grants must not stand while the next person's read is out.
+    it('draws nothing of the last person once somebody else signs in', async () => {
+        const { result, rerender } = renderHook(
+            ({ signedIn }: { signedIn: SignedInCaller }) =>
+                useConnection(baseAddress, signedIn, deploymentAnswering, nothingToDo, clock),
+            { initialProps: { signedIn: firstPerson } },
+        );
+
+        await waitFor(() => {
+            expect(result.current.accounts?.outcome).toBe('read');
+        });
+
+        rerender({ signedIn: secondPerson });
+
+        expect(result.current.session).toBeNull();
+        expect(result.current.accounts).toBeNull();
+    });
+
     // A renewal destroys the token it replaced the moment the deployment answers, so a read already on the wire comes
     // back refused for a value this client itself replaced. Signing somebody out over that would discard the session
     // the renewal just minted, which is the ordinary path for a client opened inside the renewal margin.

--- a/frontend/src/Client.App/src/shell/useConnection.ts
+++ b/frontend/src/Client.App/src/shell/useConnection.ts
@@ -66,37 +66,54 @@ export interface SignedInCaller {
 }
 
 /**
- * What one attempt answered, tagged with the attempt and the identity it answered for.
+ * What one attempt answered, tagged with the address and the identity it answered for.
  *
- * The tag is what makes "still waiting" a thing this hook works out during a render rather than a second piece of state
- * set beside the first: an answer that is not the current attempt's is a stale answer, and clearing it in the effect
- * that starts the next read would be a render spent saying what the tag already says.
+ * **The attempt is deliberately not part of that tag.** A re-read is asked for while somebody is reading — the account
+ * signals one every time a synchronization run finishes — and an answer discarded for belonging to the previous
+ * attempt would empty the whole frame for as long as the new read takes: every screen below unmounts, every read they
+ * have in flight is abandoned and reported as a deployment that is not answering, the list returns to the top of the
+ * folder, and the signal channel is closed and opened again. What is on the screen is still the truest thing anybody
+ * has until the next answer replaces it, which is what this hook already says about a machine that lost its network.
  *
- * The identity is half of that tag rather than the attempt alone, and it is the half that matters most: signing out and
- * back in as somebody else changes who is signed in without changing the attempt, so an answer tagged by attempt alone
- * would put the previous user's accounts and the previous user's grants in front of the next person for as long as
- * their own read takes. What it holds is the identity rather than the credential — the credential is deliberately the
- * thing not compared, a renewal replacing it while nothing about the deployment changed — and it is compared, never
- * read, and never rendered.
+ * The identity is what a stale answer is actually told apart by, and it is what matters: signing out and back in as
+ * somebody else changes who is signed in, so an answer left standing across that would put the previous user's
+ * accounts and the previous user's grants in front of the next person. What it holds is the identity rather than the
+ * credential — the credential is deliberately the thing not compared, a renewal replacing it while nothing about the
+ * deployment changed — and it is compared, never read, and never rendered.
  */
 interface Answered {
     readonly session: ClientResult<DeploymentSession> | null;
     readonly accounts: ClientResult<MailAccountDirectory> | null;
     readonly readAt: Date | null;
-    readonly answering: number;
     readonly presentedAt: string | null;
     readonly presenting: string | null;
 }
 
-// Before the first attempt there is nothing, tagged with an attempt and an identity no read will ever carry.
+// Before the first attempt there is nothing, tagged with an address and an identity no read will ever carry.
 const nothingRead: Answered = {
     session: null,
     accounts: null,
     readAt: null,
-    answering: -1,
     presentedAt: null,
     presenting: null,
 };
+
+/**
+ * The accounts a previous attempt answered with, where they were answered for this same address and identity.
+ *
+ * They stand while the accounts of the attempt now in flight are still being read, for the reason {@link Answered}
+ * gives: a folder tree emptied on every re-read is a folder tree emptied every time an account finishes a run. An
+ * answer for another address or another person is not kept, which is the same comparison that decides what is drawn.
+ */
+function accountsStillStanding(
+    previous: Answered,
+    baseAddress: string,
+    presenting: string,
+): Pick<Answered, 'accounts' | 'readAt'> {
+    return previous.presentedAt === baseAddress && previous.presenting === presenting
+        ? { accounts: previous.accounts, readAt: previous.readAt }
+        : { accounts: null, readAt: null };
+}
 
 /**
  * How many automatic attempts have been made, and against which identity.
@@ -230,7 +247,6 @@ export function useConnection(
                     session,
                     accounts: null,
                     readAt: null,
-                    answering: read,
                     presentedAt: baseAddress,
                     presenting,
                 });
@@ -243,14 +259,16 @@ export function useConnection(
             // On the screen as soon as it is known rather than once the accounts beside it are: what it decides — the
             // spaces, the controls, the deployment's version — is answerable now, and holding it back would leave the
             // frame saying it is still reaching a deployment that has already answered.
-            setAnswered({
+            //
+            // The accounts a previous attempt answered with stand until this attempt's replace them, which is what
+            // makes a re-read invisible to whoever is reading: the folder tree keeps its folders and their counts, and
+            // the freshness line keeps the instant those were read at rather than blanking twice per run.
+            setAnswered((previous) => ({
                 session,
-                accounts: null,
-                readAt: null,
-                answering: read,
+                ...accountsStillStanding(previous, baseAddress, presenting),
                 presentedAt: baseAddress,
                 presenting,
-            });
+            }));
 
             // A credential that may not read mail is never asked for it. The refusal would be the service's to give
             // and it would arrive as a failure on a screen, where what is true is that the client is not offering
@@ -276,7 +294,6 @@ export function useConnection(
                 session,
                 accounts,
                 readAt: now(),
-                answering: read,
                 presentedAt: baseAddress,
                 presenting,
             });
@@ -287,11 +304,12 @@ export function useConnection(
         };
     }, [baseAddress, presenting, online, read, send, onCredentialRefused, now]);
 
-    // An answer belonging to an earlier attempt, or to a credential this client is no longer signed in with, is not
-    // this attempt's, and nothing on the screen may be drawn from it: what a person is looking at then is a read in
-    // flight, which is what the frame says while it waits.
-    const current =
-        answered.answering === read && answered.presentedAt === baseAddress && answered.presenting === presenting;
+    // An answer given for another address, or for a credential this client is no longer signed in with, is nobody's to
+    // draw: what a person is looking at then is a read in flight, which is what the frame says while it waits. An
+    // answer for this same address and this same person stands whichever attempt produced it, for the reason
+    // `Answered` gives — a re-read is not a sign-out, and emptying the frame for one is what made a finished
+    // synchronization run look like the page reloading.
+    const current = answered.presentedAt === baseAddress && answered.presenting === presenting;
     const connection = current ? answered : nothingRead;
 
     // Only a deployment that did not answer is reached for again. A credential it refused, a grant it does not hold,

--- a/frontend/src/Client.App/src/shell/useConnection.ts
+++ b/frontend/src/Client.App/src/shell/useConnection.ts
@@ -104,13 +104,18 @@ const nothingRead: Answered = {
  * They stand while the accounts of the attempt now in flight are still being read, for the reason {@link Answered}
  * gives: a folder tree emptied on every re-read is a folder tree emptied every time an account finishes a run. An
  * answer for another address or another person is not kept, which is the same comparison that decides what is drawn.
+ *
+ * A grant that no longer reads mail keeps nothing either, and it is the one case that is not about who is reading. The
+ * attempt holding it asks for no accounts at all, so nothing later in it replaces what stands — a tree left up here
+ * would go on offering mail the deployment has begun refusing, for as long as that person stayed signed in.
  */
 function accountsStillStanding(
     previous: Answered,
     baseAddress: string,
     presenting: string,
+    readsMail: boolean,
 ): Pick<Answered, 'accounts' | 'readAt'> {
-    return previous.presentedAt === baseAddress && previous.presenting === presenting
+    return readsMail && previous.presentedAt === baseAddress && previous.presenting === presenting
         ? { accounts: previous.accounts, readAt: previous.readAt }
         : { accounts: null, readAt: null };
 }
@@ -256,6 +261,8 @@ export function useConnection(
 
             setReaching({ made: 0, presentedAt: baseAddress, presenting });
 
+            const readsMail = offers(session.value, 'readMail');
+
             // On the screen as soon as it is known rather than once the accounts beside it are: what it decides — the
             // spaces, the controls, the deployment's version — is answerable now, and holding it back would leave the
             // frame saying it is still reaching a deployment that has already answered.
@@ -265,7 +272,7 @@ export function useConnection(
             // the freshness line keeps the instant those were read at rather than blanking twice per run.
             setAnswered((previous) => ({
                 session,
-                ...accountsStillStanding(previous, baseAddress, presenting),
+                ...accountsStillStanding(previous, baseAddress, presenting, readsMail),
                 presentedAt: baseAddress,
                 presenting,
             }));
@@ -273,7 +280,7 @@ export function useConnection(
             // A credential that may not read mail is never asked for it. The refusal would be the service's to give
             // and it would arrive as a failure on a screen, where what is true is that the client is not offering
             // something rather than that something went wrong.
-            if (!offers(session.value, 'readMail')) {
+            if (!readsMail) {
                 return;
             }
 


### PR DESCRIPTION
Four causes behind the six things the demo deployment showed, in one change.

## A mailbox change waited out the interval

A flag, an archive, or a move to trash is written down durably and reaches the mail server on the
account's next synchronization run. Nothing brought that run forward, so the wait was the configured
`Interval` — and on an account in push mode it was the wait for the mail *server* to report
something, which a change authored here never is. A message somebody deleted therefore sat under
*moving to trash* for minutes.

`MailAccountRunSignal` ends that wait the moment the records are durable. It follows the outbox's own
signal: a hint rather than a queue entry, never awaited, never retried, carrying nothing — the run
reads the records rather than the raise. It is one raise per account rather than per change, so a
hundred messages filed at once bring one run forward instead of a hundred, and a raise arriving while
the account is mid-run is kept for the wait that follows, which is the ordinary case rather than a
corner.

Only the two recorders a person or an agent reaches raise it — the client's mutation routes and the
`set_mail_flags` tool. A rule's action and a spam verdict's are unchanged.

## The client emptied its own screen on every reconnect

`useConnection` carried the read *attempt* in the tag it compared the last answer against, so every
re-read of the session read as a different person: the accounts and the read time were cleared and
the screen went back to nothing while the new answer was still in flight. That is what the report of
a page refreshing on a signal, and of a mailbox in push mode looking like one on an interval, was
measuring — the signal channel was being torn down and rebuilt with the state behind it.

The tag is now the identity alone — base address and the person presenting — and a re-read for the
same person keeps what it already read on the screen until the new answer lands. A different person
signing in still clears everything.

## Sending with an attachment answered a server error

`POST /api/client/drafts/{draftId}/attachments` declared `application/octet-stream` through
`.Accepts<Stream>`, and that metadata is enforced by the routing pipeline: every other media type was
answered `415` before the handler ran — which is every file an author's own system names, `image/png`
and `text/plain` included. Verified against the demo deployment: `415` on both, `200` on
`application/octet-stream`.

The route admits `*/*` now. The declared type was never checked in the first place — it is recorded
against the file — so nothing is validated less than before.

## A generic browser sign-in dialog over somebody's mail

A `401` on the three OTLP telemetry routes carried the `Basic` challenge every other route on this
surface carries. The caller there is the client's own OTLP exporter, which builds its own `fetch`
with an `Authorization` header and no credentials mode, so the browser was left holding a `Basic`
challenge on a request from a signed-in page — and what it does with one is open its own sign-in
dialog. Those routes now answer the bearer challenge alone, under the same `MailFathom` realm, marked
by `NoPasswordChallenge` metadata the challenge writer reads off the endpoint.

## Notes

There is no per-mailbox push/polling indicator anywhere in the client, so nothing in it could have
been showing the wrong mode. Grafana Loki confirms push mode was genuinely active server-side and a
raw HTTP/1.1 upgrade confirms the signal hub works through nginx, so what that report measured is the
connection above being rebuilt — which is what the second cause fixes.

`http-api-contract.json` moves by one line: the draft upload request body goes from
`application/octet-stream` to `*/*`. It is a widening rather than a break, and it is named here so the
release can compose its entry.

## Verification

- `scripts/verify-full.sh` — green.
- `scripts/review-obligations.sh` — every row answered; the two it reported uncovered are answered by
  a new handler-level challenge test and by `HostCompositionTests` resolving the new singleton.
- Documentation: `docs/operations/client-endpoint.md` and `docs/features/imap-synchronization.md`.

Closes #1807
