### PR TITLE
[#1878] Serve the signal hub over WebSockets alone, and let any replica redeem a signal ticket

### DIFF
--- a/backend/src/Application/Signals/ClientSignalTicketStoreUnavailableException.cs
+++ b/backend/src/Application/Signals/ClientSignalTicketStoreUnavailableException.cs
@@ -1,0 +1,41 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Failures;
+
+namespace MailFathom.Application.Signals;
+
+/// <summary>Indicates that the deployment's signal tickets could not be reached, so the connection or the mint was refused.</summary>
+/// <remarks>
+/// <para>
+/// It exists so the failure crosses <see cref="IClientSignalTicketStore" /> as this system's own rather than as the
+/// provider's, for the reason the anti-replay record's does: the port is an application contract and one of its callers
+/// is a hub that has authenticated nothing yet, so an adapter's exception reaching there would put a database driver's
+/// type and a server's own message on the path that answers an unauthenticated caller.
+/// </para>
+/// <para>
+/// One failure covers a database that could not be reached, a statement that timed out, and a value the server refused,
+/// because all three are the same thing to the layer above: the deployment cannot say whether this ticket stands. What
+/// that layer does about it is refuse — a connection admitted on a store that could not answer is a connection opened
+/// against no ticket at all — which is why the distinction between them belongs in <see cref="Exception.InnerException" />
+/// for an operator's log rather than in a code the caller would branch on.
+/// </para>
+/// <para>
+/// The message names the record and the operator's next step. It carries no connection string, no ticket, and nothing
+/// the server said, all of which stay reachable through the inner exception.
+/// </para>
+/// </remarks>
+public sealed class ClientSignalTicketStoreUnavailableException : MailFathomException
+{
+    /// <summary>Initializes a new failure over the provider failure that revealed it.</summary>
+    /// <param name="operatorSafeMessage">A message free of provider details, credentials, and client-presented values.</param>
+    /// <param name="providerFailure">The provider failure the statement met.</param>
+    public ClientSignalTicketStoreUnavailableException(string operatorSafeMessage, Exception providerFailure)
+        : base(operatorSafeMessage, providerFailure)
+    {
+    }
+
+    /// <inheritdoc />
+    public override MailFathomErrorCode ErrorCode => MailFathomErrorCode.ClientSignalTicketStoreUnavailable;
+}

--- a/backend/src/Application/Signals/IClientSignalTicketStore.cs
+++ b/backend/src/Application/Signals/IClientSignalTicketStore.cs
@@ -1,0 +1,79 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Access;
+
+namespace MailFathom.Application.Signals;
+
+/// <summary>Where the deployment holds the unspent tickets its signal connections are opened against.</summary>
+/// <remarks>
+/// <para>
+/// The port exists because a ticket is minted by whichever replica answered the minting route and presented to
+/// whichever replica answered the connection, and nothing routes the two together: the connection skips negotiation, so
+/// it is one request the load balancer places on its own. A ticket held in a process is therefore redeemable about one
+/// time in the replica count, which is a live channel that silently stops working when an operator scales out.
+/// <see href="https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0032-reaching-a-client-from-any-replica-over-websockets-and-a-resp-backplane.md">ADR 0032</see>
+/// records that and why the ticket does not live in the optional backplane instead.
+/// </para>
+/// <para>
+/// What is held is a user, a digest of the secret half, and when the ticket stops being presentable. The secret itself
+/// never reaches the store, so a row read out of the database or out of a backup is not a ticket.
+/// </para>
+/// </remarks>
+public interface IClientSignalTicketStore
+{
+    /// <summary>Holds one minted ticket, unless the deployment already holds as many as it will hold.</summary>
+    /// <param name="identifier">The public half of the ticket, which is what a presentation is looked up by.</param>
+    /// <param name="user">The user the credential that reached the minting route named.</param>
+    /// <param name="secretDigest">The digest of the secret half, which is what a presentation is compared against.</param>
+    /// <param name="expiresAt">When presenting the ticket stops working.</param>
+    /// <param name="mostOutstanding">The most tickets the deployment holds at once, counted across every replica.</param>
+    /// <param name="cancellationToken">Cancels the write.</param>
+    /// <returns><see langword="true" /> when the ticket was held; <see langword="false" /> when the bound refused it.</returns>
+    /// <exception cref="ClientSignalTicketStoreUnavailableException">Thrown when the ticket could not be held, which the caller answers by refusing rather than by minting.</exception>
+    /// <remarks>
+    /// The bound is the caller's value and the deployment's count, in one statement: a count read and then written
+    /// against is a bound several replicas each find room under and then all exceed.
+    /// </remarks>
+    Task<bool> TryMintAsync(
+        string identifier,
+        MailUserId user,
+        ReadOnlyMemory<byte> secretDigest,
+        DateTimeOffset expiresAt,
+        int mostOutstanding,
+        CancellationToken cancellationToken);
+
+    /// <summary>Spends one ticket, reporting what it held.</summary>
+    /// <param name="identifier">The public half a connection presented, which is whatever a caller wrote.</param>
+    /// <param name="cancellationToken">Cancels the write.</param>
+    /// <returns>What the ticket held, or <see langword="null" /> where no ticket stood under that identifier.</returns>
+    /// <exception cref="ClientSignalTicketStoreUnavailableException">Thrown when the store could not answer, which the caller answers by refusing the connection rather than admitting it.</exception>
+    /// <remarks>
+    /// One statement that removes and returns together, so exactly one presentation of a ticket wins whichever replica
+    /// each of them reaches. An implementation that read and then removed would admit both. The expiry travels back
+    /// rather than being compared here, because a ticket presented past it is spent as surely as one presented in time.
+    /// </remarks>
+    Task<RedeemedClientSignalTicket?> RedeemAsync(string identifier, CancellationToken cancellationToken);
+
+    /// <summary>Forgets the tickets that can no longer be presented.</summary>
+    /// <param name="removableFrom">The instant expiry is judged against: a ticket is dropped once this has passed its recorded expiry.</param>
+    /// <param name="cancellationToken">Cancels the removal.</param>
+    /// <returns>A task that completes when the expired tickets are gone.</returns>
+    /// <exception cref="ClientSignalTicketStoreUnavailableException">Thrown when the removal could not run, which reaches the mint that triggered it rather than being swallowed.</exception>
+    /// <remarks>
+    /// Bounded by what it can match rather than by a limit the caller passes: an implementation reaches the expired
+    /// tickets through an ordering on the expiry, so the work is proportional to what has expired since the last
+    /// removal rather than to every ticket ever minted.
+    /// </remarks>
+    Task RemoveExpiredAsync(DateTimeOffset removableFrom, CancellationToken cancellationToken);
+}
+
+/// <summary>What a spent ticket held, handed back by the statement that removed it.</summary>
+/// <param name="User">The user the ticket was minted for.</param>
+/// <param name="SecretDigest">The digest of the secret half, which the presented secret is compared against in constant time.</param>
+/// <param name="ExpiresAt">When presenting the ticket stopped working.</param>
+public sealed record RedeemedClientSignalTicket(
+    MailUserId User,
+    ReadOnlyMemory<byte> SecretDigest,
+    DateTimeOffset ExpiresAt);

--- a/backend/src/Domain/Failures/MailFathomErrorCode.cs
+++ b/backend/src/Domain/Failures/MailFathomErrorCode.cs
@@ -453,6 +453,15 @@ public readonly record struct MailFathomErrorCode
     /// </remarks>
     public static MailFathomErrorCode ClientAssertionSpendUnrecordable { get; } = new(33001);
 
+    /// <summary>Gets subcategory 3, the anti-replay record: the deployment's unspent signal tickets could not be reached, so the connection or the mint was refused.</summary>
+    /// <remarks>
+    /// It shares the subcategory with the code above because both are a single-use client credential the deployment
+    /// remembers exactly once, and a store that cannot answer refuses rather than serves in either. It is a code of its
+    /// own because what it costs is different: a refused connection costs live updates while the client's own re-read
+    /// still carries the screen, where a refused assertion costs the request outright.
+    /// </remarks>
+    public static MailFathomErrorCode ClientSignalTicketStoreUnavailable { get; } = new(33002);
+
     /// <summary>Gets subcategory 4, durable jobs: a job payload serialized to more than the enqueue boundary accepts.</summary>
     /// <remarks>
     /// It is a subcategory of its own rather than one more schema-state failure, because nothing about the database is
@@ -1084,6 +1093,7 @@ public readonly record struct MailFathomErrorCode
         DatabaseSchemaStateUnreadable,
         DatabaseSchemaTextSearchConfigurationMismatch,
         ClientAssertionSpendUnrecordable,
+        ClientSignalTicketStoreUnavailable,
         JobPayloadTooLarge,
         JobHandOnRefusedAtCapacity,
         PersistenceTransientFailure,

--- a/backend/src/Host/HostComposition.cs
+++ b/backend/src/Host/HostComposition.cs
@@ -1497,9 +1497,12 @@ internal static class HostComposition
     /// <see cref="ClientSignals" /> folds nothing — which is what keeps a service with no client from holding state
     /// about signals nobody can receive.
     /// <para>
-    /// The ticket store is a singleton because it holds what is outstanding across requests, and the hub reads it from a
-    /// connection rather than from a request. The publisher itself is registered with the rest of the application graph,
-    /// unconditionally, because every raise site reaches it whether or not anything is listening.
+    /// The ticket minting is a singleton because it spans requests — a route mints and a connection spends — and the hub
+    /// reaches it from a connection rather than from a request. What it holds is the sweep interval and the count of
+    /// redemptions this process has in flight; the tickets themselves live in PostgreSQL, registered with the rest of
+    /// the infrastructure graph, so any replica redeems what any other minted. The publisher itself is registered with
+    /// the rest of the application graph, unconditionally, because every raise site reaches it whether or not anything
+    /// is listening.
     /// </para>
     /// </remarks>
     private static void AddClientSignalChannel(WebApplicationBuilder builder)

--- a/backend/src/Host/HostPipeline.cs
+++ b/backend/src/Host/HostPipeline.cs
@@ -427,7 +427,7 @@ internal static class HostPipeline
         // Outside the group deliberately, and the reasoning is in ClientSignalEndpoints: a long-lived connection is not
         // a request, so this surface's request timeout and its rate limiter are the wrong treatment for it, and what
         // bounds a client reconnecting is the ticket route inside the group that every reconnection has to spend.
-        app.MapHub<ClientSignalHub>(ClientSignalEndpoints.HubPath);
+        app.MapHub<ClientSignalHub>(ClientSignalEndpoints.HubPath, ClientSignalEndpoints.ServeOverWebSocketsAlone);
 
         if (composition.Client.AllowsOAuth)
         {

--- a/backend/src/Host/Signals/ClientSignalEndpoints.cs
+++ b/backend/src/Host/Signals/ClientSignalEndpoints.cs
@@ -53,9 +53,10 @@ internal static partial class ClientSignalEndpoints
     /// A SignalR handshake is ordinarily two requests — a negotiation and the transport it chose — and both have to
     /// reach the same process, which is why the framework's scale-out guidance asks for session affinity. It names
     /// WebSockets alone with negotiation skipped as one of the arrangements that needs none, and that is what the
-    /// client already does. Refusing the other two transports here is what makes that a property of the deployment
-    /// rather than a habit of one client: nothing can open a connection that would then have to be routed back to the
-    /// replica that answered its negotiation.
+    /// client already does. What this setting decides is what the deployment offers rather than what a caller may ask
+    /// for: the negotiate endpoint still answers, and it now offers WebSockets and nothing else, so a connection that
+    /// skips it is one request no replica has to be chosen twice for. A caller that does negotiate holds a token the
+    /// replica that answered it issued, and arranges its own routing back there; no first-party client asks for one.
     /// </para>
     /// <para>
     /// What it costs is stated in

--- a/backend/src/Host/Signals/ClientSignalEndpoints.cs
+++ b/backend/src/Host/Signals/ClientSignalEndpoints.cs
@@ -37,7 +37,7 @@ namespace MailFathom.Host.Signals;
 /// scaling out configures no session affinity.
 /// </para>
 /// </remarks>
-internal static class ClientSignalEndpoints
+internal static partial class ClientSignalEndpoints
 {
     /// <summary>The route a connection ticket is minted on, relative to the client prefix.</summary>
     internal const string TicketRoute = "/signals/ticket";
@@ -85,6 +85,7 @@ internal static class ClientSignalEndpoints
     /// <summary>Mints a ticket for the person the credential named.</summary>
     /// <param name="authorization">Reports the grant the caller holds and the user it acts for.</param>
     /// <param name="tickets">Mints the ticket and holds it until it is spent or expires.</param>
+    /// <param name="loggerFactory">Opens the logger the one refusal an operator acts on is recorded through.</param>
     /// <param name="cancellationToken">Cancels the mint with the request that asked for it.</param>
     /// <returns><c>200</c> with the ticket, or <c>503</c> where the deployment already holds every ticket it will hold or could not be asked.</returns>
     /// <exception cref="ArgumentNullException">Thrown when a required service is <see langword="null" />.</exception>
@@ -104,10 +105,12 @@ internal static class ClientSignalEndpoints
     internal static async Task<Results<Ok<ClientSignalTicketResponse>, ProblemHttpResult>> MintTicket(
         [FromServices] AccessAuthorization authorization,
         [FromServices] ClientSignalTickets tickets,
+        [FromServices] ILoggerFactory loggerFactory,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(authorization);
         ArgumentNullException.ThrowIfNull(tickets);
+        ArgumentNullException.ThrowIfNull(loggerFactory);
 
         MintedClientSignalTicket? minted;
 
@@ -117,6 +120,11 @@ internal static class ClientSignalEndpoints
         }
         catch (ClientSignalTicketStoreUnavailableException unreachable)
         {
+            // The one refusal on this route an operator acts on, and the only record of why the database could not be
+            // reached: the status it answers with is the deployment's own ceiling's as well, and the error code below
+            // tells a client the two apart without telling anybody what failed.
+            LogTicketStoreUnavailable(loggerFactory.CreateLogger(typeof(ClientSignalEndpoints)), unreachable);
+
             return TypedResults.Problem(
                 unreachable.Message,
                 statusCode: StatusCodes.Status503ServiceUnavailable,
@@ -132,6 +140,11 @@ internal static class ClientSignalEndpoints
                 statusCode: StatusCodes.Status503ServiceUnavailable)
             : TypedResults.Ok(new ClientSignalTicketResponse(minted.Value, minted.ExpiresAt));
     }
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "A signal ticket was not minted because this deployment's unspent tickets could not be reached.")]
+    private static partial void LogTicketStoreUnavailable(ILogger logger, Exception failure);
 }
 
 /// <summary>What the minting route answers with.</summary>

--- a/backend/src/Host/Signals/ClientSignalEndpoints.cs
+++ b/backend/src/Host/Signals/ClientSignalEndpoints.cs
@@ -6,6 +6,7 @@ using MailFathom.Application.Access;
 using MailFathom.Domain.Access;
 using MailFathom.Host.Configuration.Endpoints;
 using MailFathom.Host.Security.Endpoints;
+using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 
@@ -29,6 +30,11 @@ namespace MailFathom.Host.Signals;
 /// It sits beneath the client endpoint's route prefix, so <c>SurfaceIsolation</c> reads it as one of this surface's
 /// paths and a listener that does not serve the client surface answers it <c>404</c> like every other route here.
 /// </para>
+/// <para>
+/// <b>It serves one transport</b>, for the reason <see cref="ServeOverWebSocketsAlone" /> gives: a connection that
+/// skips negotiation is a single request, so nothing has to route a pair of requests to one replica and a deployment
+/// scaling out configures no session affinity.
+/// </para>
 /// </remarks>
 internal static class ClientSignalEndpoints
 {
@@ -37,6 +43,32 @@ internal static class ClientSignalEndpoints
 
     /// <summary>The path the hub answers on, which is absolute because a hub is mapped outside the client group.</summary>
     internal const string HubPath = ClientEndpointOptions.RoutePrefix + "/signals";
+
+    /// <summary>Serves the hub over WebSockets and refuses every other transport.</summary>
+    /// <param name="options">What the hub's own connection dispatcher is configured with.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="options" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// <para>
+    /// A SignalR handshake is ordinarily two requests — a negotiation and the transport it chose — and both have to
+    /// reach the same process, which is why the framework's scale-out guidance asks for session affinity. It names
+    /// WebSockets alone with negotiation skipped as one of the arrangements that needs none, and that is what the
+    /// client already does. Refusing the other two transports here is what makes that a property of the deployment
+    /// rather than a habit of one client: nothing can open a connection that would then have to be routed back to the
+    /// replica that answered its negotiation.
+    /// </para>
+    /// <para>
+    /// What it costs is stated in
+    /// <see href="https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0032-reaching-a-client-from-any-replica-over-websockets-and-a-resp-backplane.md">ADR 0032</see>:
+    /// a network or a proxy that will not pass the WebSocket upgrade gives that client no live updates at all, and it
+    /// reads its screens over the ordinary routes on its own schedule instead.
+    /// </para>
+    /// </remarks>
+    internal static void ServeOverWebSocketsAlone(HttpConnectionDispatcherOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        options.Transports = HttpTransportType.WebSockets;
+    }
 
     /// <summary>Maps the ticket route into the client group, so it inherits its requirement, its policy, and its limits.</summary>
     /// <param name="api">The client route group.</param>
@@ -52,20 +84,22 @@ internal static class ClientSignalEndpoints
     /// <summary>Mints a ticket for the person the credential named.</summary>
     /// <param name="authorization">Reports the grant the caller holds and the user it acts for.</param>
     /// <param name="tickets">Mints the ticket and holds it until it is spent or expires.</param>
-    /// <returns><c>200</c> with the ticket, or <c>503</c> where too many tickets already stand outstanding.</returns>
+    /// <param name="cancellationToken">Cancels the mint with the request that asked for it.</param>
+    /// <returns><c>200</c> with the ticket, or <c>503</c> where the deployment already holds every ticket it will hold.</returns>
     /// <exception cref="ArgumentNullException">Thrown when a required service is <see langword="null" />.</exception>
     /// <remarks>
     /// A <c>POST</c> rather than a <c>GET</c>, because minting a single-use credential changes state: a <c>GET</c> would
     /// be a route a cache, a prefetch, or a link preview could spend a ticket through.
     /// </remarks>
-    internal static Results<Ok<ClientSignalTicketResponse>, ProblemHttpResult> MintTicket(
+    internal static async Task<Results<Ok<ClientSignalTicketResponse>, ProblemHttpResult>> MintTicket(
         [FromServices] AccessAuthorization authorization,
-        [FromServices] ClientSignalTickets tickets)
+        [FromServices] ClientSignalTickets tickets,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(authorization);
         ArgumentNullException.ThrowIfNull(tickets);
 
-        var minted = tickets.Mint(authorization.RequireUser());
+        var minted = await tickets.MintAsync(authorization.RequireUser(), cancellationToken);
 
         return minted is null
             ? TypedResults.Problem(

--- a/backend/src/Host/Signals/ClientSignalEndpoints.cs
+++ b/backend/src/Host/Signals/ClientSignalEndpoints.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Access;
+using MailFathom.Application.Signals;
 using MailFathom.Domain.Access;
 using MailFathom.Host.Configuration.Endpoints;
 using MailFathom.Host.Security.Endpoints;
@@ -85,11 +86,20 @@ internal static class ClientSignalEndpoints
     /// <param name="authorization">Reports the grant the caller holds and the user it acts for.</param>
     /// <param name="tickets">Mints the ticket and holds it until it is spent or expires.</param>
     /// <param name="cancellationToken">Cancels the mint with the request that asked for it.</param>
-    /// <returns><c>200</c> with the ticket, or <c>503</c> where the deployment already holds every ticket it will hold.</returns>
+    /// <returns><c>200</c> with the ticket, or <c>503</c> where the deployment already holds every ticket it will hold or could not be asked.</returns>
     /// <exception cref="ArgumentNullException">Thrown when a required service is <see langword="null" />.</exception>
     /// <remarks>
+    /// <para>
     /// A <c>POST</c> rather than a <c>GET</c>, because minting a single-use credential changes state: a <c>GET</c> would
     /// be a route a cache, a prefetch, or a link preview could spend a ticket through.
+    /// </para>
+    /// <para>
+    /// A deployment whose tickets cannot be reached answers the same <c>503</c> as one that holds every ticket it will
+    /// hold, because what the client does about either is identical — wait and mint again, reading its screens over the
+    /// ordinary routes meanwhile. The two are told apart by the error code the answer carries and by the failure an
+    /// operator's log holds, never by the status, which is the arrangement a scanner this surface cannot reach is
+    /// answered under.
+    /// </para>
     /// </remarks>
     internal static async Task<Results<Ok<ClientSignalTicketResponse>, ProblemHttpResult>> MintTicket(
         [FromServices] AccessAuthorization authorization,
@@ -99,7 +109,22 @@ internal static class ClientSignalEndpoints
         ArgumentNullException.ThrowIfNull(authorization);
         ArgumentNullException.ThrowIfNull(tickets);
 
-        var minted = await tickets.MintAsync(authorization.RequireUser(), cancellationToken);
+        MintedClientSignalTicket? minted;
+
+        try
+        {
+            minted = await tickets.MintAsync(authorization.RequireUser(), cancellationToken);
+        }
+        catch (ClientSignalTicketStoreUnavailableException unreachable)
+        {
+            return TypedResults.Problem(
+                unreachable.Message,
+                statusCode: StatusCodes.Status503ServiceUnavailable,
+                extensions: new Dictionary<string, object?>(StringComparer.Ordinal)
+                {
+                    [RouteAuthorization.ErrorCodeExtension] = unreachable.ErrorCode.Value,
+                });
+        }
 
         return minted is null
             ? TypedResults.Problem(

--- a/backend/src/Host/Signals/ClientSignalHub.cs
+++ b/backend/src/Host/Signals/ClientSignalHub.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Globalization;
+using MailFathom.Application.Signals;
 using MailFathom.Domain.Access;
 using Microsoft.AspNetCore.SignalR;
 
@@ -19,8 +20,10 @@ namespace MailFathom.Host.Signals;
 /// <b>A connection is authenticated by a ticket and by nothing else.</b> It carries no <c>Authorization</c> header,
 /// because a browser cannot put one on a WebSocket, so <see cref="ClientSignalTickets" /> is what names the user —
 /// minted over an authenticated route that already required <see cref="MailFathomPermission.MailRead" />, spent here
-/// once, and never seen again. A connection presenting nothing, something malformed, something expired, or something
-/// already spent is aborted without being told which.
+/// once against the store every replica shares, and never seen again. A connection presenting nothing, something
+/// malformed, something expired, or something already spent is aborted without being told which, and so is one whose
+/// ticket could not be reached at all — which is the one refusal an operator has to act on, and the one logged as
+/// such.
 /// </para>
 /// <para>
 /// <b>A connection joins its user's group and no other.</b> The group is the whole of the addressing: a signal is
@@ -64,8 +67,25 @@ internal sealed partial class ClientSignalHub : Hub
     public override async Task OnConnectedAsync()
     {
         var presented = this.Context.GetHttpContext()?.Request.Query[TicketParameter].ToString();
+        MailUserId? user;
 
-        if (this.tickets.Redeem(presented) is not { } user)
+        try
+        {
+            user = await this.tickets.RedeemAsync(presented, this.Context.ConnectionAborted);
+        }
+        catch (ClientSignalTicketStoreUnavailableException failure)
+        {
+            // Told apart from every other refusal because it is the only one an operator acts on: a wrong, spent, or
+            // expired ticket is the mechanism working, and this is the deployment unable to say whether a ticket stands
+            // at all. It is a refusal either way — a connection admitted on a store that could not answer would be one
+            // opened against no ticket.
+            this.LogTicketStoreUnavailable(failure);
+            this.Context.Abort();
+
+            return;
+        }
+
+        if (user is not { } admitted)
         {
             this.LogConnectionRefused();
             this.Context.Abort();
@@ -73,7 +93,7 @@ internal sealed partial class ClientSignalHub : Hub
             return;
         }
 
-        await this.Groups.AddToGroupAsync(this.Context.ConnectionId, GroupOf(user), this.Context.ConnectionAborted);
+        await this.Groups.AddToGroupAsync(this.Context.ConnectionId, GroupOf(admitted), this.Context.ConnectionAborted);
 
         await base.OnConnectedAsync();
     }
@@ -82,4 +102,9 @@ internal sealed partial class ClientSignalHub : Hub
         Level = LogLevel.Debug,
         Message = "A signal connection presented no usable ticket and was refused.")]
     private partial void LogConnectionRefused();
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "A signal connection was refused because this deployment's unspent tickets could not be reached, so whether the ticket it presented stands is unknown.")]
+    private partial void LogTicketStoreUnavailable(Exception failure);
 }

--- a/backend/src/Host/Signals/ClientSignalTickets.cs
+++ b/backend/src/Host/Signals/ClientSignalTickets.cs
@@ -4,6 +4,7 @@
 
 using System.Buffers.Text;
 using System.Security.Cryptography;
+using MailFathom.Application.Signals;
 using MailFathom.Domain.Access;
 
 namespace MailFathom.Host.Signals;
@@ -25,15 +26,28 @@ namespace MailFathom.Host.Signals;
 /// already been spent or has already expired.
 /// </para>
 /// <para>
-/// <b>The secret half is compared in constant time.</b> A ticket is an identifier and a secret written together, and
-/// only the identifier is looked up: the secret is compared with <see cref="CryptographicOperations.FixedTimeEquals" />,
-/// so the comparison spends the same time on a value that shares a prefix with a live ticket as on one that does not.
-/// A dictionary keyed by the secret itself would leak that through its own lookup.
+/// <b>The secret half is proved against a digest, in constant time.</b> A ticket is an identifier and a secret written
+/// together, and only the identifier is looked up: what the deployment holds is a SHA-256 digest of the secret, so a
+/// row read out of the database or out of a backup opens no connection. The presented secret is hashed and the two
+/// digests compared with <see cref="CryptographicOperations.FixedTimeEquals" />, which spends the same time on a value
+/// that shares a prefix with a live ticket as on one that does not.
 /// </para>
 /// <para>
-/// Kept in memory rather than in the database, because the thing it authenticates is a connection to this process and a
-/// deployment behind a load balancer needs sticky routing for the connection itself regardless. A restart therefore
-/// costs whatever tickets were outstanding, which is a client reconnecting a moment later.
+/// <b>The ticket lives in PostgreSQL rather than in this process, and that is what lets a deployment scale out.</b>
+/// The minting route and the connection are two requests a load balancer places independently, and the connection
+/// skips negotiation precisely so that nothing has to route them together — so a ticket held in the process that
+/// minted it would be redeemable about one time in the replica count, silently. It does not live in the optional
+/// signal backplane either, because an authentication path must not depend on a component a deployment may not run.
+/// <see href="https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0032-reaching-a-client-from-any-replica-over-websockets-and-a-resp-backplane.md">ADR 0032</see>
+/// records both halves of that.
+/// </para>
+/// <para>
+/// <b>What a connection can spend is bounded here rather than by the surface.</b> The hub is mapped outside the client
+/// route group and has authenticated nothing when a ticket arrives, so a value without the shape of a minted ticket is
+/// refused before any statement runs, and at most <see cref="MostRedemptionsInFlight" /> redemptions are in flight in
+/// this process at once. A flood of handshakes therefore holds that many connections rather than the pool the rest of
+/// the deployment reads mail through; what it can still do while it lasts is crowd legitimate handshakes out of live
+/// updates, which costs signals and never mail, because the client's own re-read is the guarantee.
 /// </para>
 /// </remarks>
 internal sealed class ClientSignalTickets
@@ -42,9 +56,24 @@ internal sealed class ClientSignalTickets
     /// <remarks>Long enough for a client to mint one and open a connection with it, including a slow network, and short enough that one left in an access log or a browser's own history is worthless by the time anybody reads it.</remarks>
     internal static readonly TimeSpan Lifetime = TimeSpan.FromSeconds(30);
 
-    /// <summary>The most outstanding tickets before minting sweeps and then refuses.</summary>
-    /// <remarks>A bound at a boundary: minting is an authenticated route behind this surface's rate limiter, and this is what keeps a credential that is nonetheless spending it from growing the process's memory. Reaching it is a refusal rather than an eviction, because evicting somebody else's live ticket would turn one caller's noise into another caller's failed connection.</remarks>
+    /// <summary>The most outstanding tickets the deployment holds before minting refuses.</summary>
+    /// <remarks>
+    /// A bound at a boundary, and the deployment's rather than a process's: it is counted in the same statement that
+    /// writes the ticket, so raising the replica count does not multiply it. Minting is an authenticated route behind
+    /// this surface's rate limiter, and this is what keeps a credential that is nonetheless spending it from growing
+    /// the table. Reaching it is a refusal rather than an eviction, because evicting somebody else's live ticket would
+    /// turn one caller's noise into another caller's failed connection.
+    /// </remarks>
     internal const int MostOutstandingTickets = 10_000;
+
+    /// <summary>The most redemptions this process has in flight at once before a handshake is refused unread.</summary>
+    /// <remarks>
+    /// Sized well below the connection pool the rest of the deployment reads mail through, because redemption runs on
+    /// the hub, which has authenticated nothing: without this, a flood of handshakes would each hold a connection out
+    /// of that pool. A handshake arriving while it is full is refused without a statement, exactly as any other
+    /// unusable ticket is, and its client retries on the backoff it already has.
+    /// </remarks>
+    internal const int MostRedemptionsInFlight = 16;
 
     /// <summary>How many bytes of the ticket name it, and how many prove it.</summary>
     private const int IdentifierByteCount = 16;
@@ -62,115 +91,160 @@ internal sealed class ClientSignalTickets
     /// </remarks>
     private const int LongestPresentedTicket = 256;
 
-    private readonly Dictionary<string, OutstandingTicket> outstanding = new(StringComparer.Ordinal);
-    private readonly Lock gate = new();
+    private readonly IClientSignalTicketStore store;
     private readonly TimeProvider timeProvider;
 
-    /// <summary>Initializes the store over the clock its lifetimes are measured against.</summary>
+    private long nextSweepTicks;
+    private int redemptionsInFlight;
+
+    /// <summary>Initializes the store over where tickets are held and the clock their lifetimes are measured against.</summary>
+    /// <param name="store">Where the deployment holds the tickets it has minted and not yet spent.</param>
     /// <param name="timeProvider">Measures when a ticket was minted and whether it has expired.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeProvider" /> is <see langword="null" />.</exception>
-    public ClientSignalTickets(TimeProvider timeProvider)
+    /// <exception cref="ArgumentNullException">Thrown when a required collaborator is <see langword="null" />.</exception>
+    public ClientSignalTickets(IClientSignalTicketStore store, TimeProvider timeProvider)
     {
+        ArgumentNullException.ThrowIfNull(store);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
+        this.store = store;
         this.timeProvider = timeProvider;
+        this.nextSweepTicks = (timeProvider.GetUtcNow() + Lifetime).UtcTicks;
     }
 
-    /// <summary>Mints a ticket for one user, or reports that too many stand outstanding.</summary>
+    /// <summary>Mints a ticket for one user, or reports that the deployment holds as many as it will hold.</summary>
     /// <param name="user">The user the credential that reached the minting route named.</param>
+    /// <param name="cancellationToken">Cancels the write.</param>
     /// <returns>The minted ticket and when it expires, or <see langword="null" /> when the bound is reached.</returns>
-    internal MintedClientSignalTicket? Mint(MailUserId user)
+    /// <exception cref="ClientSignalTicketStoreUnavailableException">Thrown when the deployment's tickets could not be reached, which the route answers rather than minting a ticket nothing holds.</exception>
+    internal async Task<MintedClientSignalTicket?> MintAsync(MailUserId user, CancellationToken cancellationToken)
     {
+        await this.SweepExpiredIfDueAsync(cancellationToken);
+
         var identifier = RandomText(IdentifierByteCount);
         var secret = RandomNumberGenerator.GetBytes(SecretByteCount);
         var expiresAt = this.timeProvider.GetUtcNow() + Lifetime;
 
-        // Counted and admitted under one lock, because a bound read and then written to is a bound several callers can
-        // each find room under and then all exceed. Minting happens once per connection rather than once per request,
-        // so what a lock costs here is nothing measurable against what it is stating.
-        lock (this.gate)
-        {
-            // Swept only where the bound is what would refuse this mint, because that is the only moment the difference
-            // between a live ticket and a spent one matters. Sweeping on every mint would walk the whole store per
-            // connection for a store that is nearly always tiny, which is a cost paid on the ordinary path to tidy
-            // state the bound below already limits.
-            if (this.outstanding.Count >= MostOutstandingTickets)
-            {
-                this.SweepExpired();
-            }
+        var held = await this.store.TryMintAsync(
+            identifier,
+            user,
+            SHA256.HashData(secret),
+            expiresAt,
+            MostOutstandingTickets,
+            cancellationToken);
 
-            if (this.outstanding.Count >= MostOutstandingTickets)
-            {
-                return null;
-            }
-
-            this.outstanding[identifier] = new OutstandingTicket(user, secret, expiresAt);
-        }
-
-        return new MintedClientSignalTicket(
-            string.Concat(identifier, Separator.ToString(), Base64Url.EncodeToString(secret)),
-            expiresAt);
+        return held
+            ? new MintedClientSignalTicket(
+                string.Concat(identifier, Separator.ToString(), Base64Url.EncodeToString(secret)),
+                expiresAt)
+            : null;
     }
 
     /// <summary>Spends a presented ticket, reporting the user it named.</summary>
     /// <param name="presented">What the connection carried, which is whatever a caller wrote and is therefore untrusted.</param>
-    /// <returns>The user, or <see langword="null" /> where the ticket is malformed, unknown, expired, or already spent.</returns>
-    /// <remarks>Removing before comparing is what makes a ticket single-use even against two connections presenting it at once: the loser finds nothing to remove and is refused, whichever of them wrote the value first.</remarks>
-    internal MailUserId? Redeem(string? presented)
+    /// <param name="cancellationToken">Cancels the write.</param>
+    /// <returns>The user, or <see langword="null" /> where the ticket is malformed, unknown, expired, already spent, or arrived while this process was already redeeming as many as it will at once.</returns>
+    /// <exception cref="ClientSignalTicketStoreUnavailableException">Thrown when the deployment's tickets could not be reached, which the hub answers by refusing the connection.</exception>
+    /// <remarks>
+    /// The shape is judged before the statement rather than after it — the length, the separator, and the encoding —
+    /// so a value nothing minted costs this deployment no database work at all. Removing before comparing is what makes
+    /// a ticket single-use even against two connections presenting it at once, whichever replica each of them reaches:
+    /// the loser finds no row to remove and is refused.
+    /// </remarks>
+    internal async Task<MailUserId?> RedeemAsync(string? presented, CancellationToken cancellationToken)
     {
+        if (!TrySplit(presented, out var identifier, out var secret))
+        {
+            return null;
+        }
+
+        if (Interlocked.Increment(ref this.redemptionsInFlight) > MostRedemptionsInFlight)
+        {
+            Interlocked.Decrement(ref this.redemptionsInFlight);
+
+            return null;
+        }
+
+        try
+        {
+            if (await this.store.RedeemAsync(identifier, cancellationToken) is not { } ticket)
+            {
+                return null;
+            }
+
+            if (!CryptographicOperations.FixedTimeEquals(SHA256.HashData(secret), ticket.SecretDigest.Span))
+            {
+                return null;
+            }
+
+            return this.timeProvider.GetUtcNow() <= ticket.ExpiresAt ? ticket.User : null;
+        }
+        finally
+        {
+            Interlocked.Decrement(ref this.redemptionsInFlight);
+        }
+    }
+
+    /// <summary>Reads a presented value as the two halves a minted ticket is written as, refusing anything else.</summary>
+    /// <returns><see langword="true" /> when the value has the shape of a ticket this deployment mints.</returns>
+    private static bool TrySplit(string? presented, out string identifier, out byte[] secret)
+    {
+        identifier = string.Empty;
+        secret = [];
+
         // Bounded before it is walked rather than after, which is the order every other untrusted length here is read
         // in: a value past this is refused without an index, a slice, or a decode having been spent on it.
         if (string.IsNullOrEmpty(presented) || presented.Length > LongestPresentedTicket)
         {
-            return null;
+            return false;
         }
 
         var separator = presented.IndexOf(Separator, StringComparison.Ordinal);
 
         if (separator <= 0 || separator == presented.Length - 1)
         {
-            return null;
-        }
-
-        OutstandingTicket? ticket;
-
-        lock (this.gate)
-        {
-            if (!this.outstanding.Remove(presented[..separator], out ticket))
-            {
-                return null;
-            }
+            return false;
         }
 
         var proof = presented.AsSpan(separator + 1);
 
-        if (!Base64Url.IsValid(proof)
-            || !CryptographicOperations.FixedTimeEquals(Base64Url.DecodeFromChars(proof), ticket.Secret))
+        if (!Base64Url.IsValid(proof))
         {
-            return null;
+            return false;
         }
 
-        return this.timeProvider.GetUtcNow() <= ticket.ExpiresAt ? ticket.User : null;
+        identifier = presented[..separator];
+        secret = Base64Url.DecodeFromChars(proof);
+
+        return true;
     }
 
     private static string RandomText(int byteCount) =>
         Base64Url.EncodeToString(RandomNumberGenerator.GetBytes(byteCount));
 
-    /// <summary>Removes what can no longer be presented, so the bound above measures live tickets rather than history.</summary>
-    /// <remarks>Called under <c>gate</c>, which is what lets it enumerate the store while removing from it.</remarks>
-    private void SweepExpired()
+    /// <summary>Removes what can no longer be presented, at most once per ticket lifetime.</summary>
+    /// <remarks>
+    /// On the minting path rather than on a timer, for the reason the anti-replay record sweeps there: a table nothing
+    /// is writing to needs no sweeping, and a background timer would keep a process awake to prove it. The interval is
+    /// claimed with one atomic exchange, so concurrent mints produce one sweep rather than one each, and it stays a
+    /// process's own interval above one replica — two replicas each issuing a bounded delete every thirty seconds
+    /// costs less than anything that would have to coordinate them. A removal that fails takes the mint that triggered
+    /// it with it, because the insert about to follow reaches the same database over the same pool.
+    /// </remarks>
+    private async Task SweepExpiredIfDueAsync(CancellationToken cancellationToken)
     {
         var now = this.timeProvider.GetUtcNow();
-        var expired = this.outstanding
-            .Where(held => held.Value.ExpiresAt < now)
-            .Select(static held => held.Key)
-            .ToArray();
+        var due = Interlocked.Read(ref this.nextSweepTicks);
 
-        foreach (var identifier in expired)
+        if (now.UtcTicks < due)
         {
-            this.outstanding.Remove(identifier);
+            return;
         }
-    }
 
-    private sealed record OutstandingTicket(MailUserId User, byte[] Secret, DateTimeOffset ExpiresAt);
+        if (Interlocked.CompareExchange(ref this.nextSweepTicks, (now + Lifetime).UtcTicks, due) != due)
+        {
+            return;
+        }
+
+        await this.store.RemoveExpiredAsync(now, cancellationToken);
+    }
 }

--- a/backend/src/Infrastructure/Persistence/Entities/ClientSignalTicketEntity.cs
+++ b/backend/src/Infrastructure/Persistence/Entities/ClientSignalTicketEntity.cs
@@ -16,7 +16,9 @@ namespace MailFathom.Infrastructure.Persistence.Entities;
 /// <para>
 /// Nothing here is mail, a message, a header, or key material. A generated user identity, a digest, and an instant are
 /// the whole row, and only a request that already authenticated against a credential holding
-/// <c>mailfathom.mail.read</c> produces one — so nothing an unauthenticated caller sends can reach this table.
+/// <c>mailfathom.mail.read</c> writes one. A value an unauthenticated caller presents reaches this table in one place
+/// only — as the identifier the delete is parameterized by, once the host has refused anything without the shape of a
+/// ticket and admitted only so many redemptions at once — and it is read back rather than stored.
 /// </para>
 /// <para>
 /// It carries no concurrency token and no generated key, because it is written once and never updated. The three

--- a/backend/src/Infrastructure/Persistence/Entities/ClientSignalTicketEntity.cs
+++ b/backend/src/Infrastructure/Persistence/Entities/ClientSignalTicketEntity.cs
@@ -44,10 +44,12 @@ internal sealed class ClientSignalTicketEntity
 
     /// <summary>The longest identifier the column takes.</summary>
     /// <remarks>
-    /// A bound on the row rather than a statement of the format: what a minting host writes here is the base64url of
-    /// sixteen random bytes, which is twenty-two characters, and the host refuses a longer presented value before any
-    /// statement runs. The column is given room past that so the format stays the minting host's to decide, and stays
-    /// short enough that nothing else could be stored in it.
+    /// A bound on the row rather than a statement of the format, and it bounds what is written rather than what is
+    /// looked up: only minting writes this column, and what a minting host writes is the base64url of sixteen random
+    /// bytes, which is twenty-two characters. A presented value is bounded separately and more loosely — the host
+    /// refuses one past a length of its own before any statement runs — so an identifier longer than this simply
+    /// matches no row. The column is given room past twenty-two so the format stays the minting host's to decide, and
+    /// stays short enough that nothing else could be stored in it.
     /// </remarks>
     internal const int IdentifierLengthLimit = 64;
 

--- a/backend/src/Infrastructure/Persistence/Entities/ClientSignalTicketEntity.cs
+++ b/backend/src/Infrastructure/Persistence/Entities/ClientSignalTicketEntity.cs
@@ -1,0 +1,69 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.CodeCoverage;
+
+namespace MailFathom.Infrastructure.Persistence.Entities;
+
+/// <summary>One unspent ticket a client signal connection may be opened against, held until it is presented or expires.</summary>
+/// <remarks>
+/// <para>
+/// The identifier alone is the key, because a ticket is looked up by the half a connection presents in the open and
+/// proved by the half it presents beside it. The proof is held as a digest and never as the secret, so a row read out
+/// of the database or out of a backup opens nothing.
+/// </para>
+/// <para>
+/// Nothing here is mail, a message, a header, or key material. A generated user identity, a digest, and an instant are
+/// the whole row, and only a request that already authenticated against a credential holding
+/// <c>mailfathom.mail.read</c> produces one — so nothing an unauthenticated caller sends can reach this table.
+/// </para>
+/// <para>
+/// It carries no concurrency token and no generated key, because it is written once and never updated. The three
+/// statements against it are an insert that the deployment's own bound may refuse, a delete that returns the row it
+/// removed, and a delete of what has expired.
+/// </para>
+/// </remarks>
+[RequiresIntegrationCoverage]
+internal sealed class ClientSignalTicketEntity
+{
+    /// <summary>The table these rows live in, named here because every statement against it is composed.</summary>
+    internal const string TableName = "client_signal_tickets";
+
+    /// <summary>The key column, named here for the same reason the table is.</summary>
+    internal const string IdentifierColumnName = "Identifier";
+
+    /// <summary>The column naming whose connection the ticket opens, named here for the same reason the table is.</summary>
+    internal const string UserIdColumnName = "UserId";
+
+    /// <summary>The column holding the proof, named here for the same reason the table is.</summary>
+    internal const string SecretDigestColumnName = "SecretDigest";
+
+    /// <summary>The expiry column, named here for the same reason the table is.</summary>
+    internal const string ExpiresAtColumnName = "ExpiresAt";
+
+    /// <summary>The longest identifier the column takes.</summary>
+    /// <remarks>
+    /// A bound on the row rather than a statement of the format: what a minting host writes here is the base64url of
+    /// sixteen random bytes, which is twenty-two characters, and the host refuses a longer presented value before any
+    /// statement runs. The column is given room past that so the format stays the minting host's to decide, and stays
+    /// short enough that nothing else could be stored in it.
+    /// </remarks>
+    internal const int IdentifierLengthLimit = 64;
+
+    /// <summary>How many bytes of digest the proof column holds, which is the width of SHA-256.</summary>
+    internal const int SecretDigestByteCount = 32;
+
+    /// <summary>Gets or sets the public half of the ticket, as the minting host drew it.</summary>
+    public string Identifier { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the user whose connection this ticket opens.</summary>
+    public Guid UserId { get; set; }
+
+    /// <summary>Gets or sets the digest of the secret half, which a presented secret is compared against in constant time.</summary>
+    public byte[] SecretDigest { get; set; } = [];
+
+    /// <summary>Gets or sets when presenting the ticket stops working, in UTC.</summary>
+    /// <remarks>What the removal reads, and one of the two reasons the table cannot grow without bound: a ticket lives thirty seconds, and the deployment holds only so many at once whatever their age.</remarks>
+    public DateTimeOffset ExpiresAt { get; set; }
+}

--- a/backend/src/Infrastructure/Persistence/MailFathomDbContext.cs
+++ b/backend/src/Infrastructure/Persistence/MailFathomDbContext.cs
@@ -24,6 +24,7 @@ using MailFathom.Infrastructure.Persistence.Preferences.Configurations;
 using MailFathom.Infrastructure.Persistence.Rules.Configurations;
 using MailFathom.Infrastructure.Persistence.Secrets.Configurations;
 using MailFathom.Infrastructure.Persistence.Settings.Configurations;
+using MailFathom.Infrastructure.Persistence.Signals.Configurations;
 using MailFathom.Infrastructure.Persistence.Spam.Configurations;
 using MailFathom.Infrastructure.Persistence.Synchronization.Configurations;
 using MailFathom.Infrastructure.Persistence.ThreadStates.Configurations;
@@ -76,6 +77,8 @@ internal sealed class MailFathomDbContext : DbContext
     internal DbSet<UserPortraitEntity> UserPortraits => this.Set<UserPortraitEntity>();
 
     internal DbSet<SpentClientAssertionEntity> SpentClientAssertions => this.Set<SpentClientAssertionEntity>();
+
+    internal DbSet<ClientSignalTicketEntity> ClientSignalTickets => this.Set<ClientSignalTicketEntity>();
 
     internal DbSet<StoredSecretEntity> StoredSecrets => this.Set<StoredSecretEntity>();
 
@@ -221,6 +224,7 @@ internal sealed class MailFathomDbContext : DbContext
         modelBuilder.ApplyConfiguration(new ClientPreferencesConfiguration());
         modelBuilder.ApplyConfiguration(new UserPortraitConfiguration());
         modelBuilder.ApplyConfiguration(new SpentClientAssertionConfiguration());
+        modelBuilder.ApplyConfiguration(new ClientSignalTicketConfiguration());
         modelBuilder.ApplyConfiguration(new UserStoredContentConfiguration());
         modelBuilder.ApplyConfiguration(new StoredContentClaimConfiguration());
         modelBuilder.ApplyConfiguration(new MailboxAccountConfiguration());

--- a/backend/src/Infrastructure/Persistence/Migrations/20260911125554_AddClientSignalTickets.Designer.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260911125554_AddClientSignalTickets.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MailFathom.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace MailFathom.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(MailFathomDbContext))]
-    partial class MailFathomDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260911125554_AddClientSignalTickets")]
+    partial class AddClientSignalTickets
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Infrastructure/Persistence/Migrations/20260911125554_AddClientSignalTickets.cs
+++ b/backend/src/Infrastructure/Persistence/Migrations/20260911125554_AddClientSignalTickets.cs
@@ -1,0 +1,56 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MailFathom.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddClientSignalTickets : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "client_signal_tickets",
+                columns: table => new
+                {
+                    Identifier = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SecretDigest = table.Column<byte[]>(type: "bytea", maxLength: 32, nullable: false),
+                    ExpiresAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_client_signal_tickets", x => x.Identifier);
+                    table.ForeignKey(
+                        name: "FK_client_signal_tickets_settings_accounts_UserId",
+                        column: x => x.UserId,
+                        principalTable: "settings_accounts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_client_signal_tickets_expires_at",
+                table: "client_signal_tickets",
+                column: "ExpiresAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_client_signal_tickets_UserId",
+                table: "client_signal_tickets",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "client_signal_tickets");
+        }
+    }
+}

--- a/backend/src/Infrastructure/Persistence/PersistenceConstraintNames.cs
+++ b/backend/src/Infrastructure/Persistence/PersistenceConstraintNames.cs
@@ -584,4 +584,12 @@ internal static class PersistenceConstraintNames
     /// makes that removal proportional to what has expired rather than to everything ever spent.
     /// </remarks>
     internal const string SpentClientAssertionExpiryIndexName = "ix_spent_client_assertions_expires_at";
+
+    /// <summary>The order the unspent signal tickets are aged out through.</summary>
+    /// <remarks>
+    /// Stated for the reason the index above it is: no query reads an unspent ticket, and the one statement that
+    /// touches the table other than the insert and the spend is the removal of everything already expired. The index is
+    /// what makes that removal proportional to what has expired rather than to every ticket the deployment holds.
+    /// </remarks>
+    internal const string ClientSignalTicketExpiryIndexName = "ix_client_signal_tickets_expires_at";
 }

--- a/backend/src/Infrastructure/Persistence/Signals/ClientSignalTicketStore.cs
+++ b/backend/src/Infrastructure/Persistence/Signals/ClientSignalTicketStore.cs
@@ -1,0 +1,169 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using MailFathom.Application.Signals;
+using MailFathom.CodeCoverage;
+using MailFathom.Domain.Access;
+using MailFathom.Infrastructure.Persistence.Entities;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace MailFathom.Infrastructure.Persistence.Signals;
+
+/// <summary>Holds the deployment's unspent signal tickets in the one table every replica of it writes to.</summary>
+/// <remarks>
+/// <para>
+/// Bare commands over the data source rather than EF Core queries, for the reason the anti-replay record is written
+/// that way: none of the three statements has a query shape, the callers are a minting route and a hub rather than a
+/// unit of work, and what each of them needs is the outcome PostgreSQL reports rather than a tracked entity. A tracked
+/// spend would also be a read followed by a delete, which is exactly the pair that admits two connections on one
+/// ticket.
+/// </para>
+/// <para>
+/// The identifiers in every statement come from the mapped entity's own constants, so the statements and the schema are
+/// one description; every value is a parameter, so nothing a client presented is ever composed into text.
+/// </para>
+/// <para>
+/// Each command is bounded by the caller's own cancellation token and by whatever <c>Command Timeout</c> the composed
+/// connection string carries, which is the arrangement the anti-replay record is written under and for the same reason:
+/// these statements open no EF Core context, so <c>Persistence:CommandTimeoutSeconds</c> does not reach them.
+/// </para>
+/// <para>
+/// A failure to reach the database is translated rather than absorbed. It is not absorbed because the answer this store
+/// gives is what decides whether a connection is admitted, so a store that cannot answer is one whose caller must not
+/// admit — turning an outage into a redeemed ticket would open every connection presenting anything. It is translated
+/// because the port it crosses is an application contract and one of its callers is a hub that has authenticated
+/// nothing yet.
+/// </para>
+/// </remarks>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The dependency injection container materializes this store.")]
+[RequiresIntegrationCoverage]
+internal sealed class ClientSignalTicketStore(NpgsqlDataSource dataSource) : IClientSignalTicketStore
+{
+    /// <summary>Writes the ticket, and reports having written it, only while the deployment is under its own bound.</summary>
+    /// <remarks>
+    /// The count and the insert are one statement, so the bound is the deployment's rather than a number each replica
+    /// finds room under separately. It counts what stands rather than what is live, which is the conservative
+    /// direction: a deployment at its bound holding expired rows refuses a mint the sweep would have made room for, and
+    /// the next mint past the sweep interval is served.
+    /// </remarks>
+    private const string MintTicketStatement = $"""
+        INSERT INTO "{ClientSignalTicketEntity.TableName}"
+            ("{ClientSignalTicketEntity.IdentifierColumnName}", "{ClientSignalTicketEntity.UserIdColumnName}", "{ClientSignalTicketEntity.SecretDigestColumnName}", "{ClientSignalTicketEntity.ExpiresAtColumnName}")
+        SELECT @identifier, @userId, @secretDigest, @expiresAt
+        WHERE (SELECT count(*) FROM "{ClientSignalTicketEntity.TableName}") < @mostOutstanding;
+        """;
+
+    /// <summary>Removes the presented ticket and hands back what it held, in one statement.</summary>
+    /// <remarks>
+    /// Removing and returning together is what makes a ticket single-use across replicas: two connections presenting
+    /// one identifier at the same instant leave one with a row and one with nothing, settled by PostgreSQL rather than
+    /// by a check either of them makes between two statements. The row is removed whether or not it had expired,
+    /// because a ticket presented late is spent as surely as one presented in time and leaving it would keep a row the
+    /// sweep would otherwise have to reach.
+    /// </remarks>
+    private const string RedeemTicketStatement = $"""
+        DELETE FROM "{ClientSignalTicketEntity.TableName}"
+        WHERE "{ClientSignalTicketEntity.IdentifierColumnName}" = @identifier
+        RETURNING "{ClientSignalTicketEntity.UserIdColumnName}", "{ClientSignalTicketEntity.SecretDigestColumnName}", "{ClientSignalTicketEntity.ExpiresAtColumnName}";
+        """;
+
+    /// <summary>Removes what can no longer be presented, reaching it through the index on the expiry.</summary>
+    /// <remarks>
+    /// The comparison is against the indexed column alone, so the plan is a range over what has already expired rather
+    /// than a scan of the whole table — which is what keeps the removal proportional to the connections opened since
+    /// the last one instead of to the deployment's bound.
+    /// </remarks>
+    private const string RemoveExpiredStatement = $"""
+        DELETE FROM "{ClientSignalTicketEntity.TableName}"
+        WHERE "{ClientSignalTicketEntity.ExpiresAtColumnName}" <= @removableFrom;
+        """;
+
+    /// <inheritdoc />
+    public async Task<bool> TryMintAsync(
+        string identifier,
+        MailUserId user,
+        ReadOnlyMemory<byte> secretDigest,
+        DateTimeOffset expiresAt,
+        int mostOutstanding,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(identifier);
+
+        await using var command = dataSource.CreateCommand(MintTicketStatement);
+        command.Parameters.AddWithValue("identifier", identifier);
+        command.Parameters.AddWithValue("userId", user.Value);
+        command.Parameters.Add(new NpgsqlParameter("secretDigest", NpgsqlDbType.Bytea)
+        {
+            Value = secretDigest.ToArray(),
+        });
+        command.Parameters.AddWithValue("expiresAt", expiresAt.ToUniversalTime());
+        command.Parameters.AddWithValue("mostOutstanding", mostOutstanding);
+
+        try
+        {
+            return await command.ExecuteNonQueryAsync(cancellationToken) == 1;
+        }
+        catch (NpgsqlException failure)
+        {
+            throw Unavailable(
+                $"A signal connection ticket could not be held in {ClientSignalTicketEntity.TableName}, so no ticket was minted.",
+                failure);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<RedeemedClientSignalTicket?> RedeemAsync(string identifier, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(identifier);
+
+        await using var command = dataSource.CreateCommand(RedeemTicketStatement);
+        command.Parameters.AddWithValue("identifier", identifier);
+
+        try
+        {
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
+            if (!await reader.ReadAsync(cancellationToken))
+            {
+                return null;
+            }
+
+            return new RedeemedClientSignalTicket(
+                MailUserId.Create(reader.GetGuid(0)),
+                reader.GetFieldValue<byte[]>(1),
+                reader.GetFieldValue<DateTimeOffset>(2));
+        }
+        catch (NpgsqlException failure)
+        {
+            throw Unavailable(
+                $"The ticket a signal connection presented could not be spent against {ClientSignalTicketEntity.TableName}, so the connection was refused rather than admitted unrecorded.",
+                failure);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task RemoveExpiredAsync(DateTimeOffset removableFrom, CancellationToken cancellationToken)
+    {
+        await using var command = dataSource.CreateCommand(RemoveExpiredStatement);
+        command.Parameters.AddWithValue("removableFrom", removableFrom.ToUniversalTime());
+
+        try
+        {
+            await command.ExecuteNonQueryAsync(cancellationToken);
+        }
+        catch (NpgsqlException failure)
+        {
+            throw Unavailable(
+                $"The signal connection tickets past the point they could still be presented could not be removed from {ClientSignalTicketEntity.TableName}.",
+                failure);
+        }
+    }
+
+    private static ClientSignalTicketStoreUnavailableException Unavailable(string operatorSafeMessage, Exception failure) =>
+        new(
+            $"{operatorSafeMessage} Check that the database is reachable and that this build's migrations have been applied to it.",
+            failure);
+}

--- a/backend/src/Infrastructure/Persistence/Signals/Configurations/ClientSignalTicketConfiguration.cs
+++ b/backend/src/Infrastructure/Persistence/Signals/Configurations/ClientSignalTicketConfiguration.cs
@@ -1,0 +1,49 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Infrastructure.Persistence.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace MailFathom.Infrastructure.Persistence.Signals.Configurations;
+
+/// <summary>Declares the unspent tickets the deployment's signal connections are opened against.</summary>
+/// <remarks>
+/// The identifier is the key, and the row being removed by the presentation that reads it is the single-use rule
+/// itself rather than a property of the storage: the spend is one delete that returns what it removed, so nothing reads
+/// a row back and there is no query shape for the mapping to serve. The one index beside the key is the expiry, which
+/// the removal walks. The column names are the entity's own constants because every statement is composed, so the
+/// statements and this mapping name the same things by construction.
+/// </remarks>
+internal sealed class ClientSignalTicketConfiguration : IEntityTypeConfiguration<ClientSignalTicketEntity>
+{
+    /// <inheritdoc />
+    public void Configure(EntityTypeBuilder<ClientSignalTicketEntity> entity)
+    {
+        entity.ToTable(ClientSignalTicketEntity.TableName);
+        entity.HasKey(ticket => ticket.Identifier);
+        entity.Property(ticket => ticket.Identifier)
+            .HasColumnName(ClientSignalTicketEntity.IdentifierColumnName)
+            .HasMaxLength(ClientSignalTicketEntity.IdentifierLengthLimit)
+            .ValueGeneratedNever();
+        entity.Property(ticket => ticket.UserId)
+            .HasColumnName(ClientSignalTicketEntity.UserIdColumnName);
+        entity.Property(ticket => ticket.SecretDigest)
+            .HasColumnName(ClientSignalTicketEntity.SecretDigestColumnName)
+            .HasMaxLength(ClientSignalTicketEntity.SecretDigestByteCount)
+            .IsRequired();
+        entity.Property(ticket => ticket.ExpiresAt)
+            .HasColumnName(ClientSignalTicketEntity.ExpiresAtColumnName);
+        entity.HasIndex(ticket => ticket.ExpiresAt)
+            .HasDatabaseName(PersistenceConstraintNames.ClientSignalTicketExpiryIndexName);
+
+        // Cascade rather than a statement in the erasure walk, for the reason the preferences row carries one: a ticket
+        // is minted for one person and names nobody else, so it goes when they do without an erasure having to know
+        // this table exists. What it costs is one index on the user, which is what makes that delete cheap.
+        entity.HasOne<UserAccountEntity>()
+            .WithMany()
+            .HasForeignKey(ticket => ticket.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/backend/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/backend/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -141,6 +141,7 @@ using MailFathom.Infrastructure.Persistence.Rules;
 using MailFathom.Infrastructure.Persistence.Secrets;
 using MailFathom.Infrastructure.Persistence.Sessions;
 using MailFathom.Infrastructure.Persistence.Settings;
+using MailFathom.Infrastructure.Persistence.Signals;
 using MailFathom.Infrastructure.Persistence.Spam;
 using MailFathom.Infrastructure.Persistence.Synchronization;
 using MailFathom.Infrastructure.Persistence.ThreadStates;
@@ -392,6 +393,10 @@ public static class ServiceCollectionExtensions
         // served assertion belongs to the deployment whether or not the request that produced it goes on to commit
         // anything.
         services.AddSingleton<IClientAssertionSpendStore, ClientAssertionSpendStore>();
+        // A singleton over the pool for the same reasons, and registered here rather than beside the hub because a
+        // deployment serving no client surface still carries the table in its schema: what the client endpoint's switch
+        // decides is whether anything ever mints a ticket, not whether the deployment knows where one would go.
+        services.AddSingleton<IClientSignalTicketStore, ClientSignalTicketStore>();
         // Reads the persisted configuration layer once the process is running, which is what a reload asks. The
         // bootstrap read that composed the configuration happened before this container existed and built its own
         // data source for it; this registration is the same statement over the pool everything else uses.

--- a/backend/tests/Host.UnitTests/Signals/ClientSignalEndpointsTests.cs
+++ b/backend/tests/Host.UnitTests/Signals/ClientSignalEndpointsTests.cs
@@ -5,8 +5,10 @@
 using MailFathom.Application.Access;
 using MailFathom.Domain.Access;
 using MailFathom.Host.Signals;
+using MailFathom.Host.UnitTests.TestDoubles;
 using MailFathom.TestSupport;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
@@ -31,40 +33,68 @@ public sealed class ClientSignalEndpointsTests
 
     /// <summary>A minted ticket is answered with the value to present and the moment presenting it stops working.</summary>
     [Fact]
-    public void MintTicket_ACallerActingForAUser_AnswersTheTicketAndWhenItExpires()
+    public async Task MintTicket_ACallerActingForAUser_AnswersTheTicketAndWhenItExpires()
     {
         // Arrange
-        var tickets = new ClientSignalTickets(new FakeTimeProvider(Instant));
+        var tickets = new ClientSignalTickets(new InMemoryClientSignalTicketStore(), new FakeTimeProvider(Instant));
 
         // Act
-        var result = ClientSignalEndpoints.MintTicket(AuthorizationFor(SyntheticMailUser.Deployment), tickets);
+        var result = await ClientSignalEndpoints.MintTicket(
+            AuthorizationFor(SyntheticMailUser.Deployment),
+            tickets,
+            TestContext.Current.CancellationToken);
 
         // Assert
         var answered = Assert.IsType<Ok<ClientSignalTicketResponse>>(result.Result);
         Assert.NotNull(answered.Value);
         Assert.Equal(Instant + ClientSignalTickets.Lifetime, answered.Value.ExpiresAt);
-        Assert.Equal(SyntheticMailUser.Deployment, tickets.Redeem(answered.Value.Ticket));
+        Assert.Equal(
+            SyntheticMailUser.Deployment,
+            await tickets.RedeemAsync(answered.Value.Ticket, TestContext.Current.CancellationToken));
     }
 
     /// <summary>A deployment already holding every ticket it will hold says so as a condition that passes, not as a fault.</summary>
     [Fact]
-    public void MintTicket_WithAsManyTicketsOutstandingAsAreHeld_AnswersServiceUnavailableRatherThanATicket()
+    public async Task MintTicket_WithAsManyTicketsOutstandingAsAreHeld_AnswersServiceUnavailableRatherThanATicket()
     {
         // Arrange
-        var tickets = new ClientSignalTickets(new FakeTimeProvider(Instant));
+        var tickets = new ClientSignalTickets(new InMemoryClientSignalTicketStore(), new FakeTimeProvider(Instant));
         var authorization = AuthorizationFor(SyntheticMailUser.Deployment);
 
         for (var minted = 0; minted < ClientSignalTickets.MostOutstandingTickets; minted++)
         {
-            tickets.Mint(SyntheticMailUser.Deployment);
+            await tickets.MintAsync(SyntheticMailUser.Deployment, TestContext.Current.CancellationToken);
         }
 
         // Act
-        var result = ClientSignalEndpoints.MintTicket(authorization, tickets);
+        var result = await ClientSignalEndpoints.MintTicket(
+            authorization,
+            tickets,
+            TestContext.Current.CancellationToken);
 
         // Assert
         var refused = Assert.IsType<ProblemHttpResult>(result.Result);
         Assert.Equal(StatusCodes.Status503ServiceUnavailable, refused.StatusCode);
+    }
+
+    /// <summary>
+    /// The hub serves WebSockets and nothing else, so a server-sent-events or long-polling connection is refused to
+    /// every caller rather than served to one the client never is. That is what lets a deployment scale out without
+    /// session affinity: a connection that never negotiates is one request, and there is no second one to route with it.
+    /// </summary>
+    [Fact]
+    public void ServeOverWebSocketsAlone_AppliedToTheHubsOptions_LeavesNoTransportButWebSockets()
+    {
+        // Arrange
+        var options = new HttpConnectionDispatcherOptions();
+
+        // Act
+        ClientSignalEndpoints.ServeOverWebSocketsAlone(options);
+
+        // Assert
+        Assert.Equal(HttpTransportType.WebSockets, options.Transports);
+        Assert.False(options.Transports.HasFlag(HttpTransportType.ServerSentEvents));
+        Assert.False(options.Transports.HasFlag(HttpTransportType.LongPolling));
     }
 
     private static AccessAuthorization AuthorizationFor(MailUserId user)

--- a/backend/tests/Host.UnitTests/Signals/ClientSignalEndpointsTests.cs
+++ b/backend/tests/Host.UnitTests/Signals/ClientSignalEndpointsTests.cs
@@ -4,6 +4,8 @@
 
 using MailFathom.Application.Access;
 using MailFathom.Domain.Access;
+using MailFathom.Domain.Failures;
+using MailFathom.Host.Security.Endpoints;
 using MailFathom.Host.Signals;
 using MailFathom.Host.UnitTests.TestDoubles;
 using MailFathom.TestSupport;
@@ -75,6 +77,32 @@ public sealed class ClientSignalEndpointsTests
         // Assert
         var refused = Assert.IsType<ProblemHttpResult>(result.Result);
         Assert.Equal(StatusCodes.Status503ServiceUnavailable, refused.StatusCode);
+    }
+
+    /// <summary>
+    /// A deployment whose tickets cannot be reached answers the condition the client waits on rather than a fault,
+    /// because what the client does about it is what it does about the bound: wait and mint again.
+    /// </summary>
+    [Fact]
+    public async Task MintTicket_WhenTheTicketStoreCannotBeReached_AnswersServiceUnavailableCarryingTheErrorCode()
+    {
+        // Arrange
+        var tickets = new ClientSignalTickets(
+            new UnreachableClientSignalTicketStore(),
+            new FakeTimeProvider(Instant));
+
+        // Act
+        var result = await ClientSignalEndpoints.MintTicket(
+            AuthorizationFor(SyntheticMailUser.Deployment),
+            tickets,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var refused = Assert.IsType<ProblemHttpResult>(result.Result);
+        Assert.Equal(StatusCodes.Status503ServiceUnavailable, refused.StatusCode);
+        Assert.Equal(
+            MailFathomErrorCode.ClientSignalTicketStoreUnavailable.Value,
+            Assert.Contains(RouteAuthorization.ErrorCodeExtension, refused.ProblemDetails.Extensions));
     }
 
     /// <summary>

--- a/backend/tests/Host.UnitTests/Signals/ClientSignalEndpointsTests.cs
+++ b/backend/tests/Host.UnitTests/Signals/ClientSignalEndpointsTests.cs
@@ -12,6 +12,7 @@ using MailFathom.TestSupport;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using Xunit;
@@ -44,6 +45,7 @@ public sealed class ClientSignalEndpointsTests
         var result = await ClientSignalEndpoints.MintTicket(
             AuthorizationFor(SyntheticMailUser.Deployment),
             tickets,
+            NullLoggerFactory.Instance,
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -72,6 +74,7 @@ public sealed class ClientSignalEndpointsTests
         var result = await ClientSignalEndpoints.MintTicket(
             authorization,
             tickets,
+            NullLoggerFactory.Instance,
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -95,6 +98,7 @@ public sealed class ClientSignalEndpointsTests
         var result = await ClientSignalEndpoints.MintTicket(
             AuthorizationFor(SyntheticMailUser.Deployment),
             tickets,
+            NullLoggerFactory.Instance,
             TestContext.Current.CancellationToken);
 
         // Assert

--- a/backend/tests/Host.UnitTests/Signals/ClientSignalHubTests.cs
+++ b/backend/tests/Host.UnitTests/Signals/ClientSignalHubTests.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Host.Signals;
+using MailFathom.Host.UnitTests.TestDoubles;
 using MailFathom.TestSupport;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Connections.Features;
@@ -25,8 +26,8 @@ public sealed class ClientSignalHubTests
     public async Task OnConnectedAsync_WithALiveTicket_JoinsTheUsersGroup()
     {
         // Arrange
-        var tickets = new ClientSignalTickets(new FakeTimeProvider(Instant));
-        var minted = tickets.Mint(SyntheticMailUser.Deployment);
+        var tickets = new ClientSignalTickets(new InMemoryClientSignalTicketStore(), new FakeTimeProvider(Instant));
+        var minted = await tickets.MintAsync(SyntheticMailUser.Deployment, TestContext.Current.CancellationToken);
         var groups = Substitute.For<IGroupManager>();
         var context = ConnectionPresenting(minted!.Value);
 
@@ -55,7 +56,7 @@ public sealed class ClientSignalHubTests
     public async Task OnConnectedAsync_WithoutAUsableTicket_AbortsWithoutJoiningAnyGroup(string presented)
     {
         // Arrange
-        var tickets = new ClientSignalTickets(new FakeTimeProvider(Instant));
+        var tickets = new ClientSignalTickets(new InMemoryClientSignalTicketStore(), new FakeTimeProvider(Instant));
         var groups = Substitute.For<IGroupManager>();
         var context = ConnectionPresenting(presented);
 
@@ -81,8 +82,8 @@ public sealed class ClientSignalHubTests
     public async Task OnConnectedAsync_ReplayingATicketASecondConnectionAlreadySpent_RefusesTheSecondConnection()
     {
         // Arrange
-        var tickets = new ClientSignalTickets(new FakeTimeProvider(Instant));
-        var minted = tickets.Mint(SyntheticMailUser.Deployment);
+        var tickets = new ClientSignalTickets(new InMemoryClientSignalTicketStore(), new FakeTimeProvider(Instant));
+        var minted = await tickets.MintAsync(SyntheticMailUser.Deployment, TestContext.Current.CancellationToken);
         var groups = Substitute.For<IGroupManager>();
         var replayed = ConnectionPresenting(minted!.Value);
 
@@ -104,6 +105,37 @@ public sealed class ClientSignalHubTests
 
         // Assert
         replayed.Received(1).Abort();
+        await groups.DidNotReceive().AddToGroupAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// A deployment that cannot reach its own tickets refuses the connection rather than admitting one opened against
+    /// a ticket nothing could confirm, and the outage travels no further than the log an operator reads.
+    /// </summary>
+    [Fact]
+    public async Task OnConnectedAsync_WhenTheTicketStoreCannotBeReached_AbortsWithoutJoiningAnyGroup()
+    {
+        // Arrange
+        var tickets = new ClientSignalTickets(
+            new UnreachableClientSignalTicketStore(),
+            new FakeTimeProvider(Instant));
+        var groups = Substitute.For<IGroupManager>();
+        var context = ConnectionPresenting($"identifier.{new string('A', 43)}");
+
+        using var hub = new ClientSignalHub(tickets, NullLogger<ClientSignalHub>.Instance)
+        {
+            Context = context,
+            Groups = groups,
+        };
+
+        // Act
+        await hub.OnConnectedAsync();
+
+        // Assert
+        context.Received(1).Abort();
         await groups.DidNotReceive().AddToGroupAsync(
             Arg.Any<string>(),
             Arg.Any<string>(),

--- a/backend/tests/Host.UnitTests/Signals/ClientSignalTicketsTests.cs
+++ b/backend/tests/Host.UnitTests/Signals/ClientSignalTicketsTests.cs
@@ -203,7 +203,7 @@ public sealed class ClientSignalTicketsTests
             .Select(ticket => tickets.RedeemAsync(ticket, TestContext.Current.CancellationToken))
             .ToArray();
 
-        await deployment.WaitUntilRedeeming(ClientSignalTickets.MostRedemptionsInFlight);
+        await deployment.WaitUntilRedeemingAsync(ClientSignalTickets.MostRedemptionsInFlight);
 
         // Act
         var refused = await tickets.RedeemAsync(minted[^1], TestContext.Current.CancellationToken);
@@ -358,7 +358,7 @@ public sealed class ClientSignalTicketsTests
         internal void ReleaseRedemptions() => this.released.TrySetResult();
 
         /// <summary>Waits until the store is holding the given number of redemptions, so the bound is full before the next arrives.</summary>
-        internal async Task WaitUntilRedeeming(int count)
+        internal async Task WaitUntilRedeemingAsync(int count)
         {
             while (Volatile.Read(ref this.redeeming) < count)
             {

--- a/backend/tests/Host.UnitTests/Signals/ClientSignalTicketsTests.cs
+++ b/backend/tests/Host.UnitTests/Signals/ClientSignalTicketsTests.cs
@@ -2,7 +2,12 @@
 // Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Buffers.Text;
+using System.Security.Cryptography;
+using MailFathom.Application.Signals;
+using MailFathom.Domain.Access;
 using MailFathom.Host.Signals;
+using MailFathom.Host.UnitTests.TestDoubles;
 using MailFathom.TestSupport;
 using Microsoft.Extensions.Time.Testing;
 using Xunit;
@@ -16,14 +21,14 @@ public sealed class ClientSignalTicketsTests
 
     /// <summary>A ticket names the user the credential that minted it named, and nobody else.</summary>
     [Fact]
-    public void Redeem_AFreshlyMintedTicket_NamesTheUserItWasMintedFor()
+    public async Task RedeemAsync_AFreshlyMintedTicket_NamesTheUserItWasMintedFor()
     {
         // Arrange
-        var tickets = new ClientSignalTickets(new FakeTimeProvider(Instant));
-        var minted = tickets.Mint(SyntheticMailUser.Deployment);
+        var tickets = TicketsOver(new InMemoryClientSignalTicketStore());
+        var minted = await tickets.MintAsync(SyntheticMailUser.Deployment, TestContext.Current.CancellationToken);
 
         // Act
-        var user = tickets.Redeem(minted?.Value);
+        var user = await tickets.RedeemAsync(minted?.Value, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(SyntheticMailUser.Deployment, user);
@@ -31,16 +36,16 @@ public sealed class ClientSignalTicketsTests
 
     /// <summary>Two users minting at once each get their own, so one connection can never be opened as the other person.</summary>
     [Fact]
-    public void Redeem_TicketsMintedForTwoUsers_NamesEachUsersTicketAsTheirs()
+    public async Task RedeemAsync_TicketsMintedForTwoUsers_NamesEachUsersTicketAsTheirs()
     {
         // Arrange
-        var tickets = new ClientSignalTickets(new FakeTimeProvider(Instant));
-        var mine = tickets.Mint(SyntheticMailUser.Deployment);
-        var theirs = tickets.Mint(SyntheticMailUser.Another);
+        var tickets = TicketsOver(new InMemoryClientSignalTicketStore());
+        var mine = await tickets.MintAsync(SyntheticMailUser.Deployment, TestContext.Current.CancellationToken);
+        var theirs = await tickets.MintAsync(SyntheticMailUser.Another, TestContext.Current.CancellationToken);
 
         // Act
-        var firstUser = tickets.Redeem(mine?.Value);
-        var secondUser = tickets.Redeem(theirs?.Value);
+        var firstUser = await tickets.RedeemAsync(mine?.Value, TestContext.Current.CancellationToken);
+        var secondUser = await tickets.RedeemAsync(theirs?.Value, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(SyntheticMailUser.Deployment, firstUser);
@@ -49,35 +54,55 @@ public sealed class ClientSignalTicketsTests
 
     /// <summary>A ticket opens one connection, so one read out of a log or a browser's history opens none.</summary>
     [Fact]
-    public void Redeem_TheSameTicketTwice_AdmitsTheFirstAndRefusesTheSecond()
+    public async Task RedeemAsync_TheSameTicketTwice_AdmitsTheFirstAndRefusesTheSecond()
     {
         // Arrange
-        var tickets = new ClientSignalTickets(new FakeTimeProvider(Instant));
-        var minted = tickets.Mint(SyntheticMailUser.Deployment);
+        var tickets = TicketsOver(new InMemoryClientSignalTicketStore());
+        var minted = await tickets.MintAsync(SyntheticMailUser.Deployment, TestContext.Current.CancellationToken);
 
         // Act
-        var first = tickets.Redeem(minted?.Value);
-        var second = tickets.Redeem(minted?.Value);
+        var first = await tickets.RedeemAsync(minted?.Value, TestContext.Current.CancellationToken);
+        var second = await tickets.RedeemAsync(minted?.Value, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(SyntheticMailUser.Deployment, first);
         Assert.Null(second);
     }
 
+    /// <summary>
+    /// A ticket one replica minted opens a connection another replica answered, which is the whole reason the tickets
+    /// left this process: the load balancer places the mint and the connection independently.
+    /// </summary>
+    [Fact]
+    public async Task RedeemAsync_ATicketAnotherReplicaMinted_NamesTheUserItWasMintedFor()
+    {
+        // Arrange
+        var deployment = new InMemoryClientSignalTicketStore();
+        var mintingReplica = TicketsOver(deployment);
+        var connectingReplica = TicketsOver(deployment);
+        var minted = await mintingReplica.MintAsync(SyntheticMailUser.Deployment, TestContext.Current.CancellationToken);
+
+        // Act
+        var user = await connectingReplica.RedeemAsync(minted?.Value, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(SyntheticMailUser.Deployment, user);
+    }
+
     /// <summary>A ticket nobody presented in time stops working, which is what bounds one left where it should not be.</summary>
     [Fact]
-    public void Redeem_PastTheTicketsLifetime_RefusesIt()
+    public async Task RedeemAsync_PastTheTicketsLifetime_RefusesIt()
     {
         // Arrange
         var clock = new FakeTimeProvider(Instant);
-        var tickets = new ClientSignalTickets(clock);
-        var minted = tickets.Mint(SyntheticMailUser.Deployment);
+        var tickets = new ClientSignalTickets(new InMemoryClientSignalTicketStore(), clock);
+        var minted = await tickets.MintAsync(SyntheticMailUser.Deployment, TestContext.Current.CancellationToken);
 
         // Act
         clock.Advance(ClientSignalTickets.Lifetime + TimeSpan.FromSeconds(1));
 
         // Assert
-        Assert.Null(tickets.Redeem(minted?.Value));
+        Assert.Null(await tickets.RedeemAsync(minted?.Value, TestContext.Current.CancellationToken));
     }
 
     /// <summary>A value a caller wrote is refused however it is malformed, and none of the refusals says which.</summary>
@@ -89,83 +114,280 @@ public sealed class ClientSignalTicketsTests
     [InlineData(".proof-without-an-identifier")]
     [InlineData("identifier-without-a-proof.")]
     [InlineData("unknown.aGVsbG8")]
-    public void Redeem_AValueThatIsNotALiveTicket_RefusesIt(string? presented)
+    public async Task RedeemAsync_AValueThatIsNotALiveTicket_RefusesIt(string? presented)
     {
         // Arrange
-        var tickets = new ClientSignalTickets(new FakeTimeProvider(Instant));
-        tickets.Mint(SyntheticMailUser.Deployment);
+        var tickets = TicketsOver(new InMemoryClientSignalTicketStore());
+        await tickets.MintAsync(SyntheticMailUser.Deployment, TestContext.Current.CancellationToken);
 
         // Assert
-        Assert.Null(tickets.Redeem(presented));
+        Assert.Null(await tickets.RedeemAsync(presented, TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// A value without the shape of a minted ticket costs the deployment no database work, which is what keeps a flood
+    /// of handshakes off a store the hub reaches before anything has authenticated.
+    /// </summary>
+    [Theory]
+    [InlineData("no-separator")]
+    [InlineData("identifier.a-proof-outside-the-alphabet!")]
+    [InlineData("identifier.A")]
+    public async Task RedeemAsync_AValueWithoutTheShapeOfATicket_RefusesItWithoutAskingTheStore(string presented)
+    {
+        // Arrange
+        var tickets = new ClientSignalTickets(
+            new UnreachableClientSignalTicketStore(),
+            new FakeTimeProvider(Instant));
+
+        // Assert
+        Assert.Null(await tickets.RedeemAsync(presented, TestContext.Current.CancellationToken));
     }
 
     /// <summary>A live identifier presented with somebody else's proof is refused, and the identifier is spent finding out.</summary>
     [Fact]
-    public void Redeem_ALiveIdentifierWithTheWrongProof_RefusesItAndSpendsTheTicket()
+    public async Task RedeemAsync_ALiveIdentifierWithTheWrongProof_RefusesItAndSpendsTheTicket()
     {
         // Arrange
-        var tickets = new ClientSignalTickets(new FakeTimeProvider(Instant));
-        var minted = tickets.Mint(SyntheticMailUser.Deployment);
+        var tickets = TicketsOver(new InMemoryClientSignalTicketStore());
+        var minted = await tickets.MintAsync(SyntheticMailUser.Deployment, TestContext.Current.CancellationToken);
         var identifier = minted!.Value[..minted.Value.IndexOf('.', StringComparison.Ordinal)];
 
         // Act
-        var guessed = tickets.Redeem($"{identifier}.{new string('A', 43)}");
+        var guessed = await tickets.RedeemAsync(
+            $"{identifier}.{new string('A', 43)}",
+            TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Null(guessed);
-        Assert.Null(tickets.Redeem(minted.Value));
+        Assert.Null(await tickets.RedeemAsync(minted.Value, TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// A store that cannot say whether a ticket stands leaves its caller unable to admit, rather than answering as
+    /// though the ticket were unknown — the two are the same refusal to a client and a different one to an operator.
+    /// </summary>
+    [Fact]
+    public async Task RedeemAsync_WhenTheStoreCannotBeReached_ReportsTheOutageRatherThanRefusingQuietly()
+    {
+        // Arrange
+        var tickets = new ClientSignalTickets(
+            new UnreachableClientSignalTicketStore(),
+            new FakeTimeProvider(Instant));
+
+        // Assert
+        await Assert.ThrowsAsync<ClientSignalTicketStoreUnavailableException>(
+            () => tickets.RedeemAsync($"identifier.{new string('A', 43)}", TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// A handshake arriving while this process is already redeeming as many as it will at once is refused unread, so a
+    /// flood of them holds that many connections rather than the pool the rest of the deployment reads mail through.
+    /// </summary>
+    [Fact]
+    public async Task RedeemAsync_WhileTheInFlightBoundIsFull_RefusesTheNextWithoutAskingTheStore()
+    {
+        // Arrange
+        var deployment = new HeldClientSignalTicketStore();
+        var tickets = TicketsOver(deployment);
+        var minted = new List<string>();
+
+        for (var ticket = 0; ticket <= ClientSignalTickets.MostRedemptionsInFlight; ticket++)
+        {
+            minted.Add((await tickets.MintAsync(SyntheticMailUser.Deployment, TestContext.Current.CancellationToken))!.Value);
+        }
+
+        deployment.HoldRedemptions();
+
+        var inFlight = minted
+            .Take(ClientSignalTickets.MostRedemptionsInFlight)
+            .Select(ticket => tickets.RedeemAsync(ticket, TestContext.Current.CancellationToken))
+            .ToArray();
+
+        await deployment.WaitUntilRedeeming(ClientSignalTickets.MostRedemptionsInFlight);
+
+        // Act
+        var refused = await tickets.RedeemAsync(minted[^1], TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Null(refused);
+        Assert.Equal(ClientSignalTickets.MostRedemptionsInFlight, deployment.RedemptionCount);
+
+        deployment.ReleaseRedemptions();
+        Assert.All(await Task.WhenAll(inFlight), user => Assert.Equal(SyntheticMailUser.Deployment, user));
+
+        // The bound is a ceiling on what is in flight rather than a quota spent for good, so the ticket refused while it
+        // was full opens a connection on the next attempt.
+        Assert.Equal(
+            SyntheticMailUser.Deployment,
+            await tickets.RedeemAsync(minted[^1], TestContext.Current.CancellationToken));
     }
 
     /// <summary>Every ticket is drawn afresh, so seeing one says nothing about the next.</summary>
     [Fact]
-    public void Mint_CalledRepeatedly_ProducesADistinctValueEachTime()
+    public async Task MintAsync_CalledRepeatedly_ProducesADistinctValueEachTime()
     {
         // Arrange
-        var tickets = new ClientSignalTickets(new FakeTimeProvider(Instant));
+        var tickets = TicketsOver(new InMemoryClientSignalTicketStore());
+        var minted = new List<string>();
 
         // Act
-        var minted = Enumerable
-            .Range(0, 50)
-            .Select(_ => tickets.Mint(SyntheticMailUser.Deployment)!.Value)
-            .ToArray();
+        for (var ticket = 0; ticket < 50; ticket++)
+        {
+            minted.Add((await tickets.MintAsync(SyntheticMailUser.Deployment, TestContext.Current.CancellationToken))!.Value);
+        }
 
         // Assert
-        Assert.Equal(minted.Length, minted.Distinct(StringComparer.Ordinal).Count());
+        Assert.Equal(minted.Count, minted.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    /// <summary>The secret never reaches the deployment's store, so a row read out of the database or a backup opens nothing.</summary>
+    [Fact]
+    public async Task MintAsync_ForAUser_HoldsADigestOfTheSecretRatherThanTheSecret()
+    {
+        // Arrange
+        var deployment = new InMemoryClientSignalTicketStore();
+        var tickets = TicketsOver(deployment);
+
+        // Act
+        var minted = await tickets.MintAsync(SyntheticMailUser.Deployment, TestContext.Current.CancellationToken);
+        var identifier = minted!.Value[..minted.Value.IndexOf('.', StringComparison.Ordinal)];
+        var secret = Base64Url.DecodeFromChars(minted.Value.AsSpan(identifier.Length + 1));
+        var held = await deployment.RedeemAsync(identifier, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(held);
+        Assert.Equal(SHA256.HashData(secret), held.SecretDigest.ToArray());
+        Assert.NotEqual(secret, held.SecretDigest.ToArray());
     }
 
     /// <summary>A ticket says when it stops working, so a client mints another rather than retrying one that cannot open a connection.</summary>
     [Fact]
-    public void Mint_ForAUser_ReportsWhenPresentingItStopsWorking()
+    public async Task MintAsync_ForAUser_ReportsWhenPresentingItStopsWorking()
     {
         // Arrange
-        var tickets = new ClientSignalTickets(new FakeTimeProvider(Instant));
+        var tickets = TicketsOver(new InMemoryClientSignalTicketStore());
 
         // Act
-        var minted = tickets.Mint(SyntheticMailUser.Deployment);
+        var minted = await tickets.MintAsync(SyntheticMailUser.Deployment, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(Instant + ClientSignalTickets.Lifetime, minted?.ExpiresAt);
     }
 
-    /// <summary>Expired tickets stop counting against the bound, so a quiet deployment never runs out of them.</summary>
+    /// <summary>
+    /// The bound counts the deployment rather than a process, so two replicas minting against one store refuse where
+    /// one would have — which is what a ceiling naming the deployment has to mean.
+    /// </summary>
     [Fact]
-    public void Mint_AfterOutstandingTicketsExpired_MintsAgainRatherThanRefusing()
+    public async Task MintAsync_WhenAnotherReplicaHoldsTheBound_RefusesRatherThanMintingItsOwnShare()
     {
         // Arrange
-        var clock = new FakeTimeProvider(Instant);
-        var tickets = new ClientSignalTickets(clock);
+        var deployment = new InMemoryClientSignalTicketStore();
+        var mintingReplica = TicketsOver(deployment);
+        var secondReplica = TicketsOver(deployment);
 
         for (var minted = 0; minted < ClientSignalTickets.MostOutstandingTickets; minted++)
         {
-            tickets.Mint(SyntheticMailUser.Deployment);
+            await mintingReplica.MintAsync(SyntheticMailUser.Deployment, TestContext.Current.CancellationToken);
         }
 
-        Assert.Null(tickets.Mint(SyntheticMailUser.Deployment));
+        // Assert
+        Assert.Null(await secondReplica.MintAsync(SyntheticMailUser.Deployment, TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>Expired tickets stop counting against the bound, so a quiet deployment never runs out of them.</summary>
+    [Fact]
+    public async Task MintAsync_AfterOutstandingTicketsExpired_MintsAgainRatherThanRefusing()
+    {
+        // Arrange
+        var clock = new FakeTimeProvider(Instant);
+        var tickets = new ClientSignalTickets(new InMemoryClientSignalTicketStore(), clock);
+
+        for (var minted = 0; minted < ClientSignalTickets.MostOutstandingTickets; minted++)
+        {
+            await tickets.MintAsync(SyntheticMailUser.Deployment, TestContext.Current.CancellationToken);
+        }
+
+        Assert.Null(await tickets.MintAsync(SyntheticMailUser.Deployment, TestContext.Current.CancellationToken));
 
         // Act
         clock.Advance(ClientSignalTickets.Lifetime + TimeSpan.FromSeconds(1));
 
         // Assert
-        Assert.NotNull(tickets.Mint(SyntheticMailUser.Deployment));
+        Assert.NotNull(await tickets.MintAsync(SyntheticMailUser.Deployment, TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>The sweep runs on the minting path at most once per lifetime, so a busy deployment issues one delete rather than one per connection.</summary>
+    [Fact]
+    public async Task MintAsync_SeveralTimesWithinOneLifetime_SweepsOnceRatherThanPerMint()
+    {
+        // Arrange
+        var clock = new FakeTimeProvider(Instant);
+        var deployment = new InMemoryClientSignalTicketStore();
+        var tickets = new ClientSignalTickets(deployment, clock);
+
+        clock.Advance(ClientSignalTickets.Lifetime);
+
+        // Act
+        for (var minted = 0; minted < 5; minted++)
+        {
+            await tickets.MintAsync(SyntheticMailUser.Deployment, TestContext.Current.CancellationToken);
+        }
+
+        // Assert
+        Assert.Equal(1, deployment.RemovalCount);
+    }
+
+    private static ClientSignalTickets TicketsOver(IClientSignalTicketStore store) =>
+        new(store, new FakeTimeProvider(Instant));
+
+    /// <summary>A store whose redemptions stand still until a test lets them finish, so the in-flight bound is reachable.</summary>
+    private sealed class HeldClientSignalTicketStore : IClientSignalTicketStore
+    {
+        private readonly InMemoryClientSignalTicketStore deployment = new();
+        private readonly TaskCompletionSource released = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        private volatile bool holding;
+        private int redeeming;
+
+        /// <summary>Gets how many redemptions the store has been asked for.</summary>
+        internal int RedemptionCount => this.redeeming;
+
+        internal void HoldRedemptions() => this.holding = true;
+
+        internal void ReleaseRedemptions() => this.released.TrySetResult();
+
+        /// <summary>Waits until the store is holding the given number of redemptions, so the bound is full before the next arrives.</summary>
+        internal async Task WaitUntilRedeeming(int count)
+        {
+            while (Volatile.Read(ref this.redeeming) < count)
+            {
+                await Task.Yield();
+            }
+        }
+
+        public Task<bool> TryMintAsync(
+            string identifier,
+            MailUserId user,
+            ReadOnlyMemory<byte> secretDigest,
+            DateTimeOffset expiresAt,
+            int mostOutstanding,
+            CancellationToken cancellationToken) =>
+            this.deployment.TryMintAsync(identifier, user, secretDigest, expiresAt, mostOutstanding, cancellationToken);
+
+        public async Task<RedeemedClientSignalTicket?> RedeemAsync(string identifier, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref this.redeeming);
+
+            if (this.holding)
+            {
+                await this.released.Task;
+            }
+
+            return await this.deployment.RedeemAsync(identifier, cancellationToken);
+        }
+
+        public Task RemoveExpiredAsync(DateTimeOffset removableFrom, CancellationToken cancellationToken) =>
+            this.deployment.RemoveExpiredAsync(removableFrom, cancellationToken);
     }
 }

--- a/backend/tests/Host.UnitTests/TestDoubles/InMemoryClientSignalTicketStore.cs
+++ b/backend/tests/Host.UnitTests/TestDoubles/InMemoryClientSignalTicketStore.cs
@@ -25,9 +25,6 @@ internal sealed class InMemoryClientSignalTicketStore : IClientSignalTicketStore
     /// <remarks>The sweep is throttled rather than issued per mint, and nothing else observes that: the tickets it drops could not have been presented anyway.</remarks>
     internal int RemovalCount { get; private set; }
 
-    /// <summary>Gets how many identifiers the deployment currently holds.</summary>
-    internal int OutstandingCount => this.outstanding.Count;
-
     /// <inheritdoc />
     public Task<bool> TryMintAsync(
         string identifier,

--- a/backend/tests/Host.UnitTests/TestDoubles/InMemoryClientSignalTicketStore.cs
+++ b/backend/tests/Host.UnitTests/TestDoubles/InMemoryClientSignalTicketStore.cs
@@ -1,0 +1,59 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Concurrent;
+using MailFathom.Application.Signals;
+using MailFathom.Domain.Access;
+
+namespace MailFathom.Host.UnitTests.TestDoubles;
+
+/// <summary>The deployment's unspent signal tickets, held in this process so a test can reach them.</summary>
+/// <remarks>
+/// It models the three properties the real table has and nothing else: an identifier is held once, a spend removes and
+/// returns in one step so only the first of two presentations wins, and a removal drops exactly what has expired.
+/// Whether PostgreSQL settles a concurrent pair the way this dictionary does is not a claim a unit test can make — the
+/// orchestrated suite is where the composed statements are proven — so what this double buys is the rules the minting
+/// above the port applies: the shape it refuses unread, the digest it compares, the expiry it judges, and the sweep it
+/// throttles.
+/// </remarks>
+internal sealed class InMemoryClientSignalTicketStore : IClientSignalTicketStore
+{
+    private readonly ConcurrentDictionary<string, RedeemedClientSignalTicket> outstanding = new(StringComparer.Ordinal);
+
+    /// <summary>Gets how many removals the minting above this one has asked for.</summary>
+    /// <remarks>The sweep is throttled rather than issued per mint, and nothing else observes that: the tickets it drops could not have been presented anyway.</remarks>
+    internal int RemovalCount { get; private set; }
+
+    /// <summary>Gets how many identifiers the deployment currently holds.</summary>
+    internal int OutstandingCount => this.outstanding.Count;
+
+    /// <inheritdoc />
+    public Task<bool> TryMintAsync(
+        string identifier,
+        MailUserId user,
+        ReadOnlyMemory<byte> secretDigest,
+        DateTimeOffset expiresAt,
+        int mostOutstanding,
+        CancellationToken cancellationToken) =>
+        Task.FromResult(
+            this.outstanding.Count < mostOutstanding
+            && this.outstanding.TryAdd(identifier, new RedeemedClientSignalTicket(user, secretDigest, expiresAt)));
+
+    /// <inheritdoc />
+    public Task<RedeemedClientSignalTicket?> RedeemAsync(string identifier, CancellationToken cancellationToken) =>
+        Task.FromResult(this.outstanding.TryRemove(identifier, out var ticket) ? ticket : null);
+
+    /// <inheritdoc />
+    public Task RemoveExpiredAsync(DateTimeOffset removableFrom, CancellationToken cancellationToken)
+    {
+        this.RemovalCount++;
+
+        foreach (var ticket in this.outstanding.Where(ticket => ticket.Value.ExpiresAt <= removableFrom))
+        {
+            this.outstanding.TryRemove(ticket);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/backend/tests/Host.UnitTests/TestDoubles/UnreachableClientSignalTicketStore.cs
+++ b/backend/tests/Host.UnitTests/TestDoubles/UnreachableClientSignalTicketStore.cs
@@ -1,0 +1,38 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Signals;
+using MailFathom.Domain.Access;
+
+namespace MailFathom.Host.UnitTests.TestDoubles;
+
+/// <summary>A ticket store that cannot answer, which is what a database the deployment cannot reach looks like from above the port.</summary>
+/// <remarks>
+/// It exists so the store's one security property can fail a test rather than only be asserted in prose: a store that
+/// cannot say whether a ticket stands must leave the hub unable to admit, and a <c>catch</c> added later that answered
+/// with a user would otherwise pass every test written against a store that always answers.
+/// </remarks>
+internal sealed class UnreachableClientSignalTicketStore : IClientSignalTicketStore
+{
+    /// <inheritdoc />
+    public Task<bool> TryMintAsync(
+        string identifier,
+        MailUserId user,
+        ReadOnlyMemory<byte> secretDigest,
+        DateTimeOffset expiresAt,
+        int mostOutstanding,
+        CancellationToken cancellationToken) =>
+        throw Unavailable("The ticket could not be held because this test's store cannot answer.");
+
+    /// <inheritdoc />
+    public Task<RedeemedClientSignalTicket?> RedeemAsync(string identifier, CancellationToken cancellationToken) =>
+        throw Unavailable("The ticket could not be spent because this test's store cannot answer.");
+
+    /// <inheritdoc />
+    public Task RemoveExpiredAsync(DateTimeOffset removableFrom, CancellationToken cancellationToken) =>
+        throw Unavailable("The expired tickets could not be removed because this test's store cannot answer.");
+
+    private static ClientSignalTicketStoreUnavailableException Unavailable(string message) =>
+        new(message, new InvalidOperationException("The database is unreachable."));
+}

--- a/backend/tests/IntegrationTests/Persistence/OrchestratedClientSignalTicketTests.cs
+++ b/backend/tests/IntegrationTests/Persistence/OrchestratedClientSignalTicketTests.cs
@@ -5,7 +5,9 @@
 using MailFathom.Application.Signals;
 using MailFathom.Domain.Access;
 using MailFathom.Host.Signals;
+using MailFathom.Infrastructure.Persistence;
 using MailFathom.IntegrationTests.Orchestration;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Time.Testing;
 using Xunit;
@@ -181,6 +183,61 @@ public sealed class OrchestratedClientSignalTicketTests(MailFathomOrchestrationF
         }
     }
 
+    /// <summary>
+    /// The ceiling on unspent tickets is counted by the statement that writes one, so a deployment already holding as
+    /// many as it will hold refuses the next mint whichever replica issues it.
+    /// </summary>
+    /// <remarks>
+    /// The bound is passed to the port rather than held by it, so this case states one the table already meets instead
+    /// of writing ten thousand rows. Nothing below a real server settles it: the refusal is the
+    /// <c>WHERE (SELECT count(*) …) &lt; @mostOutstanding</c> clause of the insert, and a fake counting its own
+    /// dictionary is a different mechanism in a different process — which is exactly the per-process bound this table
+    /// replaced.
+    /// </remarks>
+    [Fact]
+    public async Task TryMintAsync_WhenTheDeploymentAlreadyHoldsTheCeiling_RefusesTheMint()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var mintingHost = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        await using var secondHost = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var user = Guid.NewGuid();
+
+        await OrchestratedForeignUser.ProvisionAsync(mintingHost, user, cancellationToken);
+
+        try
+        {
+            // Arrange
+            var deployment = await StoreOfAsync(mintingHost, cancellationToken);
+            var secondReplica = await StoreOfAsync(secondHost, cancellationToken);
+            var held = await CountUnspentTicketsAsync(mintingHost, cancellationToken);
+
+            // Act
+            var refused = await secondReplica.TryMintAsync(
+                Guid.NewGuid().ToString("N"),
+                MailUserId.Create(user),
+                new byte[32],
+                Instant + ClientSignalTickets.Lifetime,
+                (int)held,
+                cancellationToken);
+
+            var admitted = await deployment.TryMintAsync(
+                Guid.NewGuid().ToString("N"),
+                MailUserId.Create(user),
+                new byte[32],
+                Instant + ClientSignalTickets.Lifetime,
+                (int)held + 1,
+                cancellationToken);
+
+            // Assert
+            Assert.False(refused);
+            Assert.True(admitted);
+        }
+        finally
+        {
+            await OrchestratedForeignUser.EraseAsync(mintingHost, user);
+        }
+    }
+
     /// <summary>Erasing a user takes their unspent tickets with them, so nothing about a person outlives their record.</summary>
     [Fact]
     public async Task EraseAsync_AUserHoldingAnUnspentTicket_TakesTheTicketWithThem()
@@ -191,21 +248,47 @@ public sealed class OrchestratedClientSignalTicketTests(MailFathomOrchestrationF
 
         await OrchestratedForeignUser.ProvisionAsync(host, user, cancellationToken);
 
-        // Arrange
-        var minted = await (await TicketsOnAsync(host, cancellationToken)).MintAsync(MailUserId.Create(user), cancellationToken);
+        try
+        {
+            // Arrange
+            var minted = await (await TicketsOnAsync(host, cancellationToken)).MintAsync(MailUserId.Create(user), cancellationToken);
 
-        // Act
-        await OrchestratedForeignUser.EraseAsync(host, user);
+            // Act
+            await OrchestratedForeignUser.EraseAsync(host, user);
 
-        // Assert
-        Assert.Null(await (await TicketsOnAsync(host, cancellationToken)).RedeemAsync(minted?.Value, cancellationToken));
+            // Assert
+            Assert.Null(await (await TicketsOnAsync(host, cancellationToken)).RedeemAsync(minted?.Value, cancellationToken));
+        }
+        finally
+        {
+            // Erased a second time on the ordinary path, which reports that there was nothing to erase rather than
+            // failing. What the block is for is the mint above: a store that could not answer would otherwise leave a
+            // second row in the one shared settings_accounts and break every class the orderer runs after this one.
+            await OrchestratedForeignUser.EraseAsync(host, user);
+        }
     }
 
     /// <summary>Mints and spends through the host's own registered store, the way the minting route and the hub do.</summary>
+    /// <remarks>
+    /// Over a clock this class fixes rather than the wall clock, because the lifetime a ticket is judged against is
+    /// thirty seconds and what these cases measure is the statement rather than elapsed time: a contended runner
+    /// between the mint and the redemption would otherwise report a ticket that expired as a spend that returned
+    /// nothing. Each replica gets its own instance at the same instant, as two processes would.
+    /// </remarks>
     private static async Task<ClientSignalTickets> TicketsOnAsync(
         OrchestratedMailFathomServices host,
         CancellationToken cancellationToken) =>
-        new(await StoreOfAsync(host, cancellationToken), TimeProvider.System);
+        new(await StoreOfAsync(host, cancellationToken), new FakeTimeProvider(Instant));
+
+    /// <summary>Counts what the deployment holds right now, which is what the ceiling above is stated against.</summary>
+    /// <remarks>Read rather than assumed to be zero: the table is the whole deployment's and the collection this class joins leaves whatever the classes before it minted and did not spend.</remarks>
+    private static Task<long> CountUnspentTicketsAsync(
+        OrchestratedMailFathomServices host,
+        CancellationToken cancellationToken) => host.InScopeAsync(
+            (scope, token) => scope.GetRequiredService<MailFathomDbContext>()
+                .ClientSignalTickets
+                .LongCountAsync(token),
+            cancellationToken);
 
     private static Task<IClientSignalTicketStore> StoreOfAsync(
         OrchestratedMailFathomServices host,

--- a/backend/tests/IntegrationTests/Persistence/OrchestratedClientSignalTicketTests.cs
+++ b/backend/tests/IntegrationTests/Persistence/OrchestratedClientSignalTicketTests.cs
@@ -1,0 +1,215 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Signals;
+using MailFathom.Domain.Access;
+using MailFathom.Host.Signals;
+using MailFathom.IntegrationTests.Orchestration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailFathom.IntegrationTests.Persistence;
+
+/// <summary>Proves that a signal ticket one host minted opens a connection the other host answered, exactly once.</summary>
+/// <remarks>
+/// <para>
+/// This is the property the store exists for and the one nothing below a real server can establish. The spend is one
+/// composed <c>DELETE ... RETURNING</c> whose returned row is the answer, so a statement that returned a row it had not
+/// removed, a column that drifted from the entity, or a bound counted per process would all pass a unit test and would
+/// reach an operator as a live channel that stops working at the replica count.
+/// </para>
+/// <para>
+/// Two hosts rather than two calls on one, because a per-process store passes the second-call form and is exactly what
+/// this change replaced. Each host composes its own service graph over the one orchestrated database, which is what a
+/// second replica is, and each wraps that graph in its own minting so the clocks are a process's own as well.
+/// </para>
+/// <para>
+/// A user of this class's own, provisioned and erased around each case, because the table carries a foreign key onto
+/// the user record and the suite shares one database.
+/// </para>
+/// </remarks>
+[Collection(OrchestratedInfrastructureCollectionDefinition.Name)]
+public sealed class OrchestratedClientSignalTicketTests(MailFathomOrchestrationFixture orchestration)
+{
+    /// <summary>How many replicas present one ticket at once, enough that a caller reliably loses the race and well under the in-flight bound a process keeps.</summary>
+    private const int ContendingReplicas = 8;
+
+    /// <summary>The instant both replicas' clocks are set to, so a ticket's expiry is this class's rather than the wall clock's.</summary>
+    private static readonly DateTimeOffset Instant = new(2026, 9, 11, 9, 0, 0, TimeSpan.Zero);
+
+    /// <summary>A ticket minted on one replica opens a connection on another, which is what removes every need for session affinity.</summary>
+    [Fact]
+    public async Task RedeemAsync_ATicketAnotherHostMinted_NamesTheUserItWasMintedFor()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var mintingHost = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        await using var connectingHost = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var user = Guid.NewGuid();
+
+        await OrchestratedForeignUser.ProvisionAsync(mintingHost, user, cancellationToken);
+
+        try
+        {
+            // Arrange
+            var minted = await (await TicketsOnAsync(mintingHost, cancellationToken)).MintAsync(MailUserId.Create(user), cancellationToken);
+
+            // Act
+            var admitted = await (await TicketsOnAsync(connectingHost, cancellationToken)).RedeemAsync(minted?.Value, cancellationToken);
+
+            // Assert
+            Assert.Equal(MailUserId.Create(user), admitted);
+        }
+        finally
+        {
+            await OrchestratedForeignUser.EraseAsync(mintingHost, user);
+        }
+    }
+
+    /// <summary>
+    /// One ticket opens one connection whichever replica each presentation reaches, settled by the statement that
+    /// removes and returns together rather than by a check either replica makes between two statements.
+    /// </summary>
+    [Fact]
+    public async Task RedeemAsync_TheSameTicketOnTwoHosts_AdmitsTheFirstAndRefusesTheSecond()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var mintingHost = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        await using var connectingHost = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var user = Guid.NewGuid();
+
+        await OrchestratedForeignUser.ProvisionAsync(mintingHost, user, cancellationToken);
+
+        try
+        {
+            // Arrange
+            var minted = await (await TicketsOnAsync(mintingHost, cancellationToken)).MintAsync(MailUserId.Create(user), cancellationToken);
+
+            // Act
+            var first = await (await TicketsOnAsync(connectingHost, cancellationToken)).RedeemAsync(minted?.Value, cancellationToken);
+            var replayed = await (await TicketsOnAsync(mintingHost, cancellationToken)).RedeemAsync(minted?.Value, cancellationToken);
+
+            // Assert
+            Assert.Equal(MailUserId.Create(user), first);
+            Assert.Null(replayed);
+        }
+        finally
+        {
+            await OrchestratedForeignUser.EraseAsync(mintingHost, user);
+        }
+    }
+
+    /// <summary>
+    /// Several replicas presenting one ticket at the same instant leave one connection admitted and the rest refused,
+    /// settled by PostgreSQL rather than by a check any of them makes between two statements.
+    /// </summary>
+    /// <remarks>
+    /// Every presentation is queued rather than awaited in turn, because a pair started one after the other runs the
+    /// synchronous head of the first — the scope, the resolution, the command — before the second begins, and can be
+    /// serialized by the scheduler alone. An implementation that read the row and then removed it would pass that
+    /// arrangement, which is the exact defect the composed statement exists to rule out.
+    /// </remarks>
+    [Fact]
+    public async Task RedeemAsync_ManyHostsPresentingOneTicketAtOnce_AdmitsExactlyOne()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var oneHost = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        await using var anotherHost = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var user = Guid.NewGuid();
+
+        await OrchestratedForeignUser.ProvisionAsync(oneHost, user, cancellationToken);
+
+        try
+        {
+            // Arrange
+            var oneReplica = await TicketsOnAsync(oneHost, cancellationToken);
+            var anotherReplica = await TicketsOnAsync(anotherHost, cancellationToken);
+            var minted = await oneReplica.MintAsync(MailUserId.Create(user), cancellationToken);
+
+            // Act
+            var attempts = await ConcurrentIdempotency.RunAsync(
+                "Presenting one signal ticket from several replicas at once",
+                ContendingReplicas,
+                (ordinal, token) => (ordinal % 2 == 0 ? oneReplica : anotherReplica).RedeemAsync(minted?.Value, token),
+                cancellationToken);
+
+            // Assert
+            attempts.AssertSingleEffect(attempts.Results.Count(admitted => admitted is not null));
+        }
+        finally
+        {
+            await OrchestratedForeignUser.EraseAsync(oneHost, user);
+        }
+    }
+
+    /// <summary>
+    /// A ticket nobody presented in time opens nothing, and a live identifier presented with the wrong proof opens
+    /// nothing and is spent finding out — both against the real statement rather than a dictionary standing in for it.
+    /// </summary>
+    [Fact]
+    public async Task RedeemAsync_AnExpiredTicketAndAWrongProof_AreBothRefused()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var host = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var user = Guid.NewGuid();
+
+        await OrchestratedForeignUser.ProvisionAsync(host, user, cancellationToken);
+
+        try
+        {
+            // Arrange
+            var clock = new FakeTimeProvider(Instant);
+            var tickets = new ClientSignalTickets(await StoreOfAsync(host, cancellationToken), clock);
+            var expiring = await tickets.MintAsync(MailUserId.Create(user), cancellationToken);
+            var guessedAt = await tickets.MintAsync(MailUserId.Create(user), cancellationToken);
+            var identifier = guessedAt!.Value[..guessedAt.Value.IndexOf('.', StringComparison.Ordinal)];
+
+            // Act
+            var guessed = await tickets.RedeemAsync($"{identifier}.{new string('A', 43)}", cancellationToken);
+            clock.Advance(ClientSignalTickets.Lifetime + TimeSpan.FromSeconds(1));
+            var expired = await tickets.RedeemAsync(expiring?.Value, cancellationToken);
+
+            // Assert
+            Assert.Null(guessed);
+            Assert.Null(expired);
+            Assert.Null(await tickets.RedeemAsync(guessedAt.Value, cancellationToken));
+        }
+        finally
+        {
+            await OrchestratedForeignUser.EraseAsync(host, user);
+        }
+    }
+
+    /// <summary>Erasing a user takes their unspent tickets with them, so nothing about a person outlives their record.</summary>
+    [Fact]
+    public async Task EraseAsync_AUserHoldingAnUnspentTicket_TakesTheTicketWithThem()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var host = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var user = Guid.NewGuid();
+
+        await OrchestratedForeignUser.ProvisionAsync(host, user, cancellationToken);
+
+        // Arrange
+        var minted = await (await TicketsOnAsync(host, cancellationToken)).MintAsync(MailUserId.Create(user), cancellationToken);
+
+        // Act
+        await OrchestratedForeignUser.EraseAsync(host, user);
+
+        // Assert
+        Assert.Null(await (await TicketsOnAsync(host, cancellationToken)).RedeemAsync(minted?.Value, cancellationToken));
+    }
+
+    /// <summary>Mints and spends through the host's own registered store, the way the minting route and the hub do.</summary>
+    private static async Task<ClientSignalTickets> TicketsOnAsync(
+        OrchestratedMailFathomServices host,
+        CancellationToken cancellationToken) =>
+        new(await StoreOfAsync(host, cancellationToken), TimeProvider.System);
+
+    private static Task<IClientSignalTicketStore> StoreOfAsync(
+        OrchestratedMailFathomServices host,
+        CancellationToken cancellationToken) => host.InScopeAsync(
+            (scope, _) => Task.FromResult(scope.GetRequiredService<IClientSignalTicketStore>()),
+            cancellationToken);
+}

--- a/backend/tests/IntegrationTests/Persistence/OrchestratedClientSignalTicketTests.cs
+++ b/backend/tests/IntegrationTests/Persistence/OrchestratedClientSignalTicketTests.cs
@@ -169,13 +169,14 @@ public sealed class OrchestratedClientSignalTicketTests(MailFathomOrchestrationF
 
             // Act
             var guessed = await tickets.RedeemAsync($"{identifier}.{new string('A', 43)}", cancellationToken);
+            var respent = await tickets.RedeemAsync(guessedAt.Value, cancellationToken);
             clock.Advance(ClientSignalTickets.Lifetime + TimeSpan.FromSeconds(1));
             var expired = await tickets.RedeemAsync(expiring?.Value, cancellationToken);
 
             // Assert
             Assert.Null(guessed);
+            Assert.Null(respent);
             Assert.Null(expired);
-            Assert.Null(await tickets.RedeemAsync(guessedAt.Value, cancellationToken));
         }
         finally
         {

--- a/docs/architecture/stored-email-schema.md
+++ b/docs/architecture/stored-email-schema.md
@@ -471,9 +471,12 @@ must not depend on a component a deployment may not run.
 | `SecretDigest` | The SHA-256 digest of the ticket's secret half, 32 bytes. The secret itself is never stored, so a row read out of the database or out of a backup opens no connection; the presented secret is hashed and the two digests compared in constant time |
 | `ExpiresAt` | When presenting the ticket stops working, thirty seconds after it was minted. It is the one index beside the key and the foreign key's own, and the index is what makes the removal proportional to what has expired rather than to everything the deployment holds |
 
-**Nothing here is mail, and nothing an unauthenticated caller sends reaches it.** Only a request that already
-authenticated against a credential holding `mailfathom.mail.read` produces a row, so a row is a generated user
-identity, a digest, and an instant — no message, no header, no address, and no credential.
+**Nothing here is mail, and only an authenticated request writes a row.** A request that already authenticated against
+a credential holding `mailfathom.mail.read` is the only thing that produces one, so a row is a generated user identity,
+a digest, and an instant — no message, no header, no address, and no credential. A value an unauthenticated caller
+presents reaches this table in one place only: as the identifier the spend is parameterized by, once the connection it
+arrived on has been refused for anything without a ticket's shape and admitted under the replica's bound on redemptions
+in flight. It is read back rather than stored.
 
 **It cannot grow without bound, and two things hold it.** A ticket lives thirty seconds, and the removal keeps the
 table proportional to the connections opened since the last one. Beside that is a ceiling on how many unspent tickets

--- a/docs/architecture/stored-email-schema.md
+++ b/docs/architecture/stored-email-schema.md
@@ -450,6 +450,40 @@ path rather than on a timer, so a deployment whose assertion traffic stops keeps
 until the next assertion arrives. A cap with an eviction policy would be worse than none: evicting a row that has not
 expired is precisely the replay this exists to refuse.
 
+## The unspent signal connection tickets
+
+`client_signal_tickets` holds the single-use tickets a client's
+[live signal connection](../operations/client-endpoint.md#the-signal-channel) is opened against. A browser cannot put a
+header on a WebSocket, so the connection carries a ticket instead: an authenticated route mints one, the client hands
+it to the connection, and the hub spends it.
+
+It is a table rather than a dictionary in a process because a load balancer places the mint and the connection
+independently — the connection skips negotiation precisely so that nothing has to route the two together — so a ticket
+held in the process that minted it would be redeemable about one time in the replica count, silently.
+[ADR 0032](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0032-reaching-a-client-from-any-replica-over-websockets-and-a-resp-backplane.md)
+records that, and records why the ticket is not kept in the optional signal backplane instead: an authentication path
+must not depend on a component a deployment may not run.
+
+| Column | What it records |
+|---|---|
+| `Identifier` | The public half of the ticket, as the minting replica drew it — the base64url of sixteen random bytes — at most 64 characters, and the primary key. It is what a presentation is looked up by, and the row being removed by the presentation that finds it is the single-use rule itself: the spend is one `DELETE ... RETURNING` and the returned row is the whole answer |
+| `UserId` | Whose connection the ticket opens. It is the foreign key onto `settings_accounts` with `ON DELETE CASCADE`, for the reason `client_preferences` keys the same way: a ticket is minted for one person and names nobody else |
+| `SecretDigest` | The SHA-256 digest of the ticket's secret half, 32 bytes. The secret itself is never stored, so a row read out of the database or out of a backup opens no connection; the presented secret is hashed and the two digests compared in constant time |
+| `ExpiresAt` | When presenting the ticket stops working, thirty seconds after it was minted. It is the one index beside the key and the foreign key's own, and the index is what makes the removal proportional to what has expired rather than to everything the deployment holds |
+
+**Nothing here is mail, and nothing an unauthenticated caller sends reaches it.** Only a request that already
+authenticated against a credential holding `mailfathom.mail.read` produces a row, so a row is a generated user
+identity, a digest, and an instant — no message, no header, no address, and no credential.
+
+**It cannot grow without bound, and two things hold it.** A ticket lives thirty seconds, and the removal keeps the
+table proportional to the connections opened since the last one. Beside that is a ceiling on how many unspent tickets
+the deployment holds at once, counted in the same statement that writes the ticket — so it is the deployment's number
+rather than one each replica finds room under separately, and a mint past it answers `503` rather than growing the
+table. Reaching it is a refusal rather than an eviction, because evicting somebody else's live ticket would turn one
+caller's noise into another caller's failed connection. The sweep runs on the minting path rather than on a timer, at
+most once per ticket lifetime per replica, so a deployment whose clients stop connecting keeps whatever rows it held at
+that moment until the next mint arrives.
+
 ## The derived search document
 
 `email_search_documents` is one-to-one with `stored_emails` and holds what lexical search reads: `subject_text`, `participant_addresses`, `body_text`, `body_text_before_trimming`, `text_source`, `extracted_at`, and the generated `search_vector`. [Body text and the lexical index](../features/imap-synchronization.md#body-text-and-the-lexical-index) describes how each of them is derived. Every stored email has one, including a message whose body was never read: that row carries the envelope's subject alone and records its text source as not extracted, so an oversized or unparseable message is still findable rather than absent from search entirely.
@@ -1622,6 +1656,9 @@ account reach these four tables through the same cascade every other table is re
 | `ix_notifications_user_unread_condition` | `(UserId, DeduplicationKey)`, unique, where `NOT "IsRead"` | The deduplication rule itself: one unread statement per condition, and no bound at all on conditions the person has already read. Being partial is also what makes it the index an unread count is answered from, since that count is one user's rows in it — and what keeps a repeated raise a lost race a retry resolves rather than a check the application could win between the read and the write |
 | `PK_spent_client_assertions` | `(CredentialKey, Identifier)`, unique | The anti-replay rule itself. The spend is one `INSERT ... ON CONFLICT DO NOTHING` and whether a row was written is the whole answer, so two replicas presenting one identifier at the same instant are settled here rather than by a check either of them makes between two statements |
 | `ix_spent_client_assertions_expires_at` | `(ExpiresAt)` | The order the served assertions are aged out through. Nothing reads a spent assertion, so the column is indexed for the removal alone — which is what keeps that removal proportional to what has expired since the last one rather than to everything ever spent |
+| `PK_client_signal_tickets` | `(Identifier)`, unique | The single-use rule itself. The spend is one `DELETE ... RETURNING` reaching exactly one row, so two connections presenting one ticket at the same instant are settled here rather than by a check either replica makes between two statements |
+| `ix_client_signal_tickets_expires_at` | `(ExpiresAt)` | The order the unspent tickets are aged out through, indexed for the removal alone for the reason the assertions' expiry is: nothing reads a ticket by its age |
+| `IX_client_signal_tickets_UserId` | `(UserId)` | The foreign key onto the user record, which is what erasing a person reaches their unspent tickets by rather than scanning |
 | `ix_notifications_user_occurred` | `(UserId, OccurredAt, Id)` | The two ways the notification centre is worked: a page of one person's notifications newest first, and the retention sweep that erases the same person's oldest. The identifier is in the key because two notifications raised in one instant need a total order for a keyset page to continue from |
 | `IX_notifications_TargetStoredEmailId` | `(TargetStoredEmailId)` | The foreign key back to the message a notification leads to, which is what erasing that message reaches its notifications by rather than scanning |
 | `IX_stored_content_claims_ExpiresAt` | `(ExpiresAt)` | The sweep every claim statement opens with, which is what keeps the table the size of the payloads currently in flight rather than of every claim a replica ever died holding. Unfiltered, because what an expiry divides the table into changes with the clock rather than with a row |
@@ -1738,6 +1775,8 @@ user's generated identifier and the account alias are what a failure names, and 
 personal data.
 
 `spent_client_assertions` is the one table on this page whose classification depends on which credential a row was written under. For a configured key pair the `CredentialKey` column holds the name an operator gave the key, which is MailFathom's own configuration and nobody's data; for a user's registered key it holds that key's 43-character fingerprint, which is a pseudonymous identifier for an identified person and is read as their data. The other two columns are neither in both cases — a value the client minted for one request, and an instant. Nothing cascades into the table, and that is deliberate rather than an omission: the column holds a configured name as readily as a fingerprint and belongs to neither record, so there is nothing for a constraint to point at. What replaces the cascade is the row's own lifetime, which is minutes rather than a retention window somebody has to sweep against — a data-subject erasure is therefore not owed a statement here, because whatever a fingerprint could still identify is gone on its own before such a request could be answered. Neither the fingerprint nor the identifier reaches a log, a metric, a trace, or an error message — a refusal on the user path names the credential's own generated identifier. The configured key name does reach one, in the warnings that say which key presented a replayed or overlong assertion, and it is the column value there as well as in the row; it is MailFathom's own configuration rather than anybody's data, which is why that is the one part of the table a log carries.
+
+`client_signal_tickets` holds a generated user identity, which is a pseudonymous identifier for an identified person and is read as their data; the digest and the instant beside it are neither. It does cascade from the user record, so a data-subject erasure takes whatever it holds without having to know the table exists — and the row's own lifetime of thirty seconds means there is almost never anything for that cascade to reach. The digest is not a credential: it opens nothing, because what a connection presents is the secret it was derived from. Nothing here reaches a log, a metric, a trace, or an error message — a refused connection is counted rather than described, and the one refusal that names anything names the deployment's own inability to reach its database.
 
 `embedding_profiles` is the exception on this page: it holds no personal data at all. It describes a model, and the credential that reaches that model is configuration rather than a column here, so nothing in this table is a secret or is derived from anybody's mail.
 

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -2451,7 +2451,11 @@ bound it abandons a request for a page of mail, and `ClientEndpoint:RateLimiting
 against the capacity a browser is spending reading mail. What is bounded instead is the minting, which a reconnect
 cannot avoid — and a deployment holding as many unspent tickets as it will hold answers `503` rather than growing. That
 ceiling is the deployment's rather than each replica's: it is counted in the same statement that writes the ticket, so
-raising the replica count does not multiply it. What bounds the other end is the hub itself, which has authenticated
+raising the replica count does not multiply it. A deployment that cannot reach those tickets at all answers the same
+`503` on the same route, because what a client does about either is identical — wait, and mint again. The two are told
+apart by the error code the answer carries: `33002` is the database that could not be asked, and the ceiling carries
+none. An operator meeting `33002` is looking for an unreachable database rather than for ten thousand unspent tickets,
+and the log entry the refusal wrote is where that failure is. What bounds the other end is the hub itself, which has authenticated
 nothing when a connection arrives: a value without the shape of a minted ticket is refused before any statement runs,
 and each replica has only so many redemptions in flight at once, sized well below the connection pool the rest of the
 deployment reads mail through. A flood of handshakes therefore costs live updates while it lasts and never costs mail,

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -2349,6 +2349,14 @@ judged, its request is bounded, and its act is recorded.
 | `POST /api/client/signals/ticket` | Mints the single-use ticket a connection is opened against |
 | `/api/client/signals` | The hub itself, reached over a WebSocket carrying that ticket |
 
+**The hub serves WebSockets and nothing else.** A server-sent-events or long-polling connection is refused to every
+caller, and the client never asks for one: it opens the connection with negotiation skipped, which makes the whole
+handshake a single request rather than a negotiation followed by the transport it chose. That is what removes every
+reason for session affinity — there is no pair of requests for a load balancer to keep together, and the one request
+that opens the connection is the one that presents the ticket. What it costs is stated rather than discovered: a
+network or a proxy that will not pass the WebSocket upgrade gives that client no live updates at all, and the client
+reads its screens over the ordinary routes on its own schedule instead.
+
 **A connection is opened against a ticket, because a browser cannot put a header on a WebSocket.** The client mints one
 over the route above — an ordinary authenticated route on this surface, requiring `mailfathom.mail.read` like the mail
 it announces — and hands it to the connection. A ticket names the user the credential behind it already named, is
@@ -2356,6 +2364,15 @@ drawn from a cryptographically secure source, lives 30 seconds, and stops workin
 read out of a proxy's access log or a browser's own history is already spent or already expired. Nothing else opens a
 connection: a connection presenting nothing, something malformed, something expired, or something already spent is
 closed without being told which.
+
+**The deployment holds its unspent tickets in PostgreSQL, so any replica accepts a connection any other replica minted
+a ticket for.** Minting is one insert and spending is one statement that removes the row and hands back what it held,
+so exactly one presentation of a ticket wins whichever replica each of them reaches. What the row holds is the user, a
+digest of the ticket's secret half, and the expiry — never the secret itself, so a row read out of the database or out
+of a backup opens no connection. The ticket does not live in the signal backplane, because that component is optional
+and an authentication path must not depend on one: a deployment running no backplane loses signals between replicas and
+never loses connections. A deployment that cannot reach its database refuses the connection rather than admitting it,
+and says so in its log as an outage rather than as a ticket that was wrong.
 
 **One user's signals reach that user's connections and no other's.** A connection joins a group named from the user's
 own identifier the moment it is admitted, and every statement is published to one group; nothing here reads a group name
@@ -2423,12 +2440,21 @@ answer leaves what is drawn in place for the next to try again.
 **A proxy in front of this endpoint has to pass the upgrade** — `Upgrade` and `Connection` on the request, and no
 buffering or idle timeout shorter than a connection that is meant to stand open. Nothing here fails when it does not;
 the client falls back to its interval, which is what makes this safe to deploy behind a proxy nobody reconfigured.
+**It needs no session affinity, at any replica count**, and configuring it anyway gains nothing while pinning load: a
+cookie pins every request a client makes and hashing the source address puts every client behind one NAT on one
+replica, both of which distort the load the replicas were added to share.
 
 **The hub is deliberately outside this surface's request timeout and rate limiter**, and the minting route is
 deliberately inside both. `ClientEndpoint:RequestTimeout` would abandon a connection meant to stand open at the same
 bound it abandons a request for a page of mail, and `ClientEndpoint:RateLimiting` would count an open connection
 against the capacity a browser is spending reading mail. What is bounded instead is the minting, which a reconnect
-cannot avoid — and a deployment holding as many unspent tickets as it will hold answers `503` rather than growing.
+cannot avoid — and a deployment holding as many unspent tickets as it will hold answers `503` rather than growing. That
+ceiling is the deployment's rather than each replica's: it is counted in the same statement that writes the ticket, so
+raising the replica count does not multiply it. What bounds the other end is the hub itself, which has authenticated
+nothing when a connection arrives: a value without the shape of a minted ticket is refused before any statement runs,
+and each replica has only so many redemptions in flight at once, sized well below the connection pool the rest of the
+deployment reads mail through. A flood of handshakes therefore costs live updates while it lasts and never costs mail,
+because the client's own refresh is what the screen is promised on.
 
 **The connection is served only where this endpoint is.** The hub sits beneath this surface's route prefix, so a
 listener that does not serve the client surface answers it `404` exactly as it answers every other route here, and a

--- a/docs/operations/client-endpoint.md
+++ b/docs/operations/client-endpoint.md
@@ -2440,6 +2440,7 @@ answer leaves what is drawn in place for the next to try again.
 **A proxy in front of this endpoint has to pass the upgrade** — `Upgrade` and `Connection` on the request, and no
 buffering or idle timeout shorter than a connection that is meant to stand open. Nothing here fails when it does not;
 the client falls back to its interval, which is what makes this safe to deploy behind a proxy nobody reconfigured.
+
 **It needs no session affinity, at any replica count**, and configuring it anyway gains nothing while pinning load: a
 cookie pins every request a client makes and hashing the source address puts every client behind one NAT on one
 replica, both of which distort the load the replicas were added to share.


### PR DESCRIPTION
Closes #1878

## What this changes

The signal hub is now mapped with `HttpTransportType.WebSockets` as its only transport, and the deployment's unspent connection tickets moved out of a process dictionary into PostgreSQL. Together those remove every reason for session affinity on the client surface: the connection skips negotiation and is therefore one request, and any replica accepts a ticket any other replica minted. This implements the half of ADR 0032 that issue #1878 owns; the backplane half is #1879.

### The transport

`ClientSignalEndpoints.ServeOverWebSocketsAlone` is what `HostPipeline` passes to `MapHub`, so server-sent-events and long-polling connections are refused to every caller rather than served to one the client never is. The client is unchanged — it already connects with `transport: WebSockets` and `skipNegotiation: true`.

### The ticket

`IClientSignalTicketStore` is a new application port with an adapter in the shape #1835 gave `ClientAssertionSpendStore`: bare commands over the data source, identifiers composed from the mapped entity's own constants, every value a parameter, and a provider failure translated at the boundary.

- **Minting** is one `INSERT ... SELECT ... WHERE (SELECT count(*) …) < @mostOutstanding`, so the ceiling on outstanding tickets is counted across the deployment in the same statement that writes the ticket, as a limit describing the deployment must (#1293). Reaching it is still a `503` rather than an eviction.
- **Spending** is one `DELETE … RETURNING`, so exactly one presentation of a ticket wins whichever replica each of them reaches.
- **The row holds the user, a SHA-256 digest of the secret half, and the expiry** — never the secret, so a row read out of the database or a backup opens nothing. The presented secret is hashed and compared with `FixedTimeEquals`. The 30-second lifetime, the 16-byte identifier, and the 32-byte secret are unchanged.
- **Expired rows are swept** through the index on the expiry, on the minting path at most once per lifetime per replica, which is the arrangement `ClientAssertionReplayStore` already uses.
- **The row cascades from the user record**, so an erasure takes an unspent ticket without having to know the table exists.

### Redemption is bounded on the hub

The hub is mapped outside the client route group and has authenticated nothing when a ticket arrives, so `ClientSignalTickets` bounds it itself: a value without the shape of a minted ticket — its length, its separator, its encoding — is refused before any statement runs, and at most 16 redemptions are in flight per process, well below the connection pool the rest of the deployment reads mail through.

### A store that cannot answer refuses

`ClientSignalTicketStoreUnavailableException` (`MailFathomErrorCode.ClientSignalTicketStoreUnavailable`, `33002`) crosses the port instead of an `NpgsqlException`. The hub catches it, aborts the connection, and logs it at `Warning` — which is what tells that case apart from a wrong, spent, or expired ticket, logged at `Debug` as before.

## Breaking changes

- **Deployment contract.** A reverse proxy or load balancer that does not pass the WebSocket upgrade now gives a client no live updates at all: there is no fallback transport. Nothing else breaks — the client reads its screens over the ordinary routes on its own schedule, so the operator action is to pass `Upgrade` and `Connection` through, which `docs/operations/client-endpoint.md` already asked for.
- **Database schema.** Additive: one new table, `client_signal_tickets`, added by `20260911125554_AddClientSignalTickets`. Nothing existing is altered, and the release is deployable over the previous release's data.

No configuration key, MCP tool argument, or HTTP route changed.

## Verification

- `scripts/verify-fast.sh` — passed, 15614 tests over every unit suite the change reaches.
- `dotnet test --project backend/tests/PublicSurfaces.UnitTests` — passed; the HTTP API golden is unmoved by the minting route becoming asynchronous.
- `scripts/script-migration.sh` — the migration was reviewed as SQL: one `CREATE TABLE`, two `CREATE INDEX`, no destructive operation, no rewrite of an existing table.

**The migration was not applied to a live database in this session.** Several agent sessions share this machine and starting an Aspire orchestration would occupy a contended shared runtime, so `$add-migration`'s apply-and-start steps were deliberately skipped; the `Pending model changes` job on this pull request is what asserts the model and the snapshot agree.

The integration suite is the owner's to run. `OrchestratedClientSignalTicketTests` proves against two hosts over one database that a ticket minted on one opens a connection on the other, that several replicas presenting one ticket at once admit exactly one, that an expired ticket and a wrong proof are both refused, and that erasing a user takes their unspent tickets with them.
