### PR TITLE
[#1814] Order conversations awaiting a state before projecting them

### DIFF
--- a/backend/src/Infrastructure/Persistence/ThreadStates/StoredThreadStateStore.cs
+++ b/backend/src/Infrastructure/Persistence/ThreadStates/StoredThreadStateStore.cs
@@ -83,7 +83,6 @@ internal sealed class StoredThreadStateStore(
             terms);
 
         var awaiting = await Awaiting(counted, dbContext.EmailThreadStates.AsNoTracking())
-            .OrderBy(conversation => conversation.EmailThreadId)
             .Take(batchSize)
             .ToArrayAsync(cancellationToken);
 
@@ -212,11 +211,20 @@ internal sealed class StoredThreadStateStore(
     /// <summary>Groups the narrowed mail by conversation and keeps the ones no stored state currently describes.</summary>
     /// <param name="selected">The narrowed mail of one account.</param>
     /// <param name="states">The states already stored, untracked because nothing here writes.</param>
-    /// <returns>One row per conversation awaiting a state, carrying the shape it has now.</returns>
+    /// <returns>One row per conversation awaiting a state, carrying the shape it has now, ordered by conversation.</returns>
     /// <remarks>
+    /// <para>
     /// A left join rather than two round trips, and the comparison is the whole selection: a conversation with no state
     /// has never been derived, and one whose state was derived from a different count or a different newest arrival has
     /// changed since. Writing the state against the shape read here is what takes the conversation back out.
+    /// </para>
+    /// <para>
+    /// The ordering is stated here rather than by the caller because it has to be applied before the projection. A
+    /// caller ordering the returned rows orders by a member of a constructed <see cref="ThreadAwaitingStateRow" />,
+    /// which the provider cannot reduce back to the grouped column and therefore refuses to translate — a failure the
+    /// whole pass ends on rather than one row. Ordering the grouping's own key leaves the caller with nothing but the
+    /// bound to apply.
+    /// </para>
     /// </remarks>
     internal static IQueryable<ThreadAwaitingStateRow> Awaiting(
         IQueryable<StoredEmailEntity> selected,
@@ -234,6 +242,7 @@ internal sealed class StoredThreadStateStore(
         where stored == null
             || stored.DerivedFromMessageCount != conversation.MessageCount
             || stored.DerivedFromLatestArrival != conversation.LatestArrival
+        orderby conversation.EmailThreadId
         select new ThreadAwaitingStateRow(
             conversation.EmailThreadId,
             conversation.MessageCount,

--- a/backend/tests/Infrastructure.UnitTests/Persistence/ThreadStates/ThreadAwaitingStateQueryTests.cs
+++ b/backend/tests/Infrastructure.UnitTests/Persistence/ThreadStates/ThreadAwaitingStateQueryTests.cs
@@ -1,0 +1,70 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Spam.Gating;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Folders;
+using MailFathom.Infrastructure.Persistence;
+using MailFathom.Infrastructure.Persistence.Connections;
+using MailFathom.Infrastructure.Persistence.ThreadStates;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Persistence.ThreadStates;
+
+/// <summary>
+/// Proves the reader of conversations awaiting a state is a query PostgreSQL runs rather than one the provider refuses.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The pass this reader opens is the whole of the derivation, and a clause the provider cannot express ends it before a
+/// single conversation is read — which is what happened: the batch was ordered by a member of a constructed row, the
+/// provider refused to reduce that back to the grouped column, and every run of every account ended on the same
+/// exception with nothing but a log line to say so.
+/// </para>
+/// <para>
+/// The shape is worth the assertion because it is not a filtered projection: a grouping over an account's mail, a left
+/// join to the states already stored, a negated existence condition over a collection navigation for the moves that
+/// have not settled, and a bound taken after an ordering. No database is needed to establish any of it — the statement
+/// the provider would send is printable, and its absence is the failure.
+/// </para>
+/// </remarks>
+public sealed class ThreadAwaitingStateQueryTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 9, 10, 10, 0, 0, TimeSpan.Zero);
+
+    /// <summary>Every clause reaches the server, including the ordering the bound is taken after.</summary>
+    [Fact]
+    public void Awaiting_TheBatchTheDerivationPassReads_TranslatesToOneBoundedStatement()
+    {
+        // Arrange
+        var options = MailFathomDbContextDesignTimeFactory.BuildOptions(
+            orchestratedConnectionString: null,
+            designTimeConnectionString: null);
+        using var context = new MailFathomDbContext(options, PostgresTextSearchConfiguration.Default);
+
+        var counted = StoredThreadStateStore.Selecting(
+            context.StoredEmails.AsNoTracking(),
+            Guid.CreateVersion7(),
+            "work",
+            [new MailFolderIdentity(MailAccountId.Create("work"), MailFolderAlias.Create("INBOX"))],
+            new DerivedWorkAdmissionTerms([], [], [], Now));
+
+        // Act
+        var sql = StoredThreadStateStore.Awaiting(counted, context.EmailThreadStates.AsNoTracking())
+            .Take(8)
+            .ToQueryString();
+
+        // Assert
+        Assert.Contains("GROUP BY", sql, StringComparison.Ordinal);
+        Assert.Contains("NOT EXISTS (", sql, StringComparison.Ordinal);
+        Assert.Contains("LEFT JOIN", sql, StringComparison.Ordinal);
+
+        var ordering = sql.IndexOf("ORDER BY", StringComparison.Ordinal);
+        var bound = sql.IndexOf("LIMIT", StringComparison.Ordinal);
+
+        Assert.True(ordering >= 0, sql);
+        Assert.True(bound > ordering, sql);
+    }
+}


### PR DESCRIPTION
## What changed

`ThreadStateDerivationPass` ended every synchronization run with an `InvalidOperationException`, so no
conversation was ever given a derived state. The untranslatable part was neither of the two candidates the
issue named: the correlated `relocate` sub-query translates, and the pass reached the ordering before it
failed. What the provider refuses is the ordering itself — the caller ordered the projected rows by
`ThreadAwaitingStateRow.EmailThreadId`, and EF Core cannot reduce a member access on a constructed row back
to the grouped column it came from.

The ordering now sits inside `StoredThreadStateStore.Awaiting`, applied to the grouping's own key before the
projection, and the caller is left with nothing but `Take(batchSize)`. Nothing else about the selection
moved: the `relocate` exclusion, the rule-evaluation gate, the classification gate, the folder admission and
the tombstone check are all `Selecting`'s and are untouched, so a message whose move has not settled still
stays out of the derivation.

## Why it went unnoticed

Every other reader of this shape in `Infrastructure/Persistence` carries a translation test that prints the
statement the provider would send — the timeline, the previews, the search index, the attachment matches, the
thread sizes, the vector hits. This one did not, and the pass swallows the exception into a log line without
backing the account off, so the failure was invisible outside the log. `ThreadAwaitingStateQueryTests` closes
that gap: it asserts the grouping, the negated existence condition, the left join, and that the bound is
taken after an ordering, and it needs no database.

## Verification

`scripts/verify-fast.sh` — green, `Infrastructure.UnitTests` 3242/3242. The new test fails on the previous
revision with the exact exception the issue quotes.

Closes #1814
