### PR TITLE
[#1834] Walk an operator's re-derivation under the lease on its scope, so a second segment does not walk it twice

### DIFF
--- a/backend/src/Application/Coordination/IWorkLeaseRunner.cs
+++ b/backend/src/Application/Coordination/IWorkLeaseRunner.cs
@@ -1,0 +1,37 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Coordination;
+
+/// <summary>Runs one piece of work while this replica holds the lease on its scope, and runs nothing while another does.</summary>
+/// <remarks>
+/// <para>
+/// The seam application work takes a lease through, because taking one is more than a claim: the lease has to be renewed
+/// while the work runs, each statement against the store needs a scope of its own so it never shares a persistence
+/// session with the work it guards, and the lease has to be given back once the work ends. All three are the host's, so
+/// the work is handed in rather than the lease handed out, and a caller cannot forget the release.
+/// </para>
+/// <para>
+/// What a caller is promised is <see cref="WorkLease" />'s: one writer, never one runner. The token the work receives is
+/// cancelled on the first renewal that does not complete, strictly before the lease could expire and another replica
+/// take the scope, so work that observes it between steps commits nothing as a second writer.
+/// </para>
+/// </remarks>
+public interface IWorkLeaseRunner
+{
+    /// <summary>Takes the lease on a scope, runs the work under it, and gives the lease back once the work ends.</summary>
+    /// <param name="scope">The unit of work to hold.</param>
+    /// <param name="work">The work, handed a token cancelled with <paramref name="cancellationToken" /> and when the lease is lost.</param>
+    /// <param name="cancellationToken">Cancels the claim and the work.</param>
+    /// <returns><see langword="true" /> when the work ran under the lease; <see langword="false" /> when another holder has the scope or the claim could not be made, in which case the work never started.</returns>
+    /// <exception cref="OperationCanceledException">Thrown when <paramref name="cancellationToken" /> is cancelled while the lease is asked for.</exception>
+    /// <remarks>
+    /// A refusal is not a failure. The work belongs to another holder for now, or the database could not be asked, and in
+    /// both cases the caller asks again on the interval it would have run on.
+    /// </remarks>
+    Task<bool> TryRunUnderLeaseAsync(
+        WorkScope scope,
+        Func<CancellationToken, Task> work,
+        CancellationToken cancellationToken);
+}

--- a/backend/src/Application/Mail/Maintenance/StoredMailRederivationHandler.cs
+++ b/backend/src/Application/Mail/Maintenance/StoredMailRederivationHandler.cs
@@ -2,6 +2,10 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using MailFathom.Application.Coordination;
 using MailFathom.Application.Jobs;
 using MailFathom.Application.Jobs.Execution;
 using MailFathom.Application.Jobs.Payloads;
@@ -25,6 +29,14 @@ namespace MailFathom.Application.Mail.Maintenance;
 /// inside the queue's own bounds instead of turning an execution timeout into a failure of ordinary work.
 /// </para>
 /// <para>
+/// A scope is walked by one segment at a time across every replica, because a segment walks only while it holds the
+/// lease on the scope, as <see href="https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0031-dividing-singleton-work-between-replicas-with-a-leased-scope.md">ADR 0031</see>
+/// decides for an operator-asked re-derivation. Which replica the operator's request reached decides nothing: the
+/// request writes the run down, and whichever segment holds the scope's lease walks it. A segment that finds the scope
+/// held reads no mail and hands the rest on as any stopped segment does, to a successor the queue releases only once a
+/// holder that stopped renewing would have lost the scope.
+/// </para>
+/// <para>
 /// Running it twice with one payload is the same as running it once, which is what the queue asks of every handler. The
 /// pass writes the same reading of the same immutable bytes, and each batch commits the position it reached together
 /// with what it read into the run — so a second attempt that overlapped the first neither loses its progress nor counts
@@ -37,6 +49,9 @@ public sealed class StoredMailRederivationHandler : IJobHandler
     private readonly IStoredMailRederivationRunStore runStore;
     private readonly IJobStore jobs;
     private readonly OptimisticConcurrencyRetryPolicy commitPolicy;
+    private readonly IWorkLeaseRunner leases;
+    private readonly JobExecutionSettings jobSettings;
+    private readonly TimeProvider timeProvider;
     private readonly IStoredMailRederivationTelemetry telemetry;
 
     /// <summary>Initializes the handler from the walk it drives and the record it keeps.</summary>
@@ -44,6 +59,9 @@ public sealed class StoredMailRederivationHandler : IJobHandler
     /// <param name="runStore">Reads whether the scope still has a run to carry, and moves it on to its next segment.</param>
     /// <param name="jobs">Enqueues the segment that carries whatever this attempt did not reach.</param>
     /// <param name="commitPolicy">Advances the segment from a fresh read, resolving a race with an overlapping attempt.</param>
+    /// <param name="leases">Walks the scope only while this segment holds its lease.</param>
+    /// <param name="jobSettings">Names how long a lease runs, which is how long a segment refused the scope defers its successor.</param>
+    /// <param name="timeProvider">Stamps the instant a deferred successor becomes claimable.</param>
     /// <param name="telemetry">Publishes the segment and the passes beneath it.</param>
     /// <exception cref="ArgumentNullException">Thrown when a collaborator is <see langword="null" />.</exception>
     public StoredMailRederivationHandler(
@@ -51,23 +69,81 @@ public sealed class StoredMailRederivationHandler : IJobHandler
         IStoredMailRederivationRunStore runStore,
         IJobStore jobs,
         OptimisticConcurrencyRetryPolicy commitPolicy,
+        IWorkLeaseRunner leases,
+        JobExecutionSettings jobSettings,
+        TimeProvider timeProvider,
         IStoredMailRederivationTelemetry telemetry)
     {
         ArgumentNullException.ThrowIfNull(rederivation);
         ArgumentNullException.ThrowIfNull(runStore);
         ArgumentNullException.ThrowIfNull(jobs);
         ArgumentNullException.ThrowIfNull(commitPolicy);
+        ArgumentNullException.ThrowIfNull(leases);
+        ArgumentNullException.ThrowIfNull(jobSettings);
+        ArgumentNullException.ThrowIfNull(timeProvider);
         ArgumentNullException.ThrowIfNull(telemetry);
 
         this.rederivation = rederivation;
         this.runStore = runStore;
         this.jobs = jobs;
         this.commitPolicy = commitPolicy;
+        this.leases = leases;
+        this.jobSettings = jobSettings;
+        this.timeProvider = timeProvider;
         this.telemetry = telemetry;
+    }
+
+    /// <summary>How one segment's walk ended, which is what decides what it hands on and when.</summary>
+    private enum SegmentWalk
+    {
+        /// <summary>The walk was stopped with mail still ahead of it, and the rest is handed on at once.</summary>
+        Stopped = 0,
+
+        /// <summary>The walk reached the end of its scope, or the run it carried is over, so nothing is handed on.</summary>
+        ReachedEndOfScope = 1,
+
+        /// <summary>Another holder had the scope, so this segment walked nothing and defers the successor it hands on.</summary>
+        HeldElsewhere = 2,
     }
 
     /// <inheritdoc />
     public JobType JobType => JobType.RederiveStoredMail;
+
+    /// <summary>Names the lease one scope's walk is held under.</summary>
+    /// <param name="scope">The account, and the one folder of it, a run walks.</param>
+    /// <returns>The scope every segment of a run over that mail asks for.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="scope" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// <para>
+    /// Keyed exactly as the walk's position is, by the user, the account, and the folder, with <c>*</c> standing for the
+    /// whole account. A walk of one folder and a walk of the whole account are two runs with two positions, so they are
+    /// two leases as well.
+    /// </para>
+    /// <para>
+    /// A scope the lease cannot carry — longer than it leaves room for, or an account identifier holding a control
+    /// character — is named by the SHA-256 digest of the account and the folder instead, for the reason a supervised
+    /// account is: configuration accepts identifiers far longer than a lease scope, and a scope that could not be
+    /// composed would fail every segment of that run.
+    /// </para>
+    /// </remarks>
+    public static WorkScope LeaseScopeOf(StoredMailScope scope)
+    {
+        ArgumentNullException.ThrowIfNull(scope);
+
+        var user = scope.Account.User.Value;
+        var accountId = scope.Account.Id.Value;
+        var folder = scope.Folder?.Value ?? "*";
+        var readableScope = string.Create(CultureInfo.InvariantCulture, $"mail-rederivation/{user}/{accountId}/{folder}");
+
+        if (readableScope.Length <= WorkScope.MaximumLength && !accountId.Any(char.IsControl))
+        {
+            return WorkScope.Create(readableScope);
+        }
+
+        var digest = Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes($"{accountId}/{folder}")));
+
+        return WorkScope.Create(string.Create(CultureInfo.InvariantCulture, $"mail-rederivation/{user}/sha256-{digest}"));
+    }
 
     /// <inheritdoc />
     /// <exception cref="ArgumentException">Thrown when the payload is not the contract this job type names.</exception>
@@ -95,23 +171,62 @@ public sealed class StoredMailRederivationHandler : IJobHandler
 
         using var runScope = this.telemetry.BeginRun(scope.Account.Id, scope.Folder);
 
-        if (await this.WalkAsync(run.RunId, scope, runScope, cancellationToken))
+        var walk = await this.WalkUnderLeaseAsync(run, runScope, cancellationToken);
+
+        if (walk is SegmentWalk.ReachedEndOfScope)
         {
             runScope.ReachedEndOfScope();
 
             return;
         }
 
-        await this.HandOnAsync(run.RunId, scope, named, runScope);
+        DateTimeOffset? successorAvailableAt = walk is SegmentWalk.HeldElsewhere
+            ? this.timeProvider.GetUtcNow() + this.jobSettings.LeaseDuration
+            : null;
+
+        await this.HandOnAsync(run, named, runScope, successorAvailableAt);
+    }
+
+    /// <summary>Walks the scope for as long as this segment holds its lease, and says how the walk ended.</summary>
+    /// <remarks>
+    /// A stop that lands while the lease is still being asked for is a stop like any other rather than a refusal: the
+    /// claim may have been granted before it, and a refusal is what defers the successor, so reading it as one would
+    /// leave a walk nobody else holds idle for a lease's length.
+    /// </remarks>
+    private async Task<SegmentWalk> WalkUnderLeaseAsync(
+        StoredMailRederivationRun run,
+        IStoredMailRederivationRunScope runScope,
+        CancellationToken cancellationToken)
+    {
+        var reachedEndOfScope = false;
+
+        try
+        {
+            var held = await this.leases.TryRunUnderLeaseAsync(
+                LeaseScopeOf(run.Scope),
+                async walkToken => reachedEndOfScope = await this.WalkAsync(run.RunId, run.Scope, runScope, walkToken),
+                cancellationToken);
+
+            if (!held)
+            {
+                return SegmentWalk.HeldElsewhere;
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return SegmentWalk.Stopped;
+        }
+
+        return reachedEndOfScope ? SegmentWalk.ReachedEndOfScope : SegmentWalk.Stopped;
     }
 
     /// <summary>Runs passes until the scope is exhausted, the run ends beneath this attempt, or the attempt is stopped.</summary>
     /// <returns><see langword="true" /> when the run reached the end of its scope and was ended.</returns>
     /// <remarks>
     /// Cancellation is caught rather than raised, because being stopped is how an ordinary segment ends: the executor
-    /// cancels the attempt at the execution timeout, at shutdown, and when the lease has moved on, and none of the
-    /// three says the work failed. What the attempt owes afterwards is the segment that carries the rest, which is why
-    /// the caller reaches it on this path as well.
+    /// cancels the attempt at the execution timeout, at shutdown, and when the job's lease has moved on, the scope's lease
+    /// cancels it on the first renewal that does not complete, and none of those says the work failed. What the attempt
+    /// owes afterwards is the segment that carries the rest, which is why the caller reaches it on this path as well.
     /// </remarks>
     private async Task<bool> WalkAsync(
         StoredMailRederivationRunId runId,
@@ -156,6 +271,10 @@ public sealed class StoredMailRederivationHandler : IJobHandler
     }
 
     /// <summary>Moves the run on to its next segment and enqueues the job that carries it.</summary>
+    /// <param name="found">The run as this segment found it, whose segment count is the one this segment carried.</param>
+    /// <param name="payload">The scope the successor walks.</param>
+    /// <param name="runScope">The segment's report, which records what was handed on.</param>
+    /// <param name="successorAvailableAt">The instant before which the successor may not be claimed, or <see langword="null" /> for at once.</param>
     /// <remarks>
     /// Outside the attempt's cancellation, deliberately, and for the reason the worker records an outcome outside it:
     /// the one moment the rest of a walk most needs to be written down is the shutdown that stopped it, and a write
@@ -167,6 +286,13 @@ public sealed class StoredMailRederivationHandler : IJobHandler
     /// already there.
     /// </para>
     /// <para>
+    /// The run moves on only from the segment this one found it on. Two segments of one run can both stop — one walked
+    /// while the other found the scope held, or an attempt was repeated after it had already handed on — and each would
+    /// otherwise write a successor of its own, which is two chains of segments carrying one walk. The second finds the
+    /// count already moved and enqueues the successor the first wrote down instead: that key is answered with the job
+    /// already there, and where the first segment stopped between its commit and its enqueue, it is what repairs that.
+    /// </para>
+    /// <para>
     /// A run that has ended or been replaced by the time this runs reports the segment as having reached the end of the
     /// scope, exactly as the walk's own mid-loop check reports the same race. There is nothing to hand on and nothing
     /// went wrong, and a segment whose span ended with neither signal would be indistinguishable from one that stopped
@@ -174,18 +300,23 @@ public sealed class StoredMailRederivationHandler : IJobHandler
     /// </para>
     /// </remarks>
     private async Task HandOnAsync(
-        StoredMailRederivationRunId runId,
-        StoredMailScope scope,
+        StoredMailRederivationRun found,
         RederiveStoredMailJobPayload payload,
-        IStoredMailRederivationRunScope runScope)
+        IStoredMailRederivationRunScope runScope,
+        DateTimeOffset? successorAvailableAt)
     {
-        var next = await this.commitPolicy.CommitAsync(
+        var carrying = await this.commitPolicy.CommitAsync(
             async (session, attemptCancellationToken) =>
             {
-                if (await this.runStore.FindAsync(scope, attemptCancellationToken) is not { IsOutstanding: true } run
-                    || run.RunId != runId)
+                if (await this.runStore.FindAsync(found.Scope, attemptCancellationToken) is not { IsOutstanding: true } run
+                    || run.RunId != found.RunId)
                 {
                     return null;
+                }
+
+                if (run.SegmentCount != found.SegmentCount)
+                {
+                    return run;
                 }
 
                 var advanced = run with { SegmentCount = run.SegmentCount + 1 };
@@ -196,19 +327,19 @@ public sealed class StoredMailRederivationHandler : IJobHandler
             },
             CancellationToken.None);
 
-        if (next is null)
+        if (carrying is null)
         {
             runScope.ReachedEndOfScope();
 
             return;
         }
 
-        var enqueued = await this.jobs.EnqueueAsync(
-            JobEnqueueRequest.Create(
-                StoredMailRederivationRequests.KeyOf(next),
-                payload,
-                scope.Account),
-            CancellationToken.None);
+        var key = StoredMailRederivationRequests.KeyOf(carrying);
+        var successor = successorAvailableAt is { } availableAt
+            ? JobEnqueueRequest.CreateAvailableAt(key, payload, found.Scope.Account, availableAt)
+            : JobEnqueueRequest.Create(key, payload, found.Scope.Account);
+
+        var enqueued = await this.jobs.EnqueueAsync(successor, CancellationToken.None);
 
         runScope.HandedOn(enqueued.Outcome is not JobEnqueueOutcome.RefusedAtCapacity);
     }

--- a/backend/src/Application/Spam/Runs/SpamClassificationPass.cs
+++ b/backend/src/Application/Spam/Runs/SpamClassificationPass.cs
@@ -16,7 +16,10 @@ namespace MailFathom.Application.Spam.Runs;
 /// run already has per-account isolation, a jittered backoff, a slot count that stops one account starving another, and
 /// a failure path that defers the account instead of the process; a classification walk needs every one of those and
 /// none of them differently. It follows that only one pass per account is ever in flight, structurally rather than by a
-/// lock — which is the other half of what makes one outstanding run per account mean one walk of one mailbox.
+/// lock of its own — which is the other half of what makes one outstanding run per account mean one walk of one mailbox.
+/// That holds across replicas as well, because an account's run happens only on the replica holding the account's
+/// synchronization lease and a lost hold cancels the pass with the rest of that run: whichever replica an operator's
+/// request reached only wrote the run down, and a second lease for the run would be a second mechanism for one scope.
 /// </para>
 /// <para>
 /// It reaches no mail server for the mail it reads. Every message it scores was committed by an earlier run and is read

--- a/backend/src/Host/HostComposition.cs
+++ b/backend/src/Host/HostComposition.cs
@@ -10,6 +10,7 @@ using MailFathom.Application.Accounts;
 using MailFathom.Application.AiProviders;
 using MailFathom.Application.Configuration;
 using MailFathom.Application.Contacts.Collection;
+using MailFathom.Application.Coordination;
 using MailFathom.Application.EmailContent.Attachments;
 using MailFathom.Application.EmailContent.Move;
 using MailFathom.Application.EmailContent.Release;
@@ -641,6 +642,20 @@ internal static class HostComposition
         // per-scope value, and mapping it onto the application's settings is where the bound options stop being the host's shape.
         builder.Services.AddSingleton(provider =>
             provider.GetRequiredService<IOptions<JobQueueOptions>>().Value.ToExecutionSettings());
+        // The lease a job-carried walk holds its scope under is held on the job's own terms. A segment refused the scope
+        // defers its successor by the job's lease duration, which is long enough for a holder that stopped renewing to
+        // lose the scope only while the two durations are one.
+        builder.Services.AddSingleton<IWorkLeaseRunner>(provider =>
+        {
+            var jobSettings = provider.GetRequiredService<JobExecutionSettings>();
+
+            return new WorkLeaseRunner(
+                provider.GetRequiredService<IServiceScopeFactory>(),
+                provider.GetRequiredService<ILoggerFactory>(),
+                provider.GetRequiredService<TimeProvider>(),
+                jobSettings.LeaseDuration,
+                jobSettings.LeaseRenewalInterval);
+        });
         // How much of this instance background work may take is one statement about the instance, so the capacity and the
         // gate that hands it out are singletons: a per-scope ceiling would be a ceiling per pass, which bounds nothing.
         builder.Services.AddSingleton(provider =>

--- a/backend/src/Host/Hosting/Workers/WorkLeaseRunner.cs
+++ b/backend/src/Host/Hosting/Workers/WorkLeaseRunner.cs
@@ -1,0 +1,82 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Coordination;
+
+namespace MailFathom.Host.Hosting.Workers;
+
+/// <summary>Runs application work under a <see cref="WorkLeaseHold" /> taken, renewed, and given back on one pair of timings.</summary>
+/// <remarks>
+/// The hold is given back only after the work has ended, and before the caller's next step, so work that hands the rest
+/// of itself to a successor leaves the scope free for that successor to take at once.
+/// </remarks>
+internal sealed class WorkLeaseRunner : IWorkLeaseRunner
+{
+    private readonly IServiceScopeFactory scopeFactory;
+    private readonly ILoggerFactory loggerFactory;
+    private readonly TimeProvider timeProvider;
+    private readonly TimeSpan leaseDuration;
+    private readonly TimeSpan renewalInterval;
+
+    /// <summary>Initializes the runner from the timings every hold it takes is held on.</summary>
+    /// <param name="scopeFactory">Creates the scope each statement against the lease store runs in.</param>
+    /// <param name="loggerFactory">Supplies the logger each hold records a lost lease under.</param>
+    /// <param name="timeProvider">Schedules the renewals and bounds how long each may take.</param>
+    /// <param name="leaseDuration">How long a scope is held from each claim or renewal.</param>
+    /// <param name="renewalInterval">How long after the last confirmation the next renewal is sent; shorter than <paramref name="leaseDuration" />.</param>
+    public WorkLeaseRunner(
+        IServiceScopeFactory scopeFactory,
+        ILoggerFactory loggerFactory,
+        TimeProvider timeProvider,
+        TimeSpan leaseDuration,
+        TimeSpan renewalInterval)
+    {
+        this.scopeFactory = scopeFactory;
+        this.loggerFactory = loggerFactory;
+        this.timeProvider = timeProvider;
+        this.leaseDuration = leaseDuration;
+        this.renewalInterval = renewalInterval;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryRunUnderLeaseAsync(
+        WorkScope scope,
+        Func<CancellationToken, Task> work,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(work);
+
+        using var hold = await WorkLeaseHold.TryTakeAsync(
+            scope,
+            this.leaseDuration,
+            this.renewalInterval,
+            this.scopeFactory,
+            this.loggerFactory.CreateLogger<WorkLeaseHold>(),
+            this.timeProvider,
+            cancellationToken);
+
+        if (hold is null)
+        {
+            return false;
+        }
+
+        using var renewalStop = new CancellationTokenSource();
+        using var heldWork = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, hold.Lost);
+
+        var renewals = hold.KeepAsync(renewalStop.Token);
+
+        try
+        {
+            await work(heldWork.Token);
+        }
+        finally
+        {
+            await renewalStop.CancelAsync();
+            await renewals;
+            await hold.ReleaseAsync();
+        }
+
+        return true;
+    }
+}

--- a/backend/src/Host/Hosting/Workers/WorkLeaseRunner.cs
+++ b/backend/src/Host/Hosting/Workers/WorkLeaseRunner.cs
@@ -61,22 +61,13 @@ internal sealed class WorkLeaseRunner : IWorkLeaseRunner
             return false;
         }
 
-        using var renewalStop = new CancellationTokenSource();
-        using var heldWork = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, hold.Lost);
+        return await hold.RunWhileHeldAsync(
+            async heldToken =>
+            {
+                await work(heldToken);
 
-        var renewals = hold.KeepAsync(renewalStop.Token);
-
-        try
-        {
-            await work(heldWork.Token);
-        }
-        finally
-        {
-            await renewalStop.CancelAsync();
-            await renewals;
-            await hold.ReleaseAsync();
-        }
-
-        return true;
+                return true;
+            },
+            cancellationToken);
     }
 }

--- a/backend/tests/Application.UnitTests/Mail/Maintenance/StoredMailRederivationHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/Mail/Maintenance/StoredMailRederivationHandlerTests.cs
@@ -4,10 +4,12 @@
 
 using System.Security.Cryptography;
 using MailFathom.Application.Access;
+using MailFathom.Application.Coordination;
 using MailFathom.Application.EmailContent.Storage;
 using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Jobs;
+using MailFathom.Application.Jobs.Execution;
 using MailFathom.Application.Jobs.Payloads;
 using MailFathom.Application.Mail.Maintenance;
 using MailFathom.Application.Observability;
@@ -43,9 +45,18 @@ public sealed class StoredMailRederivationHandlerTests
 
     private static readonly StoredMailScope WholeAccount = new(MailAccountIdentity.Create(SyntheticMailUser.Deployment, MailAccountId.Create("work")), null);
 
+    private static readonly JobExecutionSettings JobSettings = JobExecutionSettings.Create(
+        batchSize: 10,
+        leaseDuration: TimeSpan.FromMinutes(5),
+        executionTimeout: TimeSpan.FromMinutes(2),
+        maxAttempts: 5,
+        retryBaseDelay: TimeSpan.FromSeconds(30),
+        retryMaxDelay: TimeSpan.FromMinutes(30));
+
     private readonly InMemoryStoredMailRederivationRunStore runs = new();
     private readonly IJobStore jobs = Substitute.For<IJobStore>();
     private readonly RecordingRederivationTelemetry telemetry = new();
+    private readonly ScriptedLeaseRunner leases = new();
     private readonly FakeTimeProvider timeProvider = new(Now);
 
     public StoredMailRederivationHandlerTests() => this.jobs
@@ -147,7 +158,7 @@ public sealed class StoredMailRederivationHandlerTests
 
         using CancellationTokenSource attempt = new();
         var store = new WalkStore(StoredMail(EmailsPerPass + 1), stopAfterBatches: 11, attempt);
-        var handler = this.CreateHandler(store, new RunEndingOnceStopped(this.runs, attempt, Now));
+        var handler = this.CreateHandler(store, new RunMovedOnceStopped(this.runs, attempt, run => run with { EndedAt = Now }));
 
         // Act
         await handler.RunAsync(PayloadOf(WholeAccount), attempt.Token);
@@ -250,31 +261,148 @@ public sealed class StoredMailRederivationHandlerTests
         Assert.Equal(EmailsPerPass + 2, this.runs.Find(WholeAccount)!.RederivedEmailCount);
     }
 
+    /// <summary>A segment walks under the lease its scope is named by, which is the same name on every replica.</summary>
+    [Fact]
+    public async Task RunAsync_ASegmentOfAWholeAccountRun_WalksUnderTheLeaseOfThatScope()
+    {
+        // Arrange
+        this.runs.Arrange(RunOf(segmentCount: 1));
+
+        // Act
+        await this.CreateHandler(new WalkStore(StoredMail(1)))
+            .RunAsync(PayloadOf(WholeAccount), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(
+            [$"mail-rederivation/{SyntheticMailUser.Deployment.Value}/work/*"],
+            [.. this.leases.AskedScopes.Select(scope => scope.Value)]);
+    }
+
+    /// <summary>
+    /// A scope another segment holds is not walked a second time. The segment reads no mail and still hands the rest on,
+    /// because it cannot tell a holder that is walking from one whose replica stopped holding the scope — and it defers
+    /// that successor by a lease's length, so the successor never meets a stopped holder's lease still standing.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_AScopeAnotherSegmentHolds_ReadsNoMailAndDefersItsSuccessorByALease()
+    {
+        // Arrange
+        this.runs.Arrange(RunOf(segmentCount: 1));
+        this.leases.HeldElsewhere = true;
+
+        var store = new WalkStore(StoredMail(3));
+
+        // Act
+        await this.CreateHandler(store).RunAsync(PayloadOf(WholeAccount), TestContext.Current.CancellationToken);
+
+        // Assert
+        var run = this.runs.Find(WholeAccount)!;
+        var enqueued = this.EnqueuedRequests().Single();
+
+        Assert.Empty(store.CandidateScopes);
+        Assert.Equal((0, 2), (run.RederivedEmailCount, run.SegmentCount));
+        Assert.Equal(StoredMailRederivationRequests.KeyOf(run).Value, enqueued.Key.Value);
+        Assert.Equal(Now + JobSettings.LeaseDuration, enqueued.AvailableAt);
+        Assert.Empty(this.telemetry.Runs.Single().Passes);
+    }
+
+    /// <summary>
+    /// A walk whose lease another replica took stops where it is rather than at the end of its pass, and what its
+    /// committed batches re-read stays on the run for the next holder to resume past.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_AWalkThatLosesItsLeaseMidPass_KeepsWhatItCommittedAndHandsTheRestOn()
+    {
+        // Arrange
+        this.runs.Arrange(RunOf(segmentCount: 1));
+
+        using CancellationTokenSource leaseLoss = new();
+        this.leases.Loss = leaseLoss.Token;
+
+        var store = new WalkStore(StoredMail(EmailsPerPass + 1), stopAfterBatches: 3, leaseLoss);
+
+        // Act
+        await this.CreateHandler(store).RunAsync(PayloadOf(WholeAccount), TestContext.Current.CancellationToken);
+
+        // Assert
+        var run = this.runs.Find(WholeAccount)!;
+
+        Assert.True(run.IsOutstanding);
+        Assert.Equal((BatchSize * 2, 2), (run.RederivedEmailCount, run.SegmentCount));
+        Assert.Equal(3, store.CandidateScopes.Count);
+        Assert.Null(this.EnqueuedRequests().Single().AvailableAt);
+    }
+
+    /// <summary>
+    /// Of two segments that stop over one run, only the first writes a successor down. The second finds the run already
+    /// moved past the segment it carried and names that successor rather than a second one, so the walk goes on as one
+    /// chain of segments instead of two walking the same mail by turns.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_ASegmentStoppingAfterAnotherHandedTheRunOn_NamesThatSuccessorRatherThanASecond()
+    {
+        // Arrange
+        this.runs.Arrange(RunOf(segmentCount: 1));
+
+        using CancellationTokenSource attempt = new();
+        var store = new WalkStore(StoredMail(EmailsPerPass + 1), stopAfterBatches: 11, attempt);
+        var handler = this.CreateHandler(
+            store,
+            new RunMovedOnceStopped(this.runs, attempt, run => run with { SegmentCount = 2 }));
+
+        // Act
+        await handler.RunAsync(PayloadOf(WholeAccount), attempt.Token);
+
+        // Assert
+        var run = this.runs.Find(WholeAccount)!;
+
+        Assert.Equal(2, run.SegmentCount);
+        Assert.Equal(StoredMailRederivationRequests.KeyOf(run).Value, this.EnqueuedRequests().Single().Key.Value);
+    }
+
+    /// <summary>An account identifier longer than a lease scope can carry names its lease by a digest rather than failing every segment.</summary>
+    [Fact]
+    public void LeaseScopeOf_AnAccountTooLongForAScopeToCarry_IsNamedByItsDigestWithinTheBound()
+    {
+        // Arrange
+        StoredMailScope longAccount = new(
+            MailAccountIdentity.Create(SyntheticMailUser.Deployment, MailAccountId.Create(new string('a', WorkScope.MaximumLength))),
+            MailFolderAlias.Create("inbox"));
+
+        // Act
+        var scope = StoredMailRederivationHandler.LeaseScopeOf(longAccount);
+
+        // Assert
+        Assert.StartsWith($"mail-rederivation/{SyntheticMailUser.Deployment.Value}/sha256-", scope.Value, StringComparison.Ordinal);
+        Assert.InRange(scope.Value.Length, 1, WorkScope.MaximumLength);
+    }
+
     private static RederiveStoredMailJobPayload PayloadOf(StoredMailScope scope) =>
         RederiveStoredMailJobPayload.For(scope.Account, scope.Folder);
 
-    /// <summary>Ends the scope's run on the first reading taken after the attempt was stopped, and reads through otherwise.</summary>
+    /// <summary>Moves the scope's run on the first reading taken after the attempt was stopped, and reads through otherwise.</summary>
     /// <remarks>
     /// The walk raises the cancellation from the batch that met it, so the next reading of the run is the one the
-    /// segment takes to write down what carries the rest of the scope. Ending it there is the race this covers: the
-    /// walk saw an outstanding run, and by the time the segment wrote, an overlapping attempt had finished the scope.
+    /// segment takes to write down what carries the rest of the scope. Moving it there is the race this covers: the
+    /// walk saw an outstanding run on its own segment, and by the time the segment wrote, an overlapping attempt had
+    /// finished the scope or handed the run on past it.
     /// </remarks>
-    private sealed class RunEndingOnceStopped(
+    private sealed class RunMovedOnceStopped(
         InMemoryStoredMailRederivationRunStore runs,
         CancellationTokenSource attempt,
-        DateTimeOffset endedAt)
+        Func<StoredMailRederivationRun, StoredMailRederivationRun> move)
         : IStoredMailRederivationRunStore
     {
-        private bool ended;
+        private bool moved;
 
         public async Task<StoredMailRederivationRun?> FindAsync(
             StoredMailScope scope,
             CancellationToken cancellationToken)
         {
-            if (attempt.IsCancellationRequested && !this.ended && runs.Find(scope) is { } outstanding)
+            if (attempt.IsCancellationRequested && !this.moved && runs.Find(scope) is { } outstanding)
             {
-                this.ended = true;
-                runs.Arrange(outstanding with { EndedAt = endedAt });
+                this.moved = true;
+                runs.Arrange(move(outstanding));
             }
 
             return await runs.FindAsync(scope, cancellationToken);
@@ -354,6 +482,9 @@ public sealed class StoredMailRederivationHandlerTests
             runStore ?? this.runs,
             this.jobs,
             commitPolicy,
+            this.leases,
+            JobSettings,
+            this.timeProvider,
             this.telemetry);
     }
 
@@ -492,6 +623,38 @@ public sealed class StoredMailRederivationHandlerTests
                     // Nothing is released, for the reason the segment's report releases nothing.
                 }
             }
+        }
+    }
+
+    /// <summary>Stands in for the lease table: grants every scope unless another replica is said to hold it, and lets a test take a granted lease away.</summary>
+    private sealed class ScriptedLeaseRunner : IWorkLeaseRunner
+    {
+        /// <summary>Gets the scopes asked for, in the order they were.</summary>
+        public List<WorkScope> AskedScopes { get; } = [];
+
+        /// <summary>Gets or sets whether another replica holds every scope, so nothing asked for is granted.</summary>
+        public bool HeldElsewhere { get; set; }
+
+        /// <summary>Gets or sets the token that plays a renewal another replica refused, cancelling the work under a granted lease.</summary>
+        public CancellationToken Loss { get; set; }
+
+        public async Task<bool> TryRunUnderLeaseAsync(
+            WorkScope scope,
+            Func<CancellationToken, Task> work,
+            CancellationToken cancellationToken)
+        {
+            this.AskedScopes.Add(scope);
+
+            if (this.HeldElsewhere)
+            {
+                return false;
+            }
+
+            using var heldWork = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, this.Loss);
+
+            await work(heldWork.Token);
+
+            return true;
         }
     }
 

--- a/backend/tests/Host.UnitTests/Hosting/Workers/WorkLeaseRunnerTests.cs
+++ b/backend/tests/Host.UnitTests/Hosting/Workers/WorkLeaseRunnerTests.cs
@@ -1,0 +1,125 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Coordination;
+using MailFathom.Host.Hosting.Workers;
+using MailFathom.Host.UnitTests.TestDoubles;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Hosting.Workers;
+
+public sealed class WorkLeaseRunnerTests
+{
+    /// <summary>Guards against a hung hold. No assertion depends on how long anything actually takes.</summary>
+    private static readonly TimeSpan DeadlockGuard = TimeSpan.FromSeconds(30);
+
+    private static readonly TimeSpan LeaseDuration = TimeSpan.FromMinutes(2);
+
+    private static readonly TimeSpan RenewalInterval = TimeSpan.FromSeconds(30);
+
+    private static readonly WorkScope Scope = WorkScope.Create("work-lease-runner-test");
+
+    /// <summary>A scope another replica holds is not this one's to work, so the work never starts.</summary>
+    [Fact]
+    public async Task TryRunUnderLeaseAsync_ScopeHeldElsewhere_RunsNothing()
+    {
+        // Arrange
+        var store = new ScriptedWorkLeaseStore { HeldElsewhere = true };
+        await using var services = ServicesOver(store);
+        var ran = false;
+
+        // Act
+        var held = await RunnerOver(services, new FakeTimeProvider()).TryRunUnderLeaseAsync(
+            Scope,
+            _ =>
+            {
+                ran = true;
+
+                return Task.CompletedTask;
+            },
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal((false, false), (held, ran));
+    }
+
+    /// <summary>Work runs while the scope is held and gives it back once it ends, so a successor finds it free.</summary>
+    [Fact]
+    public async Task TryRunUnderLeaseAsync_WorkThatEnds_IsHeldWhileItRunsAndGivesTheScopeBack()
+    {
+        // Arrange
+        var store = new ScriptedWorkLeaseStore();
+        await using var services = ServicesOver(store);
+        IReadOnlyCollection<WorkScope> heldWhileWorking = [];
+
+        // Act
+        var held = await RunnerOver(services, new FakeTimeProvider()).TryRunUnderLeaseAsync(
+            Scope,
+            _ =>
+            {
+                heldWhileWorking = store.HeldScopes;
+
+                return Task.CompletedTask;
+            },
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(held);
+        Assert.Equal([Scope], heldWhileWorking);
+        Assert.Equal([Scope], store.Releases);
+        Assert.Empty(store.HeldScopes);
+    }
+
+    /// <summary>A renewal another replica refused stops the work at once rather than when its next pass would have looked.</summary>
+    [Fact]
+    public async Task TryRunUnderLeaseAsync_RenewalRefused_CancelsTheWorkItGuards()
+    {
+        // Arrange
+        var clock = new FakeTimeProvider();
+        var store = new ScriptedWorkLeaseStore();
+        await using var services = ServicesOver(store);
+        var working = new TaskCompletionSource();
+        var stopped = false;
+
+        var running = RunnerOver(services, clock).TryRunUnderLeaseAsync(
+            Scope,
+            async token =>
+            {
+                working.SetResult();
+
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                }
+                catch (OperationCanceledException)
+                {
+                    stopped = true;
+                }
+            },
+            TestContext.Current.CancellationToken);
+
+        await working.Task.WaitAsync(DeadlockGuard, TestContext.Current.CancellationToken);
+
+        // Act
+        store.HeldElsewhere = true;
+        clock.Advance(RenewalInterval);
+        var held = await running.WaitAsync(DeadlockGuard, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal((true, true), (held, stopped));
+    }
+
+    private static ServiceProvider ServicesOver(ScriptedWorkLeaseStore store) =>
+        new ServiceCollection().AddSingleton<IWorkLeaseStore>(store).BuildServiceProvider();
+
+    private static WorkLeaseRunner RunnerOver(ServiceProvider services, FakeTimeProvider clock) => new(
+        services.GetRequiredService<IServiceScopeFactory>(),
+        NullLoggerFactory.Instance,
+        clock,
+        LeaseDuration,
+        RenewalInterval);
+}

--- a/backend/tests/IntegrationTests/Hosting/OrchestratedRederivationHoldTests.cs
+++ b/backend/tests/IntegrationTests/Hosting/OrchestratedRederivationHoldTests.cs
@@ -1,0 +1,68 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Coordination;
+using MailFathom.Application.Mail.Maintenance;
+using MailFathom.Domain.Accounts;
+using MailFathom.Host.Hosting.Workers;
+using MailFathom.IntegrationTests.Orchestration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace MailFathom.IntegrationTests.Hosting;
+
+/// <summary>Proves that two replicas sharing one database walk one re-derivation scope once, and that it moves when the walk ends.</summary>
+/// <remarks>
+/// Each replica is a service graph of its own over the orchestrated database, and each asks for the scope through the
+/// runner a segment walks under, by the name the segment gives it. No segment is run here, because what decides whether
+/// a second walk starts is that lease being granted, and a walk would also need stored mail this suite shares with
+/// every other test.
+/// </remarks>
+[Collection(OrchestratedInfrastructureCollectionDefinition.Name)]
+public sealed class OrchestratedRederivationHoldTests(MailFathomOrchestrationFixture orchestration)
+{
+    /// <summary>A lease long enough that nothing in the test expires underneath it, so only the walk ending can move the scope.</summary>
+    private static readonly TimeSpan LeaseDuration = TimeSpan.FromMinutes(10);
+
+    private static readonly TimeSpan LeaseRenewalInterval = TimeSpan.FromMinutes(5);
+
+    [Fact]
+    public async Task TryRunUnderLeaseAsync_TwoReplicasAskingForOneScope_WalkItOnceAndMoveItWhenTheWalkEnds()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var firstReplica = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        await using var secondReplica = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var scope = StoredMailRederivationHandler.LeaseScopeOf(new StoredMailScope(
+            MailAccountIdentity.Create(firstReplica.ServedUser, MailAccountId.Create("rederivation-handover")),
+            Folder: null));
+        var secondWalkedAlongside = true;
+
+        // Act
+        var firstWalked = await RunUnderLeaseAsync(
+            firstReplica,
+            scope,
+            async token => secondWalkedAlongside = await RunUnderLeaseAsync(secondReplica, scope, _ => Task.CompletedTask, token),
+            cancellationToken);
+        var secondWalkedAfter = await RunUnderLeaseAsync(secondReplica, scope, _ => Task.CompletedTask, cancellationToken);
+
+        // Assert
+        Assert.Equal((true, false, true), (firstWalked, secondWalkedAlongside, secondWalkedAfter));
+    }
+
+    private static Task<bool> RunUnderLeaseAsync(
+        OrchestratedMailFathomServices replica,
+        WorkScope scope,
+        Func<CancellationToken, Task> walk,
+        CancellationToken cancellationToken) =>
+        replica.InScopeAsync(
+            (serviceScope, token) => new WorkLeaseRunner(
+                serviceScope.GetRequiredService<IServiceScopeFactory>(),
+                NullLoggerFactory.Instance,
+                TimeProvider.System,
+                LeaseDuration,
+                LeaseRenewalInterval).TryRunUnderLeaseAsync(scope, walk, token),
+            cancellationToken);
+}

--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -1,6 +1,6 @@
 # IMAP synchronization
 
-<!-- describes: backend/src/Application/Synchronization/**, backend/src/Domain/Synchronization/**, backend/src/Domain/Folders/**, backend/src/Application/Folders/**, backend/src/Infrastructure/Mail/**, backend/src/Application/Mail/Mutations/**, backend/src/Application/Mail/Maintenance/**, backend/src/Domain/Mutations/**, backend/src/Host/Hosting/Workers/MailSynchronizationCoordinator.cs, backend/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs, backend/src/Host/Hosting/Workers/AccountPushNotificationWatch.cs, backend/src/Host/Hosting/Workers/WorkLeaseHold.cs -->
+<!-- describes: backend/src/Application/Synchronization/**, backend/src/Domain/Synchronization/**, backend/src/Domain/Folders/**, backend/src/Application/Folders/**, backend/src/Infrastructure/Mail/**, backend/src/Application/Mail/Mutations/**, backend/src/Application/Mail/Maintenance/**, backend/src/Domain/Mutations/**, backend/src/Host/Hosting/Workers/MailSynchronizationCoordinator.cs, backend/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs, backend/src/Host/Hosting/Workers/AccountPushNotificationWatch.cs, backend/src/Host/Hosting/Workers/WorkLeaseHold.cs, backend/src/Host/Hosting/Workers/WorkLeaseRunner.cs -->
 
 MailFathom synchronizes mailboxes read-only, on a bounded schedule, and — for an account that asks for it — the moment the mail server says something changed. Both mechanisms run the same synchronization pass over the same read-only session; what differs is only what starts one.
 
@@ -1789,6 +1789,20 @@ next release starts at the beginning.
 run, and the segment it is on, so a second request finds the segment already queued rather than starting a second walk
 over the same mail — and where the run was written down but its work never reached the queue, the same request is what
 repairs it. `mfctl mailbox rederive-status` reads the run from the row.
+
+**A second replica walks nothing another one is walking.** The request writes the run down on whichever replica
+answered it and walks nothing itself, so which replica walks is decided by the segment. Before its first pass a segment
+takes the lease `mail-rederivation/<user>/<account>/<folder>` in the lease table — `*` standing for the whole account,
+and a scope too long for the table named by a digest, as a supervised account's is — keeps it renewed on the cadence the
+job's own lease is renewed on, and gives it back before it hands the rest on, so the next segment takes it at once on
+whichever replica claims that. A walk of one folder and a walk of the whole account are two runs with two positions,
+so they are two leases as well. A segment that finds the scope held reads no mail, because what holds it is either
+another segment walking the same run or one whose replica stopped without giving it back; it hands the rest on all the
+same, to a segment the queue releases only once `Jobs:LeaseDuration` has passed, by which time a holder that stopped
+renewing has lost the scope. The run moves on only from the segment a stopping segment found it on, so two segments
+stopping over one run write one successor between them rather than two chains of segments walking the same mail by
+turns. A renewal that does not complete stops the walk at once rather than when the lease would have expired, and the
+next segment resumes past the position the last committed batch reached.
 
 A message no reader can parse keeps whatever an earlier release read from it and the walk moves past it; a row whose
 raw MIME is no longer stored is counted apart, because only a fetch could bring that message back. Neither is a failure

--- a/docs/features/spam-classification.md
+++ b/docs/features/spam-classification.md
@@ -486,6 +486,14 @@ that arrived seconds before a shutdown is still a request afterwards. A pass tha
 next fetch: classification reaches no mail server for the mail it reads, so a failure here says nothing about the
 mailbox.
 
+**A second replica neither walks the run nor takes a lease of its own for it.** The request writes the run down on
+whichever replica answered it and classifies nothing. The pass is a step of the account's synchronization run, and that
+run happens only on the replica holding the account's
+[lease](imap-synchronization.md#a-second-replica-supervises-nothing-for-an-account-the-first-one-holds), so one
+outstanding run per account and one holder per account leave one walk, advanced under the account's lease rather than
+a second one beside it. A hold that is lost cancels the pass with the rest of that run, and whichever replica takes the
+account next resumes past the position the last committed batch reached.
+
 A run ends in one of three ways. **Completed** is the walk reaching the end of its scope. **Superseded** is the profile
 having moved while the run was outstanding — a run cannot finish under terms it did not start with, and half a mailbox
 decided each way is worse than a run an operator asks for again. **Disabled** is classification having been switched

--- a/docs/operations/configuration-runtime.md
+++ b/docs/operations/configuration-runtime.md
@@ -269,6 +269,12 @@ what keeps two workers off one job: an attempt is cancelled before its lease can
 renewed at half its duration while a handler works, so a job that legitimately takes longer than one lease is not
 reclaimed while it runs.
 
+`LeaseDuration` also times the one lease a job holds beside its own. A segment of a [stored-mail
+re-derivation](../features/imap-synchronization.md#bringing-stored-mail-up-to-a-later-release) walks only while it
+holds the lease on the scope it walks, taken for this duration and renewed at half of it, and a segment that finds the
+scope held defers the segment it hands the rest on to by this duration — which is long enough for a holder that stopped
+renewing to have lost the scope because the two leases are one length.
+
 A failed attempt is classified before the attempt budget is consulted, and only a failure that could clear on its own is
 attempted again. A permanent one — a credential the dependency refused, a request it rejected, anything whose meaning is
 unknown — ends the job on its first attempt rather than spending `MaxAttempts` to reach an answer it already had. What

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -798,7 +798,6 @@ for as long as it walks, so on the gauge a walk in progress is one series, publi
 segment, and it moves between replicas as the segments do. A refused claim for such a scope is a segment that found
 another one holding it; it walked nothing and deferred the rest of the walk by `Jobs:LeaseDuration`, so an occasional
 one is ordinary and a steady stream for one scope is worth a look at the lease table.
->>>>>>> f650b670a ([#1834] State the re-derivation lease on the telemetry and job-queue configuration pages)
 
 ### What a synchronization cycle emits
 

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -792,6 +792,14 @@ they resume from — and only while a pass runs, so on the gauge each is a serie
 running a pass and leaves it when the pass ends. A refused claim for either is the ordinary answer of a replica that asked
 while another was mid-pass.
 
+A segment of an operator's re-derivation holds the scope `mail-rederivation/<user>/<account>/<folder>` — `*` for a run
+over the whole account, and `sha256-` and a digest of the account and the folder where that is too long for a scope —
+for as long as it walks, so on the gauge a walk in progress is one series, published by whichever replica claimed the
+segment, and it moves between replicas as the segments do. A refused claim for such a scope is a segment that found
+another one holding it; it walked nothing and deferred the rest of the walk by `Jobs:LeaseDuration`, so an occasional
+one is ordinary and a steady stream for one scope is worth a look at the lease table.
+>>>>>>> f650b670a ([#1834] State the re-derivation lease on the telemetry and job-queue configuration pages)
+
 ### What a synchronization cycle emits
 
 No instrumentation package exists for the mail library, so without what follows the part of MailFathom that spends the


### PR DESCRIPTION
## What changes

- **A segment of an operator's re-derivation walks under a lease on its scope.** `StoredMailRederivationHandler` takes the ADR 0031 lease `mail-rederivation/{user}/{account}/{folder}` (`*` for a whole-account run) before it reads any mail. Where that name would pass the 256-character scope bound or carry a control character, the scope is named `mail-rederivation/{user}/sha256-{digest of account and folder}` instead. The hold is renewed on the `Jobs:LeaseDuration` and `LeaseRenewalInterval` timings. A lost hold cancels the walk, and every batch it committed stays durable for whichever segment walks next.
- **A segment refused the lease reads no mail and is not an error.** It hands the run on as a stopped segment does. Its successor's availability is deferred by `Jobs:LeaseDuration`, the longest a crashed holder's lease can outlive it, because the scope lease is taken on that same duration.
- **Handing on is fenced on the run's `SegmentCount`.** Two segments of one run stopping at once therefore enqueue one successor rather than forking the chain in two. The one that loses the fence names the successor the other enqueued.
- **New port `IWorkLeaseRunner`** (`Application/Coordination`), because `Application` depends only on `Domain`. It is implemented in `Host` by `WorkLeaseRunner` over `WorkLeaseHold.TryTakeAsync` and the `RunWhileHeldAsync` that #1291 added, and registered in `HostComposition.AddJobQueue` beside the job settings whose timings it uses.
- **Spam classification: no code change.** A spam run is advanced only by `SpamClassificationPass` inside the account supervisor's pass. That pass already runs under the account's synchronization lease from #1290, on a token that lease's loss cancels, so a second replica can neither walk the run nor take a lease of its own for it. The pass's remarks and `spam-classification.md` now say that. A second lease would have been a second mechanism for a guarantee the first one already gives.

## Reading the issue against the code

The issue's premise is that a request starts a walk, so two requests could start two. That is not how the code reaches a walk today. `StoredMailRederivationRequests` records one outstanding run per scope, with primary key (user, account, folder), and enqueues a job under an idempotent key. A second request for the same scope is answered with the run already under way and starts nothing.

What could still walk one scope twice is the job queue underneath:

- a segment re-executed after its job lease expired while the first execution was still running (a paused process, a partitioned replica), and
- two segments of one run stopping at once and each handing on, which forks the chain.

The scope lease closes the first case and the `SegmentCount` fence closes the second.

The acceptance line *"a request that cannot take the lease is answered with the walk already running"* is therefore read this way: the request path is unchanged and already answers with the run under way. The segment refused the lease is what now starts no second walk and reports no error.

## Public surfaces

None changed. There is no new or renamed configuration key, no database schema change or migration, no MCP tool change, and no HTTP route change. The job payload and the job-key shape are unchanged. `Jobs:LeaseDuration` now also times the re-derivation scope lease and the deferral of a refused segment's successor, and `configuration-runtime.md` says so.

## Tests

- `StoredMailRederivationHandlerTests`:
  - a segment walks under the lease of its own scope
  - a scope another segment holds reads no mail, and its successor is deferred by one lease duration
  - a walk that loses its lease mid-pass keeps what it committed and hands the rest on
  - a segment stopping after another one handed the run on names that successor rather than enqueueing a second
  - an account too long for a scope is named by its digest, within the bound
- `WorkLeaseRunnerTests`:
  - a scope held elsewhere runs nothing
  - the scope is held while the work runs and given back when it ends
  - a refused renewal cancels the work it guards
- `OrchestratedRederivationHoldTests` (integration): two replicas over one database walk one scope once, and the scope moves when the walk ends. It is written and compiled but **not run locally**, because running the integration suite is the owner's call.

`scripts/verify-fast.sh` passes on the head.

## Documentation

- `docs/features/imap-synchronization.md`: a second replica walks nothing another one is walking.
- `docs/features/spam-classification.md`: why a spam run needs no lease of its own.
- `docs/operations/telemetry.md`: the `mail-rederivation/...` series on the held-scopes gauge, and what a refused claim for one means.
- `docs/operations/configuration-runtime.md`: what `Jobs:LeaseDuration` now also times.

ADR 0031's `describes:` marker is not widened to name `WorkLeaseRunner.cs`, because an ADR edit needs the owner's approval.

Closes #1834
