### PR TITLE
[#1914] Keep the message open when the Mail space is left

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -412,8 +412,12 @@ The **back gesture** is answered by the same frame, and on all three heads by on
 records what stands over the screen as each surface opens, `src/shellOperations/backNavigation.ts` keeps one history
 entry per layer standing, and `src/App.tsx` unwinds them topmost first before the address moves at all. So a press closes a
 drawer, a dialog, a menu, or the message drawn in front of the list, one layer at a time, and only a screen with
-nothing over it lets the gesture leave the client. Taking the navigation to another destination closes every one of
-them instead of leaving a layer behind. Android reaches that through the committed `MainActivity`, which turns
+nothing over it lets the gesture leave the client. What a press unwinds is the space in front of it, so the message
+the Mail space holds is counted while that space is on the screen and not while another one is. Taking the navigation
+to another destination closes every layer standing over the space being left, and the surfaces standing over its
+reading column with them — but not what that column is drawing: the Mail space is stood aside rather than taken down,
+so coming back to it finds the folder, the pages read, the place scrolled to and the message open exactly as they were
+left. Android reaches that through the committed `MainActivity`, which turns
 `handleBackNavigation` back on so the gesture arrives in the page as `popstate` exactly as it does in a browser —
 which is why no module here asks which head it is on.
 

--- a/frontend/src/Client.App/src/App.harness.tsx
+++ b/frontend/src/Client.App/src/App.harness.tsx
@@ -711,6 +711,25 @@ export function openingAt(address: string): void {
     window.history.replaceState(null, '', address);
 }
 
+/**
+ * Narrows the frame to the composition that draws one pane at a time, which is the phone.
+ *
+ * Called by a test before it renders, and only by one about that composition: the width is answered rather than
+ * measured, and `resetsBetweenTests` puts the wide answer back afterwards. No width query matches, which is what every
+ * width below the narrowest breakpoint is.
+ */
+export function inOnePane(): void {
+    Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        value: (query: string) => ({
+            media: query,
+            matches: false,
+            addEventListener: () => undefined,
+            removeEventListener: () => undefined,
+        }),
+    });
+}
+
 export async function goTo(space: string): Promise<void> {
     // Matched on the start of the name rather than the whole of it: a space with nothing behind it yet says so in its
     // own accessible name, and this helper is used to reach both kinds.

--- a/frontend/src/Client.App/src/App.shellLayers.test.tsx
+++ b/frontend/src/Client.App/src/App.shellLayers.test.tsx
@@ -9,6 +9,7 @@ import {
     framed,
     goTo,
     heldSession,
+    inOnePane,
     openSettings,
     renderApp,
     resetsBetweenTests,
@@ -49,20 +50,68 @@ describe('App shell layers', () => {
         expect(screen.queryByRole('dialog', { name: 'Settings' })).toBeNull();
     });
 
-    // The reading column goes with them, and for a second reason as well: what stands in it is a step the back gesture
-    // has to unwind, so a message left open under another space is a press spent on something nobody can see.
-    it('takes the message being read off the screen when the navigation goes to another destination', async () => {
+    // The reading column does not go with them. The Mail space is stood aside rather than taken down, so the message
+    // standing beside the list outlives leaving it exactly as the list's own pages and scroll offset do — and what the
+    // back gesture counts asks which space is in front rather than being answered by an empty workspace.
+    it('leaves the message being read open when the navigation goes to another destination and comes back', async () => {
         renderApp(servedFrom, heldSession, deploymentDrawingAMessage());
         await framed();
         await goTo('Mail');
-
-        const list = await screen.findByRole('listbox', { name: 'Messages' });
-        fireEvent.pointerDown(within(list).getByRole('option', { name: /Quarterly invoice/ }));
-        expect(await screen.findByText('A drawn message.')).toBeDefined();
+        await openTheInvoice();
 
         await goTo('Discover');
         await goTo('Mail');
 
-        expect(screen.queryByText('A drawn message.')).toBeNull();
+        expect(screen.getByText('A drawn message.')).toBeDefined();
+        expect(theInvoiceRow().getAttribute('aria-current')).toBe('true');
+    });
+
+    it('leaves the message in front of the list in the single-pane composition, still with its way back', async () => {
+        inOnePane();
+        renderApp(servedFrom, heldSession, deploymentDrawingAMessage());
+        await framed();
+        await goTo('Mail');
+        await openTheInvoice();
+
+        await goTo('Discover');
+        await goTo('Mail');
+
+        expect(screen.getByText('A drawn message.')).toBeDefined();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Back to the list' }));
+
+        expect(await screen.findByRole('listbox', { name: 'Messages' })).toBeDefined();
+    });
+
+    // The message counts as a step only while Mail is in front of the screen. Counted from another space, the press
+    // that should have left that space would be spent closing a message nobody can see instead.
+    it('leaves the space a press was made on rather than closing the message standing on another one', async () => {
+        inOnePane();
+        renderApp(servedFrom, heldSession, deploymentDrawingAMessage());
+        await framed();
+        await goTo('Mail');
+        await openTheInvoice();
+
+        await goTo('Discover');
+
+        act(() => {
+            window.history.back();
+        });
+
+        expect(await screen.findByRole('main', { name: 'Mail' })).toBeDefined();
+        expect(screen.getByText('A drawn message.')).toBeDefined();
     });
 });
+
+// The one message the deployment draws, opened the way a reader opens it: a row picked out of the list.
+async function openTheInvoice(): Promise<void> {
+    fireEvent.pointerDown(await screen.findByRole('option', { name: /Quarterly invoice/ }));
+
+    await screen.findByText('A drawn message.');
+}
+
+function theInvoiceRow(): HTMLElement {
+    return within(screen.getByRole('listbox', { name: 'Messages' })).getByRole('option', {
+        name: /Quarterly invoice/,
+    });
+}

--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -500,15 +500,23 @@ export function App({
     // them does to go away are one fact read twice. A press that unwinds two of them at once is what makes the
     // difference: asking the workspace again for the second step would answer with the surface the first has already
     // taken away, this event holding the revision that closed one no more than it holds the one that opened it.
-    const inFrontOfTheList = [
-        inTabs && workspace.attachment !== null ? openTabs.closeAttachment : null,
-        inTabs && workspace.fullHtml !== null ? openTabs.closeFullHtml : null,
-        twoPanes || (workspace.selection === null && workspace.conversation === null)
-            ? null
-            : () => {
-                  revise({ selection: null, conversation: null });
-              },
-    ].filter((close) => close !== null);
+    //
+    // They are the Mail space's own steps, so they count only while that space is in front. It is stood aside rather
+    // than taken down and goes on holding what it had open, which is what makes the question worth asking at all: a
+    // step counted from another space is a press spent closing a message the reader cannot see instead of leaving the
+    // space they are on.
+    const inFrontOfTheList =
+        space !== 'mail'
+            ? []
+            : [
+                  inTabs && workspace.attachment !== null ? openTabs.closeAttachment : null,
+                  inTabs && workspace.fullHtml !== null ? openTabs.closeFullHtml : null,
+                  twoPanes || (workspace.selection === null && workspace.conversation === null)
+                      ? null
+                      : () => {
+                            revise({ selection: null, conversation: null });
+                        },
+              ].filter((close) => close !== null);
 
     useBackNavigation(layers.depth + inFrontOfTheList.length, (used) => {
         let left = used;
@@ -528,15 +536,21 @@ export function App({
     // that screen rather than the layer somebody had over it. A layer that survived would be one they cannot get rid of
     // without finding its own close control, which on a phone is where it is hardest to find.
     //
-    // The reading column's own surfaces go with them, and for a second reason as well as that one: they are steps the
-    // back gesture has to unwind, and a step left standing while another space is on the screen is a press that closes
-    // something nobody can see instead of leaving the space they are in.
+    // The surfaces standing in front of the message go with them, for the same reason: a file being read and a
+    // message's own markup each stand over the reading column, and coming back to a column with one of them still on
+    // it is coming back to something nobody left it on.
+    //
+    // The message itself does not. It stands beside the list rather than over it, so there is nothing to get rid of and
+    // nothing hidden behind it — and the Mail space is stood aside rather than taken down exactly so that what it holds
+    // survives a reader going elsewhere. Emptying the workspace here is what made the space keep its pages and its
+    // scroll offset and lose the message they were reading, which is #1914. What that leaves behind is the counting
+    // above, which asks which space is in front rather than being answered by an empty workspace.
     const destination = useRef(space);
     const { closeAttachment, closeFullHtml } = openTabs;
 
     // The first destination is arrived at rather than moved to: the space is unknown until the session says which ones
     // this credential is offered, so the client's own opening screen would otherwise read as somewhere it had been
-    // taken away from — and would clear a reader's place the moment a reload restored it.
+    // taken away from.
     useEffect(() => {
         const left = destination.current;
 
@@ -549,8 +563,7 @@ export function App({
         layers.closeEvery();
         closeAttachment();
         closeFullHtml();
-        revise({ selection: null, conversation: null });
-    }, [space, layers, closeAttachment, closeFullHtml, revise]);
+    }, [space, layers, closeAttachment, closeFullHtml]);
 
     function signedIn(reached: DeploymentAddress, session: KeptSession, keptBeyondTheTab: boolean): void {
         if (adopted === null) {

--- a/frontend/src/Client.App/src/shellOperations/backNavigation.test.ts
+++ b/frontend/src/Client.App/src/shellOperations/backNavigation.test.ts
@@ -59,6 +59,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+    // The address is read by the hook and one test moves it, so it is put back rather than left for the next file.
+    window.location.hash = '';
+
     if (declaredState === undefined) {
         Reflect.deleteProperty(window.history, 'state');
     } else {
@@ -223,6 +226,27 @@ describe('useBackNavigation', () => {
         theGestureIsUsed();
 
         expect(unwound).toHaveBeenCalledExactlyOnceWith(1);
+    });
+
+    // Moving to another space is a new entry at another address rather than a step back through the screen, and it
+    // arrives as the same event a press does — before the space being arrived at has rendered, so what is standing is
+    // still the screen being left. Read as a press it would spend itself on that screen, closing a message on a space
+    // the reader has already gone from.
+    it('unwinds nothing where the event arrived at another address', () => {
+        const unwound = vi.fn();
+
+        renderHook(() => {
+            useBackNavigation(1, unwound);
+        });
+
+        act(() => {
+            window.location.hash = '#/discover';
+        });
+
+        theEntryShowing(null);
+        theGestureIsUsed();
+
+        expect(unwound).not.toHaveBeenCalled();
     });
 
     // A reload is the one time the entry showing describes a screen that no longer exists: the marks were written by

--- a/frontend/src/Client.App/src/shellOperations/backNavigation.ts
+++ b/frontend/src/Client.App/src/shellOperations/backNavigation.ts
@@ -121,9 +121,16 @@ export function useBackNavigation(steps: number, unwind: (used: number) => void)
     const reconciled = useRef(false);
     const travelling = useRef(0);
 
+    // The address the steps above were counted at. A fragment navigation is a new entry rather than a step back
+    // through the screen, and it announces itself the way a press does — the event arrives before the new address has
+    // been rendered, so what is standing is still the screen being left. Comparing the address is what tells the two
+    // apart: a press unwinds the screen it was made on, and moving somewhere else unwinds nothing.
+    const countedAt = useRef('');
+
     useEffect(() => {
         standing.current = steps;
         unwinding.current = unwind;
+        countedAt.current = window.location.hash;
     });
 
     useEffect(() => {
@@ -146,6 +153,13 @@ export function useBackNavigation(steps: number, unwind: (used: number) => void)
                     travelling.current += 1;
                 }
 
+                return;
+            }
+
+            // An entry at another address, which is somebody moving to another space rather than back through this
+            // one. What is standing was counted for the space being left, and the space arriving counts its own the
+            // moment it renders, so nothing is unwound here.
+            if (window.location.hash !== countedAt.current) {
                 return;
             }
 


### PR DESCRIPTION
Closes #1914.

## What was wrong

#1899 stood the Mail space aside instead of unmounting it, so the list kept its pages and its scroll offset. The effect in `frontend/src/Client.App/src/App.tsx` that runs on every change of space went on calling `revise({ selection: null, conversation: null })`, so the reading column was emptied anyway: the reader came back to a folder with nothing open, and the tab strip went on naming an active tab over an empty pane.

## What changed

- **Leaving a space no longer empties the workspace.** Every layer, the attachment and the full-HTML surface still close on the way out, for the reason they always did — each stands over the reading column, and coming back to one still standing is coming back to something nobody left there. The message beside the list does not, because it stands over nothing.
- **The back gesture counts the Mail space's own steps only while that space is in front.** The count was previously kept honest by the workspace being emptied; it now asks which space is in front, so a press made on another space leaves that space rather than closing a message out of sight.
- **`shellOperations/backNavigation.ts` reads a `popstate` that arrived at another address as a move rather than as a press.** A fragment navigation is a new entry, and it announces itself the way a press does — before the space being arrived at has rendered, so what is standing is still the screen being left. Counted as a press it spent itself on that screen; jsdom is where this is observable, and the arithmetic is the same wherever a head fires the event.

The tab strip and the reading column now agree by construction: nothing writes the workspace behind the strip's back.

## Tests

- Leaving and returning in the two-pane composition finds the same message open and its row still marked as the one being read.
- Leaving and returning in the single-pane composition finds the message in front of the list, and its way back still returns to the list.
- A press made on another space leaves that space rather than closing the message the Mail space holds.
- `useBackNavigation` unwinds nothing where the event arrived at another address.

`App.harness.tsx` gains `inOnePane()`, which answers every width query with no match — the composition that draws one pane at a time, which jsdom cannot measure.

## Verification

`scripts/verify-fast.sh` green on the rebased branch: lint, type check, formatting, and the whole client suite (4053 tests). The change reaches no service path, so no solution was built. No screen's appearance changed, so no design-parity capture was owed; the design mirror was checked against the project at the start of the work and nothing had moved.
