### PR TITLE
[#1813] Converge an authored mailbox change at the run's stage boundaries rather than only at its top

### DIFF
--- a/backend/src/Application/Synchronization/MailAccountRunSignal.cs
+++ b/backend/src/Application/Synchronization/MailAccountRunSignal.cs
@@ -25,8 +25,9 @@ namespace MailFathom.Application.Synchronization;
 /// A raise arriving while nothing is waiting is kept, which is the case that has to be right rather than a corner: the
 /// record is often written while the account is mid-run, and a raise dropped there would be a change waiting out the
 /// whole of the next interval. It is kept per account rather than per change, so a hundred messages filed at once bring
-/// one run forward instead of a hundred, and it is spent by the wait that takes it — a raise never survives into a
-/// second wait, which would be a run brought forward for work already done.
+/// one run forward instead of a hundred, and it is spent by whichever of the two answers it — the run already under way,
+/// at one of its own stage boundaries, or the wait that follows it. A raise never survives what answered it, which would
+/// be a run brought forward for work already done.
 /// </para>
 /// </remarks>
 public sealed class MailAccountRunSignal
@@ -36,6 +37,18 @@ public sealed class MailAccountRunSignal
     /// <summary>Says that an account has something written down that its next run should not wait an interval for.</summary>
     /// <param name="account">The account whose run is worth bringing forward.</param>
     public void BringForward(MailAccountId account) => this.WaitFor(account).BringForward();
+
+    /// <summary>Takes a raise standing against an account, so a run already under way answers it instead of the next one.</summary>
+    /// <param name="account">The account whose run is already going.</param>
+    /// <returns><see langword="true" /> when a raise was standing and this call spent it.</returns>
+    /// <remarks>
+    /// The wait between runs is not the only place a raise can be answered: a run reads the records at every one of its
+    /// own stage boundaries, and a change authored while it was under way is carried there rather than waiting out the
+    /// stages left. Spending the raise here is what keeps the wait after that run from bringing a run forward for work
+    /// this one has already done, and answering <see langword="false" /> is what keeps a boundary with nothing authored
+    /// against it from costing a query.
+    /// </remarks>
+    public bool TakeRaise(MailAccountId account) => this.WaitFor(account).TakeRaise();
 
     /// <summary>Registers the wait an account is about to make, so a raise can end it.</summary>
     /// <param name="account">The account about to wait.</param>
@@ -132,6 +145,21 @@ public sealed class MailAccountRunSignal
             // account's gate.
             claimed.Cancel();
             claimed.Dispose();
+        }
+
+        internal bool TakeRaise()
+        {
+            lock (this.gate)
+            {
+                if (!this.raised)
+                {
+                    return false;
+                }
+
+                this.raised = false;
+
+                return true;
+            }
         }
 
         internal Wait Register(CancellationToken stopping)

--- a/backend/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
+++ b/backend/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
@@ -324,21 +324,38 @@ internal sealed partial class AccountSynchronizationSupervisor
 
             if (!schedulingToken.IsCancellationRequested)
             {
-                await this.DeliverOutstandingMailAsync(workUnitToken);
-                await this.EraseExpiredDerivedRecordsAsync(runSettings, workUnitToken);
-                await this.ClassifyRequestedMailAsync(runSettings, workUnitToken);
-                await this.EvaluateMailRulesAsync(runSettings, workUnitToken);
-                await this.CutPassagesOfEvaluatedMailAsync(runSettings, workUnitToken);
-                await this.ReadAttachmentsOfCutMailAsync(runSettings, workUnitToken);
-                await this.DeriveMarksOfCutMailAsync(runSettings, workUnitToken);
-                await this.DeriveStatesOfChangedThreadsAsync(runSettings, workUnitToken);
-                await this.ReportRunToItsUserAsync(
-                    runSettings,
-                    scheduledFolders.Length,
-                    failedFolderCount,
-                    arrivedEmailCount,
-                    credentialRefused,
-                    workUnitToken);
+                Func<CancellationToken, Task>[] stagesAfterTheFolders =
+                [
+                    this.DeliverOutstandingMailAsync,
+                    token => this.EraseExpiredDerivedRecordsAsync(runSettings, token),
+                    token => this.ClassifyRequestedMailAsync(runSettings, token),
+                    token => this.EvaluateMailRulesAsync(runSettings, token),
+                    token => this.CutPassagesOfEvaluatedMailAsync(runSettings, token),
+                    token => this.ReadAttachmentsOfCutMailAsync(runSettings, token),
+                    token => this.DeriveMarksOfCutMailAsync(runSettings, token),
+                    token => this.DeriveStatesOfChangedThreadsAsync(runSettings, token),
+                    token => this.ReportRunToItsUserAsync(
+                        runSettings,
+                        scheduledFolders.Length,
+                        failedFolderCount,
+                        arrivedEmailCount,
+                        credentialRefused,
+                        token),
+                ];
+
+                foreach (var stage in stagesAfterTheFolders)
+                {
+                    // The boundary between two stages is where a change authored since this run began is carried, so a
+                    // delete or an archive somebody asked for waits out the stage under way rather than the whole run.
+                    // The stages are a list rather than a sequence of calls for that reason alone: a boundary a stage
+                    // added later did not get would be a latency nobody sees until somebody measures it again.
+                    convergenceFailed |= await this.ConvergeAuthoredChangeAsync(
+                        runSettings,
+                        schedulingToken,
+                        workUnitToken);
+
+                    await stage(workUnitToken);
+                }
             }
         }
         finally
@@ -426,6 +443,34 @@ internal sealed partial class AccountSynchronizationSupervisor
 
             return true;
         }
+    }
+
+    /// <summary>Converges a change authored since this run began, at the boundary between two of the run's stages.</summary>
+    /// <returns><see langword="true" /> when a pass ran and at least one change failed, which puts the account into backoff.</returns>
+    /// <remarks>
+    /// <para>
+    /// Gated on a raise rather than run at every boundary, because the boundaries are reached several times a run and an
+    /// account nobody changed anything on must cost neither a query nor a mailbox session for them. The raise is what
+    /// says a record was written since this run started reading, so taking it here is the whole of the condition, and
+    /// taking it is also what keeps the wait after this run from bringing a run forward for what this pass has carried.
+    /// </para>
+    /// <para>
+    /// It is withheld once the host stops scheduling, for the reason the pass at the top of the run is: convergence opens
+    /// the account's write connection, and the drain exists to let work already in flight finish rather than to start a
+    /// mailbox session inside it. The change stays recorded and the next run carries it.
+    /// </para>
+    /// </remarks>
+    private async Task<bool> ConvergeAuthoredChangeAsync(
+        MailSynchronizationOptions runSettings,
+        CancellationToken schedulingToken,
+        CancellationToken workUnitToken)
+    {
+        if (schedulingToken.IsCancellationRequested || !this.runSignal.TakeRaise(this.account.Id))
+        {
+            return false;
+        }
+
+        return await this.ConvergeOutstandingMutationsAsync(runSettings, workUnitToken);
     }
 
     /// <summary>Delivers whatever this account has been asked to send and has not seen leave.</summary>

--- a/backend/tests/Application.UnitTests/Synchronization/MailAccountRunSignalTests.cs
+++ b/backend/tests/Application.UnitTests/Synchronization/MailAccountRunSignalTests.cs
@@ -11,8 +11,9 @@ namespace MailFathom.Application.UnitTests.Synchronization;
 /// <summary>Covers what ends an account's wait between synchronization runs, and what a wait it arrived beside does with it.</summary>
 /// <remarks>
 /// The whole of this type is about timing, so the cases are the orderings: brought forward while a wait is registered,
-/// brought forward while none is, and brought forward for another account. Each is a real sequence — the record is
-/// written by a request whose timing against the account's own loop nothing coordinates.
+/// brought forward while none is, taken by the run already going before any wait sees it, and brought forward for
+/// another account. Each is a real sequence — the record is written by a request whose timing against the account's own
+/// loop nothing coordinates.
 /// </remarks>
 public sealed class MailAccountRunSignalTests
 {
@@ -118,6 +119,69 @@ public sealed class MailAccountRunSignalTests
         using var next = signal.Register(Account, CancellationToken.None);
 
         Assert.True(next.Token.IsCancellationRequested);
+    }
+
+    /// <summary>A run already going answers the raise at its next stage boundary, which is what a change authored mid-run waits for.</summary>
+    [Fact]
+    public void TakeRaise_BroughtForwardWhileTheRunWasGoing_TakesItAndLeavesTheWaitAfterwardsUnbrought()
+    {
+        // Arrange
+        var signal = new MailAccountRunSignal();
+        signal.BringForward(Account);
+
+        // Act
+        var taken = signal.TakeRaise(Account);
+
+        // Assert
+        Assert.True(taken);
+
+        using var waiting = signal.Register(Account, CancellationToken.None);
+
+        Assert.False(waiting.Token.IsCancellationRequested);
+    }
+
+    /// <summary>A boundary is reached several times a run, and one with nothing authored against it must cost no query at all.</summary>
+    [Fact]
+    public void TakeRaise_NothingBroughtForward_ReportsThereIsNothingToCarry()
+    {
+        // Arrange
+        var signal = new MailAccountRunSignal();
+
+        // Act
+        var taken = signal.TakeRaise(Account);
+
+        // Assert
+        Assert.False(taken);
+    }
+
+    /// <summary>One raise is one run brought forward, so the boundaries after the one that took it find nothing left.</summary>
+    [Fact]
+    public void TakeRaise_TheBoundaryBeforeItAlreadyTookTheRaise_ReportsThereIsNothingToCarry()
+    {
+        // Arrange
+        var signal = new MailAccountRunSignal();
+        signal.BringForward(Account);
+        signal.TakeRaise(Account);
+
+        // Act
+        var taken = signal.TakeRaise(Account);
+
+        // Assert
+        Assert.False(taken);
+    }
+
+    [Fact]
+    public void TakeRaise_BroughtForwardForAnotherAccount_LeavesThisAccountWithNothingToCarry()
+    {
+        // Arrange
+        var signal = new MailAccountRunSignal();
+        signal.BringForward(Another);
+
+        // Act
+        var taken = signal.TakeRaise(Account);
+
+        // Assert
+        Assert.False(taken);
     }
 
     /// <summary>A wait already over must not take the next one's, which would be a change waiting out the interval it was raised to avoid.</summary>

--- a/backend/tests/Host.UnitTests/Hosting/Workers/AccountSynchronizationSupervisorTests.cs
+++ b/backend/tests/Host.UnitTests/Hosting/Workers/AccountSynchronizationSupervisorTests.cs
@@ -423,16 +423,31 @@ public sealed class AccountSynchronizationSupervisorTests
     }
 
     /// <summary>
-    /// A change somebody authored reaches the mail server through this run and through nothing else, so the wait in
-    /// front of it is what a person watching a message stay where they deleted it is waiting out. The clock never moves
-    /// in this test, which is what makes the second run attributable to the signal rather than to the interval.
+    /// A change somebody authored reaches the mail server through this account's own runs and through nothing else, so
+    /// the wait in front of it is what a person watching a message stay where they deleted it is waiting out. The clock
+    /// never moves in this test, which is what makes the second convergence pass attributable to the raise rather than
+    /// to the interval. Which of the two carries it follows from where the raise lands, and the claim holds either way:
+    /// a run already under way takes it at its next stage boundary, and one landing past the last of those boundaries is
+    /// taken by the wait that follows and carried by the run it brings forward.
     /// </summary>
     [Fact]
-    public async Task RunAsync_AChangeBroughtTheRunForward_RunsAgainWithoutWaitingOutTheInterval()
+    public async Task RunAsync_AChangeBroughtTheRunForward_ConvergesAgainWithoutWaitingOutTheInterval()
     {
         // Arrange
-        var attemptCount = 0;
-        var secondRunStarted = new TaskCompletionSource();
+        var convergencePassCount = 0;
+        var convergedAfterTheRaise = new TaskCompletionSource();
+        var recordStore = Substitute.For<IMailboxMutationRecordStore>();
+        recordStore
+            .ReadOutstandingAsync(Arg.Any<MailAccountIdentity>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                if (Interlocked.Increment(ref convergencePassCount) == 2)
+                {
+                    convergedAfterTheRaise.TrySetResult();
+                }
+
+                return Task.FromResult<IReadOnlyList<OutstandingMailboxMutation>>([]);
+            });
         await using var emptyMailbox = CreateEmptyMailbox();
         var sessionFactory = Substitute.For<IMailboxSessionFactory>();
         sessionFactory
@@ -441,25 +456,18 @@ public sealed class AccountSynchronizationSupervisorTests
                 Arg.Any<MailFolderResolution>(),
                 Arg.Any<MailTransportSecurityPolicy>(),
                 Arg.Any<CancellationToken>())
-            .Returns(_ =>
-            {
-                if (Interlocked.Increment(ref attemptCount) == 2)
-                {
-                    secondRunStarted.TrySetResult();
-                }
-
-                return Task.FromResult(emptyMailbox);
-            });
+            .Returns(Task.FromResult(emptyMailbox));
         await using var harness = CreateHarness(
             SynchronizationTestHost.CreateSingleAccountOptions(enabled: true, "INBOX"),
-            sessionFactory);
+            sessionFactory,
+            mutationRecordStore: recordStore);
         var supervision = harness.StartSupervision();
 
         // Act: kept where it lands, so whether it arrives before or during the first run decides nothing.
         harness.RunSignal.BringForward(MailAccountId.Create("primary"));
 
         // Assert
-        await secondRunStarted.Task.WaitAsync(DeadlockGuard, TestContext.Current.CancellationToken);
+        await convergedAfterTheRaise.Task.WaitAsync(DeadlockGuard, TestContext.Current.CancellationToken);
         await harness.StopSchedulingAsync();
         await supervision.WaitAsync(DeadlockGuard, TestContext.Current.CancellationToken);
     }
@@ -623,6 +631,121 @@ public sealed class AccountSynchronizationSupervisorTests
         Assert.Contains(
             harness.Logger.Messages,
             message => message.Contains("runs in a row", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A change authored while a run is under way is the ordinary timing rather than a corner, and the stages that
+    /// follow the folders are minutes of derivation on a busy account. The run is held at the stage after the one that
+    /// authored the change, so it can neither have ended nor been followed by another: a second convergence pass
+    /// observed there is this run's own.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_AChangeIsAuthoredWhileTheRunIsUnderWay_ConvergesItWithoutWaitingTheRunOut()
+    {
+        // Arrange
+        var convergencePassCount = 0;
+        var convergedAfterTheChangeWasAuthored = new TaskCompletionSource();
+        var recordStore = Substitute.For<IMailboxMutationRecordStore>();
+        recordStore
+            .ReadOutstandingAsync(Arg.Any<MailAccountIdentity>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                if (Interlocked.Increment(ref convergencePassCount) == 2)
+                {
+                    convergedAfterTheChangeWasAuthored.TrySetResult();
+                }
+
+                return Task.FromResult<IReadOnlyList<OutstandingMailboxMutation>>([]);
+            });
+        var releaseTheRun = new TaskCompletionSource();
+        var attachmentTextStore = Substitute.For<IStoredEmailAttachmentTextStore>();
+        attachmentTextStore
+            .GetEmailsAwaitingAttachmentTextAsync(
+                Arg.Any<MailAccountIdentity>(),
+                Arg.Any<StoredEmailId?>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => HoldTheStageUntilReleasedAsync(releaseTheRun));
+        var chunkingStore = Substitute.For<IStoredEmailChunkingStore>();
+        await using var harness = CreateHarness(
+            SynchronizationTestHost.CreateSingleAccountOptions(enabled: true),
+            Substitute.For<IMailboxSessionFactory>(),
+            mutationRecordStore: recordStore,
+            chunkingStore: chunkingStore,
+            attachmentTextStore: attachmentTextStore);
+
+        // Authored from the stage before the held one, so the change lands mid-run at a point this test controls
+        // rather than wherever the scheduler happened to put it.
+        chunkingStore
+            .GetEmailsAwaitingChunkingAsync(Arg.Any<MailAccountIdentity>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                harness.RunSignal.BringForward(MailAccountId.Create("primary"));
+
+                return Task.FromResult<IReadOnlyList<StoredEmailAwaitingChunking>>([]);
+            });
+        var supervision = harness.StartSupervision();
+
+        // Act
+        await convergedAfterTheChangeWasAuthored.Task.WaitAsync(DeadlockGuard, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.DoesNotContain(
+            harness.Logger.Messages,
+            message => message.Contains("finished in", StringComparison.Ordinal));
+
+        releaseTheRun.SetResult();
+        await harness.StopSchedulingAsync();
+        await supervision.WaitAsync(DeadlockGuard, TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    /// The boundaries are passed several times a run on every account, and nearly every one of them has nothing
+    /// authored against it. Such a boundary must cost nothing at all — no record read, and so no write session and no
+    /// IMAP command behind one.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_NothingWasAuthoredWhileTheRunWasUnderWay_ReadsNoRecordAtItsStageBoundaries()
+    {
+        // Arrange
+        var recordStore = Substitute.For<IMailboxMutationRecordStore>();
+        recordStore
+            .ReadOutstandingAsync(Arg.Any<MailAccountIdentity>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<OutstandingMailboxMutation>>([]));
+        var releaseTheRun = new TaskCompletionSource();
+        var everyEarlierBoundaryPassed = new TaskCompletionSource();
+        var attachmentTextStore = Substitute.For<IStoredEmailAttachmentTextStore>();
+        attachmentTextStore
+            .GetEmailsAwaitingAttachmentTextAsync(
+                Arg.Any<MailAccountIdentity>(),
+                Arg.Any<StoredEmailId?>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                everyEarlierBoundaryPassed.TrySetResult();
+
+                return HoldTheStageUntilReleasedAsync(releaseTheRun);
+            });
+        await using var harness = CreateHarness(
+            SynchronizationTestHost.CreateSingleAccountOptions(enabled: true),
+            Substitute.For<IMailboxSessionFactory>(),
+            mutationRecordStore: recordStore,
+            attachmentTextStore: attachmentTextStore);
+        var supervision = harness.StartSupervision();
+
+        // Act
+        await everyEarlierBoundaryPassed.Task.WaitAsync(DeadlockGuard, TestContext.Current.CancellationToken);
+
+        // Assert: the pass at the top of the run, and not one of the boundaries behind it.
+        await recordStore.Received(1).ReadOutstandingAsync(
+            Arg.Any<MailAccountIdentity>(),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
+
+        releaseTheRun.SetResult();
+        await harness.StopSchedulingAsync();
+        await supervision.WaitAsync(DeadlockGuard, TestContext.Current.CancellationToken);
     }
 
     /// <summary>An alias nobody advertises is fixed by an edit, so waiting longer for it would only slow the folders that work.</summary>
@@ -1340,6 +1463,15 @@ public sealed class AccountSynchronizationSupervisorTests
         await release.Task;
 
         return mailbox;
+    }
+
+    /// <summary>Models a stage that does not finish, so a run cannot end while a test reads what happened before it.</summary>
+    private static async Task<IReadOnlyList<EmailAwaitingAttachmentText>> HoldTheStageUntilReleasedAsync(
+        TaskCompletionSource release)
+    {
+        await release.Task;
+
+        return [];
     }
 
     /// <summary>Models a folder the server serves and that holds no email, which is the cheapest successful run there is.</summary>

--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -573,8 +573,18 @@ is the next one whether or not anything ends the wait early. The raise carries n
 records rather than the raise, and it is one per account rather than one per change, so a hundred messages filed at
 once bring a single run forward. It is a hint and not a queue entry: never awaited, never retried, and one lost delays
 a change to the interval rather than dropping it. One arriving while the account is mid-run is the ordinary case rather
-than a corner, since the record is usually written while a run is under way, so it is kept and spent by the wait that
-follows — which is what carries the change into the next run instead of the one after that.
+than a corner, since the record is usually written while a run is under way, so it is kept until something answers it.
+
+**A run under way answers it at its next stage boundary.** A run converges before it reads its folders and again between
+each of the passes that follow them — the delivery, the retention sweep, the classification, the rules, the cut, the
+attachment reading, the two derivations, and the report — so a change recorded while any one of those is running is
+carried at the boundary after it rather than waiting out the stages left. That matters because those stages are where a
+run spends its time: the folders of a settled account take a couple of seconds and the derivations behind them take tens
+of seconds each, so a delete waiting for the run to end was waiting on work that has nothing to do with it. A boundary
+costs nothing when nothing was authored, since the raise is what it reads and no raise means no record query, no write
+session, and no IMAP command. Whichever answers the raise spends it, so a run brought forward is never a run brought
+forward for a change already carried: a raise taken at a boundary leaves the wait after that run unbrought, and one
+landing past the last boundary is taken by that wait and carried by the run it brings forward.
 
 The record answers three questions with one row.
 


### PR DESCRIPTION
Closes #1813

A run converged only at its top, and the raise a recorder makes was registered after `RunOnceAsync`
had already returned — so a change authored while a run was executing sat until that run ended, and
what a person waited out was the derivation stages behind their delete rather than anything to do
with it. Measured on the deployment: 0.9 s on a quiesced account against 14.2 s and 32.2 s on a busy
one, with run durations of 29–39 s of which the folders were about 2.5 s.

A run now converges at the boundary between each of the stages that follow its folders — the
delivery, the retention sweep, the classification, the rules, the cut, the attachment reading, the
two derivations, and the report — so a record written mid-run is carried at the next boundary rather
than by the next run.

## What changed

- `MailAccountRunSignal.TakeRaise` takes a raise standing against an account without registering a
  wait, so a run already under way can answer one. Whichever of the two answers the raise spends it,
  which is what keeps the wait after a run from bringing a run forward for a change that run already
  carried.
- `AccountSynchronizationSupervisor` runs the stages after the folders as a list and converges before
  each of them. The list is what makes the boundaries structural: a stage added later gets its
  boundary rather than a latency nobody sees until it is measured again.
- The boundary is gated on the raise, so an account nobody changed anything on costs no record query
  at one — and therefore no write session and no IMAP command. It is withheld once the host stops
  scheduling, for the reason the top-of-run pass is: the drain lets work in flight finish rather than
  opening a mailbox session inside it.

The account's run slot and ADR 0007's write-session contract are untouched: the boundaries are
sequential inside one run, after every folder session is closed, so an account still holds at most
one connection able to change its mailbox and never converges twice at once.

## Tests

- `MailAccountRunSignalTests` — a raise taken by the run leaves the wait after it unbrought, a
  boundary with nothing raised reports nothing to carry, a second boundary finds nothing left, and
  another account's raise is not this account's.
- `AccountSynchronizationSupervisorTests` — a change authored mid-run converges before that run ends
  (the run is held at the stage after the one that authored it, so it can neither have ended nor been
  followed by another); a run nobody authored anything against reads no record at its boundaries; the
  top-of-run pass still happens before any folder is opened.
- `RunAsync_AChangeBroughtTheRunForward_...` now asserts the second convergence pass rather than a
  second folder open: with the raise answerable mid-run, a second whole run is no longer the outcome,
  and the claim it was written for — the change does not wait out the interval — is what it measures.

## Documentation

`docs/features/imap-synchronization.md` states what the raise now reaches, where it already described
the raise: the boundary a run answers it at, that an unraised boundary costs nothing, and that
whichever answers it spends it.
