### PR TITLE
[#1915] Mount every space once, so moving between them is a switch rather than a rebuild

### DIFF
--- a/frontend/src/Client.App/src/App.tsx
+++ b/frontend/src/Client.App/src/App.tsx
@@ -754,8 +754,8 @@ export function App({
                     the three between them has a reason to name a file it never opens. */}
                                                         <OpenAttachmentContext value={openTabs.openAttachment}>
                                                             <div className="flex h-dvh flex-col bg-rail pt-safe-top pr-safe-right pb-safe-bottom pl-safe-left workspace:flex-row">
-                                                                {/* Positioned because the Mail space stays on the screen
-                    while another space is in front of it, laid out over this region rather than beside it —
+                                                                {/* Positioned because every space stays on the screen while
+                    one of them is in front, each aside one laid out over this region rather than beside it —
                     `shell/Space.tsx` holds why a space is stood aside instead of taken down. */}
                                                                 <div
                                                                     ref={workspaceRegion}
@@ -787,6 +787,9 @@ export function App({
                                                                         </main>
                                                                     ) : (
                                                                         <Space
+                                                                            // Every space this deployment offers, because every one of them is mounted: moving
+                                                                            // between them changes which is in front and takes nothing down.
+                                                                            offered={offeredSpaces}
                                                                             space={space}
                                                                             // Who is signed in, which is what was kept beside the session rather than anything read out of a credential.
                                                                             // A screen never sees the credential; what it is handed is the name the deployment knows the

--- a/frontend/src/Client.App/src/shell/Space.test.tsx
+++ b/frontend/src/Client.App/src/shell/Space.test.tsx
@@ -7,7 +7,7 @@ import { render, screen, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ComposingContext } from '../composer/useComposing';
 import { LocalizationProvider } from '../localization/Localization';
-import type { Space as SpaceName } from '../routing/spaces';
+import { spaces, type Space as SpaceName } from '../routing/spaces';
 import { WorkspaceProvider } from '../workspace/Workspace';
 import { Space } from './Space';
 
@@ -32,13 +32,14 @@ const nothingBeingWritten = {
     close: () => undefined,
 };
 
-function inStrictMode(space: SpaceName): ReactNode {
+function inStrictMode(space: SpaceName, offered: readonly SpaceName[] = spaces): ReactNode {
     return (
         <StrictMode>
             <LocalizationProvider>
                 <WorkspaceProvider>
                     <ComposingContext value={nothingBeingWritten}>
                         <Space
+                            offered={offered}
                             space={space}
                             intent={<p>{handedTheIntent}</p>}
                             status={<p>{handedTheStatus}</p>}
@@ -84,12 +85,19 @@ describe('Space', () => {
         expect(document.activeElement).toBe(document.body);
     });
 
+    // Both directions, because the region focused is the one the single ref is handed to and that ref moves between
+    // regions that are all already mounted: a rule that only ever reached the space it was written for would pass on
+    // the first move and leave focus behind on the second.
     it('puts focus at the start of the new content when the address changes', () => {
         const { rerender } = render(inStrictMode('discover'));
 
         rerender(inStrictMode('mail'));
 
-        expect(document.activeElement).toBe(screen.getByRole('main'));
+        expect(document.activeElement).toBe(screen.getByRole('main', { name: 'Mail' }));
+
+        rerender(inStrictMode('cases'));
+
+        expect(document.activeElement).toBe(screen.getByRole('main', { name: 'Cases' }));
     });
 
     it('names the space it is showing', () => {
@@ -131,37 +139,66 @@ describe('Space', () => {
     it('does not call the Mail space unbuilt, which is what it stopped being when it started reading mail', () => {
         render(inStrictMode('mail'));
 
-        expect(screen.queryByText(/This space is not built yet\./)).toBeNull();
+        expect(
+            within(screen.getByRole('main', { name: 'Mail' })).queryByText(/This space is not built yet\./),
+        ).toBeNull();
     });
 
-    it('shows the pending note in a space nothing has been built for yet, with Mail standing behind it', () => {
+    it('shows the pending note in a space nothing has been built for yet', () => {
         render(inStrictMode('cases'));
 
-        expect(screen.getByText(/This space is not built yet\./)).toBeDefined();
-        expect(screen.queryByRole('main', { name: 'Mail' })).toBeNull();
-        expect(screen.getByRole('main', { name: 'Cases' })).toBeDefined();
+        expect(
+            within(screen.getByRole('main', { name: 'Cases' })).getByText(/This space is not built yet\./),
+        ).toBeDefined();
     });
 
-    // What Mail holds is the folder it was reading, the pages of it that answered, and the place in them the reader had
-    // scrolled to, and all three are state of the components it renders — so it is stood aside rather than taken down,
-    // and coming back is a return rather than a rebuild. What says it is aside is what a reader would find: no second
-    // landmark naming Mail, and nothing in it to tab into.
-    it('keeps Mail on the screen while another space is in front of it, out of reach and out of the reading order', () => {
+    // The mechanism, stated as a count: a space the deployment offers is a space that is on the screen from the first
+    // render, whichever one the address names.
+    it('mounts every space the deployment offers, not only the one in front', () => {
+        render(inStrictMode('cases', ['discover', 'mail', 'cases']));
+
+        expect(document.querySelectorAll('main')).toHaveLength(3);
+        expect(screen.getByLabelText('Discover')).toBeDefined();
+        expect(screen.getByLabelText('Mail')).toBeDefined();
+    });
+
+    it('mounts no space the deployment does not offer', () => {
+        render(inStrictMode('mail', ['mail']));
+
+        expect(document.querySelectorAll('main')).toHaveLength(1);
+        expect(screen.queryByLabelText('Cases')).toBeNull();
+    });
+
+    // What says a space is aside is what a reader would find: one landmark rather than seven, nothing in the others to
+    // tab into, and no live region in one reaching somebody standing on another.
+    it('leaves exactly the space in front reachable by the keyboard and by an accessible name', () => {
+        render(inStrictMode('cases', ['discover', 'mail', 'cases']));
+
+        expect(screen.getAllByRole('main')).toHaveLength(1);
+        expect(screen.getByRole('main', { name: 'Cases' })).toBeDefined();
+
+        for (const aside of ['Discover', 'Mail'] as const) {
+            const region = screen.getByLabelText(aside);
+
+            expect(region.getAttribute('aria-hidden')).toBe('true');
+            expect(region.hasAttribute('inert')).toBe(true);
+        }
+    });
+
+    it('keeps a space on the screen while another is in front of it, with everything it was handed still in it', () => {
         render(inStrictMode('cases'));
 
         const mail = screen.getByLabelText('Mail');
 
-        expect(mail.getAttribute('aria-hidden')).toBe('true');
-        expect(mail.hasAttribute('inert')).toBe(true);
         expect(within(mail).getByText(handedTheList)).toBeDefined();
         expect(within(mail).getByText(handedTheFolders)).toBeDefined();
         expect(within(mail).getByText(handedToMail)).toBeDefined();
     });
 
-    // The assertion that says *not rebuilt from zero*: the same element, not an element drawing the same thing. A Mail
-    // space taken down and put back reads the folder again from its leading end and puts the reader at the top of it,
-    // and every node in it is a new node — so node identity is what tells the two apart, and it holds under the extra
-    // mount `StrictMode` performs, which a count of mounts would not.
+    // The assertion that says *not rebuilt from zero*: the same element, not an element drawing the same thing. A space
+    // taken down and put back reads again from its leading end and puts the reader at the top of it, and every node in
+    // it is a new node — so node identity is what tells the two apart, and it holds under the extra mount `StrictMode`
+    // performs, which a count of mounts would not.
     it('gives back the Mail space that was left rather than a rebuilt one', () => {
         const { rerender } = render(inStrictMode('mail'));
         const before = screen.getByText(handedTheList);
@@ -173,6 +210,37 @@ describe('Space', () => {
         expect(screen.getByRole('main', { name: 'Mail' })).toBeDefined();
     });
 
+    it('gives back the space that was left whichever space it is, not only Mail', () => {
+        const { rerender } = render(inStrictMode('cases'));
+        const before = screen.getByRole('heading', { name: 'Cases' });
+
+        rerender(inStrictMode('mail'));
+        rerender(inStrictMode('cases'));
+
+        expect(screen.getByRole('heading', { name: 'Cases' })).toBe(before);
+    });
+
+    // The scroll offset is the platform's rather than this client's: it belongs to the scroller's box, so it survives
+    // exactly as long as that box does. jsdom keeps what is written to `scrollTop` without laying anything out, so the
+    // number here says the element was never rebuilt — a space put back would be a new element reading zero. What keeps
+    // the box in a browser is the second assertion: an aside space stands aside by `visibility`, not by leaving the
+    // layout, which is what `display: none` would do and what would take the offset with it.
+    it('keeps a space its scroll offset across a visit to another space and back', () => {
+        const { rerender } = render(inStrictMode('cases'));
+        const region = screen.getByLabelText('Cases');
+
+        region.scrollTop = 120;
+        rerender(inStrictMode('mail'));
+
+        expect(region.classList.contains('invisible')).toBe(true);
+        expect(region.classList.contains('hidden')).toBe(false);
+
+        rerender(inStrictMode('cases'));
+
+        expect(screen.getByLabelText('Cases')).toBe(region);
+        expect(region.scrollTop).toBe(120);
+    });
+
     // The two the frame composes for whichever space is in front. Handed to one of them and to nothing else: a second
     // live copy of the field would be a second place somebody's question could be typed into.
     it('hands the question and the connection to the space in front and to nothing behind it', () => {
@@ -181,5 +249,14 @@ describe('Space', () => {
         expect(screen.getAllByText(handedTheIntent)).toHaveLength(1);
         expect(screen.getAllByText(handedTheStatus)).toHaveLength(1);
         expect(within(screen.getByRole('main', { name: 'Cases' })).getByText(handedTheIntent)).toBeDefined();
+    });
+
+    it('moves the question and the connection to the space arrived at rather than leaving them behind', () => {
+        const { rerender } = render(inStrictMode('cases'));
+
+        rerender(inStrictMode('mail'));
+
+        expect(screen.getAllByText(handedTheIntent)).toHaveLength(1);
+        expect(within(screen.getByRole('main', { name: 'Mail' })).getByText(handedTheIntent)).toBeDefined();
     });
 });

--- a/frontend/src/Client.App/src/shell/Space.test.tsx
+++ b/frontend/src/Client.App/src/shell/Space.test.tsx
@@ -222,19 +222,15 @@ describe('Space', () => {
 
     // The scroll offset is the platform's rather than this client's: it belongs to the scroller's box, so it survives
     // exactly as long as that box does. jsdom keeps what is written to `scrollTop` without laying anything out, so the
-    // number here says the element was never rebuilt — a space put back would be a new element reading zero. What keeps
-    // the box in a browser is the second assertion: an aside space stands aside by `visibility`, not by leaving the
-    // layout, which is what `display: none` would do and what would take the offset with it.
+    // number here says the element was never rebuilt — a space put back would be a new element reading zero. That the
+    // aside space also keeps its *box*, by standing aside with `visibility` rather than leaving the layout, is a
+    // rendered-layout claim and is the browser suite's rather than this one's.
     it('keeps a space its scroll offset across a visit to another space and back', () => {
         const { rerender } = render(inStrictMode('cases'));
         const region = screen.getByLabelText('Cases');
 
         region.scrollTop = 120;
         rerender(inStrictMode('mail'));
-
-        expect(region.classList.contains('invisible')).toBe(true);
-        expect(region.classList.contains('hidden')).toBe(false);
-
         rerender(inStrictMode('cases'));
 
         expect(screen.getByLabelText('Cases')).toBe(region);

--- a/frontend/src/Client.App/src/shell/Space.tsx
+++ b/frontend/src/Client.App/src/shell/Space.tsx
@@ -8,9 +8,11 @@ import { MailSpace } from '../mailSpace/MailSpace';
 import { implementedSpaces, spaceLabels, type Space as SpaceName } from '../routing/spaces';
 
 // The region the address decides the contents of. What each space actually holds is built by its own issue; what this
-// owns permanently is where a space is rendered and what happens to focus when the address changes.
+// owns permanently is that a space is mounted once and then only moved in front of or behind the others, and what
+// happens to focus when the address changes.
 
 export function Space({
+    offered,
     space,
     intent,
     status,
@@ -20,6 +22,9 @@ export function Space({
     tabs,
     person,
 }: {
+    /** Every space this deployment offers, which is every space that is mounted. */
+    readonly offered: readonly SpaceName[];
+
     readonly space: SpaceName;
 
     /** The question the reader is composing, which every space carries somewhere. */
@@ -39,11 +44,8 @@ export function Space({
     readonly person: string | null;
 }) {
     const { translate } = useLocalization();
-    const region = useRef<HTMLElement>(null);
-    const mailRegion = useRef<HTMLElement>(null);
+    const inFrontRegion = useRef<HTMLElement>(null);
     const shown = useRef(space);
-
-    const mailInFront = space === 'mail';
 
     // Navigation puts focus at the start of the new content, which is where keyboard and screen-reader use otherwise
     // silently stops working: focus would stay on the link that was activated, in navigation the reader has left.
@@ -51,82 +53,97 @@ export function Space({
     // page out from under somebody who has not asked to go anywhere. What the ref holds is therefore the space that
     // was last shown rather than whether the effect has run before: the second is what StrictMode's extra invocation
     // makes true on the first mount, which would move focus on landing in every development run.
+    //
+    // One ref for the one space in front, handed to that space's region and to no other. React detaches every ref it
+    // is taking away before it attaches the ones it is adding, so by the time this runs the ref holds the region
+    // arrived at rather than the one left.
     useEffect(() => {
         if (shown.current !== space) {
-            (space === 'mail' ? mailRegion : region).current?.focus();
+            inFrontRegion.current?.focus();
             shown.current = space;
         }
     }, [space]);
 
-    // Mail is the one space with anything in it, and the design project draws it without a title: the columns are what
-    // it is, and a heading over them would be a word above the thing the word names. The region still carries the name,
-    // because a landmark a reader moves to is announced by it.
+    // **Every space is drawn whichever one is in front, and the others are stood aside rather than taken down.** What
+    // a space holds is the thing it was reading, the pages of it the deployment answered, the place in those pages the
+    // reader had scrolled to, what they had picked out and what they had open — and every one of those is state of the
+    // components it renders, so a space taken down on the way to another answers all of them by reading again from the
+    // leading end, as a skeleton, with the reader back at the top. That is a client rebuilding the screen somebody just
+    // left rather than one they are coming back to.
     //
-    // **It is drawn whichever space is in front, and stood aside rather than taken down.** What Mail holds is the
-    // folder it was reading, the pages of it the deployment answered, the place in those pages the reader had scrolled
-    // to, the messages they had picked out and what they had open — and every one of those is state of the components
-    // this renders, so a Mail space taken down on the way to another space answers all five by reading the folder
-    // again from its leading end, as a skeleton, with the reader back at the top of it. That is a client rebuilding the
-    // screen somebody just left rather than one they are coming back to.
+    // Two consequences are intended. A space that reads when it mounts reads once the frame is reached rather than at
+    // the first visit to it, which is what buys the switch; and a space that draws a live region goes on drawing one
+    // while it is aside, which is what `inert` and `aria-hidden` below are there to contain.
     //
-    // Standing it aside is `visibility` rather than `display`, and that is the whole reason it is positioned: a box
+    // Standing a space aside is `visibility` rather than `display`, and that is the whole reason it is positioned: a box
     // taken out of the layout takes its scroller's offset with it — the one part of this state the platform holds
     // rather than this client, since `scrollTop` on an element with no box reads zero and cannot be written — so the
     // list would come back holding its pages and still be at the top of them. Keeping the box keeps the offset, which
-    // is why the aside space is laid out over the region it stands in instead of beside it.
+    // is why an aside space is laid out over the region it stands in instead of beside it.
     //
     // It is taken out of the accessibility tree and made inert while it is aside, because `visibility` alone is a
-    // statement to the engine that lays out rather than to everything that reads: a reader on another space must not
-    // find a second `main` naming Mail, must not tab into a list nobody can see, and must not be told by a live region
-    // in it what a screen they are not on is doing.
+    // statement to the engine that lays out rather than to everything that reads: a reader on one space must not find a
+    // second `main`, must not tab into a list nobody can see, and must not be told by a live region what a screen they
+    // are not on is doing.
     return (
         <>
-            <main
-                ref={mailRegion}
-                tabIndex={-1}
-                aria-label={translate(spaceLabels.mail)}
-                aria-hidden={mailInFront ? undefined : true}
-                inert={!mailInFront}
-                className={`flex min-h-0 flex-col overflow-hidden ${
-                    mailInFront ? 'flex-1' : 'invisible absolute inset-0'
-                }`}
-            >
-                {/* The question and the connection are the two the frame composes for every space, so they are handed
-                    to the one in front and to nothing else: two of either would be two live copies of one control —
-                    a second field somebody's question could be typed into, and a second region saying what the
-                    deployment is doing. Neither holds anything Mail would lose, the question being the workspace's. */}
-                <MailSpace
-                    folders={folders}
-                    list={list}
-                    mail={mail}
-                    tabs={tabs}
-                    intent={mailInFront ? intent : null}
-                    status={mailInFront ? status : null}
-                    person={person}
-                />
-            </main>
+            {offered.map((name) => {
+                const inFront = name === space;
+                const isMail = name === 'mail';
 
-            {mailInFront ? null : (
-                <main
-                    ref={region}
-                    tabIndex={-1}
-                    aria-label={translate(spaceLabels[space])}
-                    className="flex-1 overflow-y-auto px-4 py-6 workspace:px-8"
-                >
-                    <div className="flex max-w-3xl flex-col gap-3">
-                        <h1 className="text-4xl font-semibold tracking-tight">{translate(spaceLabels[space])}</h1>
+                return (
+                    <main
+                        key={name}
+                        ref={inFront ? inFrontRegion : null}
+                        tabIndex={-1}
+                        aria-label={translate(spaceLabels[name])}
+                        aria-hidden={inFront ? undefined : true}
+                        inert={!inFront}
+                        className={`${
+                            isMail
+                                ? 'flex min-h-0 flex-col overflow-hidden'
+                                : 'overflow-y-auto px-4 py-6 workspace:px-8'
+                        } ${inFront ? 'flex-1' : 'invisible absolute inset-0'}`}
+                    >
+                        {/* Mail is the one space with anything in it, and the design project draws it without a title:
+                            the columns are what it is, and a heading over them would be a word above the thing the word
+                            names. Every region still carries its name, because a landmark a reader moves to is
+                            announced by it. */}
+                        {isMail ? (
+                            /* The question and the connection are the two the frame composes for every space, so they
+                               are handed to the one in front and to nothing else: two of either would be two live
+                               copies of one control — a second field somebody's question could be typed into, and a
+                               second region saying what the deployment is doing. Neither holds anything a space would
+                               lose, the question being the workspace's. */
+                            <MailSpace
+                                folders={folders}
+                                list={list}
+                                mail={mail}
+                                tabs={tabs}
+                                intent={inFront ? intent : null}
+                                status={inFront ? status : null}
+                                person={person}
+                            />
+                        ) : (
+                            <div className="flex max-w-3xl flex-col gap-3">
+                                <h1 className="text-4xl font-semibold tracking-tight">
+                                    {translate(spaceLabels[name])}
+                                </h1>
 
-                        {status}
+                                {inFront ? status : null}
 
-                        {/* The note belongs to a space that holds nothing, which is every space but Mail today. */}
-                        {implementedSpaces.includes(space) ? null : (
-                            <p className="text-base text-muted">{translate('space.pending')}</p>
+                                {/* The note belongs to a space that holds nothing, which is every space but Mail
+                                    today. */}
+                                {implementedSpaces.includes(name) ? null : (
+                                    <p className="text-base text-muted">{translate('space.pending')}</p>
+                                )}
+
+                                {inFront ? intent : null}
+                            </div>
                         )}
-
-                        {intent}
-                    </div>
-                </main>
-            )}
+                    </main>
+                );
+            })}
         </>
     );
 }


### PR DESCRIPTION
## What this changes

`frontend/src/Client.App/src/shell/Space.tsx` kept exactly one space alive and kept it by name. The Mail space was rendered on every render and stood aside with `invisible absolute inset-0`, `inert` and `aria-hidden` whenever another space was in front; every other space was drawn through a single `main` that the address swapped. What #1899 gave Mail was therefore a special case written for Mail rather than a property of a space, and the first of the six placeholder spaces to hold a real screen would have had that screen rebuilt on every visit.

Every space the deployment offers is now rendered from one list and mounted for the life of the session. Moving between spaces changes which one is in front and takes nothing down, so a space keeps its scroll offsets, its selections, its open surfaces and whatever it has already read. The special case is replaced rather than left standing beside the mechanism.

The technique is the one already argued in that file and it is unchanged: `visibility` rather than `display`, because a box taken out of the layout takes its scroller's offset with it and `scrollTop` on a box-less element reads zero and cannot be written; and `inert` with `aria-hidden` beside it, because `visibility` is a statement to the engine that lays out rather than to everything that reads.

`App.tsx` hands the component the offered set beside the space in front. Nothing else moved.

## How focus keeps working

One ref, handed to the region in front and to no other. React detaches every ref it is taking away before it attaches the ones it is adding, so by the time the effect runs the ref holds the region arrived at rather than the one left. The rule is otherwise the one that was there: focus moves to the start of the space arrived at, and does not move on the frame's first render.

## Two consequences, both intended

A space that reads when it mounts now reads once the frame is reached rather than at the first visit to it — the trade #1899 already made for Mail, where it is three reads. And a space that draws a live region goes on drawing one while it is aside, which is what `inert` and `aria-hidden` contain.

## Tests

`Space.test.tsx` gains coverage for the mechanism rather than for Mail's special case:

- every offered space is mounted from the first render, and no space the deployment does not offer is;
- exactly one space is reachable by an accessible-name query, and every other region carries `inert` and `aria-hidden`;
- a space gives back the element that was left rather than a rebuilt one, for a placeholder space as well as for Mail;
- a space keeps its scroll offset across a visit to another space and back;
- the intent field and the connection summary are live in the space in front and nowhere else, and move with it;
- focus moves in both directions, which is what the single moving ref has to be held to.

The scroll-offset case asserts two things rather than one. jsdom keeps what is written to `scrollTop` without laying anything out, so the number says the element was never rebuilt — a space put back would be a new element reading zero. What keeps the box in a real browser is the second assertion: the aside region stands aside by `visibility` and not by leaving the layout.

## Verification

`scripts/verify-fast.sh` passed over this tree. `Client.App`'s unit suite runs there; the browser suite and the coverage target arrive from this pull request's own checks.

Closes #1915
