### PR TITLE
[#1271] Name a content-object sweep at the occasion that dispatched it, not inside the attempt

### DIFF
--- a/backend/src/Application/EmailContent/Storage/Reclamation/ContentObjectReclamationHandler.cs
+++ b/backend/src/Application/EmailContent/Storage/Reclamation/ContentObjectReclamationHandler.cs
@@ -26,7 +26,9 @@ namespace MailFathom.Application.EmailContent.Storage.Reclamation;
 /// <para>
 /// Running it twice with one payload is the same as running it once. Removing an object nothing holds succeeds, and the
 /// decision the run makes about each object is read from the endpoint and the database at the moment it makes it, so a
-/// second attempt over one segment removes what the first did not reach and nothing else.
+/// second attempt over one segment removes what the first did not reach and nothing else. The hand-on is the same
+/// either way: the sweep and the place in it are read from the payload the enqueue committed rather than composed here,
+/// so a repeated attempt enqueues the key the first one did and is answered with the segment already waiting.
 /// </para>
 /// <para>
 /// A deployment that stores content in the database has no bucket and reclaims nothing. The job type is still known to

--- a/backend/src/Application/EmailContent/Storage/Reclamation/ContentObjectReclamationScheduleSource.cs
+++ b/backend/src/Application/EmailContent/Storage/Reclamation/ContentObjectReclamationScheduleSource.cs
@@ -26,30 +26,47 @@ public sealed class ContentObjectReclamationScheduleSource : IScheduledJobSource
     /// <summary>The identity the sweep's durable state is keyed by, which is one for the whole deployment.</summary>
     internal const string ScheduleIdentity = "content-object-reclamation";
 
-    private readonly IReadOnlyList<ScheduledJob> declared;
+    private readonly JobRecurrence recurrence;
 
     /// <summary>Initializes the source over the interval the deployment configured.</summary>
     /// <param name="recurrence">The occasions a sweep is dispatched on.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="recurrence" /> is <see langword="null" />.</exception>
     /// <remarks>
-    /// Held rather than read per pass, unlike the sources over rules and over a user's declarations. Those change
-    /// while the process runs; this one is composed from a setting the host reads once, because a bucket cannot be
+    /// The interval is held rather than read per pass, unlike the sources over rules and over a user's declarations.
+    /// Those change while the process runs; this one is a setting the host reads once, because a bucket cannot be
     /// repointed without the client being rebuilt in any case.
     /// </remarks>
     public ContentObjectReclamationScheduleSource(JobRecurrence recurrence)
     {
         ArgumentNullException.ThrowIfNull(recurrence);
 
-        this.declared =
-        [
-            new ScheduledJob(
-                JobScheduleId.Create(ScheduleIdentity),
-                ReclaimContentObjectsJobPayload.FromTheStart(),
-                recurrence),
-        ];
+        this.recurrence = recurrence;
     }
 
     /// <inheritdoc />
-    public Task<IReadOnlyList<ScheduledJob>> ReadSchedulesAsync(CancellationToken cancellationToken) =>
-        Task.FromResult(this.declared);
+    /// <remarks>
+    /// <para>
+    /// The declaration is composed per read because the sweep it dispatches is named here, which is the only place that
+    /// can name it before an attempt exists. The name reaches the chain in the document the enqueue committed, so every
+    /// execution of the first leased segment reads one identity and hands the rest of the sweep on under one key.
+    /// </para>
+    /// <para>
+    /// Which of the names a pass proposes becomes the occasion's is decided by the queue rather than here. Every pass
+    /// on every replica enqueues one occasion under one key, so the first to arrive writes the sweep and the rest are
+    /// answered with the job already there — and two occasions are two keys, two documents, and two chains that are
+    /// never deduped against each other.
+    /// </para>
+    /// </remarks>
+    public Task<IReadOnlyList<ScheduledJob>> ReadSchedulesAsync(CancellationToken cancellationToken)
+    {
+        IReadOnlyList<ScheduledJob> declared =
+        [
+            new ScheduledJob(
+                JobScheduleId.Create(ScheduleIdentity),
+                ReclaimContentObjectsJobPayload.FromTheStart(Guid.CreateVersion7().ToString()),
+                this.recurrence),
+        ];
+
+        return Task.FromResult(declared);
+    }
 }

--- a/backend/src/Application/Jobs/Payloads/ReclaimContentObjectsJobPayload.cs
+++ b/backend/src/Application/Jobs/Payloads/ReclaimContentObjectsJobPayload.cs
@@ -10,13 +10,21 @@ namespace MailFathom.Application.Jobs.Payloads;
 /// <remarks>
 /// <para>
 /// A sweep of a whole bucket is more work than one attempt may hold, so it is carried by a chain of jobs: the schedule
-/// dispatches the first with nothing filled in, and every one that stops with objects still ahead of it hands the rest
-/// to the next. The three properties are what the next one needs to be both resumable and enqueueable.
+/// dispatches the first naming the sweep it begins, and every one that stops with objects still ahead of it hands the
+/// rest to the next. The four properties are what the next one needs to be both resumable and enqueueable.
 /// </para>
 /// <para>
 /// <see cref="SweepId" /> and <see cref="Segment" /> exist for the queue rather than for the work. An idempotency key
 /// is unique for the life of the table, so a chain that reused one would have its second segment silently answered as
 /// a job already enqueued; the sweep the chain belongs to and the place in it are what make each key its own.
+/// </para>
+/// <para>
+/// <b>The sweep is named by the occasion that dispatched it rather than by the attempt that carries it.</b> The
+/// identity travels in the document the enqueue committed, so every execution of one leased segment reads the same one
+/// and composes the same hand-on key. Minting it inside <see cref="ContinuingFrom" /> would make it a property of the
+/// attempt instead: an attempt whose work succeeded and whose completion the store then refused is repeated against the
+/// same payload, and two mints would hand the same position to two keys and fork one sweep into two chains walking one
+/// bucket.
 /// </para>
 /// <para>
 /// <see cref="ResumeFrom" /> is a position in the endpoint's listing. It is the one value here that came from the store
@@ -26,10 +34,16 @@ namespace MailFathom.Application.Jobs.Payloads;
 /// </remarks>
 public sealed record ReclaimContentObjectsJobPayload : IJobPayload
 {
-    /// <summary>Gets the sweep this job is a segment of, or <see langword="null" /> for the first segment a schedule dispatched.</summary>
-    public string? SweepId { get; init; }
+    /// <summary>Gets the sweep this job is a segment of, which the occasion that dispatched the chain named.</summary>
+    /// <remarks>
+    /// Required, so a document carrying none is refused by the deserializer rather than resolving to a sweep nobody
+    /// named. A first segment a previous release enqueued and had not yet run is that case, and it is refused for the
+    /// reason every payload record refuses a component that no longer validates: the occasion after it dispatches a
+    /// sweep of its own, so what the refusal costs is one interval rather than any object left unswept.
+    /// </remarks>
+    public required string SweepId { get; init; }
 
-    /// <summary>Gets which segment of that sweep this job carries, counted from the first hand-on.</summary>
+    /// <summary>Gets which segment of that sweep this job carries, counted from the one the schedule dispatched.</summary>
     public int Segment { get; init; }
 
     /// <summary>Gets the position in the listing this segment begins at, or <see langword="null" /> to begin at its start.</summary>
@@ -48,26 +62,28 @@ public sealed record ReclaimContentObjectsJobPayload : IJobPayload
     [JsonIgnore]
     public JobType JobType => JobType.ReclaimContentObjects;
 
-    /// <summary>Describes the first segment of a sweep, which begins at the start of the listing.</summary>
+    /// <summary>Describes the first segment of one sweep, which begins at the start of the listing.</summary>
+    /// <param name="sweepId">The identity of the sweep this occasion begins, which every segment of it is keyed by.</param>
     /// <returns>The payload a schedule dispatches.</returns>
-    public static ReclaimContentObjectsJobPayload FromTheStart() => new();
+    /// <exception cref="ArgumentException">Thrown when <paramref name="sweepId" /> is blank, because a segment belonging to no sweep composes no key.</exception>
+    public static ReclaimContentObjectsJobPayload FromTheStart(string sweepId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sweepId);
+
+        return new ReclaimContentObjectsJobPayload { SweepId = sweepId };
+    }
 
     /// <summary>Describes the segment that carries whatever this one did not reach.</summary>
     /// <param name="resumeFrom">The position the run stopped at.</param>
     /// <param name="oldestOrphanAge">The oldest orphan the sweep has met up to that position.</param>
     /// <returns>The payload of the next segment, belonging to the same sweep as this one.</returns>
     /// <exception cref="ArgumentException">Thrown when <paramref name="resumeFrom" /> is blank, because a segment that resumes nowhere is the first one.</exception>
-    /// <remarks>
-    /// The sweep identity is minted here when the chain began at a schedule, so a segment always belongs to a named
-    /// sweep however it was reached. It is a version 7 identifier because a chain is read in the order it ran.
-    /// </remarks>
     public ReclaimContentObjectsJobPayload ContinuingFrom(string resumeFrom, TimeSpan oldestOrphanAge)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resumeFrom);
 
-        return new ReclaimContentObjectsJobPayload
+        return this with
         {
-            SweepId = this.SweepId ?? Guid.CreateVersion7().ToString(),
             Segment = this.Segment + 1,
             ResumeFrom = resumeFrom,
             OldestOrphanAge = oldestOrphanAge,
@@ -76,9 +92,10 @@ public sealed record ReclaimContentObjectsJobPayload : IJobPayload
 
     /// <summary>Composes the identity under which this segment is enqueued.</summary>
     /// <returns>The idempotency key, which no other segment of any sweep shares.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when the payload names no sweep, which is the first segment and is enqueued by the schedule under the occasion's own key.</exception>
-    public JobIdempotencyKey ToIdempotencyKey() => this.SweepId is { Length: > 0 } sweepId
-        ? JobIdempotencyKey.Create($"{JobType.ReclaimContentObjects.Name}:{sweepId}:{this.Segment}")
-        : throw new InvalidOperationException(
-            "The first segment of a sweep is enqueued by the schedule under the occasion it was dispatched on, so it composes no key of its own.");
+    /// <remarks>
+    /// The first segment is enqueued by the schedule under the occasion's own key rather than under this one, so the
+    /// key a first segment composes is only ever the one its successor is handed on under.
+    /// </remarks>
+    public JobIdempotencyKey ToIdempotencyKey() =>
+        JobIdempotencyKey.Create($"{JobType.ReclaimContentObjects.Name}:{this.SweepId}:{this.Segment}");
 }

--- a/backend/tests/Application.UnitTests/EmailContent/Storage/Reclamation/ContentObjectReclamationHandlerTests.cs
+++ b/backend/tests/Application.UnitTests/EmailContent/Storage/Reclamation/ContentObjectReclamationHandlerTests.cs
@@ -34,7 +34,7 @@ public sealed class ContentObjectReclamationHandlerTests
 
         // Act
         await handler.RunAsync(
-            ReclaimContentObjectsJobPayload.FromTheStart(),
+            ReclaimContentObjectsJobPayload.FromTheStart("sweep-of-the-occasion"),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -55,7 +55,7 @@ public sealed class ContentObjectReclamationHandlerTests
 
         // Act
         await handler.RunAsync(
-            ReclaimContentObjectsJobPayload.FromTheStart(),
+            ReclaimContentObjectsJobPayload.FromTheStart("sweep-of-the-occasion"),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -67,6 +67,41 @@ public sealed class ContentObjectReclamationHandlerTests
                 && ((ReclaimContentObjectsJobPayload)request.Payload).ResumeFrom == "next-page"
                 && ((ReclaimContentObjectsJobPayload)request.Payload).Segment == 1),
             Arg.Is<CancellationToken>(token => token == CancellationToken.None));
+    }
+
+    /// <summary>One leased segment run twice hands the rest of the sweep on under one key, so the sweep stays one chain.</summary>
+    /// <remarks>
+    /// The executor runs one leased row's handler again whenever the work succeeded and the compare-and-set recording it
+    /// did not, and the second attempt meets the same payload. The position it stops at need not be the first one's, so
+    /// what has to agree is the key: a second key would be a second hand-on, and the sweep would fork into two chains
+    /// walking one bucket.
+    /// </remarks>
+    [Fact]
+    public async Task RunAsync_OneSegmentAttemptedTwice_HandsTheRestOnUnderOneKey()
+    {
+        // Arrange
+        var jobs = JobStoreAccepting();
+        var reclamation = Substitute.For<IContentObjectReclamation>();
+        reclamation.ReclaimAsync(Arg.Any<string?>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(
+                _ => Task.FromResult(new ContentObjectReclamationRun { ResumeFrom = "next-page" }),
+                _ => Task.FromResult(new ContentObjectReclamationRun { ResumeFrom = "a-page-further-on" }));
+
+        var handler = new ContentObjectReclamationHandler(jobs, reclamation);
+        var leased = ReclaimContentObjectsJobPayload.FromTheStart("sweep-of-the-occasion");
+
+        // Act
+        await handler.RunAsync(leased, TestContext.Current.CancellationToken);
+        await handler.RunAsync(leased, TestContext.Current.CancellationToken);
+
+        // Assert
+        var keys = jobs.ReceivedCalls()
+            .Select(call => call.GetArguments()[0])
+            .OfType<JobEnqueueRequest>()
+            .Select(request => request.Key.Value)
+            .Distinct(StringComparer.Ordinal);
+
+        Assert.Single(keys);
     }
 
     /// <summary>The shutdown that stopped a sweep is the one moment the rest of it most needs to be written down.</summary>
@@ -85,7 +120,7 @@ public sealed class ContentObjectReclamationHandlerTests
         await stopped.CancelAsync();
 
         // Act
-        await handler.RunAsync(ReclaimContentObjectsJobPayload.FromTheStart(), stopped.Token);
+        await handler.RunAsync(ReclaimContentObjectsJobPayload.FromTheStart("sweep-of-the-occasion"), stopped.Token);
 
         // Assert
         await jobs.Received(1).EnqueueAsync(
@@ -111,7 +146,7 @@ public sealed class ContentObjectReclamationHandlerTests
         // Act, Assert
         await Assert.ThrowsAsync<JobHandOnRefusedAtCapacityException>(
             () => handler.RunAsync(
-                ReclaimContentObjectsJobPayload.FromTheStart(),
+                ReclaimContentObjectsJobPayload.FromTheStart("sweep-of-the-occasion"),
                 TestContext.Current.CancellationToken));
     }
 
@@ -129,7 +164,7 @@ public sealed class ContentObjectReclamationHandlerTests
 
         // Act
         await handler.RunAsync(
-            ReclaimContentObjectsJobPayload.FromTheStart().ContinuingFrom("half-way", TimeSpan.Zero),
+            ReclaimContentObjectsJobPayload.FromTheStart("sweep-of-the-occasion").ContinuingFrom("half-way", TimeSpan.Zero),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -158,7 +193,7 @@ public sealed class ContentObjectReclamationHandlerTests
 
         // Act
         await handler.RunAsync(
-            ReclaimContentObjectsJobPayload.FromTheStart(),
+            ReclaimContentObjectsJobPayload.FromTheStart("sweep-of-the-occasion"),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -183,7 +218,7 @@ public sealed class ContentObjectReclamationHandlerTests
 
         // Act
         await handler.RunAsync(
-            ReclaimContentObjectsJobPayload.FromTheStart().ContinuingFrom("half-way", TimeSpan.FromDays(9)),
+            ReclaimContentObjectsJobPayload.FromTheStart("sweep-of-the-occasion").ContinuingFrom("half-way", TimeSpan.FromDays(9)),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -206,7 +241,7 @@ public sealed class ContentObjectReclamationHandlerTests
 
         // Act
         await handler.RunAsync(
-            ReclaimContentObjectsJobPayload.FromTheStart(),
+            ReclaimContentObjectsJobPayload.FromTheStart("sweep-of-the-occasion"),
             TestContext.Current.CancellationToken);
 
         // Assert

--- a/backend/tests/Application.UnitTests/EmailContent/Storage/Reclamation/ContentObjectReclamationScheduleSourceTests.cs
+++ b/backend/tests/Application.UnitTests/EmailContent/Storage/Reclamation/ContentObjectReclamationScheduleSourceTests.cs
@@ -31,9 +31,14 @@ public sealed class ContentObjectReclamationScheduleSourceTests
         Assert.Same(recurrence, declared.Recurrence);
     }
 
-    /// <summary>The dispatched segment begins the listing, and the chain after it is what carries the rest.</summary>
+    /// <summary>The dispatched segment begins the listing and already names the sweep the chain after it carries.</summary>
+    /// <remarks>
+    /// Naming it here is what keeps the identity out of the attempt. The document the enqueue commits is what every
+    /// execution of that leased segment reads, so a repeated attempt hands the rest of the sweep on under one key
+    /// instead of minting a second sweep and forking the chain.
+    /// </remarks>
     [Fact]
-    public async Task ReadSchedulesAsync_AConfiguredInterval_DispatchesTheSegmentThatBeginsTheListing()
+    public async Task ReadSchedulesAsync_AConfiguredInterval_DispatchesTheSegmentThatBeginsTheListingAndNamesItsSweep()
     {
         // Arrange
         var recurrence = RecurrenceOf("Every 06:00:00");
@@ -45,7 +50,25 @@ public sealed class ContentObjectReclamationScheduleSourceTests
         // Assert
         var payload = Assert.IsType<ReclaimContentObjectsJobPayload>(schedules[0].Payload);
         Assert.Null(payload.ResumeFrom);
-        Assert.Null(payload.SweepId);
+        Assert.Equal(0, payload.Segment);
+        Assert.NotEmpty(payload.SweepId);
+    }
+
+    /// <summary>Two occasions are two sweeps, or one would be answered with the chain the other was already walking.</summary>
+    [Fact]
+    public async Task ReadSchedulesAsync_ReadTwice_NamesASweepOfItsOwnEachTime()
+    {
+        // Arrange
+        var source = new ContentObjectReclamationScheduleSource(RecurrenceOf("Every 06:00:00"));
+
+        // Act
+        var one = await source.ReadSchedulesAsync(TestContext.Current.CancellationToken);
+        var another = await source.ReadSchedulesAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotEqual(
+            ((ReclaimContentObjectsJobPayload)one[0].Payload).SweepId,
+            ((ReclaimContentObjectsJobPayload)another[0].Payload).SweepId);
     }
 
     /// <summary>The identity keys the schedule's durable state, so it has to mean the same thing on every instance.</summary>

--- a/backend/tests/Application.UnitTests/Jobs/Payloads/ReclaimContentObjectsJobPayloadTests.cs
+++ b/backend/tests/Application.UnitTests/Jobs/Payloads/ReclaimContentObjectsJobPayloadTests.cs
@@ -10,38 +10,41 @@ namespace MailFathom.Application.UnitTests.Jobs.Payloads;
 
 /// <summary>Covers how one sweep's segments are chained, and why each of them is enqueueable at all.</summary>
 /// <remarks>
-/// An idempotency key is unique for the life of the queue table, so the claim that matters here is that two segments of
-/// one sweep never compose the same one. A chain that did would have its second segment silently answered as a job
-/// already enqueued, and the tail of the bucket would never be swept.
+/// An idempotency key is unique for the life of the queue table, so two claims matter here at once: two segments of one
+/// sweep never compose the same key, and one segment composes the same key however many times it is attempted. A chain
+/// that broke the first would have its second segment silently answered as a job already enqueued and the tail of the
+/// bucket would never be swept; one that broke the second would fork a sweep into two chains walking one bucket.
 /// </remarks>
 public sealed class ReclaimContentObjectsJobPayloadTests
 {
-    /// <summary>The first segment begins at the start of the listing and belongs to no chain yet.</summary>
+    private const string Sweep = "sweep-of-the-occasion";
+
+    /// <summary>The first segment begins at the start of the listing and already names the sweep it begins.</summary>
     [Fact]
-    public void FromTheStart_TheSegmentAScheduleDispatches_BeginsTheListingAndNamesNoSweep()
+    public void FromTheStart_TheSegmentAScheduleDispatches_BeginsTheListingAndNamesItsSweep()
     {
         // Act
-        var payload = ReclaimContentObjectsJobPayload.FromTheStart();
+        var payload = ReclaimContentObjectsJobPayload.FromTheStart(Sweep);
 
         // Assert
         Assert.Null(payload.ResumeFrom);
-        Assert.Null(payload.SweepId);
+        Assert.Equal(Sweep, payload.SweepId);
         Assert.Equal(0, payload.Segment);
         Assert.Equal(JobType.ReclaimContentObjects, payload.JobType);
     }
 
-    /// <summary>A segment always belongs to a named sweep, however the chain it is part of began.</summary>
+    /// <summary>A segment belongs to the sweep the occasion named rather than to one the hand-on invented.</summary>
     [Fact]
-    public void ContinuingFrom_TheFirstHandOn_MintsTheSweepTheChainIsNamedBy()
+    public void ContinuingFrom_TheFirstHandOn_StaysInTheSweepTheOccasionNamed()
     {
         // Arrange
-        var first = ReclaimContentObjectsJobPayload.FromTheStart();
+        var first = ReclaimContentObjectsJobPayload.FromTheStart(Sweep);
 
         // Act
         var second = first.ContinuingFrom("half-way", TimeSpan.Zero);
 
         // Assert
-        Assert.NotNull(second.SweepId);
+        Assert.Equal(Sweep, second.SweepId);
         Assert.Equal(1, second.Segment);
         Assert.Equal("half-way", second.ResumeFrom);
     }
@@ -51,7 +54,7 @@ public sealed class ReclaimContentObjectsJobPayloadTests
     public void ContinuingFrom_ALaterHandOn_StaysInTheSameSweepAndCountsOn()
     {
         // Arrange
-        var second = ReclaimContentObjectsJobPayload.FromTheStart().ContinuingFrom("half-way", TimeSpan.Zero);
+        var second = ReclaimContentObjectsJobPayload.FromTheStart(Sweep).ContinuingFrom("half-way", TimeSpan.Zero);
 
         // Act
         var third = second.ContinuingFrom("further-on", TimeSpan.Zero);
@@ -66,7 +69,7 @@ public sealed class ReclaimContentObjectsJobPayloadTests
     public void ToIdempotencyKey_TwoSegmentsOfOneSweep_ComposeDifferentIdentities()
     {
         // Arrange
-        var second = ReclaimContentObjectsJobPayload.FromTheStart().ContinuingFrom("half-way", TimeSpan.Zero);
+        var second = ReclaimContentObjectsJobPayload.FromTheStart(Sweep).ContinuingFrom("half-way", TimeSpan.Zero);
         var third = second.ContinuingFrom("further-on", TimeSpan.Zero);
 
         // Act
@@ -78,12 +81,48 @@ public sealed class ReclaimContentObjectsJobPayloadTests
         Assert.StartsWith(JobType.ReclaimContentObjects.Name, secondKey.Value, StringComparison.Ordinal);
     }
 
+    /// <summary>Two occasions are two sweeps, so the segments carrying them are never deduped against each other.</summary>
+    [Fact]
+    public void ToIdempotencyKey_TheSameSegmentOfTwoSweeps_ComposesDifferentIdentities()
+    {
+        // Arrange
+        var ofOneOccasion = ReclaimContentObjectsJobPayload.FromTheStart(Sweep).ContinuingFrom("half-way", TimeSpan.Zero);
+        var ofAnother = ReclaimContentObjectsJobPayload.FromTheStart("sweep-of-the-next-occasion")
+            .ContinuingFrom("half-way", TimeSpan.Zero);
+
+        // Act, Assert
+        Assert.NotEqual(ofOneOccasion.ToIdempotencyKey().Value, ofAnother.ToIdempotencyKey().Value);
+    }
+
+    /// <summary>
+    /// Two hand-ons from one segment compose one key, which is what keeps a repeated attempt from forking the sweep.
+    /// </summary>
+    /// <remarks>
+    /// The executor can run one leased row's handler twice against the same payload — the work succeeds and the
+    /// compare-and-set recording it does not — and the positions the two attempts stop at need not agree. What has to
+    /// agree is the key, so that the second hand-on is answered with the segment the first one enqueued.
+    /// </remarks>
+    [Fact]
+    public void ToIdempotencyKey_TwoHandOnsFromOneSegment_ComposeOneIdentity()
+    {
+        // Arrange
+        var segment = ReclaimContentObjectsJobPayload.FromTheStart(Sweep);
+
+        // Act
+        var ofOneAttempt = segment.ContinuingFrom("half-way", TimeSpan.Zero).ToIdempotencyKey();
+        var ofTheRepeat = segment.ContinuingFrom("further-on", TimeSpan.FromDays(9)).ToIdempotencyKey();
+
+        // Assert
+        Assert.Equal(ofOneAttempt.Value, ofTheRepeat.Value);
+    }
+
     /// <summary>A key names a position in a listing nowhere, because a listing position is what a key must not be composed of.</summary>
     [Fact]
     public void ToIdempotencyKey_ASegmentResumingFromAPosition_CarriesNoPartOfThatPosition()
     {
         // Arrange
-        var segment = ReclaimContentObjectsJobPayload.FromTheStart().ContinuingFrom("mailfathom-incoming-recognizable", TimeSpan.Zero);
+        var segment = ReclaimContentObjectsJobPayload.FromTheStart(Sweep)
+            .ContinuingFrom("mailfathom-incoming-recognizable", TimeSpan.Zero);
 
         // Act
         var key = segment.ToIdempotencyKey();
@@ -92,13 +131,12 @@ public sealed class ReclaimContentObjectsJobPayloadTests
         Assert.DoesNotContain("recognizable", key.Value, StringComparison.Ordinal);
     }
 
-    /// <summary>The first segment is enqueued by the schedule under the occasion's own key, so it composes none.</summary>
+    /// <summary>A segment belonging to no sweep could compose a key another sweep's segment shares.</summary>
     [Fact]
-    public void ToIdempotencyKey_TheSegmentAScheduleDispatches_IsRefused() =>
+    public void FromTheStart_NoSweep_IsRefused() =>
 
         // Act, Assert
-        Assert.Throws<InvalidOperationException>(
-            () => ReclaimContentObjectsJobPayload.FromTheStart().ToIdempotencyKey());
+        Assert.Throws<ArgumentException>(() => ReclaimContentObjectsJobPayload.FromTheStart("  "));
 
     /// <summary>A segment that resumes nowhere is the first one, which nothing hands on to.</summary>
     [Fact]
@@ -106,14 +144,14 @@ public sealed class ReclaimContentObjectsJobPayloadTests
 
         // Act, Assert
         Assert.Throws<ArgumentException>(
-            () => ReclaimContentObjectsJobPayload.FromTheStart().ContinuingFrom("  ", TimeSpan.Zero));
+            () => ReclaimContentObjectsJobPayload.FromTheStart(Sweep).ContinuingFrom("  ", TimeSpan.Zero));
 
     /// <summary>What the earlier segments met travels with the position, or the gauge would describe the last one alone.</summary>
     [Fact]
     public void ContinuingFrom_AHandOn_CarriesTheOldestOrphanTheSweepHasMet()
     {
         // Arrange
-        var first = ReclaimContentObjectsJobPayload.FromTheStart();
+        var first = ReclaimContentObjectsJobPayload.FromTheStart(Sweep);
 
         // Act
         var second = first.ContinuingFrom("half-way", TimeSpan.FromDays(9));

--- a/backend/tests/Infrastructure.UnitTests/Persistence/Jobs/JobPayloadDocumentTests.cs
+++ b/backend/tests/Infrastructure.UnitTests/Persistence/Jobs/JobPayloadDocumentTests.cs
@@ -42,7 +42,7 @@ public sealed class JobPayloadDocumentTests
         RecurringSendJobPayload.For(
             Account,
             RecurringSendId.Create(Guid.Parse("6f9619ff-8b86-d011-b42d-00c04fc964ff"))),
-        ReclaimContentObjectsJobPayload.FromTheStart(),
+        ReclaimContentObjectsJobPayload.FromTheStart("sweep-of-the-occasion"),
     ];
 
     /// <summary>
@@ -161,7 +161,7 @@ public sealed class JobPayloadDocumentTests
     public void Serialize_ASweepSegment_WritesThePositionAndReadsItBackAsTheSameSegment()
     {
         // Arrange
-        var payload = ReclaimContentObjectsJobPayload.FromTheStart().ContinuingFrom("half-way", TimeSpan.FromDays(9));
+        var payload = ReclaimContentObjectsJobPayload.FromTheStart("sweep-of-the-occasion").ContinuingFrom("half-way", TimeSpan.FromDays(9));
 
         // Act
         var document = JobPayloadDocument.Serialize(payload);

--- a/backend/tests/Infrastructure.UnitTests/Persistence/Jobs/JobPayloadDocumentTests.cs
+++ b/backend/tests/Infrastructure.UnitTests/Persistence/Jobs/JobPayloadDocumentTests.cs
@@ -172,6 +172,24 @@ public sealed class JobPayloadDocumentTests
         Assert.Contains("\"resumeFrom\":\"half-way\"", document, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// A segment naming no sweep is refused rather than resolved, which is what keeps a repeated attempt from handing
+    /// the rest of a sweep on under a name nobody dispatched.
+    /// </summary>
+    /// <remarks>
+    /// The shape a previous release wrote for the segment a schedule dispatched, which carried the position and no
+    /// sweep at all. The refusal costs one reclamation interval and no unswept object, because the occasion after it
+    /// dispatches a sweep of its own; resolving it instead would put the identity back inside the attempt.
+    /// </remarks>
+    [Fact]
+    public void Deserialize_ASweepSegmentNamingNoSweep_IsRefusedRatherThanResolved()
+    {
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => JobPayloadDocument.Deserialize(
+            JobType.ReclaimContentObjects,
+            """{"segment":0}"""));
+    }
+
     /// <summary>Every declared type is one this store can write, or a job of it is enqueueable and unstorable.</summary>
     /// <remarks>
     /// Stated over the closed enumeration rather than per type, because the failure this guards against is a type

--- a/docs/features/email-content.md
+++ b/docs/features/email-content.md
@@ -819,6 +819,14 @@ so a queue already at its configured depth ends the attempt rather than being re
 segment is attempted again once the queue has drained. Two runs overlapping cannot delete an object twice or
 miss one — the job's lease admits one worker, and removing an object already gone is not an error.
 
+**A sweep is named by the occasion that dispatched it, and the name is what keeps a chain one chain.** The schedule
+writes the identity into the first segment's own record at the moment it enqueues it, so every segment of that chain is
+keyed by a sweep the deployment can point at rather than by one an attempt invented. That matters because an attempt can
+run twice over one segment — the work succeeds and the record of it does not — and a name minted inside the attempt
+would differ between the two, hand the same position to two keys, and leave two chains walking one bucket. Reading it
+from the record instead means the repeat composes the key the first attempt already used and is answered with the
+segment that is waiting. Two occasions are two names, so consecutive sweeps are never answered with each other's work.
+
 Three things bound what it may touch, and each is deliberate:
 
 - **The configured key prefix is its whole authority.** It lists beneath `ContentStorage:ObjectStorage:KeyPrefix` and


### PR DESCRIPTION
## What this changes

A content-object sweep is a chain of jobs. The first segment carried no sweep identity, and the
hand-on minted one with `Guid.CreateVersion7()` when it met that null — so the identity was a
property of the attempt rather than of the occasion the schedule dispatched. `JobExecutor` can run
one leased row's handler more than once against the same unchanged payload, and the repeat minted a
different identity, composed a different key, and forked one sweep into two chains walking one
bucket.

The identity now comes from the record the enqueue committed:

- `ContentObjectReclamationScheduleSource` names the sweep when it declares the occasion's first
  segment, so the name is written into the job document before any attempt exists.
- `ReclaimContentObjectsJobPayload.SweepId` is required and is carried unchanged by every hand-on.
  `ContinuingFrom` mints nothing, and `ToIdempotencyKey` no longer has a first-segment case to
  refuse.
- The hand-on key is therefore a pure function of the leased payload. A repeated attempt composes
  the key the first one used and is answered with the segment already waiting, whichever listing
  position the two attempts happened to stop at.
- Two occasions are two names, two documents, and two chains, never deduped against each other.

## Where this diverges from the issue

The issue proposed a durable sweep record — a table, a migration, and a store — that a segment reads
its identity from. This does not add one, and the reason is that such a record cannot settle the
question on its own. One row keyed by the deployment-wide schedule identity cannot tell a repeated
attempt of one occasion's first segment from a new occasion's first segment: both arrive with an
identical payload, so the store either mints twice (the original defect) or adopts the in-flight
sweep and swallows the second occasion, which the acceptance rules out. Whatever design is chosen,
something has to name the occasion at dispatch — and once it does, the job row is already the
durable state the segment reads its identity from.

So the identity is durable and read rather than minted, the same way `IStoredMailRederivationRunStore`
makes one durable, and the hand-on key gains a property that store's segment count does not have: it
depends on nothing that changes between two attempts of one leased row. Say the word and I will add
the table on top of this, but it would be state nothing reads.

## Contract break

`SweepId` is a required property. A first segment enqueued by a previous release and not yet run is
refused by the deserializer rather than resolving to a sweep nobody named — the stance
`JobPayloadDocument` already takes towards a document that no longer parses. The cost is one
reclamation interval and no unswept object, because the occasion after it dispatches a sweep of its
own, and the row is dead-lettered rather than retried forever. No configuration key, MCP tool
argument, database column, or deployment value moves.

## Verification

`scripts/verify-fast.sh` passed over this tree. It ran the service flow and the unit suites the
change reaches: `Application.UnitTests`, `Infrastructure.UnitTests`, `PublicSurfaces.UnitTests`, and
`SharedSources.UnitTests`. The reclamation and payload tests are green, including the new one that
drives one leased segment twice and asserts a single hand-on key.

Closes #1271
