### PR TITLE
[#1825] Edit one user's record as JSON from mfctl, in the operator's own editor

### DIFF
--- a/backend/src/Cli/Administration/AdminApiClient.cs
+++ b/backend/src/Cli/Administration/AdminApiClient.cs
@@ -1266,6 +1266,32 @@ internal sealed class AdminApiClient
             cancellationToken,
             absenceMessage: NoSuchUser);
 
+    /// <summary>Commits one user's record as an editing session saved it.</summary>
+    /// <param name="token">The bearer credential to present.</param>
+    /// <param name="userId">The user whose record is written.</param>
+    /// <param name="request">The record and the version the buffer was opened over.</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
+    /// <returns>What the write did.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <exception cref="CliFailure">Thrown when the deployment refused the request or the credential, could not be reached, or answered with something that is not an outcome.</exception>
+    internal Task<UserRecordWriteAnswer> SaveUserRecordAsync(
+        string token,
+        Guid userId,
+        UserRecordSaveRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        return this.RequestAsync(
+            HttpMethod.Post,
+            AdminEndpointRoutes.UserRecordPath(userId),
+            token,
+            CliJsonContext.Default.UserRecordWriteAnswer,
+            cancellationToken,
+            JsonContent.Create(request, CliJsonContext.Default.UserRecordSaveRequest),
+            NoSuchUser);
+    }
+
     /// <summary>Declares one more mail account in a user's record.</summary>
     /// <param name="token">The bearer credential to present.</param>
     /// <param name="userId">The user the mailbox belongs to.</param>

--- a/backend/src/Cli/Administration/Users/UserRecordRequests.cs
+++ b/backend/src/Cli/Administration/Users/UserRecordRequests.cs
@@ -45,6 +45,19 @@ internal sealed record UserRecord(
     [property: JsonPropertyName("readFromConfiguration")] bool ReadFromConfiguration,
     [property: JsonPropertyName("document")] string? Document);
 
+/// <summary>One user's record as an editing session saved it.</summary>
+/// <param name="Version">The version the buffer was opened over, which the commit is accepted against.</param>
+/// <param name="Document">The record as the operator left it, which the deployment judges whole.</param>
+/// <remarks>
+/// The whole record rather than the difference, for the reason the contact amendment sends a whole record: what the
+/// deployment accepts is a document, and a difference would have to be applied by something that then decided what the
+/// record means. The version is what makes that safe — a buffer composed over a record somebody else has moved past is
+/// refused rather than merged.
+/// </remarks>
+internal sealed record UserRecordSaveRequest(
+    [property: JsonPropertyName("version")] long Version,
+    [property: JsonPropertyName("document")] string Document);
+
 /// <summary>One mail account declared into a user's record.</summary>
 /// <param name="Version">The version the record was read at.</param>
 /// <param name="Account">The declaration, as the JSON object a configuration file would have written.</param>

--- a/backend/src/Cli/CliContext.cs
+++ b/backend/src/Cli/CliContext.cs
@@ -4,10 +4,10 @@
 
 using MailFathom.Cli.Administration;
 using MailFathom.Cli.Authorization;
-using MailFathom.Cli.Commands.Configuration;
 using MailFathom.Cli.Credentials;
 using MailFathom.Cli.Credentials.SecretStores;
 using MailFathom.Cli.Diagnostics;
+using MailFathom.Cli.Editing;
 using MailFathom.Cli.Transport;
 
 namespace MailFathom.Cli;

--- a/backend/src/Cli/CliJsonContext.cs
+++ b/backend/src/Cli/CliJsonContext.cs
@@ -94,6 +94,7 @@ namespace MailFathom.Cli;
 [JsonSerializable(typeof(UserProvisioned))]
 [JsonSerializable(typeof(UserErasure))]
 [JsonSerializable(typeof(UserRecord))]
+[JsonSerializable(typeof(UserRecordSaveRequest))]
 [JsonSerializable(typeof(UserMailAccountRequest))]
 [JsonSerializable(typeof(UserMailAccountRemovalRequest))]
 [JsonSerializable(typeof(UserAdoptionRequest))]

--- a/backend/src/Cli/Commands/CliRootCommand.cs
+++ b/backend/src/Cli/Commands/CliRootCommand.cs
@@ -190,6 +190,7 @@ internal static class CliRootCommand
             AddUserCommand.Create(context),
             ListUsersCommand.Create(context),
             ShowUserRecordCommand.Create(context),
+            EditUserRecordCommand.Create(context),
             RenameUserCommand.Create(context),
             AdoptUserCommand.Create(context),
             RemoveUserCommand.Create(context),

--- a/backend/src/Cli/Commands/Configuration/EditConfigurationCommand.cs
+++ b/backend/src/Cli/Commands/Configuration/EditConfigurationCommand.cs
@@ -6,7 +6,7 @@ using System.CommandLine;
 using System.Globalization;
 using MailFathom.Cli.Administration;
 using MailFathom.Cli.Administration.Configuration;
-using MailFathom.Cli.Credentials;
+using MailFathom.Cli.Editing;
 
 namespace MailFathom.Cli.Commands.Configuration;
 
@@ -64,7 +64,7 @@ internal static class EditConfigurationCommand
         string? requestedDeployment,
         CancellationToken cancellationToken)
     {
-        var editor = EditorNamedByTheShell(context);
+        var editor = EditorDrivenDocument.EditorNamedByTheShell(context);
         var profile = await context.Deployment().ReachAsync(requestedDeployment, cancellationToken);
 
         using var transport = context.OpenTransport(profile.Endpoint, profile.Trust);
@@ -72,123 +72,18 @@ internal static class EditConfigurationCommand
 
         var opened = await client.ReadConfigurationDocumentAsync(profile.Token, cancellationToken);
         var document = opened.Document ?? string.Empty;
-        var session = Path.Combine(Path.GetTempPath(), $"mailfathom-configuration-{Guid.NewGuid():N}");
-        var buffer = Path.Combine(session, "configuration.json");
 
-        try
-        {
-            Open(session, buffer, document);
+        var saved = await EditorDrivenDocument.OpenAsync(
+            context,
+            editor,
+            "configuration",
+            "the deployment's configuration",
+            document,
+            cancellationToken);
 
-            if (context.Edit(editor, buffer) is { Saved: false } ended)
-            {
-                throw new CliFailure(WhyNothingWasWritten(editor, ended));
-            }
-
-            var saved = await ReadBackAsync(buffer, cancellationToken);
-
-            if (Abandoned(context, document, saved))
-            {
-                return CliExitCode.Success;
-            }
-
-            return await CommitAsync(context, client, profile.Token, opened, saved, evenIfShadowed, cancellationToken);
-        }
-        finally
-        {
-            Discard(session);
-        }
-    }
-
-    /// <summary>Opens the session's own directory and writes the document into it, readable by their user alone.</summary>
-    /// <exception cref="CliFailure">Thrown when the temporary directory cannot be written, which is a situation rather than a defect.</exception>
-    /// <remarks>
-    /// A temporary directory that is full, read-only, or on a filesystem that will not take a user-only mode is
-    /// something the operator can act on, so it is reported as a sentence naming the path rather than left to reach
-    /// <c>CliRunner</c> as a stack trace — the same answer the credential store and the token protector give for the
-    /// same situation.
-    /// </remarks>
-    private static void Open(string session, string buffer, string document)
-    {
-        try
-        {
-            UserOnlyStorage.CreateDirectory(session);
-
-            SettingsBuffer.Write(buffer, document);
-        }
-        catch (Exception failure) when (failure is IOException or UnauthorizedAccessException)
-        {
-            throw new CliFailure($"The editing buffer at {buffer} could not be written.", failure);
-        }
-    }
-
-    /// <summary>Reads back what the editor saved.</summary>
-    /// <exception cref="CliFailure">Thrown when the buffer cannot be read, which the editor rather than this command left it as.</exception>
-    private static async Task<string> ReadBackAsync(string buffer, CancellationToken cancellationToken)
-    {
-        try
-        {
-            return await File.ReadAllTextAsync(buffer, cancellationToken);
-        }
-        catch (Exception failure) when (failure is IOException or UnauthorizedAccessException)
-        {
-            throw new CliFailure(
-                $"The editing buffer at {buffer} could not be read back after the editor exited, so nothing was written.",
-                failure);
-        }
-    }
-
-    /// <summary>Removes the session's directory and the buffer in it, letting the invocation's own outcome stand where it cannot be removed.</summary>
-    /// <remarks>
-    /// <para>
-    /// The case is the one this command's own guidance anticipates: a graphical editor started without its wait flag
-    /// returns while still holding the file open, so the delete throws on Windows over an invocation that had already
-    /// decided what it did. Turning that into a stack trace would report a failure to somebody whose command worked,
-    /// or replace the sentence naming why nothing was written — which is the rule <c>CliRunner.Record</c> states for a
-    /// full disk.
-    /// </para>
-    /// <para>
-    /// What is left behind on that path is the session's own directory, which is readable by its user alone whatever
-    /// the editor did to the file inside it. That is why the buffer sits in a directory of its own rather than in the
-    /// temporary directory itself: an editor that saves by writing a sibling and renaming it over the target creates
-    /// that sibling under the process umask, so the mode this command set at creation does not survive the first save
-    /// — and what the file then holds is the deployment's whole persisted configuration plus anything the operator
-    /// typed over a marker.
-    /// </para>
-    /// </remarks>
-    private static void Discard(string session)
-    {
-        try
-        {
-            Directory.Delete(session, recursive: true);
-        }
-        catch (Exception failure) when (failure is IOException or UnauthorizedAccessException)
-        {
-        }
-    }
-
-    /// <summary>Reports whether the editing session asked for nothing, and says which of the two ways it did.</summary>
-    /// <remarks>
-    /// An emptied buffer is the conventional way to abandon an editor-driven command and is honoured as one, rather
-    /// than being read as a document that persists no settings at all — which is a change an operator can still make
-    /// deliberately by saving an empty JSON object.
-    /// </remarks>
-    private static bool Abandoned(CliContext context, string document, string saved)
-    {
-        if (string.IsNullOrWhiteSpace(saved))
-        {
-            context.Console.WriteLine("The buffer was emptied, so the deployment's configuration was left as it was.");
-
-            return true;
-        }
-
-        if (string.Equals(saved, document, StringComparison.Ordinal))
-        {
-            context.Console.WriteLine("The buffer was saved unchanged, so nothing was written.");
-
-            return true;
-        }
-
-        return false;
+        return saved is null
+            ? CliExitCode.Success
+            : await CommitAsync(context, client, profile.Token, opened, saved, evenIfShadowed, cancellationToken);
     }
 
     private static async Task<int> CommitAsync(
@@ -253,23 +148,4 @@ internal static class EditConfigurationCommand
             context.Console.WriteNotice($"  {path}");
         }
     }
-
-    /// <summary>Says why an editing session that did not finish wrote nothing, in terms the operator can act on.</summary>
-    /// <remarks>
-    /// The two endings need different advice. A wait flag is what repairs an editor that ran and returned before the
-    /// operator had finished; it repairs nothing for an editor the operating system never started, where the value in
-    /// the variable is the thing to correct and the system's own words are what name which way it is wrong.
-    /// </remarks>
-    private static string WhyNothingWasWritten(string editor, EditingSession ended) =>
-        ended.WhyItNeverStarted is { Length: > 0 } reason
-            ? $"The editor '{editor}' could not be started, so nothing was written: {reason}. Correct ${OperatorEditor.VisualVariable} or ${OperatorEditor.EditorVariable} to name a program on this machine."
-            : $"The editor '{editor}' did not finish successfully, so nothing was written. A graphical editor needs the flag that makes it wait — '{OperatorEditor.VisualVariable}=\"code --wait\"', for instance — because this command reads the file back when the editor exits.";
-
-    /// <summary>Finds the editor the operator's shell names, refusing rather than choosing one for them.</summary>
-    /// <exception cref="CliFailure">Thrown when neither variable names an editor.</exception>
-    private static string EditorNamedByTheShell(CliContext context) =>
-        context.Variable(OperatorEditor.VisualVariable) is { Length: > 0 } visual ? visual
-        : context.Variable(OperatorEditor.EditorVariable) is { Length: > 0 } editor ? editor
-        : throw new CliFailure(
-            $"No editor is named for this shell, so there is nothing to open the document in. Set ${OperatorEditor.VisualVariable} or ${OperatorEditor.EditorVariable} — a graphical editor needs the flag that makes it wait, such as 'code --wait'.");
 }

--- a/backend/src/Cli/Commands/Users/EditUserRecordCommand.cs
+++ b/backend/src/Cli/Commands/Users/EditUserRecordCommand.cs
@@ -1,0 +1,167 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.CommandLine;
+using System.Globalization;
+using MailFathom.Cli.Administration;
+using MailFathom.Cli.Administration.Configuration;
+using MailFathom.Cli.Administration.Users;
+using MailFathom.Cli.Editing;
+
+namespace MailFathom.Cli.Commands.Users;
+
+/// <summary>Opens one user's record in the operator's editor, and commits what they saved.</summary>
+/// <remarks>
+/// <para>
+/// The command for a change to a record that is more than one mailbox. <c>account add</c> and <c>account remove</c>
+/// each name one mailbox and the deployment composes it into the document, so changing two of them, or anything else a
+/// record carries, is a run of commands each committing a version of its own — with every intermediate one an account
+/// set the deployment briefly read. This is the same change as one transaction: the record is fetched with its version,
+/// edited, and committed against that version, so it is accepted whole or refused whole.
+/// </para>
+/// <para>
+/// What reaches the buffer is the record as the deployment redacted it, so a secret-bearing value reads as the
+/// redaction marker and a marker saved back leaves the reference beneath it alone. What does reach it is one person's
+/// mailbox identity — their mail server and their mailbox user name, which is ordinarily their own address — which is
+/// why the buffer lives in a directory readable by its user alone and is discarded whichever way the session ends.
+/// </para>
+/// </remarks>
+internal static class EditUserRecordCommand
+{
+    /// <summary>Builds the <c>user edit</c> command.</summary>
+    /// <param name="context">What the command needs from its surroundings.</param>
+    /// <returns>The command.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context" /> is <see langword="null" />.</exception>
+    internal static Command Create(CliContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var endpointOption = CliOptions.Endpoint();
+        var userOption = UserOptions.User();
+
+        Command command = new("edit", "Edit one user's record in your editor, and commit it as one change.")
+        {
+            userOption,
+            endpointOption,
+        };
+
+        command.SetAction((result, cancellationToken) => RunAsync(
+            context,
+            result.GetValue(userOption),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
+            cancellationToken));
+
+        return command;
+    }
+
+    /// <summary>Reads the record, offers it to the editor, and commits what came back.</summary>
+    /// <exception cref="CliFailure">Thrown when no editor is named, the session did not finish, or a configuration source still supplies this user's mail accounts.</exception>
+    /// <remarks>
+    /// The editor is looked for before the deployment is reached, as <c>config edit</c> does it, so an operator whose
+    /// shell names none is told so without a request going out.
+    /// </remarks>
+    private static async Task<int> RunAsync(
+        CliContext context,
+        Guid? requestedUser,
+        string? requestedDeployment,
+        CancellationToken cancellationToken)
+    {
+        var editor = EditorDrivenDocument.EditorNamedByTheShell(context);
+        var profile = await context.Deployment().ReachAsync(requestedDeployment, cancellationToken);
+
+        using var transport = context.OpenTransport(profile.Endpoint, profile.Trust);
+        var deployment = new AdminApiClient(transport, context.Console);
+
+        var user = await UserOptions.ResolveUserAsync(
+            deployment,
+            profile.Token,
+            requestedUser,
+            cancellationToken);
+
+        var opened = await deployment.ReadUserRecordAsync(profile.Token, user, cancellationToken);
+
+        // Refused before the editor opens rather than after the commit, although the deployment refuses it either way:
+        // the record already says a configuration source supplies this user, and opening an empty buffer over that
+        // would spend the operator's editing session on a write that was never going to be accepted.
+        if (opened.ReadFromConfiguration)
+        {
+            throw new CliFailure(UserOutput.RecordSuppliedByAConfigurationSource);
+        }
+
+        var saved = await EditorDrivenDocument.OpenAsync(
+            context,
+            editor,
+            "user-record",
+            "this user's record",
+            opened.Document ?? string.Empty,
+            cancellationToken);
+
+        return saved is null
+            ? CliExitCode.Success
+            : await CommitAsync(context, deployment, profile.Token, user, opened, saved, cancellationToken);
+    }
+
+    private static async Task<int> CommitAsync(
+        CliContext context,
+        AdminApiClient deployment,
+        string token,
+        Guid user,
+        UserRecord opened,
+        string saved,
+        CancellationToken cancellationToken)
+    {
+        var answer = await deployment.SaveUserRecordAsync(
+            token,
+            user,
+            new UserRecordSaveRequest(opened.Version, saved),
+            cancellationToken);
+
+        var outcome = UserOutput.ReportWrite(context, answer);
+
+        // The deployment reports a record composed over a superseded version with the same code a configuration write
+        // is refused with, because it is the same guard over a different document.
+        if (answer.Code == ConfigurationWriteAnswer.VersionSuperseded)
+        {
+            await ReportWhatMovedAsync(context, deployment, token, user, opened, cancellationToken);
+        }
+
+        return outcome;
+    }
+
+    /// <summary>Says what the writer that committed first changed, so the operator can decide again against it.</summary>
+    /// <remarks>
+    /// The record now in force is fetched rather than described from the refusal, because what an operator has to see is
+    /// what somebody else did rather than the fact that they did something. Nothing of this session is applied on top of
+    /// it: merging two edits neither author saw is the one outcome the version guard exists to prevent. The other writer
+    /// is routinely the person themselves, from the client, which is why this names the mailboxes rather than only the
+    /// version.
+    /// </remarks>
+    private static async Task ReportWhatMovedAsync(
+        CliContext context,
+        AdminApiClient deployment,
+        string token,
+        Guid user,
+        UserRecord opened,
+        CancellationToken cancellationToken)
+    {
+        var inForce = await deployment.ReadUserRecordAsync(token, user, cancellationToken);
+        var moved = SettingsBuffer.MovedBetween(opened.Document ?? string.Empty, inForce.Document ?? string.Empty);
+
+        if (moved.Count == 0)
+        {
+            context.Console.WriteNotice(
+                $"Version {inForce.Version.ToString(CultureInfo.InvariantCulture)} carries the same settings the buffer was opened over, so what moved was a value this reading redacts. Edit again to compose over it.");
+
+            return;
+        }
+
+        context.Console.WriteNotice(
+            $"These settings differ between version {opened.Version.ToString(CultureInfo.InvariantCulture)} and version {inForce.Version.ToString(CultureInfo.InvariantCulture)}:");
+
+        foreach (var path in moved)
+        {
+            context.Console.WriteNotice($"  {path}");
+        }
+    }
+}

--- a/backend/src/Cli/Commands/Users/ShowUserRecordCommand.cs
+++ b/backend/src/Cli/Commands/Users/ShowUserRecordCommand.cs
@@ -71,9 +71,7 @@ internal static class ShowUserRecordCommand
 
         if (record.ReadFromConfiguration)
         {
-            context.Console.WriteNotice(
-                "A configuration source supplies this user's mail accounts, so their record is empty and every change "
-                + "to it is refused. Run 'mfctl user adopt' to move them into their own record first.");
+            context.Console.WriteNotice(UserOutput.RecordSuppliedByAConfigurationSource);
         }
 
         return CliExitCode.Success;

--- a/backend/src/Cli/Commands/Users/UserOutput.cs
+++ b/backend/src/Cli/Commands/Users/UserOutput.cs
@@ -16,6 +16,17 @@ namespace MailFathom.Cli.Commands.Users;
 /// </remarks>
 internal static class UserOutput
 {
+    /// <summary>What a command says about a record a configuration source still supplies, before it does anything with it.</summary>
+    /// <remarks>
+    /// One sentence for the two commands that read a record and find that state: <c>user show</c> reports it beside the
+    /// empty document it just printed, and <c>user edit</c> refuses with it rather than opening a buffer over a write
+    /// that cannot be accepted. It is not what <see cref="ReportWrite" /> says about the same state, which is about a
+    /// write the deployment has already refused.
+    /// </remarks>
+    internal const string RecordSuppliedByAConfigurationSource =
+        "A configuration source supplies this user's mail accounts, so their record is empty and every change to it is "
+        + "refused. Run 'mfctl user adopt' to move them into their own record first.";
+
     /// <summary>Writes the users a deployment holds, one to a line.</summary>
     /// <param name="console">Where the listing is written.</param>
     /// <param name="users">The users, in the deployment's own order.</param>

--- a/backend/src/Cli/Editing/EditingSession.cs
+++ b/backend/src/Cli/Editing/EditingSession.cs
@@ -2,7 +2,7 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-namespace MailFathom.Cli.Commands.Configuration;
+namespace MailFathom.Cli.Editing;
 
 /// <summary>What became of an editing session, in the terms the command reports it to an operator.</summary>
 /// <remarks>

--- a/backend/src/Cli/Editing/EditorDrivenDocument.cs
+++ b/backend/src/Cli/Editing/EditorDrivenDocument.cs
@@ -1,0 +1,192 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Cli.Credentials;
+
+namespace MailFathom.Cli.Editing;
+
+/// <summary>Puts a document the deployment handed over in front of the operator, and reports what they left to commit.</summary>
+/// <remarks>
+/// <para>
+/// Two commands fetch a JSON document with the version it was read at, let the operator change it whole, and commit it
+/// against that version: the deployment's own persisted configuration, and one user's record. Everything between the
+/// fetch and the commit is the same act, so it is written once — which is also what keeps the guidance an operator
+/// reads when their editor does not cooperate from existing in two versions that drift apart.
+/// </para>
+/// <para>
+/// What each command keeps is the part that is genuinely its own: which document it fetched, what the version guard is
+/// composed over, and what a refusal means. This decides nothing about any of those and never commits anything.
+/// </para>
+/// </remarks>
+internal static class EditorDrivenDocument
+{
+    /// <summary>Finds the editor the operator's shell names, refusing rather than choosing one for them.</summary>
+    /// <param name="context">What the command needs from its surroundings.</param>
+    /// <returns>The editor as the shell names it, which may carry arguments of its own.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context" /> is <see langword="null" />.</exception>
+    /// <exception cref="CliFailure">Thrown when neither variable names an editor.</exception>
+    internal static string EditorNamedByTheShell(CliContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        return context.Variable(OperatorEditor.VisualVariable) is { Length: > 0 } visual ? visual
+            : context.Variable(OperatorEditor.EditorVariable) is { Length: > 0 } editor ? editor
+            : throw new CliFailure(
+                $"No editor is named for this shell, so there is nothing to open the document in. Set ${OperatorEditor.VisualVariable} or ${OperatorEditor.EditorVariable} — a graphical editor needs the flag that makes it wait, such as 'code --wait'.");
+    }
+
+    /// <summary>Opens a document in the operator's editor and reads back what they saved.</summary>
+    /// <param name="context">What the command needs from its surroundings.</param>
+    /// <param name="editor">The editor <see cref="EditorNamedByTheShell" /> found.</param>
+    /// <param name="buffered">What the session's directory and its buffer are named after, as a filename segment.</param>
+    /// <param name="describedAs">What the deployment holds, as the sentence reporting an abandoned session names it.</param>
+    /// <param name="document">The document as the deployment handed it over.</param>
+    /// <param name="cancellationToken">Cancels the read back.</param>
+    /// <returns>What the operator left to commit, or <see langword="null" /> where the session asked for no change.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <exception cref="CliFailure">Thrown when the buffer could not be written or read back, or the editor did not finish.</exception>
+    /// <remarks>
+    /// The buffer is removed however the session ended, including when the commit that follows throws, which is why the
+    /// caller's commit stays outside: a document left on disk is what this is careful about, and a caller that had to
+    /// remember to clean up would be the one place it is forgotten.
+    /// </remarks>
+    internal static async Task<string?> OpenAsync(
+        CliContext context,
+        string editor,
+        string buffered,
+        string describedAs,
+        string document,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(editor);
+        ArgumentException.ThrowIfNullOrWhiteSpace(buffered);
+        ArgumentException.ThrowIfNullOrWhiteSpace(describedAs);
+        ArgumentNullException.ThrowIfNull(document);
+
+        var session = Path.Combine(Path.GetTempPath(), $"mailfathom-{buffered}-{Guid.NewGuid():N}");
+        var buffer = Path.Combine(session, $"{buffered}.json");
+
+        try
+        {
+            Open(session, buffer, document);
+
+            if (context.Edit(editor, buffer) is { Saved: false } ended)
+            {
+                throw new CliFailure(WhyNothingWasWritten(editor, ended));
+            }
+
+            var saved = await ReadBackAsync(buffer, cancellationToken);
+
+            return Abandoned(context, describedAs, document, saved) ? null : saved;
+        }
+        finally
+        {
+            Discard(session);
+        }
+    }
+
+    /// <summary>Opens the session's own directory and writes the document into it, readable by their user alone.</summary>
+    /// <exception cref="CliFailure">Thrown when the temporary directory cannot be written, which is a situation rather than a defect.</exception>
+    /// <remarks>
+    /// A temporary directory that is full, read-only, or on a filesystem that will not take a user-only mode is
+    /// something the operator can act on, so it is reported as a sentence naming the path rather than left to reach
+    /// <c>CliRunner</c> as a stack trace — the same answer the credential store and the token protector give for the
+    /// same situation.
+    /// </remarks>
+    private static void Open(string session, string buffer, string document)
+    {
+        try
+        {
+            UserOnlyStorage.CreateDirectory(session);
+
+            SettingsBuffer.Write(buffer, document);
+        }
+        catch (Exception failure) when (failure is IOException or UnauthorizedAccessException)
+        {
+            throw new CliFailure($"The editing buffer at {buffer} could not be written.", failure);
+        }
+    }
+
+    /// <summary>Reads back what the editor saved.</summary>
+    /// <exception cref="CliFailure">Thrown when the buffer cannot be read, which the editor rather than this command left it as.</exception>
+    private static async Task<string> ReadBackAsync(string buffer, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await File.ReadAllTextAsync(buffer, cancellationToken);
+        }
+        catch (Exception failure) when (failure is IOException or UnauthorizedAccessException)
+        {
+            throw new CliFailure(
+                $"The editing buffer at {buffer} could not be read back after the editor exited, so nothing was written.",
+                failure);
+        }
+    }
+
+    /// <summary>Removes the session's directory and the buffer in it, letting the invocation's own outcome stand where it cannot be removed.</summary>
+    /// <remarks>
+    /// <para>
+    /// The case is the one the commands' own guidance anticipates: a graphical editor started without its wait flag
+    /// returns while still holding the file open, so the delete throws on Windows over an invocation that had already
+    /// decided what it did. Turning that into a stack trace would report a failure to somebody whose command worked,
+    /// or replace the sentence naming why nothing was written — which is the rule <c>CliRunner.Record</c> states for a
+    /// full disk.
+    /// </para>
+    /// <para>
+    /// What is left behind on that path is the session's own directory, which is readable by its user alone whatever
+    /// the editor did to the file inside it. That is why the buffer sits in a directory of its own rather than in the
+    /// temporary directory itself: an editor that saves by writing a sibling and renaming it over the target creates
+    /// that sibling under the process umask, so the mode set at creation does not survive the first save — and what the
+    /// file then holds is a whole description of what a deployment does for somebody, plus anything the operator typed
+    /// over a marker.
+    /// </para>
+    /// </remarks>
+    private static void Discard(string session)
+    {
+        try
+        {
+            Directory.Delete(session, recursive: true);
+        }
+        catch (Exception failure) when (failure is IOException or UnauthorizedAccessException)
+        {
+        }
+    }
+
+    /// <summary>Reports whether the editing session asked for nothing, and says which of the two ways it did.</summary>
+    /// <remarks>
+    /// An emptied buffer is the conventional way to abandon an editor-driven command and is honoured as one, rather
+    /// than being read as a document that states nothing at all — which is a change an operator can still make
+    /// deliberately by saving an empty JSON object.
+    /// </remarks>
+    private static bool Abandoned(CliContext context, string describedAs, string document, string saved)
+    {
+        if (string.IsNullOrWhiteSpace(saved))
+        {
+            context.Console.WriteLine($"The buffer was emptied, so {describedAs} was left as it was.");
+
+            return true;
+        }
+
+        if (string.Equals(saved, document, StringComparison.Ordinal))
+        {
+            context.Console.WriteLine("The buffer was saved unchanged, so nothing was written.");
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>Says why an editing session that did not finish wrote nothing, in terms the operator can act on.</summary>
+    /// <remarks>
+    /// The two endings need different advice. A wait flag is what repairs an editor that ran and returned before the
+    /// operator had finished; it repairs nothing for an editor the operating system never started, where the value in
+    /// the variable is the thing to correct and the system's own words are what name which way it is wrong.
+    /// </remarks>
+    private static string WhyNothingWasWritten(string editor, EditingSession ended) =>
+        ended.WhyItNeverStarted is { Length: > 0 } reason
+            ? $"The editor '{editor}' could not be started, so nothing was written: {reason}. Correct ${OperatorEditor.VisualVariable} or ${OperatorEditor.EditorVariable} to name a program on this machine."
+            : $"The editor '{editor}' did not finish successfully, so nothing was written. A graphical editor needs the flag that makes it wait — '{OperatorEditor.VisualVariable}=\"code --wait\"', for instance — because this command reads the file back when the editor exits.";
+}

--- a/backend/src/Cli/Editing/OperatorEditor.cs
+++ b/backend/src/Cli/Editing/OperatorEditor.cs
@@ -5,7 +5,7 @@
 using System.ComponentModel;
 using System.Diagnostics;
 
-namespace MailFathom.Cli.Commands.Configuration;
+namespace MailFathom.Cli.Editing;
 
 /// <summary>Runs the editor the operator's shell names, over a file this command wrote.</summary>
 /// <remarks>

--- a/backend/src/Cli/Editing/SettingsBuffer.cs
+++ b/backend/src/Cli/Editing/SettingsBuffer.cs
@@ -7,7 +7,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using MailFathom.Cli.Credentials;
 
-namespace MailFathom.Cli.Commands.Configuration;
+namespace MailFathom.Cli.Editing;
 
 /// <summary>The file an editing session opens, and what changed underneath one that was refused.</summary>
 /// <remarks>

--- a/backend/src/Host/Configuration/RootSettings/RootSettingsWriter.cs
+++ b/backend/src/Host/Configuration/RootSettings/RootSettingsWriter.cs
@@ -191,7 +191,7 @@ internal sealed partial class RootSettingsWriter(
         // rather than a user. So the sentence names both halves: the declaration to edit while the user is still
         // read from a configuration source, and the user commands that change the record once one has been adopted.
         return target.Route == ConfigurationStorageRoute.UserAccounts
-            ? $"MailFathom persists {path} in the {target.Route.Name} store rather than in the deployment's own document, so this is not where it is changed. A user still read from a configuration source is changed in the declaration that supplies them — the user's own section of the top-level Accounts collection — and served from it at the next restart; a user who has been adopted is changed with 'mfctl user account add' and 'mfctl user account remove'."
+            ? $"MailFathom persists {path} in the {target.Route.Name} store rather than in the deployment's own document, so this is not where it is changed. A user still read from a configuration source is changed in the declaration that supplies them — the user's own section of the top-level Accounts collection — and served from it at the next restart; a user who has been adopted is changed with 'mfctl user account add' and 'mfctl user account remove', or with 'mfctl user edit' for their whole record at once."
             : $"MailFathom persists {path} in the {target.Route.Name} store, which this build does not write. Configure it where that store is provisioned from.";
     }
 

--- a/backend/tests/Cli.UnitTests/CliCommandHarness.cs
+++ b/backend/tests/Cli.UnitTests/CliCommandHarness.cs
@@ -2,8 +2,8 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using MailFathom.Cli.Commands.Configuration;
 using MailFathom.Cli.Credentials;
+using MailFathom.Cli.Editing;
 using MailFathom.TestSupport;
 using Microsoft.Extensions.Time.Testing;
 
@@ -51,6 +51,34 @@ internal sealed class CliCommandHarness : IDisposable
     /// the operator would have typed, and drives the two endings apart by answering with the one it means.
     /// </remarks>
     internal Func<string, string, EditingSession>? Editor { get; set; }
+
+    /// <summary>Stands in for the operator, saving the document they would have typed into the buffer.</summary>
+    /// <param name="saved">What the buffer holds when the editor exits.</param>
+    internal void EditsTheBufferInto(string saved) =>
+        this.OpensTheBufferWith((_, path) =>
+        {
+            File.WriteAllText(path, saved);
+
+            return true;
+        });
+
+    /// <summary>Names an editor for the shell and states what the session does to the buffer.</summary>
+    /// <param name="session">What the operator does, answering whether the editor reported success.</param>
+    /// <remarks>
+    /// Both halves, because a command reads the variable before it opens anything: a session scripted without one never
+    /// reaches the editor at all, and the refusal it meets instead is the subject of a test of its own.
+    /// </remarks>
+    internal void OpensTheBufferWith(Func<string, string, bool> session) =>
+        this.OpensTheBufferWith((editor, path) =>
+            session(editor, path) ? EditingSession.Finished : EditingSession.Failed);
+
+    /// <summary>Names an editor for the shell and states what became of the session it opens.</summary>
+    /// <param name="session">What became of the editing session.</param>
+    internal void OpensTheBufferWith(Func<string, string, EditingSession> session)
+    {
+        this.Variables[OperatorEditor.VisualVariable] = "vi";
+        this.Editor = session;
+    }
 
     /// <summary>Runs one invocation against a deployment, with the credential a signed-in operator would hold.</summary>
     /// <param name="deployment">The deployment the command meets instead of a server.</param>

--- a/backend/tests/Cli.UnitTests/ConfigurationCommandTests.cs
+++ b/backend/tests/Cli.UnitTests/ConfigurationCommandTests.cs
@@ -4,7 +4,7 @@
 
 using System.Text.Json;
 using MailFathom.Cli.Administration.Configuration;
-using MailFathom.Cli.Commands.Configuration;
+using MailFathom.Cli.Editing;
 using MailFathom.Cli.Transport;
 using MailFathom.Domain.Failures;
 using MailFathom.TestSupport;
@@ -358,7 +358,7 @@ public sealed class ConfigurationCommandTests : IDisposable
             documents: [FakeConfigurationDeployment.Document(version: 1, """{ "MailboxSearch": { "SnippetsPerEmail": "3" } }""")],
             write: FakeConfigurationDeployment.Committed(version: 2));
 
-        this.EditsTheBufferInto("""{ "MailboxSearch": { "SnippetsPerEmail": "5" } }""");
+        this.harness.EditsTheBufferInto("""{ "MailboxSearch": { "SnippetsPerEmail": "5" } }""");
 
         // Act
         var exitCode = await this.RunAsync(
@@ -482,7 +482,7 @@ public sealed class ConfigurationCommandTests : IDisposable
             documents: [FakeConfigurationDeployment.Document(version: 5, """{ "MailboxSearch": { "SnippetsPerEmail": "3" } }""")],
             write: FakeConfigurationDeployment.Committed(version: 6));
 
-        this.EditsTheBufferInto(edited);
+        this.harness.EditsTheBufferInto(edited);
 
         // Act
         var exitCode = await this.RunAsync(deployment, "config", "edit", "--endpoint", Endpoint);
@@ -511,7 +511,7 @@ public sealed class ConfigurationCommandTests : IDisposable
             ]);
 
         var opened = string.Empty;
-        this.OpensTheBufferWith((_, path) =>
+        this.harness.OpensTheBufferWith((_, path) =>
         {
             opened = File.ReadAllText(path);
 
@@ -545,7 +545,7 @@ public sealed class ConfigurationCommandTests : IDisposable
             documents: [FakeConfigurationDeployment.Document(version: 1, RedactedChatDocument)]);
 
         UnixFileMode mode = default;
-        this.OpensTheBufferWith((_, path) =>
+        this.harness.OpensTheBufferWith((_, path) =>
         {
             // Guarded again inside the callback, which is the only place the mode can be read: the buffer is deleted
             // when the session ends. The platform analyzer reads a guard within the body it is protecting rather than
@@ -586,7 +586,7 @@ public sealed class ConfigurationCommandTests : IDisposable
 
         UnixFileMode mode = default;
         var containing = string.Empty;
-        this.OpensTheBufferWith((_, path) =>
+        this.harness.OpensTheBufferWith((_, path) =>
         {
             // Read inside the callback for the reason the sibling test states, and guarded again for the same one.
             if (!OperatingSystem.IsWindows())
@@ -617,7 +617,7 @@ public sealed class ConfigurationCommandTests : IDisposable
         using var deployment = FakeConfigurationDeployment.Holding(
             documents: [FakeConfigurationDeployment.Document(version: 1, """{ "MailboxSearch": { "SnippetsPerEmail": "3" } }""")]);
 
-        this.EditsTheBufferInto(string.Empty);
+        this.harness.EditsTheBufferInto(string.Empty);
 
         // Act
         var exitCode = await this.RunAsync(deployment, "config", "edit", "--endpoint", Endpoint);
@@ -636,7 +636,7 @@ public sealed class ConfigurationCommandTests : IDisposable
         using var deployment = FakeConfigurationDeployment.Holding(
             documents: [FakeConfigurationDeployment.Document(version: 1, """{ "MailboxSearch": { "SnippetsPerEmail": "3" } }""")]);
 
-        this.OpensTheBufferWith((_, _) => true);
+        this.harness.OpensTheBufferWith((_, _) => true);
 
         // Act
         var exitCode = await this.RunAsync(deployment, "config", "edit", "--endpoint", Endpoint);
@@ -654,7 +654,7 @@ public sealed class ConfigurationCommandTests : IDisposable
         // Arrange
         using var deployment = FakeConfigurationDeployment.Holding();
 
-        this.OpensTheBufferWith((_, _) => false);
+        this.harness.OpensTheBufferWith((_, _) => false);
 
         // Act
         var exitCode = await this.RunAsync(deployment, "config", "edit", "--endpoint", Endpoint);
@@ -675,7 +675,7 @@ public sealed class ConfigurationCommandTests : IDisposable
         // Arrange
         using var deployment = FakeConfigurationDeployment.Holding();
 
-        this.OpensTheBufferWith((_, _) => EditingSession.NeverStarted("No such file or directory"));
+        this.harness.OpensTheBufferWith((_, _) => EditingSession.NeverStarted("No such file or directory"));
 
         // Act
         var exitCode = await this.RunAsync(deployment, "config", "edit", "--endpoint", Endpoint);
@@ -710,7 +710,7 @@ public sealed class ConfigurationCommandTests : IDisposable
                 version: 6,
                 "The document was composed over version 5 and version 6 is in force."));
 
-        this.EditsTheBufferInto("""{"MailboxSearch":{"SnippetsPerEmail":"7"}}""");
+        this.harness.EditsTheBufferInto("""{"MailboxSearch":{"SnippetsPerEmail":"7"}}""");
 
         // Act
         var exitCode = await this.RunAsync(deployment, "config", "edit", "--endpoint", Endpoint);
@@ -815,31 +815,6 @@ public sealed class ConfigurationCommandTests : IDisposable
     /// <summary>Reads back the body of the write the command sent.</summary>
     private static JsonElement SentWrite(FakeHttpMessageHandler deployment) =>
         JsonDocument.Parse(deployment.LastConfigurationWrite() ?? "{}").RootElement;
-
-    /// <summary>Stands in for the operator, saving the document they would have typed into the buffer.</summary>
-    private void EditsTheBufferInto(string saved) =>
-        this.OpensTheBufferWith((_, path) =>
-        {
-            File.WriteAllText(path, saved);
-
-            return true;
-        });
-
-    /// <summary>Names an editor for the shell and states what the session does to the buffer.</summary>
-    /// <remarks>
-    /// Both halves, because the command reads the variable before it opens anything: a session scripted without one
-    /// never reaches the editor at all, and the refusal it meets instead is the subject of a test of its own.
-    /// </remarks>
-    private void OpensTheBufferWith(Func<string, string, bool> session) =>
-        this.OpensTheBufferWith((editor, path) =>
-            session(editor, path) ? EditingSession.Finished : EditingSession.Failed);
-
-    /// <summary>Names an editor for the shell and states what became of the session it opens.</summary>
-    private void OpensTheBufferWith(Func<string, string, EditingSession> session)
-    {
-        this.harness.Variables[OperatorEditor.VisualVariable] = "vi";
-        this.harness.Editor = session;
-    }
 
     private Task<int> RunAsync(FakeHttpMessageHandler deployment, params string[] args) =>
         this.harness.RunAsync(deployment, args);

--- a/backend/tests/Cli.UnitTests/FakeUserRecordDeployment.cs
+++ b/backend/tests/Cli.UnitTests/FakeUserRecordDeployment.cs
@@ -4,6 +4,7 @@
 
 using System.Globalization;
 using System.Net;
+using System.Text.Json;
 using MailFathom.Cli.Administration;
 using MailFathom.TestSupport;
 
@@ -21,37 +22,57 @@ internal static class FakeUserRecordDeployment
     /// <summary>Gets the version every record here reports, which a write is composed over.</summary>
     internal const long RecordVersion = 3;
 
+    /// <summary>The record a deployment answers with where a suite says nothing about one.</summary>
+    private const string EmptyRecord = "{}";
+
     /// <summary>Builds a deployment whose users read their mail accounts from their own records.</summary>
     /// <param name="users">The users the roster reports, in the order it serves them.</param>
     /// <returns>The deployment.</returns>
     internal static FakeHttpMessageHandler Holding(params Guid[] users) =>
-        Answering(users, readFromConfiguration: false, WriteCommitted, adoptable: []);
+        Answering(users, readFromConfiguration: false, WriteCommitted, adoptable: [], records: [EmptyRecord]);
+
+    /// <summary>Builds a deployment whose one user's record is the document stated.</summary>
+    /// <param name="user">The user the roster reports.</param>
+    /// <param name="records">What each successive read of the record answers with, the last one repeating.</param>
+    /// <returns>The deployment.</returns>
+    /// <remarks>
+    /// More than one record is how a writer committing between the read and the write is arranged: the buffer is opened
+    /// over the first, and the reading that reports what moved meets the next.
+    /// </remarks>
+    internal static FakeHttpMessageHandler HoldingRecords(Guid user, params string[] records) =>
+        Answering([user], readFromConfiguration: false, WriteCommitted, adoptable: [], records);
 
     /// <summary>Builds a deployment one of whose users is still supplied by a configuration source.</summary>
     /// <param name="user">The user the configuration supplies.</param>
     /// <param name="mailAccounts">The mail accounts an adoption would move.</param>
     /// <returns>The deployment.</returns>
     internal static FakeHttpMessageHandler SupplyingFromConfiguration(Guid user, params string[] mailAccounts) =>
-        Answering([user], readFromConfiguration: true, WriteCommitted, mailAccounts);
+        Answering([user], readFromConfiguration: true, WriteCommitted, mailAccounts, records: [EmptyRecord]);
 
     /// <summary>Builds a deployment that refuses every write to a record, with the code and the sentence it names.</summary>
     /// <param name="user">The user the roster reports.</param>
     /// <param name="code">The five-digit code the refusal carries.</param>
     /// <param name="message">The sentence the refusal carries.</param>
+    /// <param name="records">What each successive read of the record answers with, the last one repeating.</param>
     /// <returns>The deployment.</returns>
-    internal static FakeHttpMessageHandler RefusingTheWrite(Guid user, int code, string message) =>
+    internal static FakeHttpMessageHandler RefusingTheWrite(
+        Guid user,
+        int code,
+        string message,
+        params string[] records) =>
         Answering(
             [user],
             readFromConfiguration: false,
             string.Create(
                 CultureInfo.InvariantCulture,
                 $$"""{"committed":false,"version":{{RecordVersion}},"code":{{code}},"messages":["{{message}}"]}"""),
-            adoptable: []);
+            adoptable: [],
+            records.Length == 0 ? [EmptyRecord] : records);
 
     /// <summary>Builds a deployment holding no user at all.</summary>
     /// <returns>The deployment.</returns>
     internal static FakeHttpMessageHandler HoldingNobody() =>
-        Answering([], readFromConfiguration: false, WriteCommitted, adoptable: []);
+        Answering([], readFromConfiguration: false, WriteCommitted, adoptable: [], records: [EmptyRecord]);
 
     /// <summary>Reports the requests the command sent to one path under one method.</summary>
     /// <param name="deployment">The deployment the command was pointed at.</param>
@@ -77,20 +98,32 @@ internal static class FakeUserRecordDeployment
         CultureInfo.InvariantCulture,
         $$"""{"committed":true,"version":{{RecordVersion + 1}},"messages":[]}""");
 
+    /// <summary>Builds the deployment every shape above is one arrangement of.</summary>
+    /// <remarks>The count of record reads is the deployment's own rather than a parameter, so a suite arranging several records states them and nothing else.</remarks>
     private static FakeHttpMessageHandler Answering(
         IReadOnlyList<Guid> users,
         bool readFromConfiguration,
         string writeAnswer,
-        IReadOnlyList<string> adoptable) =>
-        new((request, _) => Task.FromResult(
-            Answer(request, users, readFromConfiguration, writeAnswer, adoptable)));
+        IReadOnlyList<string> adoptable,
+        string[] records)
+    {
+        var reads = 0;
+
+        // Advanced where the record is read rather than per request, so a suite's second record is what the second
+        // reading of the record meets rather than whatever the command happened to ask for next.
+        string NextRecord() => records[Math.Min(reads++, records.Length - 1)];
+
+        return new((request, _) => Task.FromResult(
+            Answer(request, users, readFromConfiguration, writeAnswer, adoptable, NextRecord)));
+    }
 
     private static HttpResponseMessage Answer(
         HttpRequestMessage request,
         IReadOnlyList<Guid> users,
         bool readFromConfiguration,
         string writeAnswer,
-        IReadOnlyList<string> adoptable)
+        IReadOnlyList<string> adoptable,
+        Func<string> nextRecord)
     {
         var path = request.RequestUri?.AbsolutePath ?? string.Empty;
 
@@ -131,7 +164,7 @@ internal static class FakeUserRecordDeployment
         if (path.EndsWith("/record", StringComparison.Ordinal))
         {
             return request.Method == HttpMethod.Get
-                ? FakeAdminEndpoint.Json(HttpStatusCode.OK, Record(users, readFromConfiguration))
+                ? FakeAdminEndpoint.Json(HttpStatusCode.OK, Record(users, readFromConfiguration, nextRecord()))
                 : FakeAdminEndpoint.Json(HttpStatusCode.OK, writeAnswer);
         }
 
@@ -146,12 +179,12 @@ internal static class FakeUserRecordDeployment
         CultureInfo.InvariantCulture,
         $$"""{"id":"{{user:D}}","displayName":"user-{{user:D}}","recordIsTheirOwn":{{Flag(!readFromConfiguration)}},"declaredInConfiguration":{{Flag(readFromConfiguration)}},"served":true}""");
 
-    private static string Record(IReadOnlyList<Guid> users, bool readFromConfiguration) => string.Create(
+    private static string Record(IReadOnlyList<Guid> users, bool readFromConfiguration, string document) => string.Create(
         CultureInfo.InvariantCulture,
         $$"""
           {"user":"{{(users.Count > 0 ? users[0] : Guid.Empty):D}}","displayName":"user-{{(users.Count > 0 ? users[0] : Guid.Empty):D}}",
           "version":{{RecordVersion}},"source":"{{(readFromConfiguration ? "DeploymentSection" : "UserDocument")}}",
-          "readFromConfiguration":{{Flag(readFromConfiguration)}},"document":"{}"}
+          "readFromConfiguration":{{Flag(readFromConfiguration)}},"document":{{JsonSerializer.Serialize(document)}}}
           """);
 
     private static string AdoptionPreview(

--- a/backend/tests/Cli.UnitTests/UserCommandTests.cs
+++ b/backend/tests/Cli.UnitTests/UserCommandTests.cs
@@ -4,6 +4,7 @@
 
 using System.Text.Json;
 using MailFathom.Cli.Administration;
+using MailFathom.Cli.Editing;
 using MailFathom.TestSupport;
 using Xunit;
 
@@ -21,6 +22,16 @@ public sealed class UserCommandTests : IDisposable
 
     /// <summary>The code a deployment refuses a write to a configuration-served user with.</summary>
     private const int RecordReadFromConfiguration = 12015;
+
+    /// <summary>The code a deployment refuses a record composed over a version another writer moved past with.</summary>
+    private const int VersionSuperseded = 12008;
+
+    /// <summary>A record declaring one mailbox, which an editing session opens over.</summary>
+    private const string OneMailAccount = """{"MailAccounts":[{"AccountId":"work"}]}""";
+
+    /// <summary>A record whose secret-bearing value the deployment replaced with its redaction marker.</summary>
+    private const string RedactedMailAccount =
+        """{"MailAccounts":[{"AccountId":"work","Password":{"Secret":"(redacted)"}}]}""";
 
     private static readonly Guid User = new("11111111-1111-1111-1111-111111111111");
 
@@ -562,6 +573,202 @@ public sealed class UserCommandTests : IDisposable
         // Assert
         Assert.Equal(CliExitCode.Success, exitCode);
         Assert.Empty(deployment.UserRequestsTo(HttpMethod.Delete, AdminEndpointRoutes.UserPath(AnotherUser)));
+    }
+
+    /// <summary>What the operator saved is what is committed, over the version the buffer was opened at.</summary>
+    [Fact]
+    public async Task Edit_AnEditedRecord_CommitsWhatWasSavedOverTheVersionItWasOpenedAt()
+    {
+        // Arrange
+        const string edited = """{"MailAccounts":[{"AccountId":"work"},{"AccountId":"family"}]}""";
+
+        using var deployment = FakeUserRecordDeployment.HoldingRecords(User, OneMailAccount);
+
+        this.harness.EditsTheBufferInto(edited);
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "user", "edit", "--user", $"{User:D}", "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+
+        var sent = Assert.Single(
+            deployment.UserRequestsTo(HttpMethod.Post, AdminEndpointRoutes.UserRecordPath(User)));
+
+        Assert.Equal(FakeUserRecordDeployment.RecordVersion, ReadVersion(sent.ContentAsUtf8String()));
+        Assert.Equal(edited, ReadField(sent.ContentAsUtf8String(), "document"));
+    }
+
+    /// <summary>
+    /// The buffer is the record the deployment answered with, byte for byte. What a record may carry is the deployment's
+    /// decision, so what is asserted here is that this command neither composes a document of its own nor rewrites the
+    /// one it was given.
+    /// </summary>
+    [Fact]
+    public async Task Edit_ARecordTheDeploymentRedacted_OpensTheBufferOnWhatTheDeploymentAnswered()
+    {
+        // Arrange
+        using var deployment = FakeUserRecordDeployment.HoldingRecords(User, RedactedMailAccount);
+
+        var opened = string.Empty;
+        this.harness.OpensTheBufferWith((_, path) =>
+        {
+            opened = File.ReadAllText(path);
+
+            return true;
+        });
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "user", "edit", "--user", $"{User:D}", "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Equal(RedactedMailAccount, opened);
+        Assert.Empty(deployment.UserRequestsTo(HttpMethod.Post, AdminEndpointRoutes.UserRecordPath(User)));
+    }
+
+    /// <summary>An emptied buffer is how every editor-driven command an operator has met is abandoned, and it is honoured as one.</summary>
+    [Fact]
+    public async Task Edit_AnEmptiedBuffer_LeavesTheRecordAsItWas()
+    {
+        // Arrange
+        using var deployment = FakeUserRecordDeployment.HoldingRecords(User, OneMailAccount);
+
+        this.harness.EditsTheBufferInto(string.Empty);
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "user", "edit", "--user", $"{User:D}", "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Empty(deployment.UserRequestsTo(HttpMethod.Post, AdminEndpointRoutes.UserRecordPath(User)));
+        Assert.Contains(this.harness.Console.Lines, line => line.Contains("emptied", StringComparison.Ordinal));
+    }
+
+    /// <summary>A record saved back as it was opened is nothing to commit, and spending a version on it would be a change the operator did not ask for.</summary>
+    [Fact]
+    public async Task Edit_ABufferSavedUnchanged_WritesNothing()
+    {
+        // Arrange
+        using var deployment = FakeUserRecordDeployment.HoldingRecords(User, OneMailAccount);
+
+        this.harness.EditsTheBufferInto(OneMailAccount);
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "user", "edit", "--user", $"{User:D}", "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Empty(deployment.UserRequestsTo(HttpMethod.Post, AdminEndpointRoutes.UserRecordPath(User)));
+    }
+
+    /// <summary>Nothing is opened without an editor to open it in, and nothing about one person's mailboxes is fetched for a session that cannot start.</summary>
+    [Fact]
+    public async Task Edit_NoEditorNamedByTheShell_FailsWithoutReadingTheRecord()
+    {
+        // Arrange
+        using var deployment = FakeUserRecordDeployment.HoldingRecords(User, OneMailAccount);
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "user", "edit", "--user", $"{User:D}", "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Contains(
+            this.harness.Console.Errors,
+            line => line.Contains(OperatorEditor.VisualVariable, StringComparison.Ordinal));
+        Assert.Empty(deployment.RecordedRequests);
+    }
+
+    /// <summary>An editor that did not finish is a session that produced nothing, so nothing is read back and nothing is sent.</summary>
+    [Fact]
+    public async Task Edit_AnEditorThatDidNotFinish_FailsWithoutWritingAnything()
+    {
+        // Arrange
+        using var deployment = FakeUserRecordDeployment.HoldingRecords(User, OneMailAccount);
+
+        this.harness.OpensTheBufferWith((_, _) => false);
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "user", "edit", "--user", $"{User:D}", "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Empty(deployment.UserRequestsTo(HttpMethod.Post, AdminEndpointRoutes.UserRecordPath(User)));
+    }
+
+    /// <summary>The deployment this serves usually holds one person, so the ordinary invocation names nobody.</summary>
+    [Fact]
+    public async Task Edit_ADeploymentHoldingOneUser_ActsOnThatUserWithoutBeingToldWhich()
+    {
+        // Arrange
+        using var deployment = FakeUserRecordDeployment.HoldingRecords(User, OneMailAccount);
+
+        this.harness.EditsTheBufferInto("""{"MailAccounts":[]}""");
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "user", "edit", "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Single(deployment.UserRequestsTo(HttpMethod.Post, AdminEndpointRoutes.UserRecordPath(User)));
+    }
+
+    /// <summary>
+    /// A record somebody else committed over is refused rather than merged, and what an operator has to see is what that
+    /// writer changed. The other writer is routinely the person themselves from the client.
+    /// </summary>
+    [Fact]
+    public async Task Edit_AVersionAnotherWriterMovedPast_ReportsTheSettingsThatMoved()
+    {
+        // Arrange
+        using var deployment = FakeUserRecordDeployment.RefusingTheWrite(
+            User,
+            VersionSuperseded,
+            "The record was composed over version 3 and version 4 is in force.",
+            OneMailAccount,
+            """{"MailAccounts":[{"AccountId":"work"},{"AccountId":"family"}]}""");
+
+        this.harness.EditsTheBufferInto("""{"MailAccounts":[{"AccountId":"archive"}]}""");
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "user", "edit", "--user", $"{User:D}", "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Contains(
+            this.harness.Console.Errors,
+            line => line.Contains("version 4 is in force", StringComparison.Ordinal));
+        Assert.Contains(
+            this.harness.Console.Errors,
+            line => line.Contains("MailAccounts:1:AccountId", StringComparison.Ordinal));
+    }
+
+    /// <summary>A record a file still supplies is refused before the editor opens, because the write was never going to be accepted and the operator's session would be spent on it.</summary>
+    [Fact]
+    public async Task Edit_ARecordAConfigurationSourceSupplies_RefusesWithoutOpeningTheEditor()
+    {
+        // Arrange
+        using var deployment = FakeUserRecordDeployment.SupplyingFromConfiguration(User, "work");
+
+        var openedTheEditor = false;
+        this.harness.OpensTheBufferWith((_, _) =>
+        {
+            openedTheEditor = true;
+
+            return true;
+        });
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "user", "edit", "--user", $"{User:D}", "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.False(openedTheEditor);
+        Assert.Empty(deployment.UserRequestsTo(HttpMethod.Post, AdminEndpointRoutes.UserRecordPath(User)));
+        Assert.Contains(
+            this.harness.Console.Errors,
+            line => line.Contains("mfctl user adopt", StringComparison.Ordinal));
     }
 
     public void Dispose()

--- a/backend/tests/Host.UnitTests/Configuration/RootSettings/RootSettingsWriterTests.cs
+++ b/backend/tests/Host.UnitTests/Configuration/RootSettings/RootSettingsWriterTests.cs
@@ -365,9 +365,10 @@ public sealed class RootSettingsWriterTests
 
     /// <summary>A setting another store owns is refused rather than written into the root document.</summary>
     /// <remarks>
-    /// The refusal names both ways a user's mail accounts are changed, because this writer sees a path rather than a
-    /// user and cannot tell which of the two applies: an operator handed only one of them would be sent to edit a file
-    /// that no longer reaches that user, or to a command that refuses one who has not been adopted.
+    /// The refusal names every way a user's mail accounts are changed, because this writer sees a path rather than a
+    /// user and cannot tell which of them applies: an operator handed only one would be sent to edit a file that no
+    /// longer reaches that user, to a command that refuses one who has not been adopted, or to one mailbox at a time
+    /// where the change they are making is the whole record.
     /// </remarks>
     [Fact]
     public async Task WriteAsync_ASettingAnotherStoreOwns_IsRefused()
@@ -386,6 +387,7 @@ public sealed class RootSettingsWriterTests
         Assert.Contains("user-accounts", refusal, StringComparison.Ordinal);
         Assert.Contains("Accounts collection", refusal, StringComparison.Ordinal);
         Assert.Contains("mfctl user account add", refusal, StringComparison.Ordinal);
+        Assert.Contains("mfctl user edit", refusal, StringComparison.Ordinal);
         Assert.Equal(0, deployment.Row.AcceptedCommits);
     }
 

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -220,7 +220,7 @@ what it was never granted is what the record exists to make visible.
 | `PUT /api/admin/users/{userId}/display-name` | `mailfathom.admin.configuration.write` | Replaces the label the user is told apart by. It answers with no body — the label the request carried is the whole of what changed — refuses a label another user carries, naming what to change, and answers `404` for a user this deployment holds no record for, as every other user-scoped route does. |
 | `DELETE /api/admin/users/{userId}` | `mailfathom.admin.erase` | Erases the user and every message, folder, attachment, and derived index this deployment holds for them. **This is the one route here that destroys mail, and it cannot be undone.** A user this deployment does not hold is reported as nothing erased rather than as a refusal. A user a configuration source declares is refused instead, naming the declaration to remove first: the next start would write them back and download their mailboxes again. |
 | `GET /api/admin/users/{userId}/record` | `mailfathom.admin.read` | Hands over one user's record as the redacted JSON an editing session opens, with the version it was read at and where this deployment currently reads that user's mail accounts from. |
-| `POST /api/admin/users/{userId}/record` | `mailfathom.admin.configuration.write` | Takes that record back edited and commits it as one change against the version it was opened over. |
+| `POST /api/admin/users/{userId}/record` | `mailfathom.admin.configuration.write` | Takes that record back edited and commits it as one change against the version it was opened over. It is what `mfctl user edit` sends when the editor exits, and a record another writer moved past is refused as superseded rather than merged. |
 | `POST /api/admin/users/{userId}/record/mail-accounts` | `mailfathom.admin.configuration.write` | Declares one more mailbox in the record, from the mail-account block the body carries. |
 | `POST /api/admin/users/{userId}/record/mail-accounts/removal` | `mailfathom.admin.configuration.write` | Stops the record declaring one mailbox, named by the identifier it was declared under. It withdraws no mail: everything already stored for that account stays where it is. |
 | `GET /api/admin/users/{userId}/record/adoption` | `mailfathom.admin.read` | Reports what adopting that user would copy out of this deployment's files — the configuration path behind their mail accounts, each account it would move, and each classification and scanning setting it would commit with them — and writes nothing. |
@@ -1183,6 +1183,7 @@ such user exists rather than editing somebody else's mailboxes.
 | `mfctl user list` | Reads who this deployment holds, where each one's mail accounts come from, and whether the running process serves them |
 | `mfctl user add --display-name <name>` | Records a user this deployment did not hold, and reports the identifier they were minted under |
 | `mfctl user show` | Reads one user's record as this deployment holds it, secrets redacted |
+| `mfctl user edit` | Opens that record in your `$VISUAL` or `$EDITOR` and commits what you saved as one change |
 | `mfctl user rename --display-name <name>` | Replaces the label that user is told apart by |
 | `mfctl user account add --from-file <path>` | Declares one more mailbox in that record |
 | `mfctl user account remove --id <account>` | Stops the record declaring one mailbox, leaving its stored mail alone |
@@ -1278,6 +1279,16 @@ says so.
 would switch somebody's spam protection off on the strength of an administrative act about where their settings live.
 Only the keys a user's record may hold travel — the engine settings stay the deployment's — and the preview names
 each one with the value it would take, since two of them file mail and mark it read on that user's own mail server.
+
+**`mfctl user edit` is the command for a change that is more than one mailbox.** `user account add` and
+`user account remove` each name one, and the deployment composes it into the record, so changing two of them — or
+anything else the record carries — is a run of commands each committing a version of its own, with every intermediate one
+an account set this deployment briefly read. The editing session is one change instead: the record is fetched with its
+version, opened in `$VISUAL` or `$EDITOR`, and committed against that version. An emptied buffer abandons the session
+and a buffer saved unchanged writes nothing, both reported as what they are rather than as a failure; a graphical editor
+needs the flag that makes it wait, such as `VISUAL="code --wait"`, because the command reads the file back when the
+editor exits. A record a configuration source still supplies is refused before the editor opens rather than after the
+commit, naming the adoption below.
 
 **A record is committed whole or not at all, over the version it was read at.** A candidate is bound strictly against
 the same rules a configuration file is, checked for two mail accounts declared under one identifier, checked that every

--- a/docs/operations/configuration-sources.md
+++ b/docs/operations/configuration-sources.md
@@ -1,6 +1,6 @@
 # Configuration sources
 
-<!-- describes: backend/src/Application/Configuration/**, backend/src/Host/Configuration/**, backend/src/Infrastructure/Persistence/Settings/**, backend/src/Infrastructure/Persistence/Users/**, backend/src/Cli/Commands/Configuration/**, backend/src/Host/Hosting/Startup/ServedMailUsersStartupGate.cs, backend/src/Application/Access/DeploymentMailUserUnresolvedException.cs -->
+<!-- describes: backend/src/Application/Configuration/**, backend/src/Host/Configuration/**, backend/src/Infrastructure/Persistence/Settings/**, backend/src/Infrastructure/Persistence/Users/**, backend/src/Cli/Commands/Configuration/**, backend/src/Cli/Editing/**, backend/src/Host/Hosting/Startup/ServedMailUsersStartupGate.cs, backend/src/Application/Access/DeploymentMailUserUnresolvedException.cs -->
 
 MailFathom reads its settings through the ordinary .NET configuration pipeline, plus two additions. A deployment may name a directory or a file of JSON configuration that it provisioned outside the application's own content root, which is what makes a Kubernetes ConfigMap mounted as a volume ordinary configuration rather than a shape the host cannot see. And the deployment's own persisted settings — one document in PostgreSQL, composed at startup like every other source — are layered in above those files, so a setting the deployment has persisted binds and validates exactly as one that came from a file. When an edit to that document takes effect is [its own section](#the-persisted-layer) below.
 
@@ -278,7 +278,7 @@ MailFathom persists Accounts:0:MailAccounts:0:Host in the user-accounts store ra
 document, so this is not where it is changed. A user still read from a configuration source is changed in the
 declaration that supplies them — the user's own section of the top-level Accounts collection — and served from it at
 the next restart; a user who has been adopted is changed with 'mfctl user account add' and 'mfctl user account
-remove'.
+remove', or with 'mfctl user edit' for their whole record at once.
 ```
 
 The user routes are the ones that do write that store, and until a user is adopted **they refuse too** — through the administrative record routes and through the client's own alike — because a write against an empty document would silently drop every mailbox the file was supplying. That refusal names `mfctl user adopt`, which is the one act that moves them.

--- a/docs/operations/permissions.md
+++ b/docs/operations/permissions.md
@@ -188,13 +188,14 @@ reads the roster and acts for the sole user it finds, which is one `mailfathom.a
 permission the act itself is published under. Passing `--user` skips that lookup and nothing else — the named user is
 sent as written, and the deployment refuses one it holds no record for.
 
-Skipping the lookup is not the same as making the command need one permission. Six of them read something else
+Skipping the lookup is not the same as making the command need one permission. Seven of them read something else
 unconditionally, whether or not `--user` was passed, so each needs `mailfathom.admin.read` beside its own name in every
 invocation:
 
 | Command | Reads, before the act |
 | --- | --- |
 | `mfctl user show` | the record it prints |
+| `mfctl user edit` | the record the editing session opens, and the version what you saved is committed against |
 | `mfctl user account add`, `mfctl user account remove` | the record the change is composed over, and the version it is composed at |
 | `mfctl user adopt` | what an adoption would move, which is what it asks you to confirm |
 | `mfctl user remove` | the roster, so the confirmation names the person being erased |

--- a/docs/users/administering.md
+++ b/docs/users/administering.md
@@ -665,6 +665,21 @@ the label you tell somebody apart by; nothing is keyed by it, so it moves no mai
 where the person is one your configuration declares, that file is where the label is changed, since a start puts the
 declared one back.
 
+**Changing more than one thing about somebody at once is `mfctl user edit`.** `mfctl user account add` and
+`mfctl user account remove` each name one mailbox, so two changes are two commands and the deployment briefly reads what
+is between them. `mfctl user edit` opens that person's whole record in your `$VISUAL` or `$EDITOR` and commits what you
+saved as one change — set it up as `VISUAL="code --wait"` if your editor is a graphical one, since the command reads the
+file back when the editor exits. Empty the buffer to abandon the session, or save it unchanged, and nothing is written
+either way. Passwords read back as `(redacted)`, and a marker saved back leaves the credential beneath it alone.
+
+```console
+$ mfctl user edit --user 7c02...
+Committed user record version 4.
+The replica this request reached is using this account set now. A synchronization run already in flight finishes
+against the previous version; the next run uses this one. Other replicas pick up the change after their next user write
+or restart.
+```
+
 **Recording a second person is refused while a surface they reach authenticates nobody.** A deployment serving one
 person may leave the MCP endpoint open, or hold it with a key, because there is only one answer to whose mail a caller
 is asking about. With two people there is no such answer, so give the MCP and client endpoints a username and password


### PR DESCRIPTION
Closes #1825

## What this changes

A change to one user's record that is more than a single mailbox was a run of commands. `mfctl user account add` and
`mfctl user account remove` each name one mailbox and the deployment composes it into the document, so changing two of
them — or anything else a record carries — committed a version per command, and every intermediate one was an account
set the deployment briefly read.

`mfctl user edit` is that change as one transaction. It resolves the user the way every other `user` command does,
fetches the record with its version, opens the redacted JSON in the operator's own `$VISUAL` or `$EDITOR`, and commits
what they saved against the version it was opened over — accepted whole or refused whole. An emptied buffer abandons the
session and a buffer saved unchanged writes nothing, both reported as what they are. A record a configuration source
still supplies is refused *before* the editor opens rather than after the commit, since that write was never going to be
accepted. A version another writer moved past is reported as the settings that differ between the two versions — paths
only, never values — so the operator can decide again against it rather than have two edits neither author saw merged.

The deployment route this sends to already existed (`POST /api/admin/users/{userId}/record`); nothing about the admin
endpoint changes.

## The editor plumbing moved

`OperatorEditor`, `EditingSession`, and `SettingsBuffer` move from `backend/src/Cli/Commands/Configuration/` to
`backend/src/Cli/Editing/`. They were never `config edit`'s alone — `CliContext` at the project root already reached
into that command folder for `EditingSession` — and having `Commands/Users` reach across into `Commands/Configuration`
would have made that worse rather than better.

What the two editor-driven commands share is now `EditorDrivenDocument`: the editor the shell names, the buffer in a
directory readable by its user alone, the read-back, the emptied and unchanged readings, the failure when a session did
not finish, and the discarding whichever way it ends. `EditConfigurationCommand` loses six private helpers to it and
keeps its own buffer path, so nothing an operator sees of `config edit` changes.

## Breaking changes

None. No configuration key, database column, MCP tool argument, or deployment contract moves: the command is new, the
route it calls is not, and the buffer `config edit` writes keeps its name and its shape.

## Verification

- `scripts/verify-fast.sh` — passed. Release build of the solution, then `Cli.UnitTests` (662), `Host.UnitTests` (3785),
  and `PublicSurfaces.UnitTests` (15), which is what the changed paths resolve to.
- `scripts/review-obligations.sh` — one real obligation, acted on: the refusal `RootSettingsWriter` gives for a path the
  user-accounts store owns named two of what are now three ways to change an adopted user's record. Its message and the
  copy of it quoted in `docs/operations/configuration-sources.md` now name `mfctl user edit` as well, and
  `RootSettingsWriterTests` asserts it.
- `$check-docs-licenses` — `Docs: pass`, `Changelog: n/a`, `Licenses: n/a` (no dependency moved).

## Documentation

- `docs/operations/admin-endpoint.md` — the command table gains `mfctl user edit`, the record-write route row names the
  command that sends it, and a paragraph states why a change spanning more than one mailbox belongs to one session.
- `docs/users/administering.md` — the same for the operator's guide, with the console block the command actually prints.
- `docs/operations/permissions.md` — `mfctl user edit` joins the commands that read before they act, so it needs
  `mailfathom.admin.read` beside `mailfathom.admin.configuration.write` in every invocation.
- `docs/operations/configuration-sources.md` — the quoted refusal above, and its `describes:` marker widened to
  `backend/src/Cli/Editing/**`, which is where the editing-session behaviour that page documents now lives.
