### PR TITLE
[#1926] Read an asked act only in the folder it was asked in, so a message just filed into the trash can be destroyed there

### DIFF
--- a/frontend/src/Client.App/src/mailboxActs/drawnActs.test.ts
+++ b/frontend/src/Client.App/src/mailboxActs/drawnActs.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { nothingMarkedRead, type MarkedIn, type ReadMarking } from '../readMarking/useReadMarking';
-import { flagActFor, readActFor } from './drawnActs';
+import { flagActFor, readActFor, underway } from './drawnActs';
 import { nothingActed, type ActedMessage, type AskedAct, type MailboxActs } from './useMailboxActs';
 
 const inbox = { account: 'work', folder: 'work-inbox' };
@@ -130,5 +130,62 @@ describe('readActFor', () => {
     // It is refused before it can be pressed, so what this decides is only the name the control wears while it says so.
     it('reads nothing at all the way it reads messages that are all read, so a cleared selection keeps the name', () => {
         expect(readActFor(nothingActed, nothingMarkedRead, [])).toBe('markUnread');
+    });
+});
+
+describe('underway', () => {
+    /** A message drawn in the folder an act filed it into, which is where the reader meets it next. */
+    function arrivedIn(folder: string): ActedMessage {
+        return { storedEmailId: 'message-1', account: 'work', folder, unread: false, flagged: false };
+    }
+
+    /** What a client that asked for this act, out of this folder, carries. */
+    function askedFrom(act: AskedAct['act'], from: string): MailboxActs {
+        return {
+            ...nothingActed,
+            asked: new Map([['message-1', { act, from, leaves: true, destroys: false }]]),
+        };
+    }
+
+    it('reads an act as under way in the folder it was asked in, which is where the row is still waiting', () => {
+        expect(underway(askedFrom('delete', 'work-inbox'), 'delete', [arrivedIn('work-inbox')])).toBe(true);
+    });
+
+    // Filing a message in the trash and destroying it there are one act name and two different things, so a client
+    // that read the first as the second refused to destroy the one message somebody had just put in front of it —
+    // while every other message in that folder, having no act remembered, was destroyed on the first press.
+    it('reads no act as under way where the message has arrived somewhere else, the act being finished there', () => {
+        expect(underway(askedFrom('delete', 'work-inbox'), 'delete', [arrivedIn('work-trash')])).toBe(false);
+    });
+
+    it('reads nothing at all as nothing under way, so a control over an empty selection is refused rather than held', () => {
+        expect(underway(askedFrom('archive', 'work-inbox'), 'archive', [])).toBe(false);
+    });
+});
+
+// The three rules above read a remembered act the way the row itself is drawn, which is what stops a control from
+// offering to undo something the row beside it never showed.
+describe('an act asked in another folder', () => {
+    const inTrash: ActedMessage = {
+        storedEmailId: 'message-1',
+        account: 'work',
+        folder: 'work-trash',
+        unread: false,
+        flagged: false,
+    };
+
+    function askedInTheInbox(act: AskedAct['act']): MailboxActs {
+        return {
+            ...nothingActed,
+            asked: new Map([['message-1', { act, from: 'work-inbox', leaves: true, destroys: false }]]),
+        };
+    }
+
+    it('leaves the flag control pointing the way the row is drawn, rather than at what another folder was asked', () => {
+        expect(flagActFor(askedInTheInbox('flag'), [inTrash])).toBe('flag');
+    });
+
+    it('leaves the read control pointing the way the row is drawn, which is the same rule', () => {
+        expect(readActFor(askedInTheInbox('markUnread'), nothingMarkedRead, [inTrash])).toBe('markUnread');
     });
 });

--- a/frontend/src/Client.App/src/mailboxActs/drawnActs.ts
+++ b/frontend/src/Client.App/src/mailboxActs/drawnActs.ts
@@ -6,7 +6,7 @@ import type { IconName } from '../controls/icons';
 import type { MessageKey } from '../localization/en';
 import { drawnUnread, type ReadMarking } from '../readMarking/useReadMarking';
 import type { ActRefusal } from './mailboxDestinations';
-import type { ActedMessage, FlagAct, MailboxAct, MailboxActs } from './useMailboxActs';
+import type { ActedMessage, AskedAct, FlagAct, MailboxAct, MailboxActs } from './useMailboxActs';
 
 // What the acts are called and what they are drawn as, for every surface that offers one. It is here rather than
 // beside the controls that draw them because a fourth surface now does — the toolbar, the selection bar, a row's own
@@ -55,6 +55,22 @@ export const actsOnAStrip: readonly MailboxAct[] = ['archive', 'delete', 'flag',
 export const actsInARowMenu: readonly MailboxAct[] = ['archive', 'flag', 'markUnread', 'move', 'delete'];
 
 /**
+ * What this client has asked of this message *in the folder it is drawn in*, or nothing where it has asked nothing
+ * there.
+ *
+ * One reading for the three rules below, because `useMailboxActs.ts` already draws the row this way — `actPending`
+ * states it as *an act is only pending where it was asked* — and a control that read it the other way would offer to
+ * take a flag off a row it had itself drawn unflagged. The folder is part of the question rather than a detail of it:
+ * an act that files a message elsewhere is finished the moment the message is somewhere else, and the same act name
+ * asked there again is a new act rather than the old one still travelling.
+ */
+function askedHere(acts: MailboxActs, message: ActedMessage): AskedAct | undefined {
+    const asked = acts.asked.get(message.storedEmailId);
+
+    return asked?.from === message.folder ? asked : undefined;
+}
+
+/**
  * Which way the read control goes for these messages, which is the act the `markUnread` slot above actually offers.
  *
  * **Marking read is the default, and one shared state turns it round.** Every message drawn read is offered the act
@@ -72,7 +88,7 @@ export const actsInARowMenu: readonly MailboxAct[] = ['archive', 'flag', 'markUn
  */
 export function readActFor(acts: MailboxActs, marking: ReadMarking, messages: readonly ActedMessage[]): FlagAct {
     function unreadNow(message: ActedMessage): boolean {
-        const asked = acts.asked.get(message.storedEmailId);
+        const asked = askedHere(acts, message);
 
         if (asked?.act === 'markUnread') {
             return true;
@@ -105,7 +121,7 @@ export function readActFor(acts: MailboxActs, marking: ReadMarking, messages: re
  */
 export function flagActFor(acts: MailboxActs, messages: readonly ActedMessage[]): FlagAct {
     function flaggedNow(message: ActedMessage): boolean {
-        const asked = acts.asked.get(message.storedEmailId);
+        const asked = askedHere(acts, message);
 
         if (asked?.act === 'flag') {
             return true;
@@ -132,9 +148,26 @@ export const refusalSaid: Readonly<Record<ActRefusal, MessageKey>> = {
     foldersUnknown: 'act.foldersUnknown',
 };
 
-/** Whether this act is already being carried out for every message the control is about. */
+/**
+ * Whether this act is already being carried out for every message the control is about.
+ *
+ * **An act is only under way where it was asked**, which is the rule `actPending` states and the one a control has to
+ * read the same way: the three acts that file a message elsewhere take it out of the folder they were asked in, and
+ * the message then arrives somewhere else — where that act is finished rather than travelling, whatever this client
+ * has or has not seen the deployment agree to yet.
+ *
+ * Read without that, one act name covers two different things and the second becomes unreachable: filing a message in
+ * the trash is recorded as `delete`, so the message a reader had just put there was the one message in that folder
+ * whose *delete permanently* control drew itself as already on its way and refused to be pressed, while every other
+ * message in the same folder — none of them carrying a remembered act — was destroyed on the first press.
+ */
 export function underway(acts: MailboxActs, act: MailboxAct, messages: readonly ActedMessage[]): boolean {
-    return messages.length > 0 && messages.every((message) => acts.asked.get(message.storedEmailId)?.act === act);
+    return (
+        messages.length > 0 &&
+        messages.every((message) => {
+            return askedHere(acts, message)?.act === act;
+        })
+    );
 }
 
 /**


### PR DESCRIPTION
Deleting a message from the inbox and then opening the trash left that one message with an inactive *delete* control, while every other message in the same folder deleted on the first press. Found on the demo deployment while verifying the permanent delete that #1909 closed.

Closes #1926.

## What was wrong

Filing a message in the trash and destroying it there are one act name and two different things: both are recorded as `delete`. `underway` read a remembered act against the message alone, with no question about which folder it had been asked in, so a message moved to the trash kept `{ act: 'delete', from: '<inbox>' }` and the trash's own *delete permanently* control read that as its own act already travelling. `standsInTheWay` then answered `underway`, the strip drew the control disabled, and the row menu dropped the item. Every other message in the trash carried no remembered act, which is why the defect looked arbitrary from the outside.

## What changed

The rule was already written down one file over: `actPending` states that an act is only pending where it was asked, and compares `from` against the row's own folder exactly as `actLeaving` beside it does. `underway` was the one reading that did not, so a row and the control over it disagreed about the same message.

`askedHere` is now that reading, stated once and used by all three rules in the file. Two of them had the same gap in a narrower form: a message flagged in one folder and then filed into another would have had its row drawn unflagged by `drawnFlagged` while the toolbar over it offered to take the flag off. They point the way the row is drawn now.

A control over an act still travelling in the folder it was asked in is unchanged, which is what keeps one press from being submitted twice.

## Verification

`scripts/verify-fast.sh`, green — the client flow alone, the change reaching no C# and no other stack. The suite gained five cases: the act read in the folder it was asked in, the same act read after the message arrived in the trash, an empty selection, and one for each of the two control directions.

The demo deployment is also where the other half of #1909's second item was settled: a permanent delete submitted there converged, the message answered `404` afterwards, and the trash count dropped by one. The recorded suspicion that a missing UIDPLUS extension was dead-lettering the record is therefore wrong, and what the report described is this defect instead.
