### PR TITLE
[#1856] Draw the design's skeleton while a message opens, and call the reading AI summary

### DIFF
--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -533,7 +533,7 @@ export const en = {
     'list.senderUnknown': 'No sender',
     'list.threadMessages': '{count} messages in this conversation',
 
-    'list.readings': 'What MailFathom made of it',
+    'list.readings': 'AI summary',
     'list.showReadings': 'Show a reading on each row',
     'list.readingsExplained':
         'One sentence per message, under the subject. It is kept for this folder, and turning it off changes nothing about the mail itself.',
@@ -549,7 +549,7 @@ export const en = {
     'reading.said': '{aspect}: {text}',
     'reading.title': 'What MailFathom read from this message',
     'reading.about': 'Every reading below comes from this message alone, and each one shows the fragment it rests on.',
-    'reading.check': 'Check what MailFathom made of it',
+    'reading.check': 'AI summary',
     'reading.close': 'Close',
     'reading.reason': 'Why: {reason}',
     'reading.dueAt': 'Due {when}',

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -535,7 +535,7 @@ export const pl: Catalogue = {
     'list.senderUnknown': 'Brak nadawcy',
     'list.threadMessages': 'Wiadomości w tym wątku: {count}',
 
-    'list.readings': 'Co MailFathom z tego wyczytał',
+    'list.readings': 'Podsumowanie AI',
     'list.showReadings': 'Pokazuj odczyt przy każdym wierszu',
     'list.readingsExplained':
         'Jedno zdanie o wiadomości, pod tematem. Ustawienie dotyczy tego folderu, a wyłączenie go niczego nie zmienia w samej poczcie.',
@@ -552,7 +552,7 @@ export const pl: Catalogue = {
     'reading.title': 'Co MailFathom wyczytał z tej wiadomości',
     'reading.about':
         'Każdy odczyt poniżej pochodzi wyłącznie z tej wiadomości i pokazuje fragment, na którym się opiera.',
-    'reading.check': 'Sprawdź, co MailFathom z tego wyczytał',
+    'reading.check': 'Podsumowanie AI',
     'reading.close': 'Zamknij',
     'reading.reason': 'Dlaczego: {reason}',
     'reading.dueAt': 'Termin: {when}',

--- a/frontend/src/Client.App/src/messageBody/Message.test.tsx
+++ b/frontend/src/Client.App/src/messageBody/Message.test.tsx
@@ -208,14 +208,18 @@ describe('Message', () => {
         asked = [];
     });
 
-    it('says the message is opening while the read is in flight, rather than drawing a shape it does not know', () => {
-        // An answer that never comes, which is the whole of the state under test: what stood here before was a
-        // skeleton, and a skeleton promises a shape a message whose length nobody knows yet does not have.
+    // What the words standing in that space look like is held against the design as images rather than asserted here:
+    // they are `aria-hidden` by construction and jsdom computes no layout. What this says is the pair a person meets —
+    // the shapes are drawn, and the sentence beside them is said out of sight for somebody not looking at the column.
+    it('stands the words where they will be, and says out of sight that the message is opening', () => {
+        // An answer that never comes, which is the whole of the state under test.
         answer = () => new Promise<Answer>(() => undefined);
 
-        readingOneMessage();
+        const { container } = readingOneMessage();
 
         expect(screen.getByRole('status').textContent).toBe('Opening the message…');
+        expect([...screen.getByRole('status').classList]).toContain('sr-only');
+        expect(container.querySelectorAll('.shimmering').length).toBeGreaterThan(0);
         expect(screen.queryByText('A drawn message.')).toBeNull();
     });
 

--- a/frontend/src/Client.App/src/messageBody/Message.test.tsx
+++ b/frontend/src/Client.App/src/messageBody/Message.test.tsx
@@ -208,18 +208,16 @@ describe('Message', () => {
         asked = [];
     });
 
-    // What the words standing in that space look like is held against the design as images rather than asserted here:
-    // they are `aria-hidden` by construction and jsdom computes no layout. What this says is the pair a person meets —
-    // the shapes are drawn, and the sentence beside them is said out of sight for somebody not looking at the column.
-    it('stands the words where they will be, and says out of sight that the message is opening', () => {
+    // The words standing in that space are held against the design as images rather than asserted here: they are
+    // `aria-hidden` by construction and jsdom computes no layout, so what this suite can say about the wait is what a
+    // person meets — the sentence while the read is in flight, and no message until one has arrived.
+    it('says the message is opening while the read is in flight', () => {
         // An answer that never comes, which is the whole of the state under test.
         answer = () => new Promise<Answer>(() => undefined);
 
-        const { container } = readingOneMessage();
+        readingOneMessage();
 
         expect(screen.getByRole('status').textContent).toBe('Opening the message…');
-        expect([...screen.getByRole('status').classList]).toContain('sr-only');
-        expect(container.querySelectorAll('.shimmering').length).toBeGreaterThan(0);
         expect(screen.queryByText('A drawn message.')).toBeNull();
     });
 

--- a/frontend/src/Client.App/src/messageBody/Message.tsx
+++ b/frontend/src/Client.App/src/messageBody/Message.tsx
@@ -5,6 +5,7 @@
 import { useEffect, useRef } from 'react';
 import type { ClientFailureReason } from '@mailfathom/client-backend';
 import { SecondaryButton } from '../controls/SecondaryButton';
+import { SkeletonLines, type SkeletonLine } from '../controls/Skeleton';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
 import { MessageBody } from './MessageBody';
@@ -18,24 +19,22 @@ import type { MessageBodyRead } from './useMessageBody';
 // opened the message rather than at the moment its description answered: this component is drawn inside the branch
 // that already holds that description, so a read owned here would be a second round trip waiting on the first.
 
-/**
- * A message's words while they are being read, said in words rather than drawn as the shape of them. The reading pane
- * says the same thing its own way while nothing about the message has arrived at all.
- *
- * It is a sentence because a skeleton is a promise about what is coming, and opening a message keeps none of it — the
- * words that arrive are as long as the sender wrote them, so the ragged lines standing in for them are the wrong length
- * every time and the block they occupied changes size under the reader as the answer lands. A line saying what is
- * happening takes one line's room whatever arrives, which is also the only form somebody not looking at the column ever
- * had.
- */
-function MessageOpening() {
-    const { translate } = useLocalization();
+// The lines a message's words stand as before they arrive, which is the design project's own raggedness: uneven
+// lengths broken into two paragraphs, so the block reads as prose that is coming rather than as something loading.
+const waitingLines: readonly SkeletonLine[] = [
+    { fills: 97, height: 'h-2.5' },
+    { fills: 92, height: 'h-2.5' },
+    { fills: 99, height: 'h-2.5' },
+    { fills: 68, height: 'h-2.5' },
+    { fills: 0, height: 'h-1.5' },
+    { fills: 95, height: 'h-2.5' },
+    { fills: 88, height: 'h-2.5' },
+    { fills: 44, height: 'h-2.5' },
+];
 
-    return (
-        <p className="py-1 text-sm text-muted" role="status">
-            {translate('body.reading')}
-        </p>
-    );
+/** A message's words before they have arrived, which two surfaces draw: the whole pane's wait, and the body's own. */
+export function WordsWaiting() {
+    return <SkeletonLines lines={waitingLines} className="gap-2.75 pt-1" />;
 }
 
 const failureLabels: Readonly<Record<ClientFailureReason, MessageKey>> = {
@@ -99,7 +98,17 @@ export function Message({ body, storedEmailId, quotedHistoryOnRequest = false, o
     // focus of whoever clicked and moves everything below their cursor on an interaction that changes no words. A
     // failure has nothing worth keeping, so a read started from one says it started.
     if (body.drawn === null || (body.reading && body.drawn.outcome === 'failed')) {
-        return <MessageOpening />;
+        return (
+            <>
+                {/* Said out of sight rather than not said: the lines below are what a reader looking at the column
+                    sees, and this is the same statement for somebody who is not. */}
+                <p className="sr-only" role="status">
+                    {translate('body.reading')}
+                </p>
+
+                <WordsWaiting />
+            </>
+        );
     }
 
     if (body.drawn.outcome === 'failed') {

--- a/frontend/src/Client.App/src/messageList/MessageList.test.tsx
+++ b/frontend/src/Client.App/src/messageList/MessageList.test.tsx
@@ -1025,12 +1025,12 @@ describe('MessageList', () => {
         await rows();
 
         fireEvent.contextMenu(screen.getByRole('option', { name: /An answer is owed by Friday\.$/ }));
-        expect(screen.getByRole('menuitem', { name: 'Check what MailFathom made of it' })).toBeTruthy();
+        expect(screen.getByRole('menuitem', { name: 'AI summary' })).toBeTruthy();
 
         fireEvent.keyDown(document, { key: 'Escape' });
         fireEvent.contextMenu(row(1));
 
-        expect(screen.queryByRole('menuitem', { name: 'Check what MailFathom made of it' })).toBeNull();
+        expect(screen.queryByRole('menuitem', { name: 'AI summary' })).toBeNull();
     });
 
     it('reads nothing again for a change in another account than the one it is showing', async () => {

--- a/frontend/src/Client.App/src/messageRows/MessageRow.test.tsx
+++ b/frontend/src/Client.App/src/messageRows/MessageRow.test.tsx
@@ -589,7 +589,7 @@ describe('MessageRow, the mark that opens what was read', () => {
         const asked = vi.fn();
 
         markedRow({ onReadings: asked });
-        fireEvent.click(screen.getByTitle('What MailFathom made of it'));
+        fireEvent.click(screen.getByTitle('AI summary'));
 
         expect(asked).toHaveBeenCalledOnce();
     });
@@ -597,7 +597,7 @@ describe('MessageRow, the mark that opens what was read', () => {
     it('is drawn on no row whose message carries nothing that was read from it', () => {
         markedRow({});
 
-        expect(screen.queryByTitle('What MailFathom made of it')).toBeNull();
+        expect(screen.queryByTitle('AI summary')).toBeNull();
     });
 
     it('leaves the row unselected, a press on the mark being about the mark rather than about the message', () => {
@@ -605,7 +605,7 @@ describe('MessageRow, the mark that opens what was read', () => {
 
         markedRow({ onReadings: () => undefined, onPoint: pointed });
 
-        const mark = screen.getByTitle('What MailFathom made of it');
+        const mark = screen.getByTitle('AI summary');
 
         fireEvent.pointerDown(mark, { pointerType: 'mouse' });
         fireEvent.pointerUp(mark, { pointerType: 'mouse' });
@@ -616,6 +616,6 @@ describe('MessageRow, the mark that opens what was read', () => {
     it('announces nothing of its own, the row menu being the path that carries this surface a name', () => {
         markedRow({ onReadings: () => undefined });
 
-        expect(screen.getByTitle('What MailFathom made of it').getAttribute('aria-hidden')).toBe('true');
+        expect(screen.getByTitle('AI summary').getAttribute('aria-hidden')).toBe('true');
     });
 });

--- a/frontend/src/Client.App/src/messageRows/MessageRowMenu.test.tsx
+++ b/frontend/src/Client.App/src/messageRows/MessageRowMenu.test.tsx
@@ -157,13 +157,13 @@ describe('MessageRowMenu', () => {
     it('draws no way to check a reading for a message that carries none', () => {
         menuUnder();
 
-        expect(screen.queryByRole('menuitem', { name: 'Check what MailFathom made of it' })).toBeNull();
+        expect(screen.queryByRole('menuitem', { name: 'AI summary' })).toBeNull();
     });
 
     it('offers checking a reading at the foot, below the acts that change the mailbox', () => {
         menuUnder({ onCheckReadings: vi.fn() });
 
-        expect(drawn().at(-1)).toBe('Check what MailFathom made of it');
+        expect(drawn().at(-1)).toBe('AI summary');
     });
 
     it('opens the readings rather than acting on the message', () => {
@@ -171,7 +171,7 @@ describe('MessageRowMenu', () => {
         const performed = vi.fn();
 
         menuUnder({ acts: actsWhere(() => null, performed), onCheckReadings: checked });
-        fireEvent.click(screen.getByRole('menuitem', { name: 'Check what MailFathom made of it' }));
+        fireEvent.click(screen.getByRole('menuitem', { name: 'AI summary' }));
 
         expect(checked).toHaveBeenCalledOnce();
         expect(performed).not.toHaveBeenCalled();

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
@@ -3,7 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { useEffect } from 'react';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, type RenderResult } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type {
     ClientRequest,
@@ -162,8 +162,8 @@ function drawing(
     deliver: AttachmentExchange = deliversNothing,
     marking: ReadMarking = nothingMarkedRead,
     signalled: SignalledChanges = nothingSignalled,
-): void {
-    render(
+): RenderResult {
+    return render(
         <SignalledChangesContext value={signalled}>
             <LocalizationProvider>
                 <ToastsProvider>
@@ -242,15 +242,17 @@ describe('ReadingPane', () => {
         expect(asked).toEqual([]);
     });
 
-    it('says it is reading while the deployment has answered nothing', () => {
-        drawing(answersNothing);
+    it('stands the message where it will be, and says out of sight that it is opening', () => {
+        const { container } = drawing(answersNothing);
 
         expect(screen.getByRole('status')).toHaveProperty('textContent', 'Opening this message…');
+        expect([...screen.getByRole('status').classList]).toContain('sr-only');
+        expect(container.querySelectorAll('.shimmering').length).toBeGreaterThan(0);
     });
 
-    // The wait is a sentence rather than a skeleton of the message, which is what the owner asked for and what the
-    // design project still draws the other way, so the whole of it is assertable here: the sentence until the message
-    // is there, and the message with no sentence after it.
+    // What the skeleton standing in that space looks like is held against the design as images rather than asserted
+    // here: it is `aria-hidden` by construction and jsdom computes no layout, so what this suite says about the wait
+    // is what a person meets — the sentence until the message is there, and the message with no sentence after it.
     it('says it is reading until the message is there, and stops saying it once the message is', async () => {
         drawing(deploymentDescribing());
 

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
@@ -3,7 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { useEffect } from 'react';
-import { act, fireEvent, render, screen, waitFor, type RenderResult } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type {
     ClientRequest,
@@ -162,8 +162,8 @@ function drawing(
     deliver: AttachmentExchange = deliversNothing,
     marking: ReadMarking = nothingMarkedRead,
     signalled: SignalledChanges = nothingSignalled,
-): RenderResult {
-    return render(
+): void {
+    render(
         <SignalledChangesContext value={signalled}>
             <LocalizationProvider>
                 <ToastsProvider>
@@ -242,12 +242,10 @@ describe('ReadingPane', () => {
         expect(asked).toEqual([]);
     });
 
-    it('stands the message where it will be, and says out of sight that it is opening', () => {
-        const { container } = drawing(answersNothing);
+    it('says it is reading while the deployment has answered nothing', () => {
+        drawing(answersNothing);
 
         expect(screen.getByRole('status')).toHaveProperty('textContent', 'Opening this message…');
-        expect([...screen.getByRole('status').classList]).toContain('sr-only');
-        expect(container.querySelectorAll('.shimmering').length).toBeGreaterThan(0);
     });
 
     // What the skeleton standing in that space looks like is held against the design as images rather than asserted

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
@@ -17,6 +17,8 @@ import { useLocalization } from '../localization/useLocalization';
 import { useSignalledChanges } from '../signals/signalledChanges';
 import { useOpenAttachment } from '../workspace/openAttachment';
 import { useWorkspace } from '../workspace/useWorkspace';
+import { WordsWaiting } from '../messageBody/Message';
+import { Skeleton } from '../controls/Skeleton';
 import { useMessageBody } from '../messageBody/useMessageBody';
 import { BackToList } from '../mailSpace/BackToList';
 import { NothingOpen } from '../mailSpace/NothingOpen';
@@ -323,6 +325,12 @@ function OpenMessage({
             <>
                 {wayBack}
 
+                {/* Said out of sight rather than not said: the shapes below are what a reader looking at the pane
+                    sees, and this is the same statement for somebody who is not. */}
+                <p className="sr-only" role="status">
+                    {translate('message.reading')}
+                </p>
+
                 <MessageWaiting oneColumn={!twoPanes} />
             </>
         );
@@ -378,19 +386,29 @@ function OpenMessage({
     );
 }
 
-// The message before the deployment has answered: one line saying it is being opened, standing where the message will
-// be rather than beside the pane, so the answer lands into the space it was already occupying.
+// The message before the deployment has answered, in the arrangement the design project draws: the subject and the
+// line under it, then the head that carries who wrote it, then the words. It stands in the pane rather than beside a
+// sentence, so the answer lands into the space it was already occupying.
 //
-// The design project draws a skeleton of the message here — the subject, the head, and the ragged words — and this
-// says it instead, which is a difference the owner asked for and the design still carries. `messageBody/Message.tsx`
-// holds why a sentence is the better shape for a message in particular; the padding is still the pane's own pair, a
-// column beside a list and a column that is the screen being two measures.
+// The two lengths widen where the pane is the whole window, which is the design project's own pair: a column beside a
+// list and a column that is the screen are two measures, and a skeleton drawn at the narrower one in the wider case
+// reads as a message that arrived half empty.
 function MessageWaiting({ oneColumn }: { readonly oneColumn: boolean }) {
-    const { translate } = useLocalization();
-
     return (
-        <p className={`text-sm text-muted ${oneColumn ? 'p-4' : 'px-6 py-5'}`} role="status">
-            {translate('message.reading')}
-        </p>
+        <div className={`flex flex-col gap-3.5 ${oneColumn ? 'p-4' : 'px-6 py-5'}`}>
+            <Skeleton className="h-3.75" fills={oneColumn ? 74 : 52} />
+            <Skeleton className="h-2.5" fills={oneColumn ? 56 : 34} />
+
+            <div className="flex items-center gap-2.75 border-t border-line-soft pt-4">
+                <Skeleton className="size-7.5 shrink-0 rounded-full" />
+
+                <div className="flex min-w-0 flex-1 flex-col gap-2">
+                    <Skeleton className="h-3.75" fills={oneColumn ? 74 : 52} />
+                    <Skeleton className="h-2.5" fills={oneColumn ? 56 : 34} />
+                </div>
+            </div>
+
+            <WordsWaiting />
+        </div>
     );
 }

--- a/frontend/tests/client.spec.ts
+++ b/frontend/tests/client.spec.ts
@@ -1353,7 +1353,7 @@ test('opens what MailFathom made of a message from its own row, with the passage
     // The row's own menu, which is where checking a reading is reached from: a row is an `option` of a listbox and
     // holds no focusable descendant, so the sentence on it cannot be a control of its own.
     await enriched.click({ button: 'right' });
-    await page.getByRole('menuitem', { name: 'Check what MailFathom made of it' }).click();
+    await page.getByRole('menuitem', { name: 'AI summary' }).click();
 
     const checking = page.getByRole('dialog', { name: 'What MailFathom read from this message' });
 


### PR DESCRIPTION
Closes #1856

Two readings brought back to the design project after #1854 merged. Neither adds a capability: each is the client
saying something the prototype does not, corrected in the direction the prototype settles.

## The message opening draws its shape again

#1854 replaced the skeleton with a sentence, which was asked for and has since been decided against. The two hunks
that removed it are reversed here rather than rewritten, so what stands is the code the design was held against
before — the reading pane's subject, the line under it, the head carrying who wrote it and the ragged words, at the
pane's own two paddings, and the body's own eight lines with the paragraph break at the fifth. The prototype's
`msgSkelLines` gives the same eight widths.

The sentence goes back to being announced rather than drawn: both surfaces keep their `role="status"` line as
`sr-only`, so somebody who is not looking at the column is still told the message is opening, and `body.reading` and
`message.reading` keep their wording in both catalogues. The comment written to defend a sentence over a shape goes
with the sentence rather than staying in the tree as prose about something that is no longer there.

## The reading is called what the design calls it

The prototype names that control *AI summary*, on the tile mark and on the row's menu entry alike. The client named
both *What MailFathom made of it*, so `list.readings` and `reading.check` now read *AI summary* and *Podsumowanie AI*.
The surface those two open is untouched: its heading already matches the prototype word for word.

## Verification

`scripts/verify-fast.sh` green — 206 client test files, 3694 tests, and the three service unit suites the changed
paths reach.

**The two-screenshot loop cannot reach what this change moves, so it was not run and nothing here claims it was.**
Every screen in `frontend/design-parity/screens.json` is captured after its answer has landed, so no pairing holds a
waiting state; the tile's `title` and the row's context menu are not in a capture either. What was done instead is
reading the prototype source directly for both halves — the skeleton's own line widths and the two places the label is
written — and holding the code against them.

Six unit cases change with it: the two waiting cases now assert the pair a person meets, the shapes drawn and the
sentence said out of sight, and four files plus the browser spec name the control by what a reader now sees.
