### PR TITLE
[#1806] Fix five client screens: the arrival mark, the panel's travel, the move dialog, a draft, and the settings scroll

### DIFF
--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -761,6 +761,26 @@ export function App({
                                                                                 accounts={mailAccounts}
                                                                                 online={connection.online}
                                                                                 onOpen={openTabs.openMail}
+                                                                                onOpenDraft={
+                                                                                    // A result that is a draft opens
+                                                                                    // where it was written. Handed
+                                                                                    // down only where there is a
+                                                                                    // composer to open, so a
+                                                                                    // credential that may not write
+                                                                                    // mail opens it as a message. Read
+                                                                                    // from the grant rather than off
+                                                                                    // `composing`, which holds what
+                                                                                    // had focus and is therefore not a
+                                                                                    // value to read while rendering.
+                                                                                    writesMail
+                                                                                        ? (storedEmailId) => {
+                                                                                              composing.compose({
+                                                                                                  kind: 'draft',
+                                                                                                  storedEmailId,
+                                                                                              });
+                                                                                          }
+                                                                                        : null
+                                                                                }
                                                                             >
                                                                                 <MessageList
                                                                                     key={scopeKey(workspace.scope)}
@@ -883,7 +903,14 @@ export function App({
 
 // What a composer is mounted under, so that asking for a second message replaces the first rather than editing it.
 function openingKey(opening: ComposerOpening): string {
-    return opening.kind === 'new' ? 'new' : `${opening.answers}:${opening.storedEmailId}`;
+    switch (opening.kind) {
+        case 'new':
+            return 'new';
+        case 'draft':
+            return `draft:${opening.storedEmailId}`;
+        case 'answer':
+            return `${opening.answers}:${opening.storedEmailId}`;
+    }
 }
 
 // What is being read on the right of the mail space: one message, the conversation it belongs to, the sender's own

--- a/frontend/src/Client.App/src/composer/Composer.test.tsx
+++ b/frontend/src/Client.App/src/composer/Composer.test.tsx
@@ -44,6 +44,41 @@ function draftBody(overrides: Readonly<Record<string, unknown>> = {}): string {
     });
 }
 
+// What the deployment reduced a draft's body to, which is what a draft opened in the composer is written from.
+function readBody(): string {
+    return JSON.stringify({
+        storedEmailId: messageId,
+        availability: 'Readable',
+        plainText: { text: 'Half a thought', originalCharacterCount: 14, truncation: 'None' },
+        document: {
+            schemaVersion: 1,
+            blocks: [
+                {
+                    type: 'paragraph',
+                    version: 1,
+                    alignment: 'Inherited',
+                    content: [
+                        {
+                            text: 'Half a thought',
+                            emphasis: 'None',
+                            foreground: null,
+                            link: null,
+                        },
+                    ],
+                },
+            ],
+            refusal: 'None',
+            removedRemoteReferenceCount: 0,
+            retainedRemoteImageCount: 0,
+            inlineImageCount: 0,
+            undrawnInlineImageCount: 0,
+            truncated: false,
+        },
+        selfContainedHtml: null,
+        remoteImagesRequested: false,
+    });
+}
+
 // The message an answer is written against, which the composer reads before it can address one.
 function messageBody(): string {
     return JSON.stringify({
@@ -78,6 +113,7 @@ function messageBody(): string {
 /** What each route answers with, so one test states only the answer it is about. */
 interface Answers {
     readonly message?: { readonly status: number; readonly body: string };
+    readonly body?: { readonly status: number; readonly body: string };
     readonly save?: { readonly status: number; readonly body: string };
     readonly send?: { readonly status: number; readonly body: string };
     readonly withdrawal?: { readonly status: number; readonly body: string };
@@ -100,6 +136,10 @@ function deployment(answers: Answers = {}): { transport: MailFathomTransport; as
 }
 
 function answerFor(request: ClientRequest, answers: Answers): { status: number; body: string } {
+    if (request.path.includes('/body')) {
+        return answers.body ?? { status: 200, body: readBody() };
+    }
+
     if (request.path.includes('/messages/')) {
         return answers.message ?? { status: 200, body: messageBody() };
     }
@@ -190,7 +230,7 @@ function drawComposer(
 // The composer itself. Under jsdom the window reads narrow, where the composer stands over the whole screen and is
 // therefore a dialog rather than a region — so this names it by the label it carries in either shape.
 function composerFrame(): HTMLElement {
-    return screen.getByRole('dialog', { name: /^(New message|Reply|Reply to everyone|Forward)$/u });
+    return screen.getByRole('dialog', { name: /^(New message|Draft|Reply|Reply to everyone|Forward)$/u });
 }
 
 /** The send confirmation, named rather than taken by role alone: the composer around it is a dialog too. */
@@ -260,6 +300,7 @@ describe('Composer, a message of its own', () => {
     it('starts from what this tab was writing rather than from an empty message', () => {
         rememberComposition({
             answering: null,
+            continuing: null,
             account: 'work',
             subject: 'Invoice',
             to: ['ada@example.invalid'],
@@ -1003,6 +1044,49 @@ describe('Composer, a message of its own', () => {
     });
 });
 
+describe('Composer, a draft', () => {
+    const continued: ComposerOpening = { kind: 'draft', storedEmailId: messageId };
+
+    it('says it is reading the draft rather than a message being answered, which is a different wait', () => {
+        drawComposer(continued);
+
+        expect(screen.getByText('Reading the draft you are carrying on…')).toBeDefined();
+    });
+
+    // A draft is not an answer, so what opens is the window somebody writes a message in: the addresses they had
+    // typed, the subject still theirs to edit, and the words back where they left them.
+    it('opens as the window a message is written in, on what was filed rather than on nothing', async () => {
+        drawComposer(continued);
+
+        expect(await screen.findByRole('dialog', { name: 'Draft' })).toBeDefined();
+        expect(screen.getByRole('button', { name: 'Remove reader@example.invalid from To' })).toBeDefined();
+        expect(screen.getByText('Half a thought')).toBeDefined();
+    });
+
+    it('offers the subject for editing, a draft being a message of its own rather than one the deployment words', async () => {
+        drawComposer(continued);
+
+        const subject = await screen.findByRole('textbox', { name: 'Subject' });
+
+        expect((subject as HTMLInputElement).value).toBe('Quarterly invoice');
+    });
+
+    // The words are what a draft is, so a body the deployment could not answer with is a draft to carry on rather
+    // than a window to refuse: what was filed as its headers still opens.
+    it('opens on the headers alone where the words could not be read, rather than refusing the draft', async () => {
+        drawComposer(continued, { body: { status: 503, body: '' } });
+
+        expect(await screen.findByRole('dialog', { name: 'Draft' })).toBeDefined();
+        expect(screen.getByRole('button', { name: 'Remove reader@example.invalid from To' })).toBeDefined();
+    });
+
+    it('says what went wrong where the draft itself could not be read, rather than opening an empty window', async () => {
+        drawComposer(continued, { message: { status: 503, body: '' } });
+
+        expect(await screen.findByText(/did not answer/u)).toBeDefined();
+    });
+});
+
 describe('Composer, an answer', () => {
     const replying: ComposerOpening = { kind: 'answer', answers: 'everyone', storedEmailId: messageId };
 
@@ -1110,6 +1194,7 @@ describe('Composer, an answer', () => {
     it('reads nothing where this tab was already writing that answer', () => {
         rememberComposition({
             answering: { storedEmailId: messageId, answers: 'everyone' },
+            continuing: null,
             account: 'work',
             subject: 'Re: Quarterly invoice',
             to: ['billing@example.invalid'],

--- a/frontend/src/Client.App/src/composer/Composer.test.tsx
+++ b/frontend/src/Client.App/src/composer/Composer.test.tsx
@@ -1063,6 +1063,16 @@ describe('Composer, a draft', () => {
         expect(screen.getByText('Half a thought')).toBeDefined();
     });
 
+    // A draft's recipients are written already, exactly as an answer's are, so what somebody came back for is the
+    // words rather than the address standing above them.
+    it('opens with the cursor in the words rather than in recipients that are already written', async () => {
+        drawComposer(continued);
+
+        await screen.findByText('Half a thought');
+
+        expect(document.activeElement).toBe(screen.getByRole('textbox', { name: 'Message' }));
+    });
+
     it('offers the subject for editing, a draft being a message of its own rather than one the deployment words', async () => {
         drawComposer(continued);
 

--- a/frontend/src/Client.App/src/composer/Composer.tsx
+++ b/frontend/src/Client.App/src/composer/Composer.tsx
@@ -4,6 +4,7 @@
 
 import { useEffect, useId, useRef, useState, type KeyboardEvent, type ReactNode } from 'react';
 import {
+    readMailBody,
     readMailMessage,
     type ClientFailureReason,
     type ClientSession,
@@ -18,7 +19,14 @@ import { sizeOf } from '../localization/octets';
 import { useLocalization } from '../localization/useLocalization';
 import { useWideWorkspace } from '../shell/useWideWorkspace';
 import { useToasts, type Toast } from '../toasts/useToasts';
-import { anythingWritten, answerTo, nothingWrittenYet, type ComposerOpening, type Composition } from './composition';
+import {
+    anythingWritten,
+    answerTo,
+    draftContinued,
+    nothingWrittenYet,
+    type ComposerOpening,
+    type Composition,
+} from './composition';
 import { DiscardConfirmation } from './DiscardConfirmation';
 import { forgetComposition, rememberComposition, rememberedComposition } from './keptComposition';
 import { RecipientField } from './RecipientField';
@@ -110,8 +118,9 @@ const withdrawalTitle = {
 const reachableControls =
     'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]';
 
-const titles: Readonly<Record<'new' | MailDraftAnswer, MessageKey>> = {
+const titles: Readonly<Record<'new' | 'draft' | MailDraftAnswer, MessageKey>> = {
     new: 'compose.titleNew',
+    draft: 'compose.titleDraft',
     senderOnly: 'compose.titleReply',
     everyone: 'compose.titleReplyAll',
     forward: 'compose.titleForward',
@@ -182,6 +191,41 @@ export function Composer({
             // keyed by the address.
             setKnown([...new Set(answer.value.headers.participants.map((participant) => participant.address))]);
             setComposition((held) => held ?? answerTo(answer.value, opening.answers));
+        });
+
+        return () => {
+            listening = false;
+        };
+    }, [session, transport, opening]);
+
+    // A draft is read the same way an answer is, and in two reads rather than one: the message route describes who it
+    // is for and what it is about, and the body route is what holds the words. The body is asked for without the
+    // sender's own markup, because what goes back into the composer is the reduced tree rather than markup this client
+    // never parses — `draftWords.ts` is where that reading is stated. A body that could not be read opens the draft on
+    // what the message route did answer, so the addresses and the subject are not lost with the words.
+    useEffect(() => {
+        if (opening.kind !== 'draft') {
+            return;
+        }
+
+        let listening = true;
+
+        void Promise.all([
+            readMailMessage(session, transport, opening.storedEmailId),
+            readMailBody(session, transport, opening.storedEmailId, { remoteImages: false, fullHtml: false }),
+        ]).then(([answer, body]) => {
+            if (!listening) {
+                return;
+            }
+
+            if (answer.outcome === 'failed') {
+                setReading({ kind: 'unread', reason: answer.failure.reason });
+
+                return;
+            }
+
+            setKnown([...new Set(answer.value.headers.participants.map((participant) => participant.address))]);
+            setComposition((held) => held ?? draftContinued(answer.value, body.outcome === 'read' ? body.value : null));
         });
 
         return () => {
@@ -334,7 +378,7 @@ export function Composer({
     // a chosen file is held here until the message is saved or sent, so it costs nothing and is offered offline.
     const sendable = online && stillBeingWritten;
 
-    const title = translate(titles[opening.kind === 'new' ? 'new' : opening.answers]);
+    const title = translate(titles[opening.kind === 'answer' ? opening.answers : opening.kind]);
 
     return (
         <section
@@ -382,7 +426,7 @@ export function Composer({
             </div>
 
             {composition === null ? (
-                <BeforeAnythingIsWritten reading={reading} />
+                <BeforeAnythingIsWritten reading={reading} opening={opening} />
             ) : (
                 <>
                     {accounts.length > 1 && composition.answering === null ? (
@@ -584,21 +628,38 @@ function opened(opening: ComposerOpening, accounts: readonly MailAccount[]): Com
 }
 
 function sameOpening(kept: Composition, opening: ComposerOpening): boolean {
-    return opening.kind === 'new'
-        ? kept.answering === null
-        : kept.answering?.storedEmailId === opening.storedEmailId && kept.answering.answers === opening.answers;
+    switch (opening.kind) {
+        case 'new':
+            return kept.answering === null && kept.continuing === null;
+        case 'draft':
+            return kept.continuing === opening.storedEmailId;
+        case 'answer':
+            return (
+                kept.answering?.storedEmailId === opening.storedEmailId && kept.answering.answers === opening.answers
+            );
+    }
 }
 
 // The composer before there is a message in it, which happens only for an answer: the conversation it is written
 // against has to be read before it can be addressed. Both states say what is happening, and the way out of either is
 // the control the header already carries — with nothing written, it closes rather than asking.
-function BeforeAnythingIsWritten({ reading }: { readonly reading: Reading }) {
+function BeforeAnythingIsWritten({
+    reading,
+    opening,
+}: {
+    readonly reading: Reading;
+    readonly opening: ComposerOpening;
+}) {
     const { translate } = useLocalization();
+
+    // What is being read differs between the two openings that read anything at all, and so does what a reader is
+    // owed while it happens: an answer waits on the message it answers, a draft on the words that reader wrote.
+    const said = opening.kind === 'draft' ? 'compose.readingDraft' : 'compose.reading';
 
     return (
         <div className="flex flex-1 flex-col items-start gap-3 px-4.25 py-6">
             <p aria-live="polite" className="text-base text-muted text-pretty">
-                {translate(reading.kind === 'reading' ? 'compose.reading' : failureSaid[reading.reason])}
+                {translate(reading.kind === 'reading' ? said : failureSaid[reading.reason])}
             </p>
         </div>
     );

--- a/frontend/src/Client.App/src/composer/Composer.tsx
+++ b/frontend/src/Client.App/src/composer/Composer.tsx
@@ -242,14 +242,16 @@ export function Composer({
     }, [composition]);
 
     // Opening the composer is a view change, so focus goes into it rather than staying on the control that opened it.
-    // Once, as the fields appear, on the first one there is to write in — the words for an answer, whose recipients are
-    // written already, and the recipients for a message of its own.
+    // Once, as the fields appear, on the first one there is to write in — the words wherever the recipients are written
+    // already, which an answer and a draft carried on both are, and the recipients for a message of its own.
     const written = composition !== null;
 
     useEffect(() => {
         if (written) {
             frame.current
-                ?.querySelector<HTMLElement>(opening.kind === 'answer' ? '[contenteditable="true"]' : 'input')
+                ?.querySelector<HTMLElement>(
+                    opening.kind === 'answer' || opening.kind === 'draft' ? '[contenteditable="true"]' : 'input',
+                )
                 ?.focus();
         }
     }, [written, opening.kind]);

--- a/frontend/src/Client.App/src/composer/composition.test.ts
+++ b/frontend/src/Client.App/src/composer/composition.test.ts
@@ -8,6 +8,7 @@ import {
     anythingWritten,
     answeredSubject,
     answerTo,
+    draftContinued,
     looksLikeAnAddress,
     nothingWrittenYet,
     whatWouldBeMissing,
@@ -97,6 +98,44 @@ describe('answerTo', () => {
         expect(composed.answering).toEqual({ storedEmailId: 'e1', answers: 'everyone' });
         expect(composed.account).toBe('work');
         expect(composed.words).toEqual([]);
+    });
+});
+
+describe('draftContinued', () => {
+    // A draft is a message this deployment already holds, so nothing here is composed: what was filed is what comes
+    // back, including the blind copies a reply would never have derived.
+    it('opens the composer on what was filed, each header where its author put it', () => {
+        const filed = message('Half written', [
+            participant('From', 'me@example.invalid'),
+            participant('To', 'ada@example.invalid'),
+            participant('Cc', 'grace@example.invalid'),
+            participant('Bcc', 'alan@example.invalid'),
+        ]);
+
+        const composed = draftContinued(filed, null);
+
+        expect(composed.subject).toBe('Half written');
+        expect(composed.account).toBe('work');
+        expect(composed.to).toStrictEqual(['ada@example.invalid']);
+        expect(composed.cc).toStrictEqual(['grace@example.invalid']);
+        expect(composed.bcc).toStrictEqual(['alan@example.invalid']);
+    });
+
+    // It answers nothing — a draft is a message of its own — and says instead which stored message the words came
+    // from, which is what tells one composition from another when neither answers anything.
+    it('answers nothing and says which stored message it was carried on from', () => {
+        const composed = draftContinued(message('Half written', []), null);
+
+        expect(composed.answering).toBeNull();
+        expect(composed.continuing).toBe('e1');
+    });
+
+    it('opens on an empty subject where the draft was filed without one, rather than on nothing at all', () => {
+        expect(draftContinued(message(null, []), null).subject).toBe('');
+    });
+
+    it('opens on no words where the body could not be read, which is a draft to carry on rather than one to refuse', () => {
+        expect(draftContinued(message('Half written', []), null).words).toStrictEqual([]);
     });
 });
 

--- a/frontend/src/Client.App/src/composer/composition.ts
+++ b/frontend/src/Client.App/src/composer/composition.ts
@@ -2,7 +2,14 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import type { MailDraftAnswer, MailDraftComposition, MailMessage, MailParticipant } from '@mailfathom/client-backend';
+import type {
+    MailBody,
+    MailDraftAnswer,
+    MailDraftComposition,
+    MailMessage,
+    MailParticipant,
+} from '@mailfathom/client-backend';
+import { draftWords } from './draftWords';
 import { htmlOf, plainTextOf, type WrittenNode } from './writtenText';
 
 // What somebody is writing, as values rather than as anything on the screen. The composer draws it, the confirmation
@@ -14,15 +21,29 @@ import { htmlOf, plainTextOf, type WrittenNode } from './writtenText';
 // and edits before anything is saved. The account, the subject, and the threading identifiers of an answer are the
 // deployment's and are never sent from here — `wireComposition` is where that shows.
 
-/** What opening the composer is: a message of its own, or an answer to one this deployment holds. */
+/**
+ * What opening the composer is: a message of its own, an answer to one this deployment holds, or a draft already in a
+ * drafts folder being carried on with.
+ */
 export type ComposerOpening =
     | { readonly kind: 'new' }
-    | { readonly kind: 'answer'; readonly answers: MailDraftAnswer; readonly storedEmailId: string };
+    | { readonly kind: 'answer'; readonly answers: MailDraftAnswer; readonly storedEmailId: string }
+    | { readonly kind: 'draft'; readonly storedEmailId: string };
 
 /** What the author has written, and what it is being written against. */
 export interface Composition {
     /** The message this answers and which answer it is, or `null` for a message of its own. */
     readonly answering: { readonly storedEmailId: string; readonly answers: MailDraftAnswer } | null;
+
+    /**
+     * The message in a drafts folder this was opened from, or `null` where it was not opened from one.
+     *
+     * It says where the words came from and nothing else: a save still writes a draft of its own, because the client
+     * surface publishes no route that reads a draft back or takes a stored message over as the one being written. What
+     * it is for is telling one composition from another — a message of its own and a draft carried on with both answer
+     * nothing, so without it the tab would restore whichever of the two it kept last into either.
+     */
+    readonly continuing: string | null;
 
     /** The account it goes out as, which an answer reads from the message it answers and therefore never states. */
     readonly account: string;
@@ -56,7 +77,7 @@ export const mostRecipientsInOneHeader = 256;
 
 /** A message of its own, addressed to nobody and about nothing yet. */
 export function nothingWrittenYet(account: string): Composition {
-    return { answering: null, account, subject: '', to: [], cc: [], bcc: [], words: [] };
+    return { answering: null, continuing: null, account, subject: '', to: [], cc: [], bcc: [], words: [] };
 }
 
 /**
@@ -72,6 +93,7 @@ export function answerTo(message: MailMessage, answers: MailDraftAnswer): Compos
 
     return {
         answering: { storedEmailId: message.storedEmailId, answers },
+        continuing: null,
         account: message.account,
         subject: answeredSubject(message.headers.subject, answers),
 
@@ -81,6 +103,30 @@ export function answerTo(message: MailMessage, answers: MailDraftAnswer): Compos
         cc: answers === 'everyone' ? everybody.filter((address) => !to.includes(address)) : [],
         bcc: [],
         words: [],
+    };
+}
+
+/**
+ * The draft somebody has just opened, put back into the composer that writes one.
+ *
+ * A draft is a message this deployment already holds, so nothing here is composed: the account, the addresses, the
+ * subject, and the words are read back exactly as they were filed. What it is not is the deployment's own draft
+ * record — the client surface publishes no route that reads one back — so `continuing` says which stored message the
+ * words came from and a save still writes a draft of its own beside it.
+ *
+ * @param message The draft being carried on with, as the deployment described it.
+ * @param body Its body as the deployment reduced it, or `null` where it could not be read.
+ */
+export function draftContinued(message: MailMessage, body: MailBody | null): Composition {
+    return {
+        answering: null,
+        continuing: message.storedEmailId,
+        account: message.account,
+        subject: message.headers.subject ?? '',
+        to: addressesOf(message.headers.participants, ['To']),
+        cc: addressesOf(message.headers.participants, ['Cc']),
+        bcc: addressesOf(message.headers.participants, ['Bcc']),
+        words: body === null ? [] : draftWords(body),
     };
 }
 

--- a/frontend/src/Client.App/src/composer/draftWords.test.ts
+++ b/frontend/src/Client.App/src/composer/draftWords.test.ts
@@ -37,6 +37,18 @@ function paragraph(...content: readonly MailInlineRun[]): MailDocumentBlock {
     return { type: 'paragraph', content, alignment: 'Inherited' };
 }
 
+// Every block the composer has no shape for, which is what it drops rather than approximates.
+const undrawn: readonly MailDocumentBlock[] = [
+    { type: 'separator' },
+    {
+        type: 'image',
+        image: { source: 'cid:one', alternativeText: null, width: null, height: null },
+        link: null,
+        alignment: 'Inherited',
+    },
+    { type: 'unimplemented', identity: 'chart', version: 3 },
+];
+
 function bodyOf(blocks: readonly MailDocumentBlock[], plainText = ''): MailBody {
     return {
         storedEmailId: 'message-1',
@@ -148,18 +160,15 @@ describe('draftWords', () => {
     });
 
     it('drops a block the composer has nothing to write it with, rather than approximating one', () => {
-        const undrawn: readonly MailDocumentBlock[] = [
-            { type: 'separator' },
-            {
-                type: 'image',
-                image: { source: 'cid:one', alternativeText: null, width: null, height: null },
-                link: null,
-                alignment: 'Inherited',
-            },
-            { type: 'unimplemented', identity: 'chart', version: 3 },
-        ];
+        expect(htmlOf(draftWords(bodyOf([...undrawn.slice(0, 1), paragraph(run('one')), ...undrawn.slice(1)])))).toBe(
+            '<p>one</p>',
+        );
+    });
 
-        expect(draftWords(bodyOf(undrawn))).toStrictEqual([]);
+    // The blocks are dropped one by one, so a message made of nothing else reduces to nothing at all — and what is
+    // left to open the composer on is the rendering the deployment always carries beside the document.
+    it('falls back to the plain text where every block is one it has nothing to write', () => {
+        expect(plainTextOf(draftWords(bodyOf(undrawn, 'The chart is attached')))).toBe('The chart is attached');
     });
 
     it('keeps preformatted text line by line, which is the shape the composer’s own region produces', () => {

--- a/frontend/src/Client.App/src/composer/draftWords.test.ts
+++ b/frontend/src/Client.App/src/composer/draftWords.test.ts
@@ -1,0 +1,175 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { describe, expect, it } from 'vitest';
+import type { MailBody, MailDocumentBlock, MailInlineRun, MailTextEmphasis } from '@mailfathom/client-backend';
+import { draftWords } from './draftWords';
+import { htmlOf, plainTextOf } from './writtenText';
+
+const nothingEmphasised: MailTextEmphasis = {
+    bold: false,
+    italic: false,
+    underline: false,
+    strikethrough: false,
+    monospace: false,
+};
+
+function run(text: string, emphasis: Partial<MailTextEmphasis> = {}, target: string | null = null): MailInlineRun {
+    return {
+        text,
+        emphasis: { ...nothingEmphasised, ...emphasis },
+        foreground: null,
+        link:
+            target === null
+                ? null
+                : {
+                      target,
+                      host: null,
+                      asciiHost: null,
+                      deception: 'NotApplicable',
+                      worthWarningAbout: false,
+                  },
+    };
+}
+
+function paragraph(...content: readonly MailInlineRun[]): MailDocumentBlock {
+    return { type: 'paragraph', content, alignment: 'Inherited' };
+}
+
+function bodyOf(blocks: readonly MailDocumentBlock[], plainText = ''): MailBody {
+    return {
+        storedEmailId: 'message-1',
+        availability: 'Readable',
+        plainText: { text: plainText, originalCharacterCount: plainText.length, truncation: 'None' },
+        document:
+            blocks.length === 0
+                ? null
+                : {
+                      blocks,
+                      refusal: 'None',
+                      removedRemoteReferenceCount: 0,
+                      retainedRemoteImageCount: 0,
+                      inlineImageCount: 0,
+                      undrawnInlineImageCount: 0,
+                      truncated: false,
+                  },
+        selfContainedHtml: null,
+        remoteImagesRequested: false,
+    };
+}
+
+describe('draftWords', () => {
+    it('carries each paragraph across as a paragraph, which is what the composer writes one as', () => {
+        expect(htmlOf(draftWords(bodyOf([paragraph(run('Half a thought')), paragraph(run('and the rest'))])))).toBe(
+            '<p>Half a thought</p><p>and the rest</p>',
+        );
+    });
+
+    it('wraps a run in each emphasis it carries, one element inside another rather than a shape named for the pair', () => {
+        expect(htmlOf(draftWords(bodyOf([paragraph(run('urgent', { bold: true, italic: true }))])))).toBe(
+            '<p><em><strong>urgent</strong></em></p>',
+        );
+    });
+
+    // The composer writes no code, so borrowing an element that means something else would say what the author did
+    // not: what is lost is the face the run was set in rather than the words.
+    it('drops the one emphasis the composer has no element for, keeping the words that carried it', () => {
+        expect(htmlOf(draftWords(bodyOf([paragraph(run('rm -rf', { monospace: true }))])))).toBe('<p>rm -rf</p>');
+    });
+
+    it('keeps a link the client would follow, and draws one it would not as its own words', () => {
+        const followed = draftWords(bodyOf([paragraph(run('the page', {}, 'https://example.test/page'))]));
+        const refused = draftWords(bodyOf([paragraph(run('the page', {}, 'javascript:alert(1)'))]));
+
+        expect(htmlOf(followed)).toBe('<p><a href="https://example.test/page">the page</a></p>');
+        expect(htmlOf(refused)).toBe('<p>the page</p>');
+    });
+
+    // The composer writes no headings, so the line keeps the weight that says it was one rather than levelling into
+    // the prose around it.
+    it('carries a heading across as the strongest emphasis the composer does write', () => {
+        const heading: MailDocumentBlock = {
+            type: 'heading',
+            level: 2,
+            content: [run('Agenda')],
+            alignment: 'Inherited',
+        };
+
+        expect(htmlOf(draftWords(bodyOf([heading])))).toBe('<p><strong>Agenda</strong></p>');
+    });
+
+    it('carries a list across as the list it was, its items in the order they were written', () => {
+        const list: MailDocumentBlock = {
+            type: 'list',
+            ordered: true,
+            items: [{ blocks: [paragraph(run('first'))] }, { blocks: [paragraph(run('second'))] }],
+        };
+
+        expect(htmlOf(draftWords(bodyOf([list])))).toBe('<ol><li><p>first</p></li><li><p>second</p></li></ol>');
+    });
+
+    it('carries a quotation across as one, which is a shape the composer draws', () => {
+        const quote: MailDocumentBlock = { type: 'quote', depth: 1, blocks: [paragraph(run('you wrote'))] };
+
+        expect(htmlOf(draftWords(bodyOf([quote])))).toBe('<blockquote><p>you wrote</p></blockquote>');
+    });
+
+    // The grid is not something the composer draws. A table dropped whole would take the message's words with it, so
+    // what is kept is what the cells say, in the order they say it.
+    it('keeps what a table’s cells say although the grid around them is lost', () => {
+        const table: MailDocumentBlock = {
+            type: 'table',
+            columns: [{ widthShare: null }, { widthShare: null }],
+            rows: [
+                {
+                    isHeader: false,
+                    cells: [
+                        {
+                            columnSpan: 1,
+                            rowSpan: 1,
+                            alignment: 'Inherited',
+                            background: null,
+                            blocks: [paragraph(run('Monday'))],
+                        },
+                        {
+                            columnSpan: 1,
+                            rowSpan: 1,
+                            alignment: 'Inherited',
+                            background: null,
+                            blocks: [paragraph(run('nine'))],
+                        },
+                    ],
+                },
+            ],
+        };
+
+        expect(htmlOf(draftWords(bodyOf([table])))).toBe('<p>Monday</p><p>nine</p>');
+    });
+
+    it('drops a block the composer has nothing to write it with, rather than approximating one', () => {
+        const undrawn: readonly MailDocumentBlock[] = [
+            { type: 'separator' },
+            {
+                type: 'image',
+                image: { source: 'cid:one', alternativeText: null, width: null, height: null },
+                link: null,
+                alignment: 'Inherited',
+            },
+            { type: 'unimplemented', identity: 'chart', version: 3 },
+        ];
+
+        expect(draftWords(bodyOf(undrawn))).toStrictEqual([]);
+    });
+
+    it('keeps preformatted text line by line, which is the shape the composer’s own region produces', () => {
+        const preformatted: MailDocumentBlock = { type: 'preformatted', text: 'one\ntwo' };
+
+        expect(htmlOf(draftWords(bodyOf([preformatted])))).toBe('<p>one</p><p>two</p>');
+    });
+
+    // A body the deployment could not reduce is answered as plain text, which is the rendering it always carries.
+    it('falls back to the plain text where the deployment reduced no document at all', () => {
+        expect(plainTextOf(draftWords(bodyOf([], 'Sent from a phone\n\nsorry')))).toBe('Sent from a phone\n\nsorry');
+    });
+});

--- a/frontend/src/Client.App/src/composer/draftWords.ts
+++ b/frontend/src/Client.App/src/composer/draftWords.ts
@@ -19,14 +19,15 @@ import { followable, type WrittenElement, type WrittenNode } from './writtenText
 // **What the composer cannot write is not written.** A draft carrying a table, a picture, or a block a later
 // deployment publishes has no shape here — the composer's set is what a person can type with its own controls, and
 // inventing an approximation would put words on the screen the author never wrote. A table's cells are still walked,
-// because the words in them are the message; the grid is what is lost. A body the deployment could not reduce at all
-// falls back to its plain text, which is the rendering it always answers with.
+// because the words in them are the message; the grid is what is lost. A body that leaves nothing the composer can
+// write — one the deployment could not reduce at all, and one whose every block is a block this has no shape for —
+// falls back to its plain text, which is the rendering the deployment always answers with.
 
 /** The words of a draft, as the closed tree the composer writes. */
 export function draftWords(body: MailBody): readonly WrittenNode[] {
-    const blocks = body.document?.blocks ?? [];
+    const written = (body.document?.blocks ?? []).flatMap(writtenBlock);
 
-    return blocks.length === 0 ? paragraphsOf(body.plainText.text) : blocks.flatMap(writtenBlock);
+    return written.length === 0 ? paragraphsOf(body.plainText.text) : written;
 }
 
 // One block as the elements the composer has for it. An empty array is a block it has none for, which is dropped

--- a/frontend/src/Client.App/src/composer/draftWords.ts
+++ b/frontend/src/Client.App/src/composer/draftWords.ts
@@ -1,0 +1,109 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import type { MailBody, MailDocumentBlock, MailInlineRun, MailTextEmphasis } from '@mailfathom/client-backend';
+import { followable, type WrittenElement, type WrittenNode } from './writtenText';
+
+// A draft the deployment holds, read back into the closed tree the composer writes. It is the one direction
+// `writtenText.ts` does not already cover: that module reads an editable region into the tree and renders the tree
+// back out, and this reads the *deployment's* description of a message into the same tree so a draft can be carried
+// on with rather than only read.
+//
+// **It reads the reduced document rather than the sender's markup**, which is the whole reason it can exist at all.
+// ADR 0024 keeps this client from parsing mail markup anywhere, and nothing here does: what arrives is already the
+// typed tree the reading pane draws, checked at the client's trust boundary in `mailBody.ts`, and this walks it into a
+// second typed tree. No string is parsed, no sanitizer is pinned, and what a hostile draft can put in the composer is
+// bounded by what `WrittenNode` can express.
+//
+// **What the composer cannot write is not written.** A draft carrying a table, a picture, or a block a later
+// deployment publishes has no shape here — the composer's set is what a person can type with its own controls, and
+// inventing an approximation would put words on the screen the author never wrote. A table's cells are still walked,
+// because the words in them are the message; the grid is what is lost. A body the deployment could not reduce at all
+// falls back to its plain text, which is the rendering it always answers with.
+
+/** The words of a draft, as the closed tree the composer writes. */
+export function draftWords(body: MailBody): readonly WrittenNode[] {
+    const blocks = body.document?.blocks ?? [];
+
+    return blocks.length === 0 ? paragraphsOf(body.plainText.text) : blocks.flatMap(writtenBlock);
+}
+
+// One block as the elements the composer has for it. An empty array is a block it has none for, which is dropped
+// rather than approximated.
+function writtenBlock(block: MailDocumentBlock): readonly WrittenNode[] {
+    switch (block.type) {
+        case 'paragraph':
+            return [wrapping('p', runsWritten(block.content))];
+
+        // The composer writes no headings, so a heading is a paragraph in the strongest emphasis it does write. That
+        // keeps the line reading as the line it was rather than levelling it into the prose around it.
+        case 'heading':
+            return [wrapping('p', [wrapping('strong', runsWritten(block.content))])];
+
+        case 'list':
+            return [
+                wrapping(
+                    block.ordered ? 'ol' : 'ul',
+                    block.items.map((item) => wrapping('li', item.blocks.flatMap(writtenBlock))),
+                ),
+            ];
+
+        case 'quote':
+            return [wrapping('blockquote', block.blocks.flatMap(writtenBlock))];
+
+        case 'preformatted':
+            return paragraphsOf(block.text);
+
+        // The grid is not something the composer draws, so what is kept is what the cells say, in the order they say
+        // it. A table dropped whole would take the message's words with it.
+        case 'table':
+            return block.rows.flatMap((row) => row.cells.flatMap((cell) => cell.blocks.flatMap(writtenBlock)));
+
+        case 'image':
+        case 'separator':
+        case 'unimplemented':
+            return [];
+    }
+}
+
+// The runs of one paragraph, each wrapped in whatever it carries. A run is wrapped from the inside out, so a bold
+// italic link is one element inside another rather than a shape this had to name.
+function runsWritten(runs: readonly MailInlineRun[]): readonly WrittenNode[] {
+    return runs.map((run) => {
+        let written: WrittenNode = { text: run.text };
+
+        for (const element of emphasised(run.emphasis)) {
+            written = { element, address: null, holds: [written] };
+        }
+
+        // A link the composer would not make is drawn as its own words instead, which is the same refusal
+        // `writtenText.ts` states for one somebody pastes: a scheme this client will not follow is not one it will
+        // put back on the screen as a link either.
+        return run.link !== null && followable(run.link.target)
+            ? { element: 'a' as const, address: run.link.target, holds: [written] }
+            : written;
+    });
+}
+
+// Which of the composer's own emphases a run carries. Monospace is not among them: the composer writes no code and a
+// run that was monospace loses that rather than borrowing an element that means something else.
+function emphasised(emphasis: MailTextEmphasis): readonly WrittenElement[] {
+    return [
+        ...(emphasis.bold ? (['strong'] as const) : []),
+        ...(emphasis.italic ? (['em'] as const) : []),
+        ...(emphasis.underline ? (['u'] as const) : []),
+        ...(emphasis.strikethrough ? (['s'] as const) : []),
+    ];
+}
+
+// Text with its line breaks kept, as one paragraph per line. A line is a paragraph rather than a `br` because that is
+// what the composer's own editable region produces from typing, and a draft that goes back through it should come out
+// the shape it went in.
+function paragraphsOf(text: string): readonly WrittenNode[] {
+    return text.split('\n').map((line) => wrapping('p', line === '' ? [] : [{ text: line }]));
+}
+
+function wrapping(element: WrittenElement, holds: readonly WrittenNode[]): WrittenNode {
+    return { element, address: null, holds };
+}

--- a/frontend/src/Client.App/src/composer/keptComposition.test.ts
+++ b/frontend/src/Client.App/src/composer/keptComposition.test.ts
@@ -35,6 +35,14 @@ describe('rememberedComposition', () => {
         expect(rememberedComposition()).toEqual(answering);
     });
 
+    it('reads back a draft with the stored message it was carried on from', () => {
+        const carriedOn: Composition = { ...written, continuing: 'e1' };
+
+        rememberComposition(carriedOn);
+
+        expect(rememberedComposition()).toEqual(carriedOn);
+    });
+
     it('answers nothing where nothing was kept', () => {
         expect(rememberedComposition()).toBeNull();
     });
@@ -67,6 +75,11 @@ describe('rememberedComposition', () => {
             JSON.stringify({ ...written, answering: { storedEmailId: 'e1', answers: 'shout' } }),
         ],
         ['an answer that is a list', JSON.stringify({ ...written, answering: [] })],
+        ['a draft carried on from something that is not text', JSON.stringify({ ...written, continuing: 7 })],
+        [
+            'a draft carried on from an identifier longer than one',
+            JSON.stringify({ ...written, continuing: 'x'.repeat(257) }),
+        ],
     ])('answers nothing for %s, rather than a message with a hole in it', (_, stored) => {
         window.sessionStorage.setItem(storageKey, stored);
 

--- a/frontend/src/Client.App/src/composer/keptComposition.test.ts
+++ b/frontend/src/Client.App/src/composer/keptComposition.test.ts
@@ -80,6 +80,10 @@ describe('rememberedComposition', () => {
             'a draft carried on from an identifier longer than one',
             JSON.stringify({ ...written, continuing: 'x'.repeat(257) }),
         ],
+        [
+            'a message that is both an answer and a draft carried on, which nothing here writes',
+            JSON.stringify({ ...written, answering: { storedEmailId: 'e1', answers: 'everyone' }, continuing: 'e2' }),
+        ],
     ])('answers nothing for %s, rather than a message with a hole in it', (_, stored) => {
         window.sessionStorage.setItem(storageKey, stored);
 

--- a/frontend/src/Client.App/src/composer/keptComposition.ts
+++ b/frontend/src/Client.App/src/composer/keptComposition.ts
@@ -106,7 +106,12 @@ function compositionIn(value: unknown): Composition | null {
         return null;
     }
 
-    if (continuing !== null && (typeof continuing !== 'string' || continuing.length > longestIdentifier)) {
+    // An answer and a draft carried on are two messages to have started from, and nothing here writes both at once —
+    // so a value carrying both is a shape this client did not write, whatever each half of it says on its own.
+    if (
+        continuing !== null &&
+        (answering !== null || typeof continuing !== 'string' || continuing.length > longestIdentifier)
+    ) {
         return null;
     }
 

--- a/frontend/src/Client.App/src/composer/keptComposition.ts
+++ b/frontend/src/Client.App/src/composer/keptComposition.ts
@@ -85,6 +85,7 @@ function compositionIn(value: unknown): Composition | null {
     const subject = record['subject'];
     const words = writtenTextIn(record['words']);
     const answering = answeringIn(record['answering'] ?? null);
+    const continuing = record['continuing'] ?? null;
     const to = addressesIn(record['to']);
     const cc = addressesIn(record['cc']);
     const bcc = addressesIn(record['bcc']);
@@ -105,7 +106,11 @@ function compositionIn(value: unknown): Composition | null {
         return null;
     }
 
-    return { answering, account, subject, to, cc, bcc, words };
+    if (continuing !== null && (typeof continuing !== 'string' || continuing.length > longestIdentifier)) {
+        return null;
+    }
+
+    return { answering, continuing, account, subject, to, cc, bcc, words };
 }
 
 // Answers `undefined` for a shape it refuses, because `null` is what a message of its own legitimately kept.

--- a/frontend/src/Client.App/src/controls/ChoiceSegment.test.tsx
+++ b/frontend/src/Client.App/src/controls/ChoiceSegment.test.tsx
@@ -1,0 +1,53 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ChoiceSegment } from './ChoiceSegment';
+
+// What the two segments say on the screen this stands in for. Held here rather than written into the markup below,
+// where it would read as copy this repository keeps in a catalogue rather than as a fixture.
+const light = 'Light';
+const dark = 'Dark';
+
+/** A group of two segments as every screen draws one: several of them sharing a name. */
+function drawn(chosen: string, onChoose: (value: string) => void = () => undefined) {
+    return render(
+        <>
+            <ChoiceSegment shape="row" name="theme" value="light" chosen={chosen === 'light'} onChoose={onChoose}>
+                {light}
+            </ChoiceSegment>
+            <ChoiceSegment shape="row" name="theme" value="dark" chosen={chosen === 'dark'} onChoose={onChoose}>
+                {dark}
+            </ChoiceSegment>
+        </>,
+    );
+}
+
+describe('ChoiceSegment', () => {
+    it('is one choice out of a group, reported under the words it carries', () => {
+        drawn('light');
+
+        expect(screen.getByRole('radio', { name: light, checked: true })).toBeDefined();
+        expect(screen.getByRole('radio', { name: dark, checked: false })).toBeDefined();
+    });
+
+    it('answers with the value of the segment that was chosen, which the caller reads back into its own set', () => {
+        const chosen = vi.fn();
+
+        drawn('light', chosen);
+        fireEvent.click(screen.getByRole('radio', { name: dark }));
+
+        expect(chosen).toHaveBeenCalledWith('dark');
+    });
+
+    // The radio is hidden by being taken out of the flow, so whichever ancestor is positioned is the one it stands
+    // against. A panel that scrolls and is not one reports it as overflow standing below everything a reader can see,
+    // which is a second scrollbar on a surface that already has one — so the segment carries the containing block.
+    it('keeps the radio it hides inside a box of its own, rather than against whatever happens to be positioned', () => {
+        drawn('light');
+
+        expect(screen.getByRole('radio', { name: light }).parentElement?.classList.contains('relative')).toBe(true);
+    });
+});

--- a/frontend/src/Client.App/src/controls/ChoiceSegment.tsx
+++ b/frontend/src/Client.App/src/controls/ChoiceSegment.tsx
@@ -41,7 +41,9 @@ export function ChoiceSegment({
 
     return (
         <label
-            className={`cursor-pointer transition has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-offset-2 has-[:focus-visible]:outline-accent ${look.shape} ${
+            // `relative` for the reason `Switch` carries one: the radio is hidden by being taken out of the flow, and
+            // an ancestor that scrolls would otherwise report it as overflow standing outside every clip.
+            className={`relative cursor-pointer transition has-[:focus-visible]:outline-2 has-[:focus-visible]:outline-offset-2 has-[:focus-visible]:outline-accent ${look.shape} ${
                 chosen ? look.chosen : look.unchosen
             }`}
         >

--- a/frontend/src/Client.App/src/controls/Switch.test.tsx
+++ b/frontend/src/Client.App/src/controls/Switch.test.tsx
@@ -45,6 +45,15 @@ describe('Switch', () => {
         expect(chosen).toHaveBeenCalledWith(false);
     });
 
+    // The input is hidden by being taken out of the flow, so whichever ancestor is positioned is the one it stands
+    // against. A panel that scrolls and is not one reports it as overflow standing below everything a reader can see,
+    // which is a second scrollbar on a surface that already has one — so the control carries the containing block.
+    it('keeps the input it hides inside a box of its own, rather than against whatever happens to be positioned', () => {
+        drawn(false, () => undefined);
+
+        expect(screen.getByRole('switch').parentElement?.classList.contains('relative')).toBe(true);
+    });
+
     // What an inert switch refuses is the browser's own activation behaviour, which `fireEvent` dispatches past, so
     // what is asserted here is the state a browser reads that from rather than a click it would never have delivered.
     it('is inert rather than absent where the screen cannot act on it', () => {

--- a/frontend/src/Client.App/src/controls/Switch.tsx
+++ b/frontend/src/Client.App/src/controls/Switch.tsx
@@ -26,7 +26,12 @@ export function Switch({
     readonly disabled?: boolean;
 }) {
     return (
-        <>
+        // The input is hidden by being taken out of the flow, so it is positioned against whichever ancestor is
+        // positioned — and a scrolling panel that is not one leaves it standing at its static position outside every
+        // clip between here and there, which the panel's own scroller then reports as overflow nobody can see. So the
+        // control carries the containing block itself rather than each screen remembering to, and the wrapper is what
+        // keeps the track the input's next sibling, which is what `peer-checked` reads.
+        <span className="relative flex shrink-0">
             <input
                 type="checkbox"
                 role="switch"
@@ -40,6 +45,6 @@ export function Switch({
             <span className="flex w-7.5 shrink-0 items-center rounded-full bg-line-strong p-0.5 transition peer-checked:justify-end peer-checked:bg-accent peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-accent">
                 <span className="size-3.25 rounded-full bg-panel" />
             </span>
-        </>
+        </span>
     );
 }

--- a/frontend/src/Client.App/src/folders/FolderRow.tsx
+++ b/frontend/src/Client.App/src/folders/FolderRow.tsx
@@ -3,13 +3,11 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import type { KeyboardEvent } from 'react';
-import type { MailFolderRole } from '@mailfathom/client-backend';
 import { Icon } from '../controls/Icon';
 import { MailboxMark } from '../controls/MailboxMark';
-import type { IconName } from '../controls/icons';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
-import { folderRoleLabels } from '../workspace/mailScope';
+import { folderRoleIcons, folderRoleLabels } from '../workspace/mailScope';
 import type { FolderTreeRow } from './folderTreeRows';
 
 // One row of the tree, which is its own component because it is the row of a list and because it carries everything a
@@ -40,19 +38,6 @@ import type { FolderTreeRow } from './folderTreeRows';
 // than the list sits where its last entry does: a mailbox nested six deep is rare, and a row indented off the side of
 // a narrow column is worse than one that stops moving.
 const levelIndents: readonly string[] = ['ps-2.75', 'ps-6', 'ps-9', 'ps-12', 'ps-14'];
-
-const roleIcons: Readonly<Record<MailFolderRole, IconName>> = {
-    Inbox: 'inbox',
-    Drafts: 'draft',
-    Sent: 'send',
-    Archive: 'archive',
-    Junk: 'report',
-    Trash: 'delete',
-    Flagged: 'flag',
-    Important: 'label_important',
-    All: 'all_inbox',
-    Outbox: 'outbox',
-};
 
 // How a row is drawn, which is four cases rather than one expression: a group or a folder, each at the column's width
 // or at the rail's. Named here rather than spelled into the markup, for the reason `frontend/src`'s instructions give
@@ -137,7 +122,7 @@ export function FolderRow({
                 <MailboxMark ordinal={groupOrdinal} />
             ) : (
                 <Icon
-                    name={row.role === null ? 'folder' : roleIcons[row.role]}
+                    name={row.role === null ? 'folder' : folderRoleIcons[row.role]}
                     className={`${folded ? 'size-6' : 'size-4.5'} shrink-0 ${selected ? 'text-accent-deep' : 'text-muted'}`}
                 />
             )}

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -338,11 +338,13 @@ export const en = {
     'act.moveClose': 'Close',
 
     'compose.titleNew': 'New message',
+    'compose.titleDraft': 'Draft',
     'compose.titleReply': 'Reply',
     'compose.titleReplyAll': 'Reply to everyone',
     'compose.titleForward': 'Forward',
     'compose.close': 'Close the message',
     'compose.reading': 'Reading the message you are answering…',
+    'compose.readingDraft': 'Reading the draft you are carrying on…',
     'compose.from': 'From',
     'compose.to': 'To',
     'compose.cc': 'Cc',

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -338,11 +338,13 @@ export const pl: Catalogue = {
     'act.moveClose': 'Zamknij',
 
     'compose.titleNew': 'Nowa wiadomość',
+    'compose.titleDraft': 'Szkic',
     'compose.titleReply': 'Odpowiedź',
     'compose.titleReplyAll': 'Odpowiedź do wszystkich',
     'compose.titleForward': 'Przekazanie dalej',
     'compose.close': 'Zamknij wiadomość',
     'compose.reading': 'Odczytujemy wiadomość, na którą odpowiadasz…',
+    'compose.readingDraft': 'Wczytywanie szkicu, który kontynuujesz…',
     'compose.from': 'Od',
     'compose.to': 'Do',
     'compose.cc': 'DW',

--- a/frontend/src/Client.App/src/mailSpace/SelectionBar.test.tsx
+++ b/frontend/src/Client.App/src/mailSpace/SelectionBar.test.tsx
@@ -6,7 +6,7 @@ import { useEffect } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { LocalizationProvider } from '../localization/Localization';
-import type { MoveDestination } from '../mailboxActs/mailboxDestinations';
+import type { MoveDestination, MoveDestinationGroup } from '../mailboxActs/mailboxDestinations';
 import { MailboxActsContext, nothingActed, type ActedMessage, type MailboxActs } from '../mailboxActs/useMailboxActs';
 import { ListedMailContext, nothingListed, type ListedMail } from '../messageList/useListedMail';
 import { WorkspaceProvider } from '../workspace/Workspace';
@@ -18,7 +18,13 @@ const drawnRows: readonly ActedMessage[] = [
     { storedEmailId: 'message-2', account: 'work', folder: 'work-inbox' },
 ];
 
-const clients: MoveDestination = { alias: 'work-clients', name: 'Projects / Clients' };
+const clients: MoveDestination = { alias: 'work-clients', name: 'Projects / Clients', role: null };
+const work: MoveDestinationGroup = {
+    accountId: 'work',
+    accountName: 'Northwind \u00b7 work',
+    ordinal: 0,
+    destinations: [clients],
+};
 
 function Picks({ selected }: { readonly selected: readonly string[] }) {
     const { workspace, revise } = useWorkspace();
@@ -124,7 +130,7 @@ describe('SelectionBar', () => {
     it('files everything picked out in the folder somebody chose, rather than in one this client guessed', () => {
         const performed = vi.fn();
 
-        drawBar(['message-1'], { perform: performed, destinationsOf: () => [clients] });
+        drawBar(['message-1'], { perform: performed, destinationsOf: () => [work] });
 
         fireEvent.click(screen.getByRole('button', { name: 'Move' }));
         fireEvent.click(screen.getByRole('button', { name: 'Projects / Clients' }));

--- a/frontend/src/Client.App/src/mailboxActs/ActQuestions.tsx
+++ b/frontend/src/Client.App/src/mailboxActs/ActQuestions.tsx
@@ -115,7 +115,7 @@ export function ActQuestions({
 
             <MoveChoice
                 asked={filing}
-                destinations={acts.destinationsOf(messages)}
+                groups={acts.destinationsOf(messages)}
                 onChosen={(destination) => {
                     acts.perform('move', messages, destination);
                     onActed?.();

--- a/frontend/src/Client.App/src/mailboxActs/MailboxActControls.test.tsx
+++ b/frontend/src/Client.App/src/mailboxActs/MailboxActControls.test.tsx
@@ -6,13 +6,19 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { LocalizationProvider } from '../localization/Localization';
 import { MailboxActControls } from './MailboxActControls';
-import type { ActRefusal, MoveDestination } from './mailboxDestinations';
+import type { ActRefusal, MoveDestination, MoveDestinationGroup } from './mailboxDestinations';
 import { MailboxActsContext, nothingActed, type ActedMessage, type MailboxActs } from './useMailboxActs';
 
 const invoice: ActedMessage = { storedEmailId: 'message-1', account: 'work', folder: 'work-inbox' };
 const receipt: ActedMessage = { storedEmailId: 'message-2', account: 'work', folder: 'work-inbox' };
 
-const clients: MoveDestination = { alias: 'work-clients', name: 'Projects / Clients' };
+const clients: MoveDestination = { alias: 'work-clients', name: 'Projects / Clients', role: null };
+const work: MoveDestinationGroup = {
+    accountId: 'work',
+    accountName: 'Northwind \u00b7 work',
+    ordinal: 0,
+    destinations: [clients],
+};
 
 function drawControls(
     acts: Partial<MailboxActs> = {},
@@ -97,7 +103,7 @@ describe('MailboxActControls', () => {
     });
 
     it('offers the folders the messages could go to, asked of the messages rather than of the mailbox', () => {
-        const offered = vi.fn(() => [clients]);
+        const offered = vi.fn(() => [work]);
 
         drawControls({ destinationsOf: offered }, [invoice, receipt]);
         fireEvent.click(screen.getByRole('button', { name: 'Move' }));

--- a/frontend/src/Client.App/src/mailboxActs/MailboxActs.test.tsx
+++ b/frontend/src/Client.App/src/mailboxActs/MailboxActs.test.tsx
@@ -479,6 +479,36 @@ describe('MailboxActsProvider', () => {
         });
     });
 
+    // What a folder is *for* is the account's own label rather than anything about its name, and it is the same
+    // reading `archive` and `delete` are resolved through — which is why the answer comes from here rather than from
+    // a second reader beside the one screen that asks.
+    it('names what the account labels the folder a message is in, which is how a drafts folder is recognised', async () => {
+        const { held } = acting(deploymentAnswering());
+
+        await waitFor(() => {
+            expect(held().folderRoleOf(invoice)).toBe('Inbox');
+        });
+    });
+
+    it('names none for a folder the account never described, rather than guessing one', async () => {
+        const { held } = acting(deploymentAnswering());
+
+        await waitFor(() => {
+            expect(held().folderRoleOf(invoice)).toBe('Inbox');
+        });
+
+        expect(held().folderRoleOf({ ...invoice, folder: 'work-clients' })).toBeNull();
+        expect(held().folderRoleOf({ ...invoice, account: 'nobody' })).toBeNull();
+    });
+
+    // A session that may neither file mail nor delete it reads no folders at all, so nothing here says what any of
+    // them is for.
+    it('names none where the folders were never read, which is a session that files and deletes nothing', () => {
+        const { held } = acting(deploymentAnswering(), { moves: false, deletes: false });
+
+        expect(held().folderRoleOf(invoice)).toBeNull();
+    });
+
     it('reads no folders for a credential that may neither file mail nor delete it, both acts being refused', () => {
         const deployment = deploymentAnswering();
 

--- a/frontend/src/Client.App/src/mailboxActs/MailboxActs.tsx
+++ b/frontend/src/Client.App/src/mailboxActs/MailboxActs.tsx
@@ -14,6 +14,7 @@ import {
     type ClientSession,
     type MailFathomTransport,
     type MailFolderDirectory,
+    type MailFolderRole,
     type MailMutationResult,
 } from '@mailfathom/client-backend';
 import type { MessageKey } from '../localization/en';
@@ -21,6 +22,7 @@ import { useLocalization } from '../localization/useLocalization';
 import { useToasts } from '../toasts/useToasts';
 import {
     deletesPermanently,
+    destinationName,
     destinationsFor,
     filingFor,
     refusalFor,
@@ -366,7 +368,9 @@ export function MailboxActsProvider({
                 kind: 'neutral',
                 title: destroyed
                     ? translate('act.deletedPermanently')
-                    : translate(actReported[act], { folder: destination?.name ?? '' }),
+                    : translate(actReported[act], {
+                          folder: destination === undefined ? '' : destinationName(destination, translate),
+                      }),
                 body: counted(recorded.length),
                 ...wayBack,
             });
@@ -442,6 +446,17 @@ export function MailboxActsProvider({
         });
     }
 
+    // Which role a message's own folder plays, read out of the same tree the destinations are read from. Matched by
+    // the account as well as the alias, because an alias names a folder inside one account and two accounts may spell
+    // one the same way.
+    function folderRoleOf(message: ActedMessage): MailFolderRole | null {
+        return (
+            held.directory?.accounts
+                .find((entry) => entry.account.id === message.account)
+                ?.folders.find((folder) => folder.alias === message.folder)?.role ?? null
+        );
+    }
+
     function perform(act: MailboxAct, messages: readonly ActedMessage[], destination?: MoveDestination): void {
         if (session === null || refusalOf(act, messages) !== null) {
             return;
@@ -472,6 +487,7 @@ export function MailboxActsProvider({
             : {
                   asked: held.asked,
                   refusalOf,
+                  folderRoleOf,
                   destinationsOf: (messages) => destinationsFor(held.directory, messages),
                   deletesPermanently: destroys,
                   perform,

--- a/frontend/src/Client.App/src/mailboxActs/MoveChoice.test.tsx
+++ b/frontend/src/Client.App/src/mailboxActs/MoveChoice.test.tsx
@@ -6,11 +6,18 @@ import { useRef } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { LocalizationProvider } from '../localization/Localization';
-import type { MoveDestination } from './mailboxDestinations';
+import type { MoveDestination, MoveDestinationGroup } from './mailboxDestinations';
 import { MoveChoice } from './MoveChoice';
 
-const archive: MoveDestination = { alias: 'work-archive', name: 'Archive' };
-const clients: MoveDestination = { alias: 'work-clients', name: 'Projects / Clients' };
+const archive: MoveDestination = { alias: 'work-archive', name: 'INBOX.Archiwum', role: 'Archive' };
+const clients: MoveDestination = { alias: 'work-clients', name: 'Projects / Clients', role: null };
+
+const work: MoveDestinationGroup = {
+    accountId: 'work',
+    accountName: 'Northwind \u00b7 work',
+    ordinal: 0,
+    destinations: [archive, clients],
+};
 
 // What stands in for the control a strip draws to open this dialog. Named through a value rather than written into
 // the markup because the lint rule that keeps copy in the catalogues reads the markup, and this is a test's scaffold
@@ -31,7 +38,7 @@ function Asking({ onChosen }: { readonly onChosen: (destination: MoveDestination
                 {opener}
             </button>
 
-            <MoveChoice asked={asked} destinations={[archive, clients]} onChosen={onChosen} />
+            <MoveChoice asked={asked} groups={[work]} onChosen={onChosen} />
         </>
     );
 }
@@ -53,6 +60,15 @@ describe('MoveChoice', () => {
         expect(screen.getByRole('dialog', { name: 'File in another folder' })).toBeDefined();
         expect(screen.getByRole('button', { name: 'Archive' })).toBeDefined();
         expect(screen.getByRole('button', { name: 'Projects / Clients' })).toBeDefined();
+    });
+
+    it('gathers the folders under the account they belong to, rather than as one list of folders from nowhere', () => {
+        open();
+
+        const group = screen.getByRole('region', { name: work.accountName });
+
+        expect(group).toBeDefined();
+        expect(screen.getByRole('button', { name: 'Archive' }).closest('section')).toBe(group);
     });
 
     it('answers with the folder that was picked, which is what the act is then performed with', () => {

--- a/frontend/src/Client.App/src/mailboxActs/MoveChoice.tsx
+++ b/frontend/src/Client.App/src/mailboxActs/MoveChoice.tsx
@@ -4,12 +4,20 @@
 
 import { useId, type RefObject } from 'react';
 import { Icon } from '../controls/Icon';
+import { MailboxMark } from '../controls/MailboxMark';
 import { SurfaceControl } from '../controls/SurfaceControl';
 import { useLocalization } from '../localization/useLocalization';
-import type { MoveDestination } from './mailboxDestinations';
+import { folderRoleIcons } from '../workspace/mailScope';
+import { destinationName, type MoveDestination, type MoveDestinationGroup } from './mailboxDestinations';
 
-// Where mail is being filed, asked as the design project draws it: the folders of the one account the messages are in,
-// each named by its place on the server rather than by MailFathom's own name for it.
+// Where mail is being filed, asked as the design project draws it: the folders grouped under the mailbox they belong
+// to, each group headed by that mailbox's name and its colour, and each folder named and drawn the way the folder
+// column names and draws it — by the role it plays where it plays one, and by its place on the server otherwise.
+//
+// The grouping is what a reader needs first, and it is a statement rather than a list header: filing is an act inside
+// one mailbox, so saying which one is saying what will happen. Exactly one group is offered today, because a message
+// moves between folders of its own account and nowhere else and a selection spanning two accounts is refused before
+// this dialog is reached; `mailboxDestinations.ts` is where that is decided.
 //
 // It is a choice rather than a confirmation, which is why it is not `Confirmation`: nothing here states a consequence
 // or offers a way back, because picking a folder *is* the act and the toast that follows is where taking it back is
@@ -21,19 +29,24 @@ import type { MoveDestination } from './mailboxDestinations';
 
 export function MoveChoice({
     asked,
-    destinations,
+    groups,
     onChosen,
 }: {
     readonly asked: RefObject<HTMLDialogElement | null>;
 
-    /** The folders that may be picked, which is what the account holds. */
-    readonly destinations: readonly MoveDestination[];
+    /** The folders that may be picked, under the account each belongs to, which is what the user holds. */
+    readonly groups: readonly MoveDestinationGroup[];
 
     /** What to do with the folder somebody picked, run once the dialog has closed and focus has been restored. */
     readonly onChosen: (destination: MoveDestination) => void;
 }) {
     const { translate } = useLocalization();
     const asks = useId();
+
+    // What a press answers with is a position in this one list, so the groups are flattened once here rather than the
+    // press composing an identity out of two indices. An alias would not do: it names a folder inside its own account
+    // and the type admits more than one account, so two groups could answer with the same word.
+    const offered = groups.flatMap((group) => group.destinations);
 
     return (
         <dialog
@@ -48,7 +61,7 @@ export function MoveChoice({
                 // engine clears it on the next `showModal`: an answer read twice would file the mail again.
                 dialog.returnValue = '';
 
-                const destination = picked === '' ? undefined : destinations[Number(picked)];
+                const destination = picked === '' ? undefined : offered[Number(picked)];
 
                 if (destination !== undefined) {
                     onChosen(destination);
@@ -71,22 +84,39 @@ export function MoveChoice({
                 />
             </div>
 
-            <ul className="flex max-h-96 flex-col overflow-y-auto py-1.5">
-                {destinations.map((destination, pressed) => (
-                    <li key={destination.alias}>
-                        <button
-                            type="button"
-                            className="flex w-full items-center gap-2.5 px-4 py-2.25 text-start text-base text-text-soft transition hover:bg-hover hover:text-text"
-                            onClick={() => {
-                                asked.current?.close(String(pressed));
-                            }}
-                        >
-                            <Icon name="folder" className="size-4.5 shrink-0 text-muted" />
-                            <span className="truncate">{destination.name}</span>
-                        </button>
-                    </li>
+            <div className="flex max-h-96 flex-col overflow-y-auto py-1.5">
+                {groups.map((group) => (
+                    <section key={group.accountId} aria-label={group.accountName}>
+                        <p className="flex items-center gap-2 px-4 pt-2 pb-1 text-2xs tracking-widest text-faint uppercase">
+                            <MailboxMark ordinal={group.ordinal} />
+                            <span className="min-w-0 flex-1 truncate">{group.accountName}</span>
+                        </p>
+
+                        <ul className="flex flex-col">
+                            {group.destinations.map((destination) => (
+                                <li key={destination.alias}>
+                                    <button
+                                        type="button"
+                                        className="flex w-full items-center gap-2.5 px-4 py-2.25 text-start text-base text-text-soft transition hover:bg-hover hover:text-text"
+                                        onClick={() => {
+                                            asked.current?.close(String(offered.indexOf(destination)));
+                                        }}
+                                    >
+                                        <Icon
+                                            name={
+                                                destination.role === null ? 'folder' : folderRoleIcons[destination.role]
+                                            }
+                                            className="size-4.5 shrink-0 text-muted"
+                                        />
+
+                                        <span className="truncate">{destinationName(destination, translate)}</span>
+                                    </button>
+                                </li>
+                            ))}
+                        </ul>
+                    </section>
                 ))}
-            </ul>
+            </div>
         </dialog>
     );
 }

--- a/frontend/src/Client.App/src/mailboxActs/mailboxDestinations.test.ts
+++ b/frontend/src/Client.App/src/mailboxActs/mailboxDestinations.test.ts
@@ -74,13 +74,26 @@ describe('folderWithRole', () => {
 });
 
 describe('destinationsFor', () => {
-    it('offers the folders of the one account the messages are in, named by their place on the server', () => {
+    it('offers the one account the messages are in, its folders named by their role and their place on the server', () => {
         expect(destinationsFor(wholeMailbox, [inWork('message-1')])).toStrictEqual([
-            { alias: 'work-archive', name: 'Archive' },
-            { alias: 'work-inbox', name: 'INBOX' },
-            { alias: 'work-clients', name: 'Projects / Clients' },
-            { alias: 'work-trash', name: 'Trash' },
+            {
+                accountId: 'work',
+                accountName: 'work',
+                ordinal: 1,
+                destinations: [
+                    { alias: 'work-inbox', name: 'INBOX', role: 'Inbox' },
+                    { alias: 'work-archive', name: 'Archive', role: 'Archive' },
+                    { alias: 'work-trash', name: 'Trash', role: 'Trash' },
+                    { alias: 'work-clients', name: 'Projects / Clients', role: null },
+                ],
+            },
         ]);
+    });
+
+    it('counts the account the way the folder column counts its groups, so a mailbox keeps its colour', () => {
+        const oneAccount = directoryOf({ work: [folder('work-inbox', 'Inbox', ['INBOX'])] });
+
+        expect(destinationsFor(oneAccount, [inWork('message-1')])[0]?.ordinal).toBe(0);
     });
 
     it('offers nothing across two accounts, a folder belonging to the account it is in', () => {

--- a/frontend/src/Client.App/src/mailboxActs/mailboxDestinations.ts
+++ b/frontend/src/Client.App/src/mailboxActs/mailboxDestinations.ts
@@ -3,6 +3,8 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import type { MailFolder, MailFolderDirectory, MailFolderRole } from '@mailfathom/client-backend';
+import type { MessageKey } from '../localization/en';
+import { folderRoleLabels, roleRank } from '../workspace/mailScope';
 import { changesAFlag, type ActedMessage, type MailboxAct } from './useMailboxActs';
 
 // Where an act files a message, worked out from the folders each account has rather than guessed from a name.
@@ -23,6 +25,39 @@ export interface MoveDestination {
 
     /** What the folder is called, which is its place on the server rather than its alias. */
     readonly name: string;
+
+    /**
+     * The role the folder plays, or `null` where its configuration labels it with none.
+     *
+     * Where it has one, the role is what names the folder on the screen and `name` is not drawn at all — an inbox is
+     * an inbox whatever the provider called the folder and in whatever language, which is the rule the folder column
+     * already draws by. Carried rather than resolved here because the name it stands for is a translation, and this
+     * module composes values rather than words.
+     */
+    readonly role: MailFolderRole | null;
+}
+
+/**
+ * The destinations of one account, which is how the design project draws the choice.
+ *
+ * A move stays inside the account the message is in, so exactly one group is offered today; the grouping is what says
+ * *which mailbox these folders belong to* rather than a promise that two of them could be offered at once.
+ */
+export interface MoveDestinationGroup {
+    readonly accountId: string;
+
+    /** What the mailbox is called, which is the name its own configuration gives it. */
+    readonly accountName: string;
+
+    /**
+     * Which group the account is among the user's, counted the way the folder column counts them, which is what
+     * colours its mark. Everything a reader tells one mailbox from another by is that colour, so it is read from the
+     * whole directory rather than from the one account offered here — the same mailbox carries the same hue wherever
+     * it appears, and an ordinal taken from a list of one would recolour it inside this dialog.
+     */
+    readonly ordinal: number;
+
+    readonly destinations: readonly MoveDestination[];
 }
 
 /** Why an act cannot be performed on the messages it was asked about, each a sentence of its own on the screen. */
@@ -47,6 +82,18 @@ export type ActRefusal =
 
     /** This client has not read the folders, so it does not know where the act would file to. */
     | 'foldersUnknown';
+
+/**
+ * What one destination is called on the screen: the role it plays where it plays one, and its place on the server
+ * otherwise.
+ *
+ * One rule rather than one per screen, because the dialog offering the folder and the toast reporting the move name
+ * the same folder — and a reader told they filed into *Archive* by one and into *INBOX.Archiwum* by the other has been
+ * told about two folders.
+ */
+export function destinationName(destination: MoveDestination, translate: (key: MessageKey) => string): string {
+    return destination.role === null ? destination.name : translate(folderRoleLabels[destination.role]);
+}
 
 /** The folder an account labels with that role, or `null` where its configuration labels none. */
 export function folderWithRole(
@@ -84,7 +131,12 @@ export function accountsAmong(messages: readonly ActedMessage[]): readonly strin
 }
 
 /**
- * The folders the named messages could be filed into, which are the folders of the one account they are all in.
+ * The folders the named messages could be filed into, grouped under the account they belong to.
+ *
+ * That is the one account the messages are all in: a message moves between folders of its own account and nowhere
+ * else, and a selection spanning two of them is refused before this is asked. So the answer is at most one group, and
+ * it is a group rather than a bare list because what a reader has to know first is which mailbox they are filing
+ * inside — the same thing the folder column says with the account's name and its colour above every folder it holds.
  *
  * The folder they are already in is offered like any other: the deployment answers a message already there as its own
  * outcome, so leaving it out would be this client deciding what a folder holds from a list it read minutes ago.
@@ -92,16 +144,35 @@ export function accountsAmong(messages: readonly ActedMessage[]): readonly strin
 export function destinationsFor(
     directory: MailFolderDirectory | null,
     messages: readonly ActedMessage[],
-): readonly MoveDestination[] {
+): readonly MoveDestinationGroup[] {
     const accounts = accountsAmong(messages);
+    const [only] = accounts;
 
-    if (accounts.length !== 1) {
+    if (accounts.length !== 1 || only === undefined || directory === null) {
         return [];
     }
 
-    return foldersOf(directory, accounts[0] ?? '')
-        .map((folder) => ({ alias: folder.alias, name: nameOf(folder) }))
-        .sort((one, other) => one.name.localeCompare(other.name));
+    const at = directory.accounts.findIndex((entry) => entry.account.id === only);
+    const entry = directory.accounts[at];
+
+    if (entry === undefined) {
+        return [];
+    }
+
+    return [
+        {
+            accountId: entry.account.id,
+            accountName: entry.account.displayName,
+
+            // The folder column draws a row for every mailbox at once above the accounts wherever there is more than
+            // one, and counts its groups from that row. Counted the same way here so that a mailbox keeps its hue
+            // across the two screens.
+            ordinal: directory.accounts.length > 1 ? at + 1 : at,
+            destinations: entry.folders
+                .map((folder) => ({ alias: folder.alias, name: nameOf(folder), role: folder.role }))
+                .sort(byOfferedOrder),
+        },
+    ];
 }
 
 /**
@@ -165,9 +236,18 @@ export function refusalFor(
 // exactly the folder its mail already sits in, which is a dialog with nothing in it to choose — while a selection
 // spread across two folders of a two-folder account has two destinations that each move half of it.
 function movesSomething(directory: MailFolderDirectory, messages: readonly ActedMessage[]): boolean {
-    return destinationsFor(directory, messages).some((destination) =>
-        messages.some((message) => message.folder !== destination.alias),
+    return destinationsFor(directory, messages).some((group) =>
+        group.destinations.some((destination) => messages.some((message) => message.folder !== destination.alias)),
     );
+}
+
+// The order the folders are offered in, which is the folder column's own: the roles first, in the order a mail client
+// has shown them in for thirty years, and everything else after them by name. Two screens listing one account's
+// folders in two different orders would be two mailboxes as far as a reader is concerned.
+function byOfferedOrder(one: MoveDestination, other: MoveDestination): number {
+    const byRole = roleRank(one.role) - roleRank(other.role);
+
+    return byRole === 0 ? one.name.localeCompare(other.name) : byRole;
 }
 
 /**

--- a/frontend/src/Client.App/src/mailboxActs/useMailboxActs.test.ts
+++ b/frontend/src/Client.App/src/mailboxActs/useMailboxActs.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest';
 import type { MailTimelineEntry } from '@mailfathom/client-backend';
-import { actPending, nothingActed, type MailboxAct, type MailboxActs } from './useMailboxActs';
+import { actPending, nothingActed, opensAsDraft, type MailboxAct, type MailboxActs } from './useMailboxActs';
 
 const email: MailTimelineEntry = {
     id: 'message-1',
@@ -64,5 +64,23 @@ describe('actPending', () => {
     it('stops saying a message is being marked unread once the deployment reports it unread', () => {
         expect(actPending(asking('markUnread'), email)).toBe('markUnread');
         expect(actPending(asking('markUnread'), { ...email, unread: true })).toBeNull();
+    });
+});
+
+// Where a message opens is decided by what its own account calls the folder it is in rather than by what the folder
+// is named: a deployment whose drafts folder is `Entwürfe` still opens one in the composer.
+describe('opensAsDraft', () => {
+    it('says a message in the folder its account labels for drafts is one to carry on writing', () => {
+        expect(opensAsDraft({ ...nothingActed, folderRoleOf: () => 'Drafts' }, email)).toBe(true);
+    });
+
+    it('says a message in any other folder is one to read', () => {
+        expect(opensAsDraft({ ...nothingActed, folderRoleOf: () => 'Inbox' }, email)).toBe(false);
+    });
+
+    // A session that may not file mail reads no folders at all, so nothing says which folder is for drafts — and a
+    // message opened as mail is the answer that costs a reader nothing.
+    it('says a message is one to read where no folder was read at all', () => {
+        expect(opensAsDraft(nothingActed, email)).toBe(false);
     });
 });

--- a/frontend/src/Client.App/src/mailboxActs/useMailboxActs.ts
+++ b/frontend/src/Client.App/src/mailboxActs/useMailboxActs.ts
@@ -129,6 +129,14 @@ export function useMailboxActs(): MailboxActs {
  *
  * Stated once, beside the acts, because two lists open a message — the mailbox's own and the search's — and a second
  * reading of *this is a draft* is how the two come to open the same message differently.
+ *
+ * A workspace whose folders have not arrived yet names no role, so a message pressed in the window between it mounting
+ * and that read landing opens as mail. The list and the folders are read in the same render pass, and a press that does
+ * nothing while a second read finishes is worse than the surface this opens instead — so what closes the window is the
+ * one shared reading of the folders `MailboxActs.tsx` already carries as its debt, rather than a wait on the press.
+ *
+ * ponytail: a press classified against a folder tree that may not have landed. The single `/folders` read the client
+ * shares is the upgrade, and it closes this window in the same move as it closes the second read.
  */
 export function opensAsDraft(acts: MailboxActs, email: MailTimelineEntry): boolean {
     return acts.folderRoleOf({ storedEmailId: email.id, account: email.account, folder: email.folder }) === 'Drafts';

--- a/frontend/src/Client.App/src/mailboxActs/useMailboxActs.ts
+++ b/frontend/src/Client.App/src/mailboxActs/useMailboxActs.ts
@@ -3,8 +3,8 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { createContext, useContext } from 'react';
-import type { MailTimelineEntry } from '@mailfathom/client-backend';
-import type { ActRefusal, MoveDestination } from './mailboxDestinations';
+import type { MailFolderRole, MailTimelineEntry } from '@mailfathom/client-backend';
+import type { ActRefusal, MoveDestination, MoveDestinationGroup } from './mailboxDestinations';
 
 // The things a person does to their own mailbox from the Mail space, as an operation on messages rather than as
 // anything on a screen. It belongs to the application rather than to the toolbar, because five surfaces reach the same
@@ -61,8 +61,24 @@ export interface MailboxActs {
     /** Why the act cannot be performed on those messages, or `null` where it can. */
     readonly refusalOf: (act: MailboxAct, messages: readonly ActedMessage[]) => ActRefusal | null;
 
-    /** The folders those messages could be filed into, which are their one account's. */
-    readonly destinationsOf: (messages: readonly ActedMessage[]) => readonly MoveDestination[];
+    /**
+     * The role the folder that message is in plays, or `null` where it plays none and where this client has not read
+     * the user's folders at all.
+     *
+     * Answered here because this is where the folders are already held, and asked because opening a message is not one
+     * behaviour for every folder: a message in a drafts folder is something somebody was writing, and it opens in the
+     * composer rather than in the reading pane. The question is about where a message sits rather than about what may
+     * be done to it, which is the one thing here that is not an act — kept together with the acts because a second
+     * reader of `/folders` costs every session a request, which the note in `MailboxActs.tsx` already weighs.
+     *
+     * A session whose credential may not file mail reads no folders, so every message answers `null` there and a draft
+     * opens as a message. That is the same limitation as the acts themselves being refused, and it goes when the read
+     * does.
+     */
+    readonly folderRoleOf: (message: ActedMessage) => MailFolderRole | null;
+
+    /** The folders those messages could be filed into, under the one account they are all in. */
+    readonly destinationsOf: (messages: readonly ActedMessage[]) => readonly MoveDestinationGroup[];
 
     /**
      * Whether `delete` would destroy those messages rather than file them in the trash.
@@ -92,6 +108,7 @@ export interface MailboxActs {
 export const nothingActed: MailboxActs = {
     asked: new Map(),
     refusalOf: () => 'notOffered',
+    folderRoleOf: () => null,
     destinationsOf: () => [],
     deletesPermanently: () => false,
     perform: () => undefined,
@@ -101,6 +118,20 @@ export const MailboxActsContext = createContext<MailboxActs>(nothingActed);
 
 export function useMailboxActs(): MailboxActs {
     return useContext(MailboxActsContext);
+}
+
+/**
+ * Whether opening that message is opening a draft, which is the composer rather than the reading pane.
+ *
+ * A draft is a message somebody was writing, so pressing it puts them back where they were writing it. What decides
+ * that is the role its folder plays rather than anything on the message: a mail server files a draft where its own
+ * configuration says drafts go, and a folder called `Entwürfe` is the drafts folder as surely as one called `Drafts`.
+ *
+ * Stated once, beside the acts, because two lists open a message — the mailbox's own and the search's — and a second
+ * reading of *this is a draft* is how the two come to open the same message differently.
+ */
+export function opensAsDraft(acts: MailboxActs, email: MailTimelineEntry): boolean {
+    return acts.folderRoleOf({ storedEmailId: email.id, account: email.account, folder: email.folder }) === 'Drafts';
 }
 
 /**

--- a/frontend/src/Client.App/src/messageList/MessageList.test.tsx
+++ b/frontend/src/Client.App/src/messageList/MessageList.test.tsx
@@ -510,6 +510,18 @@ describe('MessageList', () => {
         expect(carried().selection).toBe('message-2');
     });
 
+    // A drafts folder holds what somebody was writing rather than what arrived, so the reading pane is the wrong
+    // surface for one: what a reader asked for is the words back under their own cursor.
+    it('opens a draft in the composer rather than in the reading pane, and leaves the pane where it was', async () => {
+        renderList(answering(wholeFolder), { acts: { ...nothingActed, folderRoleOf: () => 'Drafts' } });
+
+        await rows();
+        fireEvent.pointerDown(row(2));
+
+        expect(composing.compose).toHaveBeenCalledWith({ kind: 'draft', storedEmailId: 'message-2' });
+        expect(carried().selection).toBeNull();
+    });
+
     it('picks a message out rather than opening it while others are already picked out', async () => {
         renderList(answering(wholeFolder));
 

--- a/frontend/src/Client.App/src/messageList/MessageList.tsx
+++ b/frontend/src/Client.App/src/messageList/MessageList.tsx
@@ -26,7 +26,7 @@ import { Skeleton } from '../controls/Skeleton';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
 import { ActQuestions } from '../mailboxActs/ActQuestions';
-import { useMailboxActs, type ActedMessage } from '../mailboxActs/useMailboxActs';
+import { opensAsDraft, useMailboxActs, type ActedMessage } from '../mailboxActs/useMailboxActs';
 import { useComposing } from '../composer/useComposing';
 import { MessageReading } from '../messageRows/MessageReading';
 import { leadingReading, readingsOf } from '../messageRows/messageReadings';
@@ -522,8 +522,22 @@ export function MessageList({
         const email = rowAt(held, row);
 
         if (email !== null) {
-            onOpen(email.id, email.subject, email.threadId);
+            opened(email);
         }
+    }
+
+    // What pressing a row does, which is not one thing: a draft is a message somebody was writing, so it opens in the
+    // composer they were writing it in rather than in the pane that reads mail. Everything else is the frame's to
+    // place, which is what `onOpen` asks for. A client whose credential may not write mail composes nothing, so a
+    // draft opens there as an ordinary message rather than as a control that does nothing.
+    function opened(email: MailTimelineEntry): void {
+        if (composing.offered && opensAsDraft(acts, email)) {
+            composing.compose({ kind: 'draft', storedEmailId: email.id });
+
+            return;
+        }
+
+        onOpen(email.id, email.subject, email.threadId);
     }
 
     function point(event: PointerEvent<HTMLLIElement>, row: number): void {
@@ -566,7 +580,7 @@ export function MessageList({
         // as open, and a selection is the modifier's, the drag's, the menu's, or the keyboard's to make.
         dragging.current = true;
         setAnchor(email.id);
-        onOpen(email.id, email.subject, email.threadId);
+        opened(email);
     }
 
     // Closing the menu puts focus back on the row it was opened from, because that is where the reader was: a menu

--- a/frontend/src/Client.App/src/notifications/NotificationCentre.test.tsx
+++ b/frontend/src/Client.App/src/notifications/NotificationCentre.test.tsx
@@ -124,6 +124,29 @@ describe('NotificationCentre', () => {
         expect(screen.queryByRole('dialog', { name: 'Notifications' })).toBeNull();
     });
 
+    // `translate-x-*` and `translate-y-*` write the one `translate` property, so a class list that leaves both on the
+    // panel at once composes a diagonal — which is the travel a reader sees as a slide out of the lower corner rather
+    // than the one axis the design project draws for each composition. Nothing in jsdom applies a stylesheet, so what
+    // is asserted is that every displacement the panel carries is gated on exactly one of the two compositions.
+    it('travels along one axis in each composition: up from under a phone, in from the side beside a rail', () => {
+        panel();
+
+        const displaced = [...screen.getByRole('dialog', { name: 'Notifications' }).classList].filter((name) =>
+            name.includes('translate-'),
+        );
+
+        expect(displaced.length).toBeGreaterThan(0);
+        expect(
+            displaced.filter((name) => name.startsWith('max-workspace:')).every((name) => name.includes('-y-')),
+        ).toBe(true);
+        expect(displaced.filter((name) => name.startsWith('workspace:')).every((name) => name.includes('-x-'))).toBe(
+            true,
+        );
+        expect(displaced.every((name) => name.startsWith('max-workspace:') || name.startsWith('workspace:'))).toBe(
+            true,
+        );
+    });
+
     it('says how many arrived beside its own title', () => {
         panel({ unreadCount: 4 });
 

--- a/frontend/src/Client.App/src/notifications/NotificationCentre.tsx
+++ b/frontend/src/Client.App/src/notifications/NotificationCentre.tsx
@@ -136,6 +136,12 @@ export function NotificationCentre({
             // The two compositions are the design project's own: a sheet that stops above the bottom navigation in a
             // narrow window, and a panel standing beside the rail in a wide one. Where it comes from differs with it,
             // which is what the two motions and the two closed positions below say.
+            //
+            // Each closed position is written under the composition it belongs to rather than one of them under the
+            // breakpoint and the other under nothing. `translate-y-*` and `-translate-x-*` are two axes of the one
+            // `translate` property, so a vertical offset left standing outside the breakpoint composes with the
+            // horizontal one above it and the panel travels diagonally out of the corner instead of in from the side.
+            // `max-workspace:` and `workspace:` never both apply, which is what keeps each composition to one axis.
             // The panel is in the platform's top layer, where the frame's safe-area padding is not around it: the top
             // inset is padded away inside it, and the bottom one is a margin because what the sheet stops above is the
             // bottom navigation, which the frame has already lifted clear of the gesture bar.
@@ -145,7 +151,7 @@ export function NotificationCentre({
                     : swipe.springing
                       ? 'motion-spring'
                       : 'motion-sheet workspace:motion-panel'
-            } translate-y-full open:translate-y-0 starting:open:translate-y-full workspace:-translate-x-full workspace:open:translate-x-0 workspace:starting:open:-translate-x-full`}
+            } max-workspace:translate-y-full max-workspace:open:translate-y-0 max-workspace:starting:open:translate-y-full workspace:-translate-x-full workspace:open:translate-x-0 workspace:starting:open:-translate-x-full`}
             onPointerDown={swipe.onPanelPointerDown}
             onCancel={(event) => {
                 // Refused so that leaving by the keyboard is the same act as leaving by the scrim: the centre is asked

--- a/frontend/src/Client.App/src/search/MailSearch.test.tsx
+++ b/frontend/src/Client.App/src/search/MailSearch.test.tsx
@@ -156,6 +156,7 @@ function searchUnder(
                     accounts={[work]}
                     online={true}
                     onOpen={() => undefined}
+                    onOpenDraft={null}
                     now={now}
                 >
                     <p>{mailInScope}</p>

--- a/frontend/src/Client.App/src/search/MailSearch.tsx
+++ b/frontend/src/Client.App/src/search/MailSearch.tsx
@@ -72,6 +72,7 @@ export function MailSearch({
     online,
     children,
     onOpen,
+    onOpenDraft,
     now = systemClock,
 }: {
     readonly session: ClientSession;
@@ -88,6 +89,9 @@ export function MailSearch({
 
     /** Opens a result, handed straight to the results below — the reason `MessageList` gives. */
     readonly onOpen: (storedEmailId: string, subject: string | null) => void;
+
+    /** Opens a result that is a draft in the composer, or `null` where the frame has no composer to open one in. */
+    readonly onOpenDraft: ((storedEmailId: string) => void) | null;
 
     /**
      * What the current instant is, which is the calendar day the deployment resolves a relative expression against.
@@ -316,6 +320,7 @@ export function MailSearch({
                             setAsk(widened(ask));
                         }}
                         onOpen={onOpen}
+                        onOpenDraft={onOpenDraft}
                     />
                 </>
             )}

--- a/frontend/src/Client.App/src/search/SearchResults.test.tsx
+++ b/frontend/src/Client.App/src/search/SearchResults.test.tsx
@@ -7,6 +7,7 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import type { ClientRequest, ClientSession, MailFathomTransport } from '@mailfathom/client-backend';
 import { LocalizationProvider } from '../localization/Localization';
+import { MailboxActsContext, nothingActed, type MailboxActs } from '../mailboxActs/useMailboxActs';
 import { everything } from '../workspace/mailScope';
 import { useWorkspace, type Workspace } from '../workspace/useWorkspace';
 import { WorkspaceProvider } from '../workspace/Workspace';
@@ -112,6 +113,8 @@ interface Drawn {
     readonly online: boolean;
     readonly narrowed: boolean;
     readonly onWiden: () => void;
+    readonly acts: MailboxActs;
+    readonly onOpenDraft: ((storedEmailId: string) => void) | null;
 }
 
 // Opening is the frame's, exactly as it is for the message list, so this stands in for what the frame does with the
@@ -123,6 +126,7 @@ function ResultsOpeningIntoTheWorkspace(drawn: {
     readonly online: boolean;
     readonly narrowed: boolean;
     readonly onWiden: () => void;
+    readonly onOpenDraft: ((storedEmailId: string) => void) | null;
 }) {
     const { revise } = useWorkspace();
 
@@ -138,21 +142,31 @@ function ResultsOpeningIntoTheWorkspace(drawn: {
 
 function resultsUnder(
     transport: MailFathomTransport,
-    { ask = anywhere, online = true, narrowed = false, onWiden = () => undefined }: Partial<Drawn> = {},
+    {
+        ask = anywhere,
+        online = true,
+        narrowed = false,
+        onWiden = () => undefined,
+        acts = nothingActed,
+        onOpenDraft = null,
+    }: Partial<Drawn> = {},
 ): ReactElement {
     return (
         <LocalizationProvider>
-            <WorkspaceProvider>
-                <ResultsOpeningIntoTheWorkspace
-                    session={session}
-                    transport={transport}
-                    ask={ask}
-                    online={online}
-                    narrowed={narrowed}
-                    onWiden={onWiden}
-                />
-                <SelectionProbe />
-            </WorkspaceProvider>
+            <MailboxActsContext value={acts}>
+                <WorkspaceProvider>
+                    <ResultsOpeningIntoTheWorkspace
+                        session={session}
+                        transport={transport}
+                        ask={ask}
+                        online={online}
+                        narrowed={narrowed}
+                        onWiden={onWiden}
+                        onOpenDraft={onOpenDraft}
+                    />
+                    <SelectionProbe />
+                </WorkspaceProvider>
+            </MailboxActsContext>
         </LocalizationProvider>
     );
 }
@@ -400,6 +414,41 @@ describe('SearchResults', () => {
 
         expect(carried().selection).toBe('message-2');
         expect(await rows()).toHaveLength(2);
+    });
+
+    // A search reaches across every folder, so a drafts folder is among what it can find. What a reader asked for
+    // there is the words back under their own cursor rather than the reading pane, exactly as in the list — and the
+    // frame is what performs it, this column only saying which result was opened.
+    it('asks the frame to carry a draft on rather than opening it in the reading pane', async () => {
+        const carriedOn = vi.fn();
+
+        render(
+            resultsUnder(answering(pageOf([result(1)])), {
+                acts: { ...nothingActed, folderRoleOf: () => 'Drafts' },
+                onOpenDraft: carriedOn,
+            }),
+        );
+
+        const found = await rows();
+
+        fireEvent.pointerDown(found[0] ?? document.body);
+
+        expect(carriedOn).toHaveBeenCalledWith('message-1');
+        expect(carried().selection).toBeNull();
+    });
+
+    // Nothing about a draft changes what the column does where the frame offered no way to carry one on: the result
+    // opens as any other does, rather than being a row that answers nothing when it is pressed.
+    it('opens a draft in the reading pane where the frame offered no composer to carry it on in', async () => {
+        render(
+            resultsUnder(answering(pageOf([result(1)])), { acts: { ...nothingActed, folderRoleOf: () => 'Drafts' } }),
+        );
+
+        const found = await rows();
+
+        fireEvent.pointerDown(found[0] ?? document.body);
+
+        expect(carried().selection).toBe('message-1');
     });
 
     it('opens the result the keyboard is on', async () => {

--- a/frontend/src/Client.App/src/search/SearchResults.tsx
+++ b/frontend/src/Client.App/src/search/SearchResults.tsx
@@ -21,6 +21,7 @@ import {
 import { SecondaryButton } from '../controls/SecondaryButton';
 import type { MessageKey } from '../localization/en';
 import { useLocalization, type Translate } from '../localization/useLocalization';
+import { opensAsDraft, useMailboxActs } from '../mailboxActs/useMailboxActs';
 import { MessageRow } from '../messageRows/MessageRow';
 import { estimatedRowHeight, offsetOfRow, windowOf } from '../messageRows/rowWindow';
 import { useWorkspace } from '../workspace/useWorkspace';
@@ -74,6 +75,7 @@ export function SearchResults({
     narrowed,
     onWiden,
     onOpen,
+    onOpenDraft,
 }: {
     readonly session: ClientSession;
     readonly transport: MailFathomTransport;
@@ -90,9 +92,18 @@ export function SearchResults({
 
     /** Opens a result, which the list asks for rather than performs — the reason `MessageList` gives. */
     readonly onOpen: (storedEmailId: string, subject: string | null) => void;
+
+    /**
+     * Opens a result that is a draft in the composer, or `null` where the frame has no composer to open one in.
+     *
+     * Asked for rather than performed, for the same reason opening a message is: what a draft opens *into* is the
+     * frame's, and a list that reached for the composer itself would be the second component deciding it.
+     */
+    readonly onOpenDraft: ((storedEmailId: string) => void) | null;
 }) {
     const { translate } = useLocalization();
     const { workspace, revise } = useWorkspace();
+    const acts = useMailboxActs();
 
     const [found, setFound] = useState<FoundMail | null>(null);
     const [failure, setFailure] = useState<ClientFailure | null>(null);
@@ -251,6 +262,16 @@ export function SearchResults({
             citedAttachment:
                 cited === undefined ? null : { storedEmailId: result.id, position: cited.attachmentPosition },
         });
+        // A result that is a draft opens where it was written, exactly as a row in the mailbox's own list does — the
+        // message a search lands on is the same message in the same folder. Where the frame offered no way to open one
+        // — a credential that may not write mail — the draft opens as an ordinary message rather than as a press that
+        // does nothing.
+        if (onOpenDraft !== null && opensAsDraft(acts, result)) {
+            onOpenDraft(result.id);
+
+            return;
+        }
+
         onOpen(result.id, result.subject);
     }
 

--- a/frontend/src/Client.App/src/thread/Thread.test.tsx
+++ b/frontend/src/Client.App/src/thread/Thread.test.tsx
@@ -579,7 +579,7 @@ describe('Thread', () => {
         expect(screen.queryByText('Opened from the list')).toBeNull();
     });
 
-    it('marks nothing on a message it stood the reader in front of alone, however much history they then show', async () => {
+    it('marks the latest message once the history stands beside it, and nothing while it stands alone', async () => {
         drawing(deploymentAnswering(pageOf(['one', 'two', 'three'])), { threadId, openAt: 'three' });
 
         expect(await screen.findByText('The whole of what three says.')).toBeDefined();
@@ -588,7 +588,7 @@ describe('Thread', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Show 2 earlier messages' }));
 
         expect(screen.getByText('The whole of what one says.')).toBeDefined();
-        expect(screen.queryByText('Opened from the list')).toBeNull();
+        expect(screen.getByText('Opened from the list')).toBeDefined();
     });
 
     it('marks a message a search result brought somebody to only until it has been seen', async () => {

--- a/frontend/src/Client.App/src/thread/Thread.tsx
+++ b/frontend/src/Client.App/src/thread/Thread.tsx
@@ -468,6 +468,11 @@ export function Thread({
                                 session={session}
                                 transport={transport}
                                 message={message}
+                                // A rule pointing at the only message on the screen points at nothing, so the mark
+                                // waits for the rest of the correspondence to stand beside it. Asked here rather than
+                                // where the arrival is decided, because it is a question about what is drawn: showing
+                                // the history is what makes the marked message one among several, and that is exactly
+                                // when saying which one the list opened starts being worth anything.
                                 mark={drawn.length > 1 && message.email.id === arrival?.storedEmailId ? mark : null}
                                 online={online}
                                 onShowFullHtml={() => {

--- a/frontend/src/Client.App/src/thread/threadOpening.test.ts
+++ b/frontend/src/Client.App/src/thread/threadOpening.test.ts
@@ -75,25 +75,25 @@ describe('arrivesAt', () => {
     it('arrives at the message somebody was sent to, which is the context they came for', () => {
         const messages = [message('one', 0, true), message('two', 1), message('three', 2)];
 
-        expect(arrivesAt(messages, 'two')).toStrictEqual({ storedEmailId: 'two', amongOthers: true });
+        expect(arrivesAt(messages, 'two')).toStrictEqual({ storedEmailId: 'two' });
     });
 
     it('arrives at the latest of a conversation nobody named a message in', () => {
         const messages = [message('one', 0), message('two', 1, true), message('three', 2)];
 
-        expect(arrivesAt(messages, null)).toStrictEqual({ storedEmailId: 'three', amongOthers: false });
+        expect(arrivesAt(messages, null)).toStrictEqual({ storedEmailId: 'three' });
     });
 
     it('arrives at the latest where the message named is not among those read', () => {
         const messages = [message('one', 0), message('two', 1, true)];
 
-        expect(arrivesAt(messages, 'somewhere-else')).toStrictEqual({ storedEmailId: 'two', amongOthers: false });
+        expect(arrivesAt(messages, 'somewhere-else')).toStrictEqual({ storedEmailId: 'two' });
     });
 
-    it('arrives among others where the message named is the conversation only up to its latest', () => {
+    it('arrives at a message inside the history rather than at the latest, where that is what was named', () => {
         const messages = [message('one', 0), message('two', 1), message('three', 2)];
 
-        expect(arrivesAt(messages, 'one')).toStrictEqual({ storedEmailId: 'one', amongOthers: true });
+        expect(arrivesAt(messages, 'one')).toStrictEqual({ storedEmailId: 'one' });
     });
 
     it('arrives nowhere in a conversation holding no message anybody may see', () => {
@@ -102,39 +102,39 @@ describe('arrivesAt', () => {
 });
 
 describe('arrivalMark', () => {
-    const amongOthers = { storedEmailId: 'two', amongOthers: true };
-    const alone = { storedEmailId: 'three', amongOthers: false };
+    const insideTheHistory = { storedEmailId: 'two' };
+    const theLatest = { storedEmailId: 'three' };
 
     it('marks the message somebody opened from the list as the one they opened', () => {
-        expect(arrivalMark({ threadId: 'a-conversation', openAt: 'two' }, amongOthers, false)).toBe('list');
+        expect(arrivalMark({ threadId: 'a-conversation', openAt: 'two' }, insideTheHistory, false)).toBe('list');
     });
 
     it('marks nothing in a conversation opened on its own subject, where nobody was sent to a message', () => {
-        expect(arrivalMark({ threadId: 'a-conversation', openAt: null }, alone, false)).toBeNull();
+        expect(arrivalMark({ threadId: 'a-conversation', openAt: null }, theLatest, false)).toBeNull();
     });
 
     it('marks nothing while the conversation has not decided where it arrives', () => {
         expect(arrivalMark({ threadId: 'a-conversation', openAt: 'two' }, null, false)).toBeNull();
     });
 
-    it('marks nothing where the conversation stood the reader in front of that message alone', () => {
-        expect(arrivalMark({ threadId: 'a-conversation', openAt: 'three' }, alone, false)).toBeNull();
+    it('marks the latest message of a conversation opened from the list, the history being shown beside it', () => {
+        expect(arrivalMark({ threadId: 'a-conversation', openAt: 'three' }, theLatest, false)).toBe('list');
     });
 
     it('marks a message landed on from a search result as one somebody was brought to', () => {
-        expect(arrivalMark({ threadId: 'a-conversation', openAt: 'two', fromResult: true }, amongOthers, false)).toBe(
-            'result',
-        );
+        expect(
+            arrivalMark({ threadId: 'a-conversation', openAt: 'two', fromResult: true }, insideTheHistory, false),
+        ).toBe('result');
     });
 
     it('marks a landing that has settled as nothing at all, which is the ordinary open message', () => {
         expect(
-            arrivalMark({ threadId: 'a-conversation', openAt: 'two', fromResult: true }, amongOthers, true),
+            arrivalMark({ threadId: 'a-conversation', openAt: 'two', fromResult: true }, insideTheHistory, true),
         ).toBeNull();
     });
 
     it('marks a landing arrived at alone, it saying what the client just did rather than where somebody is', () => {
-        expect(arrivalMark({ threadId: 'a-conversation', openAt: 'three', fromResult: true }, alone, false)).toBe(
+        expect(arrivalMark({ threadId: 'a-conversation', openAt: 'three', fromResult: true }, theLatest, false)).toBe(
             'result',
         );
     });

--- a/frontend/src/Client.App/src/thread/threadOpening.ts
+++ b/frontend/src/Client.App/src/thread/threadOpening.ts
@@ -5,11 +5,10 @@
 import type { MailThreadMessage, MailThreadPage } from '@mailfathom/client-backend';
 import type { OpenConversation } from '../workspace/openConversation';
 
-// Where a conversation puts the reader when it is first drawn. A conversation shows its latest message and hides
-// everything before it behind one control, so the only question left is which message the reader arrived at: the one
-// they named, where the conversation holds it, and the latest otherwise. That answer decides two things — where focus
-// is placed, and whether the history starts shown, because arriving at a message the history holds cannot leave that
-// message hidden.
+// Where a conversation puts the reader when it is first drawn. A conversation shows the message it was opened at and
+// hides everything else behind one control, so the only question left is which message that is: the one they named,
+// where the conversation holds it, and the latest otherwise. That answer decides two things — where focus is placed,
+// and which message is marked out from the ones around it once the rest of the correspondence stands beside it.
 //
 // It is decided once, from what is held at the moment the conversation stops reading, and never again: a later page
 // arriving would otherwise move the reader off the message they came for.
@@ -28,17 +27,6 @@ export function holdsMessage(messages: readonly MailThreadMessage[], storedEmail
 export interface Arrival {
     /** The message arrived at, by the identity it is reached by. */
     readonly storedEmailId: string;
-
-    /**
-     * Whether the conversation stood the reader in front of messages other than the one they arrived at.
-     *
-     * True exactly where the arrival is not the conversation's latest, which is the one case the pane opens with its
-     * history shown. It decides that, and it decides whether the arrival is marked out from what surrounds it — both
-     * being questions about where the reader landed rather than about what they have done since, which is why the
-     * answer is taken here and never recomputed. A mark derived from what is drawn would appear on a message already
-     * on the screen the moment somebody showed the history, moving its words sideways under them.
-     */
-    readonly amongOthers: boolean;
 }
 
 /**
@@ -55,7 +43,7 @@ export function arrivesAt(messages: readonly MailThreadMessage[], openAt: string
     const latest = messages[messages.length - 1]?.email.id ?? null;
     const storedEmailId = openAt !== null && holdsMessage(messages, openAt) ? openAt : latest;
 
-    return storedEmailId === null ? null : { storedEmailId, amongOthers: storedEmailId !== latest };
+    return storedEmailId === null ? null : { storedEmailId };
 }
 
 /**
@@ -71,13 +59,13 @@ export type ArrivalMark = 'list' | 'result';
  * What marks the message a conversation arrived at, or `null` where nothing does.
  *
  * Nothing is marked where the conversation was opened on its own subject, because there is no message somebody was
- * sent to and a mark saying otherwise would be a sentence that is not true. Nothing is marked either where the
- * conversation stood the reader in front of that message alone: a rule pointing at the only thing on the screen points
- * at nothing.
+ * sent to and a mark saying otherwise would be a sentence that is not true.
  *
- * Every answer here is a function of the arrival, which is decided once, so a mark neither appears nor disappears
- * while somebody reads. Showing the history is the gesture that would otherwise do it, and a message already on the
- * screen gaining a rule and an indent is words moving sideways under a reader.
+ * What is *not* asked here is whether the marked message is standing alone on the screen. A rule pointing at the only
+ * thing drawn points at nothing, so that case carries no mark either — but it is a question about what is drawn rather
+ * than about where the reader landed, and it changes under the one control the conversation offers. `Thread.tsx` asks
+ * it where the messages are drawn, which is what keeps the mark on the message the list opened once the rest of the
+ * correspondence is shown beside it, whether that message is the conversation's latest or one inside its history.
  *
  * @param conversation The conversation as it was opened.
  * @param arrival Where it arrived, or `null` where it has not decided yet.
@@ -97,5 +85,5 @@ export function arrivalMark(
         return settled ? null : 'result';
     }
 
-    return arrival.amongOthers ? 'list' : null;
+    return 'list';
 }

--- a/frontend/src/Client.App/src/workspace/mailScope.ts
+++ b/frontend/src/Client.App/src/workspace/mailScope.ts
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import type { MailFolderDirectory, MailFolderRole } from '@mailfathom/client-backend';
+import type { IconName } from '../controls/icons';
 import type { MessageKey } from '../localization/en';
 
 // What the client is looking at, which the list, the search, and the next question are all asked against. It is one
@@ -64,6 +65,26 @@ export const folderRoleLabels: Readonly<Record<MailFolderRole, MessageKey>> = {
     Important: 'folder.important',
     All: 'folder.all',
     Outbox: 'folder.outbox',
+};
+
+/**
+ * The symbol each role is drawn with, which stands beside the name for the same reason the name stands instead of the
+ * provider's: it says what the folder is rather than what it was called.
+ *
+ * Exhaustive by its own type, as the names above are, and stated here beside them because the tree is no longer the
+ * only screen drawing a folder — the dialog that files mail into one draws the same folders and owes the same symbol.
+ */
+export const folderRoleIcons: Readonly<Record<MailFolderRole, IconName>> = {
+    Inbox: 'inbox',
+    Drafts: 'draft',
+    Sent: 'send',
+    Archive: 'archive',
+    Junk: 'report',
+    Trash: 'delete',
+    Flagged: 'flag',
+    Important: 'label_important',
+    All: 'all_inbox',
+    Outbox: 'outbox',
 };
 
 /** Whether the value is one of the roles this surface publishes. */


### PR DESCRIPTION
Closes #1806

Five defects reported together, each on a different screen, each small on its own. Every one of them
is fixed at the place all its callers route through rather than on the screen it was noticed on.

## The conversation view stopped marking the message opened from the list

`arrivalMark` asked whether the arrival stood among other messages while `threadOpening.ts` still
held one, so pressing *Show earlier messages* took the mark off the very message the mark was about.
The question moves to `Thread.tsx`, which is the only place that knows how many messages are on the
screen at the moment one is drawn, and `Arrival` loses the `amongOthers` member it carried for that
one reader.

## The notification panel travelled diagonally

The panel carried `translate-y-full` outside the breakpoint and `-translate-x-full` inside it.
`translate-x-*` and `translate-y-*` write the one `translate` property, so the two composed and the
sheet came in from the lower corner instead of from the side. Each closed position is now written
under the composition it belongs to — `max-workspace:` for the phone's bottom-to-top sheet,
`workspace:` for the panel that slides in beside the rail — and those two variants never both apply.

## The move dialog named folders by their alias and listed them flat

It now names a folder by the role its account labels it with, and by its path where the account
labels none, drawing the folder column's own icon beside it. `destinationName` states that once, so
the dialog and the toast that reports the move name the same folder rather than two. The folders are
gathered under the account they belong to, with that mailbox's name, its colour mark and the ordinal
the folder column counts by, and they are ordered the way the folder column orders them.

Exactly one group can be offered today, and the type says so rather than pretending otherwise: a
move is resolved against the message's own account and a selection spanning two accounts is refused
before this dialog is reached. The grouping is what says *which mailbox you are filing inside*.

## Opening a draft opened the reading pane

A message in a folder its account labels for drafts now opens the composer, from the message list and
from the search results alike. What decides it is `folderRoleOf` on `MailboxActs` — the folders are
already held there for `archive` and `delete`, so no second reader of `/folders` is added — and
`opensAsDraft` states the reading once for both lists.

The composer reads the message and its body back and opens on what was filed: the addresses, the
subject, and the words, walked out of the reduced document the deployment already answers with.
`draftWords.ts` is that walk. It parses no markup and pins no sanitizer — what arrives is the typed
tree the reading pane draws, checked at the client's own trust boundary — and a block the composer
cannot write is dropped rather than approximated, a table's cells excepted, whose words are the
message.

**A save writes a new draft beside the stored one.** The client surface publishes no route that reads
a draft record back or takes a stored message over as the one being written, so `continuing` says
which stored message the words came from and nothing more. That is a gap in `/api/client` rather than
a choice made here, and it is worth an issue of its own.

## The settings screen carried two scrollbars

`sr-only` takes the hidden input of a switch and of a choice segment out of the flow, so each stood
against whichever ancestor happened to be positioned rather than against the panel that scrolls. The
dialog then reported them as overflow standing below everything a reader can see, and drew a second
scrollbar for it. Measured in a browser against the fixture corpus at 1280×724: the dialog's
`scrollHeight` was 565 against a `clientHeight` of 466 before, and matches it after.

Both controls now carry the containing block themselves, which fixes it wherever either is drawn
rather than only on this screen.

## Out of scope

- The move dialog's *New folder here* row: creating a folder is a write the client surface does not
  publish.
- Every screen this change touches carries substantial pre-existing drift from the design project —
  the settings card's own geometry above all. Measured with the parity scripts before and after: the
  settings screen differs from the design in 63.67% of its pixels before this change and 63.52%
  after, the notification panel in 59.60%, and the conversation view in 44.64% at desktop. The
  conversation view's own capture is byte-identical before and after. Closing that drift is its own
  work.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm test` — 203 files, 3589 tests, green.
- `scripts/verify-full.sh` — passed, 300 contract assertions.
- The settings scrollbar was measured in Chromium against the fixture corpus, before and after, at
  three viewport sizes.
- The three changed screens were captured against the design mirror with
  `scripts/capture-design.sh`, `scripts/capture-client.sh` and `scripts/compare-captures.sh`, and
  each client capture was compared against a capture of the same screen with this change reverted.
