### PR TITLE
[#1866] Draw one statement per aspect in a conversation's state, and never draw a stale state as current

### DIFF
--- a/backend/src/AI/ThreadStates/ThreadStateInstructions.cs
+++ b/backend/src/AI/ThreadStates/ThreadStateInstructions.cs
@@ -42,8 +42,7 @@ internal static class ThreadStateInstructions
         The object may carry four fields, each an array: "agreements", "openQuestions", "commitments" and
         "differences". Omit any array you have nothing for, or write it empty; an omitted statement is a better answer
         than a guessed one, and an object carrying nothing at all is a valid answer for a conversation there is nothing
-        to say about. Write at most {ThreadStateReading.MaximumEntriesPerAspect} entries in each array, most important
-        first.
+        to say about. Put at most {EmailThreadState.MaximumEntriesPerAspect} in each array, the most important first.
 
         Every entry is an object with two required fields. "text" is the statement itself, at most
         {ThreadStateEntry.MaximumTextLength} characters, written as one plain sentence in the language the conversation

--- a/backend/src/AI/ThreadStates/ThreadStateReading.cs
+++ b/backend/src/AI/ThreadStates/ThreadStateReading.cs
@@ -30,15 +30,6 @@ namespace MailFathom.AI.ThreadStates;
 /// </remarks>
 internal static class ThreadStateReading
 {
-    /// <summary>The greatest number of statements one aspect keeps from one answer.</summary>
-    /// <remarks>
-    /// A block beside a conversation is read at a glance, and a model handed a long exchange will happily write one
-    /// agreement per message. The leading entries are kept, because a producer told to write the important ones first
-    /// does. Three rather than more because the block is a row of cards above the correspondence: four aspects at three
-    /// statements each is already the point where the row starts wrapping into the space the conversation needs.
-    /// </remarks>
-    internal const int MaximumEntriesPerAspect = 3;
-
     private const string JsonFence = "```";
 
     /// <summary>Reads the statements out of an agent's answer.</summary>
@@ -67,6 +58,10 @@ internal static class ThreadStateReading
     }
 
     /// <summary>Reads one array of written statements into the statements of one aspect.</summary>
+    /// <remarks>
+    /// A model handed a long exchange will happily write one agreement per message, so the leading entries that
+    /// survive are kept and the rest fall away: a producer told to write the most important first does.
+    /// </remarks>
     private static IEnumerable<ThreadStateEntry> Aspect(
         ThreadStateAspect aspect,
         IReadOnlyList<ThreadStateEntryDocument?>? written,
@@ -74,7 +69,7 @@ internal static class ThreadStateReading
         (written ?? [])
             .Select(entry => ToEntry(aspect, entry, messages))
             .OfType<ThreadStateEntry>()
-            .Take(MaximumEntriesPerAspect);
+            .Take(EmailThreadState.MaximumEntriesPerAspect);
 
     /// <summary>Turns one written statement into a statement, or into nothing where the conversation cannot back it.</summary>
     private static ThreadStateEntry? ToEntry(

--- a/backend/src/Application/Emails/ThreadStates/EmailThreadState.cs
+++ b/backend/src/Application/Emails/ThreadStates/EmailThreadState.cs
@@ -32,16 +32,50 @@ namespace MailFathom.Application.Emails.ThreadStates;
 /// <param name="Entries">What was derived, in the order the producer named it, and empty where there was nothing to say.</param>
 /// <param name="DerivedFrom">The shape of the conversation the derivation was made from.</param>
 /// <param name="DerivedAt">When the derivation ran.</param>
+/// <param name="IsCurrent">
+/// Whether the conversation still has the shape the state was derived from. A state just derived is current by
+/// construction; a stored one stops being current the moment a message joins or leaves the conversation, and stays so
+/// until a pass derives it again — which can be indefinitely, while the answering allowance is spent. A reader is never
+/// shown one that is not as though it were.
+/// </param>
 public sealed record EmailThreadState(
     EmailThreadId ThreadId,
     ThreadStateCoverage Coverage,
     IReadOnlyList<ThreadStateEntry> Entries,
     ThreadStateRevision DerivedFrom,
-    DateTimeOffset DerivedAt)
+    DateTimeOffset DerivedAt,
+    bool IsCurrent)
 {
+    /// <summary>The greatest number of statements one aspect of a state holds.</summary>
+    /// <remarks>
+    /// One, because the block is read at a glance: the design draws a single line under each label, and a second
+    /// agreement beside the first turns the row of cards into the paragraph the block exists to spare somebody. The
+    /// derivation is asked for the most important statement first, so the one kept is the one worth keeping.
+    /// </remarks>
+    public const int MaximumEntriesPerAspect = 1;
+
     /// <summary>Gets the statements of one aspect, in the order the producer named them.</summary>
     /// <param name="aspect">The aspect to read.</param>
     /// <returns>The statements, which is empty where the derivation produced none of that aspect.</returns>
     public IReadOnlyList<ThreadStateEntry> Of(ThreadStateAspect aspect) =>
         [.. this.Entries.Where(entry => entry.Aspect == aspect)];
+
+    /// <summary>Narrows the state to the statements a reader is shown: the leading ones of each aspect.</summary>
+    /// <returns>This state where no aspect holds more than it may, and otherwise a copy holding only the leading statements of each.</returns>
+    /// <remarks>
+    /// A state recorded while more statements per aspect were kept is read this way rather than derived again. Its
+    /// statements were stored in the order the derivation ranked them, so the first of each is the one it ranked most
+    /// important, and deriving every stored conversation again would spend the answering allowance to arrive there.
+    /// </remarks>
+    public EmailThreadState Leading()
+    {
+        IReadOnlyList<ThreadStateEntry> leading =
+        [
+            .. this.Entries
+                .GroupBy(static entry => entry.Aspect)
+                .SelectMany(static aspect => aspect.Take(MaximumEntriesPerAspect)),
+        ];
+
+        return leading.Count == this.Entries.Count ? this : this with { Entries = leading };
+    }
 }

--- a/backend/src/Application/Emails/ThreadStates/IStoredThreadStateReader.cs
+++ b/backend/src/Application/Emails/ThreadStates/IStoredThreadStateReader.cs
@@ -28,7 +28,9 @@ public interface IStoredThreadStateReader
     /// <returns>
     /// The state, or <see langword="null" /> where no derivation has reached the conversation — which is what a client
     /// draws as not derived yet rather than as nothing to say. A conversation the scope admits no message of also reads
-    /// as nothing, so a state is never published for an exchange this caller may not see.
+    /// as nothing, so a state is never published for an exchange this caller may not see. A state the conversation has
+    /// changed since carries <see cref="EmailThreadState.IsCurrent" /> <see langword="false" />, decided by the same
+    /// comparison that puts the conversation back in front of the derivation.
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="scope" /> is <see langword="null" />.</exception>
     Task<EmailThreadState?> ReadStateAsync(

--- a/backend/src/Application/Emails/ThreadStates/MailThreadStateBrowser.cs
+++ b/backend/src/Application/Emails/ThreadStates/MailThreadStateBrowser.cs
@@ -59,7 +59,10 @@ public sealed class MailThreadStateBrowser
     /// <summary>Reads where one of the acting user's conversations stands.</summary>
     /// <param name="threadId">The conversation, as a message row published it.</param>
     /// <param name="cancellationToken">Propagates caller cancellation.</param>
-    /// <returns>The state, or <see langword="null" /> where this deployment has none for that conversation.</returns>
+    /// <returns>
+    /// The state, holding only the leading statements of each aspect — see <see cref="EmailThreadState.Leading" /> — or
+    /// <see langword="null" /> where this deployment has none for that conversation.
+    /// </returns>
     /// <exception cref="SensitiveContentScannerUnavailableException">Thrown when a switched-on scanner could not establish what the state carries, which refuses it rather than serving it unscanned.</exception>
     /// <exception cref="PrincipalNotAuthorizedException">Thrown when the use case was reached by anything but a caller granted <see cref="MailFathomPermission.MailRead" />.</exception>
     public async Task<EmailThreadState?> ReadStateAsync(EmailThreadId threadId, CancellationToken cancellationToken)
@@ -77,7 +80,7 @@ public sealed class MailThreadStateBrowser
 
         var state = await this.stateReader.ReadStateAsync(threadId, scope, cancellationToken);
 
-        return state is null ? null : await this.GuardedAsync(state, cancellationToken);
+        return state is null ? null : await this.GuardedAsync(state.Leading(), cancellationToken);
     }
 
     /// <summary>Scans everything the block would publish, under the point this surface is read on.</summary>

--- a/backend/src/Application/Emails/ThreadStates/ThreadStateDerivationPass.cs
+++ b/backend/src/Application/Emails/ThreadStates/ThreadStateDerivationPass.cs
@@ -153,7 +153,8 @@ public sealed class ThreadStateDerivationPass
                 derivation.Coverage,
                 derivation.Entries,
                 thread.Revision,
-                this.timeProvider.GetUtcNow());
+                this.timeProvider.GetUtcNow(),
+                IsCurrent: true);
 
             // Committed one conversation at a time rather than one batch at a time, because a derivation that is
             // settled has already been paid for: holding it until the last of the batch had answered would lose every

--- a/backend/src/Host/Api/ClientMailThreadStateEndpoint.cs
+++ b/backend/src/Host/Api/ClientMailThreadStateEndpoint.cs
@@ -88,7 +88,12 @@ internal static class ClientMailThreadStateEndpoint
 /// <param name="ThreadId">The conversation, as the request named it.</param>
 /// <param name="Coverage">Whether the whole conversation was read, or it runs past what one derivation may read at all.</param>
 /// <param name="DerivedAt">When the state was derived, which is what a client says the block is as of.</param>
-/// <param name="Entries">The statements, in aspect order and within an aspect in the order the derivation put them.</param>
+/// <param name="Current">
+/// Whether the state was derived from the conversation as it stands now. <see langword="false" /> once a message has
+/// joined or left it since, which is exactly when the next derivation pass would derive it again; a client never draws
+/// such a state as the conversation's current one.
+/// </param>
+/// <param name="Entries">The statements, at most one of each aspect, in aspect order.</param>
 /// <remarks>
 /// <c>coverage</c> is what a conversation too large to read in one bound is published as, and it arrives with no
 /// entries: a partial reading of a long exchange presented as its state would be worse than saying nothing, so the
@@ -98,6 +103,7 @@ internal sealed record ClientMailThreadStateResponse(
     Guid ThreadId,
     string Coverage,
     DateTimeOffset DerivedAt,
+    bool Current,
     IReadOnlyList<ClientMailThreadStateEntryResponse> Entries)
 {
     /// <summary>Describes one conversation's state for the wire.</summary>
@@ -112,6 +118,7 @@ internal sealed record ClientMailThreadStateResponse(
             state.ThreadId.Value,
             state.Coverage.ToString(),
             state.DerivedAt,
+            state.IsCurrent,
             [.. state.Entries.Select(ClientMailThreadStateEntryResponse.For)]);
     }
 }

--- a/backend/src/Infrastructure/Persistence/ThreadStates/StoredThreadStateReader.cs
+++ b/backend/src/Infrastructure/Persistence/ThreadStates/StoredThreadStateReader.cs
@@ -4,8 +4,11 @@
 
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.ThreadStates;
+using MailFathom.Application.Folders;
+using MailFathom.Application.Spam.Gating;
 using MailFathom.CodeCoverage;
 using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
 using MailFathom.Infrastructure.Persistence.Emails;
 using MailFathom.Infrastructure.Persistence.Emails.Threads;
 using MailFathom.Infrastructure.Persistence.Entities;
@@ -25,9 +28,18 @@ namespace MailFathom.Infrastructure.Persistence.ThreadStates;
 /// surface has no conversation for, so it has no state either. Answering otherwise would report a withheld folder's
 /// contents one derived sentence at a time.
 /// </para>
+/// <para>
+/// Whether the state still describes the conversation is asked of the mail as well, and in the derivation pass's own
+/// terms — see <see cref="OwedADerivation" />. A stored state is written against the shape the conversation had, and
+/// a reply that arrived since changes the conversation without changing the record, so the record alone cannot say.
+/// </para>
 /// </remarks>
 [RequiresIntegrationCoverage]
-internal sealed class StoredThreadStateReader(MailFathomDbContext dbContext) : IStoredThreadStateReader
+internal sealed class StoredThreadStateReader(
+    MailFathomDbContext dbContext,
+    IMailFolderParticipationReader folderParticipation,
+    DerivedWorkGate derivedWorkGate)
+    : IStoredThreadStateReader
 {
     /// <inheritdoc />
     public async Task<EmailThreadState?> ReadStateAsync(
@@ -51,6 +63,8 @@ internal sealed class StoredThreadStateReader(MailFathomDbContext dbContext) : I
             .AsNoTracking()
             .Where(state => state.EmailThreadId == surviving)
             .Select(state => new StoredThreadStateRow(
+                state.EmailThread!.UserId,
+                state.EmailThread.MailboxAccountId,
                 state.Coverage,
                 state.DerivedAt,
                 state.DerivedFromMessageCount,
@@ -72,6 +86,16 @@ internal sealed class StoredThreadStateReader(MailFathomDbContext dbContext) : I
             return null;
         }
 
+        var owed = await OwedADerivation(
+                dbContext.StoredEmails.AsNoTracking(),
+                dbContext.EmailThreadStates.AsNoTracking(),
+                surviving,
+                stored.UserId,
+                stored.MailboxAccountId,
+                folderParticipation.FoldersGeneratingEmbeddings,
+                derivedWorkGate.ReadTerms())
+            .AnyAsync(cancellationToken);
+
         return new EmailThreadState(
             EmailThreadId.Create(surviving),
             stored.Coverage,
@@ -84,8 +108,41 @@ internal sealed class StoredThreadStateReader(MailFathomDbContext dbContext) : I
                     entry.DueAt)),
             ],
             new ThreadStateRevision(stored.DerivedFromMessageCount, stored.DerivedFromLatestArrival),
-            stored.DerivedAt);
+            stored.DerivedAt,
+            IsCurrent: !owed);
     }
+
+    /// <summary>Asks the derivation pass's own question of one conversation: whether it is owed a derivation now.</summary>
+    /// <param name="emails">The stored mail to count the conversation from.</param>
+    /// <param name="states">The states already stored.</param>
+    /// <param name="survivingThreadId">The conversation, as the surviving thread of any merge.</param>
+    /// <param name="userId">The user whose account the conversation belongs to.</param>
+    /// <param name="mailboxAccountId">The configured account the conversation belongs to.</param>
+    /// <param name="embeddedFolders">The folders a mapping admits to derived work.</param>
+    /// <param name="terms">The classification terms in force.</param>
+    /// <returns>One row where the stored state no longer describes the conversation, and none where it still does.</returns>
+    /// <remarks>
+    /// The selection and the comparison are the store's, composed rather than restated, so a read calls a state current
+    /// exactly when the next pass would leave the conversation alone. A second comparison written here would be a second
+    /// opinion about the same shape, and the day the two disagreed a reader would be shown as current a state the pass
+    /// had already queued to replace — or be told a state was stale that no pass would ever derive again.
+    /// </remarks>
+    internal static IQueryable<ThreadAwaitingStateRow> OwedADerivation(
+        IQueryable<StoredEmailEntity> emails,
+        IQueryable<EmailThreadStateEntity> states,
+        Guid survivingThreadId,
+        Guid userId,
+        string mailboxAccountId,
+        IReadOnlyList<MailFolderIdentity> embeddedFolders,
+        DerivedWorkAdmissionTerms terms) =>
+        StoredThreadStateStore.Awaiting(
+            StoredThreadStateStore.Selecting(
+                emails.Where(email => email.EmailThreadId == survivingThreadId),
+                userId,
+                mailboxAccountId,
+                embeddedFolders,
+                terms),
+            states.Where(state => state.EmailThreadId == survivingThreadId));
 
     /// <summary>Narrows one conversation's messages to the mail the scope admits.</summary>
     /// <remarks>
@@ -103,6 +160,8 @@ internal sealed class StoredThreadStateReader(MailFathomDbContext dbContext) : I
             scope);
 
     private sealed record StoredThreadStateRow(
+        Guid UserId,
+        string MailboxAccountId,
         ThreadStateCoverage Coverage,
         DateTimeOffset DerivedAt,
         int DerivedFromMessageCount,

--- a/backend/tests/AI.UnitTests/ThreadStates/ThreadStateReadingTests.cs
+++ b/backend/tests/AI.UnitTests/ThreadStates/ThreadStateReadingTests.cs
@@ -108,7 +108,7 @@ public sealed class ThreadStateReadingTests
         var written = string.Join(
             ',',
             Enumerable
-                .Range(0, ThreadStateReading.MaximumEntriesPerAspect + 4)
+                .Range(0, EmailThreadState.MaximumEntriesPerAspect + 4)
                 .Select(static ordinal => $$"""{ "text": "Agreement {{ordinal}}.", "messages": [0] }"""));
         var answer = $$"""{ "agreements": [{{written}}] }""";
 
@@ -116,8 +116,7 @@ public sealed class ThreadStateReadingTests
         var entries = ThreadStateReading.Read(answer, Messages());
 
         // Assert
-        Assert.Equal(ThreadStateReading.MaximumEntriesPerAspect, entries.Count);
-        Assert.Equal("Agreement 0.", entries[0].Text);
+        Assert.Equal("Agreement 0.", Assert.Single(entries).Text);
     }
 
     /// <summary>An owner and a date belong to a commitment, so one written on another aspect is dropped rather than refused.</summary>

--- a/backend/tests/Application.UnitTests/Emails/ThreadStates/MailThreadStateBrowserTests.cs
+++ b/backend/tests/Application.UnitTests/Emails/ThreadStates/MailThreadStateBrowserTests.cs
@@ -46,6 +46,35 @@ public sealed class MailThreadStateBrowserTests
     }
 
     /// <summary>
+    /// A state recorded while three statements of an aspect were kept is read as the first of each aspect, which is the
+    /// one the derivation ranked most important, rather than derived again to arrive there.
+    /// </summary>
+    [Fact]
+    public async Task ReadStateAsync_AStoredStateHoldingThreeStatementsOfOneAspect_AnswersWithTheFirstOfEachAspect()
+    {
+        // Arrange
+        var question = ThreadStateEntry.Create(
+            ThreadStateAspect.OpenQuestion,
+            "Whether the yard can be spared on the ninth.",
+            [StoredEmailId.Create(Guid.CreateVersion7())]);
+        var stored = State(
+        [
+            Agreement("The response time stays at two hours."),
+            Agreement("The fixings are inside the figure."),
+            Agreement("Delivery is on the ninth."),
+            question,
+        ]);
+        var browser = CreateBrowser(ReaderReturning(stored));
+
+        // Act
+        var state = await browser.ReadStateAsync(Conversation, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(state);
+        Assert.Equal([stored.Entries[0], question], state.Entries);
+    }
+
+    /// <summary>
     /// A conversation this deployment has derived nothing about is an absence a screen draws, so the read answers with
     /// nothing rather than raising anything a caller would have to catch.
     /// </summary>
@@ -158,7 +187,8 @@ public sealed class MailThreadStateBrowserTests
             ThreadStateCoverage.WholeThread,
             entries,
             new ThreadStateRevision(2, new DateTimeOffset(2026, 9, 7, 16, 0, 0, TimeSpan.Zero)),
-            new DateTimeOffset(2026, 9, 8, 9, 0, 0, TimeSpan.Zero));
+            new DateTimeOffset(2026, 9, 8, 9, 0, 0, TimeSpan.Zero),
+            IsCurrent: true);
 
     private static ThreadStateEntry Agreement(string text) =>
         ThreadStateEntry.Create(

--- a/backend/tests/Host.UnitTests/Api/ClientMailThreadStateEndpointTests.cs
+++ b/backend/tests/Host.UnitTests/Api/ClientMailThreadStateEndpointTests.cs
@@ -72,6 +72,7 @@ public sealed class ClientMailThreadStateEndpointTests
         Assert.Equal(Conversation.Value, block.ThreadId);
         Assert.Equal(nameof(ThreadStateCoverage.WholeThread), block.Coverage);
         Assert.Equal(DerivedAt, block.DerivedAt);
+        Assert.True(block.Current);
         Assert.Equal(
             [nameof(ThreadStateAspect.Agreement), nameof(ThreadStateAspect.Commitment)],
             block.Entries.Select(static entry => entry.Aspect));
@@ -124,7 +125,8 @@ public sealed class ClientMailThreadStateEndpointTests
             ThreadStateCoverage.ThreadTooLarge,
             [],
             new ThreadStateRevision(400, null),
-            DerivedAt));
+            DerivedAt,
+            IsCurrent: true));
 
         // Act
         var result = await this.ReadAsync();
@@ -134,6 +136,54 @@ public sealed class ClientMailThreadStateEndpointTests
 
         Assert.Equal(nameof(ThreadStateCoverage.ThreadTooLarge), block!.Coverage);
         Assert.Empty(block.Entries);
+    }
+
+    /// <summary>
+    /// A state recorded while three statements of an aspect were kept is published as the first of them, which is the
+    /// one the derivation ranked most important, rather than as a row of cards the design does not draw.
+    /// </summary>
+    [Fact]
+    public async Task ReadStateAsync_AStoredStateHoldingThreeStatementsOfOneAspect_PublishesTheFirst()
+    {
+        // Arrange
+        this.Holding(State(
+        [
+            ThreadStateEntry.Create(ThreadStateAspect.Agreement, "The response time stays at two hours.", [FirstMessage]),
+            ThreadStateEntry.Create(ThreadStateAspect.Agreement, "The fixings are inside the figure.", [FirstMessage]),
+            ThreadStateEntry.Create(ThreadStateAspect.Agreement, "Delivery is on the ninth.", [SecondMessage]),
+            ThreadStateEntry.Create(ThreadStateAspect.OpenQuestion, "Whether the yard is free.", [SecondMessage]),
+        ]));
+
+        // Act
+        var result = await this.ReadAsync();
+
+        // Assert
+        var block = Assert.IsType<Ok<ClientMailThreadStateResponse>>(result.Result).Value;
+
+        Assert.Equal(
+            ["The response time stays at two hours.", "Whether the yard is free."],
+            block!.Entries.Select(static entry => entry.Text));
+    }
+
+    /// <summary>
+    /// A message joined the conversation after its state was derived, so the reader reports the state as no longer
+    /// describing it and the route says so rather than publishing the block as the conversation's current one.
+    /// </summary>
+    [Fact]
+    public async Task ReadStateAsync_AMessageJoinedTheConversationSinceTheStateWasDerived_AnswersThatItIsNotCurrent()
+    {
+        // Arrange
+        var derivedBeforeTheReply = State(
+            [ThreadStateEntry.Create(ThreadStateAspect.Agreement, "The response time stays at two hours.", [FirstMessage])]);
+        this.Holding(derivedBeforeTheReply with { IsCurrent = false });
+
+        // Act
+        var result = await this.ReadAsync();
+
+        // Assert
+        var block = Assert.IsType<Ok<ClientMailThreadStateResponse>>(result.Result).Value;
+
+        Assert.False(block!.Current);
     }
 
     /// <summary>
@@ -180,7 +230,8 @@ public sealed class ClientMailThreadStateEndpointTests
             ThreadStateCoverage.WholeThread,
             entries,
             new ThreadStateRevision(2, new DateTimeOffset(2026, 9, 7, 16, 0, 0, TimeSpan.Zero)),
-            DerivedAt);
+            DerivedAt,
+            IsCurrent: true);
 
     private void Holding(EmailThreadState? state) =>
         this.stateReader

--- a/backend/tests/Infrastructure.UnitTests/Persistence/ThreadStates/ThreadAwaitingStateQueryTests.cs
+++ b/backend/tests/Infrastructure.UnitTests/Persistence/ThreadStates/ThreadAwaitingStateQueryTests.cs
@@ -67,4 +67,35 @@ public sealed class ThreadAwaitingStateQueryTests
         Assert.True(ordering >= 0, sql);
         Assert.True(bound > ordering, sql);
     }
+
+    /// <summary>
+    /// The read of one conversation's state asks the pass's own question of that conversation alone, so the grouping and
+    /// the comparison reach the server narrowed to it rather than as a scan of the account.
+    /// </summary>
+    [Fact]
+    public void OwedADerivation_TheQuestionOneReadAsksOfItsConversation_TranslatesToTheSelectionNarrowedToIt()
+    {
+        // Arrange
+        var options = MailFathomDbContextDesignTimeFactory.BuildOptions(
+            orchestratedConnectionString: null,
+            designTimeConnectionString: null);
+        using var context = new MailFathomDbContext(options, PostgresTextSearchConfiguration.Default);
+
+        // Act
+        var sql = StoredThreadStateReader.OwedADerivation(
+                context.StoredEmails.AsNoTracking(),
+                context.EmailThreadStates.AsNoTracking(),
+                Guid.CreateVersion7(),
+                Guid.CreateVersion7(),
+                "work",
+                [new MailFolderIdentity(MailAccountId.Create("work"), MailFolderAlias.Create("INBOX"))],
+                new DerivedWorkAdmissionTerms([], [], [], Now))
+            .ToQueryString();
+
+        // Assert
+        Assert.Contains("GROUP BY", sql, StringComparison.Ordinal);
+        Assert.Contains("LEFT JOIN", sql, StringComparison.Ordinal);
+        Assert.Contains("\"DerivedFromMessageCount\"", sql, StringComparison.Ordinal);
+        Assert.Contains("\"DerivedFromLatestArrival\"", sql, StringComparison.Ordinal);
+    }
 }

--- a/backend/tests/PublicSurfaces.UnitTests/http-api-contract.json
+++ b/backend/tests/PublicSurfaces.UnitTests/http-api-contract.json
@@ -2412,6 +2412,9 @@
           "coverage": {
             "type": "string"
           },
+          "current": {
+            "type": "boolean"
+          },
           "derivedAt": {
             "format": "date-time",
             "type": "string"
@@ -2431,6 +2434,7 @@
           "threadId",
           "coverage",
           "derivedAt",
+          "current",
           "entries"
         ],
         "type": "object"

--- a/docs/features/thread-state.md
+++ b/docs/features/thread-state.md
@@ -32,8 +32,10 @@ somebody scanning for what they still owe should not have to find it among what 
 supports, and no reader could tell them apart. The sources name messages in the same terms the Discover run's citations
 name them, so the same reader resolves both: following one is opening a message the mailbox already holds.
 
-At most three statements are kept per aspect. The block is a row of cards a reader glances at, and a fourth agreement
-is a paragraph nobody reads in the place a glance was promised.
+**One statement is kept per aspect**: the first, because the derivation is asked to put the most important first. The
+block is a row of cards a reader glances at, one line under each label, and a second agreement beside the first is a
+paragraph nobody reads in the place a glance was promised. A state recorded while more were kept is read as the first
+statement of each aspect rather than derived again, which is what it would have led with anyway.
 
 ## Nothing to say, and too much to read
 
@@ -159,7 +161,15 @@ A statement is a sentence derived from somebody's mail and inherits its classifi
 ## What a client reads
 
 `GET /api/client/threads/{threadId}/state` answers with the block: the conversation, the coverage, when it was derived,
-and the statements with their sources.
+whether it is current, and the statements with their sources.
+
+**A stale state is never published as current.** Between a reply arriving and the next pass reaching the conversation
+— which is indefinite while the answering allowance is spent — the stored record describes a conversation that no
+longer exists, and its newest message may have withdrawn exactly what the block says. So `current` is `false` whenever
+the conversation's shape no longer matches the one the state was derived from, and it is decided by the same selection
+and comparison the pass uses to find what is owed rather than by a second one: a read calls a state current exactly
+when the next pass would leave the conversation alone. A client draws no statement of a state that is not current, in
+any composition, and says in the block that the conversation has changed since.
 
 **Absence is a `404`, and it is a state rather than a failure.** A deployment that never turned the derivation on, one
 that has not reached this conversation yet, and a conversation this caller does not hold all answer the same way, and a

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -1001,6 +1001,26 @@ UUID matches no route and is the same `404`. A credential whose grant does not c
 **The conversation is served from the local copy.** Nothing here contacts a mail server, so no screen waits on IMAP, and
 opening a thread cannot set the remote `\Seen` flag.
 
+### The conversation state route
+
+`GET /api/client/threads/{threadId}/state` answers with where one conversation stands, as
+[a conversation's state](../features/thread-state.md) describes: `threadId`, `coverage` (`WholeThread` or
+`ThreadTooLarge`, the second with no entries), `derivedAt`, `current`, and `entries`. Each entry carries its `aspect`,
+its `text`, the `owedBy` and `dueAt` only a commitment may carry, and its `sources` as citation targets the
+[citation route](#the-citation-route) resolves.
+
+**`entries` holds at most one statement per aspect**, in aspect order, and a state recorded while more were kept
+answers with the first of each.
+
+**`current` is `false` once the conversation has changed since the state was derived** — a message joined it or left
+it — decided by the comparison the derivation pass uses to find what it owes a new derivation. The record is still
+served, because it is the only record there is, and a client does not draw it as the conversation's current state.
+
+**A conversation with no state is answered `404`**: a deployment that never turned the derivation on, one that has not
+reached this conversation, and a conversation this user does not hold all answer the same way, and none of them is a
+failure. A credential whose grant does not carry `mailfathom.mail.read` is answered `403`. Nothing on this route starts
+a derivation or reaches a provider.
+
 ### The message route
 
 ```http

--- a/frontend/src/Client.App/src/localization/en.ts
+++ b/frontend/src/Client.App/src/localization/en.ts
@@ -836,6 +836,8 @@ export const en = {
     'threadState.tooLarge':
         'This conversation is longer than a state can be derived from in one go, so none was derived rather than one drawn from part of it.',
     'threadState.none': 'Nothing has been derived about where this conversation stands.',
+    'threadState.stale':
+        'This conversation has changed since where it stands was last derived, so that reading is held back until it is derived again.',
     'threadState.offline':
         'This machine is offline, so where this conversation stands cannot be read. It is read once the network comes back.',
 

--- a/frontend/src/Client.App/src/localization/pl.ts
+++ b/frontend/src/Client.App/src/localization/pl.ts
@@ -841,6 +841,8 @@ export const pl: Catalogue = {
     'threadState.tooLarge':
         'Ta rozmowa jest dłuższa, niż obejmuje jedno wyprowadzenie stanu, więc żaden nie powstał — zamiast takiego, który opisywałby tylko jej część.',
     'threadState.none': 'Nie wyprowadzono jeszcze niczego o tym, na czym stanęła ta rozmowa.',
+    'threadState.stale':
+        'Ta rozmowa zmieniła się od ostatniego wyprowadzenia tego, na czym stanęła, więc tamten odczyt czeka na ponowne wyprowadzenie.',
     'threadState.offline':
         'Ta maszyna jest bez sieci, więc nie można odczytać, na czym stanęła ta rozmowa. Odczyta się, gdy sieć wróci.',
 

--- a/frontend/src/Client.App/src/thread/Thread.test.tsx
+++ b/frontend/src/Client.App/src/thread/Thread.test.tsx
@@ -855,6 +855,7 @@ describe('Thread', () => {
                         threadId,
                         coverage: 'WholeThread',
                         derivedAt: '2026-09-08T09:00:00+00:00',
+                        current: true,
                         entries: [
                             {
                                 aspect: 'Agreement',

--- a/frontend/src/Client.App/src/thread/ThreadState.test.tsx
+++ b/frontend/src/Client.App/src/thread/ThreadState.test.tsx
@@ -85,9 +85,16 @@ function entry(overrides: Partial<MailThreadStateEntry> = {}): MailThreadStateEn
     };
 }
 
-function stateOf(entries: readonly MailThreadStateEntry[], coverage: MailThreadState['coverage'] = 'WholeThread') {
-    return { threadId: 'a-conversation', coverage, derivedAt: '2026-09-08T09:00:00+00:00', entries };
+function stateOf(
+    entries: readonly MailThreadStateEntry[],
+    coverage: MailThreadState['coverage'] = 'WholeThread',
+    current = true,
+): MailThreadState {
+    return { threadId: 'a-conversation', coverage, derivedAt: '2026-09-08T09:00:00+00:00', current, entries };
 }
+
+const staleSentence =
+    'This conversation has changed since where it stands was last derived, so that reading is held back until it is derived again.';
 
 function drawing(
     state: MailThreadState | null,
@@ -252,6 +259,33 @@ describe('ThreadState', () => {
         expect(screen.getByRole('status').textContent).toBe(
             'Nothing has been derived about where this conversation stands.',
         );
+    });
+
+    // A message the conversation gained since the state was derived may have withdrawn exactly what the block says, so
+    // no composition draws the statements as though they were still where the conversation stands.
+    it.each([
+        ['the desktop', theDesktopComposition],
+        ['the tablet', theTabletComposition],
+        ['a phone', () => undefined],
+    ])(
+        'says the conversation changed, rather than drawing a state it has moved past, in %s composition',
+        (_, width) => {
+            width();
+
+            render(drawing(stateOf([entry()], 'WholeThread', false)));
+
+            expect(screen.getByRole('status').textContent).toBe(staleSentence);
+            expect(screen.queryByText('The response time stays at two hours.')).toBeNull();
+        },
+    );
+
+    it('draws the statements of a state that still describes the conversation', () => {
+        theDesktopComposition();
+
+        render(drawing(stateOf([entry()], 'WholeThread', true)));
+
+        expect(screen.getByText('The response time stays at two hours.')).toBeDefined();
+        expect(screen.queryByText(staleSentence)).toBeNull();
     });
 
     it('says a conversation too long to derive a state for, rather than drawing one from part of it', () => {

--- a/frontend/src/Client.App/src/thread/ThreadState.tsx
+++ b/frontend/src/Client.App/src/thread/ThreadState.tsx
@@ -27,6 +27,10 @@ import { sourceOf, type ThreadStateSource } from './threadStateSources';
 // Absence is a state rather than a failure, and it is the common one: a deployment that never turned the derivation
 // on and one that has not reached this conversation yet both answer with nothing at all. So a conversation with no
 // state says so in a sentence and keeps its own chrome, rather than drawing an error somebody would try to act on.
+//
+// A state the conversation has moved past since it was derived is drawn the same way, in every composition. The
+// design draws no such state, and its statements may be exactly what the newest message withdrew — so the block says
+// the conversation changed rather than drawing a reading nothing marks as out of date.
 
 const aspectLabels: Readonly<Record<MailThreadStateAspect, MessageKey>> = {
     Agreement: 'threadState.agreement',
@@ -41,6 +45,10 @@ function nothingDrawn(reading: boolean, online: boolean, state: MailThreadState 
         // nothing about it once the messages are in hand: the conversation stands on the screen and only this block is
         // waiting. So the block says which of the two it is rather than looking busy for as long as the network is out.
         return online ? 'threadState.reading' : 'threadState.offline';
+    }
+
+    if (state?.current === false) {
+        return 'threadState.stale';
     }
 
     return state?.coverage === 'ThreadTooLarge' ? 'threadState.tooLarge' : 'threadState.none';
@@ -72,10 +80,11 @@ export function ThreadState({
     const wideWorkspace = useWideWorkspace();
     const desktop = useDesktopComposition();
 
-    const entries = state?.entries ?? [];
+    const entries = state?.current === true ? state.entries : [];
 
-    // Nothing to draw is three different sentences and one shape: a block still being read, a conversation too long
-    // for a state to be derived from in one go, and a conversation nothing has been derived about at all.
+    // Nothing to draw is four different sentences and one shape: a block still being read, a state the conversation
+    // has moved past, a conversation too long for a state to be derived from in one go, and a conversation nothing has
+    // been derived about at all.
     if (entries.length === 0) {
         return (
             <section

--- a/frontend/src/Client.Backend/src/mailThreadState.test.ts
+++ b/frontend/src/Client.Backend/src/mailThreadState.test.ts
@@ -31,6 +31,7 @@ function bodyOf(state: Readonly<Record<string, unknown>> = {}): string {
         threadId,
         coverage: 'WholeThread',
         derivedAt: '2026-09-08T09:00:00+00:00',
+        current: true,
         entries: [agreement],
         ...state,
     });
@@ -86,9 +87,22 @@ describe('readMailThreadState', () => {
                 threadId,
                 coverage: 'WholeThread',
                 derivedAt: '2026-09-08T09:00:00+00:00',
+                current: true,
                 entries: [agreement, commitment],
             },
         });
+    });
+
+    // The conversation gained or lost a message after the state was derived, and the deployment says so rather than a
+    // client having to work it out from anything else the block carries.
+    it('reads a state the conversation has changed since as one that is not current', async () => {
+        const answered = await readMailThreadState(
+            session,
+            answering({ status: 200, body: bodyOf({ current: false }) }),
+            threadId,
+        );
+
+        expect(answered.outcome === 'read' && answered.value?.current).toBe(false);
     });
 
     it('reaches the state on the client surface of the deployment it signed in to', async () => {
@@ -158,6 +172,8 @@ describe('readMailThreadState', () => {
         ['a statement saying nothing', { entries: [{ ...agreement, text: '' }] }],
         ['a coverage this client cannot draw', { coverage: 'Partial' }],
         ['a derivation instant nothing can date', { derivedAt: 'the other day' }],
+        ['no word on whether it is current', { current: undefined }],
+        ['a currency that is not a yes or a no', { current: 'yes' }],
         ['a due date nothing can date', { entries: [{ ...agreement, aspect: 'Commitment', dueAt: 'soon' }] }],
         ['a statement that is not a record at all', { entries: ['settled'] }],
         ['an owner that is not a name', { entries: [{ ...agreement, aspect: 'Commitment', owedBy: 7 }] }],

--- a/frontend/src/Client.Backend/src/mailThreadState.ts
+++ b/frontend/src/Client.Backend/src/mailThreadState.ts
@@ -70,7 +70,13 @@ export interface MailThreadState {
     /** When the state was derived, which is what a screen says the block is as of. */
     readonly derivedAt: string;
 
-    /** The statements, in aspect order and within an aspect in the order the derivation put them. */
+    /**
+     * Whether the state was derived from the conversation as it stands now. `false` once a message has joined or left
+     * it since, and a screen never draws such a state as the conversation's current one.
+     */
+    readonly current: boolean;
+
+    /** The statements, at most one of each aspect, in aspect order. */
     readonly entries: readonly MailThreadStateEntry[];
 }
 
@@ -147,14 +153,15 @@ function parseState(body: string): MailThreadState | null {
     const threadId = record['threadId'];
     const coverage = record['coverage'];
     const derivedAt = record['derivedAt'];
+    const current = record['current'];
 
-    if (!isIdentity(threadId) || !isCoverage(coverage) || !isInstant(derivedAt)) {
+    if (!isIdentity(threadId) || !isCoverage(coverage) || !isInstant(derivedAt) || typeof current !== 'boolean') {
         return null;
     }
 
     const entries = parseEntries(record['entries']);
 
-    return entries === null ? null : { threadId, coverage, derivedAt, entries };
+    return entries === null ? null : { threadId, coverage, derivedAt, current, entries };
 }
 
 function parseEntries(value: unknown): readonly MailThreadStateEntry[] | null {

--- a/frontend/tests/fixtures/mail.ts
+++ b/frontend/tests/fixtures/mail.ts
@@ -340,6 +340,7 @@ export const conversationState = {
     threadId: conversationId,
     coverage: 'WholeThread',
     derivedAt: '2026-08-31T08:20:00+00:00',
+    current: true,
     entries: [
         {
             aspect: 'Agreement',


### PR DESCRIPTION
## Summary

A conversation's state is now drawn the way the design draws it — one statement under each label — and a state the conversation has moved past is never drawn as current.

- **One statement per aspect.** `EmailThreadState.MaximumEntriesPerAspect` is `1` and is the single constant the derivation's instruction, the reading of the agent's answer, and the read path all use. The agent is asked for at most one entry per array, the most important first, so nothing is stored that no screen draws.
- **Old records are read, not re-derived.** A state stored while three per aspect were kept is read as the first statement of each aspect (`EmailThreadState.Leading()`, applied by `MailThreadStateBrowser`). Its statements were stored in the order the derivation ranked them, so the first is the one it ranked most important; re-deriving every stored conversation would spend the answering allowance to arrive there.
- **Staleness is decided by the pass's own comparison.** `StoredThreadStateReader.OwedADerivation` composes `StoredThreadStateStore.Selecting` and `StoredThreadStateStore.Awaiting` — the exact selection and comparison the derivation pass uses to find what it owes — narrowed to the one conversation. A read calls a state current exactly when the next pass would leave the conversation alone; there is no second comparison to drift from the first.
- **`GET /api/client/threads/{threadId}/state` carries `current`.** `false` once a message has joined or left the conversation since the state was derived.
- **The client never draws a stale state as current.** In every composition — desktop cards, tablet chips, phone bar and sheet — a state with `current: false` draws none of its statements and the block says the conversation has changed since, in the same sentence shape the block already uses for *reading*, *offline*, *too large*, and *nothing derived*.

## Public surfaces

- **HTTP API (additive):** `ClientMailThreadStateResponse` gains a required boolean `current`; `http-api-contract.json` is regenerated. A client older than this change ignores the field; the client in this change refuses a body without it, which is only reachable against a deployment older than this change, and the two ship together.
- MCP tool contract, configuration schema, database schema, deployment contract: unchanged. No migration — old rows are narrowed on read.

## The design at implementation time

Read from the design mirror, which was current against the design project when the work started. The design draws one card per aspect (label + value), which is what this change implements. **The design draws no state for a conversation-state block that has fallen behind its conversation.** Rather than invent one, the client draws that case in the block's existing status-sentence shape, with no statements; the gap is named to the owner, and the drawing follows the design once it has one.

The resting compositions do not change visually (the corpus already holds one statement per aspect), so there is no design/client pair to hold side by side for this change; the one new visual state has no design counterpart to compare against.

## Tests

- `ClientMailThreadStateEndpointTests`: a stored state holding three statements of one aspect publishes the first; a state the conversation changed since answers `current: false`; a current state answers `current: true`.
- `MailThreadStateBrowserTests`: three statements of one aspect are read as the first of each aspect.
- `ThreadAwaitingStateQueryTests`: the read's one-conversation question translates to the grouped, left-joined comparison the pass runs.
- `ThreadStateReadingTests`: more statements of one aspect than the block holds keeps the leading one.
- `ThreadState.test.tsx`: a stale state is drawn as the changed-since sentence, with no statement, in the desktop, tablet, and phone compositions; a current state draws its statements.
- `mailThreadState.test.ts`: `current: false` is read; a body with no `current`, or a non-boolean one, is refused.

The reader itself is `[RequiresIntegrationCoverage]`; its behaviour against PostgreSQL (a reply joining the conversation turning `current` false) is the integration suite's, which this change did not run.

## Verification

- `scripts/verify-fast.sh`: passed end to end on the rebased branch (Release build, the reached service suites, client lint, type check, suite, and formatting). Its formatting pass re-wrapped one `it.each` in `ThreadState.test.tsx`, so it recorded nothing; that file alone was then re-checked with ESLint, Prettier, and the `thread/` suite (99 passed). Two re-runs of the whole gate were stopped by the host running low on memory, not by a failure.
- `scripts/test-agent-workflow.sh`: 318 passed, 0 failed (includes the corpus-against-contract comparison).
- `$check-docs-licenses`: Docs pass, Changelog n/a, Licenses n/a.

Closes #1866
