### PR TITLE
[#1909] Wash a row in the colour of the act taking it, say what a permanent delete does, take a flag off, draft a reply, and let a PDF draw

### DIFF
--- a/backend/src/Host/Configuration/Chat/ChatModelOptions.cs
+++ b/backend/src/Host/Configuration/Chat/ChatModelOptions.cs
@@ -187,11 +187,11 @@ internal sealed class ChatModelOptions : IValidatableObject, IProviderEndpointRe
     public ThreadStateOptions ThreadState { get; set; } = new();
 
     /// <summary>Gets or sets whether a reply is drafted from the conversation it answers, and where its manner comes from.</summary>
-    /// <remarks>Present rather than nullable for the reason the blocks above are: its own <c>Enabled</c> is what says whether a drafting runs, and off is the default and a supported deployment.</remarks>
+    /// <remarks>Present rather than nullable for the reason the blocks above are: its own <c>Enabled</c> is what says whether a drafting runs, and on is the default for the reason the block beneath it is on — the block itself says why, and what turning it off leaves is the composer somebody writes in themselves.</remarks>
     public ReplyDraftingOptions ReplyDrafting { get; set; } = new();
 
     /// <summary>Gets or sets whether a sentence typed into the search field is read into the filters it describes.</summary>
-    /// <remarks>Present rather than nullable for the reason the three blocks above are, and on by default unlike any of them — the block itself says why, and what turning it off leaves is the word search every deployment serves.</remarks>
+    /// <remarks>Present rather than nullable for the reason the three blocks above are, and on by default as the block above it is — the block itself says why, and what turning it off leaves is the word search every deployment serves.</remarks>
     public MailSearchPhrasingOptions SearchPhrasing { get; set; } = new();
 
     /// <summary>Gets whether the deployment declared a chat provider at all.</summary>
@@ -208,7 +208,9 @@ internal sealed class ChatModelOptions : IValidatableObject, IProviderEndpointRe
             // it. What each member contributes here is whether writing it was unambiguous intent. Most have no useful
             // default, so any value at all is; the API has one, so what counts is a value other than it, which nobody
             // writes by accident. The bounds and the timeout contribute nothing either way, because a deployment that
-            // accepted their defaults is indistinguishable from one that wrote them out.
+            // accepted their defaults is indistinguishable from one that wrote them out. The two blocks that are on by
+            // default are absent for that same reason: their `Enabled` reads true on a section nobody wrote, so reading
+            // one as intent would refuse every deployment that left the section alone.
             if (this.Model.Trim().Length > 0
                 || this.PublishedModel.Trim().Length > 0
                 || this.Address.Trim().Length > 0
@@ -219,8 +221,7 @@ internal sealed class ChatModelOptions : IValidatableObject, IProviderEndpointRe
                 || this.Unauthenticated
                 || this.RelevanceFilter.Enabled
                 || this.Enrichment.Enabled
-                || this.ThreadState.Enabled
-                || this.ReplyDrafting.Enabled)
+                || this.ThreadState.Enabled)
             {
                 yield return new ValidationResult(
                     "The Chat section declares settings but no Alias, so no chat provider is configured and nothing in it is read. Give the endpoint an alias, or remove the section.",

--- a/backend/src/Host/Configuration/Chat/ReplyDraftingOptions.cs
+++ b/backend/src/Host/Configuration/Chat/ReplyDraftingOptions.cs
@@ -11,8 +11,13 @@ namespace MailFathom.Host.Configuration.Chat;
 /// drafting runs against the declared chat endpoint and has nowhere to send a conversation without one.
 /// </para>
 /// <para>
-/// Off by default, and off is not a lesser deployment. The composer is then the composer somebody writes in
-/// themselves, which is what every deployment served before this existed and what one without a provider serves now.
+/// <strong>On by default, on the same reading that puts the phrase search on beside it: what decides the default is
+/// who spends the money and when.</strong> A drafting runs when a person presses the button that asks for one, which
+/// is the same shape as asking a question and is offered by every deployment declaring an endpoint — unlike
+/// enrichment, which runs over mail as it arrives and would put an operator's bill behind a mailbox somebody else
+/// fills. Turning it off is therefore a decision about cost, and a deployment that takes it serves the composer
+/// somebody writes in themselves, which is what every deployment served before this existed and what one without a
+/// provider serves now.
 /// </para>
 /// <para>
 /// The second switch is here rather than folded into the first because the two decisions are about different mail.
@@ -31,7 +36,7 @@ namespace MailFathom.Host.Configuration.Chat;
 internal sealed class ReplyDraftingOptions
 {
     /// <summary>Gets or sets whether a reply is drafted from the conversation it answers.</summary>
-    public bool Enabled { get; set; }
+    public bool Enabled { get; set; } = true;
 
     /// <summary>Gets or sets whether the draft's manner is derived from the answering account's own recent sent mail.</summary>
     /// <remarks>On where drafting is on, because a reply that does not sound like its sender is one somebody rewrites rather than edits, and the mail it reads is their own.</remarks>

--- a/backend/tests/Host.UnitTests/Configuration/Chat/ChatDeclarationRulesTests.cs
+++ b/backend/tests/Host.UnitTests/Configuration/Chat/ChatDeclarationRulesTests.cs
@@ -297,11 +297,11 @@ public sealed class ChatDeclarationRulesTests
     /// deployment had stopped writing, or withholding one it had started writing.
     /// </summary>
     [Fact]
-    public void FindChangesNeedingRestart_ReplyDraftingTurnedOn_RefusesRatherThanBeingIgnored()
+    public void FindChangesNeedingRestart_ReplyDraftingTurnedOff_RefusesRatherThanBeingIgnored()
     {
         // Arrange
         var candidate = Declared();
-        candidate.ReplyDrafting.Enabled = true;
+        candidate.ReplyDrafting.Enabled = false;
 
         // Act
         var errors = ChatDeclarationRules.FindChangesNeedingRestart(candidate, Declared());

--- a/backend/tests/Host.UnitTests/Configuration/Chat/ReplyDraftingOptionsTests.cs
+++ b/backend/tests/Host.UnitTests/Configuration/Chat/ReplyDraftingOptionsTests.cs
@@ -16,9 +16,9 @@ namespace MailFathom.Host.UnitTests.Configuration.Chat;
 /// </remarks>
 public sealed class ReplyDraftingOptionsTests
 {
-    /// <summary>Off is the default and a supported deployment: the composer is the one somebody writes in themselves.</summary>
+    /// <summary>On is the default wherever an endpoint is declared, so a deployment that wrote no block drafts replies.</summary>
     [Fact]
-    public void Validate_AChatEndpointWithNoReplyDraftingBlock_IsAcceptedAndLeavesTheDraftingOff()
+    public void Validate_AChatEndpointWithNoReplyDraftingBlock_IsAcceptedAndLeavesTheDraftingOn()
     {
         // Arrange
         var settings = Declared();
@@ -27,7 +27,22 @@ public sealed class ReplyDraftingOptionsTests
         var errors = Validate(settings);
 
         // Assert
-        Assert.False(settings.ReplyDrafting.Enabled);
+        Assert.True(settings.ReplyDrafting.Enabled);
+        Assert.Empty(errors);
+    }
+
+    /// <summary>Turning it off is a supported deployment, and it is the operator's spend decision rather than a lesser instance.</summary>
+    [Fact]
+    public void Validate_ADeclinedDraftingOnADeclaredEndpoint_IsAccepted()
+    {
+        // Arrange
+        var settings = Declared();
+        settings.ReplyDrafting.Enabled = false;
+
+        // Act
+        var errors = Validate(settings);
+
+        // Assert
         Assert.Empty(errors);
     }
 
@@ -60,19 +75,23 @@ public sealed class ReplyDraftingOptionsTests
         Assert.Empty(errors);
     }
 
-    /// <summary>The drafting runs against the declared endpoint and has nowhere to send a conversation without one.</summary>
+    /// <summary>
+    /// A drafting left on declares no provider, because on is what a section nobody wrote already reads: taking it as
+    /// intent would refuse every deployment that never opened the block, which is most of them.
+    /// </summary>
     [Fact]
-    public void Validate_AnEnabledDraftingWithoutAChatEndpoint_IsRefused()
+    public void Validate_TheDraftingLeftOnWithNoChatEndpoint_DeclaresNoProvider()
     {
         // Arrange
         var settings = new ChatModelOptions();
-        settings.ReplyDrafting.Enabled = true;
 
         // Act
         var errors = Validate(settings);
 
         // Assert
-        Assert.Contains(errors, error => error.Contains("no Alias", StringComparison.Ordinal));
+        Assert.False(settings.IsConfigured);
+        Assert.True(settings.ReplyDrafting.Enabled);
+        Assert.Empty(errors);
     }
 
     /// <summary>

--- a/docs/features/reply-drafting.md
+++ b/docs/features/reply-drafting.md
@@ -115,11 +115,12 @@ Asking a provider to write a reply to a conversation this deployment stored no t
 on its own: a model given nothing writes a fluent message resting on nothing at all, so the drafting answers with
 nothing instead.
 
-## Turning it on
+## Turning it off
 
-Off by default, and off is a supported deployment: the composer offers no drafting and every reply is written by hand
-exactly as before. Turning it on needs a declared chat endpoint and is a spend decision — one provider call per reply
-somebody deliberately asked for.
+On wherever a chat endpoint is declared, and read nowhere else: a deployment with no endpoint drafts nothing whatever
+the key says. Turning it off is a supported deployment and a spend decision — the composer then offers no drafting and
+every reply is written by hand exactly as before. What it costs where it is on is one provider call per reply somebody
+deliberately asked for.
 
 [AI configuration § `Chat:ReplyDrafting`](../operations/configuration-ai.md#drafting-a-reply--chatreplydrafting) holds
 the two keys, and [the client endpoint](../operations/client-endpoint.md#the-reply-drafting-routes) the two routes it is

--- a/docs/operations/configuration-ai.md
+++ b/docs/operations/configuration-ai.md
@@ -741,10 +741,11 @@ Writing a first version of the reply somebody is about to send, out of the conve
 their own account writes, so a composer opens on a draft they edit rather than on a blank field. A block inside `Chat`
 for the reason the blocks above are: it drafts with that endpoint and has nowhere to send a conversation without one.
 
-Off by default, and off is a supported deployment: the composer asks this deployment once whether it drafts at all, is
-told it does not, and offers nothing — every reply is written by hand exactly as before. Turning it on is a spend
-decision, and a smaller one than the derivations above: it costs one call per reply somebody deliberately asked for
-rather than one per message or conversation arriving.
+On by default, on the reading that puts the phrase search below it on: what decides the default is who spends the
+money and when. A drafting costs one call per reply somebody deliberately pressed a button for, rather than one per
+message or conversation arriving, so a deployment that declared an endpoint is already paying for that shape of call.
+Turning it off is a supported deployment and a spend decision: the composer asks this deployment once whether it
+drafts at all, is told it does not, and offers nothing — every reply is then written by hand exactly as before.
 
 **Nothing it produces is sent, queued, or stored.** The draft comes back as text in the client, and saving it as a
 draft or sending it stays behind the person confirming those acts.
@@ -761,7 +762,7 @@ reaches the provider, and what a drafting that produced nothing answers with.
 
 | Key | Type | Default | Constraint | Change |
 | --- | --- | --- | --- | --- |
-| `Chat:ReplyDrafting:Enabled` | bool | `false` | turning it on requires a declared `Chat:Alias` | restart |
+| `Chat:ReplyDrafting:Enabled` | bool | `true` | it is read only where `Chat:Alias` declares an endpoint, so a deployment without one drafts nothing whatever this says | restart |
 | `Chat:ReplyDrafting:StyleFromSentMail` | bool | `true` | written off, no sent mail is read and the draft is written from the conversation alone. It changes what leaves the deployment rather than only what the draft reads like, which is why it is an operator's decision rather than a constant | restart |
 
 ### Reading a typed sentence into filters — `Chat:SearchPhrasing`

--- a/frontend/src/Client.App/src/mailSpace/HeadActs.test.tsx
+++ b/frontend/src/Client.App/src/mailSpace/HeadActs.test.tsx
@@ -6,10 +6,10 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { ComposingContext, type Composing } from '../composer/useComposing';
 import { LocalizationProvider } from '../localization/Localization';
-import { MailboxActsContext, nothingActed, type MailboxActs } from '../mailboxActs/useMailboxActs';
-import { HeadActs, type HeadMessage } from './HeadActs';
+import { MailboxActsContext, nothingActed, type ActedMessage, type MailboxActs } from '../mailboxActs/useMailboxActs';
+import { HeadActs } from './HeadActs';
 
-const message: HeadMessage = {
+const message: ActedMessage = {
     storedEmailId: '00000000-0000-4000-8000-000000000000',
     account: 'work',
     folder: 'work-inbox',
@@ -24,7 +24,7 @@ function drawHead({
     compact = false,
 }: {
     readonly offered?: boolean;
-    readonly acting?: HeadMessage | null;
+    readonly acting?: ActedMessage | null;
     readonly acts?: MailboxActs;
     readonly compact?: boolean;
 } = {}): { composed: ReturnType<typeof vi.fn> } {
@@ -98,18 +98,24 @@ describe('HeadActs', () => {
         expect(performed).not.toHaveBeenCalled();
     });
 
-    it('says an act already on its way is on its way rather than submitting it twice', () => {
+    // A flag already on its way is what the next press is read against, exactly as the read control reads one: the
+    // control turns round at once rather than saying the first press is still travelling, so pressing it twice gives
+    // the two directions rather than the same act submitted again.
+    it('turns the flag round where one is already on its way, so the next press takes it off', () => {
         const performed = vi.fn();
         drawHead({
             acts: {
                 ...actsOffering(performed),
-                asked: new Map([[message.storedEmailId, { act: 'flag', from: message.folder, leaves: false }]]),
+                asked: new Map([
+                    [message.storedEmailId, { act: 'flag', from: message.folder, leaves: false, destroys: false }],
+                ]),
             },
         });
 
-        fireEvent.click(screen.getByRole('button', { name: 'Flag — this is already on its way to your mail server.' }));
+        expect(screen.queryByRole('button', { name: 'Flag' })).toBeNull();
+        fireEvent.click(screen.getByRole('button', { name: 'Unflag' }));
 
-        expect(performed).not.toHaveBeenCalled();
+        expect(performed).toHaveBeenCalledWith('unflag', [message]);
     });
 
     it('draws the three as what they are where the deployment refuses writing at all', () => {

--- a/frontend/src/Client.App/src/mailSpace/HeadActs.tsx
+++ b/frontend/src/Client.App/src/mailSpace/HeadActs.tsx
@@ -9,7 +9,7 @@ import { Control } from '../controls/Control';
 import type { ControlShape } from '../controls/controlShapes';
 import { PlannedControl } from '../controls/PlannedControl';
 import { useLocalization } from '../localization/useLocalization';
-import { refusalSaid, standsInTheWay } from '../mailboxActs/drawnActs';
+import { flagActFor, refusalSaid, standsInTheWay } from '../mailboxActs/drawnActs';
 import { useMailboxActs, type ActedMessage } from '../mailboxActs/useMailboxActs';
 
 // What stands at the end of the head of a message or a conversation, beside its subject: handing the thread to the
@@ -28,17 +28,13 @@ import { useMailboxActs, type ActedMessage } from '../mailboxActs/useMailboxActs
 // mailbox act, exactly as the toolbar's five are. Neither is a second implementation — a head that composed its own
 // reply or wrote its own flag is how two surfaces come to answer a message differently.
 //
-// **The flag is the one control in this client that goes both ways**, because this is the one surface that can: a head
-// is about exactly one message and already holds whether it is flagged, while a strip stands over whatever is picked
-// out and cannot say which direction a single control would take. `mailboxActs/drawnActs.ts` carries that difference.
+// **The flag goes both ways here and on every other surface**, under the one rule `mailboxActs/drawnActs.ts` states:
+// a message drawn flagged is offered the act that takes the flag off. A head is about exactly one message, which is
+// the simplest case of that rule rather than a case of its own — reading it here would be a second answer to which
+// direction one message's flag goes.
 //
 // The head's own words for forwarding and flagging differ from the toolbar's — *Przekaż* and *Oflaguj* against
 // *Prześlij dalej* and *Flaga* — which is why they are keys of their own rather than the toolbar's reused.
-
-/** The message a head's acts are about: where it is, so a mailbox act can name it, and which way its flag goes. */
-export interface HeadMessage extends ActedMessage {
-    readonly flagged: boolean;
-}
 
 export function HeadActs({
     compact,
@@ -53,7 +49,7 @@ export function HeadActs({
      * around it: the head says who wrote *that* message and when, so the three acts under it answer, forward, and flag
      * the same one. An act over a whole conversation is a screen of its own and is not what this draws.
      */
-    readonly message: HeadMessage | null;
+    readonly message: ActedMessage | null;
 }) {
     const { translate } = useLocalization();
     const acts = useMailboxActs();
@@ -74,9 +70,9 @@ export function HeadActs({
               }
             : null;
 
-    // Which way the flag goes, which is the message's own state rather than a control's: a flagged message is offered
-    // the act that takes the flag off, and every other message the act that puts one on.
-    const flagging = message?.flagged === true ? 'unflag' : 'flag';
+    // Which way the flag goes, read through the one rule every surface reads it through, so the head and the toolbar
+    // over the same message never offer opposite directions.
+    const flagging = flagActFor(acts, message === null ? [] : [message]);
     const flagLabel = translate(flagging === 'unflag' ? 'message.unflag' : 'message.flag');
 
     // Either the act or the sentence saying why it cannot be taken, decided here rather than inside the markup: a

--- a/frontend/src/Client.App/src/mailSpace/MailToolbar.test.tsx
+++ b/frontend/src/Client.App/src/mailSpace/MailToolbar.test.tsx
@@ -19,7 +19,7 @@ const declaredMatchMedia = Object.getOwnPropertyDescriptor(window, 'matchMedia')
 
 const messageId = '00000000-0000-4000-8000-000000000000';
 
-const place = { storedEmailId: messageId, account: 'work', folder: 'work-inbox', unread: false };
+const place = { storedEmailId: messageId, account: 'work', folder: 'work-inbox', unread: false, flagged: false };
 
 function Opens({ selection }: { readonly selection: string | null }) {
     const { revise } = useWorkspace();

--- a/frontend/src/Client.App/src/mailSpace/SelectionBar.test.tsx
+++ b/frontend/src/Client.App/src/mailSpace/SelectionBar.test.tsx
@@ -14,8 +14,8 @@ import { useWorkspace, type Workspace } from '../workspace/useWorkspace';
 import { SelectionBar } from './SelectionBar';
 
 const drawnRows: readonly ActedMessage[] = [
-    { storedEmailId: 'message-1', account: 'work', folder: 'work-inbox', unread: false },
-    { storedEmailId: 'message-2', account: 'work', folder: 'work-inbox', unread: false },
+    { storedEmailId: 'message-1', account: 'work', folder: 'work-inbox', unread: false, flagged: false },
+    { storedEmailId: 'message-2', account: 'work', folder: 'work-inbox', unread: false, flagged: false },
 ];
 
 const clients: MoveDestination = { alias: 'work-clients', name: 'Projects / Clients', role: null };

--- a/frontend/src/Client.App/src/mailboxActs/MailboxActControls.test.tsx
+++ b/frontend/src/Client.App/src/mailboxActs/MailboxActControls.test.tsx
@@ -9,8 +9,20 @@ import { MailboxActControls } from './MailboxActControls';
 import type { ActRefusal, MoveDestination, MoveDestinationGroup } from './mailboxDestinations';
 import { MailboxActsContext, nothingActed, type ActedMessage, type MailboxActs } from './useMailboxActs';
 
-const invoice: ActedMessage = { storedEmailId: 'message-1', account: 'work', folder: 'work-inbox', unread: false };
-const receipt: ActedMessage = { storedEmailId: 'message-2', account: 'work', folder: 'work-inbox', unread: false };
+const invoice: ActedMessage = {
+    storedEmailId: 'message-1',
+    account: 'work',
+    folder: 'work-inbox',
+    unread: false,
+    flagged: false,
+};
+const receipt: ActedMessage = {
+    storedEmailId: 'message-2',
+    account: 'work',
+    folder: 'work-inbox',
+    unread: false,
+    flagged: false,
+};
 
 const clients: MoveDestination = { alias: 'work-clients', name: 'Projects / Clients', role: null };
 const work: MoveDestinationGroup = {
@@ -82,6 +94,30 @@ describe('MailboxActControls', () => {
         expect(performed).toHaveBeenCalledWith('markRead', unread);
     });
 
+    // The same one control read the same way: the design draws the flag slot as a toggle on the toolbar and in a row's
+    // menu, so a strip standing over a flagged selection offers taking the flag off rather than putting a second one on.
+    it('offers to take the flag off where every message is flagged, and performs that rather than its opposite', () => {
+        const performed = vi.fn();
+        const flagged = [
+            { ...invoice, flagged: true },
+            { ...receipt, flagged: true },
+        ];
+
+        drawControls({ perform: performed }, flagged);
+
+        expect(screen.queryByRole('button', { name: 'Flag' })).toBeNull();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Unflag' }));
+
+        expect(performed).toHaveBeenCalledWith('unflag', flagged);
+    });
+
+    it('offers to put a flag on where the messages are a mixture, which is the one act all of them can take', () => {
+        drawControls({}, [invoice, { ...receipt, flagged: true }]);
+
+        expect(screen.getByRole('button', { name: 'Flag' })).toBeDefined();
+    });
+
     it('offers to mark read where the messages are a mixture, which is the one act all of them can take', () => {
         drawControls({}, [invoice, { ...receipt, unread: true }]);
 
@@ -143,7 +179,7 @@ describe('MailboxActControls', () => {
         const performed = vi.fn();
 
         drawControls({
-            asked: new Map([['message-1', { act: 'archive', from: invoice.folder, leaves: true }]]),
+            asked: new Map([['message-1', { act: 'archive', from: invoice.folder, leaves: true, destroys: false }]]),
             perform: performed,
         });
 
@@ -159,10 +195,14 @@ describe('MailboxActControls', () => {
     });
 
     it('goes on offering an act asked of only some of the messages, the rest of them not having it yet', () => {
-        drawControls({ asked: new Map([['message-1', { act: 'archive', from: invoice.folder, leaves: true }]]) }, [
-            invoice,
-            receipt,
-        ]);
+        drawControls(
+            {
+                asked: new Map([
+                    ['message-1', { act: 'archive', from: invoice.folder, leaves: true, destroys: false }],
+                ]),
+            },
+            [invoice, receipt],
+        );
 
         expect(screen.getByRole('button', { name: 'Archive' })).toBeDefined();
     });

--- a/frontend/src/Client.App/src/mailboxActs/MailboxActControls.tsx
+++ b/frontend/src/Client.App/src/mailboxActs/MailboxActControls.tsx
@@ -9,7 +9,7 @@ import { PlannedControl } from '../controls/PlannedControl';
 import { useLocalization } from '../localization/useLocalization';
 import { useReadMarking } from '../readMarking/useReadMarking';
 import { ActQuestions } from './ActQuestions';
-import { actsDrawn, actsOnAStrip, readActFor, refusalSaid, standsInTheWay } from './drawnActs';
+import { actsDrawn, actsOnAStrip, flagActFor, readActFor, refusalSaid, standsInTheWay } from './drawnActs';
 import { useMailboxActs, type ActedMessage, type MailboxAct } from './useMailboxActs';
 
 // The five things a person does to a mailbox, drawn once for the two strips that offer them: the toolbar, over the
@@ -51,10 +51,16 @@ export function MailboxActControls({
     return (
         <>
             {actsOnAStrip.map((slot) => {
-                // The read control is the one slot that goes both ways, and which way is the messages' own state
-                // rather than the strip's: everything under it drawn read is offered the act that marks them unread,
-                // and anything else the act that marks them read. Every other slot is the act it names.
-                const asked = slot === 'markUnread' ? readActFor(acts, marking, messages) : slot;
+                // Two slots go both ways, and which way is the messages' own state rather than the strip's:
+                // everything under the read control drawn read is offered the act that marks them unread, everything
+                // under the flag control drawn flagged is offered the act that takes the flag off, and anything else
+                // is offered the act each slot is named for. Every other slot is the act it names.
+                const asked =
+                    slot === 'markUnread'
+                        ? readActFor(acts, marking, messages)
+                        : slot === 'flag'
+                          ? flagActFor(acts, messages)
+                          : slot;
                 const { icon, label } = actsDrawn[asked];
 
                 // Either the deployment's refusal or the fact that this act is already on its way for every message

--- a/frontend/src/Client.App/src/mailboxActs/MailboxActs.test.tsx
+++ b/frontend/src/Client.App/src/mailboxActs/MailboxActs.test.tsx
@@ -33,9 +33,27 @@ import { useMailboxActs, type ActedMessage, type MailboxAct, type MailboxActs } 
 
 const session: ClientSession = { baseAddress: 'https://mail.example.invalid', authorization: 'Basic dGVzdA==' };
 
-const invoice: ActedMessage = { storedEmailId: 'message-1', account: 'work', folder: 'work-inbox', unread: false };
-const receipt: ActedMessage = { storedEmailId: 'message-2', account: 'work', folder: 'work-inbox', unread: false };
-const discarded: ActedMessage = { storedEmailId: 'message-3', account: 'work', folder: 'work-trash', unread: false };
+const invoice: ActedMessage = {
+    storedEmailId: 'message-1',
+    account: 'work',
+    folder: 'work-inbox',
+    unread: false,
+    flagged: false,
+};
+const receipt: ActedMessage = {
+    storedEmailId: 'message-2',
+    account: 'work',
+    folder: 'work-inbox',
+    unread: false,
+    flagged: false,
+};
+const discarded: ActedMessage = {
+    storedEmailId: 'message-3',
+    account: 'work',
+    folder: 'work-trash',
+    unread: false,
+    flagged: false,
+};
 
 const folders = JSON.stringify({
     synchronizationEnabled: true,
@@ -287,6 +305,7 @@ const heapedInTrash: ActedMessage[] = Array.from({ length: mostMessagesPerMutati
     account: 'work',
     folder: 'work-trash',
     unread: false,
+    flagged: false,
 }));
 
 /** The records each call to a delete's withdrawal or release route named, one list per call. */
@@ -453,7 +472,12 @@ describe('MailboxActsProvider', () => {
             body: { deletes: [{ storedEmailId: 'message-3' }] },
         });
         expect(screen.getByRole('button', { name: 'Undo' })).toBeDefined();
-        expect(held().asked.get('message-3')).toStrictEqual({ act: 'delete', from: 'work-trash', leaves: false });
+        expect(held().asked.get('message-3')).toStrictEqual({
+            act: 'delete',
+            from: 'work-trash',
+            leaves: false,
+            destroys: true,
+        });
     });
 
     // The delete waits for exactly as long as the toast stands, so taking it back is cancelling the records it wrote
@@ -755,6 +779,7 @@ describe('MailboxActsProvider', () => {
             account: 'work',
             folder: 'work-inbox',
             unread: false,
+            flagged: false,
         }));
 
         const deployment: Deployment = {
@@ -861,7 +886,12 @@ describe('MailboxActsProvider', () => {
         const filedInto = { moves: [{ storedEmailId: 'message-1', destinationFolder: 'work-archive' }] };
 
         expect(submitted(deployment).map(({ body }) => body)).toStrictEqual([filedInto, filedInto]);
-        expect(held().asked.get('message-1')).toStrictEqual({ act: 'move', from: 'work-inbox', leaves: true });
+        expect(held().asked.get('message-1')).toStrictEqual({
+            act: 'move',
+            from: 'work-inbox',
+            leaves: true,
+            destroys: false,
+        });
     });
 
     it('stops claiming an act the account stopped retrying once the person lets it go', async () => {

--- a/frontend/src/Client.App/src/mailboxActs/MailboxActs.tsx
+++ b/frontend/src/Client.App/src/mailboxActs/MailboxActs.tsx
@@ -268,12 +268,12 @@ export function MailboxActsProvider({
      * The folder each message was in is written down with it, because an act is about a message *in a place*: it is
      * what the sentence a row wears is drawn against, and what says the row is to leave this list and no other.
      */
-    function remember(act: MailboxAct, messages: readonly ActedMessage[], leaves: boolean): void {
+    function remember(act: MailboxAct, messages: readonly ActedMessage[], leaves: boolean, destroys: boolean): void {
         setKept((current) => {
             const asked = new Map(current.session === session ? current.asked : []);
 
             for (const message of messages) {
-                asked.set(message.storedEmailId, { act, from: message.folder, leaves });
+                asked.set(message.storedEmailId, { act, from: message.folder, leaves, destroys });
             }
 
             return { session, directory: current.session === session ? current.directory : null, asked };
@@ -563,7 +563,7 @@ export function MailboxActsProvider({
             return;
         }
 
-        remember('delete', messages, true);
+        remember('delete', messages, true, true);
 
         for (const batch of batchesOf(records)) {
             // Nothing is reported and nothing is waited for: what this asks for is what would have happened anyway
@@ -656,7 +656,7 @@ export function MailboxActsProvider({
 
         const asking = session;
 
-        remember(act, messages, leaves);
+        remember(act, messages, leaves, destroying);
 
         void submitted(asking, act, messages, destination, destroying).then((answered) => {
             // An answer arriving after somebody else has signed in is neither theirs to be told about nor their queue's

--- a/frontend/src/Client.App/src/mailboxActs/drawnActs.test.ts
+++ b/frontend/src/Client.App/src/mailboxActs/drawnActs.test.ts
@@ -4,13 +4,13 @@
 
 import { describe, expect, it } from 'vitest';
 import { nothingMarkedRead, type MarkedIn, type ReadMarking } from '../readMarking/useReadMarking';
-import { readActFor } from './drawnActs';
+import { flagActFor, readActFor } from './drawnActs';
 import { nothingActed, type ActedMessage, type AskedAct, type MailboxActs } from './useMailboxActs';
 
 const inbox = { account: 'work', folder: 'work-inbox' };
 
-function message(storedEmailId: string, unread: boolean): ActedMessage {
-    return { storedEmailId, ...inbox, unread };
+function message(storedEmailId: string, unread: boolean, flagged = false): ActedMessage {
+    return { storedEmailId, ...inbox, unread, flagged };
 }
 
 /** What a client that has marked exactly these messages read carries. */
@@ -24,9 +24,50 @@ function marked(...storedEmailIds: readonly string[]): ReadMarking {
 function asking(...asked: readonly (readonly [string, AskedAct['act']])[]): MailboxActs {
     return {
         ...nothingActed,
-        asked: new Map(asked.map(([id, act]) => [id, { act, from: inbox.folder, leaves: false }])),
+        asked: new Map(asked.map(([id, act]) => [id, { act, from: inbox.folder, leaves: false, destroys: false }])),
     };
 }
+
+describe('flagActFor', () => {
+    it('offers to take the flag off where every message is flagged, which is the one state that turns it round', () => {
+        const flagged = [message('message-1', false, true), message('message-2', false, true)];
+
+        expect(flagActFor(nothingActed, flagged)).toBe('unflag');
+    });
+
+    it('offers to put a flag on where no message carries one', () => {
+        const plain = [message('message-1', false), message('message-2', false)];
+
+        expect(flagActFor(nothingActed, plain)).toBe('flag');
+    });
+
+    it('offers to put a flag on where the messages are a mixture of the two, which is the default', () => {
+        const mixed = [message('message-1', false, true), message('message-2', false)];
+
+        expect(flagActFor(nothingActed, mixed)).toBe('flag');
+    });
+
+    it('reads one message the same way it reads several, which is what the head of a message reads', () => {
+        expect(flagActFor(nothingActed, [message('message-1', false, true)])).toBe('unflag');
+        expect(flagActFor(nothingActed, [message('message-1', false)])).toBe('flag');
+    });
+
+    // Which is what makes pressing the control twice give a reader both directions rather than the same one twice: a
+    // mailbox mutation converges minutes after it is written down, so the deployment goes on reporting the old state.
+    it('reads a message asked to be flagged as flagged, so the next press offers to take it off', () => {
+        expect(flagActFor(asking(['message-1', 'flag']), [message('message-1', false)])).toBe('unflag');
+    });
+
+    it('reads a message asked to be unflagged as unflagged, which is the same rule in the other direction', () => {
+        expect(flagActFor(asking(['message-1', 'unflag']), [message('message-1', false, true)])).toBe('flag');
+    });
+
+    // A control over nothing is refused before it can be pressed, so what this decides is only the name it wears while
+    // it says so — and a strip whose wording changed as a selection was cleared would be reading as a second act.
+    it('offers to put a flag on where nothing is picked out, rather than reading an empty list as all flagged', () => {
+        expect(flagActFor(nothingActed, [])).toBe('flag');
+    });
+});
 
 describe('readActFor', () => {
     it('offers to mark unread where every message is read, which is the one state that turns it round', () => {

--- a/frontend/src/Client.App/src/mailboxActs/drawnActs.ts
+++ b/frontend/src/Client.App/src/mailboxActs/drawnActs.ts
@@ -42,15 +42,11 @@ export const actsSaidInAMenu: Readonly<Record<MailboxAct, MessageKey>> = {
     move: 'menu.move',
 };
 
-// Taking a flag off is in neither order below, and that is the difference between a strip and a head rather than an
-// omission. A strip and a row's menu stand over whatever is picked out — one message or two hundred, flagged and
-// unflagged among them — so which direction a single control would go in is a question they cannot answer; the head of
-// the message being read is about exactly one message whose flag the screen is already holding, which is why the design
-// draws the toggle there and *Flaga* here.
-//
-// **Marking read is the one slot in an order below that goes both ways**, which is not the same case: a rule decides it
-// rather than a single message, so a strip can answer it over any number of them. `readActFor` is that rule, and the
-// two orders name the slot by the act it reads as most of the time.
+// **Two slots in the orders below go both ways, and a rule decides each of them rather than a single message.** The
+// design draws both as toggles — a row's context menu says *Remove flag* over a flagged message and the toolbar says
+// the same — so a strip standing over two hundred messages answers the direction the way it answers the read one: from
+// what the messages under it are drawn as, which it holds for every one of them. `readActFor` and `flagActFor` are
+// those two rules, and the orders name each slot by the act it reads as most of the time.
 
 /** The order a strip of controls draws them in: the toolbar, and the bar that stands over a selection. */
 export const actsOnAStrip: readonly MailboxAct[] = ['archive', 'delete', 'flag', 'markUnread', 'move'];
@@ -90,6 +86,39 @@ export function readActFor(acts: MailboxActs, marking: ReadMarking, messages: re
     }
 
     return messages.every((message) => !unreadNow(message)) ? 'markUnread' : 'markRead';
+}
+
+/**
+ * Which way the flag control goes for these messages, which is the act the `flag` slot above actually offers.
+ *
+ * **Putting a flag on is the default, and one shared state turns it round**, exactly as the read control's rule
+ * reads: every message drawn flagged is offered the act that takes the flag off, and anything else — none of them
+ * flagged, or a mixture — is offered the act that puts one on. Read against what the reader is looking at rather than
+ * against what the deployment last answered, because a mailbox mutation converges minutes after it is written down
+ * and a control offering to flag a row already drawn flagged would be offering to do what has been done.
+ *
+ * A pending act of its own wins over the observation, which is what makes pressing the control twice give a reader
+ * the two directions rather than the same one.
+ *
+ * An empty list is offered the act that puts a flag on, for the reason an empty list is offered `markUnread`: it is
+ * refused before it can be pressed, so what this decides there is only the name the control wears while it says so.
+ */
+export function flagActFor(acts: MailboxActs, messages: readonly ActedMessage[]): FlagAct {
+    function flaggedNow(message: ActedMessage): boolean {
+        const asked = acts.asked.get(message.storedEmailId);
+
+        if (asked?.act === 'flag') {
+            return true;
+        }
+
+        if (asked?.act === 'unflag') {
+            return false;
+        }
+
+        return message.flagged;
+    }
+
+    return messages.length > 0 && messages.every(flaggedNow) ? 'unflag' : 'flag';
 }
 
 /** Why a control cannot act, exhaustive by its own type so a reason added later has to be given words. */

--- a/frontend/src/Client.App/src/mailboxActs/mailboxDestinations.test.ts
+++ b/frontend/src/Client.App/src/mailboxActs/mailboxDestinations.test.ts
@@ -49,13 +49,19 @@ const wholeMailbox = directoryOf({
 });
 
 function inWork(storedEmailId: string): ActedMessage {
-    return { storedEmailId, account: 'work', folder: 'work-inbox', unread: false };
+    return { storedEmailId, account: 'work', folder: 'work-inbox', unread: false, flagged: false };
 }
 
-const atHome: ActedMessage = { storedEmailId: 'message-9', account: 'home', folder: 'home-inbox', unread: false };
+const atHome: ActedMessage = {
+    storedEmailId: 'message-9',
+    account: 'home',
+    folder: 'home-inbox',
+    unread: false,
+    flagged: false,
+};
 
 function inWorkTrash(storedEmailId: string): ActedMessage {
-    return { storedEmailId, account: 'work', folder: 'work-trash', unread: false };
+    return { storedEmailId, account: 'work', folder: 'work-trash', unread: false, flagged: false };
 }
 
 describe('folderWithRole', () => {
@@ -158,6 +164,7 @@ describe('refusalFor', () => {
             account: 'work',
             folder: 'work-clients',
             unread: false,
+            flagged: false,
         };
 
         expect(refusalFor('move', [inWork('message-1'), filed], twoFolders, everythingOffered)).toBeNull();
@@ -216,6 +223,7 @@ describe('deletesPermanently', () => {
             account: 'home',
             folder: 'work-trash',
             unread: false,
+            flagged: false,
         };
 
         expect(deletesPermanently(wholeMailbox, [elsewhere])).toBe(false);

--- a/frontend/src/Client.App/src/mailboxActs/useMailboxActs.test.ts
+++ b/frontend/src/Client.App/src/mailboxActs/useMailboxActs.test.ts
@@ -41,8 +41,9 @@ function asking(
     storedEmailId = email.id,
     from = email.folder,
     leaves = act === 'archive' || act === 'move' || act === 'delete',
+    destroys = act === 'delete' && !leaves,
 ): MailboxActs {
-    return { ...nothingActed, asked: new Map([[storedEmailId, { act, from, leaves }]]) };
+    return { ...nothingActed, asked: new Map([[storedEmailId, { act, from, leaves, destroys }]]) };
 }
 
 // What retires a pending act, which is the whole of why this client polls nothing: an act writes a record and the

--- a/frontend/src/Client.App/src/mailboxActs/useMailboxActs.ts
+++ b/frontend/src/Client.App/src/mailboxActs/useMailboxActs.ts
@@ -60,6 +60,16 @@ export interface ActedMessage {
      * since, which is the one place that correction belongs.
      */
     readonly unread: boolean;
+
+    /**
+     * Whether the deployment last reported the message flagged.
+     *
+     * Carried beside the reading above and for the same reason: the flag control's direction is the message's own
+     * state rather than a control's, so a strip standing over a selection can answer it over any number of messages
+     * from what is written down here. `drawnActs.ts` reads it against what this client has asked since, which is the
+     * one place that correction belongs.
+     */
+    readonly flagged: boolean;
 }
 
 /**
@@ -81,6 +91,16 @@ export interface AskedAct {
 
     /** Whether the act takes the message out of that folder rather than leaving it there. */
     readonly leaves: boolean;
+
+    /**
+     * Whether this delete destroys the message rather than filing it in the trash, and `false` for every other act.
+     *
+     * Carried rather than read back off `leaves`, because the two stop agreeing at the moment the way back closes: a
+     * permanent delete is asked for with nothing leaving — the row stays and says what is about to happen to it — and
+     * the released delete then takes the row out of the list, which flips `leaves` and would leave the sentence the
+     * row wears reading *moving to the trash* about a message being destroyed.
+     */
+    readonly destroys: boolean;
 }
 
 export interface MailboxActs {
@@ -181,6 +201,7 @@ export function opensAsDraft(acts: MailboxActs, email: MailTimelineEntry): boole
             account: email.account,
             folder: email.folder,
             unread: email.unread,
+            flagged: email.flagged,
         }) === 'Drafts'
     );
 }

--- a/frontend/src/Client.App/src/messageList/ListedMail.test.tsx
+++ b/frontend/src/Client.App/src/messageList/ListedMail.test.tsx
@@ -13,8 +13,15 @@ function drawn(at: number): {
     readonly account: string;
     readonly folder: string;
     readonly unread: boolean;
+    readonly flagged: boolean;
 } {
-    return { id: `message-${String(at)}`, account: 'work', folder: 'work-inbox', unread: at % 2 === 0 };
+    return {
+        id: `message-${String(at)}`,
+        account: 'work',
+        folder: 'work-inbox',
+        unread: at % 2 === 0,
+        flagged: at % 3 === 0,
+    };
 }
 
 function held(): ListedMail {
@@ -36,6 +43,7 @@ describe('ListedMailProvider', () => {
             account: 'work',
             folder: 'work-inbox',
             unread: false,
+            flagged: false,
         });
     });
 

--- a/frontend/src/Client.App/src/messageList/ListedMail.tsx
+++ b/frontend/src/Client.App/src/messageList/ListedMail.tsx
@@ -25,6 +25,7 @@ export function ListedMailProvider({ children }: { readonly children: ReactNode 
                     account: email.account,
                     folder: email.folder,
                     unread: email.unread,
+                    flagged: email.flagged,
                 });
             }
 

--- a/frontend/src/Client.App/src/messageList/MessageList.test.tsx
+++ b/frontend/src/Client.App/src/messageList/MessageList.test.tsx
@@ -278,7 +278,7 @@ describe('MessageList', () => {
         const transport = answering(wholeFolder);
         const leaving: MailboxActs = {
             ...nothingActed,
-            asked: new Map([['message-2', { act: 'archive', from: 'INBOX', leaves: true }]]),
+            asked: new Map([['message-2', { act: 'archive', from: 'INBOX', leaves: true, destroys: false }]]),
         };
         const drawn = renderList(transport, { acts: leaving });
 
@@ -287,7 +287,7 @@ describe('MessageList', () => {
         const going = going2();
 
         expect(going).not.toBeNull();
-        expect([...(going?.classList ?? [])]).toContain('animate-row-filed');
+        expect([...(going?.classList ?? [])]).toContain('animate-row-going');
 
         act(() => {
             animationEnded(going as Element);
@@ -309,7 +309,7 @@ describe('MessageList', () => {
     it('takes a whole selection out at the press rather than holding rows no reader could watch go', async () => {
         const filed = Array.from({ length: 30 }, (_, at): [string, AskedAct] => [
             `message-${String(at)}`,
-            { act: 'archive', from: 'INBOX', leaves: true },
+            { act: 'archive', from: 'INBOX', leaves: true, destroys: false },
         ]);
 
         renderList(answering(wholeFolder), { acts: { ...nothingActed, asked: new Map(filed) } });
@@ -476,8 +476,8 @@ describe('MessageList', () => {
             acts: {
                 ...nothingActed,
                 asked: new Map([
-                    ['message-0', { act: 'archive', from: 'INBOX', leaves: true }],
-                    ['message-1', { act: 'archive', from: 'INBOX', leaves: true }],
+                    ['message-0', { act: 'archive', from: 'INBOX', leaves: true, destroys: false }],
+                    ['message-1', { act: 'archive', from: 'INBOX', leaves: true, destroys: false }],
                 ]),
             },
         });
@@ -1304,7 +1304,13 @@ describe('MessageList, under a finger carried across a row', () => {
     // The places the list has drawn, which is what every act names and which a list under no provider holds none of.
     const listed = {
         ...nothingListed,
-        placeOf: (id: string) => ({ storedEmailId: id, account: 'work', folder: 'INBOX', unread: false }),
+        placeOf: (id: string) => ({
+            storedEmailId: id,
+            account: 'work',
+            folder: 'INBOX',
+            unread: false,
+            flagged: false,
+        }),
     };
 
     function listWithPlaces(drawn: Partial<Drawn> = {}): RenderResult {
@@ -1330,7 +1336,7 @@ describe('MessageList, under a finger carried across a row', () => {
         carry(row(0), swipeDistance);
 
         expect(performed).toHaveBeenCalledWith('archive', [
-            { storedEmailId: 'message-0', account: 'work', folder: 'INBOX', unread: false },
+            { storedEmailId: 'message-0', account: 'work', folder: 'INBOX', unread: false, flagged: false },
         ]);
     });
 

--- a/frontend/src/Client.App/src/messageList/useListedMail.test.ts
+++ b/frontend/src/Client.App/src/messageList/useListedMail.test.ts
@@ -7,8 +7,8 @@ import type { ActedMessage } from '../mailboxActs/useMailboxActs';
 import { actedMessages, nothingListed, type ListedMail } from './useListedMail';
 
 const drawn: readonly ActedMessage[] = [
-    { storedEmailId: 'message-1', account: 'work', folder: 'work-inbox', unread: false },
-    { storedEmailId: 'message-2', account: 'home', folder: 'home-inbox', unread: true },
+    { storedEmailId: 'message-1', account: 'work', folder: 'work-inbox', unread: false, flagged: false },
+    { storedEmailId: 'message-2', account: 'home', folder: 'home-inbox', unread: true, flagged: false },
 ];
 
 const listing: ListedMail = {

--- a/frontend/src/Client.App/src/messageList/useListedMail.ts
+++ b/frontend/src/Client.App/src/messageList/useListedMail.ts
@@ -46,6 +46,7 @@ export interface ListedMail {
             readonly account: string;
             readonly folder: string;
             readonly unread: boolean;
+            readonly flagged: boolean;
         }[],
     ) => void;
 

--- a/frontend/src/Client.App/src/messageRows/MessageRow.test.tsx
+++ b/frontend/src/Client.App/src/messageRows/MessageRow.test.tsx
@@ -69,6 +69,19 @@ function drawMoved(moved: {
     return screen.getByRole('option');
 }
 
+// What the row carries, which is the element holding the row's own background — and therefore the one the going
+// animation is played on, since an inset shadow on the row around it would be painted underneath that background and
+// never appear. `styles.css` holds the whole of that reasoning.
+function carriedBy(row: HTMLElement): HTMLElement {
+    const carried = row.querySelector('div');
+
+    if (carried === null) {
+        throw new Error('The row drew nothing to carry.');
+    }
+
+    return carried;
+}
+
 function drawRow(
     note?: string,
     unread = false,
@@ -177,8 +190,9 @@ function asking(
     storedEmailId = email.id,
     from = email.folder,
     leaves = act === 'archive' || act === 'move' || act === 'delete',
+    destroys = act === 'delete' && !leaves,
 ): MailboxActs {
-    return { ...nothingActed, asked: new Map([[storedEmailId, { act, from, leaves }]]) };
+    return { ...nothingActed, asked: new Map([[storedEmailId, { act, from, leaves, destroys }]]) };
 }
 
 /** What a client that has marked exactly this message read carries, which is what a row reads its state through. */
@@ -614,13 +628,26 @@ describe('MessageRow, a row that moved', () => {
         { named: 'filed', asked: 'move', drawn: 'animate-row-filed' },
         { named: 'deleted', asked: 'delete', drawn: 'animate-row-deleted' },
     ])('goes out in the colour of the act where the message is being $named', ({ asked, drawn }) => {
-        expect(drawMoved({ acts: asking(asked) }).className).toContain(drawn);
+        expect(carriedBy(drawMoved({ acts: asking(asked) })).className).toContain(drawn);
+    });
+
+    // The wash is an inset shadow and the carried element is what holds the row's own background, so a wash put on the
+    // row around it plays underneath that background and a reader sees a row travelling and fading without ever
+    // changing colour — which is what the demo showed. The leaving stays on the row, because that is where the row
+    // reports having gone from.
+    it('plays the wash on what carries the row and the leaving on the row, so both are drawn', () => {
+        const row = drawMoved({ acts: asking('archive') });
+
+        expect(row.className).toContain('animate-row-going');
+        expect(row.className).toContain('pointer-events-none');
+        expect(row.className).not.toContain('animate-row-filed');
+        expect(carriedBy(row).className).toContain('animate-row-filed');
     });
 
     it('goes out rather than landing where a row that had just arrived was acted on, having left either way', () => {
         const row = drawMoved({ arrived: true, acts: asking('archive') });
 
-        expect(row.className).toContain('animate-row-filed');
+        expect(carriedBy(row).className).toContain('animate-row-filed');
         expect(row.className).not.toContain('animate-row-landing');
     });
 
@@ -629,12 +656,12 @@ describe('MessageRow, a row that moved', () => {
     it('stays where it is for a delete that destroys the mail rather than filing it in the trash', () => {
         const row = drawMoved({ acts: asking('delete', email.id, email.folder, false) });
 
-        expect(row.className).not.toContain('animate-row-deleted');
-        expect(row.className).not.toContain('animate-row-filed');
+        expect(carriedBy(row).className).not.toContain('animate-row-deleted');
+        expect(carriedBy(row).className).not.toContain('animate-row-filed');
     });
 
     it('draws neither for a flag act, which takes the row nowhere', () => {
-        expect(drawMoved({ acts: asking('flag') }).className).not.toContain('animate-row-filed');
+        expect(carriedBy(drawMoved({ acts: asking('flag') })).className).not.toContain('animate-row-filed');
     });
 
     it('says it has gone rather than settled once the animation it went out on has run', () => {

--- a/frontend/src/Client.App/src/messageRows/MessageRow.tsx
+++ b/frontend/src/Client.App/src/messageRows/MessageRow.tsx
@@ -66,12 +66,17 @@ const actPendingSaid: Readonly<Record<FilingAct, MessageKey>> = {
 // already in the trash it destroys the mail, so the row stays where it is for the seconds in which the deployment is
 // still holding the change back — and it says *that*, because a row reading `Moving to the trash…` in the trash would
 // be describing an act that is not the one about to happen.
+//
+// It reads what the act destroys rather than whether the row is leaving, because the two stop agreeing at the exact
+// moment somebody is watching: the way back closes, the released delete takes the row out of the list, and a sentence
+// read off the leaving would turn into `Moving to the trash…` over a message being destroyed — on the last frames
+// anybody sees of it.
 function actPendingWording(asked: AskedAct): MessageKey | null {
     if (changesAFlag(asked.act)) {
         return null;
     }
 
-    return asked.act === 'delete' && !asked.leaves ? 'act.deletingPermanently' : actPendingSaid[asked.act];
+    return asked.destroys ? 'act.deletingPermanently' : actPendingSaid[asked.act];
 }
 
 // What each direction of a swipe shows behind the row it is carrying, which is the design project's own: the act the
@@ -226,13 +231,18 @@ export function MessageRow({
     // takes the message out of the folder it is drawn in goes out at all, and the act is what names the colour: the
     // design draws red for a deletion and orange for filing a message somewhere else, archive and move alike. A row
     // that goes because the folder was read again is not held while it goes and plays neither.
-    // Nothing lands on it while it goes, which is the design project's own: a row already out of the folder is not a
-    // row to open, and the half-second it is still drawn for is exactly long enough to be clicked on by accident.
-    const going = !acting?.leaves
-        ? null
-        : acting.act === 'delete'
-          ? 'pointer-events-none animate-row-deleted'
-          : 'pointer-events-none animate-row-filed';
+    //
+    // **The colour is drawn on what the row carries and the leaving on the row**, which is two animations on two
+    // elements and is forced rather than chosen: the wash is an inset shadow, and one inset into the row is painted
+    // underneath the opaque element the row carries, so it is invisible for the whole animation and what a reader
+    // sees is a row travelling and fading without ever changing colour. The leaving stays on the row because that is
+    // where it is reported from — `onAnimationEnd` below reads the row's own animation and nothing inside it.
+    //
+    // Nothing lands on the row while it goes, which is the design project's own: a row already out of the folder is
+    // not a row to open, and the half-second it is still drawn for is exactly long enough to be clicked on by
+    // accident.
+    const wash = !acting?.leaves ? null : acting.act === 'delete' ? 'animate-row-deleted' : 'animate-row-filed';
+    const going = wash === null ? null : 'pointer-events-none animate-row-going';
 
     // What the reserved line holds: what the act says about itself where it says anything, else whatever the screen
     // would otherwise put there. Worked out here rather than in the markup, because the line is also hidden from the
@@ -353,8 +363,8 @@ export function MessageRow({
                 // a ring around them, which is the design project's mark and keeps the row's own lines where they
                 // were.
                 className={`flex h-full cursor-pointer flex-col justify-center gap-0.75 overflow-hidden border-s-4 ps-2.5 pe-3.5 ${
-                    swipe.carried === 0 ? 'transition' : ''
-                } ${
+                    wash ?? ''
+                } ${swipe.carried === 0 ? 'transition' : ''} ${
                     selected
                         ? 'border-s-accent bg-accent-soft'
                         : open

--- a/frontend/src/Client.App/src/messageRows/MessageRowMenu.test.tsx
+++ b/frontend/src/Client.App/src/messageRows/MessageRowMenu.test.tsx
@@ -38,7 +38,7 @@ const email = {
 } as unknown as MailTimelineEntry;
 
 const messages: readonly ActedMessage[] = [
-    { storedEmailId: email.id, account: 'work', folder: 'INBOX', unread: false },
+    { storedEmailId: email.id, account: 'work', folder: 'INBOX', unread: false, flagged: false },
 ];
 
 function actsWhere(refusalOf: (act: MailboxAct) => ActRefusal | null, perform = vi.fn()): MailboxActs {
@@ -101,10 +101,23 @@ describe('MessageRowMenu', () => {
         ]);
     });
 
+    // The design draws the row's context menu with *Remove the flag* over a flagged message, so the menu reads the flag
+    // the way it reads the read mark: the opposite of the state the row is in.
+    it('offers to take the flag off a flagged row, which is the other direction of the one act', () => {
+        menuUnder({
+            about: [{ storedEmailId: email.id, account: 'work', folder: 'INBOX', unread: false, flagged: true }],
+        });
+
+        expect(drawn()).toContain('Remove the flag');
+        expect(drawn()).not.toContain('Flag');
+    });
+
     // The same one control read the same way the strip reads it: the menu offers the opposite of the state the row is
     // in, so what it says is decided by the row rather than fixed in the list of acts.
     it('offers to mark an unread row read, which is the other direction of the one act', () => {
-        menuUnder({ about: [{ storedEmailId: email.id, account: 'work', folder: 'INBOX', unread: true }] });
+        menuUnder({
+            about: [{ storedEmailId: email.id, account: 'work', folder: 'INBOX', unread: true, flagged: false }],
+        });
 
         expect(drawn()).toContain('Mark as read');
         expect(drawn()).not.toContain('Mark as unread');

--- a/frontend/src/Client.App/src/messageRows/MessageRowMenu.tsx
+++ b/frontend/src/Client.App/src/messageRows/MessageRowMenu.tsx
@@ -6,7 +6,7 @@ import type { MailTimelineEntry } from '@mailfathom/client-backend';
 import { useComposing, type Composing } from '../composer/useComposing';
 import { ContextMenu, type ContextMenuItem } from '../contextMenu/ContextMenu';
 import type { MenuPoint } from '../contextMenu/menuPlacement';
-import { actsDrawn, actsInARowMenu, actsSaidInAMenu, readActFor, underway } from '../mailboxActs/drawnActs';
+import { actsDrawn, actsInARowMenu, actsSaidInAMenu, flagActFor, readActFor, underway } from '../mailboxActs/drawnActs';
 import { useMailboxActs, type ActedMessage, type MailboxActs } from '../mailboxActs/useMailboxActs';
 import type { Translate } from '../localization/useLocalization';
 import { useLocalization } from '../localization/useLocalization';
@@ -133,10 +133,16 @@ function rowItems({
         : [];
 
     const mailbox = actsInARowMenu
-        // The read item is the one slot that goes both ways, and which way is the message's own state rather than the
-        // menu's — `mailboxActs/drawnActs.ts` holds the rule, and it is the same rule a strip reads, so a row's menu
-        // and the toolbar over it never offer opposite directions for one message.
-        .map((slot) => (slot === 'markUnread' ? readActFor(acts, marking, messages) : slot))
+        // The read item and the flag item are the two slots that go both ways, and which way is the message's own
+        // state rather than the menu's — `mailboxActs/drawnActs.ts` holds both rules, and they are the rules a strip
+        // reads, so a row's menu and the toolbar over it never offer opposite directions for one message.
+        .map((slot) =>
+            slot === 'markUnread'
+                ? readActFor(acts, marking, messages)
+                : slot === 'flag'
+                  ? flagActFor(acts, messages)
+                  : slot,
+        )
         .filter((act) => acts.refusalOf(act, messages) === null && !underway(acts, act, messages))
         .map((act) => ({
             icon: actsDrawn[act].icon,

--- a/frontend/src/Client.App/src/readingPane/AttachmentView.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/AttachmentView.test.tsx
@@ -412,8 +412,22 @@ describe('AttachmentView documents', () => {
         const drawn = await screen.findByTitle('contract.pdf');
 
         expect(drawn.getAttribute('src')).toBe('blob:https://mail.example.invalid/one');
-        expect(drawn.getAttribute('sandbox')).toBe('');
         expect(held.asked[0]?.shown).toEqual({ as: 'document' });
+    });
+
+    // A sandbox with nothing granted puts the frame in an origin that fails every same-origin check, and the address
+    // it is given is an object URL this document minted — so the engine refuses to resolve it and a reader is shown a
+    // blocked frame instead of their file. The attribute bought nothing here either: the blob is minted as a PDF by
+    // the client rather than by the sender, so the engine can only ever draw it with the viewer it carries.
+    it('grants the document frame an origin, so the address the client minted resolves', async () => {
+        theEngineDrawsDocuments(true);
+
+        const held = reading({ outcome: 'shown', content: 'blob:https://mail.example.invalid/one' });
+        drawing(contract, held.exchange);
+
+        const drawn = await screen.findByTitle('contract.pdf');
+
+        expect(drawn.hasAttribute('sandbox')).toBe(false);
     });
 
     // The octets behind an object address stay alive for as long as anything holds the address, so a surface that

--- a/frontend/src/Client.App/src/readingPane/AttachmentView.tsx
+++ b/frontend/src/Client.App/src/readingPane/AttachmentView.tsx
@@ -34,9 +34,10 @@ import { shownAttachment, type NotShown } from './shownAttachment';
 //
 // Nothing a file carries reaches a host other than the deployment. The octets arrive over the client surface under the
 // credential the reader signed in with, and what is drawn from them is a picture in an `img`, words React escaped, or a
-// document in a sandboxed frame over an object URL. None of the three resolves a reference the sender wrote out of the
-// page this client runs in: the first two cannot, and the third holds an opaque origin with no flag granted, so a file
-// whose content names an address reaches neither that address nor anything of the client.
+// document in a frame over an object URL the client minted as a PDF. None of the three resolves a reference the sender
+// wrote out of the page this client runs in: the first two cannot, and the third is drawn by the engine's own viewer,
+// which resolves nothing of this document's and reaches no part of it. The frame that draws it carries no `sandbox`,
+// and the note beside that element says why the attribute both bought nothing here and stopped the file loading.
 
 // What a refusal is worded as: one sentence each, saying what could not be done and what to do about it, exactly as the
 // download beside it does — a reader who pressed *open* is owed as much as one who pressed *download*.
@@ -305,10 +306,19 @@ function Inside({
     }
 
     if (reading.drawnAs.as === 'document') {
-        // `sandbox` with nothing granted, which is what the frame is for: the viewer that draws the document is the
-        // engine's own and needs none of the flags, so a file that turned out to carry script, a form, or a navigation
-        // gets no way to run one. It is not the anti-tracking mechanism — the octets are already in hand and came from
-        // the deployment — and ADR 0024's reading holds here too: a sandbox answers *executes* and never *fetches*.
+        // **No `sandbox`, and the absence is what makes the frame draw anything at all.** A sandbox with nothing
+        // granted puts the frame in an origin that fails every same-origin check, and the address here is an object
+        // URL this document minted — so the engine refuses to resolve it and the reader is shown a blocked frame
+        // rather than their file. Granting the origin back to repair that would leave the attribute stating a
+        // restriction it no longer applies.
+        //
+        // What the attribute was guarding against cannot arise here, which is why dropping it costs nothing. A frame
+        // renders by what the resource says it is, and what this resource says is the client's own constant:
+        // `deployment/attachmentExchange.ts` mints the blob as `application/pdf` rather than as whatever the sender
+        // declared, and `shownAttachment.ts` reaches that branch for that one media type. So the engine draws it with
+        // the viewer it carries and can never read it as a document of markup — the same property ADR 0024 rests the
+        // picture on, where an `img` draws octets and does nothing else with them. A PDF's own script runs inside that
+        // viewer, which resolves no reference of this document's and reaches no part of it.
         //
         // The height is the pane's rather than the document's, because a frame cannot be measured from outside it
         // without granting a script, and a document is what somebody opened this surface to read: it scrolls inside
@@ -317,7 +327,6 @@ function Inside({
             <iframe
                 src={answer.content}
                 title={named}
-                sandbox=""
                 className="h-full min-h-0 w-full flex-1 rounded-md border-none bg-panel"
             />
         );

--- a/frontend/src/Client.App/src/readingPane/MessageHeaders.test.tsx
+++ b/frontend/src/Client.App/src/readingPane/MessageHeaders.test.tsx
@@ -7,10 +7,11 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import type { MailMessageHeaders } from '@mailfathom/client-backend';
 import { LocalizationProvider } from '../localization/Localization';
-import type { HeadMessage } from '../mailSpace/HeadActs';
+
 import { WorkspaceProvider } from '../workspace/Workspace';
 import { useWorkspace } from '../workspace/useWorkspace';
 import { MessageHeaders } from './MessageHeaders';
+import type { ActedMessage } from '../mailboxActs/useMailboxActs';
 
 const headers: MailMessageHeaders = {
     subject: 'Quarterly invoice',
@@ -28,7 +29,7 @@ const headers: MailMessageHeaders = {
 
 // The message the head's acts are about, which this file states only so the head can be drawn: what those acts do is
 // `mailSpace/HeadActs.test.tsx`'s.
-const message: HeadMessage = {
+const message: ActedMessage = {
     storedEmailId: 'a1',
     account: 'reader@example.invalid',
     folder: 'INBOX',

--- a/frontend/src/Client.App/src/readingPane/MessageHeaders.tsx
+++ b/frontend/src/Client.App/src/readingPane/MessageHeaders.tsx
@@ -9,7 +9,8 @@ import type { MessageKey } from '../localization/en';
 import { wordInstant } from '../localization/instants';
 import { useLocalization } from '../localization/useLocalization';
 import { BackToList } from '../mailSpace/BackToList';
-import { HeadActs, type HeadMessage } from '../mailSpace/HeadActs';
+import { HeadActs } from '../mailSpace/HeadActs';
+import type { ActedMessage } from '../mailboxActs/useMailboxActs';
 import { useTwoPanes } from '../shell/useWideWorkspace';
 import { useWorkspace } from '../workspace/useWorkspace';
 
@@ -71,7 +72,7 @@ export function MessageHeaders({
     readonly headers: MailMessageHeaders;
 
     /** The message the head's acts are about, which is the one being read. */
-    readonly message: HeadMessage;
+    readonly message: ActedMessage;
 
     /**
      * What the head is called where that is not this message's own subject — a conversation says its own subject once,

--- a/frontend/src/Client.App/src/styles.css
+++ b/frontend/src/Client.App/src/styles.css
@@ -453,13 +453,35 @@
 
        The wash arrives quickly and holds, because the row is gone before it could settle back — a row that faded out
        of a wash still half drawn would be saying the act was half performed. The shadows are inset for the reason
-       `row-changed`'s are: the row keeps its own place in the column while it goes. */
+       `row-changed`'s are: the row keeps its own place in the column while it goes.
+
+       **The wash and the going are two animations on two elements, which is the design's own arrangement and is
+       forced here rather than chosen.** An inset shadow is painted between an element's background and its content,
+       so one inset into the row sits underneath the opaque element the row carries and never appears at all — which
+       leaves the travel and the fade playing over a row that never changes colour. So the wash below is played on
+       what carries the row, where the background it has to cover is, and `row-going` beside it is played on the row,
+       where the leaving has to be reported from. */
+
+    --animate-row-going: row-going 460ms cubic-bezier(0.4, 0, 0.2, 1) both;
+
+    /* The leaving half, which says *this one is going* and carries no colour: the act names the colour and the two
+       washes below are where it is drawn. The row keeps the space the window drew for it, for the reason stated
+       above, so nothing here closes a height. */
+    @keyframes row-going {
+        0% {
+            opacity: 1;
+        }
+
+        100% {
+            opacity: 0;
+            transform: translateX(-22px);
+        }
+    }
     @keyframes row-deleted {
         0% {
             box-shadow:
                 inset 3px 0 0 transparent,
                 inset 0 0 0 0 var(--color-error-soft);
-            opacity: 1;
         }
 
         28% {
@@ -472,8 +494,6 @@
             box-shadow:
                 inset 3px 0 0 var(--color-error),
                 inset 0 0 0 40px var(--color-error-soft);
-            opacity: 0;
-            transform: translateX(-22px);
         }
     }
 
@@ -482,7 +502,6 @@
             box-shadow:
                 inset 3px 0 0 transparent,
                 inset 0 0 0 0 var(--color-warning-soft);
-            opacity: 1;
         }
 
         28% {
@@ -495,8 +514,6 @@
             box-shadow:
                 inset 3px 0 0 var(--color-warning),
                 inset 0 0 0 40px var(--color-warning-soft);
-            opacity: 0;
-            transform: translateX(-22px);
         }
     }
 

--- a/frontend/src/Client.App/src/thread/Thread.tsx
+++ b/frontend/src/Client.App/src/thread/Thread.tsx
@@ -19,7 +19,7 @@ import {
 import { SecondaryButton } from '../controls/SecondaryButton';
 import type { MessageKey } from '../localization/en';
 import { useLocalization } from '../localization/useLocalization';
-import type { HeadMessage } from '../mailSpace/HeadActs';
+import type { ActedMessage } from '../mailboxActs/useMailboxActs';
 import { MessageWaiting } from '../messageBody/Message';
 import { MessageHeaders } from '../readingPane/MessageHeaders';
 import { useTwoPanes } from '../shell/useWideWorkspace';
@@ -613,7 +613,7 @@ function headersOf(message: MailThreadMessage): MailMessageHeaders {
 }
 
 /** The message the head's acts are about, which is the one the conversation is standing on. */
-function actedOn(message: MailThreadMessage): HeadMessage {
+function actedOn(message: MailThreadMessage): ActedMessage {
     const email = message.email;
 
     return {


### PR DESCRIPTION
Seven defects reported from the demo deployment after the round of pull requests meant to close them. Five are fixed here, one is a deployment-side finding this change cannot close, and one is another issue.

Closes #1909.

## The row wash, drawn where a reader can see it

An inset `box-shadow` is painted between an element's own background and its content, so the red and orange washes — played on the outer row, whose carried element holds an opaque `bg-panel` — were painted *underneath* that background and never appeared at all. What the demo showed was the travel and the fade with no colour, which is exactly that.

The exit is now two animations on two elements, and the arrangement is forced rather than chosen. `row-going` carries the opacity and the travel and stays on the row, because `onAnimationEnd` is what reports the row has gone and its guard refuses an event bubbling from a child. `row-deleted` and `row-filed` keep only the wash and move to the element that holds the background.

## What a permanent delete says about itself

`leaves` was being read as *destroys*, and the two stop agreeing at the exact moment somebody is watching: a permanent delete is asked for with nothing leaving, the row stays and says what is about to happen, and then the released delete takes the row out of the list — flipping `leaves` and turning the row's sentence into *Moving to the trash…* over a message being destroyed. An act now records `destroys` beside `leaves`, and the row's wording reads that.

**The other half of that report is not closed here.** The message still being on the server after a reload was not reproduced locally: the client's release path runs when the withdrawal card goes, and the service's own release is implemented. What is worth checking on the deployment is that `MailKitImapWriteSession.DeleteAsync` requires the UIDPLUS extension, so an IMAP server that does not advertise it dead-letters the record while the client goes on saying the delete was asked for. Testing that would mean destroying mail on the demo deployment, which this change did not do.

## Taking a flag off

`flag` was hardcoded in both act orders and `unflag` in neither, so the control only ever flagged. The design draws a toggle on the strip and in a row's menu alike. `flagActFor` now decides the direction from what the rows are drawn as, exactly as `readActFor` already does for the read control, and a pending act of its own wins over the observation so two presses give two directions. `ActedMessage` carries `flagged` for it, which also lets the head of a message stop answering the question a second way.

## Drafting a reply, and the composer's drafting block

One cause for both. `Chat:ReplyDrafting:Enabled` defaulted to `false`, so a deployment that declared a chat endpoint and never opened the block answered `draftsReplies: false` — which is what withheld `DraftingBlock` from the composer and sent *Draft a reply* to the Discover space instead. Both surfaces were already built and already match the design; neither was reachable.

It now defaults to `true`, on the same reading that puts the phrase search beside it on: what decides the default is who spends the money and when, and a drafting costs one provider call per reply somebody deliberately pressed a button for. Turning it off stays a supported deployment and a spend decision.

`ChatModelOptions` also stops reading that switch as intent in its no-alias rule. An option that is on by default reads `true` on a section nobody wrote, so taking it as a declaration would refuse every deployment that left the section alone.

**Configuration break, and the operator's action.** A deployment that declares `Chat:Alias` and writes no `Chat:ReplyDrafting` block starts drafting replies after this release, and pays for one provider call per reply a person asks for. An operator who does not want that writes `Chat:ReplyDrafting:Enabled=false` and restarts. A deployment with no `Chat:Alias` is unaffected: the key is read nowhere without one.

## The PDF frame

`sandbox=""` puts the frame in an opaque origin, which fails the same-origin check on the object URL this document minted for the attachment — so the engine refuses to resolve it and a reader sees a blocked frame instead of their file. That is what Edge showed.

The attribute is dropped rather than granted back, because what it was guarding against cannot arise on this surface: `deployment/attachmentExchange.ts` mints the blob as the client's own `application/pdf` constant rather than as whatever the sender declared, and `shownAttachment.ts` reaches the document branch for that one media type. So the engine can only ever draw it with its own viewer, which resolves nothing of this document's and reaches no part of it. ADR 0024 governs the two markup surfaces and is untouched — neither carries `src`, and the browser suite's assertion is about the frame drawing a sender's markup.

## Not in this change

Filing a message into another account's folder is #1910. It needs a two-step mutation — append at the destination, remove at the source — with failure semantics of its own, which is a decision rather than a fix.

## Verification

`scripts/verify-fast.sh`, green. The unit suites covering each changed module are extended: eight cases for the flag direction, a strip toggle and a mixed selection, a menu item that takes the flag off, a test that the wash plays on what carries the row while the leaving plays on the row, a test that the document frame carries no `sandbox`, and three on the drafting default and the declaration rules.
