### PR TITLE
[#1873] Remove the emptied MailSynchronization:Accounts from the shipped appsettings.json, so the image starts again

### DIFF
--- a/backend/src/Host/Configuration/ComposedSettings.cs
+++ b/backend/src/Host/Configuration/ComposedSettings.cs
@@ -117,7 +117,7 @@ internal static class ComposedSettings
                     : []),
             .. Refusal<ServedMailUsers>(
                 WithdrawnDeploymentMailAccountsSection,
-                configuration.GetSection(WithdrawnDeploymentMailAccountsSection).GetChildren().Any()
+                configuration.GetSection(WithdrawnDeploymentMailAccountsSection).Exists()
                     ?
                     [
                         $"{WithdrawnDeploymentMailAccountsSection} is no longer read: a mail account belongs to the user who owns it, and this deployment reads every one of them from that user's own record. Nothing imports what the section declared. Declare each account with 'mfctl user account add' in the record of the user this deployment already serves, keeping its AccountId so the mail already stored under it stays that mailbox's, and record anybody else with 'mfctl user add' first; then remove the section from your configuration.",

--- a/backend/src/Host/appsettings.json
+++ b/backend/src/Host/appsettings.json
@@ -15,7 +15,6 @@
     "WriteConnectionIdlePeriod": "00:02:00",
     "MaxMutationAttempts": 5,
     "ShutdownDrainTimeout": "00:00:10",
-    "Accounts": [],
     "MaxMetadataBatchSize": 100,
     "MaxRawMimeBytes": 26214400,
     "MaxMetadataBatchesPerRun": 10,

--- a/backend/tests/Host.UnitTests/Configuration/ComposedSettingsWithdrawnUserAndMailboxSectionTests.cs
+++ b/backend/tests/Host.UnitTests/Configuration/ComposedSettingsWithdrawnUserAndMailboxSectionTests.cs
@@ -62,11 +62,13 @@ public sealed class ComposedSettingsWithdrawnUserAndMailboxSectionTests
     }
 
     /// <summary>
-    /// An upgraded file whose accounts were emptied rather than deleted declares no mailbox, so it stops no start. It is
-    /// read from JSON because an empty array is a shape only a file can state.
+    /// An upgraded file whose accounts were emptied rather than deleted still names a key the strict mail binding has no
+    /// property for, so the start stops either way; refusing it here is what makes the sentence naming the section,
+    /// rather than the binder's report of an unknown key, the one the operator reads. It is read from JSON because an
+    /// empty array is a shape only a file can state.
     /// </summary>
     [Fact]
-    public void FindWithdrawnUserAndMailboxSectionRefusals_AMailSectionCarryingAnEmptyAccountList_IsNotRefused()
+    public void FindWithdrawnUserAndMailboxSectionRefusals_AMailSectionCarryingAnEmptyAccountList_IsRefusedNamingTheSection()
     {
         // Arrange
         var configuration = new ConfigurationBuilder()
@@ -78,7 +80,8 @@ public sealed class ComposedSettingsWithdrawnUserAndMailboxSectionTests
         var refusals = ComposedSettings.FindWithdrawnUserAndMailboxSectionRefusals(configuration);
 
         // Assert
-        Assert.Empty(refusals);
+        var refusal = Assert.Single(refusals);
+        Assert.Equal("MailSynchronization:Accounts", refusal.SectionName);
     }
 
     /// <summary>

--- a/backend/tests/Host.UnitTests/Host.UnitTests.csproj
+++ b/backend/tests/Host.UnitTests/Host.UnitTests.csproj
@@ -64,4 +64,10 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Host\Host.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- The defaults every image ships, carried as a resource so the composition test layers the real file without
+         reaching the file system. -->
+    <EmbeddedResource Include="..\..\src\Host\appsettings.json" LogicalName="MailFathom.Host.appsettings.json" />
+  </ItemGroup>
 </Project>

--- a/backend/tests/Host.UnitTests/HostCompositionTests.cs
+++ b/backend/tests/Host.UnitTests/HostCompositionTests.cs
@@ -316,6 +316,46 @@ public sealed class HostCompositionTests
         var services = ComposeServices(shape);
 
         // Act
+        var unbuildable = await ReportUnbuildableAsync(services);
+
+        // Assert
+        // Reported together rather than through Assert.Empty, which abbreviates a collection: one missing registration
+        // usually leaves several services unbuildable, and the reader needs the one that is actually absent.
+        if (unbuildable.Length > 0)
+        {
+            Assert.Fail(
+                $"The '{shape}' deployment registered services it cannot build:{Environment.NewLine}  "
+                + string.Join($"{Environment.NewLine}  ", unbuildable));
+        }
+    }
+
+    /// <summary>
+    /// The host's own <c>appsettings.json</c> travels in every image beneath whatever an operator states, so a key in it
+    /// that a strict binding has no property for stops every deployment before the operator's configuration is read.
+    /// Every other composition here clears that layer away, which is why this one puts it back.
+    /// </summary>
+    [Fact]
+    public async Task Compose_OverTheShippedDefaults_ResolvesEveryServiceItRegistered()
+    {
+        // Arrange
+        var builder = ConfiguredBuilder("probes only", overTheShippedDefaults: true);
+        HostComposition.Compose(builder);
+
+        // Act
+        var unbuildable = await ReportUnbuildableAsync(builder.Services);
+
+        // Assert
+        if (unbuildable.Length > 0)
+        {
+            Assert.Fail(
+                $"The shipped defaults compose services that cannot be built:{Environment.NewLine}  "
+                + string.Join($"{Environment.NewLine}  ", unbuildable));
+        }
+    }
+
+    /// <summary>Resolves every service a composition registered, returning what could not be built.</summary>
+    private static async Task<string[]> ReportUnbuildableAsync(IServiceCollection services)
+    {
         // Released asynchronously, because the graph holds connection pools that implement only IAsyncDisposable and
         // the container refuses to release one synchronously.
         await using var provider = services.BuildServiceProvider(new ServiceProviderOptions
@@ -336,7 +376,7 @@ public sealed class HostCompositionTests
             await starting.StartingAsync(TestContext.Current.CancellationToken);
         }
 
-        string[] unbuildable =
+        return
         [
             .. services
                 .Where(IsWorthResolving)
@@ -360,16 +400,6 @@ public sealed class HostCompositionTests
                 .Select(registration => ReportBuilding(scope.ServiceProvider, registration))
                 .OfType<string>(),
         ];
-
-        // Assert
-        // Reported together rather than through Assert.Empty, which abbreviates a collection: one missing registration
-        // usually leaves several services unbuildable, and the reader needs the one that is actually absent.
-        if (unbuildable.Length > 0)
-        {
-            Assert.Fail(
-                $"The '{shape}' deployment registered services it cannot build:{Environment.NewLine}  "
-                + string.Join($"{Environment.NewLine}  ", unbuildable));
-        }
     }
 
     [Fact]
@@ -840,11 +870,12 @@ public sealed class HostCompositionTests
     /// The configuration sources the framework supplies are cleared rather than layered under, because they are this
     /// machine's: the host's own <c>appsettings.json</c> travels into the test output through the project reference, and
     /// an environment variable set for a developer's run would otherwise decide what a shape composes. What each shape
-    /// states is then the whole of what the composition reads.
+    /// states is then the whole of what the composition reads, beside the shipped defaults where a test asks for them.
     /// </remarks>
     private static WebApplicationBuilder ConfiguredBuilder(
         string shape,
-        IReadOnlyList<KeyValuePair<string, string?>>? beyondTheShape = null)
+        IReadOnlyList<KeyValuePair<string, string?>>? beyondTheShape = null,
+        bool overTheShippedDefaults = false)
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
         {
@@ -853,6 +884,14 @@ public sealed class HostCompositionTests
         });
 
         builder.Configuration.Sources.Clear();
+
+        if (overTheShippedDefaults)
+        {
+            builder.Configuration.AddJsonStream(
+                typeof(HostCompositionTests).Assembly.GetManifestResourceStream("MailFathom.Host.appsettings.json")
+                    ?? throw new InvalidOperationException("The shipped appsettings.json is not embedded in this assembly."));
+        }
+
         builder.Configuration.AddInMemoryCollection([.. Database, .. Shapes[shape], .. beyondTheShape ?? []]);
 
         // The one service this test decides for itself, and it is the framework's rather than MailFathom's: data


### PR DESCRIPTION
Closes #1873

## What was wrong

#1827 withdrew `MailSynchronization:Accounts`, and `MailSynchronizationOptions` is bound with `ErrorOnUnknownConfiguration`. The host's own `backend/src/Host/appsettings.json` still carried `"Accounts": []` in that section. The file ships in every image, so every image since #1827 crash-loops at start with the binder's report:

```
'ErrorOnUnknownConfiguration' was set on the provided BinderOptions, but the following properties were not found on the instance of MailFathom.Host.Configuration.Mail.MailSynchronizationOptions: 'Accounts'
```

Observed on a deployment running `0.8.0-nightly.55`: the host restarted in a loop and never reported ready.

The refusal written for the withdrawn section did not catch it either. `ComposedSettings.FindWithdrawnUserAndMailboxSectionRefusals` asked whether the section had children. An empty array has none, and a unit test asserted that an emptied section is not refused. The strict binder then refused it anyway, a moment later, with a sentence that names neither the replacement nor the commands.

## Why no test caught it

`HostCompositionTests` clears every configuration source before composing, so the shipped `appsettings.json` never reached a composition in any suite that runs on a pull request.

## What changed

- **`appsettings.json`:** the emptied `Accounts` entry is removed.
- **The refusal:** it now fires when the key exists (`Exists()`) rather than when it has children. A file carrying the section in any shape (entries, `[]`, or a blank value) is stopped with the sentence naming the section and the `mfctl` commands. The test that asserted the opposite is replaced. The top-level `Accounts` rule is unchanged, because nothing binds the configuration root strictly.
- **Regression test:** `HostCompositionTests.Compose_OverTheShippedDefaults_ResolvesEveryServiceItRegistered` composes the host over the shipped `appsettings.json` and resolves every registration. The file reaches the test as an embedded resource of `Host.UnitTests`, so the suite still reads no file system. The resolution pass the existing theory runs moved into a helper that both tests share.

## Breaking changes

None. This restores the behaviour #1827 documented in `docs/operations/configuration-sources.md`, which says that a file still carrying `MailSynchronization:Accounts` does not start and that the refusal names the section.

## Operator action

None for a file that never carried the section. A deployment stuck on an image from the nightly that shipped the broken default starts again on the first image built from this change. No configuration edit is needed.
