### PR TITLE
[#1877] Catch the screens up after the signal channel drops, keep reopening it, and refresh every five minutes while visible

### DIFF
--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -2387,7 +2387,7 @@ else that moved — a message that changed folder, was deleted, or whose keyword
 whole of what a run found, and a client re-reads. A flag a publisher did not observe is left out rather than reported as
 cleared: a reconciliation window states both, and a change this deployment authored states the one it wrote.
 
-**A client that does not know the sixth kind ignores it and re-reads on its own interval**, exactly as it ignores any
+**A client that does not know the sixth kind ignores it and catches up on its next refresh**, exactly as it ignores any
 other kind it does not know; the client and the service ship under one version, so this is an addition rather than a
 break.
 
@@ -2404,8 +2404,21 @@ arrivals stay two statements so a client is never told that mail arrived without
 
 **A client with no channel behaves exactly as one that never had it.** Every screen re-reads over the routes above, and
 the channel only decides when. So a deployment behind a reverse proxy that does not pass the WebSocket upgrade, or one
-whose client could not connect for any other reason, serves the same client with the same data on its own interval;
-the client says nothing about a channel that is merely down, and reconnects on a bounded jittered backoff.
+whose client could not connect for any other reason, serves the same client with the same data on the client's own
+interval; the client says nothing about a channel that is merely down. It reconnects on a jittered backoff that stops
+growing at thirty seconds and never stops while somebody is signed in, and it tries at once when its window comes back
+to the front or the browser reports its network back.
+
+**A client catches up on what it could not be told.** Nothing buffers a statement for a connection that is not open, so
+a gap in the channel is a gap in what the client heard — a dropped socket, a rolling upgrade, a network that went and
+came back, and, above one replica, a statement lost behind a connection that stayed open. So the client refreshes: it
+reads again everything it draws — the folder tree and its counts, the pages of the list it holds, the open message, the
+accounts, and the notification centre — whenever a connection stands again after one stood for the same sign-in, and
+every five minutes while its window is visible, counted from the last refresh rather than on a fixed clock. It never
+refreshes while the window is hidden, and refreshes at once when a window hidden past those five minutes comes back. A
+refresh is the act the client's *Refresh* control performs, it keeps what the person is in the middle of — the
+selection, the open message, where they are in the list, and any change still pending — and one the deployment does not
+answer leaves what is drawn in place for the next to try again.
 
 **A proxy in front of this endpoint has to pass the upgrade** — `Upgrade` and `Connection` on the request, and no
 buffering or idle timeout shorter than a connection that is meant to stand open. Nothing here fails when it does not;

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -373,7 +373,7 @@ export function App({
     // What the deployment says has changed while somebody is looking at it, held on the same three conditions every
     // read above is: a credential that may not read mail is told nothing about it, and a machine with no network has
     // no connection to open. A screen subscribes to decide what to read again; nothing here renders, and a deployment
-    // that serves no channel leaves every screen on the interval it already had.
+    // that serves no channel leaves every screen on the interval the hook refreshes it on.
     const signalledChanges = useSignals(
         readsMail && connection.online ? session : null,
         readMail,
@@ -382,23 +382,28 @@ export function App({
     );
 
     // The account's own state is the frame's to re-read, because what it moves is what the frame draws: how current
-    // each account is, and the freshness line beside it. Every other kind is a screen's, and each of them subscribes
-    // where it decides what to ask for again.
+    // each account is, and the freshness line beside it. A refresh reads it again too, and quietly — one the deployment
+    // does not answer leaves the frame as it stands. Every other kind is a screen's, and each of them subscribes where
+    // it decides what to ask for again.
     //
     // Through a ref because the way to ask is a new function on every render while the subscription is not: reading it
     // when a signal arrives is what keeps one subscription across the renders, instead of one torn down and rebuilt
     // every time anything on this frame changes.
-    const rereadConnection = useRef(connection.reread);
+    const connectionNow = useRef(connection);
 
     useEffect(() => {
-        rereadConnection.current = connection.reread;
-    }, [connection.reread]);
+        connectionNow.current = connection;
+    }, [connection]);
 
     useEffect(
         () =>
             signalledChanges.listen((signal) => {
                 if (signal.kind === 'account.state') {
-                    rereadConnection.current();
+                    connectionNow.current.reread();
+                }
+
+                if (signal.kind === 'refresh') {
+                    connectionNow.current.refresh();
                 }
             }),
         [signalledChanges],
@@ -875,16 +880,10 @@ export function App({
                                                                     onPointerDown={swipe.onNavigationPointerDown}
                                                                     onClickCapture={swipe.onNavigationClickCapture}
                                                                     refresh={
-                                                                        // On the same grant the bell is, and for the same reason: today
-                                                                        // the two things it reads again are the mail and the centre, and
-                                                                        // a credential that may read neither would press it for nothing.
-                                                                        readsMail ? (
-                                                                            <Refresh
-                                                                                readNotificationsAgain={
-                                                                                    notifications.readAgain
-                                                                                }
-                                                                            />
-                                                                        ) : null
+                                                                        // On the same grant the bell is, and for the same reason: what it
+                                                                        // reads again is the mail and the centre, and a credential that may
+                                                                        // read neither would press it for nothing.
+                                                                        readsMail ? <Refresh /> : null
                                                                     }
                                                                     notifications={
                                                                         // Offered on the grant the routes are admitted under, and absent

--- a/frontend/src/Client.App/src/folders/FolderTree.test.tsx
+++ b/frontend/src/Client.App/src/folders/FolderTree.test.tsx
@@ -5,13 +5,14 @@
 import type { ReactElement } from 'react';
 import { act, fireEvent, render, screen, waitFor, within, type RenderResult } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { ClientSession, ClientSignal, MailFathomTransport } from '@mailfathom/client-backend';
+import type { ClientSession, MailFathomTransport } from '@mailfathom/client-backend';
 import { LocalizationProvider } from '../localization/Localization';
 import { ReadMarkingContext, nothingMarkedRead, type MarkedIn, type ReadMarking } from '../readMarking/useReadMarking';
 import {
     SignalledChangesContext,
     nothingSignalled,
     type SignalListener,
+    type SignalledChange,
     type SignalledChanges,
 } from '../signals/signalledChanges';
 import { WorkspaceProvider } from '../workspace/Workspace';
@@ -216,11 +217,12 @@ function pressed(on: HTMLElement): readonly (string | null)[] {
 }
 
 /** A deployment a test speaks for, so what a signal does to the tree is asserted rather than waited for. */
-function deploymentSaying(): { changes: SignalledChanges; say: (signal: ClientSignal) => void } {
+function deploymentSaying(): { changes: SignalledChanges; say: (signal: SignalledChange) => void } {
     const listeners = new Set<SignalListener>();
 
     return {
         changes: {
+            refresh: () => undefined,
             listen: (listener) => {
                 listeners.add(listener);
 
@@ -901,7 +903,8 @@ describe('FolderTree, in a folded column', () => {
         expect(reads).toBe(2);
     });
 
-    it.each<{ signal: ClientSignal; named: string }>([
+    it.each<{ signal: SignalledChange; named: string }>([
+        { signal: { kind: 'refresh' }, named: 'a refresh' },
         { signal: { kind: 'folders.changed', account: 'work' }, named: 'the mapping moving' },
         { signal: { kind: 'mail.changed', account: 'work', folder: 'INBOX', emails: ['m-1'] }, named: 'mail changing' },
         {
@@ -936,6 +939,41 @@ describe('FolderTree, in a folded column', () => {
 
         await drawn();
         expect(reads).toBe(2);
+    });
+
+    it('keeps the tree on the screen when a refresh is not answered', async () => {
+        const deployment = deploymentSaying();
+        let reads = 0;
+
+        renderTree(
+            () => {
+                reads += 1;
+
+                return Promise.resolve(
+                    reads === 1
+                        ? { status: 200, headers: {}, body: JSON.stringify(tree) }
+                        : { status: 503, headers: {}, body: '' },
+                );
+            },
+            true,
+            undefined,
+            deployment.changes,
+        );
+
+        await drawn();
+
+        act(() => {
+            deployment.say({ kind: 'refresh' });
+        });
+
+        await waitFor(() => {
+            expect(reads).toBe(2);
+        });
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(row(/^Work/)).toBeDefined();
     });
 
     it('reads nothing again for a star, which moves no count this tree draws', async () => {

--- a/frontend/src/Client.App/src/folders/FolderTree.tsx
+++ b/frontend/src/Client.App/src/folders/FolderTree.tsx
@@ -124,7 +124,15 @@ export function FolderTree({
 
         void readMailFolders(session, transport).then((result) => {
             if (listening) {
-                setAnswered({ attempt, result });
+                // A read under a tree already drawn — a signal, a refresh — that the deployment did not answer leaves the
+                // tree standing rather than replacing it with a sentence about a failure: what is drawn is still the
+                // truest thing anybody has, and the next signal or refresh asks again. A first read and a retry have
+                // nothing drawn under them, so their failure is said.
+                setAnswered((current) =>
+                    result.outcome === 'failed' && current?.attempt === attempt && current.result.outcome === 'read'
+                        ? current
+                        : { attempt, result },
+                );
             }
         });
 
@@ -165,7 +173,8 @@ export function FolderTree({
 
     // Four of the six kinds move this tree, because all four move a count it draws: mail arriving in a folder, a
     // message changing folder, the mapping itself moving, and a read mark. It re-reads under whatever is drawn rather
-    // than replacing it, so a reader whose pointer is on a row keeps the row.
+    // than replacing it, so a reader whose pointer is on a row keeps the row. A refresh reads it again the same way, for
+    // the reason it reads everything again: something may have moved that nobody said.
     //
     // A stated flag is the one that is read rather than acted on wholesale. A count is derived from every message in a
     // folder rather than from the ones a statement names, so there is nothing to apply in place — but a statement about
@@ -174,6 +183,7 @@ export function FolderTree({
         () =>
             signalledChanges.listen((signal) => {
                 if (
+                    signal.kind === 'refresh' ||
                     signal.kind === 'folders.changed' ||
                     signal.kind === 'mail.arrived' ||
                     signal.kind === 'mail.changed' ||

--- a/frontend/src/Client.App/src/messageList/ListedMail.test.tsx
+++ b/frontend/src/Client.App/src/messageList/ListedMail.test.tsx
@@ -55,7 +55,6 @@ describe('ListedMailProvider', () => {
             selectAll: everything,
             takeFocus: () => undefined,
             stand: () => undefined,
-            readAgain: () => undefined,
         });
         listed.selectAll();
 
@@ -73,7 +72,6 @@ describe('ListedMailProvider', () => {
             selectAll: () => undefined,
             takeFocus: () => undefined,
             stand: stood,
-            readAgain: () => undefined,
         });
         listed.stand('commitments');
 
@@ -91,7 +89,6 @@ describe('ListedMailProvider', () => {
             selectAll: () => undefined,
             takeFocus: focused,
             stand: () => undefined,
-            readAgain: () => undefined,
         });
         listed.takeFocus();
 

--- a/frontend/src/Client.App/src/messageList/ListedMail.tsx
+++ b/frontend/src/Client.App/src/messageList/ListedMail.tsx
@@ -45,9 +45,6 @@ export function ListedMailProvider({ children }: { readonly children: ReactNode 
         stand: (view) => {
             mailbox.current?.stand(view);
         },
-        readAgain: () => {
-            mailbox.current?.readAgain();
-        },
         listing: (list) => {
             mailbox.current = list;
         },

--- a/frontend/src/Client.App/src/messageList/MessageList.test.tsx
+++ b/frontend/src/Client.App/src/messageList/MessageList.test.tsx
@@ -5,13 +5,7 @@
 import type { ReactElement } from 'react';
 import { act, fireEvent, render, screen, waitFor, within, type RenderResult } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type {
-    ClientRequest,
-    ClientSession,
-    ClientSignal,
-    MailAccount,
-    MailFathomTransport,
-} from '@mailfathom/client-backend';
+import type { ClientRequest, ClientSession, MailAccount, MailFathomTransport } from '@mailfathom/client-backend';
 import { ComposingContext, type Composing } from '../composer/useComposing';
 import { swipeDistance } from '../controls/swipeAcross';
 import { MailboxActsContext, nothingActed, type MailboxActs } from '../mailboxActs/useMailboxActs';
@@ -20,6 +14,7 @@ import {
     SignalledChangesContext,
     nothingSignalled,
     type SignalListener,
+    type SignalledChange,
     type SignalledChanges,
 } from '../signals/signalledChanges';
 import { everything, type MailScope } from '../workspace/mailScope';
@@ -200,11 +195,12 @@ interface Drawn {
 }
 
 /** A deployment a test speaks for, so what a signal does to the list is asserted rather than waited for. */
-function deploymentSaying(): { changes: SignalledChanges; say: (signal: ClientSignal) => void } {
+function deploymentSaying(): { changes: SignalledChanges; say: (signal: SignalledChange) => void } {
     const listeners = new Set<SignalListener>();
 
     return {
         changes: {
+            refresh: () => undefined,
             listen: (listener) => {
                 listeners.add(listener);
 
@@ -906,6 +902,72 @@ describe('MessageList', () => {
 
         expect((await rows()).length).toBe(drawn);
         expect(screen.queryByText('Reading your mail…')).toBeNull();
+    });
+
+    it('reads the page on the screen again on a refresh, drawing its rows the whole time', async () => {
+        const deployment = deploymentSaying();
+        let reads = 0;
+
+        renderList(
+            () => {
+                reads += 1;
+
+                return reads === 1
+                    ? Promise.resolve({ status: 200, body: wholeFolder, headers: {} })
+                    : new Promise(() => undefined);
+            },
+            { changes: deployment.changes },
+        );
+
+        const drawn = (await rows()).length;
+
+        act(() => {
+            deployment.say({ kind: 'refresh' });
+        });
+
+        await waitFor(() => {
+            expect(reads).toBe(2);
+        });
+
+        // The rows themselves rather than their number: a page dropped and read again would still count as many rows,
+        // drawn as the skeleton of a page arriving.
+        expect((await rows()).length).toBe(drawn);
+        expect(row(0)).toBeDefined();
+    });
+
+    it('keeps its rows and says nothing when a refresh is not answered', async () => {
+        const deployment = deploymentSaying();
+        let reads = 0;
+
+        renderList(
+            () => {
+                reads += 1;
+
+                return Promise.resolve(
+                    reads === 1
+                        ? { status: 200, body: wholeFolder, headers: {} }
+                        : { status: 503, body: '', headers: {} },
+                );
+            },
+            { changes: deployment.changes },
+        );
+
+        await rows();
+
+        act(() => {
+            deployment.say({ kind: 'refresh' });
+        });
+
+        await waitFor(() => {
+            expect(reads).toBe(2);
+        });
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(row(0)).toBeDefined();
+        expect(screen.queryByRole('alert')).toBeNull();
+        expect(reads).toBe(2);
     });
 
     it('reads again for mail the deployment named as changed', async () => {

--- a/frontend/src/Client.App/src/messageList/MessageList.tsx
+++ b/frontend/src/Client.App/src/messageList/MessageList.tsx
@@ -47,6 +47,9 @@ import {
     heldRows,
     nothingHeld,
     positionOfRow,
+    refillsHeldRows,
+    refreshAsked,
+    refreshUnanswered,
     rowAt,
     rowCountOf,
     trimmedAround,
@@ -228,6 +231,10 @@ export function MessageList({
     const wantedDirection = wanted?.direction ?? null;
     const wantedRefilling = wanted?.refilling ?? null;
 
+    // Whether the page wanted is one a refresh marked while its rows stay drawn, which decides what its failure does: a
+    // read the reader is still looking at rows through says nothing when it is not answered, and the rows stay.
+    const wantedQuietly = refillsHeldRows(shown, wanted);
+
     // The one effect that puts a request on the wire, which is what an effect is for. What it asked for travels with
     // the answer, so a page knows where it belongs and an answer to a read this list has moved on from is discarded.
     useEffect(() => {
@@ -249,7 +256,11 @@ export function MessageList({
                     return;
                 }
 
-                if (result.outcome === 'failed') {
+                const refilled = asked.refilling;
+
+                if (result.outcome === 'failed' && wantedQuietly && refilled !== null) {
+                    setHeld((current) => refreshUnanswered(current, refilled));
+                } else if (result.outcome === 'failed') {
                     setFailure(result.failure);
                 } else {
                     // Where each message belongs, written down as the page arrives, because the surfaces that act on a
@@ -272,7 +283,7 @@ export function MessageList({
         return () => {
             listening = false;
         };
-    }, [session, transport, scope, listing, wantedCursor, wantedDirection, wantedRefilling, listed]);
+    }, [session, transport, scope, listing, wantedCursor, wantedDirection, wantedRefilling, wantedQuietly, listed]);
 
     // Where the reader is, written down once they have stopped moving, and again the moment the page goes away —
     // whichever comes first. The second is what makes a reload a continuation rather than a race with the first: a
@@ -348,6 +359,13 @@ export function MessageList({
     useEffect(
         () =>
             signalledChanges.listen((signal) => {
+                // A refresh marks every page the list holds rather than dropping one, so the rows stay drawn while the
+                // pages on the screen are read again — and a list that had stopped on a failure is let try again.
+                if (signal.kind === 'refresh') {
+                    setFailure(null);
+                    setHeld(refreshAsked);
+                }
+
                 if (signal.kind === 'mail.arrived' && scopeReaches(scope, signal.account, signal.folder)) {
                     setHeld(arrivalNoticed);
                 }
@@ -494,14 +512,6 @@ export function MessageList({
             // then drawn in the panel where every other narrowing is.
             stand: (view) => {
                 readWith({ ...listing, filters: narrowedToView(listing.filters, view, new Date()) });
-            },
-
-            // The same act the deployment's own arrival signal performs, and deliberately the same one: the leading
-            // page is let go of and read again while the reader is looking at it, so the list is never emptied and
-            // never stands as a skeleton of itself. A reader who has scrolled away keeps every row in front of them
-            // and meets the new leading page when they come back to it.
-            readAgain: () => {
-                setHeld(arrivalNoticed);
             },
         });
 

--- a/frontend/src/Client.App/src/messageList/heldTimeline.test.ts
+++ b/frontend/src/Client.App/src/messageList/heldTimeline.test.ts
@@ -15,6 +15,9 @@ import {
     nothingHeld,
     pagesKeptEitherSide,
     positionOfRow,
+    refillsHeldRows,
+    refreshAsked,
+    refreshUnanswered,
     rowAt,
     rowCountOf,
     rowOfSlot,
@@ -325,6 +328,72 @@ describe('arrivalNoticed', () => {
 
     it('leaves a list that has read nothing alone', () => {
         expect(arrivalNoticed(nothingHeld)).toBe(nothingHeld);
+    });
+});
+
+describe('refreshAsked', () => {
+    it('marks every page it holds to be read again, keeping each of its rows drawn', () => {
+        const held = refreshAsked(readForward(3));
+
+        expect(held.slots.every((slot) => slot.stale)).toBe(true);
+        expect(heldRows(held)).toStrictEqual(heldRows(readForward(3)));
+    });
+
+    it('asks for the page on the screen again, through the cursor it was read under', () => {
+        expect(wantedFor(refreshAsked(readForward(3)), 4, 7)).toStrictEqual({
+            cursor: 'after-4',
+            direction: 'forward',
+            refilling: 1,
+        });
+    });
+
+    it('stops asking once the page on the screen has answered, leaving the others for when they are reached', () => {
+        const refilling: TimelineRead = { cursor: 'after-4', direction: 'forward', refilling: 1 };
+        const held = answered(refreshAsked(readForward(3)), page(4), refilling);
+
+        expect(held.slots[1]?.stale).toBe(false);
+        expect(wantedFor(held, 4, 7)).toBeNull();
+        expect(wantedFor(held, 8, 9)?.refilling).toBe(2);
+    });
+
+    it('leaves a page it had already dropped as it was, which the list reads again once it is reached anyway', () => {
+        const held = refreshAsked(trimmedAround(readForward(6), 20, 23));
+
+        expect(held.slots[0]?.emails).toBeNull();
+        expect(held.slots[0]?.stale).toBe(false);
+    });
+
+    it('leaves a list that has read nothing alone', () => {
+        expect(refreshAsked(nothingHeld)).toBe(nothingHeld);
+    });
+});
+
+describe('refreshUnanswered', () => {
+    it('stops asking for a page the deployment did not answer, and keeps its rows', () => {
+        const held = refreshUnanswered(refreshAsked(readForward(1)), 0);
+
+        expect(held.slots[0]?.stale).toBe(false);
+        expect(heldRows(held)).toStrictEqual(heldRows(readForward(1)));
+        expect(wantedFor(held, 0, 3)?.refilling).toBeNull();
+    });
+});
+
+describe('refillsHeldRows', () => {
+    it('answers that a read of a page still drawn is one the reader is looking through', () => {
+        const held = refreshAsked(readForward(2));
+
+        expect(refillsHeldRows(held, wantedFor(held, 0, 3))).toBe(true);
+    });
+
+    it('answers that a read of a dropped page is not, since nothing of it is drawn', () => {
+        const held = trimmedAround(readForward(6), 20, 23);
+
+        expect(refillsHeldRows(held, wantedFor(held, 0, 3))).toBe(false);
+    });
+
+    it('answers that a read extending the list is not, and neither is no read at all', () => {
+        expect(refillsHeldRows(readForward(2), extending('after-8'))).toBe(false);
+        expect(refillsHeldRows(readForward(2), null)).toBe(false);
     });
 });
 

--- a/frontend/src/Client.App/src/messageList/heldTimeline.ts
+++ b/frontend/src/Client.App/src/messageList/heldTimeline.ts
@@ -33,6 +33,12 @@ export interface TimelineSlot {
     /** The rows, or `null` where they have been dropped and the cursor above is how they come back. */
     readonly emails: readonly MailTimelineEntry[] | null;
 
+    /**
+     * Whether the rows held here may no longer be what the deployment holds, because a refresh asked for everything to
+     * be read again. They stay drawn meanwhile, and the page is read again from its own cursor while it is on the screen.
+     */
+    readonly stale: boolean;
+
     readonly nextCursor: string | null;
     readonly previousCursor: string | null;
 }
@@ -175,14 +181,17 @@ export interface TimelineRead {
     readonly refilling: number | null;
 }
 
-/** The page a read the list has not made yet would ask for, or `null` where what is on the screen is all held. */
+/**
+ * The page a read the list has not made yet would ask for, or `null` where what is on the screen is all held and none of
+ * it is waiting to be read again.
+ */
 export function wantedFor(held: HeldTimeline, firstRow: number, lastRow: number): TimelineRead | null {
     let passed = 0;
 
     for (const [at, slot] of held.slots.entries()) {
         const beyond = passed + slot.rowCount;
 
-        if (slot.emails === null && passed <= lastRow && beyond > firstRow) {
+        if ((slot.emails === null || slot.stale) && passed <= lastRow && beyond > firstRow) {
             return { cursor: slot.askedWith, direction: slot.readAs, refilling: at };
         }
 
@@ -211,6 +220,7 @@ function slotFor(page: MailTimelinePage, read: TimelineRead): TimelineSlot {
         emails: page.emails,
         nextCursor: page.nextCursor,
         previousCursor: page.previousCursor,
+        stale: false,
     };
 }
 
@@ -256,6 +266,48 @@ export function changeNoticed(held: HeldTimeline, storedEmailIds: readonly strin
     }
 
     return { slots: held.slots.map((slot) => (holdsNamed(slot) ? { ...slot, emails: null } : slot)) };
+}
+
+/**
+ * What the list knows once a refresh asked for everything it holds to be read again.
+ *
+ * Every page holding rows is marked rather than dropped, which is what separates a refresh from a signal naming mail:
+ * the rows stay drawn while their page is read again, so a reader sees rows change rather than the list turning into
+ * its own skeleton every five minutes. What is on the screen is read again now and what is not when the reader reaches
+ * it, on the rule `arrivalNoticed` states.
+ *
+ * @param held What the list knows now.
+ * @returns What the list knows, and the list itself where it holds no rows.
+ */
+export function refreshAsked(held: HeldTimeline): HeldTimeline {
+    return held.slots.some((slot) => slot.emails !== null)
+        ? { slots: held.slots.map((slot) => (slot.emails === null ? slot : { ...slot, stale: true })) }
+        : held;
+}
+
+/**
+ * What the list knows once reading one of its stale pages again was not answered.
+ *
+ * The rows stay where they are and the page stops being asked for: they are still the truest thing the list has, and
+ * the next refresh asks again. Asking again at once would be a request per render against a deployment that is not
+ * answering.
+ *
+ * @param held What the list knows now.
+ * @param slot The page the read was refilling.
+ * @returns What the list knows.
+ */
+export function refreshUnanswered(held: HeldTimeline, slot: number): HeldTimeline {
+    return { slots: held.slots.map((standing, at) => (at === slot ? { ...standing, stale: false } : standing)) };
+}
+
+/**
+ * Whether a read refills a page whose rows are still drawn, which is the one read whose failure takes nothing off the
+ * screen: only a stale page is read again while it holds its rows.
+ */
+export function refillsHeldRows(held: HeldTimeline, read: TimelineRead | null): boolean {
+    const refilling = read?.refilling ?? null;
+
+    return refilling !== null && (held.slots[refilling]?.emails ?? null) !== null;
 }
 
 /**

--- a/frontend/src/Client.App/src/messageList/useListedMail.ts
+++ b/frontend/src/Client.App/src/messageList/useListedMail.ts
@@ -55,9 +55,6 @@ export interface ListedMail {
 
     /** Puts one of the tree's standing views in force on the list, and does nothing where no list is on the screen. */
     readonly stand: (view: StandingView) => void;
-
-    /** Reads the leading end of the list again, and does nothing where no list is on the screen. */
-    readonly readAgain: () => void;
 }
 
 /** What a list on the screen answers for, filled by the list itself and by nothing above it. */
@@ -70,13 +67,6 @@ export interface ListedMailbox {
      * is: what a view sets is filters on the folder in front of the reader, and the folder's filters are the list's.
      */
     readonly stand: (view: StandingView) => void;
-
-    /**
-     * Reads the leading end of the list again, which is the list's own act for the reason the two above are: what the
-     * leading end *is* — which page, read with which cursor, under which filters — is the list's alone, and a refresh
-     * asked from the rail knows none of it.
-     */
-    readonly readAgain: () => void;
 }
 
 /** What a tree with no provider above it reads, which is a client where nothing outside a list can reach into one. */
@@ -87,7 +77,6 @@ export const nothingListed: ListedMail = {
     takeFocus: () => undefined,
     listing: () => undefined,
     stand: () => undefined,
-    readAgain: () => undefined,
 };
 
 export const ListedMailContext = createContext<ListedMail>(nothingListed);

--- a/frontend/src/Client.App/src/notifications/NotificationCentre.test.tsx
+++ b/frontend/src/Client.App/src/notifications/NotificationCentre.test.tsx
@@ -59,7 +59,6 @@ const acts = {
     remove: vi.fn(),
     follow: vi.fn(),
     show: vi.fn(),
-    readAgain: vi.fn(),
 };
 
 function centre(held: Partial<Centre> = {}): Centre {

--- a/frontend/src/Client.App/src/notifications/useNotificationCentre.test.tsx
+++ b/frontend/src/Client.App/src/notifications/useNotificationCentre.test.tsx
@@ -413,6 +413,50 @@ describe('useNotificationCentre', () => {
         expect(result.current.notifications.map((row) => row.id)).toEqual(['n-second', 'n-mail']);
     });
 
+    // An empty centre is the one that would show it: the panel draws the failure wherever it has no row to draw, so a
+    // refresh nobody pressed would otherwise turn a quiet bell into an error.
+    it('says nothing when a refresh is not answered, leaving an empty centre empty', async () => {
+        const { transport } = deployment({ unreadCount: 0, notifications: [] });
+        let refusing = false;
+        const refusingThePage: MailFathomTransport = (request) =>
+            refusing && new URL(request.path).pathname === '/api/client/notifications'
+                ? Promise.resolve({ status: 503, headers: {}, body: '' })
+                : transport(request);
+        const signalling = deploymentSaying();
+        const { result } = centreOf(refusingThePage, session, signalling.changes);
+
+        act(() => {
+            result.current.show();
+        });
+        await settled();
+
+        refusing = true;
+
+        act(() => {
+            signalling.say({ kind: 'refresh' });
+        });
+        await settled();
+
+        expect(result.current.failure).toBeNull();
+        expect(result.current.notifications).toEqual([]);
+    });
+
+    it('still says a page read failed when it was the panel opening that asked for it', async () => {
+        const { transport } = deployment({ unreadCount: 0, notifications: [] });
+        const refusingThePage: MailFathomTransport = (request) =>
+            new URL(request.path).pathname === '/api/client/notifications'
+                ? Promise.resolve({ status: 503, headers: {}, body: '' })
+                : transport(request);
+        const { result } = centreOf(refusingThePage);
+
+        act(() => {
+            result.current.show();
+        });
+        await settled();
+
+        expect(result.current.failure).toBe('unavailable');
+    });
+
     it('costs one page read when the refresh finds something waiting, and marks it as having arrived', async () => {
         const { transport, requests, hold } = deployment({ unreadCount: 1, notifications: [mail] });
         const signalling = deploymentSaying();

--- a/frontend/src/Client.App/src/notifications/useNotificationCentre.test.tsx
+++ b/frontend/src/Client.App/src/notifications/useNotificationCentre.test.tsx
@@ -9,7 +9,6 @@ import type {
     ClientNotification,
     ClientRequest,
     ClientSession,
-    ClientSignal,
     MailFathomTransport,
     NotificationTarget,
 } from '@mailfathom/client-backend';
@@ -20,6 +19,7 @@ import {
     SignalledChangesContext,
     nothingSignalled,
     type SignalListener,
+    type SignalledChange,
     type SignalledChanges,
 } from '../signals/signalledChanges';
 import { ToastsProvider } from '../toasts/Toasts';
@@ -193,11 +193,12 @@ function looking(at: boolean): void {
 let signedInAs: ClientSession | null = session;
 
 /** A deployment a test speaks for, so what a raised notification does to the bell is asserted rather than polled for. */
-function deploymentSaying(): { changes: SignalledChanges; say: (signal: ClientSignal) => void } {
+function deploymentSaying(): { changes: SignalledChanges; say: (signal: SignalledChange) => void } {
     const listeners = new Set<SignalListener>();
 
     return {
         changes: {
+            refresh: () => undefined,
             listen: (listener) => {
                 listeners.add(listener);
 
@@ -389,9 +390,10 @@ describe('useNotificationCentre', () => {
         expect([...result.current.arrived]).toEqual(['n-second']);
     });
 
-    it('reads the page and the count again when it is asked to by hand, which is what the rail refresh asks', async () => {
+    it('reads the page and the count again on a refresh, whoever asked for it', async () => {
         const { transport, requests, hold } = deployment({ unreadCount: 1, notifications: [mail] });
-        const { result } = centreOf(transport);
+        const signalling = deploymentSaying();
+        const { result } = centreOf(transport, session, signalling.changes);
 
         await settled();
 
@@ -401,7 +403,7 @@ describe('useNotificationCentre', () => {
         hold(2, [{ ...mail, id: 'n-second' }, mail]);
 
         act(() => {
-            result.current.readAgain();
+            signalling.say({ kind: 'refresh' });
         });
         await settled();
 
@@ -413,7 +415,8 @@ describe('useNotificationCentre', () => {
 
     it('costs one page read when the refresh finds something waiting, and marks it as having arrived', async () => {
         const { transport, requests, hold } = deployment({ unreadCount: 1, notifications: [mail] });
-        const { result } = centreOf(transport);
+        const signalling = deploymentSaying();
+        const { result } = centreOf(transport, session, signalling.changes);
 
         // Opened first, so the centre has been read once and what a later read brings is an arrival rather than the
         // list appearing — which is the case the count rising and the press are both about.
@@ -426,7 +429,7 @@ describe('useNotificationCentre', () => {
         hold(2, [{ ...mail, id: 'n-second' }, mail]);
 
         act(() => {
-            result.current.readAgain();
+            signalling.say({ kind: 'refresh' });
         });
         await settled();
 

--- a/frontend/src/Client.App/src/notifications/useNotificationCentre.ts
+++ b/frontend/src/Client.App/src/notifications/useNotificationCentre.ts
@@ -131,6 +131,12 @@ export function useNotificationCentre(
     // rather than two effects racing to read the same route.
     const [asked, setAsked] = useState(0);
 
+    // Whether the page read the token asks for next is a refresh's, handed from the listener that asks to the read it
+    // starts. A refresh the deployment did not answer says nothing and leaves what is drawn — an empty centre stays the
+    // empty state rather than becoming a failure — for the next one to try again. A ref because nothing is drawn from it
+    // and setting it must not start a read of its own.
+    const quietly = useRef(false);
+
     // What has already been drawn or announced, so an arrival is a notification this client has not seen rather than
     // one it has stopped showing. A ref because nothing on the screen is drawn from it, and it must not restart the
     // reads below when it grows.
@@ -233,6 +239,7 @@ export function useNotificationCentre(
             // The count is read rather than left to the interval because the badge is what a reader who does not open
             // the panel is looking at.
             if (signal.kind === 'refresh') {
+                quietly.current = true;
                 setAsked((token) => token + 1);
                 void count(false);
             }
@@ -363,6 +370,10 @@ export function useNotificationCentre(
 
         const attempted = new AbortController();
 
+        // Taken by the read it was set for, so a read the panel opening or an arrival asks for afterwards is not quiet.
+        const keepsWhatStands = quietly.current;
+        quietly.current = false;
+
         setReading(known.current?.session !== session);
 
         void (async () => {
@@ -375,7 +386,9 @@ export function useNotificationCentre(
             setReading(false);
 
             if (answer.outcome === 'failed') {
-                setFailure(answer.failure.reason);
+                if (!keepsWhatStands) {
+                    setFailure(answer.failure.reason);
+                }
 
                 return;
             }

--- a/frontend/src/Client.App/src/notifications/useNotificationCentre.ts
+++ b/frontend/src/Client.App/src/notifications/useNotificationCentre.ts
@@ -77,13 +77,6 @@ export interface NotificationCentre {
     readonly show: () => void;
     readonly hide: () => void;
 
-    /**
-     * Reads what has happened again, whether or not the panel is open. It is what the rail's refresh asks of the
-     * centre: the count is polled on its own and a page is read when somebody looks, so a reader who wants to know
-     * now has nothing to press without it.
-     */
-    readonly readAgain: () => void;
-
     /** Puts one notification into the read state stated, which is what the row's own control does. */
     readonly markRead: (ids: readonly string[], read: boolean) => void;
 
@@ -174,12 +167,6 @@ export function useNotificationCentre(
         setFailure(null);
     }
 
-    // Reading the count as this effect is currently able to, held so that asking for one by hand does not have to
-    // restart the interval and the subscription that live beside it. It is written by the effect rather than declared
-    // outside it, because what a read needs — the session, the transport, the controller that abandons it — is the
-    // effect's own and none of it is this hook's for as long as this hook exists.
-    const countNow = useRef<(() => void) | null>(null);
-
     useEffect(() => {
         if (session === null || !online) {
             return;
@@ -215,10 +202,6 @@ export function useNotificationCentre(
             }
         }
 
-        countNow.current = () => {
-            void count(false);
-        };
-
         void count(true);
 
         const polling = window.setInterval(() => {
@@ -243,10 +226,19 @@ export function useNotificationCentre(
             if (signal.kind === 'notification.raised') {
                 void count(true);
             }
+
+            // A refresh asks for the page and for the count, and for the count as a count alone: the page is asked for
+            // here already, so a rise it finds must not ask for it a second time — the second answer would arrive
+            // against a centre the first had filled, and an arrival would be drawn as though it had always been there.
+            // The count is read rather than left to the interval because the badge is what a reader who does not open
+            // the panel is looking at.
+            if (signal.kind === 'refresh') {
+                setAsked((token) => token + 1);
+                void count(false);
+            }
         });
 
         return () => {
-            countNow.current = null;
             attempted.abort();
             window.clearInterval(polling);
             document.removeEventListener('visibilitychange', returned);
@@ -262,17 +254,6 @@ export function useNotificationCentre(
 
     const hide = useCallback((): void => {
         setShown(false);
-    }, []);
-
-    // The same token a rise in the count bumps, so asking for a page by hand and something having arrived stay one
-    // mechanism rather than two reads racing on the same route. The count is read beside it rather than left to the
-    // interval, because the badge is what a reader who does not open the panel is looking at — and it is the read the
-    // effect above is holding rather than a second one composed here, so a press cannot outlive the session it was
-    // made under. It is asked for as a count alone, so a press that finds notifications waiting costs the one page
-    // read bumped here rather than a second one the rise would otherwise ask for.
-    const readAgain = useCallback((): void => {
-        setAsked((token) => token + 1);
-        countNow.current?.();
     }, []);
 
     // Coming back through the notification the operating system showed is the same act as reaching for the bell, so it
@@ -537,7 +518,6 @@ export function useNotificationCentre(
         failure,
         show,
         hide,
-        readAgain,
         markRead,
         markAllRead,
         remove,

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.test.tsx
@@ -5,13 +5,7 @@
 import { useEffect } from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type {
-    ClientRequest,
-    ClientResponse,
-    ClientSession,
-    ClientSignal,
-    MailFathomTransport,
-} from '@mailfathom/client-backend';
+import type { ClientRequest, ClientResponse, ClientSession, MailFathomTransport } from '@mailfathom/client-backend';
 import { AttachmentExchangeContext, type AttachmentExchange } from '../deployment/attachmentExchange';
 import { OpenAttachmentContext, type OpenedAttachment } from '../workspace/openAttachment';
 import { LocalizationProvider } from '../localization/Localization';
@@ -31,6 +25,7 @@ import {
     SignalledChangesContext,
     nothingSignalled,
     type SignalListener,
+    type SignalledChange,
     type SignalledChanges,
 } from '../signals/signalledChanges';
 import { ReadingPane } from './ReadingPane';
@@ -191,11 +186,12 @@ function drawing(
 }
 
 /** A deployment with a channel open, and the handle a test says something over it with. */
-function deploymentSaying(): { changes: SignalledChanges; say: (signal: ClientSignal) => void } {
+function deploymentSaying(): { changes: SignalledChanges; say: (signal: SignalledChange) => void } {
     const listeners = new Set<SignalListener>();
 
     return {
         changes: {
+            refresh: () => undefined,
             listen: (listener) => {
                 listeners.add(listener);
 
@@ -597,6 +593,58 @@ describe('ReadingPane against a deployment that says what changed', () => {
         await waitFor(() => {
             expect(asked.filter((request) => !request.path.includes('/body')).length).toBe(before + 1);
         });
+    });
+
+    it('reads the message again on a refresh', async () => {
+        // Arrange
+        asked.length = 0;
+        const signalling = deploymentSaying();
+        drawing(deploymentDescribing(), messageId, true, deliversNothing, nothingMarkedRead, signalling.changes);
+        await screen.findByText('Quarterly invoice');
+        const before = asked.filter((request) => !request.path.includes('/body')).length;
+
+        // Act
+        act(() => {
+            signalling.say({ kind: 'refresh' });
+        });
+
+        // Assert
+        await waitFor(() => {
+            expect(asked.filter((request) => !request.path.includes('/body')).length).toBe(before + 1);
+        });
+    });
+
+    it('keeps the message on the screen when a refresh is not answered', async () => {
+        // Arrange
+        asked.length = 0;
+        const signalling = deploymentSaying();
+        const answering = deploymentDescribing();
+        let described = 0;
+        const answersOnce: MailFathomTransport = (request) => {
+            if (request.path.includes('/body')) {
+                return answering(request);
+            }
+
+            described += 1;
+
+            return described === 1 ? answering(request) : Promise.resolve({ status: 503, body: '', headers: {} });
+        };
+        drawing(answersOnce, messageId, true, deliversNothing, nothingMarkedRead, signalling.changes);
+        await screen.findByText('Quarterly invoice');
+
+        // Act
+        act(() => {
+            signalling.say({ kind: 'refresh' });
+        });
+        await waitFor(() => {
+            expect(described).toBe(2);
+        });
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        // Assert
+        expect(screen.getByText('Quarterly invoice')).toBeDefined();
     });
 
     it('applies a stated flag to the message it is drawing rather than reading it again', async () => {

--- a/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
+++ b/frontend/src/Client.App/src/readingPane/ReadingPane.tsx
@@ -229,7 +229,18 @@ function OpenMessage({
                 return;
             }
 
-            setAnswer({ read, result: answered });
+            // A quiet read the deployment did not answer leaves the message it was reading again where it stands: what a
+            // reader is part-way through is still the truest thing anybody has, and the next signal or refresh asks
+            // again. `missing` is not that — it is the deployment saying the message is gone — and is let go of below.
+            setAnswer((current) =>
+                read.quietly &&
+                answered.outcome === 'failed' &&
+                answered.failure.reason !== 'missing' &&
+                current?.result.outcome === 'read' &&
+                current.read.storedEmailId === read.storedEmailId
+                    ? current
+                    : { read, result: answered },
+            );
 
             // A message the deployment no longer holds is let go of rather than drawn as a failure to press through.
             // What is open outlives the message across a reload, so somebody returning to a client whose message has
@@ -286,11 +297,15 @@ function OpenMessage({
 
     // A message the deployment says has changed is read again where it is the one on the screen, quietly, so what a
     // reader is part-way through stays in front of them until the new answer replaces it. A signal naming other mail is
-    // not this message's business: the list it names re-reads its own rows.
+    // not this message's business: the list it names re-reads its own rows. A refresh is every message's business, and
+    // reads this one again the same way.
     useEffect(
         () =>
             signalledChanges.listen((signal) => {
-                if (signal.kind === 'mail.changed' && signal.emails.includes(storedEmailId)) {
+                if (
+                    signal.kind === 'refresh' ||
+                    (signal.kind === 'mail.changed' && signal.emails.includes(storedEmailId))
+                ) {
                     setRead((current) => ({ storedEmailId, attempt: current.attempt + 1, quietly: true }));
                 }
 

--- a/frontend/src/Client.App/src/shell/ConnectionSummary.test.tsx
+++ b/frontend/src/Client.App/src/shell/ConnectionSummary.test.tsx
@@ -67,6 +67,7 @@ function renderSummary(connection: Partial<Connection>, pending: PendingChanges 
                         online: true,
                         attempts: 0,
                         reread: () => undefined,
+                        refresh: () => undefined,
                         ...connection,
                     }}
                 />

--- a/frontend/src/Client.App/src/shell/Refresh.test.tsx
+++ b/frontend/src/Client.App/src/shell/Refresh.test.tsx
@@ -2,54 +2,108 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { LocalizationProvider } from '../localization/Localization';
-import { ListedMailContext, nothingListed } from '../messageList/useListedMail';
-import { Refresh } from './Refresh';
+import { SignalledChangesContext, type SignalListener, type SignalledChanges } from '../signals/signalledChanges';
+import { Refresh, refreshShownFor } from './Refresh';
 
-function drawing(readListAgain: () => void, readNotificationsAgain: () => void): void {
+/** Changes a test speaks for: a refresh is told to every listener, as the hook tells it, and each press is counted. */
+function signalling(): { changes: SignalledChanges; refreshed: () => void; pressed: () => number } {
+    const listeners = new Set<SignalListener>();
+    let pressed = 0;
+
+    function refreshed(): void {
+        for (const listener of [...listeners]) {
+            listener({ kind: 'refresh' });
+        }
+    }
+
+    return {
+        changes: {
+            listen: (listener) => {
+                listeners.add(listener);
+
+                return () => {
+                    listeners.delete(listener);
+                };
+            },
+            refresh: () => {
+                pressed += 1;
+                refreshed();
+            },
+        },
+        refreshed,
+        pressed: () => pressed,
+    };
+}
+
+function drawing(changes: SignalledChanges): HTMLElement {
     render(
         <LocalizationProvider>
-            <ListedMailContext value={{ ...nothingListed, readAgain: readListAgain }}>
-                <Refresh readNotificationsAgain={readNotificationsAgain} />
-            </ListedMailContext>
+            <SignalledChangesContext value={changes}>
+                <Refresh />
+            </SignalledChangesContext>
         </LocalizationProvider>,
     );
+
+    return screen.getByRole('button', { name: 'Refresh' });
 }
 
 describe('Refresh', () => {
-    it('reads the list and the notification centre again on one press, which is what a global refresh means', () => {
-        const list = vi.fn();
-        const centre = vi.fn();
-
-        drawing(list, centre);
-        fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
-
-        expect(list).toHaveBeenCalledTimes(1);
-        expect(centre).toHaveBeenCalledTimes(1);
+    afterEach(() => {
+        vi.useRealTimers();
     });
 
-    it('asks the list nothing on a screen with no list on it, rather than refusing the press', () => {
-        const centre = vi.fn();
+    it('asks the client to refresh on a press, which every screen hears and reads again for', () => {
+        const deployment = signalling();
 
-        render(
-            <LocalizationProvider>
-                <Refresh readNotificationsAgain={centre} />
-            </LocalizationProvider>,
-        );
+        fireEvent.click(drawing(deployment.changes));
 
-        fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+        expect(deployment.pressed()).toBe(1);
+    });
 
-        expect(centre).toHaveBeenCalledTimes(1);
+    it('says a refresh nobody pressed is under way, exactly as it says one that was pressed', () => {
+        const deployment = signalling();
+        const control = drawing(deployment.changes);
+
+        expect(control.getAttribute('aria-disabled')).toBe('false');
+
+        act(() => {
+            deployment.refreshed();
+        });
+
+        expect(control.getAttribute('aria-disabled')).toBe('true');
+    });
+
+    it('stops saying so after one beat', () => {
+        vi.useFakeTimers();
+        const deployment = signalling();
+        const control = drawing(deployment.changes);
+
+        fireEvent.click(control);
+        act(() => {
+            vi.advanceTimersByTime(refreshShownFor - 1);
+        });
+        expect(control.getAttribute('aria-disabled')).toBe('true');
+
+        act(() => {
+            vi.advanceTimersByTime(1);
+        });
+        expect(control.getAttribute('aria-disabled')).toBe('false');
+    });
+
+    it('refuses a second press while one is under way', () => {
+        const deployment = signalling();
+        const control = drawing(deployment.changes);
+
+        fireEvent.click(control);
+        fireEvent.click(control);
+
+        expect(deployment.pressed()).toBe(1);
     });
 
     it('carries a name that says what it does rather than what it looks like', () => {
-        drawing(
-            () => undefined,
-            () => undefined,
-        );
-
-        expect(screen.getByRole('button', { name: 'Refresh' })).toBeDefined();
+        expect(drawing(signalling().changes)).toBeDefined();
     });
 });

--- a/frontend/src/Client.App/src/shell/Refresh.tsx
+++ b/frontend/src/Client.App/src/shell/Refresh.tsx
@@ -2,49 +2,87 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+import { useEffect, useState } from 'react';
 import { Icon } from '../controls/Icon';
 import { useLocalization } from '../localization/useLocalization';
-import { useListedMail } from '../messageList/useListedMail';
+import { useSignalledChanges } from '../signals/signalledChanges';
 
 // The one control in the navigation that goes nowhere and changes nothing: it asks the client to read again what it is
-// already showing. Today that is the mail in front of the reader and the notification centre, and the list is expected
-// to grow rather than the control to multiply — a second refresh button for a second list would be a client where
-// *refresh* means something different in each corner of it.
+// already showing. What that is belongs to the screens rather than to this control — the folder tree and its counts,
+// the pages of the list, the open message, the accounts, and the notification centre each hear the refresh and read
+// again what they draw — so a screen added later joins by listening rather than by growing this control, and *refresh*
+// means one thing in the client rather than something different in each corner of it.
 //
-// **It never empties what it is refreshing.** Each surface reads its own leading end again and keeps every row it has
-// while the answer is on the wire, which is the standing rule for every list in this client: a list is drawn as a
-// skeleton once, when it has nothing, and every later change reaches the rows it actually touched.
+// **It is the same act the client performs on its own.** A connection to the deployment standing again after a gap,
+// and the interval a visible window refreshes on, both ask for exactly this, and the control answers each of them the
+// way it answers a press — so a refresh nobody pressed is still one a reader can see happening.
 //
-// **It says nothing about being busy, because the surfaces do.** The list draws the rows it is reading again and the
-// centre says it is reading, each in the place its answer will land — which is where somebody is looking. The design
-// project spins this control's own symbol instead, and it is drawn there as a dashed demo affordance whose one press
-// invents an arrival, an edit and a removal; a real control saying it is busy in a corner nobody is watching would be
-// the wrong half of that.
+// **Nothing it refreshes is emptied.** Each surface reads again under what it draws and keeps it while the answer is
+// on the wire, and one the deployment did not answer keeps it afterwards as well: a refresh that failed is one the next
+// repeats, never an error on the screen.
 //
 // It is drawn the two ways the navigation around it is, exactly as the bell beside it: an item with its name under it
 // where the navigation is a sheet, and the symbol alone in the rail of a wide window.
 
-export function Refresh({ readNotificationsAgain }: { readonly readNotificationsAgain: () => void }) {
+/** How long the control says a refresh is under way, which is one beat of the design project's pulse. */
+export const refreshShownFor = 1_000;
+
+// The design project's two looks for the control: at rest it is the rail's panel, and under way it is the accent — its
+// ground, its line, and its glyph. A pointer over it draws the hover ground and the text colour over either look,
+// leaving the line it stands in, which is the order the design draws them in.
+const resting =
+    'text-muted hover:bg-hover hover:text-text workspace:border-line workspace:bg-panel workspace:text-muted workspace:hover:bg-hover workspace:hover:text-text';
+const underWay =
+    'bg-accent-soft text-accent-deep hover:bg-hover hover:text-text workspace:border-accent-line workspace:bg-accent-soft workspace:text-accent-deep workspace:hover:bg-hover workspace:hover:text-text';
+
+export function Refresh() {
     const { translate } = useLocalization();
+    const changes = useSignalledChanges();
+    const [working, setWorking] = useState(false);
 
-    // What *everything* means is composed here rather than handed in whole, because the two halves are reached
-    // differently and neither is this control's: the mail is whatever list is on the screen, which only that list
-    // knows, and the notification centre is a hook the frame holds. A third list joins this function.
-    const listed = useListedMail();
+    // Heard rather than set on the press, so the control says the same thing whoever asked: a press, a connection
+    // standing again, or the interval.
+    useEffect(
+        () =>
+            changes.listen((change) => {
+                if (change.kind === 'refresh') {
+                    setWorking(true);
+                }
+            }),
+        [changes],
+    );
 
-    function press(): void {
-        listed.readAgain();
-        readNotificationsAgain();
-    }
+    // ponytail: one beat of the pulse rather than until every surface's read has landed, which no surface reports; tie
+    // it to their reads if a refresh ever takes long enough for the difference to show.
+    useEffect(() => {
+        if (!working) {
+            return;
+        }
+
+        const settling = window.setTimeout(() => {
+            setWorking(false);
+        }, refreshShownFor);
+
+        return () => {
+            window.clearTimeout(settling);
+        };
+    }, [working]);
 
     return (
         <button
             type="button"
             aria-label={translate('shell.refresh')}
-            className="flex flex-1 cursor-pointer flex-col items-center gap-0.75 rounded-2xl px-0.5 py-1.75 text-2xs font-medium text-muted transition hover:bg-hover hover:text-text workspace:size-8.5 workspace:flex-none workspace:justify-center workspace:gap-0 workspace:rounded-xl workspace:border workspace:border-line workspace:bg-panel workspace:px-0 workspace:py-0 workspace:text-muted workspace:hover:border-accent-line workspace:hover:bg-accent-soft workspace:hover:text-accent-deep"
-            onClick={press}
+            // Refused while one is under way, which is the design project's rule: a second press would read everything
+            // again under reads that have not landed yet.
+            aria-disabled={working}
+            className={`flex flex-1 cursor-pointer flex-col items-center gap-0.75 rounded-2xl px-0.5 py-1.75 text-2xs font-medium transition workspace:size-8.5 workspace:flex-none workspace:justify-center workspace:gap-0 workspace:rounded-xl workspace:border workspace:px-0 workspace:py-0 ${working ? underWay : resting}`}
+            onClick={() => {
+                if (!working) {
+                    changes.refresh();
+                }
+            }}
         >
-            <Icon name="refresh" className="size-5" />
+            <Icon name="refresh" className={working ? 'size-5 animate-working' : 'size-5'} />
 
             {/* The name is under the symbol wherever the navigation carries names, and gone in the rail, where the
                 design draws this control as the symbol alone. */}

--- a/frontend/src/Client.App/src/shell/useConnection.test.ts
+++ b/frontend/src/Client.App/src/shell/useConnection.test.ts
@@ -180,6 +180,62 @@ describe('useConnection', () => {
         expect(result.current.readAt).toEqual(readAt);
     });
 
+    it('reads the session and the accounts again on a refresh', async () => {
+        const paths: string[] = [];
+        const recording: DeploymentTransport = () => (request) => {
+            paths.push(request.path);
+
+            return Promise.resolve(request.path.endsWith('/session') ? readsMail : oneAccount);
+        };
+
+        const { result } = renderHook(() => useConnection(baseAddress, firstPerson, recording, nothingToDo, clock));
+
+        await waitFor(() => {
+            expect(result.current.accounts?.outcome).toBe('read');
+        });
+
+        const readSoFar = paths.length;
+
+        act(() => {
+            result.current.refresh();
+        });
+
+        await waitFor(() => {
+            expect(paths.slice(readSoFar).some((path) => path.endsWith('/session'))).toBe(true);
+            expect(paths.slice(readSoFar).some((path) => !path.endsWith('/session'))).toBe(true);
+        });
+    });
+
+    // A refresh is the client's own and nobody is waiting on it, so one the deployment did not answer is the next one's
+    // to repeat: the frame that stood stays, rather than being replaced by a deployment that stopped answering.
+    it('keeps what it read on the screen when a refresh is not answered', async () => {
+        let failing = false;
+        const failingLater: DeploymentTransport = () => (request) =>
+            failing
+                ? Promise.resolve({ status: 503, body: '', headers: {} })
+                : Promise.resolve(request.path.endsWith('/session') ? readsMail : oneAccount);
+
+        const { result } = renderHook(() => useConnection(baseAddress, firstPerson, failingLater, nothingToDo, clock));
+
+        await waitFor(() => {
+            expect(result.current.accounts?.outcome).toBe('read');
+        });
+
+        failing = true;
+
+        act(() => {
+            result.current.refresh();
+        });
+        await act(async () => {
+            for (let turn = 0; turn < 10; turn += 1) {
+                await Promise.resolve();
+            }
+        });
+
+        expect(result.current.session?.outcome).toBe('read');
+        expect(result.current.accounts?.outcome).toBe('read');
+    });
+
     // The other half of keeping what was read: a grant that stopped reading mail asks for no accounts at all, so
     // nothing later in the attempt replaces the tree that stands — and one left up goes on offering mail the
     // deployment has begun refusing, for as long as that person stays signed in.

--- a/frontend/src/Client.App/src/shell/useConnection.ts
+++ b/frontend/src/Client.App/src/shell/useConnection.ts
@@ -48,6 +48,13 @@ export interface Connection {
 
     /** Reads everything again, from a person asking rather than from the client trying on its own. */
     readonly reread: () => void;
+
+    /**
+     * Reads everything again on the client's own account — a refresh — leaving what stands on the screen where the
+     * deployment does not answer: a refresh that failed is one the next repeats, not a frame replaced by a deployment
+     * that stopped answering.
+     */
+    readonly refresh: () => void;
 }
 
 /**
@@ -120,6 +127,15 @@ function accountsStillStanding(
         : { accounts: null, readAt: null };
 }
 
+/** Whether what stands was read, and for this same address and identity, which is what a refresh that failed leaves up. */
+function readFor(previous: Answered, baseAddress: string, presenting: string): boolean {
+    return (
+        previous.presentedAt === baseAddress &&
+        previous.presenting === presenting &&
+        previous.session?.outcome === 'read'
+    );
+}
+
 /**
  * How many automatic attempts have been made, and against which identity.
  *
@@ -184,6 +200,10 @@ export function useConnection(
     const presenting = signedIn?.identity ?? null;
     const authorization = signedIn?.authorization ?? null;
     const carried = useRef(authorization);
+
+    // Whether the next read is a refresh, handed from the call asking for one to the read it starts. A ref because
+    // nothing is drawn from it and setting it must not start a read of its own.
+    const quietly = useRef(false);
     const [read, setRead] = useState(0);
     const [reaching, setReaching] = useState<Reaching>(noneMade);
     const [answered, setAnswered] = useState<Answered>(nothingRead);
@@ -205,6 +225,11 @@ export function useConnection(
         if (baseAddress === null || presenting === null || !online) {
             return;
         }
+
+        // Taken by the read it was set for, so every read after it — a person's, an automatic retry — is not a refresh
+        // unless it was asked for as one.
+        const keepsWhatStands = quietly.current;
+        quietly.current = false;
 
         // Abandoning is what says an answer is nobody's to render any more, and it is one mechanism rather than two:
         // the signal already has to travel to the transport, so a second flag beside it would be a second thing to
@@ -248,13 +273,17 @@ export function useConnection(
             }
 
             if (session.outcome === 'failed') {
-                setAnswered({
+                const unanswered: Answered = {
                     session,
                     accounts: null,
                     readAt: null,
                     presentedAt: baseAddress,
                     presenting,
-                });
+                };
+
+                setAnswered((previous) =>
+                    keepsWhatStands && readFor(previous, baseAddress, presenting) ? previous : unanswered,
+                );
 
                 return;
             }
@@ -294,6 +323,12 @@ export function useConnection(
             if (accounts.outcome === 'failed' && accounts.failure.reason === 'unauthenticated') {
                 refused(presentedToList);
 
+                return;
+            }
+
+            // The accounts the previous attempt answered with already stand, above, so a refresh that could not read
+            // them again leaves them there.
+            if (keepsWhatStands && accounts.outcome === 'failed') {
                 return;
             }
 
@@ -350,7 +385,12 @@ export function useConnection(
         online,
         attempts,
         reread: () => {
+            quietly.current = false;
             setReaching(noneMade);
+            setRead((token) => token + 1);
+        },
+        refresh: () => {
+            quietly.current = true;
             setRead((token) => token + 1);
         },
     };

--- a/frontend/src/Client.App/src/signals/signalChannel.test.ts
+++ b/frontend/src/Client.App/src/signals/signalChannel.test.ts
@@ -1,0 +1,74 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { browserSchedule } from './signalChannel';
+
+// The wait between two connections, which ends early on the browser's two reasons to think the deployment is reachable
+// again. The connection itself is SignalR's and is proven by the deployment it reaches, not here.
+
+/** Starts a wait and answers whether it is over yet. */
+function waiting(milliseconds: number): () => boolean {
+    let over = false;
+
+    void browserSchedule.wait(milliseconds).then(() => {
+        over = true;
+    });
+
+    return () => over;
+}
+
+function windowIs(state: DocumentVisibilityState): void {
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue(state);
+}
+
+describe('browserSchedule', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it('ends a wait once its time has passed', async () => {
+        const over = waiting(30_000);
+
+        await vi.advanceTimersByTimeAsync(29_999);
+        expect(over()).toBe(false);
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(over()).toBe(true);
+    });
+
+    it('ends a wait at once when the network comes back', async () => {
+        const over = waiting(30_000);
+
+        window.dispatchEvent(new Event('online'));
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(over()).toBe(true);
+    });
+
+    it('ends a wait at once when the window comes back to the front', async () => {
+        const over = waiting(30_000);
+
+        windowIs('visible');
+        document.dispatchEvent(new Event('visibilitychange'));
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(over()).toBe(true);
+    });
+
+    it('goes on waiting when the window is put out of sight', async () => {
+        const over = waiting(30_000);
+
+        windowIs('hidden');
+        document.dispatchEvent(new Event('visibilitychange'));
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(over()).toBe(false);
+    });
+});

--- a/frontend/src/Client.App/src/signals/signalChannel.ts
+++ b/frontend/src/Client.App/src/signals/signalChannel.ts
@@ -20,7 +20,7 @@ import { signalMethod, type MailFathomSignalChannel, type SignalStreamSchedule }
  * which is a second request carrying the same ticket — and a ticket opens exactly one connection, so the negotiation
  * would spend it and the socket that followed would be refused. Skipping it is permitted precisely because one
  * transport is named, and a deployment behind a proxy that will not pass the upgrade therefore fails to connect rather
- * than falling back to long polling: the client reads on its own interval, which is what it does anyway.
+ * than falling back to long polling: the client refreshes on its own interval, which is what it does anyway.
  *
  * Logging is off because the deployment already records what it refused, and a client that logged its own connection
  * attempts would write the address it presented a ticket to into a browser console.
@@ -44,11 +44,32 @@ export const openSignalChannel: MailFathomSignalChannel = async (opening) => {
     return { close: () => connection.stop() };
 };
 
-/** How the stream waits, which is the browser's own timer and the browser's own source of a spread. */
+/**
+ * How the stream waits, which is the browser's own timer and the browser's own source of a spread.
+ *
+ * A wait also ends the moment the browser gives a reason to think the deployment is reachable again — its network
+ * coming back, or the window coming back to the front — so a client somebody returns to tries at once rather than
+ * sitting out the rest of a thirty-second wait it began while nobody was looking.
+ */
 export const browserSchedule: SignalStreamSchedule = {
     wait: (milliseconds) =>
         new Promise((resolve) => {
-            window.setTimeout(resolve, milliseconds);
+            function over(): void {
+                window.clearTimeout(waiting);
+                window.removeEventListener('online', over);
+                document.removeEventListener('visibilitychange', returned);
+                resolve();
+            }
+
+            function returned(): void {
+                if (document.visibilityState === 'visible') {
+                    over();
+                }
+            }
+
+            const waiting = window.setTimeout(over, milliseconds);
+            window.addEventListener('online', over);
+            document.addEventListener('visibilitychange', returned);
         }),
     draw: () => Math.random(),
 };

--- a/frontend/src/Client.App/src/signals/signalledChanges.ts
+++ b/frontend/src/Client.App/src/signals/signalledChanges.ts
@@ -14,8 +14,18 @@ import type { ClientSignal } from '@mailfathom/client-backend';
 // Nothing here decides what to re-read. Which screens care about which statement is each screen's, which is what keeps
 // this module free of every route the client reads.
 
+/**
+ * What a screen is told: one of the deployment's own statements, or a refresh.
+ *
+ * A refresh is the client's own statement rather than the deployment's, and it says the widest thing either of them
+ * can: that something may have changed which nobody was told about, so every screen reads again what it draws. It is
+ * what the rail's refresh control asks for, and what the client asks for itself once its connection stands again after
+ * a gap and on an interval while its window is visible — one act, whoever asked for it.
+ */
+export type SignalledChange = ClientSignal | { readonly kind: 'refresh' };
+
 /** What a screen does with one statement. */
-export type SignalListener = (signal: ClientSignal) => void;
+export type SignalListener = (change: SignalledChange) => void;
 
 /** How a screen hears what the deployment said. */
 export interface SignalledChanges {
@@ -25,10 +35,16 @@ export interface SignalledChanges {
      * @returns How to stop listening.
      */
     readonly listen: (listener: SignalListener) => () => void;
+
+    /**
+     * Tells every screen to read again what it draws, and starts the interval over from now. Nothing happens where
+     * nobody who may read mail is signed in or the machine has no network, which is when there is nothing to read over.
+     */
+    readonly refresh: () => void;
 }
 
 /** What a tree with no channel above it hears, which is every client whose deployment serves no hub. */
-export const nothingSignalled: SignalledChanges = { listen: () => () => undefined };
+export const nothingSignalled: SignalledChanges = { listen: () => () => undefined, refresh: () => undefined };
 
 export const SignalledChangesContext = createContext<SignalledChanges>(nothingSignalled);
 

--- a/frontend/src/Client.App/src/signals/useSignals.test.tsx
+++ b/frontend/src/Client.App/src/signals/useSignals.test.tsx
@@ -3,7 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 import { act, renderHook } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type {
     ClientSession,
     ClientSignal,
@@ -11,7 +11,8 @@ import type {
     SignalChannelOpening,
     SignalStreamSchedule,
 } from '@mailfathom/client-backend';
-import { useSignals } from './useSignals';
+import type { SignalledChange, SignalledChanges } from './signalledChanges';
+import { refreshInterval, useSignals } from './useSignals';
 
 // What is proven here is the connection's lifetime and the fan-out, because those are what this hook owns: the package
 // decides what a payload has to be and when to open again, and the channel itself is the composition root's. So the
@@ -66,6 +67,12 @@ function channelHoldingOneConnection(): {
     };
 }
 
+/** A schedule whose wait is over at once, so a connection that dropped is opened again within one settling. */
+const reopensAtOnce: SignalStreamSchedule = {
+    wait: () => Promise.resolve(),
+    draw: () => 0,
+};
+
 /** Lets the ticket read and the opening that follows it settle, neither being synchronous. */
 async function settled(): Promise<void> {
     await act(async () => {
@@ -73,6 +80,36 @@ async function settled(): Promise<void> {
             await Promise.resolve();
         }
     });
+}
+
+/** Moves the scheduled clock on, letting whatever it set off settle. */
+async function pass(milliseconds: number): Promise<void> {
+    await act(async () => {
+        await vi.advanceTimersByTimeAsync(milliseconds);
+    });
+}
+
+/** Whether the window is on the screen, which is what the interval asks before it refreshes. */
+function windowIs(state: DocumentVisibilityState): void {
+    vi.spyOn(document, 'visibilityState', 'get').mockReturnValue(state);
+}
+
+function windowComesBack(): void {
+    windowIs('visible');
+    act(() => {
+        document.dispatchEvent(new Event('visibilitychange'));
+    });
+}
+
+/** Listens to a hook's changes, answering how many of what it heard were refreshes. */
+function listening(changes: SignalledChanges): () => number {
+    const told: SignalledChange[] = [];
+
+    act(() => {
+        changes.listen((change) => told.push(change));
+    });
+
+    return () => told.filter((change) => change.kind === 'refresh').length;
 }
 
 describe('useSignals', () => {
@@ -97,8 +134,8 @@ describe('useSignals', () => {
 
     it('tells every listener what the deployment said', async () => {
         const deployment = channelHoldingOneConnection();
-        const first: ClientSignal[] = [];
-        const second: ClientSignal[] = [];
+        const first: SignalledChange[] = [];
+        const second: SignalledChange[] = [];
 
         const view = renderHook(() => useSignals(session, mintsTickets, deployment.channel, neverReopens));
 
@@ -118,7 +155,7 @@ describe('useSignals', () => {
 
     it('says nothing to a listener that has stopped listening', async () => {
         const deployment = channelHoldingOneConnection();
-        const told: ClientSignal[] = [];
+        const told: SignalledChange[] = [];
 
         const view = renderHook(() => useSignals(session, mintsTickets, deployment.channel, neverReopens));
 
@@ -140,7 +177,7 @@ describe('useSignals', () => {
 
     it('says nothing about a payload the deployment could not have sent', async () => {
         const deployment = channelHoldingOneConnection();
-        const told: ClientSignal[] = [];
+        const told: SignalledChange[] = [];
 
         const view = renderHook(() => useSignals(session, mintsTickets, deployment.channel, neverReopens));
 
@@ -199,5 +236,158 @@ describe('useSignals', () => {
 
         expect(view.result.current).toBe(before);
         expect(deployment.opened).toHaveLength(1);
+    });
+});
+
+describe('useSignals catching up', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it('refreshes nothing when the first connection stands, there being nothing it could have missed', async () => {
+        const deployment = channelHoldingOneConnection();
+        const view = renderHook(() => useSignals(session, mintsTickets, deployment.channel, reopensAtOnce));
+        const refreshes = listening(view.result.current);
+
+        await settled();
+
+        expect(deployment.opened).toHaveLength(1);
+        expect(refreshes()).toBe(0);
+    });
+
+    it('refreshes every screen once a connection stands again after dropping', async () => {
+        const deployment = channelHoldingOneConnection();
+        const view = renderHook(() => useSignals(session, mintsTickets, deployment.channel, reopensAtOnce));
+        const refreshes = listening(view.result.current);
+
+        await settled();
+        act(() => {
+            deployment.opened[0]?.dropped();
+        });
+        await settled();
+
+        expect(deployment.opened).toHaveLength(2);
+        expect(refreshes()).toBe(1);
+    });
+
+    // The network going closes the stream and its coming back opens another for the same person, which is a gap in what
+    // the screens were told exactly as a drop is.
+    it('refreshes every screen when the network comes back for the same person', async () => {
+        const deployment = channelHoldingOneConnection();
+        let signedInAs: ClientSession | null = session;
+        const view = renderHook(() => useSignals(signedInAs, mintsTickets, deployment.channel, neverReopens));
+        const refreshes = listening(view.result.current);
+
+        await settled();
+        signedInAs = null;
+        view.rerender();
+        await settled();
+        signedInAs = session;
+        view.rerender();
+        await settled();
+
+        expect(deployment.opened).toHaveLength(2);
+        expect(refreshes()).toBe(1);
+    });
+
+    it('refreshes nothing for a connection opened for somebody else, whose screens have only just been read', async () => {
+        const deployment = channelHoldingOneConnection();
+        let signedInAs: ClientSession | null = session;
+        const view = renderHook(() => useSignals(signedInAs, mintsTickets, deployment.channel, neverReopens));
+        const refreshes = listening(view.result.current);
+
+        await settled();
+        signedInAs = somebodyElse;
+        view.rerender();
+        await settled();
+
+        expect(deployment.opened).toHaveLength(2);
+        expect(refreshes()).toBe(0);
+    });
+
+    it('refreshes every five minutes while the window is visible', async () => {
+        vi.useFakeTimers();
+        windowIs('visible');
+        const deployment = channelHoldingOneConnection();
+        const view = renderHook(() => useSignals(session, mintsTickets, deployment.channel, neverReopens));
+        const refreshes = listening(view.result.current);
+
+        await settled();
+        await pass(refreshInterval - 1);
+        expect(refreshes()).toBe(0);
+
+        await pass(1);
+        expect(refreshes()).toBe(1);
+
+        await pass(refreshInterval);
+        expect(refreshes()).toBe(2);
+    });
+
+    it('refreshes nothing while the window is hidden, and at once when it comes back after the interval ran out', async () => {
+        vi.useFakeTimers();
+        windowIs('hidden');
+        const deployment = channelHoldingOneConnection();
+        const view = renderHook(() => useSignals(session, mintsTickets, deployment.channel, neverReopens));
+        const refreshes = listening(view.result.current);
+
+        await settled();
+        await pass(refreshInterval * 3);
+        expect(refreshes()).toBe(0);
+
+        windowComesBack();
+        expect(refreshes()).toBe(1);
+    });
+
+    it('refreshes nothing for a window that comes back before the interval ran out', async () => {
+        vi.useFakeTimers();
+        windowIs('hidden');
+        const deployment = channelHoldingOneConnection();
+        const view = renderHook(() => useSignals(session, mintsTickets, deployment.channel, neverReopens));
+        const refreshes = listening(view.result.current);
+
+        await settled();
+        await pass(refreshInterval / 5);
+        windowComesBack();
+        expect(refreshes()).toBe(0);
+
+        await pass(refreshInterval);
+        expect(refreshes()).toBe(1);
+    });
+
+    it('counts the interval from the last refresh rather than on a fixed clock', async () => {
+        vi.useFakeTimers();
+        windowIs('visible');
+        const deployment = channelHoldingOneConnection();
+        const view = renderHook(() => useSignals(session, mintsTickets, deployment.channel, neverReopens));
+        const refreshes = listening(view.result.current);
+
+        await settled();
+        await pass(refreshInterval - 60_000);
+        act(() => {
+            view.result.current.refresh();
+        });
+        expect(refreshes()).toBe(1);
+
+        await pass(60_000);
+        expect(refreshes()).toBe(1);
+
+        await pass(refreshInterval - 60_000);
+        expect(refreshes()).toBe(2);
+    });
+
+    it('refreshes nothing, on the interval or when asked, where nobody is signed in', async () => {
+        vi.useFakeTimers();
+        windowIs('visible');
+        const deployment = channelHoldingOneConnection();
+        const view = renderHook(() => useSignals(null, mintsTickets, deployment.channel, neverReopens));
+        const refreshes = listening(view.result.current);
+
+        act(() => {
+            view.result.current.refresh();
+        });
+        await pass(refreshInterval * 2);
+
+        expect(refreshes()).toBe(0);
     });
 });

--- a/frontend/src/Client.App/src/signals/useSignals.ts
+++ b/frontend/src/Client.App/src/signals/useSignals.ts
@@ -10,24 +10,37 @@ import {
     type MailFathomTransport,
     type SignalStreamSchedule,
 } from '@mailfathom/client-backend';
-import type { SignalledChanges, SignalListener } from './signalledChanges';
+import type { SignalledChange, SignalledChanges, SignalListener } from './signalledChanges';
+
+/** How long a visible client goes without reading again what it draws, counted from the last time it did. */
+export const refreshInterval = 5 * 60_000;
 
 /**
- * Holds a connection to the deployment's signal channel for as long as one credential does.
+ * Holds a connection to the deployment's signal channel for as long as one credential does, and refreshes every screen
+ * whenever what the connection says may not be everything that changed.
  *
  * The connection is what this effect synchronizes with, which is what an effect is for. It opens once a session
  * exists, and signing out or being pointed at another deployment closes it and opens nothing — so nothing about one
  * deployment reaches a client that has left it.
  *
- * **A channel that never opens is silent.** Nothing here is rendered, nothing here fails, and no screen is told: a
- * deployment serving no hub, a proxy that will not pass the upgrade, and a connection that dropped are one thing to a
- * person reading their mail — a client on its own interval, which is what every screen already does.
+ * **A channel that never opens is silent.** Nothing here is rendered and nothing here fails: a deployment serving no
+ * hub, a proxy that will not pass the upgrade, and a connection that dropped are one thing to a person reading their
+ * mail — a client refreshing on its own interval.
  *
- * @param session Who is asking, or `null` where nobody is signed in or the credential may not read mail.
+ * **What the connection could not say is caught up on instead.** Nothing buffers a statement for a connection that is
+ * not there, so a gap in it is a gap in what the screens were told. A connection standing again after one stood for the
+ * same session therefore refreshes every screen, and so does the interval: every five minutes while the window is
+ * visible, counted from the last refresh rather than on a fixed clock. The interval is also what covers the one gap no
+ * reconnect sees — a statement lost behind a connection that stayed open — and what a deployment serving no channel is
+ * read on. Nothing runs while the window is hidden, and a window coming back after the interval ran out while it was
+ * hidden refreshes at once.
+ *
+ * @param session Who is asking, or `null` where nobody is signed in, the credential may not read mail, or the machine
+ * has no network.
  * @param transport How the ticket each connection is opened against is minted.
  * @param channel How a connection is opened, which is the composition root's to supply.
  * @param schedule How the stream waits before opening again.
- * @returns What a screen subscribes to.
+ * @returns What a screen subscribes to, and the way to refresh every screen.
  */
 export function useSignals(
     session: ClientSession | null,
@@ -40,6 +53,15 @@ export function useSignals(
     // reopen the connection.
     const listeners = useRef(new Set<SignalListener>());
 
+    // What a refresh does, written by the effect that holds the interval a refresh starts over, and `null` whenever
+    // that effect holds nothing — which is when there is nothing a refresh could read over.
+    const refreshing = useRef<(() => void) | null>(null);
+
+    // The session a connection last stood for. One standing again for the same session is a reopening whatever closed
+    // the last — a drop, or the network going, which closes the stream and opens a new one for the same session — and
+    // one standing for another is a first opening: somebody signing in, or a renewed token.
+    const stoodFor = useRef<ClientSession | null>(null);
+
     const changes = useMemo<SignalledChanges>(
         () => ({
             listen: (listener) => {
@@ -48,6 +70,9 @@ export function useSignals(
                 return () => {
                     listeners.current.delete(listener);
                 };
+            },
+            refresh: () => {
+                refreshing.current?.();
             },
         }),
         [],
@@ -58,21 +83,67 @@ export function useSignals(
             return;
         }
 
+        function tell(change: SignalledChange): void {
+            // A copy, because a screen that unmounts on what it was told would otherwise be removed from the set being
+            // walked.
+            for (const listener of [...listeners.current]) {
+                listener(change);
+            }
+        }
+
+        let waiting = 0;
+        let due = false;
+
+        function refresh(): void {
+            countFromNow();
+            tell({ kind: 'refresh' });
+        }
+
+        function countFromNow(): void {
+            window.clearTimeout(waiting);
+            due = false;
+            waiting = window.setTimeout(elapsed, refreshInterval);
+        }
+
+        // Due rather than run while the window is hidden, and nothing is counted until it is back: a hidden window is
+        // somebody not looking, and reading for them is spending their deployment's time on a screen nobody sees.
+        function elapsed(): void {
+            if (document.visibilityState === 'visible') {
+                refresh();
+            } else {
+                due = true;
+            }
+        }
+
+        function returned(): void {
+            if (due && document.visibilityState === 'visible') {
+                refresh();
+            }
+        }
+
+        refreshing.current = refresh;
+        countFromNow();
+        document.addEventListener('visibilitychange', returned);
+
         const stream = openSignalStream(
             session,
             transport,
             channel,
-            (signal) => {
-                // A copy, because a screen that unmounts on what it was told would otherwise be removed from the set
-                // being walked.
-                for (const listener of [...listeners.current]) {
-                    listener(signal);
+            tell,
+            () => {
+                if (stoodFor.current === session) {
+                    refresh();
                 }
+
+                stoodFor.current = session;
             },
             schedule,
         );
 
         return () => {
+            refreshing.current = null;
+            window.clearTimeout(waiting);
+            document.removeEventListener('visibilitychange', returned);
             void stream.close();
         };
     }, [session, transport, channel, schedule]);

--- a/frontend/src/Client.App/src/styles.css
+++ b/frontend/src/Client.App/src/styles.css
@@ -339,6 +339,22 @@
        this file that removes every animation. */
     --animate-spin: spin 1.2s linear infinite;
 
+    /* How a control says that what it asked for is under way without turning anything, which is the design project's
+       pulse: the symbol dims and brightens once a second. The rail's refresh is the surface drawing it. Removed under
+       `prefers-reduced-motion` by the same rule as the spin, which leaves the control's accent colours saying it. */
+    --animate-working: working 1s ease-in-out infinite;
+
+    @keyframes working {
+        0%,
+        100% {
+            opacity: 0.35;
+        }
+
+        50% {
+            opacity: 1;
+        }
+    }
+
     /* What a toast does beyond that: it arrives from the edge it is stacked against, it leaves the same way, and the
        bar along its bottom edge empties over its lifetime. All three are the design project's, and they are declared
        here for the reason every other duration is — a component writing one of its own is the same drift as one

--- a/frontend/src/Client.Backend/src/signals.test.ts
+++ b/frontend/src/Client.Backend/src/signals.test.ts
@@ -58,6 +58,19 @@ function scheduleRecording(waits: number[]): SignalStreamSchedule {
     };
 }
 
+// The same, except that the wait after the last one it was told to allow never ends. A stream that never stops trying
+// would otherwise try forever inside one test, so this is what lets a test count how far past the budget it went.
+function scheduleWaiting(waits: number[], allowed: number): SignalStreamSchedule {
+    return {
+        wait: (milliseconds) => {
+            waits.push(milliseconds);
+
+            return waits.length < allowed ? Promise.resolve() : new Promise<void>(() => undefined);
+        },
+        draw: () => 0.5,
+    };
+}
+
 /** Lets a test drive the channel the way a deployment would: opening it, sending a payload, and dropping it. */
 function channelUnderTest(): {
     channel: MailFathomSignalChannel;
@@ -276,6 +289,7 @@ describe('openSignalStream', () => {
             answering({ status: 200, body: minted }),
             channel.channel,
             () => undefined,
+            () => undefined,
             scheduleRecording([]),
         );
 
@@ -295,6 +309,7 @@ describe('openSignalStream', () => {
             answering({ status: 200, body: minted }),
             channel.channel,
             (signal) => told.push(signal),
+            () => undefined,
             scheduleRecording([]),
         );
 
@@ -315,6 +330,7 @@ describe('openSignalStream', () => {
             answering({ status: 200, body: minted }),
             channel.channel,
             () => undefined,
+            () => undefined,
             scheduleRecording(waits),
         );
 
@@ -328,20 +344,66 @@ describe('openSignalStream', () => {
         await stream.close();
     });
 
-    it('gives up after the bounded number of attempts against a deployment serving no channel', async () => {
+    it('says a connection stands each time one does, the first and every one reopened after a drop', async () => {
+        let stood = 0;
+        const channel = channelUnderTest();
+        const stream = openSignalStream(
+            session,
+            answering({ status: 200, body: minted }),
+            channel.channel,
+            () => undefined,
+            () => {
+                stood += 1;
+            },
+            scheduleRecording([]),
+        );
+
+        await settle();
+        expect(stood).toBe(1);
+
+        channel.openings[0]?.dropped();
+        await settle();
+
+        expect(stood).toBe(2);
+
+        await stream.close();
+    });
+
+    it('says nothing stands against a deployment serving no channel', async () => {
+        let stood = 0;
+        const stream = openSignalStream(
+            session,
+            answering({ status: 404, body: '' }),
+            () => Promise.reject(new Error('never asked')),
+            () => undefined,
+            () => {
+                stood += 1;
+            },
+            scheduleWaiting([], 3),
+        );
+
+        await settle();
+
+        expect(stood).toBe(0);
+
+        await stream.close();
+    });
+
+    it('goes on trying past the budget at the longest wait rather than stopping', async () => {
         const waits: number[] = [];
         const stream = openSignalStream(
             session,
             answering({ status: 404, body: '' }),
             () => Promise.reject(new Error('never asked')),
             () => undefined,
-            scheduleRecording(waits),
+            () => undefined,
+            scheduleWaiting(waits, mostReconnectionAttempts + 3),
         );
 
         await settle();
 
-        expect(waits).toHaveLength(mostReconnectionAttempts);
-        expect(waits.at(-1)).toBe(30_000);
+        expect(waits).toHaveLength(mostReconnectionAttempts + 3);
+        expect(waits.slice(mostReconnectionAttempts - 1)).toStrictEqual([30_000, 30_000, 30_000, 30_000]);
 
         await stream.close();
     });
@@ -352,6 +414,7 @@ describe('openSignalStream', () => {
             session,
             answering({ status: 200, body: minted }),
             channel.channel,
+            () => undefined,
             () => undefined,
             scheduleRecording([]),
         );

--- a/frontend/src/Client.Backend/src/signals.ts
+++ b/frontend/src/Client.Backend/src/signals.ts
@@ -4,7 +4,7 @@
 
 import { failed, failureReasonForStatus, read, type ClientResult } from './failure';
 import { asRecord } from './json';
-import { mostReconnectionAttempts, reconnectionDelay } from './reconnection';
+import { reconnectionDelay } from './reconnection';
 import { headersFor, routeFor, type ClientSession } from './session';
 import { spanned } from './telemetry';
 import { send, type MailFathomTransport } from './transport';
@@ -208,15 +208,19 @@ export function parseClientSignal(payload: unknown): ClientSignal | null {
  * Opens a connection and keeps one open, telling the caller what the deployment says changed.
  *
  * A connection is opened by minting a ticket and handing it to the channel, and a ticket opens exactly one — so every
- * reopening mints another. Both halves are retried on the same bounded, spread schedule the shell reaches a lost
- * deployment on, and after `mostReconnectionAttempts` the stream stops trying: a client whose channel never came back
- * reads on its own interval, which is what it does when a deployment serves no channel at all.
+ * reopening mints another. Both halves are retried on the same spread schedule the shell reaches a lost deployment on,
+ * and the stream never stops trying on its own: past `mostReconnectionAttempts` it goes on at the longest wait the
+ * schedule has. A rolling upgrade that keeps the hub away for longer than a minute is no reason for an open client to
+ * stop hearing about mail until somebody reloads it, so only the caller closing the stream ends it.
  *
  * **Nothing here reports a failure.** A deployment that serves no hub, a proxy that will not pass the upgrade, and a
  * connection that dropped are all the same thing to a person looking at the screen — a client reading on its interval
  * — and saying so would be a client complaining about an optimization it never promised.
  *
- * @param told Called once per statement, after the payload has been read as one of the five.
+ * @param told Called once per statement, after the payload has been read as one of the six.
+ * @param opened Called each time a connection has opened and stands. Whatever was said while none stood was said to
+ * nobody, so this is the moment a caller reads again what it draws — except after the first opening, which only the
+ * caller can tell apart, since only it knows whether anything was drawn before it.
  * @returns The subscription, which the caller closes when the person signs out or the deployment changes.
  */
 export function openSignalStream(
@@ -224,6 +228,7 @@ export function openSignalStream(
     transport: MailFathomTransport,
     channel: MailFathomSignalChannel,
     told: (signal: ClientSignal) => void,
+    opened: () => void,
     schedule: SignalStreamSchedule,
 ): SignalStream {
     let open: SignalChannelHandle | null = null;
@@ -246,12 +251,9 @@ export function openSignalStream(
             // A connection that stood and then dropped is not the next failed attempt in a row: the schedule measures
             // how long a deployment has been unreachable, and one that answered is reachable. It is still waited out
             // before another is opened, so a deployment closing every connection at once costs one attempt a second
-            // rather than a loop.
+            // rather than a loop. Past the budget the wait stops growing rather than the stream stopping, because the
+            // schedule caps it at its longest.
             refusals = outcome === 'opened' ? 0 : refusals + 1;
-
-            if (refusals > mostReconnectionAttempts) {
-                return;
-            }
 
             await schedule.wait(reconnectionDelay(refusals, schedule.draw()));
         }
@@ -289,6 +291,7 @@ export function openSignalStream(
             return 'opened';
         }
 
+        opened();
         await ended.reached;
         open = null;
 


### PR DESCRIPTION
## What changes

A gap in the signal channel is now a gap the client catches up on, instead of one it never hears about until the next reload.

- **The stream never stops while somebody is signed in.** `openSignalStream` no longer gives up after `mostReconnectionAttempts`: past the budget it keeps trying at the longest wait the schedule has (30 s), and only the caller closing it ends it. It now reports each connection that opens and stands (`opened`).
- **A wait ends early when the deployment is probably reachable again.** `browserSchedule.wait` resolves at once on `online`, and on `visibilitychange` to visible, so a client somebody returns to tries straight away rather than sitting out the rest of a 30-second wait.
- **One refresh act, three ways to ask for it.** `SignalledChanges` now carries `{ kind: 'refresh' }` beside the six statements, and `useSignals` asks for it:
  - when a connection stands again after one stood for the **same** session (a drop, or the network going and coming back) — never on the first opening, a sign-in, or a renewed token;
  - every **five minutes while the window is visible**, counted from the last refresh rather than on a fixed clock; nothing runs while hidden, and a window hidden past the interval refreshes at once when it comes back;
  - when somebody presses the rail's *Refresh*, which is now exactly the same act.
- **Every surface hears it and reads again what it draws**: the folder tree and its counts, the pages of the list it holds, the open message, the accounts, and the notification centre (page and count). `readAgain` on the list and the centre is gone; the control no longer reaches into either.
- **Nothing a refresh reads again is emptied, and a refresh that is not answered says nothing.** The list marks its held pages stale (`refreshAsked`) instead of dropping them, so rows stay drawn — no skeleton — while the pages on the screen are read again, and an unanswered one keeps its rows (`refreshUnanswered`) with no alert. The tree, the open message, and the frame's session and accounts keep what stands when a quiet read fails. Selection, the open message, the place in the list, and pending changes are untouched.
- **The control says a refresh is under way whoever asked.** *Refresh* hears the refresh rather than setting state on its press, so the interval and a reconnect draw it exactly as a press does: the design's busy look (accent-soft ground, accent line, accent-deep glyph, the `mfpulse` 1 s pulse as `--animate-working`), with a second press refused (`aria-disabled`) while it holds. Motion is removed under `prefers-reduced-motion`; the accent still says it.

## Public surfaces

None. The MCP tool contract, the configuration schema, the database schema, and the deployment contract are untouched; this is client behaviour only. `docs/operations/client-endpoint.md` § *The signal channel* states the new reconnect and catch-up behaviour.

## Design parity

Held against the design mirror (stamp `84cbf4437f311220`) at the desktop composition, 1440 × 900, as captured images of the rail's lower cluster:

- **Busy, pointer away** — accent-soft ground, accent line, accent-deep glyph: matches.
- **Busy, hovered** — the hover ground and text colour over the accent line: matches.
- **Hover** — the client's rail hover was the accent (ground, line, glyph); the prototype's is `--hover` with `--text` and leaves the line alone. Aligned to the design in both looks.

Two differences remain, and neither is this change's:

- At rest, the client's glyph reads a shade lighter than the prototype's `--text2`. The resting colour was not touched here.
- The cluster sits about 8 px lower than the prototype's, because the prototype draws its own *PROTOTYPE* caption above it.

## Corner cut

The busy look holds for one pulse beat (1 s, `refreshShownFor`) rather than until every surface's read has landed, since no surface reports completion. It is marked with a `ponytail:` comment in `Refresh.tsx` and is worth tying to the reads if a refresh ever takes long enough for the difference to show.

## Verification

`scripts/verify-fast.sh` passes on this head: the client flow — ESLint, the three `tsc` projects, the whole Vitest suite (214 files, 3 902 tests), and Prettier with nothing rewritten.

New and changed tests:

- `signals.test.ts` — the stream goes on past the budget at the longest wait, reports each connection that stands, and reports nothing where no channel is served.
- `useSignals.test.tsx` — a reopened connection refreshes and a first one does not; the network coming back for the same person refreshes and somebody else's connection does not; the interval refreshes while visible, never while hidden, and at once on a return past it, counted from the last refresh; nothing refreshes where nobody is signed in.
- `signalChannel.test.ts` — the wait ends on its time, on `online`, and on becoming visible, and not on becoming hidden.
- `Refresh.test.tsx` — a press asks for a refresh; the busy look follows any refresh, clears after one beat, and refuses a second press.
- Tree, list, reading pane, connection, and notification centre — a refresh reads again, and an unanswered one keeps what is drawn.
- `heldTimeline.test.ts` — the stale marking.

Closes #1877
