### PR TITLE
[#1295] Ship the deployment contract for more than one replica: the chart, the rollout, and the page that says what scales

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ This file is loaded into every agent session in either stack, so it holds what h
 | Where | Read when | What it holds |
 |---|---|---|
 | `backend/AGENTS.md` | A change anywhere under `backend/` | The service stack's whole contract: the .NET and C# conventions and the asynchronous return types, comment and XML-documentation discipline, the clean-architecture boundaries, the cross-boundary email invariants, package pinning and lock files, and the two verification rules that are this solution's alone |
-| `backend/src/AGENTS.md` | A change under `backend/src/` | What holds for the service's production code alone: API and failure design, dependency injection and configuration, and the lifetime and bounds every outbound HTTP client is registered with |
+| `backend/src/AGENTS.md` | A change under `backend/src/` | What holds for the service's production code alone: that several independent replicas run this code and what each design decision owes that — which state is one replica's, what a guarantee may rest on, how singleton work is excluded and a contested row claimed, and what a rolling upgrade running two builds obliges — then API and failure design, dependency injection and configuration, and the lifetime and bounds every outbound HTTP client is registered with |
 | `backend/tests/AGENTS.md` | A change under `backend/tests/` | The service suite's own policy, coverage, and what belongs in the integration suite instead |
 | `backend/src/Infrastructure/AGENTS.md` | A change under `backend/src/Infrastructure/` | Persistence and EF Core rules, and email-protocol safety |
 | `backend/src/Mcp/AGENTS.md` | A change under `backend/src/Mcp/` | Where a result type and the types nested inside one are placed |

--- a/backend/src/AGENTS.md
+++ b/backend/src/AGENTS.md
@@ -23,10 +23,15 @@ method: it is wherever a guarantee was quietly resting on being the only process
   threads, sockets, or memory is a bound, and a bound is legitimately one process's — but then say so where an operator
   meets it, in the configuration reference, as `× replicaCount`. ADR 0031 records both halves and the asymmetry between
   them.
-- **Work that must not run twice takes a lease.** `IWorkLeaseStore` and `WorkLeaseHolder` are the mechanism, the unit of
-  exclusion is the scope of the row that already records the work's progress, every write against a leased scope is
-  conditional on the holder still matching, and the holder stops on the first renewal it fails rather than when the
-  expiry passes. A new singleton worker takes a lease keyed that way rather than inventing coordination beside it, and
+- **Work that must not run twice takes a lease, through `IWorkLeaseRunner`.** That is the seam, and it is the seam
+  because taking a lease is more than claiming one: the renewal while the work runs, the persistence scope each
+  statement against the store needs of its own, and the release once the work ends are all the host's, so the work is
+  handed in rather than the lease handed out and no caller can forget the release. `IWorkLeaseStore` is the store
+  beneath it and `WorkLeaseHolder` names one hold rather than one process, which is what makes every write against a
+  leased scope conditional on the holder still matching; the hold the runner takes cancels the work on the first
+  renewal that does not complete, strictly before the lease could expire and another replica take the scope. The unit
+  of exclusion is the scope of the row that already records the work's progress, so a new singleton worker keys its
+  lease that way rather than inventing coordination beside it, and
   [ADR 0031](../../docs/decisions/0031-dividing-singleton-work-between-replicas-with-a-leased-scope.md) holds the
   reasoning, including why a PostgreSQL advisory lock was not chosen.
 - **A row a competing replica may already have written is claimed, never adopted.** Take it under

--- a/backend/src/AGENTS.md
+++ b/backend/src/AGENTS.md
@@ -2,6 +2,55 @@
 
 These instructions apply under `backend/src/` in addition to `backend/AGENTS.md` and the repository root instructions.
 
+## Several replicas run this code, and every design decision here is made against that
+
+**MailFathom is a product that runs as *n* independent processes against one database, and `n` is the operator's to
+choose.** The Helm chart takes a `replicaCount`, raising it is supported and documented, and
+`docs/operations/deployment-kubernetes.md` § *Running more than one replica* is what an operator reads before doing it.
+So the deployment this code is written for is not one process that happens to be alone today: it is several processes
+on different nodes, sharing nothing but PostgreSQL and an optional RESP backplane, started and stopped independently,
+and — for the length of every rolling upgrade — **running two different builds of this repository at once**. Write every
+feature against that deployment from the first line, because the shape that has to change afterwards is never one
+method: it is wherever a guarantee was quietly resting on being the only process in the world.
+
+- **In-process state belongs to one replica and is invisible to the others.** A `static` field, a `SemaphoreSlim`, a
+  `lock`, an `IMemoryCache`, a `Channel`, a dictionary on a singleton, a counter, a set of seen identifiers — each of
+  those is one process's, and a deployment of *n* replicas has *n* of them that never meet. That is not a detail to
+  document later; it decides whether the thing being built works at all.
+- **A guarantee may never rest on in-process state, and a bound may.** Uniqueness, once-only execution, anti-replay,
+  and "this runs on exactly one replica" are guarantees: they are a row in PostgreSQL or they do not exist, because the
+  replica that would have refused the second attempt is not the replica the second attempt reaches. A ceiling on
+  threads, sockets, or memory is a bound, and a bound is legitimately one process's — but then say so where an operator
+  meets it, in the configuration reference, as `× replicaCount`. ADR 0031 records both halves and the asymmetry between
+  them.
+- **Work that must not run twice takes a lease.** `IWorkLeaseStore` and `WorkLeaseHolder` are the mechanism, the unit of
+  exclusion is the scope of the row that already records the work's progress, every write against a leased scope is
+  conditional on the holder still matching, and the holder stops on the first renewal it fails rather than when the
+  expiry passes. A new singleton worker takes a lease keyed that way rather than inventing coordination beside it, and
+  [ADR 0031](../../docs/decisions/0031-dividing-singleton-work-between-replicas-with-a-leased-scope.md) holds the
+  reasoning, including why a PostgreSQL advisory lock was not chosen.
+- **A row a competing replica may already have written is claimed, never adopted.** Take it under
+  `FOR UPDATE SKIP LOCKED` or with a compare-and-set on the state the claim was resolved over, and report a conflict and
+  re-resolve rather than writing on the strength of a key. Two replicas reaching one scheduled occasion is the
+  ordinary case, not the race to treat as unlikely.
+- **A rolling upgrade runs two builds against one database.** So a schema change is additive and the older build keeps
+  serving against it; a new job type is claimed only by a replica whose build registers a handler for it, which is what
+  leaves work an older replica cannot run for a newer one; and nothing may assume every replica knows about a concept
+  this change introduced. A migration or a contract that requires every process to move at once has no window in which
+  to do it.
+- **A client's connection is held by one replica and a signal is raised by another.** Anything a client has to be told
+  crosses replicas over the signal backplane rather than reaching whoever raised it, and a client's session and its
+  connection ticket are rows precisely so that no request needs affinity.
+  [ADR 0032](../../docs/decisions/0032-reaching-a-client-from-any-replica-over-websockets-and-a-resp-backplane.md) and
+  [ADR 0033](../../docs/decisions/0033-where-a-signed-in-session-lives-so-every-replica-accepts-it.md) are those two
+  answers.
+- **An instrument measures its own process.** A meter, a gauge, and a counter are per replica, so a dashboard sums what
+  is additive and takes the maximum of what is a level; `docs/operations/telemetry.md` states which is which per
+  instrument, and a new instrument states it there as well.
+- **The test for coordination is the second replica.** A behaviour that claims, leases, or spends states what happens
+  to the attempt that lost — refused, conflicted, or asked again next interval — and a unit test asserts that outcome
+  rather than only the happy path of the replica that won.
+
 ## Service conventions
 
 `backend/AGENTS.md` holds the .NET and C# conventions, the asynchronous return types, and the service's architecture boundaries, and they govern this directory like every other under `backend/`. What follows is what is true of the production code alone.

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -340,7 +340,7 @@
 # **On one host it does nothing, and that is the expected state.** A backplane carries a client signal from the instance
 # that raised it to the instances holding the connections that have to hear about it, and this file runs one MailFathom
 # — so every signal already reaches every connection this deployment holds. It is here so that this shape offers the
-# same component the Helm chart does, and so that a deployment which grows a second instance has the piece provisioned
+# same component the Helm chart does, and so that a deployment which expects to move to the chart can provision it
 # before it needs one. **Running more than one MailFathom under Compose is not supported**: the service publishes fixed
 # host ports, so a second container has nothing to bind, and nothing here balances requests between two of them. The
 # application asks for nothing further — its coordination is rows in PostgreSQL — so what stops at one instance is this

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -341,8 +341,10 @@
 # that raised it to the instances holding the connections that have to hear about it, and this file runs one MailFathom
 # — so every signal already reaches every connection this deployment holds. It is here so that this shape offers the
 # same component the Helm chart does, and so that a deployment which grows a second instance has the piece provisioned
-# before it needs one. Running more than one MailFathom under Compose is not supported today; issue #1295 decides
-# whether it will be.
+# before it needs one. **Running more than one MailFathom under Compose is not supported**: the service publishes fixed
+# host ports, so a second container has nothing to bind, and nothing here balances requests between two of them. The
+# application asks for nothing further — its coordination is rows in PostgreSQL — so what stops at one instance is this
+# deployment shape, and the Helm chart is where more than one replica is supported.
 #
 # Enabling it is a profile and a credential rather than a switch, because what says a backplane exists is the
 # configuration section itself. In this order:

--- a/deploy/compose/compose.yaml
+++ b/deploy/compose/compose.yaml
@@ -485,7 +485,7 @@ services:
     # replica that raised it to the replicas holding the connections that have to hear about it, and this file runs one
     # MailFathom — so every signal already reaches every connection this deployment holds, and the server relays each
     # one back to the single subscriber that published it. It is here so that this shape offers the same component the
-    # chart does, and so that a deployment which grows a second instance has the piece already provisioned.
+    # chart does, and so that a deployment which expects to move to the chart can provision it before it needs one.
     profiles:
       - signal-backplane
     # A digest rather than a tag, and the same digest the Helm chart renders — Valkey 9.1.2 — so the server this starts

--- a/deploy/compose/compose.yaml
+++ b/deploy/compose/compose.yaml
@@ -185,8 +185,13 @@ services:
       #
       # **On one host it changes nothing an operator can observe**, and that is the expected state rather than a
       # misconfiguration: a signal raised here already reaches every client connection this deployment holds, because
-      # there is only one process holding them. What it is for is a second instance, and #1295 is where running one is
-      # decided. Until then this is the same component the chart offers, provisioned ahead of needing it.
+      # there is only one process holding them. What it is for is a second instance, and **this shape runs one**: the
+      # ports below are published on fixed host addresses, so a second container has nothing to bind, and nothing here
+      # balances requests between two of them or holds a client's connection across a replacement. MailFathom itself
+      # asks for nothing further — leases, sessions, and spent assertions are all rows in PostgreSQL — so what stops at
+      # one instance is this deployment shape rather than the application, and the Helm chart is where more than one
+      # replica is supported and stated. The server is here so that this shape offers the same component the chart
+      # does, provisioned ahead of needing it.
       #
       # The reference is a file under ./secrets/mailfathom/ like every other credential MailFathom reads, and what it
       # holds is a whole StackExchange.Redis connection string rather than a bare password: `valkey:6379,password=...`

--- a/deploy/helm/mailfathom/README.md
+++ b/deploy/helm/mailfathom/README.md
@@ -18,6 +18,7 @@ MailFathom synchronizes your IMAP accounts into a PostgreSQL database you run, i
 | A SpamAssassin Deployment and Service, only when `spamScanning.enabled` and `.scanner.deploy` are both true | |
 | A Silo object-store StatefulSet, its claim, and its Service, only when `contentStorage.objectStorage.deploy.enabled` is true | Any bucket, or any access key inside one |
 | A Valkey StatefulSet and two Services for the signal backplane, only when `signalBackplane.enabled` and `.valkey.deploy` are both true | |
+| A PodDisruptionBudget for the application pods, and the Deployment's rollout strategy, both from values | Any HorizontalPodAutoscaler, or any metric-driven scaling |
 | An optional Ingress | |
 
 Both scanners are off, and off means nothing is rendered for them: an opt-in nobody took pulls no image and holds no memory. Take either deliberately — they are the two pods in this release that receive mail content in the clear, and the spam scanner's container adds `SETUID` and `SETGID` back to the capabilities the application pod drops entirely. Neither is given a service-account token.
@@ -66,6 +67,32 @@ chart deliberately offers none, because the RESP client the SignalR backplane pa
 a line Valkey no longer writes and refuses the connection outright. Read what replication is worth before turning it
 on: the client's own re-read is the guarantee, so this shortens a gap rather than making a signal reliable.
 [Replicating the backplane](https://krzysztof318.github.io/MailFathom/operations/deployment-kubernetes.html#replicating-the-backplane)
+is the page.
+
+## Running more than one replica
+
+`replicaCount` is supported above 1, and what it gives is request capacity and an upgrade with nothing down — never a
+second copy of any work. A mail account is synchronized by whichever replica holds its lease and by no other, so
+replicas divide the accounts rather than each taking all of them, and a single large mailbox is no faster for it.
+Neither is the database more available: one the chart deploys is a single-replica StatefulSet on a ReadWriteOnce claim
+whatever this number says. A signed-in session is a row in PostgreSQL, so every replica accepts one any other replica
+minted; a client assertion is spent in a row as well, so an identifier any replica served is refused by every replica.
+Every ceiling worded as one process's — `Jobs:MaxConcurrentJobs`, `MailSynchronization:MaxInFlightRawMimeBytes`,
+`Embeddings:MaxQueuedEmails`, `Resilience:AiProviderInvocation:ConcurrencyLimit` — multiplies by the replica count, and
+every ceiling worded as the deployment's is a row the replicas share.
+
+**The chart renders two things for it**, both from values and both stated rather than inherited. The rollout keeps a pod
+serving at every instant (`strategy.rollingUpdate.maxUnavailable: 0`), which is what makes a new pod that refuses a
+schema behind it harmless and what puts two versions in service for the length of a rollout — safe, because a leased
+scope is released by the pod stopping and claimed by whoever takes it next. And a PodDisruptionBudget
+(`podDisruptionBudget.maxUnavailable: 1`, turned off with `podDisruptionBudget.enabled: false`) makes a node drain take
+the replicas one at a time, so leased work is handed over instead of waiting out an expiry with nothing running it.
+
+**Three things are your load balancer's**, because the client's signal channel is a WebSocket that never negotiates a
+fallback: pass the upgrade, keep no idle timeout shorter than a standing connection, and use no session affinity — none
+is needed, since the session, the handshake's ticket, and the signal all live outside the process. And more than one
+replica serving the client surface needs the backplane above; the chart refuses that combination without it.
+[Running more than one replica](https://krzysztof318.github.io/MailFathom/operations/deployment-kubernetes.html#running-more-than-one-replica)
 is the page.
 
 ## Installing

--- a/deploy/helm/mailfathom/README.md
+++ b/deploy/helm/mailfathom/README.md
@@ -78,8 +78,10 @@ Neither is the database more available: one the chart deploys is a single-replic
 whatever this number says. A signed-in session is a row in PostgreSQL, so every replica accepts one any other replica
 minted; a client assertion is spent in a row as well, so an identifier any replica served is refused by every replica.
 Every ceiling worded as one process's — `Jobs:MaxConcurrentJobs`, `MailSynchronization:MaxInFlightRawMimeBytes`,
-`Embeddings:MaxQueuedEmails`, `Resilience:AiProviderInvocation:ConcurrencyLimit` — multiplies by the replica count, and
-every ceiling worded as the deployment's is a row the replicas share.
+`Embeddings:MaxQueuedEmails`, `Resilience:AiProviderInvocation:ConcurrencyLimit`, and every endpoint's
+`RateLimiting` — multiplies by the replica count, and every ceiling worded as the deployment's is a row the replicas
+share. The administrative endpoint's is the one to divide first: its bucket is the whole endpoint's rather than one
+caller's, and the limiter is what stands between an API key and unbounded guessing.
 
 **The chart renders two things for it**, both from values and both stated rather than inherited. The rollout keeps a pod
 serving at every instant (`strategy.rollingUpdate.maxUnavailable: 0`), which is what makes a new pod that refuses a

--- a/deploy/helm/mailfathom/ci/golden/content-storage.yaml
+++ b/deploy/helm/mailfathom/ci/golden/content-storage.yaml
@@ -6,6 +6,25 @@
 # Committed so a change in what the chart produces is visible in the diff rather than only a failure to
 # produce anything. Regenerate with: scripts/render-helm-manifests.sh --update
 ---
+# Source: mailfathom/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: mailfathom
+  labels:
+    helm.sh/chart: mailfathom-0.0.0
+    app.kubernetes.io/name: mailfathom
+    app.kubernetes.io/instance: mailfathom
+    app.kubernetes.io/version: ""
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: mailfathom
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mailfathom
+      app.kubernetes.io/instance: mailfathom
+---
 # Source: mailfathom/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -157,6 +176,11 @@ metadata:
     app.kubernetes.io/part-of: mailfathom
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: mailfathom

--- a/deploy/helm/mailfathom/ci/golden/defaults.yaml
+++ b/deploy/helm/mailfathom/ci/golden/defaults.yaml
@@ -6,6 +6,25 @@
 # Committed so a change in what the chart produces is visible in the diff rather than only a failure to
 # produce anything. Regenerate with: scripts/render-helm-manifests.sh --update
 ---
+# Source: mailfathom/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: mailfathom
+  labels:
+    helm.sh/chart: mailfathom-0.0.0
+    app.kubernetes.io/name: mailfathom
+    app.kubernetes.io/instance: mailfathom
+    app.kubernetes.io/version: ""
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: mailfathom
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mailfathom
+      app.kubernetes.io/instance: mailfathom
+---
 # Source: mailfathom/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -157,6 +176,11 @@ metadata:
     app.kubernetes.io/part-of: mailfathom
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: mailfathom

--- a/deploy/helm/mailfathom/ci/golden/nightly.yaml
+++ b/deploy/helm/mailfathom/ci/golden/nightly.yaml
@@ -6,6 +6,27 @@
 # Committed so a change in what the chart produces is visible in the diff rather than only a failure to
 # produce anything. Regenerate with: scripts/render-helm-manifests.sh --update
 ---
+# Source: mailfathom/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: mailfathom
+  labels:
+    helm.sh/chart: mailfathom-0.0.0
+    app.kubernetes.io/name: mailfathom
+    app.kubernetes.io/instance: mailfathom
+    app.kubernetes.io/version: "nightly-0.0.0-nightly.1-0000000"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: mailfathom
+
+    io.mailfathom/release-channel: nightly
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mailfathom
+      app.kubernetes.io/instance: mailfathom
+---
 # Source: mailfathom/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -285,6 +306,11 @@ metadata:
     io.mailfathom/release-channel: nightly
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: mailfathom

--- a/deploy/helm/mailfathom/ci/golden/object-store.yaml
+++ b/deploy/helm/mailfathom/ci/golden/object-store.yaml
@@ -6,6 +6,25 @@
 # Committed so a change in what the chart produces is visible in the diff rather than only a failure to
 # produce anything. Regenerate with: scripts/render-helm-manifests.sh --update
 ---
+# Source: mailfathom/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: mailfathom
+  labels:
+    helm.sh/chart: mailfathom-0.0.0
+    app.kubernetes.io/name: mailfathom
+    app.kubernetes.io/instance: mailfathom
+    app.kubernetes.io/version: ""
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: mailfathom
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mailfathom
+      app.kubernetes.io/instance: mailfathom
+---
 # Source: mailfathom/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -181,6 +200,11 @@ metadata:
     app.kubernetes.io/part-of: mailfathom
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: mailfathom

--- a/deploy/helm/mailfathom/ci/golden/release.yaml
+++ b/deploy/helm/mailfathom/ci/golden/release.yaml
@@ -100,6 +100,8 @@ metadata:
     app.kubernetes.io/part-of: mailfathom
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: mailfathom

--- a/deploy/helm/mailfathom/ci/golden/signal-backplane-external.yaml
+++ b/deploy/helm/mailfathom/ci/golden/signal-backplane-external.yaml
@@ -6,6 +6,25 @@
 # Committed so a change in what the chart produces is visible in the diff rather than only a failure to
 # produce anything. Regenerate with: scripts/render-helm-manifests.sh --update
 ---
+# Source: mailfathom/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: mailfathom
+  labels:
+    helm.sh/chart: mailfathom-0.0.0
+    app.kubernetes.io/name: mailfathom
+    app.kubernetes.io/instance: mailfathom
+    app.kubernetes.io/version: ""
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: mailfathom
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mailfathom
+      app.kubernetes.io/instance: mailfathom
+---
 # Source: mailfathom/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -166,6 +185,11 @@ metadata:
     app.kubernetes.io/part-of: mailfathom
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: mailfathom

--- a/deploy/helm/mailfathom/ci/golden/signal-backplane-replication.yaml
+++ b/deploy/helm/mailfathom/ci/golden/signal-backplane-replication.yaml
@@ -6,6 +6,25 @@
 # Committed so a change in what the chart produces is visible in the diff rather than only a failure to
 # produce anything. Regenerate with: scripts/render-helm-manifests.sh --update
 ---
+# Source: mailfathom/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: mailfathom
+  labels:
+    helm.sh/chart: mailfathom-0.0.0
+    app.kubernetes.io/name: mailfathom
+    app.kubernetes.io/instance: mailfathom
+    app.kubernetes.io/version: ""
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: mailfathom
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mailfathom
+      app.kubernetes.io/instance: mailfathom
+---
 # Source: mailfathom/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -216,6 +235,11 @@ metadata:
     app.kubernetes.io/part-of: mailfathom
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: mailfathom

--- a/deploy/helm/mailfathom/ci/golden/signal-backplane-valkey.yaml
+++ b/deploy/helm/mailfathom/ci/golden/signal-backplane-valkey.yaml
@@ -6,6 +6,25 @@
 # Committed so a change in what the chart produces is visible in the diff rather than only a failure to
 # produce anything. Regenerate with: scripts/render-helm-manifests.sh --update
 ---
+# Source: mailfathom/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: mailfathom
+  labels:
+    helm.sh/chart: mailfathom-0.0.0
+    app.kubernetes.io/name: mailfathom
+    app.kubernetes.io/instance: mailfathom
+    app.kubernetes.io/version: ""
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: mailfathom
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mailfathom
+      app.kubernetes.io/instance: mailfathom
+---
 # Source: mailfathom/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -216,6 +235,11 @@ metadata:
     app.kubernetes.io/part-of: mailfathom
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: mailfathom

--- a/deploy/helm/mailfathom/ci/refusals/a-rollout-that-can-never-take-a-step-values.yaml
+++ b/deploy/helm/mailfathom/ci/refusals/a-rollout-that-can-never-take-a-step-values.yaml
@@ -1,0 +1,28 @@
+# Copyright © 2026 Krzysztof Kasprowicz
+# Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+# Project repository: https://github.com/Krzysztof318/MailFathom
+
+# refuses: A rollout allowed neither a pod below the replica count nor a pod above it can never replace anything
+
+# The one rollout the pair of halves makes impossible, written the way an operator arrives at it: `maxSurge: 0` alone,
+# which is what a tight quota asks for, leaving the chart's own `maxUnavailable: 0` underneath — because Helm merges a
+# values document into the defaults rather than replacing them. Each half is a legitimate zero by itself, which is why
+# the schema accepts both and this is the validation helper's refusal rather than the schema's.
+#
+# The percentage form is the same refusal and is not given a document of its own: the helper reads `0` and `0%` as one
+# value, and a second document here would render the same failure through a different spelling.
+image:
+  repository: example/mailfathom
+  tag: 0.1.0-verification
+  allowVersionMismatch: true
+
+secrets:
+  existingSecret: mailfathom-secrets
+
+database:
+  deploy:
+    superuserPasswordSecret: mailfathom-postgres-superuser
+
+strategy:
+  rollingUpdate:
+    maxSurge: 0

--- a/deploy/helm/mailfathom/ci/release-values.yaml
+++ b/deploy/helm/mailfathom/ci/release-values.yaml
@@ -106,3 +106,15 @@ ingress:
     - secretName: mailfathom-tls
       hosts:
         - mailfathom.example.test
+
+# The other branch of both workload decisions, matching every other choice this file renders the far side of. `Recreate`
+# is the rollout type that accepts no `rollingUpdate` block, so this document proves the chart renders none beside it —
+# Helm merges a values document into the chart's defaults rather than replacing them, and the block left underneath
+# would be a Deployment the API server refuses. The budget is off, which renders no PodDisruptionBudget at all, for the
+# deployment whose disruption policy belongs to something else in its cluster. Every other document here renders the
+# defaults: the rolling type with its block, and the budget.
+strategy:
+  type: Recreate
+
+podDisruptionBudget:
+  enabled: false

--- a/deploy/helm/mailfathom/templates/_helpers.tpl
+++ b/deploy/helm/mailfathom/templates/_helpers.tpl
@@ -142,6 +142,24 @@ run supplies one — see Chart.yaml.
   {{- fail (printf "image.tag is %q but this chart documents application version %q. Deploying a different version than the chart describes is allowed, but it has to be said: set image.allowVersionMismatch=true." .Values.image.tag .Chart.AppVersion) -}}
 {{- end -}}
 
+{{/*
+A rollout that can never take a step. Each half is a legitimate zero on its own — no pod below the replica count, or no
+pod above it — and the pair is what the API server refuses, so this is the helper's to catch rather than the schema's.
+It is refused here rather than left to the cluster because of how a values document reaches this chart: Helm merges it
+into these defaults, so an operator who writes `maxSurge: 0` alone under a tight quota keeps `maxUnavailable: 0`
+underneath and installs a Deployment that is rejected after the release is already being applied. Both forms of zero
+are read, a count and a percentage, and an absent half is left alone: Kubernetes then applies its own default, which is
+not zero.
+*/}}
+{{- if eq .Values.strategy.type "RollingUpdate" -}}
+  {{- $rollingUpdate := .Values.strategy.rollingUpdate | default dict -}}
+  {{- $unavailable := printf "%v" (dig "maxUnavailable" "unset" $rollingUpdate) -}}
+  {{- $surge := printf "%v" (dig "maxSurge" "unset" $rollingUpdate) -}}
+  {{- if and (has $unavailable (list "0" "0%")) (has $surge (list "0" "0%")) -}}
+    {{- fail (printf "strategy.rollingUpdate.maxUnavailable is %v and strategy.rollingUpdate.maxSurge is %v. A rollout allowed neither a pod below the replica count nor a pod above it can never replace anything, and the API server refuses the Deployment rather than stalling it. Raise one of the two: maxSurge 1 keeps every replica serving and needs room for one more pod, and maxUnavailable 1 needs no extra room and takes one replica out while it is replaced." $unavailable $surge) -}}
+  {{- end -}}
+{{- end -}}
+
 {{- if .Values.database.deploy.enabled -}}
   {{- if .Values.database.host -}}
     {{- fail (printf "database.host is %q while database.deploy.enabled is true. The chart is deploying the server and derives its address from the release name, so a second address here would name somewhere the release did not install. Clear it, or turn database.deploy.enabled off to use a server you already operate." .Values.database.host) -}}

--- a/deploy/helm/mailfathom/templates/deployment.yaml
+++ b/deploy/helm/mailfathom/templates/deployment.yaml
@@ -12,6 +12,22 @@ metadata:
     {{- include "mailfathom.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- /*
+    Stated rather than left to Kubernetes, because what it decides is whether an upgrade ever has fewer pods serving
+    than `replicaCount` and whether two versions run together. The default keeps a pod serving at every instant, which
+    is what holds the schema order this chart's notes and its page both give: a new pod refuses a schema behind it and
+    never becomes ready, and the pods already serving are still there.
+
+    The `rollingUpdate` block is rendered only beside the type that accepts one. Helm merges a values document into
+    this chart's defaults rather than replacing them, so a deployment selecting `Recreate` would otherwise keep the
+    default's block underneath and produce a Deployment the API server refuses.
+  */}}
+  strategy:
+    type: {{ .Values.strategy.type }}
+    {{- if eq .Values.strategy.type "RollingUpdate" }}
+    rollingUpdate:
+      {{- toYaml .Values.strategy.rollingUpdate | nindent 6 }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "mailfathom.selectorLabels" . | nindent 6 }}

--- a/deploy/helm/mailfathom/templates/poddisruptionbudget.yaml
+++ b/deploy/helm/mailfathom/templates/poddisruptionbudget.yaml
@@ -1,0 +1,28 @@
+{{- /*
+Copyright © 2026 Krzysztof Kasprowicz
+Licensed under the GNU Affero General Public License, Version 3. See LICENSE in the project root for license information.
+Project repository: https://github.com/Krzysztof318/MailFathom
+*/ -}}
+{{- if .Values.podDisruptionBudget.enabled }}
+{{- include "mailfathom.validate" . -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "mailfathom.fullname" . }}
+  labels:
+    {{- include "mailfathom.labels" . | nindent 4 }}
+spec:
+  {{- /*
+    How many pods may be missing rather than how many must remain, which is the form that reads the same at every
+    replica count: a budget demanding one pod remain would refuse every drain of the single-replica default, and the
+    cluster upgrade that never finishes reports itself as a node that will not cordon rather than as this object.
+
+    What it buys above one replica is that a drain takes the replicas one at a time. Work a replica holds under a lease
+    moves to another when the pod stopping releases it, and a drain taking every holder at once instead leaves each
+    scope waiting out its expiry with nothing running it.
+  */}}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "mailfathom.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/mailfathom/values.schema.json
+++ b/deploy/helm/mailfathom/values.schema.json
@@ -54,7 +54,7 @@
                   "pattern": "^(0|[1-9][0-9]?|100)%$"
                 }
               ],
-              "description": "How many pods below the replica count a rollout may go, as a count or a percentage. The chart's default is 0, which is what keeps a pod serving at every instant of an upgrade."
+              "description": "How many pods below the replica count a rollout may go, as a count or a percentage. The chart's default is 0, which is what keeps a pod serving at every instant of an upgrade. A percentage above 100 is refused here because Kubernetes refuses one too: more than every pod cannot be taken away."
             },
             "maxSurge": {
               "oneOf": [
@@ -64,7 +64,7 @@
                 },
                 {
                   "type": "string",
-                  "pattern": "^(0|[1-9][0-9]?|100)%$"
+                  "pattern": "^(0|[1-9][0-9]*)%$"
                 }
               ],
               "description": "How many pods above the replica count a rollout may start, as a count or a percentage. Either half may be zero on its own, and both being zero is a rollout that can never take a step: the chart's own validation refuses that pair, in either form, rather than leaving it to the API server to reject the Deployment after a release is already being applied."

--- a/deploy/helm/mailfathom/values.schema.json
+++ b/deploy/helm/mailfathom/values.schema.json
@@ -67,7 +67,7 @@
                   "pattern": "^(0|[1-9][0-9]?|100)%$"
                 }
               ],
-              "description": "How many pods above the replica count a rollout may start, as a count or a percentage. Kubernetes refuses both halves being zero, because that is a rollout that can never take a step."
+              "description": "How many pods above the replica count a rollout may start, as a count or a percentage. Either half may be zero on its own, and both being zero is a rollout that can never take a step: the chart's own validation refuses that pair, in either form, rather than leaving it to the API server to reject the Deployment after a release is already being applied."
             }
           }
         }

--- a/deploy/helm/mailfathom/values.schema.json
+++ b/deploy/helm/mailfathom/values.schema.json
@@ -20,7 +20,85 @@
     },
     "replicaCount": {
       "type": "integer",
-      "minimum": 0
+      "minimum": 0,
+      "description": "How many MailFathom processes serve this deployment. More than one gives request capacity and an upgrade with nothing down, and divides no single account's synchronization, which one lease holds at a time. Above one the chart's own validation refuses a values document serving the client surface with no signal backplane; nothing else about several replicas is a refusal, and every ceiling worded as one process's multiplies with this number."
+    },
+    "strategy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "RollingUpdate",
+            "Recreate"
+          ],
+          "description": "How an upgrade replaces the pods. 'RollingUpdate' with the chart's defaults keeps a pod serving at every instant, which is what makes a new pod that refuses the schema it finds harmless. 'Recreate' stops every pod before starting one, and the chart renders no rollingUpdate block beside it."
+        },
+        "rollingUpdate": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Rendered only beside the type that accepts one, so selecting 'Recreate' leaves nothing here to refuse. Both halves are named here rather than passed through, because a misspelled key would otherwise reach the API server as a rollout with the chart's defaults silently still in force.",
+          "properties": {
+            "maxUnavailable": {
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                {
+                  "type": "string",
+                  "pattern": "^(0|[1-9][0-9]?|100)%$"
+                }
+              ],
+              "description": "How many pods below the replica count a rollout may go, as a count or a percentage. The chart's default is 0, which is what keeps a pod serving at every instant of an upgrade."
+            },
+            "maxSurge": {
+              "oneOf": [
+                {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                {
+                  "type": "string",
+                  "pattern": "^(0|[1-9][0-9]?|100)%$"
+                }
+              ],
+              "description": "How many pods above the replica count a rollout may start, as a count or a percentage. Kubernetes refuses both halves being zero, because that is a rollout that can never take a step."
+            }
+          }
+        }
+      }
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "enabled",
+        "maxUnavailable"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether a PodDisruptionBudget is rendered for the application pods. On, a drain takes them one at a time, so leased work is handed over rather than waiting out an expiry. Off renders no object, for a cluster where something else owns disruption policy for this workload."
+        },
+        "maxUnavailable": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 1
+            },
+            {
+              "type": "string",
+              "pattern": "^([1-9][0-9]?|100)%$"
+            }
+          ],
+          "description": "How many pods a voluntary disruption may take at once, as a count or a percentage. Zero is refused in either form: a budget permitting no disruption at all blocks every drain rather than pacing one, and reports itself as a node that will not cordon. The budget is deliberately not expressible as how many pods must remain, which would refuse every drain of the single-replica default."
+        }
+      }
     },
     "image": {
       "type": "object",

--- a/deploy/helm/mailfathom/values.yaml
+++ b/deploy/helm/mailfathom/values.yaml
@@ -781,9 +781,10 @@ ingress:
 # StatefulSet on a ReadWriteOnce claim whatever this number says. They do not divide one account's synchronization,
 # which is one lease and therefore one replica's at a time, so a single large mailbox is not synchronized faster by
 # raising this. And they multiply every ceiling worded as one process's rather than the deployment's —
-# `Jobs:MaxConcurrentJobs`, `MailSynchronization:MaxInFlightRawMimeBytes`, `Embeddings:MaxQueuedEmails`, and
-# `Resilience:AiProviderInvocation:ConcurrencyLimit` are each replica's own, so a deployment of *n* replicas runs up to
-# *n* times them and a provider's concurrency is respected by dividing rather than by restating. Every ceiling worded
+# `Jobs:MaxConcurrentJobs`, `MailSynchronization:MaxInFlightRawMimeBytes`, `Embeddings:MaxQueuedEmails`,
+# `Resilience:AiProviderInvocation:ConcurrencyLimit`, and every endpoint's `RateLimiting` block are each replica's own,
+# so a deployment of *n* replicas runs up to *n* times them and both a provider's concurrency and an endpoint's burst
+# are respected by dividing rather than by restating. Every ceiling worded
 # as the deployment's is a row each replica shares and stays the figure it names; the configuration reference says
 # which of the two each setting is, per setting.
 #
@@ -803,6 +804,11 @@ replicaCount: 1
 # same idempotency key. `Recreate` is the other type Kubernetes accepts and stops every pod before starting one; the
 # chart renders no `rollingUpdate` block beside it, so selecting it here produces a manifest the API server accepts
 # rather than one it refuses.
+#
+# Either half may be zero on its own and both may not, because a rollout allowed neither a pod below the replica count
+# nor a pod above it can never replace anything. The chart refuses that pair itself — a values document is *merged*
+# into the defaults above rather than replacing them, so writing `maxSurge: 0` alone keeps the zero underneath and
+# would otherwise install a Deployment the API server rejects.
 strategy:
   type: RollingUpdate
   rollingUpdate:

--- a/deploy/helm/mailfathom/values.yaml
+++ b/deploy/helm/mailfathom/values.yaml
@@ -761,7 +761,66 @@ ingress:
   #      - mailfathom.example.test
 
 ### Workload
+#
+# How many MailFathom processes serve this deployment. One is the default and asks nothing of you; more than one is
+# supported, and what it gives is request capacity and an upgrade with nothing down — never a second copy of any work.
+# A mail account is synchronized by whichever replica holds its lease and by no other, a deployment-wide sweep by
+# whichever holds the sweep's, and a request, a tool call, or a page is answered by whichever replica the Service
+# routed it to.
+#
+# **Two things have to hold above one replica, and the chart refuses the one it can see.** A client's live updates need
+# `signalBackplane` above, because the replica that raised a signal is routinely not the replica holding the connection
+# that has to hear about it — so a values document serving the client surface with more than one replica and no
+# backplane is refused rather than installed. A signed-in session needs nothing at all: it is a row in PostgreSQL, so
+# every replica accepts one any other replica minted and honours its revocation, and no session affinity is asked of
+# whatever balances the traffic. What that load balancer does owe the client's one standing connection — the WebSocket
+# upgrade passed, and no idle timeout shorter than a connection MailFathom keeps alive — is stated on the page named
+# below, because it is a requirement of your ingress rather than a value here.
+#
+# **What several replicas do not give.** They are not availability for the database: one the chart deploys is a single
+# StatefulSet on a ReadWriteOnce claim whatever this number says. They do not divide one account's synchronization,
+# which is one lease and therefore one replica's at a time, so a single large mailbox is not synchronized faster by
+# raising this. And they multiply every ceiling worded as one process's rather than the deployment's —
+# `Jobs:MaxConcurrentJobs`, `MailSynchronization:MaxInFlightRawMimeBytes`, `Embeddings:MaxQueuedEmails`, and
+# `Resilience:AiProviderInvocation:ConcurrencyLimit` are each replica's own, so a deployment of *n* replicas runs up to
+# *n* times them and a provider's concurrency is respected by dividing rather than by restating. Every ceiling worded
+# as the deployment's is a row each replica shares and stays the figure it names; the configuration reference says
+# which of the two each setting is, per setting.
+#
+# docs/operations/deployment-kubernetes.md holds the operator's reading of all of it, under *Running more than one
+# replica*.
 replicaCount: 1
+
+# **How an upgrade replaces the pods, stated by the chart rather than inherited from Kubernetes.** The default below
+# starts a replacement pod before any running pod is taken away and waits for it to pass its probes, so at every
+# instant of a rollout at least `replicaCount` pods are serving — which is what makes the schema step's order hold: a
+# new pod that refuses the schema it finds never becomes ready, and the pods already serving keep serving rather than
+# having been replaced by it.
+#
+# Two versions therefore run together for the length of a rollout, and that is safe rather than tolerated: leased work
+# moves to the replacement when the pod being stopped releases its lease, a claim reaches only the job types the
+# claiming replica's own build registers a handler for, and two replicas reaching one scheduled occasion compose the
+# same idempotency key. `Recreate` is the other type Kubernetes accepts and stops every pod before starting one; the
+# chart renders no `rollingUpdate` block beside it, so selecting it here produces a manifest the API server accepts
+# rather than one it refuses.
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 1
+
+# **What a drain may take at once.** A PodDisruptionBudget is the only thing that makes a node upgrade evict these pods
+# one at a time; without one, a drain that reaches two nodes takes every replica on them together, and work held under
+# a lease then waits out the lease rather than being handed over — up to `MailSynchronization:LeaseDuration` per
+# account, two minutes by default, with nothing synchronizing in between.
+#
+# It is expressed as how many pods may be missing rather than how many must remain, deliberately: `maxUnavailable: 1`
+# reads the same at every replica count, while a budget demanding one pod remain would block every drain of the
+# single-replica default forever — a cluster upgrade that never finishes, reported as a node that will not cordon.
+# Turn it off where something else in your cluster owns disruption policy for this workload.
+podDisruptionBudget:
+  enabled: true
+  maxUnavailable: 1
 
 resources:
   requests:

--- a/deploy/quadlet/mailfathom-valkey.container
+++ b/deploy/quadlet/mailfathom-valkey.container
@@ -12,8 +12,11 @@
 # **On one host it does nothing, and that is the expected state rather than a misconfiguration.** This directory runs one
 # MailFathom, so every signal already reaches every client connection the deployment holds and the server relays each one
 # back to the single subscriber that published it. It is here so that this shape offers the same component the Helm chart
-# does, and so that a deployment which grows a second instance has the piece provisioned before it needs one. Running
-# more than one MailFathom under Quadlet is not supported today; issue #1295 decides whether it will be.
+# does, and so that a deployment which grows a second instance has the piece provisioned before it needs one.
+# **Running more than one MailFathom under Quadlet is not supported**: mailfathom.container publishes fixed host ports,
+# so a second unit has nothing to bind, and nothing here balances requests between two of them. The application asks
+# for nothing further — its coordination is rows in PostgreSQL — so what stops at one instance is this deployment
+# shape, and the Helm chart is where more than one replica is supported.
 #
 # Rootless, like the units beside it, and installed under ~/.config/containers/systemd/.
 

--- a/deploy/quadlet/mailfathom-valkey.container
+++ b/deploy/quadlet/mailfathom-valkey.container
@@ -12,7 +12,7 @@
 # **On one host it does nothing, and that is the expected state rather than a misconfiguration.** This directory runs one
 # MailFathom, so every signal already reaches every client connection the deployment holds and the server relays each one
 # back to the single subscriber that published it. It is here so that this shape offers the same component the Helm chart
-# does, and so that a deployment which grows a second instance has the piece provisioned before it needs one.
+# does, and so that a deployment which expects to move to the chart can provision it before it needs one.
 # **Running more than one MailFathom under Quadlet is not supported**: mailfathom.container publishes fixed host ports,
 # so a second unit has nothing to bind, and nothing here balances requests between two of them. The application asks
 # for nothing further — its coordination is rows in PostgreSQL — so what stops at one instance is this deployment

--- a/deploy/quadlet/mailfathom.container
+++ b/deploy/quadlet/mailfathom.container
@@ -227,7 +227,11 @@ Environment=Persistence__Password__SecretReference=systemd-credential:mailfathom
 #
 # **On one host it changes nothing an operator can observe**, and that is the expected state: a signal raised here
 # already reaches every client connection this deployment holds, because one process holds them all. What it is for is a
-# second instance, and running one under Quadlet is not supported today — issue #1295 decides whether it will be.
+# second instance, and **running one under Quadlet is not supported**: the PublishPort= lines above name fixed host
+# addresses, so a second unit has nothing to bind, and nothing here balances requests between two of them or holds a
+# client's connection across a restart. MailFathom asks for nothing further — leases, sessions, and spent assertions
+# are rows in PostgreSQL — so what stops at one instance is this deployment shape rather than the application, and the
+# Helm chart is where more than one replica is supported.
 #
 # The reference is a systemd credential like the database password, so it needs a LoadCredentialEncrypted= line in the
 # [Service] section below. What it holds is a whole StackExchange.Redis connection string rather than a bare password:

--- a/docs/operations/deployment-compose.md
+++ b/docs/operations/deployment-compose.md
@@ -839,8 +839,8 @@ The stack has a sixth service, `valkey`, and it is not started either. It sits b
 carries a client signal from the instance that raised it to the instances holding the connections that have to hear
 about it, and this file runs one MailFathom — so every signal already reaches every connection this deployment holds,
 and the server relays each one back to the single subscriber that published it. It is here so that this shape offers the
-same component [the chart](deployment-kubernetes.md) does, and so that a deployment which grows a second instance has
-the piece provisioned before it needs one.
+same component [the chart](deployment-kubernetes.md) does, and so that a deployment which expects to move to the chart
+can provision it before it needs one.
 
 **Running more than one MailFathom under Compose is not supported**, and the reason is this shape rather than the
 application. The service publishes fixed host ports, so a second container has nothing to bind; nothing here balances

--- a/docs/operations/deployment-compose.md
+++ b/docs/operations/deployment-compose.md
@@ -840,7 +840,14 @@ carries a client signal from the instance that raised it to the instances holdin
 about it, and this file runs one MailFathom — so every signal already reaches every connection this deployment holds,
 and the server relays each one back to the single subscriber that published it. It is here so that this shape offers the
 same component [the chart](deployment-kubernetes.md) does, and so that a deployment which grows a second instance has
-the piece provisioned before it needs one. Running more than one MailFathom under Compose is not supported today.
+the piece provisioned before it needs one.
+
+**Running more than one MailFathom under Compose is not supported**, and the reason is this shape rather than the
+application. The service publishes fixed host ports, so a second container has nothing to bind; nothing here balances
+requests between two of them, holds a client's connection across a replacement, or gates a replacement on a readiness
+probe. What the application needs above one instance it already has — its coordination is rows in PostgreSQL, and this
+backplane — so [the chart](deployment-kubernetes.md#running-more-than-one-replica) is where more than one replica is
+supported and stated.
 [`SignalBackplane`](configuration-endpoints.md#signalbackplane) is what the section means, and
 [the signal channel](client-endpoint.md#the-signal-channel) is what a client does when a signal does not arrive.
 

--- a/docs/operations/deployment-kubernetes.md
+++ b/docs/operations/deployment-kubernetes.md
@@ -405,21 +405,30 @@ not about MailFathom at all:
   claim whatever this number says, so a node taking that pod takes the deployment with it. Point the chart at a server
   somebody operates before the replica count is what your availability rests on.
 - **Every ceiling worded as one process's multiplies.** `Jobs:MaxConcurrentJobs`,
-  `MailSynchronization:MaxInFlightRawMimeBytes`, `Embeddings:MaxQueuedEmails`, and
-  `Resilience:AiProviderInvocation:ConcurrencyLimit` are each replica's own, deliberately: what they bound is that
+  `MailSynchronization:MaxInFlightRawMimeBytes`, `Embeddings:MaxQueuedEmails`,
+  `Resilience:AiProviderInvocation:ConcurrencyLimit`, and every endpoint's `RateLimiting` are each replica's own,
+  deliberately: what they bound is that
   process's threads, memory, and sockets. A deployment of *n* replicas runs up to *n* times them, so a provider's own
   concurrency is respected by dividing the figure rather than by restating it. Every ceiling worded as the
   deployment's — the two content-storage ceilings, the paced request rates, the answering spend — is a row each replica
   shares and stays the figure it names. The [configuration reference](configuration-reference.md) says which of the two
   each setting is, per setting.
 
-**Nothing about several replicas weakens a security property.** A client assertion is spendable once for the whole
-deployment, because the record of a spent identifier is a row under a unique constraint rather than a dictionary in one
-process — so an identifier any replica served is refused by every replica, and there is no window to route around. It is
-a shared store rather than affinity for a reason worth stating: affinity is honoured by the client, and the client here
-is whoever captured the assertion.
+**No guarantee is weakened by several replicas, and one budget is multiplied by them.** A client assertion is spendable
+once for the whole deployment, because the record of a spent identifier is a row under a unique constraint rather than a
+dictionary in one process — so an identifier any replica served is refused by every replica, and there is no window to
+route around. It is a shared store rather than affinity for a reason worth stating: affinity is honoured by the client,
+and the client here is whoever captured the assertion.
 [The assertions this deployment has already served](../architecture/stored-email-schema.md#the-assertions-this-deployment-has-already-served)
 is the table.
+
+**The endpoint rate limiters are the exception, and they are a bound rather than a guarantee.**
+`McpEndpoint:RateLimiting`, `AdminEndpoint:RateLimiting`, and `ClientEndpoint:RateLimiting` each count in one process,
+so a deployment of *n* replicas admits up to *n* times what one of them declares and `TokenCapacity` is the largest
+burst one caller may spend at one replica. That matters most on the administrative surface, where the limiter is what
+stands between an API key and unbounded guessing: divide the figure when the replica count is raised rather than
+leaving it as it was sized for one process.
+[Rate limiting](configuration-endpoints.md#rate-limiting) states every value and which of the two it is.
 
 **A signed-in session needs nothing either.** It is a row in PostgreSQL, so every replica accepts a session any other
 replica minted and honours its revocation the moment it is written;
@@ -467,6 +476,12 @@ for, so work a newer replica introduced waits for one instead of failing on an o
 scheduled occasion compose the same idempotency key; and a leased scope is released by the pod being stopped and
 claimed by whichever replica takes it next. `Recreate` is the other type Kubernetes accepts, and the chart
 renders no `rollingUpdate` block beside it, so choosing it produces a Deployment the API server accepts.
+
+Either half of `rollingUpdate` may be zero and both may not, and the chart refuses that pair rather than letting the
+API server reject the Deployment while a release is being applied. The refusal exists because a values document is
+merged into the chart's defaults rather than replacing them: writing `maxSurge: 0` alone — which is what a tight quota
+asks for — keeps `maxUnavailable: 0` underneath, and a rollout allowed neither a pod below the replica count nor a pod
+above it can never replace anything.
 
 **A rolling upgrade hands leased work over rather than parking it.** A pod stopping releases every lease it holds, so
 the account it was synchronizing is claimable immediately. The release is an optimization of the ordinary case and

--- a/docs/operations/deployment-kubernetes.md
+++ b/docs/operations/deployment-kubernetes.md
@@ -380,6 +380,109 @@ Two more things belong to the same decision:
 `ClientEndpoint:Authentication` requires is still required of it. Serving the page grants nobody anything; what it
 exposes is the application's own code, which is published under AGPL-3.0-only in this repository.
 
+## Running more than one replica
+
+`replicaCount` is a value like any other, and raising it is supported:
+
+```yaml
+replicaCount: 3
+```
+
+**What it gives is capacity and an upgrade with nothing down, and never a second copy of any work.** Every request, tool
+call, and page is answered by whichever replica the Service routed it to, and that is the whole of the gain on the
+serving side. On the working side a scope is held by one replica at a time under a lease row — one mail account's
+synchronization, one deployment-wide sweep, one operator-asked re-derivation, the stored-content move — so three
+replicas divide the accounts between themselves rather than each synchronizing all of them.
+[ADR 0031](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0031-dividing-singleton-work-between-replicas-with-a-leased-scope.md)
+is that mechanism, and the administrative surface answers who holds what.
+
+**What one replica does that several do not** is worth reading before raising the number, because two of the three are
+not about MailFathom at all:
+
+- **A single account is not synchronized faster.** Its supervision is one lease, so the parallelism is between accounts
+  and never inside one. A deployment with one large mailbox gains nothing here.
+- **The database is not made available.** One the chart deploys is a single-replica StatefulSet on a ReadWriteOnce
+  claim whatever this number says, so a node taking that pod takes the deployment with it. Point the chart at a server
+  somebody operates before the replica count is what your availability rests on.
+- **Every ceiling worded as one process's multiplies.** `Jobs:MaxConcurrentJobs`,
+  `MailSynchronization:MaxInFlightRawMimeBytes`, `Embeddings:MaxQueuedEmails`, and
+  `Resilience:AiProviderInvocation:ConcurrencyLimit` are each replica's own, deliberately: what they bound is that
+  process's threads, memory, and sockets. A deployment of *n* replicas runs up to *n* times them, so a provider's own
+  concurrency is respected by dividing the figure rather than by restating it. Every ceiling worded as the
+  deployment's — the two content-storage ceilings, the paced request rates, the answering spend — is a row each replica
+  shares and stays the figure it names. The [configuration reference](configuration-reference.md) says which of the two
+  each setting is, per setting.
+
+**Nothing about several replicas weakens a security property.** A client assertion is spendable once for the whole
+deployment, because the record of a spent identifier is a row under a unique constraint rather than a dictionary in one
+process — so an identifier any replica served is refused by every replica, and there is no window to route around. It is
+a shared store rather than affinity for a reason worth stating: affinity is honoured by the client, and the client here
+is whoever captured the assertion.
+[The assertions this deployment has already served](../architecture/stored-email-schema.md#the-assertions-this-deployment-has-already-served)
+is the table.
+
+**A signed-in session needs nothing either.** It is a row in PostgreSQL, so every replica accepts a session any other
+replica minted and honours its revocation the moment it is written;
+[the session token routes](client-endpoint.md#the-session-token-routes) is that half. What a client's live updates need
+is [the backplane below](#signals-between-replicas), which is the one thing above one replica the chart refuses to
+install without.
+
+### What your load balancer owes the client's connection
+
+The signal channel is a WebSocket and it never negotiates a fallback, so whatever routes traffic to these pods owes it
+three things. They are the ingress controller's, the mesh's, or the cloud load balancer's settings rather than chart
+values, which is why they are stated here and templated nowhere:
+
+- **Pass the WebSocket upgrade.** A proxy that strips `Connection` and `Upgrade`, or answers the handshake itself,
+  leaves the client with no channel and a screen that updates only on its own re-read.
+- **Keep no idle timeout shorter than a standing connection.** The connection carries a keep-alive frame rather than
+  traffic, so a timeout measured on bytes closes a healthy channel; the client reconnects and re-reads, which costs a
+  request per timeout and a gap per reconnect.
+- **Use no session affinity.** It is not needed for anything — the session is a row, the ticket redeeming the handshake
+  is a row, and a signal crosses replicas over the backplane — and turning it on concentrates connections rather than
+  balancing them.
+
+### What the chart renders for the rollout and the drain
+
+Two objects an operator would otherwise have to add themselves, both from values:
+
+```yaml
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 1
+
+podDisruptionBudget:
+  enabled: true
+  maxUnavailable: 1
+```
+
+**The rollout keeps a pod serving at every instant**, because `maxUnavailable: 0` starts the replacement and waits for
+its probes before anything is taken away. That is what makes the schema order above hold on an upgrade as well as on an
+install: a new pod that refuses a schema behind it never becomes ready, and the pods already serving are still there
+rather than having been replaced by it. It also means **two versions run together for the length of a rollout**, which
+is safe rather than tolerated — a claim reaches only the job types the claiming replica's own build registers a handler
+for, so work a newer replica introduced waits for one instead of failing on an older one; two replicas reaching one
+scheduled occasion compose the same idempotency key; and a leased scope is released by the pod being stopped and
+claimed by whichever replica takes it next. `Recreate` is the other type Kubernetes accepts, and the chart
+renders no `rollingUpdate` block beside it, so choosing it produces a Deployment the API server accepts.
+
+**A rolling upgrade hands leased work over rather than parking it.** A pod stopping releases every lease it holds, so
+the account it was synchronizing is claimable immediately. The release is an optimization of the ordinary case and
+nothing rests on it: a replica that was killed rather than stopped leaves its scopes held until they expire, which is
+`MailSynchronization:LeaseDuration` for an account and two minutes by default. Raise
+`terminationGracePeriodSeconds` and `MailSynchronization:ShutdownDrainTimeout` together if a drain has to wait for
+longer work — the grace period shorter than the drain kills the process with the drain still running.
+
+**The PodDisruptionBudget is what makes a node drain pace itself.** Without one, a drain reaching two nodes evicts every
+replica on them at once, and each scope those replicas held then waits out its expiry with nothing running it — which
+for a deployment carrying leases is an outage of synchronization rather than a handover. It is expressed as how many
+pods may be missing rather than how many must remain, which reads the same at every replica count: a budget demanding
+one pod remain would refuse every drain of the single-replica default, and a cluster upgrade that never finishes
+reports itself as a node that will not cordon. Turn it off where something else in your cluster owns disruption policy
+for this workload.
+
 ## Signals between replicas
 
 A client's live updates arrive over one connection, held by whichever replica answered its handshake. Above one replica
@@ -947,7 +1050,9 @@ derived — the answering audit trail and the embeddings.
 
 `nodeSelector`, `tolerations`, `affinity`, `topologySpreadConstraints`, `priorityClassName`, `resources`,
 `podAnnotations`, `podLabels`, `service.type`, `service.annotations`, and `terminationGracePeriodSeconds` are all
-values. Nothing requires editing a template.
+values. Nothing requires editing a template. `strategy` and `podDisruptionBudget` are values as well, and
+[what the chart renders for the rollout and the drain](#what-the-chart-renders-for-the-rollout-and-the-drain) is what
+each of them decides.
 
 `terminationGracePeriodSeconds` defaults to 60 against a 10-second `MailSynchronization:ShutdownDrainTimeout`. Raise
 them together: a grace period shorter than the drain kills the process with the drain still running.

--- a/docs/operations/deployment-kubernetes.md
+++ b/docs/operations/deployment-kubernetes.md
@@ -424,11 +424,14 @@ is the table.
 
 **The endpoint rate limiters are the exception, and they are a bound rather than a guarantee.**
 `McpEndpoint:RateLimiting`, `AdminEndpoint:RateLimiting`, and `ClientEndpoint:RateLimiting` each count in one process,
-so a deployment of *n* replicas admits up to *n* times what one of them declares and `TokenCapacity` is the largest
-burst one caller may spend at one replica. That matters most on the administrative surface, where the limiter is what
-stands between an API key and unbounded guessing: divide the figure when the replica count is raised rather than
-leaving it as it was sized for one process.
-[Rate limiting](configuration-endpoints.md#rate-limiting) states every value and which of the two it is.
+so a deployment of *n* replicas admits up to *n* times what one of them declares. What `TokenCapacity` is the burst of
+differs by surface: one caller's, at one replica, on the MCP and client surfaces, and **the whole endpoint's** on the
+administrative one, where the credential is judged behind the limiter so an administrative request is still anonymous
+when it is counted and every caller shares one bucket. That is the surface where this matters most, because the limiter
+is what stands between an API key and unbounded guessing — so divide the figure when the replica count is raised rather
+than leaving it as it was sized for one process.
+[Rate limiting](configuration-endpoints.md#rate-limiting) is every value and which of the two it is, and
+[the administrative endpoint's own](admin-endpoint.md#rate-limiting) is why its bucket is not partitioned.
 
 **A signed-in session needs nothing either.** It is a row in PostgreSQL, so every replica accepts a session any other
 replica minted and honours its revocation the moment it is written;

--- a/docs/operations/deployment-kubernetes.md
+++ b/docs/operations/deployment-kubernetes.md
@@ -13,6 +13,7 @@ operates the cluster, and the chart is written so that it cannot pretend otherwi
 | A personal-data analyzer Deployment and Service, and a SpamAssassin Deployment and Service, only when the section that owns each is enabled and left to deploy its own | Any schema step |
 | A Silo object-store StatefulSet, its claim, and its Service, only when `contentStorage.objectStorage.deploy.enabled` is true | Any bucket, or any access key inside one |
 | A Valkey StatefulSet and two Services for the signal backplane, only when `signalBackplane.enabled` and `.valkey.deploy` are both true | |
+| A PodDisruptionBudget for the application pods, at any replica count, unless `podDisruptionBudget.enabled` is false | Any HorizontalPodAutoscaler, or any metric-driven scaling |
 | An optional Ingress | |
 
 ## What you supply
@@ -477,8 +478,11 @@ rather than having been replaced by it. It also means **two versions run togethe
 is safe rather than tolerated — a claim reaches only the job types the claiming replica's own build registers a handler
 for, so work a newer replica introduced waits for one instead of failing on an older one; two replicas reaching one
 scheduled occasion compose the same idempotency key; and a leased scope is released by the pod being stopped and
-claimed by whichever replica takes it next. `Recreate` is the other type Kubernetes accepts, and the chart
-renders no `rollingUpdate` block beside it, so choosing it produces a Deployment the API server accepts.
+claimed by whichever replica takes it next. `Recreate` is the other type Kubernetes accepts, and the chart renders no
+`rollingUpdate` block beside it, so choosing it produces a Deployment the API server accepts — but it stops every pod
+before starting one, so an upgrade under it has a window with nothing serving whatever order the schema is applied in.
+The order [upgrading](#upgrading-rolling-back-and-uninstalling) gives is the one with no such window, and that holds
+under the rolling default rather than under this type.
 
 Either half of `rollingUpdate` may be zero and both may not, and the chart refuses that pair rather than letting the
 API server reject the Deployment while a release is being applied. The refusal exists because a values document is
@@ -1081,7 +1085,9 @@ Back up the database — and the bucket beside it where `contentStorage.backend`
 [what you now back up](#what-you-now-back-up-and-in-which-order) gives — and apply the new release's
 `mailfathom-schema-<version>.sql` **before** the upgrade. The new pod
 refuses to start against a schema that is behind it, and the old pod keeps serving against a schema that is ahead — so
-that order is the one with no window in which nothing serves.
+that order is the one with no window in which nothing serves. That last part is the rolling default's:
+`strategy.type: Recreate` stops every pod before starting one, so an upgrade under it has a window whatever order the
+schema is applied in.
 
 ```bash
 helm upgrade mailfathom deploy/helm/mailfathom --namespace mailfathom --values values.yaml

--- a/docs/operations/deployment-quadlet.md
+++ b/docs/operations/deployment-quadlet.md
@@ -769,8 +769,8 @@ it is how the backplane is off.
 carries a client signal from the instance that raised it to the instances holding the connections that have to hear
 about it, and this directory runs one MailFathom — so every signal already reaches every connection the deployment holds,
 and the server relays each one back to the single subscriber that published it. It is here so that this shape offers the
-same component [the chart](deployment-kubernetes.md) does, and so that a deployment which grows a second instance has the
-piece provisioned before it needs one.
+same component [the chart](deployment-kubernetes.md) does, and so that a deployment which expects to move to the chart
+can provision it before it needs one.
 
 **Running more than one MailFathom under Quadlet is not supported**, and the reason is this shape rather than the
 application. `mailfathom.container` publishes fixed host ports, so a second unit has nothing to bind; nothing here

--- a/docs/operations/deployment-quadlet.md
+++ b/docs/operations/deployment-quadlet.md
@@ -770,7 +770,14 @@ carries a client signal from the instance that raised it to the instances holdin
 about it, and this directory runs one MailFathom — so every signal already reaches every connection the deployment holds,
 and the server relays each one back to the single subscriber that published it. It is here so that this shape offers the
 same component [the chart](deployment-kubernetes.md) does, and so that a deployment which grows a second instance has the
-piece provisioned before it needs one. Running more than one MailFathom under Quadlet is not supported today.
+piece provisioned before it needs one.
+
+**Running more than one MailFathom under Quadlet is not supported**, and the reason is this shape rather than the
+application. `mailfathom.container` publishes fixed host ports, so a second unit has nothing to bind; nothing here
+balances requests between two of them, holds a client's connection across a restart, or gates one on a readiness probe.
+What the application needs above one instance it already has — its coordination is rows in PostgreSQL, and this
+backplane — so [the chart](deployment-kubernetes.md#running-more-than-one-replica) is where more than one replica is
+supported and stated.
 [`SignalBackplane`](configuration-endpoints.md#signalbackplane) is what the section means, and
 [the signal channel](client-endpoint.md#the-signal-channel) is what a client does when a signal does not arrive.
 

--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -97,11 +97,13 @@ what MailFathom asks for — because the replica that noticed a change is routin
 connection.
 The chart refuses to render the combination that would otherwise install, start, and serve every request while telling
 its clients nothing.
-[Signals between replicas](../operations/deployment-kubernetes.md#signals-between-replicas) is the page.
+[Signals between replicas](../operations/deployment-kubernetes.md#signals-between-replicas) is the page, and
+[running more than one replica](../operations/deployment-kubernetes.md#running-more-than-one-replica) is what that
+number gives, what it does not, and what your load balancer owes a client's connection.
 
-Compose and the Quadlet units offer the same server as an opt-in of their own, where it does nothing until a second
-instance exists — a profile in one, a unit you either copy or do not in the other — so a deployment that expects to grow
-can provision it before it needs one. [The signal backplane](../operations/deployment-compose.md#the-signal-backplane)
+Compose and the Quadlet units offer the same server as an opt-in of their own, where on one host it does nothing — a
+profile in one, a unit you either copy or do not in the other — so a deployment that expects to move to the chart can
+provision it before it needs one. [The signal backplane](../operations/deployment-compose.md#the-signal-backplane)
 and [its Quadlet unit](../operations/deployment-quadlet.md#the-signal-backplane) are those two pages.
 
 ## What every shape needs


### PR DESCRIPTION
Closes #1295

`replicaCount` sat under a bare `### Workload` heading with nothing said about what a larger number does, and the two
objects that decide what an upgrade and a drain do to a deployment carrying leases were left to Kubernetes' own
defaults. Every dependency this waited on has landed — #1294, #1880, #1881, #1917, and #1900 — so this is the change
that says, where an operator reads it, that raising the number is supported and what it costs.

## What the chart now renders

**`strategy`, from values, defaulting to a rolling update with `maxUnavailable: 0` and `maxSurge: 1`.** A replacement
pod starts and passes its probes before anything is taken away, so at least `replicaCount` pods are serving at every
instant of a rollout — which is what makes the documented schema order hold on an upgrade as well as on an install: a
new pod that refuses a schema behind it never becomes ready and never displaces one that is serving. The
`rollingUpdate` block is rendered only beside the type that accepts one, because Helm merges a values document into
the chart's defaults rather than replacing them, and a deployment selecting `Recreate` would otherwise keep the
default's block underneath and produce a Deployment the API server refuses.

**A `policy/v1` PodDisruptionBudget, on by default at `maxUnavailable: 1`, turned off with
`podDisruptionBudget.enabled: false`.** It is what makes a node drain evict these pods one at a time, so a leased scope
is released by the pod being stopped and claimed by whichever replica takes it next rather than waiting out its expiry
with nothing running it. It is expressed as how many pods may be missing rather than how many must remain,
deliberately: `maxUnavailable: 1` reads the same at every replica count, while a budget demanding one pod remain would
refuse every drain of the single-replica default — a cluster upgrade that never finishes, reported as a node that will
not cordon.

The schema names both halves of `rollingUpdate` rather than passing an object through, so a misspelled key is refused
at `helm install` instead of arriving as a rollout the chart's defaults are silently still in force for. Zero is
refused for the budget in either the count or the percentage form, because a budget permitting no disruption at all
blocks a drain rather than pacing one.

## What the pages now say

`values.yaml` documents `replicaCount` where it is set: that several replicas give request capacity and an upgrade with
nothing down and never a second copy of any work, that they neither divide one account's synchronization nor make the
database available, which ceilings are each process's and therefore multiply, and that the client's live updates need
the backplane while a signed-in session needs nothing because it is a row.

`docs/operations/deployment-kubernetes.md` gains **Running more than one replica**: the same reading at length, what a
rolling upgrade does to leased work, why an assertion replay is refused across replicas by a shared store rather than
by affinity, and the three things a load balancer owes the client's signal connection — pass the WebSocket upgrade,
keep no idle timeout shorter than a standing connection, use no session affinity. The chart README states what is
rendered for more than one replica and repeats those three, and `docs/users/installation.md` points at the section from
where a reader chooses a deployment shape.

The Compose and Quadlet assets answer the question they had deferred to this issue. **One instance, and the reason is
the shape rather than the application**: both publish fixed host ports, so a second container or unit has nothing to
bind, and nothing there balances requests between two of them or holds a client's connection across a replacement.
MailFathom itself asks for nothing further, its coordination being rows in PostgreSQL, which is why the chart is where
more than one replica is supported.

## Deployment contract

A minor may break this surface and this one is additive, but it is not invisible to an operator, so both halves are
worth naming:

- **A PodDisruptionBudget now renders by default.** An upgrade of an existing release gains one object. The operator
  action, where something else in the cluster owns disruption policy for this workload, is
  `podDisruptionBudget.enabled: false`.
- **The Deployment now states its rollout strategy.** At one replica this is what Kubernetes was already computing
  from its 25% defaults; above one it is stricter, and a deployment wanting the old behaviour writes its own
  `strategy.rollingUpdate`.

No configuration key, database column, or MCP tool argument moves.

## And the instructions the service code is written against

`backend/src/AGENTS.md` opens with a section saying what the deployment this code is for actually is, at the owner's
request, because the chart now documents a replica count above one and every design decision beneath it is made
against that: *n* processes on different nodes sharing only PostgreSQL and an optional backplane, started and stopped
independently, and running two builds of this repository at once for the length of every rolling upgrade. It states
which state is one replica's and invisible to the others, that a guarantee may never rest on that state while a bound
legitimately may and then says so as `× replicaCount`, that work which must not run twice takes a lease keyed by the
scope of the row recording its progress, that a contested row is claimed under `FOR UPDATE SKIP LOCKED` or a
compare-and-set rather than adopted, what two builds at once oblige of a schema change and a new job type, where a
client's connection and session live, that an instrument measures its own process, and that a coordinating behaviour
owes a test for the attempt that lost.

## Verification

- `scripts/render-helm-manifests.sh` passes. The golden manifests under `ci/golden/` carry the new object and the
  stated strategy, and `ci/release-values.yaml` renders the other branch of both decisions — `Recreate` with no
  `rollingUpdate` block, and the budget off rendering no object — so neither branch is produced only by a value
  document nobody verifies. The three `ci/*-values.yaml` cases at `replicaCount: 2` already existed and now render both
  new objects; the five refusals still refuse for the reasons they record.
- `scripts/verify-fast.sh` passes: 15821 tests, 0 failed, the service suites having been reached by the instructions
  file under `backend/src/`. Before that file joined the change it reported the deployment half as reaching neither
  stack, which is what the whole-tree contracts on this pull request answer for.
- `scripts/test-agent-workflow.sh`: 315 passed, 0 failed, which is the licensing header on the new template and the
  absolute-link rule on the chart README.
- `scripts/review-obligations.sh` reports three pages for the compose and Valkey paths — personal-data-analyzer
  languages, secret rotation, telemetry — each read and each silent about instance count, so none owes a change.

Issue: https://github.com/Krzysztof318/MailFathom/issues/1295
Pull request: https://github.com/Krzysztof318/MailFathom/pull/1925
