### PR TITLE
[#1931] Hold the client's log vocabulary to its floors, and write the rule that keeps it there

### DIFF
--- a/backend/src/Host/Observability/ClientTelemetry/ClientTelemetryLevel.cs
+++ b/backend/src/Host/Observability/ClientTelemetry/ClientTelemetryLevel.cs
@@ -32,7 +32,7 @@ internal enum ClientTelemetryLevel
     /// <summary>The default, and one record per signed-in session: what a collector keeping everything at its own default level would otherwise be filled with.</summary>
     Info = 2,
 
-    /// <summary>Only what an operator would act on, such as a credential a deployment stopped accepting.</summary>
+    /// <summary>Only what an operator would act on and this deployment cannot see for itself, such as a signal hub a client could not reach.</summary>
     Warn = 3,
 
     /// <summary>Only a failure, such as a region of the client that threw while it was being drawn.</summary>

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -1401,6 +1401,14 @@ bundle over `http://tauri.localhost` answers exactly as one serving from a schem
 it is written at is fixed by the occurrence rather than chosen at the call site — so a dashboard grouping on that
 attribute reads the same shape from every client, and the floor below can be reasoned about from this table alone.
 
+**Two records sit above `INFO`, and the rule that keeps it to two is worth reading before the table.** A record above
+the default floor passes two tests rather than one: an operator would act on it, *and* this deployment cannot see it
+for itself. The second is the one usually failed. A deployment already records every refusal it issued, so a client
+telling it that a credential was declined or a write refused is a second copy of something nobody can act on any better
+for having twice — those are the client's own account of what it did and sit at `DEBUG` with the rest of it. What
+passes both is what never reached the deployment at all, and what happened where it cannot see: a signal hub that
+refused until the client had nothing but its own interval left, and a region that threw while it was being drawn.
+
 | Severity | Record | When it is written |
 | --- | --- | --- |
 | `INFO` | `session_started` | A signed-in session begins |
@@ -1408,12 +1416,14 @@ attribute reads the same shape from every client, and the floor below can be rea
 | `DEBUG` | `deployment_read` | The session route answered, carrying `mailfathom.client.deployment.version`, the size of the grant as `…deployment.permissions`, and the level as `…deployment.telemetry` |
 | `DEBUG` | `signed_in` | A sign-in produced a credential, with `mailfathom.client.kept` saying whether it was kept |
 | `DEBUG` | `sign_in_refused` | A sign-in did not, with `mailfathom.client.refusal` naming which of the closed set of reasons |
+| `DEBUG` | `credential_no_longer_accepted` | The deployment stopped taking the credential a session held |
 | `DEBUG` | `request_failed` | A request produced no answer the client could act on, with the same `mailfathom.client.request`, `…outcome`, and `…failure` the span beside it carries, and `…request.duration_ms` |
 | `DEBUG` | `signals_opened` | A connection to the signal hub stands |
 | `DEBUG` | `signals_dropped` | One ended |
 | `DEBUG` | `signals_refused` | One could not be opened, with `mailfathom.client.attempt` counting the attempt |
 | `DEBUG` | `signal_refused` | The hub sent a payload this client does not act on |
 | `DEBUG` | `act_asked` | The client asked the deployment to change something, with `mailfathom.client.act` naming which act and `…messages` counting them |
+| `DEBUG` | `act_refused` | The deployment refused a change the client had already drawn, and the client put the screen back |
 | `DEBUG` | `message_sent` | The client asked the deployment to send a message somebody wrote in it, with `mailfathom.client.send` naming how that ended and `…refusal` naming which refusal where it was refused |
 | `DEBUG` | `send_withdrawn` | Somebody asked for a send back before the deployment had let it go, with `mailfathom.client.withdrawal` naming what the deployment answered — `withdrawn`, `alreadyBeingSent`, `pastRecall`, or `noSuchSend`, and `failed` where the request produced no answer |
 | `DEBUG` | `preferences_stated` | A preference write went out, with `mailfathom.client.stated` saying whether the deployment held it or refused it — never which preference moved or what it was set to |
@@ -1421,9 +1431,7 @@ attribute reads the same shape from every client, and the floor below can be rea
 | `TRACE` | `request_completed` | A request produced an answer, with the same attributes `request_failed` carries minus the failure |
 | `TRACE` | `signal_received` | The hub said something changed, with `mailfathom.client.signal` naming the kind |
 | `TRACE` | `navigated` | Somebody moved to another space, with `mailfathom.client.space` and `…navigation.duration_ms` |
-| `WARN` | `credential_no_longer_accepted` | The deployment stopped taking the credential a session held |
 | `WARN` | `signals_unreachable` | The hub refused every attempt for long enough that the client is reading on its own interval alone |
-| `WARN` | `act_refused` | The deployment refused a change the client had already drawn, and the client put the screen back |
 | `ERROR` | `render_failed` | A region threw while it was being drawn and the boundary around it contained the failure — `FATAL` where that region is the whole application, which is a client nobody can use rather than a part nobody can see |
 
 **A deployment states how much of that it wants, and the client stops writing the rest.**
@@ -1437,8 +1445,8 @@ records the buffer exists for within seconds of somebody opening a folder.
 conservative: a deployment serving hundreds of clients pays for every record each of them sends, so what ships by
 default is the line that says a session exists, and everything a defect report actually needs is turned on for as long
 as the report takes. `debug` is the level to ask for then — it adds the sign-in, the deployment read, the signal hub,
-the acts, the sends and the withdrawals, the preference writes, the notification answer, and the failed requests, and
-leaves out the two per-request and per-move streams that `trace` adds.
+the acts, the sends and the withdrawals, the preference writes, the notification answer, the failed requests, and the
+two refusals the deployment issued itself, and leaves out the two per-request and per-move streams that `trace` adds.
 
 **A record made before the deployment answers is held at `info` too.** The client has no level until the session route
 has answered, and the alternative to standing on the default there is picking between recording a `TRACE` stream into a

--- a/frontend/src/AGENTS.md
+++ b/frontend/src/AGENTS.md
@@ -73,6 +73,45 @@ Four things may never cross, in either direction:
 - Bound what a screen asks for. A route that can answer with a mailbox-sized collection is called with the window the
   screen actually shows, and the client refuses an answer larger than it asked for rather than rendering it.
 
+## What the client records about itself, and at which level
+
+The occurrences this client may record are a closed set declared once in `Client.Backend/src/telemetry.ts`, beside the
+severity each one is written at, and both halves of the client write into it. A severity is therefore a property of the
+occurrence rather than of the call site: a new record is added in that file with its level argued there, and a screen
+passes no level of its own. What an operator then reads is
+[Telemetry](../../docs/operations/telemetry.md#what-the-client-publishes-about-itself), and the floor beneath the whole
+vocabulary is the deployment's own answer rather than anything decided here.
+
+Which level a record takes is the answer to _who is this for_, and the levels are not a scale of how much the
+occurrence mattered.
+
+- **`INFO` is the level nobody asked for.** It is the floor a deployment ships with, so what sits there is what every
+  collector is charged for by every signed-in client at once. Exactly one occurrence is there — a session beginning —
+  and it stays the only one: anything that happens more than once a session belongs below it, however much the screen
+  reporting it matters to whoever is in front of it.
+- **`DEBUG` is the client's own account of what it did**, and it is where nearly everything belongs. It is what an
+  operator lowers the floor to while somebody's report is open, so the bar is that it would help read that report
+  rather than that it is worth keeping.
+- **`TRACE` is the stream beneath that** — a record per request and one per move between screens — which is only ever
+  worth having from one client at a time.
+- **`WARN` and above pass two tests rather than one: an operator would act on it, _and_ the deployment cannot see it
+  for itself.** The second is the one usually failed, and failing it is not a matter of degree. A deployment already
+  writes down every refusal it issued, so a client record of a credential it declined or a write it refused is a second
+  copy of something nobody can act on any better for having twice — both are the client's own account and sit at
+  `DEBUG` with the rest of it. What passes both is what never reached the deployment, or what happened where it cannot
+  see: a signal hub that refused until the client had nothing but its own interval left, and a region that threw while
+  it was being drawn.
+- **`FATAL` says the client is unusable**, rather than that a failure was severe. One call site reaches it — the
+  containment boundary around the whole application, where `ERROR` would report a client nobody can use as a region
+  nobody can see.
+
+Two things follow that a diff makes easy to miss. A record is never raised a level because what it reports matters to
+the person using the client: what they are owed is a notice on the screen, which § _UX_ already requires, and the record
+is for whoever reads a collector hours later. And **the browser console is not this vocabulary** — what is written
+there is for somebody with the developer tools open, it reaches no deployment, and it neither substitutes for a record
+nor relaxes what a record may carry. `main.tsx` is the one place that writes to it, so that React's own account of a
+failed render survives a handler being stated at all.
+
 ## State: what is stored, what is derived, and where an effect is wrong
 
 - **Where a setting is kept follows one rule rather than whichever module was open first.** What a person sets

--- a/frontend/src/Client.App/src/mailboxActs/MailboxActs.tsx
+++ b/frontend/src/Client.App/src/mailboxActs/MailboxActs.tsx
@@ -686,16 +686,17 @@ export function MailboxActsProvider({
             // it into the folder it is already in has not taken it out of the list it is drawn in either.
             forget(messages.filter((message) => !written.has(message.storedEmailId)).map((one) => one.storedEmailId));
 
-            // The one thing this client does that a deployment's own records do not already show: the screen had drawn
-            // the act as done and has just put itself back, which somebody using it experiences as the client undoing
-            // their work. It is above the default floor because it is a deployment refusing writes it accepted the
-            // request for, which is a thing to look at rather than a thing to read.
+            // What this adds to what the deployment already wrote down is the screen: it had drawn the act as done and
+            // has just put itself back, which somebody using it experiences as the client undoing their work. That is a
+            // defect report against this client rather than something whoever reads a collector acts on, and the
+            // refusal itself is the deployment's own answer read back to it — so it is the client's account of what it
+            // did and sits at the level the rest of that account does.
             //
             // Counted over the batches the deployment actually answered, and never over one that failed to reach it.
             // A dropped connection or a credential that expired leaves `writtenDown` with nothing from that batch,
             // which is indistinguishable here from a deployment declining every message in it — so counting both
-            // would put every transport failure into the one record an operator reads to find a deployment refusing
-            // writes. `request_failed` already reports that half, at the level a transport failure belongs to.
+            // would put every transport failure into the one record that says a deployment declined a write it had
+            // answered. `request_failed` already reports that half, under the name a reader groups it by.
             const declined = answered
                 .filter(({ answer }) => answer.outcome === 'read')
                 .flatMap(({ messages: batch }) => batch)

--- a/frontend/src/Client.App/src/telemetry/clientTelemetry.test.ts
+++ b/frontend/src/Client.App/src/telemetry/clientTelemetry.test.ts
@@ -186,15 +186,23 @@ describe('clientTelemetryForThisApplication', () => {
         expect(record?.attributes).toEqual({ 'mailfathom.client.event': 'session_started' });
     });
 
-    it('records a credential the deployment stopped accepting as a warning', async () => {
+    // Both of these are a refusal the deployment issued and has already written down for itself, so what is asserted is
+    // that this client's copy of one sits with the rest of its own account rather than above a floor nobody asked for.
+    it('records a refusal the deployment itself issued as the client’s own account of what it did', async () => {
         const telemetry = clientTelemetryForThisApplication();
 
+        telemetry.exportFor(session, true, 'debug');
         telemetry.happened('credential_no_longer_accepted');
+        telemetry.happened('act_refused', { 'mailfathom.client.act': 'archive', 'mailfathom.client.messages': 2 });
 
-        const [record] = await written(() => records.getFinishedLogRecords());
+        await vi.waitFor(() => {
+            expect(records.getFinishedLogRecords().length).toBe(2);
+        });
 
-        expect(record?.severityNumber).toBe(SeverityNumber.WARN);
-        expect(record?.attributes).toEqual({ 'mailfathom.client.event': 'credential_no_longer_accepted' });
+        expect(records.getFinishedLogRecords().map((record) => record.severityNumber)).toEqual([
+            SeverityNumber.DEBUG,
+            SeverityNumber.DEBUG,
+        ]);
     });
 
     it('records a failure a boundary contained as an error, naming the region and what was thrown', async () => {
@@ -292,11 +300,11 @@ describe('clientTelemetryForThisApplication', () => {
 
             telemetry.exportFor(session, true, 'warn');
             telemetry.happened('session_started');
-            telemetry.happened('credential_no_longer_accepted');
+            telemetry.renderFailed('reading_pane', new TypeError('A message this pane cannot draw.'));
 
             const [only, ...rest] = await written(() => records.getFinishedLogRecords());
 
-            expect(only?.attributes['mailfathom.client.event']).toBe('credential_no_longer_accepted');
+            expect(only?.attributes['mailfathom.client.event']).toBe('render_failed');
             expect(rest).toEqual([]);
         });
 

--- a/frontend/src/Client.Backend/src/telemetry.test.ts
+++ b/frontend/src/Client.Backend/src/telemetry.test.ts
@@ -530,6 +530,30 @@ describe('what the whole of this package records', () => {
     });
 });
 
+// What a deployment is charged for when it has asked for nothing is a property of the whole table rather than of any
+// one occurrence, so it is asserted over the table: the next record added to the vocabulary passes these two or it does
+// not go above the floor.
+describe('what this client asks a deployment that asked for nothing to keep', () => {
+    const eventsAt = (keep: (severity: SeverityNumber) => boolean): readonly string[] =>
+        Object.entries(severityOf)
+            .filter(([, severity]) => keep(severity))
+            .map(([event]) => event)
+            .sort();
+
+    it('writes exactly one occurrence at the floor that ships', () => {
+        expect(eventsAt((severity) => severity === SeverityNumber.INFO)).toEqual(['session_started']);
+    });
+
+    // Two tests rather than one: an operator would act on it, and the deployment cannot see it for itself. A refusal
+    // the deployment issued fails the second however serious it reads, which is what keeps this level worth reading.
+    it('writes above it only what the deployment could not have recorded for itself', () => {
+        expect(eventsAt((severity) => severity > SeverityNumber.INFO)).toEqual([
+            'render_failed',
+            'signals_unreachable',
+        ]);
+    });
+});
+
 describe('the level a deployment asks for', () => {
     it('reads every level this client publishes and nothing else', () => {
         for (const level of ['off', 'trace', 'debug', 'info', 'warn', 'error', 'fatal']) {

--- a/frontend/src/Client.Backend/src/telemetry.ts
+++ b/frontend/src/Client.Backend/src/telemetry.ts
@@ -145,10 +145,14 @@ export type ClientEvent =
  * at once, so exactly one occurrence is written there — a session beginning — and everything that happens more than
  * once a session sits below it. `DEBUG` is the client's own account of what it did, which is what an operator lowers
  * the floor to when somebody reports something; `TRACE` is the stream beneath that, a record per request and one per
- * move between screens, which is only ever worth having for one client at a time. Above `INFO` is what an operator
- * would act on rather than read: a credential a deployment stopped accepting, a hub that has been unreachable for long
- * enough that the interval is all a client has left, and an act a deployment refused after the screen had already drawn
- * it as done.
+ * move between screens, which is only ever worth having for one client at a time.
+ *
+ * Above `INFO` an occurrence passes two tests rather than one: an operator would act on it, *and* the deployment cannot
+ * see it for itself. The second is what keeps that level worth reading, because a deployment already holds its own
+ * record of every refusal it issued — so a client record of the same refusal is a second copy of something nobody can
+ * act on any better for having twice. Two occurrences pass both. A hub that has refused for long enough that the
+ * interval is all a client has left never reached the deployment to be recorded there, and a region that threw while it
+ * was being drawn happened somewhere the deployment cannot see at all.
  */
 export const severityOf: Readonly<Record<ClientEvent, SeverityNumber>> = {
     session_started: SeverityNumber.INFO,
@@ -157,12 +161,24 @@ export const severityOf: Readonly<Record<ClientEvent, SeverityNumber>> = {
     deployment_read: SeverityNumber.DEBUG,
     signed_in: SeverityNumber.DEBUG,
     sign_in_refused: SeverityNumber.DEBUG,
+
+    // The deployment declining a credential it issued, which it has already written down as a refusal of its own. It is
+    // also the ordinary end of a session rather than a fault: a machine asleep past the renewal margin wakes holding a
+    // token nobody renewed, and one record per client per weekend is what putting this above the default floor buys.
+    credential_no_longer_accepted: SeverityNumber.DEBUG,
+
     request_failed: SeverityNumber.DEBUG,
     signals_opened: SeverityNumber.DEBUG,
     signals_dropped: SeverityNumber.DEBUG,
     signals_refused: SeverityNumber.DEBUG,
     signal_refused: SeverityNumber.DEBUG,
     act_asked: SeverityNumber.DEBUG,
+
+    // The deployment declining writes it answered, which is again its own answer read back to it. What the client adds
+    // is that the screen had drawn them as done and has put itself back, and that is a defect report against a client
+    // rather than something whoever is reading a collector can act on.
+    act_refused: SeverityNumber.DEBUG,
+
     message_sent: SeverityNumber.DEBUG,
     send_withdrawn: SeverityNumber.DEBUG,
     preferences_stated: SeverityNumber.DEBUG,
@@ -172,9 +188,7 @@ export const severityOf: Readonly<Record<ClientEvent, SeverityNumber>> = {
     signal_received: SeverityNumber.TRACE,
     navigated: SeverityNumber.TRACE,
 
-    credential_no_longer_accepted: SeverityNumber.WARN,
     signals_unreachable: SeverityNumber.WARN,
-    act_refused: SeverityNumber.WARN,
 
     render_failed: SeverityNumber.ERROR,
 };


### PR DESCRIPTION
The client got twenty-two log records in #1913, each written at a severity the occurrence fixes
rather than the call site chooses. What that change did not write down is the rule the severities
were assigned by — and two of them do not survive reading it out loud.

## The rule

`INFO` is the floor a deployment ships with, so what sits there is what every collector is charged
for by every signed-in client whether or not anybody asked for it. Exactly one record is there, a
session beginning, and it stays the only one.

Above it a record now passes **two** tests rather than one: an operator would act on it, *and* this
deployment cannot see it for itself. The second is the one usually failed, and failing it is not a
matter of degree — a deployment already records every refusal it issued, so a client telling it the
same thing again is a second copy nobody can act on any better for having twice.

## What moves

| Record | Was | Is | Why |
| --- | --- | --- | --- |
| `credential_no_longer_accepted` | `WARN` | `DEBUG` | The deployment declining a credential it issued, already on its own record. It is also the ordinary end of a session: a machine asleep past the renewal margin wakes holding a token nobody renewed, so this was one warning per client per weekend |
| `act_refused` | `WARN` | `DEBUG` | The deployment declining writes it answered, again its own answer read back to it. What the client adds is that the screen had drawn them as done, which is a defect report against this client rather than an action for whoever reads a collector |

`signals_unreachable` stays at `WARN` and `render_failed` at `ERROR` — `FATAL` where the region is
the whole application — because each passes both tests: the first never reached the deployment at
all, and the second happened where it cannot see.

Nothing is promoted, and `INFO` still holds exactly `session_started`.

## Where the rule now lives

`frontend/src/AGENTS.md` gains a section stating it, so the next record added to the vocabulary is
read off a rule rather than off whichever neighbouring record looked similar — including the part
that is easy to get wrong twice over: a record is never raised a level because what it reports
matters to the person using the client, and the browser console is not this vocabulary.

`docs/operations/telemetry.md` moves the two rows and states the two tests above its severity table.
The `Warn` member of the backend's `ClientTelemetryLevel` named one of the moved records as its
example and now names one that is still written there.

## Tests

The wire package's suite asserts the *shape* of the table rather than one entry — exactly one
occurrence at `INFO`, and above it only the two that pass both tests — so the next record added is
held to the rule by the suite as well as by the prose. The application's suite asserts that both
moved records are written at `DEBUG`, and the test proving a floor still admits what is above it now
uses a record that is still above it.

## Breaking change

None to any of the four public surfaces. `ClientEndpoint:TelemetryLevel` keeps its key, its values,
and its default; the session route answers as before. What changes is which records a deployment
sees at a given level, which is an observability change rather than a contract one — an operator who
wants the two moved records asks for `Debug`, which is the level a defect report was already worth
turning on.

Closes #1931
